### PR TITLE
fix(cloud): preserve history attachments

### DIFF
--- a/.changeset/cloud-history-attachments.md
+++ b/.changeset/cloud-history-attachments.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: preserve user attachments in Cloud history

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -78,7 +78,12 @@ type AuiV0AttachmentPart =
   | Unstable_AudioMessagePart
   | DataMessagePart<ReadonlyJSONValue>;
 
-type AuiV0Attachment = Omit<CompleteAttachment, "content" | "file"> & {
+type AuiV0Attachment = {
+  readonly id: string;
+  readonly type: CompleteAttachment["type"];
+  readonly name: string;
+  readonly contentType?: string;
+  readonly status: CompleteAttachment["status"];
   readonly content: readonly AuiV0AttachmentPart[];
 };
 

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -1,8 +1,14 @@
 import type {
+  DataMessagePart,
+  FileMessagePart,
+  ImageMessagePart,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
+  TextMessagePart,
+  Unstable_AudioMessagePart,
 } from "../../../types/message";
+import type { CompleteAttachment } from "../../../types/attachment";
 import { fromThreadMessageLike } from "../../../runtime/utils/thread-message-like";
 import type { CloudMessage } from "assistant-cloud";
 import { isJSONValue } from "../../../utils/json/is-json";
@@ -65,10 +71,22 @@ type AuiV0MessagePart =
       readonly filename?: string;
     };
 
+type AuiV0AttachmentPart =
+  | TextMessagePart
+  | ImageMessagePart
+  | FileMessagePart
+  | Unstable_AudioMessagePart
+  | DataMessagePart<ReadonlyJSONValue>;
+
+type AuiV0Attachment = Omit<CompleteAttachment, "content" | "file"> & {
+  readonly content: readonly AuiV0AttachmentPart[];
+};
+
 type AuiV0Message = {
   readonly role: "assistant" | "user" | "system";
   readonly status?: MessageStatus;
   readonly content: readonly AuiV0MessagePart[];
+  readonly attachments?: readonly AuiV0Attachment[];
   readonly metadata: {
     readonly unstable_state?: ReadonlyJSONValue;
     readonly unstable_annotations: readonly ReadonlyJSONValue[];
@@ -83,14 +101,59 @@ type AuiV0Message = {
   };
 };
 
-export function auiV0Encode(message: ThreadMessage): AuiV0Message {
-  // TODO attachments are currently intentionally ignored
-  // info: ID and createdAt are ignored (we use the server value instead)
+const encodeAttachmentPart = (
+  part: CompleteAttachment["content"][number],
+): AuiV0AttachmentPart => {
+  const type = part.type;
+  switch (type) {
+    case "text":
+    case "image":
+    case "file":
+    case "audio":
+      return part;
 
+    case "data": {
+      if (!isJSONValue(part.data)) {
+        console.warn(`attachment data is not JSON! ${JSON.stringify(part)}`);
+      }
+      return { ...part, data: part.data as ReadonlyJSONValue };
+    }
+
+    default: {
+      const unhandledType: never = type;
+      throw new Error(
+        `Attachment part type not supported by aui/v0: ${unhandledType}`,
+      );
+    }
+  }
+};
+
+const encodeAttachments = (
+  message: ThreadMessage,
+): readonly AuiV0Attachment[] | undefined => {
+  if (message.role !== "user" || message.attachments.length === 0) {
+    return undefined;
+  }
+
+  return message.attachments.map(
+    ({ id, type, name, contentType, status, content }) => ({
+      id,
+      type,
+      name,
+      status,
+      ...(contentType != null ? { contentType } : undefined),
+      content: content.map(encodeAttachmentPart),
+    }),
+  );
+};
+
+export function auiV0Encode(message: ThreadMessage): AuiV0Message {
+  // info: ID and createdAt are ignored (we use the server value instead)
   const status: MessageStatus | undefined =
     message.status?.type === "running"
       ? { type: "incomplete", reason: "cancelled" }
       : message.status;
+  const attachments = encodeAttachments(message);
 
   return {
     role: message.role,
@@ -172,6 +235,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
     }),
     metadata: message.metadata as AuiV0Message["metadata"],
     ...(status ? { status } : undefined),
+    ...(attachments ? { attachments } : undefined),
   };
 }
 

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { auiV0Encode } from "../react/runtimes/cloud/auiV0";
+import { auiV0Decode, auiV0Encode } from "../react/runtimes/cloud/auiV0";
 
 describe("auiV0Encode", () => {
   it("preserves document source parts in the core cloud encoder", () => {
@@ -49,6 +49,110 @@ describe("auiV0Encode", () => {
             index: 0,
           },
         },
+      },
+    ]);
+  });
+
+  it("preserves user attachments in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "proposal.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQ=",
+              mimeType: "application/pdf",
+              filename: "proposal.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(encoded.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "proposal.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+            filename: "proposal.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("auiV0Decode", () => {
+  it("restores user attachments from core cloud history", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "proposal.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQ=",
+              mimeType: "application/pdf",
+              filename: "proposal.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      height: 0,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+      updated_at: new Date("2026-03-15T00:00:00.000Z"),
+      format: "aui/v0",
+      content: content as never,
+    });
+
+    expect(decoded.message.role).toBe("user");
+    if (decoded.message.role !== "user") throw new Error("expected user");
+    expect(decoded.message.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "proposal.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+            filename: "proposal.pdf",
+          },
+        ],
       },
     ]);
   });

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -97,6 +97,35 @@ describe("auiV0Encode", () => {
       },
     ]);
   });
