### PR TITLE
docs: add ChatGPT subscription guide

### DIFF
--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -61,6 +61,8 @@ Create a `.env` file with your API key:
 OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
+Developing locally with a ChatGPT Plus or Pro plan? You can skip the API key and run on your subscription instead; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription).
+
   </Step>
   <Step>
 

--- a/apps/docs/content/docs/guides/chatgpt-subscription.mdx
+++ b/apps/docs/content/docs/guides/chatgpt-subscription.mdx
@@ -1,0 +1,97 @@
+---
+title: ChatGPT Subscription
+description: Run your assistant-ui app on your ChatGPT Plus or Pro subscription via Codex OAuth. Local development without an OpenAI API key.
+platforms: ["react"]
+---
+
+If you have a ChatGPT Plus or Pro subscription, you can run your assistant-ui app against it locally instead of paying per token with an API key. OpenAI's Codex CLI authenticates via OAuth and caches tokens on your machine; requests made with those tokens hit the Responses API endpoint at `chatgpt.com` and bill to your plan. The same mechanism powers Codex itself and a growing set of local agents.
+
+This is a personal-use setup for apps running on your own machine. For anything deployed or shared, use an API key.
+
+## Log in with Codex
+
+Authenticate once with the Codex CLI. The login flow runs OAuth in your browser and writes access and refresh tokens to `~/.codex/auth.json`:
+
+```sh
+npx @openai/codex login
+```
+
+Everything below reads that file; no environment variables or API keys are involved.
+
+## AI SDK route
+
+The community AI SDK provider [`openai-oauth-provider`](https://github.com/EvanZhouDev/openai-oauth) picks up `~/.codex/auth.json` automatically, refreshes tokens as needed, and supports streaming, tool calls, and reasoning traces.
+
+```sh
+npm install openai-oauth-provider
+```
+
+In your chat route, swap `@ai-sdk/openai` for the OAuth provider. Starting from the default assistant-ui template route, only the model changes; `frontendTools` and the UI message stream response work as before:
+
+```ts title="/app/api/chat/route.ts" {10}
+import { createOpenAIOAuth } from "openai-oauth-provider";
+import { frontendTools } from "@assistant-ui/react-ai-sdk";
+import {
+  type JSONSchema7,
+  streamText,
+  convertToModelMessages,
+  type UIMessage,
+} from "ai";
+
+const openai = createOpenAIOAuth();
+
+export async function POST(req: Request) {
+  const {
+    messages,
+    system,
+    tools,
+  }: {
+    messages: UIMessage[];
+    system?: string;
+    tools?: Record<string, { description?: string; parameters: JSONSchema7 }>;
+  } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-5.3-codex"),
+    messages: await convertToModelMessages(messages),
+    system,
+    tools: {
+      ...frontendTools(tools ?? {}),
+    },
+  });
+
+  return result.toUIMessageStreamResponse({
+    sendReasoning: true,
+  });
+}
+```
+
+The provider discovers which models your plan includes (for example `gpt-5.4` and `gpt-5.3-codex`) from your ChatGPT account.
+
+## Eve agents
+
+Eve's `defineAgent` accepts a provider-authored AI SDK `LanguageModel`, so the same provider drops into an eve agent config:
+
+```ts title="agent/agent.ts"
+import { defineAgent } from "eve";
+import { createOpenAIOAuth } from "openai-oauth-provider";
+
+export default defineAgent({
+  model: createOpenAIOAuth()("gpt-5.3-codex"),
+});
+```
+
+## OpenAI-compatible proxy
+
+For stacks that take an OpenAI base URL rather than an AI SDK model, the same package ships a local proxy:
+
+```sh
+npx openai-oauth
+# OpenAI-compatible endpoint ready at http://127.0.0.1:10531/v1
+```
+
+Point any OpenAI-compatible client at that URL; no API key is required.
+
+<Callout type="warn">
+  Your OAuth tokens live in `~/.codex/auth.json`, so this only works where that file exists. A deployed instance would bill every visitor to your subscription. `openai-oauth-provider` is an unofficial community package, available models depend on your ChatGPT plan, and OpenAI sanctions this auth flow for Codex tooling, so treat it as personal use.
+</Callout>

--- a/apps/docs/content/docs/guides/chatgpt-subscription.mdx
+++ b/apps/docs/content/docs/guides/chatgpt-subscription.mdx
@@ -83,14 +83,25 @@ export default defineAgent({
 
 ## OpenAI-compatible proxy
 
-For stacks that take an OpenAI base URL rather than an AI SDK model, the same package ships a local proxy:
+For stacks that take an OpenAI base URL rather than an AI SDK model, the same project publishes a sibling package, `openai-oauth`, whose CLI runs a local proxy:
 
 ```sh
 npx openai-oauth
 # OpenAI-compatible endpoint ready at http://127.0.0.1:10531/v1
 ```
 
-Point any OpenAI-compatible client at that URL; no API key is required.
+Point any OpenAI-compatible client at that URL. No real API key is involved, but most clients require one at construction, so pass a placeholder:
+
+```ts
+import { OpenAI } from "openai";
+
+const openai = new OpenAI({
+  baseURL: "http://127.0.0.1:10531/v1",
+  apiKey: "unused",
+});
+```
+
+The proxy binds to `127.0.0.1` by default; keep it that way, since any caller that can reach the endpoint bills your subscription.
 
 <Callout type="warn">
   Your OAuth tokens live in `~/.codex/auth.json`, so this only works where that file exists. A deployed instance would bill every visitor to your subscription. `openai-oauth-provider` is an unofficial community package, available models depend on your ChatGPT plan, and OpenAI sanctions this auth flow for Codex tooling, so treat it as personal use.

--- a/apps/docs/content/docs/guides/index.mdx
+++ b/apps/docs/content/docs/guides/index.mdx
@@ -95,3 +95,13 @@ Read and drive runtime state from your own code.
     Access threads, messages, composer, and tool state via `useAui` and the runtime scope tree.
   </Card>
 </Cards>
+
+## Providers
+
+Alternative ways to connect a model.
+
+<Cards>
+  <Card title="ChatGPT Subscription" href="/docs/guides/chatgpt-subscription">
+    Run your app locally on a ChatGPT Plus or Pro plan via Codex OAuth, no API key required.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/guides/meta.json
+++ b/apps/docs/content/docs/guides/meta.json
@@ -29,6 +29,8 @@
     "speech",
     "---Programmatic---",
     "context-api",
+    "---Providers---",
+    "chatgpt-subscription",
     "---Resilience---",
     "resumable-streams",
     "resumable-stream-stores",

--- a/apps/docs/content/docs/integrations/gateways/index.mdx
+++ b/apps/docs/content/docs/integrations/gateways/index.mdx
@@ -8,7 +8,7 @@ import { VercelIcon } from "@/components/icons/vercel";
 
 LLM gateways sit between your route handler and the upstream provider. They give you a single endpoint that fronts many providers, plus features like multi-provider fallback, prompt caching, and BYOK (bring-your-own-key) flows. Most are OpenAI API-compatible, so the integration is a `baseURL` swap on `createOpenAI` from `@ai-sdk/openai`.
 
-For pure observability (proxy that logs every call) see [Helicone](/docs/integrations/observability/helicone). The gateways here overlap in spirit but are positioned around routing rather than logging.
+For pure observability (proxy that logs every call) see [Helicone](/docs/integrations/observability/helicone). The gateways here overlap in spirit but are positioned around routing rather than logging. For local personal projects there is also a keyless option in the same `baseURL`-swap shape: a local OAuth proxy billed to your ChatGPT subscription; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription).
 
 ## Compare
 

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -698,7 +698,7 @@ const OpenAIAdapter: ChatModelAdapter = {
 };
 ```
 
-For local development on a ChatGPT Plus or Pro plan, the same client can run without an API key by pointing `baseURL` at a local OAuth proxy; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription#openai-compatible-proxy).
+For local development on a ChatGPT Plus or Pro plan, the same client can run without a real API key by pointing `baseURL` at a local OAuth proxy and passing a placeholder `apiKey`; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription#openai-compatible-proxy).
 
 ### Custom REST API
 

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -698,6 +698,8 @@ const OpenAIAdapter: ChatModelAdapter = {
 };
 ```
 
+For local development on a ChatGPT Plus or Pro plan, the same client can run without an API key by pointing `baseURL` at a local OAuth proxy; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription#openai-compatible-proxy).
+
 ### Custom REST API
 
 ```tsx

--- a/apps/docs/content/docs/runtimes/eve/overview.mdx
+++ b/apps/docs/content/docs/runtimes/eve/overview.mdx
@@ -56,7 +56,7 @@ export default function Home() {
 - An Eve app mounted with `eve/next`.
 - A model credential for the model configured in `agent/agent.ts`.
 
-Eve's default gateway model ids route through the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway). Use `AI_GATEWAY_API_KEY` or Vercel OIDC, or configure a direct provider `LanguageModel`.
+Eve's default gateway model ids route through the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway). Use `AI_GATEWAY_API_KEY` or Vercel OIDC, or configure a direct provider `LanguageModel`. For local development, a direct `LanguageModel` can also run on a ChatGPT Plus or Pro plan without any API key; see [ChatGPT Subscription](/docs/guides/chatgpt-subscription).
 
 ## Install
 


### PR DESCRIPTION
adds a guide for running assistant-ui on a ChatGPT Plus/Pro subscription via Codex OAuth instead of an API key, the same mechanism pi, opencode plugins, and other local agents use. no OAuth code on our side: `codex login` writes `~/.codex/auth.json` and the community `openai-oauth-provider` AI SDK provider picks it up.

- new `guides/chatgpt-subscription.mdx` under a new `---Providers---` sidebar section: codex login, AI SDK route swap (based on the default template route, `createOpenAIOAuth()` line highlighted), eve `defineAgent` one-liner, and the `npx openai-oauth` local proxy for anything that takes an OpenAI base URL. one callout covers the constraints: local-only credentials, unofficial community package, plan-dependent models.
- cross-linked from the places users reach for an OpenAI key: installation's "Add API key" step, eve overview credentials paragraph, LLM gateways intro (same `baseURL`-swap shape), and local-runtime's OpenAI adapter example.

mdx compiles clean via `fumadocs-mdx`; skipped mastra/cloudflare/helicone key mentions since the pattern is unverified or wrong (deployed environments) there.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

