### PR TITLE
fix(react-google-adk): invalid request JSON errors

### DIFF
--- a/.changeset/adk-invalid-json-error.md
+++ b/.changeset/adk-invalid-json-error.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: clarify invalid ADK proxy request body errors

--- a/packages/react-google-adk/src/server/parseAdkRequest.test.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.test.ts
@@ -85,12 +85,14 @@ describe("parseAdkRequest", () => {
       method: "POST",
       body: "not json",
     });
-    await expect(parseAdkRequest(req)).rejects.toThrow();
+    await expect(parseAdkRequest(req)).rejects.toThrow(
+      'Invalid JSON in Google ADK proxy request body. Expected a JSON object like {"message":"Hello"} or {"type":"tool-result",...}.',
+    );
   });
 
   it("throws on non-object body", async () => {
     await expect(parseAdkRequest(makeRequest([1, 2, 3]))).rejects.toThrow(
-      "Request body must be a JSON object",
+      "Google ADK proxy request body must be a JSON object",
     );
   });
 });

--- a/packages/react-google-adk/src/server/parseAdkRequest.ts
+++ b/packages/react-google-adk/src/server/parseAdkRequest.ts
@@ -46,11 +46,13 @@ export const parseAdkRequest = async (
   try {
     body = (await request.json()) as Record<string, unknown>;
   } catch {
-    throw new Error("Invalid JSON in request body");
+    throw new Error(
+      'Invalid JSON in Google ADK proxy request body. Expected a JSON object like {"message":"Hello"} or {"type":"tool-result",...}.',
+    );
   }
 
   if (!body || typeof body !== "object" || Array.isArray(body)) {
-    throw new Error("Request body must be a JSON object");
+    throw new Error("Google ADK proxy request body must be a JSON object");
   }
 
   const config: AdkSendMessageConfig = {};


### PR DESCRIPTION
## Summary

Clarifies the errors thrown by `parseAdkRequest` when an ADK proxy route receives malformed JSON or a non-object JSON body.

## Why

When testing ADK proxy routes locally, a malformed request body currently only says `Invalid JSON in request body`. The new message names the Google ADK proxy request body and shows the two supported request shapes: a user message or a tool result.

## Checks

- `pnpm --filter @assistant-ui/react-google-adk test`
- `pnpm --filter @assistant-ui/react-google-adk build`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

