### PR TITLE
ci(template-metrics): surface unenforced gate when the main baseline is missing

### DIFF
--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -134,12 +134,19 @@ jobs:
 
       # always(): run even if the comment step failed (e.g. fork 403), so the
       # gate verdict is never lost. Only blocks PRs; pushes refresh the baseline.
+      # A missing baseline (evicted cache) cannot be compared against, so the
+      # gate downgrades to a loud warning instead of passing as if it ran.
       - name: Enforce regression gate
         if: always() && github.event_name == 'pull_request'
         run: |
-          if [ "$(cat metrics-gate.txt 2>/dev/null)" = "fail" ]; then
+          verdict="$(cat metrics-gate.txt 2>/dev/null)"
+          if [ "$verdict" = "fail" ]; then
             echo "::error::Template metrics regressed past the configured limits. See the PR comment."
             exit 1
+          fi
+          if [ "$verdict" = "no-baseline" ]; then
+            echo "::warning::No main baseline was restored (cache evicted or never created); the regression gate was not enforced for this run. The next push to main touching templates/ or packages/ui/ recreates it."
+            exit 0
           fi
           echo "Template metrics within limits."
 

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -13,7 +13,9 @@
 //   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile] [commentFile]
 //
 // report writes "pass"/"fail" to gateFile based on the regression thresholds
-// (env: MAX_LOC_INCREASE applied to total LOC, MAX_BUNDLE_INCREASE_KB).
+// (env: MAX_LOC_INCREASE applied to total LOC, MAX_BUNDLE_INCREASE_KB), or
+// "no-baseline" when there is nothing to compare against (evicted cache), so
+// the workflow can surface the unenforced gate instead of passing silently.
 
 import { execFileSync } from "node:child_process";
 import {
@@ -307,11 +309,15 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
   }
 
   writeFileSync(outMd, lines.join("\n"));
-  if (gateFile) writeFileSync(gateFile, regressions.length ? "fail" : "pass");
+  if (gateFile)
+    writeFileSync(
+      gateFile,
+      !hasBaseline ? "no-baseline" : regressions.length ? "fail" : "pass",
+    );
   if (commentFile)
     writeFileSync(
       commentFile,
-      hasAnyLocChange || regressions.length ? "post" : "skip",
+      hasAnyLocChange || regressions.length || !hasBaseline ? "post" : "skip",
     );
 }
 


### PR DESCRIPTION
When the `install-footprint-main-*` cache is evicted, every template reports `(new)`, the gate has nothing to compare against, and the check passes silently: any LOC increase lands ungated and gets baked into the next baseline. This is exactly how #4726's +64 went green without ever being compared to the 50-line limit.

## What

- `template-metrics.mjs` now writes a third gate verdict, `no-baseline`, when there is no baseline to compare against, and posts the sticky PR comment in that state so the `_No baseline found_` note is visible on the PR.
- The workflow's enforce step turns that verdict into a `::warning::` (check stays green): the gate was not enforced this run, and the next push to main touching `templates/` or `packages/ui/` recreates the baseline.

## Why warn instead of fail

Failing would block every open templates/ui PR from the moment of eviction until a main push refreshes the cache — punishing PRs for an infra event they didn't cause. A loud warning plus a visible PR comment makes the bypass reviewable without turning it into an outage.

## Notes

- Verified locally: the report script writes `no-baseline`/`fail`/`pass` and `post`/`skip` correctly for empty, regressed, and unchanged baselines.
- Workflow-only + repo script; no changeset needed.
- Stacked on #4757 (both edit the enforce step); rebases to a 2-file diff once that merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

