### PR TITLE
fix(docs): add visible keyboard focus ring to shared tab triggers

### DIFF
--- a/apps/docs/components/shared/tab.tsx
+++ b/apps/docs/components/shared/tab.tsx
@@ -62,7 +62,7 @@ const tabIndicatorVariants = cva(
 );
 
 const tabItemVariants = cva(
-  "relative flex h-[30px] cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-2 text-sm leading-5 whitespace-nowrap transition-all duration-300 focus:outline-none data-[active=true]:font-medium",
+  "focus-visible:ring-ring/50 relative flex h-[30px] cursor-pointer items-center justify-center gap-2 rounded-md px-3 py-2 text-sm leading-5 whitespace-nowrap transition-all duration-300 outline-none focus-visible:ring-2 focus-visible:ring-inset data-[active=true]:font-medium",
   {
     variants: {
       variant: {


### PR DESCRIPTION
the demo switcher tabs on the homepage (Base / ChatGPT / Claude / ...) are keyboard-focusable but showed no focus indication at all: `tabItemVariants` in the shared `Tab` component set `focus:outline-none`, killing the browser's default outline without providing a replacement. tabbing through the page gave no clue which tab had focus.

- `tabItemVariants` now uses the docs app's standard focus pattern (`outline-none focus-visible:ring-2 focus-visible:ring-ring/50`, same as `dropdown-menu`, `weekly-downloads-stat`, and the thread-list samples), so keyboard focus shows a ring and mouse clicks don't.
- the ring is `focus-visible:ring-inset`: the triggers sit flush against `TabContainer`'s `overflow-x-auto` padding box and the horizontal `Tab` root is itself `overflow-hidden`, so an outset ring gets clipped flat on the top and left of the first tab (confirmed by inflating the ring in devtools). inset draws just within the trigger's own `rounded-md` edge, immune to both clips with zero layout change.
- the ring inherits the trigger's existing `rounded-md`, matching the hover pill's geometry, and applies to both the content-tab and navigation-link renders of `TabItem` — the homepage showcase is currently the only `shared/tab` consumer.

| | before | after |
|---|---|---|
| light | ![before light](https://gist.githubusercontent.com/AVGVSTVS96/4737e4dbde1555aecbb14a89be03fe2d/raw/0b64d5821c65d9ee667a7dd9f20c984c60493c94/pr-before-light-crop.png) | ![after light](https://gist.githubusercontent.com/AVGVSTVS96/4737e4dbde1555aecbb14a89be03fe2d/raw/0b64d5821c65d9ee667a7dd9f20c984c60493c94/pr-after-light-crop.png) |
| dark | ![before dark](https://gist.githubusercontent.com/AVGVSTVS96/4737e4dbde1555aecbb14a89be03fe2d/raw/0b64d5821c65d9ee667a7dd9f20c984c60493c94/pr-before-dark-crop.png) | ![after dark](https://gist.githubusercontent.com/AVGVSTVS96/4737e4dbde1555aecbb14a89be03fe2d/raw/0b64d5821c65d9ee667a7dd9f20c984c60493c94/pr-after-dark-crop.png) |

verified locally: drove the homepage in a browser — tabbed onto the demo switcher, `document.activeElement.matches(":focus-visible")` is true and the ring is visible, complete on all four sides of the leftmost tab, and radius-cohesive with the pill in both light and dark; clicking a tab shows no ring. `oxlint` and `oxfmt` are clean for the file.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

