### PR TITLE
feat(docs): exit showcase zoom on outside click and wheel

### DIFF
--- a/apps/docs/components/home/example-showcase.tsx
+++ b/apps/docs/components/home/example-showcase.tsx
@@ -17,7 +17,10 @@ import React from "react";
 import { flushSync } from "react-dom";
 
 const ExampleWrapper = ({ children }: { children: React.ReactNode }) => (
-  <div className="not-prose h-full overflow-hidden rounded-2xl border">
+  <div
+    className="not-prose h-full overflow-hidden rounded-2xl border"
+    data-slot="example-shell"
+  >
     {children}
   </div>
 );
@@ -144,10 +147,27 @@ export function ExampleShowcase() {
     );
   }, []);
 
+  // Radix portals mount into <body>, so a portaled dropdown's contents fail
+  // the shell containment check; require the target to sit inside the panel.
+  const isOutsideShell = React.useCallback(
+    (target: EventTarget | null) =>
+      target instanceof Element &&
+      panelRef.current?.contains(target) === true &&
+      !target.closest(
+        '[data-slot="example-shell"], [data-slot="tab-item"], [data-slot="tab-actions"]',
+      ),
+    [],
+  );
+
   // Inline, the demo is a static preview: clicking anywhere except the tab bar
-  // expands it to fullscreen, where it becomes interactive.
+  // expands it to fullscreen, where it becomes interactive. Fullscreen, the
+  // same click on the padding around the shell exits.
   const handlePanelClick = (e: React.MouseEvent) => {
-    if (isFullscreen) return;
+    if (isFullscreen) {
+      if (e.defaultPrevented) return;
+      if (isOutsideShell(e.target)) toggleFullscreen();
+      return;
+    }
     if ((e.target as HTMLElement).closest('[data-slot="tab-list"]')) return;
     toggleFullscreen();
   };
@@ -161,7 +181,15 @@ export function ExampleShowcase() {
       if (e.defaultPrevented) return;
       if (e.key === "Escape") toggleFullscreen();
     };
+    // Page scroll is locked, so a wheel gesture outside the shell can only
+    // mean "get back to the page". The deltaY check keeps horizontal trackpad
+    // swipes over the overflow-x tab bar from exiting.
+    const handleWheel = (e: WheelEvent) => {
+      if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+      if (isOutsideShell(e.target)) toggleFullscreen();
+    };
     document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("wheel", handleWheel, { passive: true });
     document.body.style.overflow = "hidden";
     // The homepage <main> creates a z-2 stacking context, which would paint
     // the overlay beneath the sticky z-50 site header.
@@ -171,12 +199,13 @@ export function ExampleShowcase() {
     }
     return () => {
       document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("wheel", handleWheel);
       document.body.style.overflow = "";
       if (stackingAncestor instanceof HTMLElement) {
         stackingAncestor.style.zIndex = "";
       }
     };
-  }, [isFullscreen, toggleFullscreen]);
+  }, [isFullscreen, isOutsideShell, toggleFullscreen]);
 
   const activeSlug = EXAMPLE_TABS[activeIndex]?.slug;
 


### PR DESCRIPTION
the zoomed demo showcase could only be exited via the X button or Escape, which isn't where your hand goes: you click the dead space around the demo, or you scroll expecting the page to move (it can't — zoom locks body scroll). both gestures now read as "get me back to the page" and unzoom.

- `ExampleWrapper` gains `data-slot="example-shell"` so the exit logic can tell the demo shell apart from the padding around it with a `closest` check.
- `isOutsideShell` accepts a target only when it's DOM-contained in the panel and not inside the shell, a `tab-item`, or `tab-actions` — so tab switching, the open-demo link, and the X button keep working, and Radix-portaled dropdown content (which mounts into `<body>`) can never count as outside.
- `handlePanelClick` grows a fullscreen branch that unzooms on such clicks, deferring to open Radix layers via `e.defaultPrevented` the same way the existing Escape handler does.
- a passive `wheel` listener in the fullscreen effect unzooms when the gesture lands outside the shell; a `deltaY > deltaX` guard keeps horizontal trackpad swipes over the overflow-x tab bar from exiting, and scrolling inside the chat UI is untouched.

verified locally: drove the homepage showcase in a browser — clicks on the blank tab-bar space and the bottom/left padding exit, clicks inside the chat UI and on tab triggers don't (tab switch still applies), wheel over the padding exits while wheel inside the shell and horizontal wheel over the tab bar don't, and Escape plus the X button still work. `oxlint`, `oxfmt --check`, and `tsc --noEmit` are clean for the file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

