### PR TITLE
fix(react-ai-sdk): validate frontend tool schemas

### DIFF
--- a/.changeset/validate-frontend-tool-schemas.md
+++ b/.changeset/validate-frontend-tool-schemas.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: validate frontend tool schemas before conversion

--- a/packages/react-ai-sdk/src/frontendTools.test.ts
+++ b/packages/react-ai-sdk/src/frontendTools.test.ts
@@ -149,4 +149,57 @@ describe("frontendTools", () => {
 
     expect(tools.getWeather).not.toHaveProperty("providerOptions");
   });
+
+  it("names the malformed frontend tool when parameters are missing", () => {
+    expect(() =>
+      frontendTools({
+        getWeather: {
+          description: "Get the weather",
+        },
+      } as never),
+    ).toThrow(
+      'frontendTools() expected tool "getWeather" to include a JSON Schema parameters object.',
+    );
+  });
+
+  it("rejects non-object tools request bodies", () => {
+    expect(() => frontendTools(null as never)).toThrow(
+      "frontendTools() expected tools to be an object keyed by tool name.",
+    );
+    expect(() => frontendTools([] as never)).toThrow(
+      "frontendTools() expected tools to be an object keyed by tool name.",
+    );
+  });
+
+  it("names frontend tool entries with malformed field types", () => {
+    expect(() =>
+      frontendTools({
+        getWeather: null,
+      } as never),
+    ).toThrow(
+      'frontendTools() expected tool "getWeather" to be an object with a JSON Schema parameters object.',
+    );
+
+    expect(() =>
+      frontendTools({
+        getWeather: {
+          description: 123,
+          parameters: { type: "object" },
+        },
+      } as never),
+    ).toThrow(
+      'frontendTools() expected tool "getWeather" description to be a string.',
+    );
+
+    expect(() =>
+      frontendTools({
+        getWeather: {
+          parameters: { type: "object" },
+          providerOptions: "anthropic",
+        },
+      } as never),
+    ).toThrow(
+      'frontendTools() expected tool "getWeather" providerOptions to be an object.',
+    );
+  });
 });

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -11,15 +11,71 @@ export const defaultToModelOutput = ({ output }: { output: unknown }) => {
   return toAISDKDefaultOutput(result);
 };
 
-export const frontendTools = (tools: Record<string, ToolJSONSchema>): ToolSet =>
-  Object.fromEntries(
-    Object.entries(tools).map(([name, t]) => [
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const validateFrontendTool = (
+  name: string,
+  tool: unknown,
+): asserts tool is ToolJSONSchema => {
+  if (!isPlainObject(tool)) {
+    throw new Error(
+      `frontendTools() expected tool "${name}" to be an object with a JSON Schema parameters object.`,
+    );
+  }
+
+  if (!isPlainObject(tool.parameters)) {
+    throw new Error(
+      `frontendTools() expected tool "${name}" to include a JSON Schema parameters object.`,
+    );
+  }
+
+  if (tool.description !== undefined && typeof tool.description !== "string") {
+    throw new Error(
+      `frontendTools() expected tool "${name}" description to be a string.`,
+    );
+  }
+
+  if (
+    tool.providerOptions !== undefined &&
+    !isPlainObject(tool.providerOptions)
+  ) {
+    throw new Error(
+      `frontendTools() expected tool "${name}" providerOptions to be an object.`,
+    );
+  }
+};
+
+const validateFrontendTools = (
+  tools: unknown,
+): asserts tools is Record<string, ToolJSONSchema> => {
+  if (!isPlainObject(tools)) {
+    throw new Error(
+      "frontendTools() expected tools to be an object keyed by tool name.",
+    );
+  }
+
+  for (const [name, tool] of Object.entries(tools)) {
+    validateFrontendTool(name, tool);
+  }
+};
+
+export const frontendTools = (
+  tools: Record<string, ToolJSONSchema>,
+): ToolSet => {
+  validateFrontendTools(tools);
+
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [
       name,
       {
-        ...(t.description !== undefined && { description: t.description }),
-        inputSchema: jsonSchema(t.parameters),
+        ...(tool.description !== undefined && {
+          description: tool.description,
+        }),
+        inputSchema: jsonSchema(tool.parameters),
         toModelOutput: defaultToModelOutput,
-        ...(t.providerOptions && { providerOptions: t.providerOptions }),
+        ...(tool.providerOptions && { providerOptions: tool.providerOptions }),
       },
     ]),
   ) as ToolSet;
+};

--- a/packages/react-ai-sdk/src/frontendTools.ts
+++ b/packages/react-ai-sdk/src/frontendTools.ts
@@ -14,10 +14,10 @@ export const defaultToModelOutput = ({ output }: { output: unknown }) => {
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const validateFrontendTool = (
+function validateFrontendTool(
   name: string,
   tool: unknown,
-): asserts tool is ToolJSONSchema => {
+): asserts tool is ToolJSONSchema {
   if (!isPlainObject(tool)) {
     throw new Error(
       `frontendTools() expected tool "${name}" to be an object with a JSON Schema parameters object.`,
@@ -44,11 +44,11 @@ const validateFrontendTool = (
       `frontendTools() expected tool "${name}" providerOptions to be an object.`,
     );
   }
-};
+}
 
-const validateFrontendTools = (
+function validateFrontendTools(
   tools: unknown,
-): asserts tools is Record<string, ToolJSONSchema> => {
+): asserts tools is Record<string, ToolJSONSchema> {
   if (!isPlainObject(tools)) {
     throw new Error(
       "frontendTools() expected tools to be an object keyed by tool name.",
@@ -58,7 +58,7 @@ const validateFrontendTools = (
   for (const [name, tool] of Object.entries(tools)) {
     validateFrontendTool(name, tool);
   }
-};
+}
 
 export const frontendTools = (
   tools: Record<string, ToolJSONSchema>,


### PR DESCRIPTION
## Summary

Validate uploaded frontend tool schemas inside `frontendTools()` before converting them to AI SDK tools. Malformed request bodies now fail with an actionable error that names the bad tool and field instead of crashing later inside schema conversion.

## Why

Backend routes often pass `tools` straight from `await req.json()` into `frontendTools(tools ?? {})`. If a custom client, stale frontend build, proxy, or manual test sends a malformed payload like `tools: { getWeather: { description: "Get weather" } }` without `parameters`, the route should explain that `getWeather` is malformed instead of producing a vague lower-level error.

## Testing

- `./node_modules/.bin/vitest run src/frontendTools.test.ts` in `packages/react-ai-sdk`
- `./node_modules/.bin/vitest run` in `packages/react-ai-sdk`
- `./node_modules/.bin/aui-build` in `packages/react-ai-sdk`
- `./node_modules/.bin/oxlint packages/react-ai-sdk/src/frontendTools.ts packages/react-ai-sdk/src/frontendTools.test.ts --no-error-on-unmatched-pattern`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