+
+  it("omits missing attachment contentType in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "notes.txt",
+          status: { type: "complete" },
+          content: [{ type: "text", text: "notes" }],
+        },
+      ],
+    });
+
+    expect(encoded.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "notes.txt",
+        status: { type: "complete" },
+        content: [{ type: "text", text: "notes" }],
+      },
+    ]);
+  });
 });
 
 describe("auiV0Decode", () => {

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -78,7 +78,12 @@ type AuiV0AttachmentPart =
   | Unstable_AudioMessagePart
   | DataMessagePart<ReadonlyJSONValue>;
 
-type AuiV0Attachment = Omit<CompleteAttachment, "content" | "file"> & {
+type AuiV0Attachment = {
+  readonly id: string;
+  readonly type: CompleteAttachment["type"];
+  readonly name: string;
+  readonly contentType?: string;
+  readonly status: CompleteAttachment["status"];
   readonly content: readonly AuiV0AttachmentPart[];
 };
 

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -1,7 +1,13 @@
 import type {
+  CompleteAttachment,
+  DataMessagePart,
+  FileMessagePart,
+  ImageMessagePart,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
+  TextMessagePart,
+  Unstable_AudioMessagePart,
 } from "@assistant-ui/core";
 import { fromThreadMessageLike } from "../runtime-cores/external-store/ThreadMessageLike";
 import type { CloudMessage } from "assistant-cloud";
@@ -65,10 +71,22 @@ type AuiV0MessagePart =
       readonly filename?: string;
     };
 
+type AuiV0AttachmentPart =
+  | TextMessagePart
+  | ImageMessagePart
+  | FileMessagePart
+  | Unstable_AudioMessagePart
+  | DataMessagePart<ReadonlyJSONValue>;
+
+type AuiV0Attachment = Omit<CompleteAttachment, "content" | "file"> & {
+  readonly content: readonly AuiV0AttachmentPart[];
+};
+
 type AuiV0Message = {
   readonly role: "assistant" | "user" | "system";
   readonly status?: MessageStatus;
   readonly content: readonly AuiV0MessagePart[];
+  readonly attachments?: readonly AuiV0Attachment[];
   readonly metadata: {
     readonly unstable_state?: ReadonlyJSONValue;
     readonly unstable_annotations: readonly ReadonlyJSONValue[];
@@ -83,14 +101,59 @@ type AuiV0Message = {
   };
 };
 
-export function auiV0Encode(message: ThreadMessage): AuiV0Message {
-  // TODO attachments are currently intentionally ignored
-  // info: ID and createdAt are ignored (we use the server value instead)
+const encodeAttachmentPart = (
+  part: CompleteAttachment["content"][number],
+): AuiV0AttachmentPart => {
+  const type = part.type;
+  switch (type) {
+    case "text":
+    case "image":
+    case "file":
+    case "audio":
+      return part;
 
+    case "data": {
+      if (!isJSONValue(part.data)) {
+        console.warn(`attachment data is not JSON! ${JSON.stringify(part)}`);
+      }
+      return { ...part, data: part.data as ReadonlyJSONValue };
+    }
+
+    default: {
+      const unhandledType: never = type;
+      throw new Error(
+        `Attachment part type not supported by aui/v0: ${unhandledType}`,
+      );
+    }
+  }
+};
+
+const encodeAttachments = (
+  message: ThreadMessage,
+): readonly AuiV0Attachment[] | undefined => {
+  if (message.role !== "user" || message.attachments.length === 0) {
+    return undefined;
+  }
+
+  return message.attachments.map(
+    ({ id, type, name, contentType, status, content }) => ({
+      id,
+      type,
+      name,
+      status,
+      ...(contentType != null ? { contentType } : undefined),
+      content: content.map(encodeAttachmentPart),
+    }),
+  );
+};
+
+export function auiV0Encode(message: ThreadMessage): AuiV0Message {
+  // info: ID and createdAt are ignored (we use the server value instead)
   const status: MessageStatus | undefined =
     message.status?.type === "running"
       ? { type: "incomplete", reason: "cancelled" }
       : message.status;
+  const attachments = encodeAttachments(message);
 
   return {
     role: message.role,
@@ -172,6 +235,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
     }),
     metadata: message.metadata as AuiV0Message["metadata"],
     ...(status ? { status } : undefined),
+    ...(attachments ? { attachments } : undefined),
   };
 }
 

--- a/packages/react/src/tests/auiV0Encode.test.ts
+++ b/packages/react/src/tests/auiV0Encode.test.ts
@@ -97,6 +97,35 @@ describe("auiV0Encode", () => {
       },
     ]);
   });
