### PR TITLE
docs: add runtime error handling patterns

### DIFF
--- a/apps/docs/content/docs/primitives/error.mdx
+++ b/apps/docs/content/docs/primitives/error.mdx
@@ -113,6 +113,29 @@ Renders the current error text for the active message.
 
 ## Patterns
 
+### Runtime-Level Alert
+
+Use message errors for failures that belong next to a specific assistant message. If your app shell needs a toast, banner, or retry affordance for the active run, read the thread-level status with `useRuntimeStatus()`.
+
+```tsx
+import { useRuntimeStatus } from "@assistant-ui/react";
+
+function RuntimeErrorAlert() {
+  const status = useRuntimeStatus();
+
+  if (!status.isError) return null;
+
+  const message =
+    typeof status.error === "string"
+      ? status.error
+      : "The assistant failed to respond.";
+
+  return <div role="alert">{message}</div>;
+}
+```
+
+Runtime errors are runtime state, not React render errors. Keep React error boundaries for component crashes, and use `ErrorPrimitive` or `useRuntimeStatus()` for model, stream, tool, and adapter failures.
+
 ### Styled Error Alert
 
 ```tsx


### PR DESCRIPTION
## Summary
- add a short runtime-level error alert pattern to the Error primitive docs
- show how app chrome can use `useRuntimeStatus()` for banners, toasts, or retry UI
- clarify that runtime/model/stream/tool failures are runtime state, while React error boundaries remain for component crashes

## Dependency
This is a follow-up to #4762 and should land after #4762 merges, because the example depends on the new `useRuntimeStatus()` API introduced there.

## Validation
- `pnpm --filter @assistant-ui/docs build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

