### PR TITLE
docs: frontend tools snippets to empty object

### DIFF
--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -145,7 +145,7 @@ export async function POST(req: Request) {
     model: openai("gpt-5.4-nano"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -164,7 +164,7 @@ export async function POST(req: Request) {
     model: anthropic("claude-sonnet-4-6"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -183,7 +183,7 @@ export async function POST(req: Request) {
     model: azure("your-deployment-name"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -202,7 +202,7 @@ export async function POST(req: Request) {
     model: bedrock("anthropic.claude-sonnet-4-6-v1:0"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -221,7 +221,7 @@ export async function POST(req: Request) {
     model: google("gemini-2.0-flash"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -240,7 +240,7 @@ export async function POST(req: Request) {
     model: vertex("gemini-2.0-flash"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -259,7 +259,7 @@ export async function POST(req: Request) {
     model: groq("llama-3.3-70b-versatile"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -278,7 +278,7 @@ export async function POST(req: Request) {
     model: fireworks("accounts/fireworks/models/llama-v3p3-70b-instruct"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -297,7 +297,7 @@ export async function POST(req: Request) {
     model: cohere("command-r-plus"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -316,7 +316,7 @@ export async function POST(req: Request) {
     model: ollama("llama3"),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }
@@ -335,7 +335,7 @@ export async function POST(req: Request) {
     model: chromeai(),
     system,
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse();
 }

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -245,7 +245,7 @@ export async function POST(req: Request) {
     system,
     messages: await convertToModelMessages(messages),
     tools: {
-      ...frontendTools(tools),
+      ...frontendTools(tools ?? {}),
       // your backend tools...
     },
   });
@@ -444,7 +444,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model: getModel(config?.modelName),
     messages: await convertToModelMessages(messages),
-    tools: frontendTools(tools),
+    tools: frontendTools(tools ?? {}),
   });
   return result.toUIMessageStreamResponse({
     messageMetadata: ({ part }) => {


### PR DESCRIPTION
## Summary

- default copied `frontendTools` docs snippets to `tools ?? {}`
- keeps custom backend snippets from throwing when a request body omits frontend tools

## Validation

- `pnpm --filter @assistant-ui/docs build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

