### PR TITLE
fix(docs): trap tab focus inside the zoomed homepage demo

### DIFF
--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -169,11 +169,34 @@ export function ExampleShowcase() {
     if (stackingAncestor instanceof HTMLElement) {
       stackingAncestor.style.zIndex = "50";
     }
+    // The panel stays in the page's DOM (no portal), so keep Tab focus inside
+    // by inerting every element outside its ancestor chain. Radix portals
+    // opened while zoomed mount into <body> afterwards and stay interactive.
+    const inertedSiblings: HTMLElement[] = [];
+    for (
+      let node: HTMLElement | null = panelRef.current;
+      node && node !== document.body;
+      node = node.parentElement
+    ) {
+      for (const sibling of node.parentElement?.children ?? []) {
+        if (
+          sibling !== node &&
+          sibling instanceof HTMLElement &&
+          !sibling.inert
+        ) {
+          sibling.inert = true;
+          inertedSiblings.push(sibling);
+        }
+      }
+    }
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
       document.body.style.overflow = "";
       if (stackingAncestor instanceof HTMLElement) {
         stackingAncestor.style.zIndex = "";
+      }
+      for (const sibling of inertedSiblings) {
+        sibling.inert = false;
       }
     };
   }, [isFullscreen, toggleFullscreen]);


### PR DESCRIPTION
when the homepage demo zooms to fullscreen, Tab could still reach links and buttons on the page underneath the overlay: the panel is a `fixed inset-0` div that stays in place in the page's DOM (no portal, since the FLIP animation needs the element to keep its identity), so nothing stopped focus from walking the rest of the document behind it.

- the fullscreen effect now walks from the panel up to `<body>` and sets `inert` on every sibling along the ancestor chain, so the only focusable content left is the overlay itself; cleanup restores exactly the elements it inerted.
- Radix portals opened while zoomed (dropdowns, popovers inside the demo) mount into `<body>` after the effect runs, so they stay interactive.
- pre-inerted elements are skipped and left untouched on cleanup.

verified locally with agent-browser: after zooming, the site header reports `inert`, 28 consecutive Tab presses never left the overlay (focus cycled through the demo's tabs, composer, and suggestion buttons), and after exiting `document.querySelectorAll("[inert]")` is empty.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

