### PR TITLE
ci: de-duplicate .turbo cache key between build and test jobs

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -106,9 +106,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-build-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.ref }}-
+            ${{ runner.os }}-turbo-build-${{ github.ref }}-
+            ${{ runner.os }}-turbo-build-
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies
@@ -158,9 +159,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.ref }}-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-test-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-turbo-${{ github.ref }}-
+            ${{ runner.os }}-turbo-test-${{ github.ref }}-
+            ${{ runner.os }}-turbo-test-
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies


### PR DESCRIPTION
## What

The Build and Test jobs in `code-quality.yaml` run in parallel and save `.turbo` under the same key, so the second saver loses its cache. This gives each job a `build`/`test` discriminator in the key.

```diff
  # build job
- key: ${{ runner.os }}-turbo-${{ github.ref }}-${{ github.sha }}
+ key: ${{ runner.os }}-turbo-build-${{ github.ref }}-${{ github.sha }}
  restore-keys: |
+   ${{ runner.os }}-turbo-build-${{ github.ref }}-
+   ${{ runner.os }}-turbo-build-
    ${{ runner.os }}-turbo-

  # test job: same change with `-test-`
```

## Why

- Both jobs save under the identical key `…-turbo-<ref>-<sha>` (build line 109, test line 161).
- `actions/cache` entries are immutable: the second save is skipped (`Cache already exists. Not saving cache.`), or loses a 409 race when concurrent.
- So the job that finishes second, in practice Test, fails to persist its cache on effectively every run.
- Turbo `test` tasks are cacheable (logs replay), so that lost cache is exactly what would make test-only reruns near-instant.

## Impact

- Test's `.turbo` cache now persists on every run; later test-only runs replay from cache instead of re-executing.
- The shared `…-turbo-` fallback is kept, so both jobs still restore today's warm caches on the first runs after merge (no cold start) and can still cross-seed from each other.
- No wrong results possible: turbo is content-addressed per task, so a restored cache that does not match just misses and re-runs that task.

## Why the discriminator goes right after `turbo-`

`turbo-build-…` keeps the `restore-keys` prefix hierarchy clean: same-job-same-branch, then same-job-any-branch (main), then any turbo cache. Putting it after `<sha>` would break the middle tier, since you cannot prefix-match "this job on any commit" with the sha in front of it.

## Notes

- CI: cache keys only. No job command, filter, dependency, or pass/fail change. Worst case if wrong is a cache miss, never a wrong result.
- Storage: code-quality now keeps two `.turbo` caches per run instead of one (the intended cost). GitHub's ~10 GB per-repo LRU eviction ages out old per-sha entries, so no pruning step is needed.
- No output change to build outputs, test results, or published artifacts.
- Changeset: none. Workflow-only; no published package touched.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

