### PR TITLE
ci(template-metrics): accept deliberate LOC increases via template-loc-ok label

### DIFF
--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -134,11 +134,21 @@ jobs:
 
       # always(): run even if the comment step failed (e.g. fork 403), so the
       # gate verdict is never lost. Only blocks PRs; pushes refresh the baseline.
+      # A maintainer accepts a deliberate increase by applying the
+      # template-loc-ok label. Labels are read at run time (the event payload is
+      # stale), so labeling plus a re-run flips the verdict without a new push;
+      # merging refreshes the baseline, so the acceptance never carries over.
       - name: Enforce regression gate
         if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "$(cat metrics-gate.txt 2>/dev/null)" = "fail" ]; then
-            echo "::error::Template metrics regressed past the configured limits. See the PR comment."
+            if gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.labels[].name' | grep -qx "template-loc-ok"; then
+              echo "::notice::Template metrics exceed the limits; increase accepted via the template-loc-ok label."
+              exit 0
+            fi
+            echo "::error::Template metrics regressed past the configured limits. See the PR comment. A maintainer can accept a deliberate increase by applying the template-loc-ok label and re-running this check."
             exit 1
           fi
           echo "Template metrics within limits."


### PR DESCRIPTION
The template-metrics gate blocks any PR that grows a template's install footprint past `MAX_LOC_INCREASE`, with no way to accept an increase that is deliberate. #4726 hit this: an approved feature whose honest floor is ~+64 lines, over the 50-line limit, leaving only bad options (golf the component, bump the global limit, or admin-merge over red).

## What

- The "Enforce regression gate" step now checks the PR's labels before failing: if a maintainer has applied `template-loc-ok`, the gate passes with a `::notice::` instead of failing.
- Labels are read at run time via `gh api` (not the stale event payload), so applying the label and re-running the check flips the verdict without needing a new push.
- The failure message now tells authors the label exists.

## Why this shape

- The 50-line default stays untouched, so the gate keeps catching accidental bloat.
- Only users with triage rights can apply labels, so the label itself is the maintainer sign-off, visible on the PR.
- The acceptance is self-expiring: merging refreshes the main baseline, so the allowance never carries over to the next PR.
- No `labeled` trigger type added: any label event (bug, docs, ...) would kick off a full metrics build; a manual re-run after labeling is cheaper and rare.

## Notes

- Workflow-only change; no changeset needed.
- Once merged: apply `template-loc-ok` to #4726 and re-run its Template Metrics check.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

