### PR TITLE
fix(core): malformed local thread storage

### DIFF
--- a/.changeset/local-thread-storage-validation.md
+++ b/.changeset/local-thread-storage-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: ignore malformed local thread storage

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
@@ -6,6 +6,21 @@ import {
   parseStoredThreadMetadata,
 } from "./LocalStorageThreadListAdapter";
 
+const storedMessage = (
+  id: string,
+  role: "user" | "assistant" | "system" = "user",
+) => ({
+  id,
+  role,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  content: [],
+  metadata: { custom: {} },
+  ...(role === "user" ? { attachments: [] } : undefined),
+  ...(role === "assistant"
+    ? { status: { type: "complete", reason: "stop" } }
+    : undefined),
+});
+
 const createStorage = (
   entries: Record<string, string> = {},
 ): AsyncStorageLike & { get(key: string): string | undefined } => {
@@ -61,12 +76,12 @@ describe("parseStoredMessageRepository", () => {
         headId: "message-2",
         messages: [
           {
-            message: { id: "message-1", role: "user", content: [] },
+            message: storedMessage("message-1"),
             parentId: null,
           },
           { message: { role: "user", content: [] }, parentId: null },
           {
-            message: { id: "message-2", role: "assistant", content: [] },
+            message: storedMessage("message-2", "assistant"),
             parentId: "message-1",
           },
         ],
@@ -86,21 +101,87 @@ describe("parseStoredMessageRepository", () => {
         headId: "missing",
         messages: [
           {
-            message: { id: "message-1", role: "user", content: [] },
+            message: storedMessage("message-1"),
             parentId: null,
           },
         ],
       }),
     );
 
-    expect(repo).toEqual({
-      messages: [
-        {
-          message: { id: "message-1", role: "user", content: [] },
-          parentId: null,
-        },
-      ],
-    });
+    expect(repo.headId).toBeUndefined();
+    expect(repo.messages.map((item) => item.message.id)).toEqual(["message-1"]);
+  });
+
+  it("skips messages missing the required thread message shell", () => {
+    const repo = parseStoredMessageRepository(
+      JSON.stringify({
+        messages: [
+          { message: { id: "missing-role" }, parentId: null },
+          {
+            message: {
+              ...storedMessage("missing-content"),
+              content: undefined,
+            },
+            parentId: null,
+          },
+          {
+            message: { ...storedMessage("missing-metadata"), metadata: {} },
+            parentId: null,
+          },
+          {
+            message: storedMessage("valid"),
+            parentId: null,
+          },
+        ],
+      }),
+    );
+
+    expect(repo.messages.map((item) => item.message.id)).toEqual(["valid"]);
+  });
+
+  it("skips messages whose parent is missing, skipped, or appears later", () => {
+    const repo = parseStoredMessageRepository(
+      JSON.stringify({
+        headId: "child-of-root",
+        messages: [
+          {
+            message: storedMessage("child-of-missing"),
+            parentId: "missing",
+          },
+          {
+            message: storedMessage("child-of-invalid"),
+            parentId: "invalid",
+          },
+          {
+            message: { id: "invalid" },
+            parentId: null,
+          },
+          {
+            message: storedMessage("child-before-parent"),
+            parentId: "late-parent",
+          },
+          {
+            message: storedMessage("late-parent"),
+            parentId: null,
+          },
+          {
+            message: storedMessage("child-of-root"),
+            parentId: "late-parent",
+          },
+        ],
+      }),
+    );
+
+    expect(
+      repo.messages.map((item) => ({
+        id: item.message.id,
+        parentId: item.parentId,
+      })),
+    ).toEqual([
+      { id: "late-parent", parentId: null },
+      { id: "child-of-root", parentId: "late-parent" },
+    ]);
+    expect(repo.headId).toBe("child-of-root");
   });
 });
 

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { AsyncStorageLike } from "./LocalStorageThreadListAdapter";
+import {
+  createLocalStorageAdapter,
+  parseStoredMessageRepository,
+  parseStoredThreadMetadata,
+} from "./LocalStorageThreadListAdapter";
+
+const createStorage = (
+  entries: Record<string, string> = {},
+): AsyncStorageLike & { get(key: string): string | undefined } => {
+  const values = new Map(Object.entries(entries));
+  return {
+    get: (key) => values.get(key),
+    getItem: async (key) => values.get(key) ?? null,
+    setItem: async (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: async (key) => {
+      values.delete(key);
+    },
+  };
+};
+
+describe("parseStoredThreadMetadata", () => {
+  it("returns an empty list for invalid JSON", () => {
+    expect(parseStoredThreadMetadata("{not-json")).toEqual([]);
+  });
+
+  it("skips malformed thread records while preserving valid records", () => {
+    const threads = parseStoredThreadMetadata(
+      JSON.stringify([
+        { remoteId: "thread-1", status: "regular", title: "Trip plan" },
+        { remoteId: 123, status: "regular" },
+        { remoteId: "thread-2", status: "archived", custom: { pinned: true } },
+        { remoteId: "thread-3", status: "deleted" },
+      ]),
+    );
+
+    expect(threads).toEqual([
+      { remoteId: "thread-1", status: "regular", title: "Trip plan" },
+      { remoteId: "thread-2", status: "archived", custom: { pinned: true } },
+    ]);
+  });
+
+  it("defaults old thread records without status to regular", () => {
+    expect(
+      parseStoredThreadMetadata(JSON.stringify([{ remoteId: "old" }])),
+    ).toEqual([{ remoteId: "old", status: "regular" }]);
+  });
+});
+
+describe("parseStoredMessageRepository", () => {
+  it("returns empty history for invalid JSON", () => {
+    expect(parseStoredMessageRepository("{not-json")).toEqual({ messages: [] });
+  });
+
+  it("skips malformed message records", () => {
+    const repo = parseStoredMessageRepository(
+      JSON.stringify({
+        headId: "message-2",
+        messages: [
+          {
+            message: { id: "message-1", role: "user", content: [] },
+            parentId: null,
+          },
+          { message: { role: "user", content: [] }, parentId: null },
+          {
+            message: { id: "message-2", role: "assistant", content: [] },
+            parentId: "message-1",
+          },
+        ],
+      }),
+    );
+
+    expect(repo.messages.map((item) => item.message.id)).toEqual([
+      "message-1",
+      "message-2",
+    ]);
+    expect(repo.headId).toBe("message-2");
+  });
+
+  it("drops a head id that points at a skipped message", () => {
+    const repo = parseStoredMessageRepository(
+      JSON.stringify({
+        headId: "missing",
+        messages: [
+          {
+            message: { id: "message-1", role: "user", content: [] },
+            parentId: null,
+          },
+        ],
+      }),
+    );
+
+    expect(repo).toEqual({
+      messages: [
+        {
+          message: { id: "message-1", role: "user", content: [] },
+          parentId: null,
+        },
+      ],
+    });
+  });
+});
+
+describe("createLocalStorageAdapter", () => {
+  it("lists no threads when the stored thread list is invalid JSON", async () => {
+    const storage = createStorage({ "@assistant-ui:threads": "{not-json" });
+    const adapter = createLocalStorageAdapter({ storage });
+
+    await expect(adapter.list()).resolves.toEqual({ threads: [] });
+  });
+
+  it("overwrites malformed thread storage when initializing a thread", async () => {
+    const storage = createStorage({ "@assistant-ui:threads": "{not-json" });
+    const adapter = createLocalStorageAdapter({ storage });
+
+    await expect(adapter.initialize("thread-1")).resolves.toEqual({
+      remoteId: "thread-1",
+      externalId: undefined,
+    });
+
+    expect(JSON.parse(storage.get("@assistant-ui:threads") ?? "")).toEqual([
+      { remoteId: "thread-1", status: "regular" },
+    ]);
+  });
+});

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -66,6 +66,50 @@ const parseStoredThread = (value: unknown): StoredThreadMetadata | null => {
   };
 };
 