+
+  it("omits missing attachment contentType in the legacy cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "notes.txt",
+          status: { type: "complete" },
+          content: [{ type: "text", text: "notes" }],
+        },
+      ],
+    });
+
+    expect(encoded.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "notes.txt",
+        status: { type: "complete" },
+        content: [{ type: "text", text: "notes" }],
+      },
+    ]);
+  });
 });
 
 describe("auiV0Decode", () => {

--- a/packages/react/src/tests/auiV0Encode.test.ts
+++ b/packages/react/src/tests/auiV0Encode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { auiV0Encode } from "../legacy-runtime/cloud/auiV0";
+import { auiV0Decode, auiV0Encode } from "../legacy-runtime/cloud/auiV0";
 
 describe("auiV0Encode", () => {
   it("preserves document source parts in the legacy cloud encoder", () => {
@@ -49,6 +49,110 @@ describe("auiV0Encode", () => {
             index: 0,
           },
         },
+      },
+    ]);
+  });
+
+  it("preserves user attachments in the legacy cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "proposal.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQ=",
+              mimeType: "application/pdf",
+              filename: "proposal.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(encoded.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "proposal.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+            filename: "proposal.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("auiV0Decode", () => {
+  it("restores user attachments from legacy cloud history", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "proposal.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:application/pdf;base64,JVBERi0xLjQ=",
+              mimeType: "application/pdf",
+              filename: "proposal.pdf",
+            },
+          ],
+        },
+      ],
+    });
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      height: 0,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+      updated_at: new Date("2026-03-15T00:00:00.000Z"),
+      format: "aui/v0",
+      content: content as never,
+    });
+
+    expect(decoded.message.role).toBe("user");
+    if (decoded.message.role !== "user") throw new Error("expected user");
+    expect(decoded.message.attachments).toEqual([
+      {
+        id: "att-1",
+        type: "document",
+        name: "proposal.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+            filename: "proposal.pdf",
+          },
+        ],
       },
     ]);
   });


### PR DESCRIPTION
## Summary

Preserve user attachments when encoding `aui/v0` Cloud history messages instead of dropping them. This updates both the core Cloud runtime and the legacy React Cloud runtime, then covers encode/decode behavior with tests.

## Why

A user message with uploaded files or images could persist its text to Cloud history while losing attachment metadata/content after reload or export. Keeping attachments in the Cloud payload avoids that data-loss case.

## Testing

- `./node_modules/.bin/vitest run src/tests/auiV0Encode.test.ts` in `packages/core`
- `./node_modules/.bin/vitest run` in `packages/core`
- `./node_modules/.bin/vitest run src/tests/auiV0Encode.test.ts` in `packages/react`
- `./node_modules/.bin/vitest run` in `packages/react`
- `./node_modules/.bin/aui-build` in `packages/core`
- `./node_modules/.bin/aui-build` in `packages/react`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

