### PR TITLE
fix(react-langgraph): defer frontend tool-result resume until the current run finishes

### DIFF
--- a/.changeset/langgraph-defer-tool-resume.md
+++ b/.changeset/langgraph-defer-tool-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: defer frontend tool-result resume until the current run finishes so runs never overlap

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -2139,7 +2139,10 @@ declare const useLangGraphMessages: <TMessage extends {
   messages: TMessage[];
   messageMetadata: Map<string, LangGraphTupleMetadata>;
   uiMessages: UIMessage[];
-  sendMessage: (newMessages: TMessage[], config: LangGraphSendMessageConfig, onComplete?: () => void) => Promise<void>;
+  sendMessage: (newMessages: TMessage[], config: LangGraphSendMessageConfig, onComplete?: (info: {
+    aborted: boolean;
+    error: unknown;
+  }) => void) => Promise<void>;
   cancel: () => void;
   setInterrupt: import("react").Dispatch<import("react").SetStateAction<LangGraphInterruptState | undefined>>;
   setMessages: (msgs: TMessage[]) => void;

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -3052,6 +3052,10 @@ describe("useLangGraphMessages", {}, () => {
     });
 
     expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      aborted: false,
+      error: undefined,
+    });
   });
 
   it("invokes onComplete on abort path", async () => {
@@ -3096,6 +3100,69 @@ describe("useLangGraphMessages", {}, () => {
 
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+    expect(onComplete).toHaveBeenCalledWith({
+      aborted: true,
+      error: undefined,
+    });
+  });
+
+  it("reports a top-level error event through onComplete", async () => {
+    const onComplete = vi.fn();
+    const errorData = { message: "graph failed" };
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "error", data: errorData },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ type: "human", content: "hi" }],
+        {},
+        onComplete,
+      );
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      aborted: false,
+      error: errorData,
+    });
+  });
+
+  it("does not report a subgraph error event through onComplete", async () => {
+    const onComplete = vi.fn();
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      { event: "error|subgraph", data: { message: "recoverable" } },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ type: "human", content: "hi" }],
+        {},
+        onComplete,
+      );
+    });
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith({
+      aborted: false,
+      error: undefined,
     });
   });
 

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -213,10 +213,12 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     async (
       newMessages: TMessage[],
       config: LangGraphSendMessageConfig,
-      onComplete?: () => void,
+      onComplete?: (info: { aborted: boolean; error: unknown }) => void,
     ) => {
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
+      let caughtError: unknown;
+      let aborted = false;
       try {
         // ensure all messages have an ID
         const newMessagesWithId = newMessages.map((m) =>
@@ -355,6 +357,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               onError?.(chunk.data);
               // namespaced errors come from subgraphs, which the parent may recover from
               if (!eventNamespace) {
+                caughtError = chunk.data;
                 const messages = accumulator.getMessages();
                 const lastAiMessage = messages.findLast(
                   (m): m is TMessage & { type: string; id: string } =>
@@ -415,13 +418,18 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
           !abortController.signal.aborted &&
           !(error instanceof Error && error.name === "AbortError")
         ) {
+          caughtError = error;
           throw error;
         }
+        aborted = true;
       } finally {
         if (abortControllerRef.current === abortController) {
           abortControllerRef.current = null;
         }
-        onComplete?.();
+        onComplete?.({
+          aborted: aborted || abortController.signal.aborted,
+          error: caughtError,
+        });
       }
     },
     [

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1103,5 +1103,61 @@ describe("useLangGraphRuntime", () => {
         expect(auiResult.current.thread().getState().isRunning).toBe(false),
       );
     });
+
+    it("merges a staggered same-run tool result into the stashed resume", async () => {
+      const gateB = deferred<void>();
+      const gateDrain = deferred<void>();
+      const staggeredAiMessage = {
+        event: "messages/complete",
+        data: [
+          {
+            id: "ai-1",
+            type: "ai" as const,
+            content: "",
+            tool_calls: [
+              { id: "tc-1", name: "my_tool", args: {} },
+              { id: "tc-2", name: "my_tool", args: {} },
+            ],
+          },
+        ],
+      };
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gateB.promise;
+          yield staggeredAiMessage;
+          await gateDrain.promise;
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      const auiResult = await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      // flush so tool A's batch is stashed before tool B streams in
+      await act(async () => {});
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        gateB.resolve();
+      });
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(2));
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        gateDrain.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(streamMock.mock.calls[1]![0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1", status: "success" },
+        { type: "tool", tool_call_id: "tc-2", status: "success" },
+      ]);
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+    });
   });
 });

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -5,14 +5,17 @@ import type {
   AttachmentAdapter,
   RemoteThreadListAdapter,
 } from "@assistant-ui/core";
