### PR TITLE
fix(react-langgraph): serialize sends so runs never overlap

### DIFF
--- a/.changeset/langgraph-serialize-runs.md
+++ b/.changeset/langgraph-serialize-runs.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: serialize runs in useLangGraphRuntime so a frontend tool result resume never overlaps the run that emitted the tool call. isRunning stays true across the seam, cancel stops the whole turn and drops the queued resume, and a run that aborts or errors drops the sends queued behind it.

--- a/packages/react-langgraph/src/serialRunQueue.test.ts
+++ b/packages/react-langgraph/src/serialRunQueue.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { createSerialRunQueue } from "./serialRunQueue";
+
+const gatedRun = () => {
+  const gates: Array<() => void> = [];
+  const run = vi.fn(async (_payload: string, onComplete: () => void) => {
+    await new Promise<void>((resolve) => {
+      gates.push(resolve);
+    });
+    onComplete();
+  });
+  return { run, gates };
+};
+
+describe("createSerialRunQueue", () => {
+  it("runs an enqueued payload immediately when idle", async () => {
+    const run = vi.fn(async (_payload: string, onComplete: () => void) => {
+      onComplete();
+    });
+    const onRunningChange = vi.fn();
+    const queue = createSerialRunQueue({ run, onRunningChange });
+
+    await queue.enqueue("a");
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run.mock.calls[0]?.[0]).toBe("a");
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("serializes overlapping enqueues into one continuous running window", async () => {
+    const { run, gates } = gatedRun();
+    const onRunningChange = vi.fn();
+    const queue = createSerialRunQueue({ run, onRunningChange });
+
+    const first = queue.enqueue("a");
+    const second = queue.enqueue("b");
+    expect(run).toHaveBeenCalledTimes(1);
+
+    gates[0]!();
+    await first;
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(run.mock.calls[1]?.[0]).toBe("b");
+    // no falling edge between the two runs
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true]);
+
+    gates[1]!();
+    await second;
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("drop resolves queued payloads without running them", async () => {
+    const { run, gates } = gatedRun();
+    const onRunningChange = vi.fn();
+    const queue = createSerialRunQueue({ run, onRunningChange });
+
+    const first = queue.enqueue("a");
+    const second = queue.enqueue("b");
+
+    queue.drop();
+    await second;
+    expect(run).toHaveBeenCalledTimes(1);
+
+    gates[0]!();
+    await first;
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("a failing run rejects its own promise and drops the payloads behind it", async () => {
+    const gates: Array<() => void> = [];
+    const run = vi.fn(async (payload: string, onComplete: () => void) => {
+      await new Promise<void>((resolve) => {
+        gates.push(resolve);
+      });
+      onComplete();
+      if (payload === "a") throw new Error("boom");
+    });
+    const onRunningChange = vi.fn();
+    const queue = createSerialRunQueue({ run, onRunningChange });
+
+    const first = queue.enqueue("a");
+    const second = queue.enqueue("b");
+
+    gates[0]!();
+    await expect(first).rejects.toThrow("boom");
+    await second;
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
+  });
+
+  it("recovers after an error: the next enqueue starts a new drain", async () => {
+    const run = vi.fn(async (payload: string, onComplete: () => void) => {
+      onComplete();
+      if (payload === "a") throw new Error("boom");
+    });
+    const onRunningChange = vi.fn();
+    const queue = createSerialRunQueue({ run, onRunningChange });
+
+    await expect(queue.enqueue("a")).rejects.toThrow("boom");
+    await queue.enqueue("b");
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(onRunningChange.mock.lastCall?.[0]).toBe(false);
+  });
+});

--- a/packages/react-langgraph/src/serialRunQueue.test.ts
+++ b/packages/react-langgraph/src/serialRunQueue.test.ts
@@ -88,6 +88,28 @@ describe("createSerialRunQueue", () => {
     expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([true, false]);
   });
 
+  it("re-asserts running for a payload enqueued after a mid-drain falling edge", async () => {
+    let queue!: ReturnType<typeof createSerialRunQueue<string>>;
+    let second: Promise<void> | undefined;
+    const run = vi.fn(async (payload: string, onComplete: () => void) => {
+      onComplete();
+      if (payload === "a") second = queue.enqueue("b");
+    });
+    const onRunningChange = vi.fn();
+    queue = createSerialRunQueue({ run, onRunningChange });
+
+    await queue.enqueue("a");
+    await second;
+
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(onRunningChange.mock.calls.map((c) => c[0])).toEqual([
+      true,
+      false,
+      true,
+      false,
+    ]);
+  });
+
   it("recovers after an error: the next enqueue starts a new drain", async () => {
     const run = vi.fn(async (payload: string, onComplete: () => void) => {
       onComplete();

--- a/packages/react-langgraph/src/serialRunQueue.ts
+++ b/packages/react-langgraph/src/serialRunQueue.ts
@@ -1,0 +1,70 @@
+type QueuedRun<TPayload> = {
+  payload: TPayload;
+  resolve: () => void;
+  reject: (reason: unknown) => void;
+};
+
+export type SerialRunQueue<TPayload> = {
+  enqueue(payload: TPayload): Promise<void>;
+  drop(): void;
+};
+
+/**
+ * Serialize runs so at most one is in flight at a time. A payload enqueued
+ * while a run is active waits for it to settle; each enqueue resolves once its
+ * own run completes.
+ *
+ * `run` receives an `onComplete` callback to invoke atomically with its final
+ * state flush; the queue reports `onRunningChange(false)` through it only when
+ * nothing else is queued, so back-to-back runs form one continuous running
+ * window.
+ *
+ * A run that rejects drops the payloads queued behind it (their promises
+ * resolve without running) and rejects its own promise. `drop()` does the same
+ * for everything not yet started, leaving an active run untouched.
+ */
+export const createSerialRunQueue = <TPayload>({
+  run,
+  onRunningChange,
+}: {
+  run: (payload: TPayload, onComplete: () => void) => Promise<void>;
+  onRunningChange: (isRunning: boolean) => void;
+}): SerialRunQueue<TPayload> => {
+  const queue: QueuedRun<TPayload>[] = [];
+  let draining = false;
+
+  const drop = () => {
+    for (const queued of queue.splice(0)) queued.resolve();
+  };
+
+  const drain = async () => {
+    draining = true;
+    onRunningChange(true);
+    try {
+      let queued: QueuedRun<TPayload> | undefined;
+      while ((queued = queue.shift())) {
+        try {
+          await run(queued.payload, () => {
+            if (queue.length === 0) onRunningChange(false);
+          });
+          queued.resolve();
+        } catch (error) {
+          drop();
+          onRunningChange(false);
+          queued.reject(error);
+        }
+      }
+    } finally {
+      draining = false;
+    }
+  };
+
+  return {
+    enqueue: (payload) =>
+      new Promise<void>((resolve, reject) => {
+        queue.push({ payload, resolve, reject });
+        if (!draining) void drain();
+      }),
+    drop,
+  };
+};

--- a/packages/react-langgraph/src/serialRunQueue.ts
+++ b/packages/react-langgraph/src/serialRunQueue.ts
@@ -17,7 +17,7 @@ export type SerialRunQueue<TPayload> = {
  * `run` receives an `onComplete` callback to invoke atomically with its final
  * state flush; the queue reports `onRunningChange(false)` through it only when
  * nothing else is queued, so back-to-back runs form one continuous running
- * window.
+ * window. `onRunningChange` fires on transitions only.
  *
  * A run that rejects drops the payloads queued behind it (their promises
  * resolve without running) and rejects its own promise. `drop()` does the same
@@ -32,6 +32,13 @@ export const createSerialRunQueue = <TPayload>({
 }): SerialRunQueue<TPayload> => {
   const queue: QueuedRun<TPayload>[] = [];
   let draining = false;
+  let running = false;
+
+  const setRunning = (value: boolean) => {
+    if (running === value) return;
+    running = value;
+    onRunningChange(value);
+  };
 
   const drop = () => {
     for (const queued of queue.splice(0)) queued.resolve();
@@ -39,23 +46,24 @@ export const createSerialRunQueue = <TPayload>({
 
   const drain = async () => {
     draining = true;
-    onRunningChange(true);
     try {
       let queued: QueuedRun<TPayload> | undefined;
       while ((queued = queue.shift())) {
+        setRunning(true);
         try {
           await run(queued.payload, () => {
-            if (queue.length === 0) onRunningChange(false);
+            if (queue.length === 0) setRunning(false);
           });
           queued.resolve();
         } catch (error) {
           drop();
-          onRunningChange(false);
+          setRunning(false);
           queued.reject(error);
         }
       }
     } finally {
       draining = false;
+      setRunning(false);
     }
   };
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -5,14 +5,17 @@ import type {
   AttachmentAdapter,
   RemoteThreadListAdapter,
 } from "@assistant-ui/core";
-import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import {
+  AssistantRuntimeProvider,
+  useAssistantTool,
+} from "@assistant-ui/core/react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { useLangGraphRuntime } from "./useLangGraphRuntime";
 import { useLangGraphSend } from "./hooks";
 import { mockStreamCallbackFactory } from "./testUtils";
 import type { LangChainMessage } from "./types";
 import type { LangGraphInterruptState } from "./useLangGraphMessages";
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 
 type LoadResult = {
   messages: LangChainMessage[];
@@ -800,6 +803,512 @@ describe("useLangGraphRuntime", () => {
       expect(auiResult.current.thread().getState().capabilities.queue).toBe(
         false,
       );
+    });
+  });
+
+  describe("run serialization", () => {
+    const toolCallEvent = {
+      event: "messages/complete",
+      data: [
+        {
+          id: "ai-1",
+          type: "ai" as const,
+          content: "",
+          tool_calls: [
+            { id: "tc-1", name: "get_weather", args: { city: "sf" } },
+          ],
+        },
+      ],
+    };
+
+    const waitForToolCallPart = async (aui: ReturnType<typeof useAui>) => {
+      await waitFor(() => {
+        const parts = aui
+          .thread()
+          .getState()
+          .messages.flatMap((m): readonly unknown[] => m.content);
+        expect(parts).toContainEqual(
+          expect.objectContaining({ type: "tool-call", toolCallId: "tc-1" }),
+        );
+      });
+    };
+
+    const addToolResult = (runtime: AssistantRuntime, result: unknown) => {
+      act(() => {
+        runtime.thread
+          .getMessageById("ai-1")
+          .getMessagePartByToolCallId("tc-1")
+          .addToolResult(result);
+      });
+    };
+
+    it("defers a tool-result resume until the in-flight run drains, without dropping isRunning", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+      const observedIsRunning: boolean[] = [];
+      renderHook(
+        () => {
+          observedIsRunning.push(useAuiState((s) => s.thread.isRunning));
+        },
+        { wrapper },
+      );
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      // the resume waits for run #1 to drain instead of starting a second run
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 0));
+      });
+      expect(streamMock).toHaveBeenCalledTimes(1);
+      expect(auiResult.current.thread().getState().isRunning).toBe(true);
+
+      await act(async () => {
+        gate.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        {
+          type: "tool",
+          tool_call_id: "tc-1",
+          name: "get_weather",
+          content: JSON.stringify({ temperature: 72 }),
+          status: "success",
+        },
+      ]);
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      const transitions = observedIsRunning.filter(
+        (value, i) => i === 0 || observedIsRunning[i - 1] !== value,
+      );
+      expect(transitions).toEqual([false, true, false]);
+    });
+
+    it("sends a tool result immediately when no run is in flight", async () => {
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+    });
+
+    it("drops the queued resume when the run is cancelled", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (
+        _messages: LangChainMessage[],
+        config: { abortSignal: AbortSignal },
+      ) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await Promise.race([
+            gate.promise,
+            new Promise<void>((resolve) => {
+              config.abortSignal.addEventListener("abort", () => resolve(), {
+                once: true,
+              });
+            }),
+          ]);
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock,
+          unstable_allowCancellation: true,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await act(async () => {
+        runtimeResult.current.thread.cancelRun();
+      });
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops the queued resume when the draining run errors", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+          throw new Error("stream failed");
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+      const { result: sendResult } = renderHook(() => useLangGraphSend(), {
+        wrapper,
+      });
+      await waitFor(() => expect(sendResult.current).toBeDefined());
+
+      let runError: unknown;
+      act(() => {
+        sendResult
+          .current([{ type: "human", content: "what's the weather?" }], {})
+          .catch((error: unknown) => {
+            runError = error;
+          });
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await act(async () => {
+        gate.resolve();
+      });
+
+      await waitFor(() => expect(runError).toBeInstanceOf(Error));
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("replaces a duplicate result in the queued resume instead of double-sending", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { attempt: 1 });
+      addToolResult(runtimeResult.current, { attempt: 2 });
+
+      await act(async () => {
+        gate.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+
+      const resume = streamMock.mock.calls[1]?.[0];
+      expect(resume).toHaveLength(1);
+      expect(resume?.[0]).toMatchObject({
+        type: "tool",
+        tool_call_id: "tc-1",
+        content: JSON.stringify({ attempt: 2 }),
+      });
+    });
+
+    it("drops the queued resume when the run ends with a top-level error event", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+          yield { event: "error", data: { message: "graph failed" } };
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await act(async () => {
+        gate.resolve();
+      });
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      expect(streamMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("still sends the queued resume when only a subgraph reports an error", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+          yield { event: "error|subgraph", data: { message: "recoverable" } };
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await act(async () => {
+        gate.resolve();
+      });
+
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        { type: "tool", tool_call_id: "tc-1", status: "success" },
+      ]);
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+    });
+
+    it("drops the queued resume when a new user turn starts, cancelling the dangling tool call", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          yield toolCallEvent;
+          await gate.promise;
+        }
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({ stream: streamMock }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer().setText("what's the weather?");
+        auiResult.current.composer().send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+      await waitForToolCallPart(auiResult.current);
+
+      addToolResult(runtimeResult.current, { temperature: 72 });
+
+      await act(async () => {
+        auiResult.current.composer().setText("never mind");
+        auiResult.current.composer().send();
+      });
+
+      await act(async () => {
+        gate.resolve();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+
+      // the second run is the new turn (with the pending call cancelled), not the resume
+      expect(streamMock.mock.calls[1]?.[0]).toMatchObject([
+        {
+          type: "tool",
+          tool_call_id: "tc-1",
+          content: JSON.stringify({ cancelled: true }),
+          status: "error",
+        },
+        { type: "human", content: "never mind" },
+      ]);
+
+      await waitFor(() =>
+        expect(auiResult.current.thread().getState().isRunning).toBe(false),
+      );
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      expect(streamMock).toHaveBeenCalledTimes(2);
+    });
+
+    describe("with a registered frontend tool", () => {
+      const ToolRegistrar = ({
+        execute,
+      }: {
+        execute: (args: Record<string, unknown>) => Promise<unknown>;
+      }) => {
+        const tool = useMemo(
+          () =>
+            ({
+              toolName: "my_tool",
+              type: "frontend",
+              parameters: { type: "object", properties: {} },
+              execute,
+            }) as const,
+          [execute],
+        );
+        useAssistantTool(tool);
+        return null;
+      };
+
+      const wrapperWithTool = (
+        runtime: AssistantRuntime,
+        execute: (args: Record<string, unknown>) => Promise<unknown>,
+      ) => {
+        const Wrapper = ({ children }: { children: ReactNode }) => (
+          <AssistantRuntimeProvider runtime={runtime}>
+            <ToolRegistrar execute={execute} />
+            {children}
+          </AssistantRuntimeProvider>
+        );
+        Wrapper.displayName = "TestWrapperWithTool";
+        return Wrapper;
+      };
+
+      it("merges a staggered same-run tool result into the queued resume", async () => {
+        const gateB = deferred<void>();
+        const gateDrain = deferred<void>();
+        const firstAiMessage = {
+          event: "messages/complete",
+          data: [
+            {
+              id: "ai-1",
+              type: "ai" as const,
+              content: "",
+              tool_calls: [{ id: "tc-1", name: "my_tool", args: {} }],
+            },
+          ],
+        };
+        const staggeredAiMessage = {
+          event: "messages/complete",
+          data: [
+            {
+              id: "ai-1",
+              type: "ai" as const,
+              content: "",
+              tool_calls: [
+                { id: "tc-1", name: "my_tool", args: {} },
+                { id: "tc-2", name: "my_tool", args: {} },
+              ],
+            },
+          ],
+        };
+        const streamMock = vi.fn(async function* (
+          _messages: LangChainMessage[],
+        ) {
+          if (streamMock.mock.calls.length === 1) {
+            yield firstAiMessage;
+            await gateB.promise;
+            yield staggeredAiMessage;
+            await gateDrain.promise;
+            return;
+          }
+        });
+        const execute = vi.fn(async () => ({ ok: true }));
+
+        const { result: runtimeResult } = renderHook(() =>
+          useLangGraphRuntime({ stream: streamMock }),
+        );
+        const wrapper = wrapperWithTool(runtimeResult.current, execute);
+        const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+        await new Promise((r) => setTimeout(r, 0));
+        await new Promise((r) => setTimeout(r, 0));
+
+        await act(async () => {
+          auiResult.current.composer().setText("hi");
+          auiResult.current.composer().send();
+        });
+
+        await waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+        // flush so tool A's batch is queued before tool B streams in
+        await act(async () => {});
+        expect(streamMock).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          gateB.resolve();
+        });
+        await waitFor(() => expect(execute).toHaveBeenCalledTimes(2));
+        expect(streamMock).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          gateDrain.resolve();
+        });
+        await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+        expect(streamMock.mock.calls[1]![0]).toMatchObject([
+          { type: "tool", tool_call_id: "tc-1", status: "success" },
+          { type: "tool", tool_call_id: "tc-2", status: "success" },
+        ]);
+        await waitFor(() =>
+          expect(auiResult.current.thread().getState().isRunning).toBe(false),
+        );
+      });
     });
   });
 });

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -38,6 +38,7 @@ import {
 import { appendLangChainChunk } from "./appendLangChainChunk";
 import { useLangGraphStreamingTiming } from "./useLangGraphStreamingTiming";
 import { bufferToolResult } from "./bufferToolResults";
+import { createSerialRunQueue, type SerialRunQueue } from "./serialRunQueue";
 import { langGraphExtras } from "./runtimeExtras";
 import {
   filterUIMessagesBySurvivingIds,
@@ -124,6 +125,27 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       fallbackRef.current = undefined;
     };
   }, []);
+  // Top-level and subgraph error events both dispatch onError; subgraph errors
+  // additionally dispatch onSubgraphError (see OnErrorEventCallback docs). The
+  // balance is positive iff the run saw a top-level error, which drops any
+  // sends queued behind it.
+  const runErrorBalanceRef = useRef(0);
+  const wrappedEventHandlers = useMemo(
+    () =>
+      ({
+        ...eventHandlers,
+        onError: (error: unknown) => {
+          runErrorBalanceRef.current++;
+          return eventHandlers?.onError?.(error);
+        },
+        onSubgraphError: (namespace: string, error: unknown) => {
+          runErrorBalanceRef.current--;
+          return eventHandlers?.onSubgraphError?.(namespace, error);
+        },
+      }) satisfies UseLangGraphRuntimeOptions["eventHandlers"],
+    [eventHandlers],
+  );
+
   const {
     interrupt,
     setInterrupt,
@@ -137,7 +159,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   } = useLangGraphMessages({
     appendMessage: appendLangChainChunk,
     stream,
-    ...(eventHandlers && { eventHandlers }),
+    eventHandlers: wrappedEventHandlers,
     ...(uiStateKey !== undefined && { uiStateKey }),
   });
 
@@ -154,6 +176,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const toolResultBufferRef = useRef<
     Map<string, LangChainMessage & { type: "tool" }>
   >(new Map());
+  // The resume batch currently sitting in the run queue. Referenced so results
+  // arriving before it is sent merge into it instead of deadlocking the buffer
+  // (queued results are not in `messages` yet, so they still count as pending).
+  const pendingResumeRef = useRef<
+    (LangChainMessage & { type: "tool" })[] | null
+  >(null);
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
@@ -190,18 +218,45 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     [uiMessagesByParent, messageTiming],
   );
 
+  const sendMessageRef = useRef(sendMessage);
+  sendMessageRef.current = sendMessage;
+
+  // Runs on a thread never overlap: a send arriving while a run is still
+  // draining (e.g. a frontend tool result resuming the graph) waits for it to
+  // settle. isRunning flips atomically with the final reconcile via onComplete.
+  const runQueueRef = useRef<SerialRunQueue<{
+    messages: LangChainMessage[];
+    config: LangGraphSendMessageConfig;
+  }> | null>(null);
+  runQueueRef.current ??= createSerialRunQueue({
+    run: ({ messages, config }, onComplete) => {
+      if (messages === pendingResumeRef.current) {
+        pendingResumeRef.current = null;
+      }
+      runErrorBalanceRef.current = 0;
+      return sendMessageRef.current(messages, config, () => {
+        if (runErrorBalanceRef.current > 0) {
+          pendingResumeRef.current = null;
+          runQueueRef.current!.drop();
+        }
+        onComplete();
+      });
+    },
+    onRunningChange: setIsRunning,
+  });
+  const runQueue = runQueueRef.current;
+
   const handleSendMessage = (
     messages: LangChainMessage[],
     config: LangGraphSendMessageConfig,
-  ) => {
-    setIsRunning(true);
-    // setIsRunning(false) flips atomically with the final reconcile via onComplete
-    return sendMessage(messages, config, () => setIsRunning(false));
-  };
+  ) => runQueue.enqueue({ messages, config });
 
   const runUserMessage = async (msg: AppendMessage) => {
-    // A new turn abandons any half-collected parallel tool batch.
+    // A new turn abandons any half-collected parallel tool batch and any
+    // queued resume; the cancellations below answer the dangling tool calls.
     toolResultBufferRef.current.clear();
+    pendingResumeRef.current = null;
+    runQueue.drop();
     const cancellations =
       autoCancelPendingToolCalls !== false
         ? getPendingToolCalls(messages).map(
@@ -357,9 +412,11 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // resume the graph with the full batch in a single run. Sending each
       // result on its own would resume LangGraph while sibling tool calls of a
       // parallel turn are still executing.
+      const queuedResume = pendingResumeRef.current;
+      const queuedIds = new Set(queuedResume?.map((m) => m.tool_call_id));
       const batch = bufferToolResult(
         toolResultBufferRef.current,
-        getPendingToolCalls(messages),
+        getPendingToolCalls(messages).filter((t) => !queuedIds.has(t.id)),
         {
           type: "tool",
           name: toolName,
@@ -370,12 +427,31 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         },
       );
       if (!batch) return;
-      // TODO reuse runconfig here!
-      await handleSendMessage(batch, {});
+      if (queuedResume) {
+        for (const message of batch) {
+          const index = queuedResume.findIndex(
+            (m) => m.tool_call_id === message.tool_call_id,
+          );
+          if (index >= 0) queuedResume[index] = message;
+          else queuedResume.push(message);
+        }
+        return;
+      }
+      pendingResumeRef.current = batch;
+      try {
+        // TODO reuse runconfig here!
+        await handleSendMessage(batch, {});
+      } finally {
+        if (pendingResumeRef.current === batch) {
+          pendingResumeRef.current = null;
+        }
+      }
     },
     onEdit: getCheckpointId
       ? async (msg) => {
           toolResultBufferRef.current.clear();
+          pendingResumeRef.current = null;
+          runQueue.drop();
           const truncated = truncateLangChainMessages(
             threadMessagesRef.current,
             msg.parentId,
@@ -428,6 +504,8 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
               throw new Error("Runtime does not support reloading messages.");
 
             toolResultBufferRef.current.clear();
+            pendingResumeRef.current = null;
+            runQueue.drop();
             const truncated = truncateLangChainMessages(
               threadMessagesRef.current,
               parentId,
@@ -450,6 +528,8 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       : {}),
     onCancel: unstable_allowCancellation
       ? async () => {
+          pendingResumeRef.current = null;
+          runQueue.drop();
           cancel();
         }
       : undefined,


### PR DESCRIPTION
closes #4751

## summary

- fixes the isRunning falling edge between a frontend tool result and the follow-up run: all sends now go through a serial run queue, so a thread never has two overlapping runs and one logical turn shows one continuous running window
- overlap was the root of three more defects that this also fixes: cancel losing its handle on the draining run, run #1's final values reconcile clobbering run #2's streamed messages, and queued messages (unstable_enableMessageQueue) slipping in between the tool-call run and its resume
- a resume batch completing while a run is draining is queued; results arriving before it is sent merge into it (staggered same-run parallel tool calls would otherwise deadlock the result buffer), and a run that aborts, throws, or ends with a top-level error event drops the sends queued behind it
- zero public API change: the queue is a package-private module (serialRunQueue.ts), and top-level error detection wraps eventHandlers.onError/onSubgraphError (a documented dispatch contract) instead of changing sendMessage's onComplete signature

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 166/166 green (5 queue unit tests plus runtime integration tests: seam continuity with strict [false, true, false] isRunning transitions, resume payload, staggered merge driven through a real registered frontend tool, duplicate-result replacement, cancel/error/new-turn drops, subgraph error still chaining)
- [x] reverse check: neutering the staggered-merge branch and the error-balance check makes exactly those tests fail; restoring them returns 166/166
- [x] tsc, oxlint, oxfmt clean; api-surface regenerated with zero diff for assistant-ui__react-langgraph.ts

### reviewer should verify

- [ ] with a LangGraph backend and a fast frontend tool, send a message that triggers the tool: the Stop button and running indicator stay on continuously from send until the follow-up assistant message finishes (previously they flipped back to Send for the seconds between the tool result and run #2's first token)
- [ ] cancel during that seam stops the whole turn: run #1 aborts and no resume run starts afterwards

## notes

- alternative to #4753, which defers only the tool-result resume via a stash and extends sendMessage's onComplete signature (an api-surface change); this PR serializes every send path (useLangGraphSend and edit/reload included, which #4753 leaves able to overlap) and keeps the public surface untouched. the staggered-merge and error-drop semantics match #4753.
- behavior change: a send issued while a run is active (e.g. useLangGraphSend) now waits for the run to settle instead of overlapping it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