+const parseDate = (value: unknown): Date | null => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value !== "string" && typeof value !== "number") return null;
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const isMessageRole = (value: unknown): value is ThreadMessage["role"] =>
+  value === "system" || value === "user" || value === "assistant";
+
+const parseStoredThreadMessage = (value: unknown): ThreadMessage | null => {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  if (!isMessageRole(value.role)) return null;
+  if (!Array.isArray(value.content)) return null;
+
+  const createdAt = parseDate(value.createdAt);
+  if (!createdAt) return null;
+
+  const metadata = value.metadata;
+  if (!isRecord(metadata) || !isRecord(metadata.custom)) return null;
+
+  if (value.role === "assistant") {
+    const status = value.status;
+    if (!isRecord(status) || typeof status.type !== "string") return null;
+  }
+
+  return {
+    ...value,
+    createdAt,
+    metadata: {
+      ...metadata,
+      custom: metadata.custom,
+    },
+    ...(value.role === "user"
+      ? {
+          attachments: Array.isArray(value.attachments)
+            ? value.attachments
+            : [],
+        }
+      : undefined),
+  } as ThreadMessage;
+};
+
 export const parseStoredThreadMetadata = (
   raw: string | null,
 ): StoredThreadMetadata[] => {
@@ -83,8 +127,8 @@ const parseStoredMessageRepositoryItem = (
 ): ExportedMessageRepositoryItem | null => {
   if (!isRecord(value)) return null;
 
-  const message = value.message;
-  if (!isRecord(message) || typeof message.id !== "string") return null;
+  const message = parseStoredThreadMessage(value.message);
+  if (!message) return null;
 
   const parentId = value.parentId;
   if (
@@ -96,7 +140,7 @@ const parseStoredMessageRepositoryItem = (
   }
 
   return {
-    message: message as ThreadMessage,
+    message,
     parentId: parentId ?? null,
     ...(isRecord(value.runConfig)
       ? { runConfig: value.runConfig as RunConfig }
@@ -112,9 +156,18 @@ export const parseStoredMessageRepository = (
     return { messages: [] };
   }
 
-  const messages = parsed.messages.flatMap((item) => {
+  const candidateMessages = parsed.messages.flatMap((item) => {
     const parsedItem = parseStoredMessageRepositoryItem(item);
     return parsedItem ? [parsedItem] : [];
+  });
+
+  const acceptedIds = new Set<string>();
+  const messages = candidateMessages.flatMap((item) => {
+    if (acceptedIds.has(item.message.id)) return [];
+    if (item.parentId !== null && !acceptedIds.has(item.parentId)) return [];
+
+    acceptedIds.add(item.message.id);
+    return [item];
   });
 
   const headId =

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -37,6 +37,10 @@ type StoredThreadMetadata = {
   custom?: Record<string, unknown> | undefined;
 };
 
+type StoredSystemMessage = Extract<ThreadMessage, { role: "system" }>;
+type StoredUserMessage = Extract<ThreadMessage, { role: "user" }>;
+type StoredAssistantMessage = Extract<ThreadMessage, { role: "assistant" }>;
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -91,23 +95,79 @@ const parseStoredThreadMessage = (value: unknown): ThreadMessage | null => {
   if (value.role === "assistant") {
     const status = value.status;
     if (!isRecord(status) || typeof status.type !== "string") return null;
+
+    const submittedFeedback = isRecord(metadata.submittedFeedback)
+      ? metadata.submittedFeedback
+      : undefined;
+    const submittedFeedbackType = submittedFeedback?.type;
+
+    return {
+      id: value.id,
+      role: "assistant",
+      content: value.content as StoredAssistantMessage["content"],
+      status: status as StoredAssistantMessage["status"],
+      createdAt,
+      metadata: {
+        unstable_state: (metadata.unstable_state ??
+          null) as StoredAssistantMessage["metadata"]["unstable_state"],
+        unstable_annotations: Array.isArray(metadata.unstable_annotations)
+          ? (metadata.unstable_annotations as StoredAssistantMessage["metadata"]["unstable_annotations"])
+          : [],
+        unstable_data: Array.isArray(metadata.unstable_data)
+          ? (metadata.unstable_data as StoredAssistantMessage["metadata"]["unstable_data"])
+          : [],
+        steps: Array.isArray(metadata.steps)
+          ? (metadata.steps as StoredAssistantMessage["metadata"]["steps"])
+          : [],
+        ...(submittedFeedbackType === "positive" ||
+        submittedFeedbackType === "negative"
+          ? {
+              submittedFeedback: {
+                type: submittedFeedbackType,
+              },
+            }
+          : undefined),
+        ...(metadata.timing !== undefined
+          ? {
+              timing: metadata.timing as NonNullable<
+                StoredAssistantMessage["metadata"]["timing"]
+              >,
+            }
+          : undefined),
+        ...(metadata.isOptimistic === true
+          ? { isOptimistic: true }
+          : undefined),
+        custom: metadata.custom,
+      },
+    };
   }
 
+  if (value.role === "user") {
+    return {
+      id: value.id,
+      role: "user",
+      content: value.content as StoredUserMessage["content"],
+      attachments: Array.isArray(value.attachments)
+        ? (value.attachments as StoredUserMessage["attachments"])
+        : [],
+      createdAt,
+      metadata: {
+        custom: metadata.custom,
+      },
+    };
+  }
+
+  if (value.content.length !== 1) return null;
+
   return {
-    ...value,
+    id: value.id,
+    role: "system",
+    content: [value.content[0] as StoredSystemMessage["content"][0]],
     createdAt,
     metadata: {
-      ...metadata,
       custom: metadata.custom,
     },
-    ...(value.role === "user"
-      ? {
-          attachments: Array.isArray(value.attachments)
-            ? value.attachments
-            : [],
-        }
-      : undefined),
-  } as ThreadMessage;
+  };
 };
 
 export const parseStoredThreadMetadata = (

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -8,6 +8,7 @@ import type {
   RemoteThreadMetadata,
   ThreadHistoryAdapter,
   ThreadMessage,
+  RunConfig,
 } from "../../index";
 import type {
   ExportedMessageRepository,
@@ -36,6 +37,99 @@ type StoredThreadMetadata = {
   custom?: Record<string, unknown> | undefined;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseJSON = (raw: string | null): unknown => {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
+const parseStoredThread = (value: unknown): StoredThreadMetadata | null => {
+  if (!isRecord(value) || typeof value.remoteId !== "string") return null;
+
+  const status = value.status ?? "regular";
+  if (status !== "regular" && status !== "archived") return null;
+
+  return {
+    remoteId: value.remoteId,
+    status,
+    ...(typeof value.externalId === "string"
+      ? { externalId: value.externalId }
+      : undefined),
+    ...(typeof value.title === "string" ? { title: value.title } : undefined),
+    ...(isRecord(value.custom) ? { custom: value.custom } : undefined),
+  };
+};
+
+export const parseStoredThreadMetadata = (
+  raw: string | null,
+): StoredThreadMetadata[] => {
+  const parsed = parseJSON(raw);
+  if (!Array.isArray(parsed)) return [];
+
+  return parsed.flatMap((item) => {
+    const thread = parseStoredThread(item);
+    return thread ? [thread] : [];
+  });
+};
+
+const parseStoredMessageRepositoryItem = (
+  value: unknown,
+): ExportedMessageRepositoryItem | null => {
+  if (!isRecord(value)) return null;
+
+  const message = value.message;
+  if (!isRecord(message) || typeof message.id !== "string") return null;
+
+  const parentId = value.parentId;
+  if (
+    parentId !== undefined &&
+    parentId !== null &&
+    typeof parentId !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    message: message as ThreadMessage,
+    parentId: parentId ?? null,
+    ...(isRecord(value.runConfig)
+      ? { runConfig: value.runConfig as RunConfig }
+      : undefined),
+  };
+};
+
+export const parseStoredMessageRepository = (
+  raw: string | null,
+): ExportedMessageRepository => {
+  const parsed = parseJSON(raw);
+  if (!isRecord(parsed) || !Array.isArray(parsed.messages)) {
+    return { messages: [] };
+  }
+
+  const messages = parsed.messages.flatMap((item) => {
+    const parsedItem = parseStoredMessageRepositoryItem(item);
+    return parsedItem ? [parsedItem] : [];
+  });
+
+  const headId =
+    parsed.headId === null ||
+    (typeof parsed.headId === "string" &&
+      messages.some((item) => item.message.id === parsed.headId))
+      ? parsed.headId
+      : undefined;
+
+  return {
+    ...(headId !== undefined ? { headId } : undefined),
+    messages,
+  };
+};
+
 class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
   constructor(
     private storage: AsyncStorageLike,
@@ -52,8 +146,7 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
     if (!remoteId) return { messages: [] };
 
     const raw = await this.storage.getItem(this._messagesKey(remoteId));
-    if (!raw) return { messages: [] };
-    return JSON.parse(raw) as ExportedMessageRepository;
+    return parseStoredMessageRepository(raw);
   }
 
   async append(item: ExportedMessageRepositoryItem): Promise<void> {
@@ -61,9 +154,7 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
 
     const key = this._messagesKey(remoteId);
     const raw = await this.storage.getItem(key);
-    const repo: ExportedMessageRepository = raw
-      ? (JSON.parse(raw) as ExportedMessageRepository)
-      : { messages: [] };
+    const repo = parseStoredMessageRepository(raw);
 
     const idx = repo.messages.findIndex(
       (m) => m.message.id === item.message.id,
@@ -110,7 +201,7 @@ export const createLocalStorageAdapter = (
 
   const loadThreadMetadata = async (): Promise<StoredThreadMetadata[]> => {
     const raw = await storage.getItem(threadsKey);
-    return raw ? (JSON.parse(raw) as StoredThreadMetadata[]) : [];
+    return parseStoredThreadMetadata(raw);
   };
 
   const saveThreadMetadata = async (


### PR DESCRIPTION
## Summary
- parse local thread metadata and message history defensively before using it
- skip malformed thread/message records and treat invalid JSON as empty storage
- keep older thread records without a status by defaulting them to `regular`
- add tests for invalid JSON, skipped malformed rows, invalid head ids, and reinitializing after bad storage

## Why
`createLocalStorageAdapter` reads from browser storage, which can be stale, manually edited in DevTools, or partially corrupted. The adapter previously trusted parsed values with type casts, so malformed local data could break thread listing or history loading.

## Testing
- `pnpm --filter @assistant-ui/core test -- src/react/adapters/LocalStorageThreadListAdapter.test.ts`
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