-import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import {
+  AssistantRuntimeProvider,
+  useAssistantTool,
+} from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { useLangGraphRuntime } from "./useLangGraphRuntime";
 import { useLangGraphSend } from "./hooks";
 import { mockStreamCallbackFactory } from "./testUtils";
 import type { LangChainMessage } from "./types";
 import type { LangGraphInterruptState } from "./useLangGraphMessages";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 type LoadResult = {
   messages: LangChainMessage[];
@@ -799,6 +802,305 @@ describe("useLangGraphRuntime", () => {
 
       expect(auiResult.current.thread().getState().capabilities.queue).toBe(
         false,
+      );
+    });
+  });
+
+  describe("frontend tool-result resume defers to the draining run", () => {
+    const ToolRegistrar = ({
+      execute,
+    }: {
+      execute: (args: Record<string, unknown>) => Promise<unknown>;
+    }) => {
+      const tool = useMemo(
+        () =>
+          ({
+            toolName: "my_tool",
+            type: "frontend",
+            parameters: { type: "object", properties: {} },
+            execute,
+          }) as const,
+        [execute],
+      );
+      useAssistantTool(tool);
+      return null;
+    };
+
+    const wrapperWithTool = (
+      runtime: AssistantRuntime,
+      execute: (args: Record<string, unknown>) => Promise<unknown>,
+    ) => {
+      const Wrapper = ({ children }: { children: ReactNode }) => (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <ToolRegistrar execute={execute} />
+          {children}
+        </AssistantRuntimeProvider>
+      );
+      Wrapper.displayName = "TestWrapperWithTool";
+      return Wrapper;
+    };
+
+    const toolCallAiMessage = {
+      event: "messages/complete",
+      data: [
+        {
+          id: "ai-1",
+          type: "ai" as const,
+          content: "",
+          tool_calls: [{ id: "tc-1", name: "my_tool", args: {} }],
+        },
+      ],
+    };
+
+    const mountAndSend = async (
+      streamMock: ReturnType<typeof vi.fn>,
+      execute: (args: Record<string, unknown>) => Promise<unknown>,
+      options: Omit<Parameters<typeof useLangGraphRuntime>[0], "stream"> = {},
+    ) => {
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ ...options, stream: streamMock }),
+      );
+      const wrapper = wrapperWithTool(runtimeResult.current, execute);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      await act(async () => {
+        auiResult.current.composer().setText("hi");
+        auiResult.current.composer().send();
+      });
+
+      return auiResult;
+    };
+
+    it("keeps isRunning true across the run seam and resumes once run #1 drains", async () => {
+      const gate1 = deferred<void>();
+      const gate2 = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gate1.promise;
+          return;
+        }
+        yield metadataEvent;
+        await gate2.promise;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      const auiResult = await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+      // tool result is stashed, not sent, while run #1 is still in flight
+      expect(streamMock).toHaveBeenCalledTimes(1);
+      expect(auiResult.current.thread().getState().isRunning).toBe(true);
+
+      // draining run #1 chains the resume with no falling edge in between
+      await act(async () => {
+        gate1.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(auiResult.current.thread().getState().isRunning).toBe(true);
+
+      // the resume run settles isRunning back to false once it drains
+      await act(async () => {
+        gate2.resolve();
+      });
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+    });
+
+    it("starts the resume run only after run #1 is fully drained", async () => {
+      const gate1 = deferred<void>();
+      const order: string[] = [];
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          order.push("run1-start");
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gate1.promise;
+          order.push("run1-drained");
+          return;
+        }
+        order.push("run2-start");
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        gate1.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+
+      expect(order).toEqual(["run1-start", "run1-drained", "run2-start"]);
+    });
+
+    it("resumes with the buffered ToolMessage batch as run #2's input", async () => {
+      const gate1 = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gate1.promise;
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        gate1.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1", status: "success" },
+      ]);
+    });
+
+    it("sends a tool result that resolves after the run finished immediately", async () => {
+      const run1Gate = deferred<void>();
+      const executeGate = deferred<{ ok: boolean }>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await run1Gate.promise;
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(() => executeGate.promise);
+
+      const auiResult = await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+
+      // run #1 finishes while the tool is still executing (HITL / slow tool)
+      await act(async () => {
+        run1Gate.resolve();
+      });
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(true),
+      );
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      // the post-run result is sent immediately, with no deferral
+      await act(async () => {
+        executeGate.resolve({ ok: true });
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1" },
+      ]);
+    });
+
+    it("drops the stashed resume when run #1 is cancelled", async () => {
+      const streamMock = vi.fn(async function* (
+        _messages: LangChainMessage[],
+        config: { abortSignal: AbortSignal },
+      ) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await new Promise<void>((_resolve, reject) => {
+            config.abortSignal.addEventListener("abort", () => {
+              const err = new Error("The operation was aborted.");
+              err.name = "AbortError";
+              reject(err);
+            });
+          });
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      const auiResult = await mountAndSend(streamMock, execute, {
+        unstable_allowCancellation: true,
+      });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        auiResult.current.thread().cancelRun();
+      });
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops the stashed resume when run #1 reports a top-level error event", async () => {
+      const gate1 = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gate1.promise;
+          yield { event: "error", data: { message: "graph failed" } };
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      const auiResult = await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        gate1.resolve();
+      });
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("chains the resume when only a subgraph reports an error event", async () => {
+      const gate1 = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield metadataEvent;
+          yield toolCallAiMessage;
+          await gate1.promise;
+          yield { event: "error|subgraph", data: { message: "recoverable" } };
+          return;
+        }
+        yield metadataEvent;
+      });
+      const execute = vi.fn(async () => ({ ok: true }));
+
+      const auiResult = await mountAndSend(streamMock, execute);
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+      expect(streamMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        gate1.resolve();
+      });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
       );
     });
   });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -154,6 +154,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const toolResultBufferRef = useRef<
     Map<string, LangChainMessage & { type: "tool" }>
   >(new Map());
