### PR TITLE
ci: temporarily run Claude Code review on Opus 4.8

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -90,7 +90,10 @@ env:
   # - mcp__github_inline_comment__create_inline_comment: Create inline code comments
   # - Bash(gh ...): Read-only GitHub CLI commands for PR/issue info
   # Note: gh pr comment is NOT allowed - Claude must use update_claude_comment only
-  CLAUDE_ARGS: '--model fable --effort high --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+  # Temporarily on Opus 4.8 while Fable usage credits are exhausted; swap back to
+  # `--model fable` when access returns. The Fable-specific machinery below
+  # (Opus-fallback flagging) stays in place for that switch-back.
+  CLAUDE_ARGS: '--model claude-opus-4-8 --effort high --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Summary
Fable 5 usage credits for the Claude Code review workflow are exhausted, so this pins the review to `claude-opus-4-8` until Fable access returns.

## Changes
- `--model fable` → `--model claude-opus-4-8` in `CLAUDE_ARGS`, with a comment marking the swap as temporary
- All other Fable machinery is left intact (the Opus-fallback flagging step, effort setting, prompt) so switching back is a one-line revert of the model flag

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