+  // A frontend tool result resolving while the streaming run is still draining
+  // is stashed here and sent from that run's completion callback, so run #2
+  // never starts while run #1 is in flight.
+  const inFlightRef = useRef(0);
+  const pendingResumeRef = useRef<LangChainMessage[] | null>(null);
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
@@ -194,14 +199,28 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     messages: LangChainMessage[],
     config: LangGraphSendMessageConfig,
   ) => {
+    inFlightRef.current++;
     setIsRunning(true);
     // setIsRunning(false) flips atomically with the final reconcile via onComplete
-    return sendMessage(messages, config, () => setIsRunning(false));
+    return sendMessage(messages, config, (info) => {
+      if (info.aborted || info.error !== undefined)
+        pendingResumeRef.current = null;
+      inFlightRef.current--;
+      if (inFlightRef.current > 0) return;
+      const pending = pendingResumeRef.current;
+      if (pending) {
+        pendingResumeRef.current = null;
+        void handleSendMessage(pending, {});
+        return;
+      }
+      setIsRunning(false);
+    });
   };
 
   const runUserMessage = async (msg: AppendMessage) => {
     // A new turn abandons any half-collected parallel tool batch.
     toolResultBufferRef.current.clear();
+    pendingResumeRef.current = null;
     const cancellations =
       autoCancelPendingToolCalls !== false
         ? getPendingToolCalls(messages).map(
@@ -370,12 +389,17 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         },
       );
       if (!batch) return;
+      if (inFlightRef.current > 0) {
+        pendingResumeRef.current = batch;
+        return;
+      }
       // TODO reuse runconfig here!
       await handleSendMessage(batch, {});
     },
     onEdit: getCheckpointId
       ? async (msg) => {
           toolResultBufferRef.current.clear();
+          pendingResumeRef.current = null;
           const truncated = truncateLangChainMessages(
             threadMessagesRef.current,
             msg.parentId,
@@ -428,6 +452,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
               throw new Error("Runtime does not support reloading messages.");
 
             toolResultBufferRef.current.clear();
+            pendingResumeRef.current = null;
             const truncated = truncateLangChainMessages(
               threadMessagesRef.current,
               parentId,
@@ -471,6 +496,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // drop stale callbacks and abort the pending load on thread switch/unmount
       const controller = new AbortController();
       toolResultBufferRef.current.clear();
+      pendingResumeRef.current = null;
       setIsLoadingThread(true);
       load(externalId, { signal: controller.signal })
         .then(({ messages, interrupts, uiMessages }) => {

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -158,7 +158,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   // is stashed here and sent from that run's completion callback, so run #2
   // never starts while run #1 is in flight.
   const inFlightRef = useRef(0);
-  const pendingResumeRef = useRef<LangChainMessage[] | null>(null);
+  const pendingResumeRef = useRef<
+    (LangChainMessage & { type: "tool" })[] | null
+  >(null);
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
@@ -376,9 +378,13 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // resume the graph with the full batch in a single run. Sending each
       // result on its own would resume LangGraph while sibling tool calls of a
       // parallel turn are still executing.
+      // Stashed results are not in `messages` yet, so they must not count as
+      // pending or a later same-run tool call could never complete its batch.
+      const stashed = pendingResumeRef.current;
+      const stashedIds = new Set(stashed?.map((m) => m.tool_call_id));
       const batch = bufferToolResult(
         toolResultBufferRef.current,
-        getPendingToolCalls(messages),
+        getPendingToolCalls(messages).filter((t) => !stashedIds.has(t.id)),
         {
           type: "tool",
           name: toolName,
@@ -390,7 +396,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       );
       if (!batch) return;
       if (inFlightRef.current > 0) {
-        pendingResumeRef.current = batch;
+        pendingResumeRef.current = [
+          ...(stashed ?? []).filter(
+            (m) => !batch.some((b) => b.tool_call_id === m.tool_call_id),
+          ),
+          ...batch,
+        ];
         return;
       }
       // TODO reuse runconfig here!


### PR DESCRIPTION
fixes #4751

## What

Defers the frontend tool-result resume in `useLangGraphRuntime` to the tail of the currently draining run, so a turn never has two overlapping runs. Same design the AG-UI runtime got in #4241; the LangGraph runtime never received the equivalent.

- `useLangGraphRuntime`: a tool-result batch completing while a run is in flight is stashed and sent from that run's completion callback. The settle branch is skipped when a resume chains, so `isRunning` stays `true` across the seam.
- Stash is dropped on abort/error (AG-UI parity) and cleared at every boundary that clears the tool-result buffer (new turn, edit, reload, thread load).
- `useLangGraphMessages`: `sendMessage`'s `onComplete` now receives `{ aborted, error }` so the caller can tell clean completion from abort/error. Append-only; zero-arg callbacks stay assignable.
- Tests: adds the executing-client-tool falling-edge integration coverage skipped in #4246 (seam continuity, strict run ordering, resume payload, slow/HITL results still send immediately, cancel drops the stash).
- Changeset: patch, `@assistant-ui/react-langgraph`.

## Why

Overlapping runs share single-run bookkeeping (see #4751): the first run's completion clobbers `isRunning` to `false` while the resume run streams, `cancel()` loses its handle on the first run, and the first run's final values reconcile can transiently clobber the resume run's messages. One run at a time fixes all three at the root; a pending-run counter would only repair the flag.

## Impact

- One logical turn shows one continuous `isRunning = true` window; no mid-turn flicker to Send/idle.
- Queued messages (`unstable_enableMessageQueue`) can no longer slip in between the tool-call run and its resume.
- Behavior change: if the run aborts or errors after the result was collected, the resume is dropped; `autoCancelPendingToolCalls` cleans up the pending call on the next send.
- Wire format and #4250 batching semantics untouched; only the send timing moves.
- Out of scope: `useLangGraphSend` / `useLangGraphSendCommand` sends can still overlap a run; those are explicit consumer actions (e.g. interrupt resume) with different timing semantics.

## Verification

Reproduced in a real browser against a mock LangGraph stream (the first run emits the tool call then drains for 1.5s, the resume run delays 3s before its first token, frontend tool resolves instantly), driven with Playwright on both branches with identical steps.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

