### PR TITLE
fix(react-ink): preserve TextInput cursor when a controlled owner corrects an edit

### DIFF
--- a/.changeset/textinput-cursor-preserving-sync.md
+++ b/.changeset/textinput-cursor-preserving-sync.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: preserve the TextInput cursor when a controlled owner corrects an edit

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -1224,7 +1224,7 @@ import { TextInput } from "@assistant-ui/react-ink";
 
 Store-free, controlled single/multi-line text field. Ink ships no native text input, so this is the terminal equivalent of the DOM `<textarea>` or React Native's `<TextInput>` — the editing engine (buffer, grapheme-aware cursor, and the full emacs/arrow keymap) without any runtime or composer coupling. `ComposerPrimitive.Input` is a thin adapter that wraps `TextInput` and binds it to the composer store; reach for `TextInput` directly when you need an editable field outside the thread composer (for example, editing a value before confirming an action).
 
-It is controlled on `value`/`onChange`, so an external owner can override the text at any time (the buffer absorbs the echo without thrashing the cursor):
+It is controlled on `value`/`onChange`, so an external owner can override the text at any time (the buffer absorbs the echo without thrashing the cursor). An owner may also transform the emitted text in `onChange` (uppercase, mask, reject); the buffer applies the corrected value while keeping the cursor at the edit position, snapped to a grapheme boundary. A replacement that does not respond to an edit (a programmatic set while idle) still places the cursor at the end:
 
 ```tsx
 const [command, setCommand] = useState(approval.action.command);
@@ -1241,7 +1241,7 @@ const [command, setCommand] = useState(approval.action.command);
 |------|------|-------------|
 | `value` | `string` | Current text (controlled) |
 | `onChange` | `(text: string) => void` | Called with the next text whenever the buffer changes |
-| `onSubmit` | `(text: string) => void` | Called with the current text on Enter when `submitOnEnter` is set |
+| `onSubmit` | `(text: string) => void` | Called on Enter when `submitOnEnter` is set, with the text as displayed; owners that validate in `onChange` should validate again in `onSubmit` |
 | `submitOnEnter` | `boolean` | Whether Enter calls `onSubmit` (default: `false`) |
 | `placeholder` | `string` | Placeholder text when empty (default: `""`) |
 | `autoFocus` | `boolean` | Auto-focus on mount (default: `true`) |

--- a/packages/react-ink/src/primitives/textInput/TextInput.tsx
+++ b/packages/react-ink/src/primitives/textInput/TextInput.tsx
@@ -5,7 +5,6 @@ import {
   getGraphemeAt,
   textBufferReducer,
   useTextBuffer,
-  type TextBufferState,
 } from "./useTextBuffer";
 
 // cap dedup map so an owner that drops echoes can't grow the counter without bound
@@ -54,11 +53,10 @@ export const TextInput = ({
     const previousCursorOffset = bufferStateRef.current.cursorOffset;
     counter.clear();
     setText(value);
-    let nextState: TextBufferState = {
+    let nextState = textBufferReducer(bufferStateRef.current, {
+      type: "set-text",
       text: value,
-      cursorOffset: value.length,
-      preferredColumn: undefined,
-    };
+    });
     if (isCorrection) {
       const restoreCursor = {
         type: "set-cursor",

--- a/packages/react-ink/src/primitives/textInput/TextInput.tsx
+++ b/packages/react-ink/src/primitives/textInput/TextInput.tsx
@@ -5,6 +5,7 @@ import {
   getGraphemeAt,
   textBufferReducer,
   useTextBuffer,
+  type TextBufferState,
 } from "./useTextBuffer";
 
 // cap dedup map so an owner that drops echoes can't grow the counter without bound
@@ -47,14 +48,27 @@ export const TextInput = ({
     }
     if (value === text) return;
 
+    // a mismatched value while echoes are pending is the owner correcting our
+    // own edit; keep the cursor at the edit instead of jumping to the end
+    const isCorrection = counter.size > 0;
+    const previousCursorOffset = bufferStateRef.current.cursorOffset;
     counter.clear();
     setText(value);
-    bufferStateRef.current = {
+    let nextState: TextBufferState = {
       text: value,
       cursorOffset: value.length,
       preferredColumn: undefined,
     };
-  }, [setText, value, text]);
+    if (isCorrection) {
+      const restoreCursor = {
+        type: "set-cursor",
+        cursorOffset: previousCursorOffset,
+      } as const;
+      dispatchAction(restoreCursor);
+      nextState = textBufferReducer(nextState, restoreCursor);
+    }
+    bufferStateRef.current = nextState;
+  }, [setText, value, text, dispatchAction]);
 
   const commitAction = (
     action: Parameters<typeof textBufferReducer>[1],

--- a/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
+++ b/packages/react-ink/src/primitives/textInput/useTextBuffer.ts
@@ -43,6 +43,18 @@ const stepGraphemeLeft = (text: string, offset: number) => {
   return previous;
 };
 
+const snapToGraphemeBoundary = (text: string, offset: number) => {
+  if (offset <= 0) return 0;
+  if (offset >= text.length) return text.length;
+  let previous = 0;
+  for (const { index } of graphemeSegmenter.segment(text)) {
+    if (index === offset) return offset;
+    if (index > offset) break;
+    previous = index;
+  }
+  return previous;
+};
+
 const stepGraphemeRight = (text: string, offset: number) => {
   if (offset >= text.length) return text.length;
   for (const { index, segment } of graphemeSegmenter.segment(text)) {
@@ -303,7 +315,10 @@ export const textBufferReducer = (
     case "set-cursor":
       return clearPreferredColumn(
         state,
-        clamp(action.cursorOffset, 0, state.text.length),
+        snapToGraphemeBoundary(
+          state.text,
+          clamp(action.cursorOffset, 0, state.text.length),
+        ),
       );
   }
 };

--- a/packages/react-ink/src/tests/TextInput.test.tsx
+++ b/packages/react-ink/src/tests/TextInput.test.tsx
@@ -273,4 +273,52 @@ describe("TextInput", () => {
     expect(emitted[0]).toBe("x");
     expect(emitted[1]).toBe("z👍👍");
   });
+
+  it("falls back to cursor-at-end when a deferred correction lands after pending edits were reconciled", async () => {
+    const emitted: string[] = [];
+    const { rerender } = render(
+      <TextInput value="hello" onChange={(text) => emitted.push(text)} />,
+    );
+    await flush();
+
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("a", {});
+    inputHandler?.("b", {});
+    await settle();
+
+    rerender(
+      <TextInput value="HELABLO" onChange={(text) => emitted.push(text)} />,
+    );
+    await settle();
+    inputHandler?.("z", {});
+    await settle();
+
+    expect(emitted).toEqual(["helalo", "helablo", "HELABLOz"]);
+  });
+
+  it("submits the optimistic buffer text while a correction is pending", async () => {
+    const onSubmit = vi.fn();
+    const Upper = () => {
+      const [value, setValue] = useState("hello");
+      return (
+        <TextInput
+          value={value}
+          submitOnEnter
+          onSubmit={onSubmit}
+          onChange={(text) => setValue(text.toUpperCase())}
+        />
+      );
+    };
+    render(<Upper />);
+    await flush();
+
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("x", {});
+    inputHandler?.("", { return: true });
+    await settle();
+
+    expect(onSubmit).toHaveBeenCalledWith("helxlo");
+  });
 });

--- a/packages/react-ink/src/tests/TextInput.test.tsx
+++ b/packages/react-ink/src/tests/TextInput.test.tsx
@@ -42,6 +42,11 @@ const flush = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
+const settle = async () => {
+  await flush();
+  await flush();
+};
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -185,5 +190,87 @@ describe("TextInput", () => {
 
     expect(lastFrame()).toContain("filled");
     expect(lastFrame()).not.toContain("Type here");
+  });
+
+  it("preserves the cursor when a normalizing owner corrects an edit", async () => {
+    const emitted: string[] = [];
+    const Upper = () => {
+      const [value, setValue] = useState("hello");
+      return (
+        <TextInput
+          value={value}
+          onChange={(text) => {
+            emitted.push(text);
+            setValue(text.toUpperCase());
+          }}
+        />
+      );
+    };
+    render(<Upper />);
+    await flush();
+
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("a", {});
+    await settle();
+    inputHandler?.("b", {});
+    await settle();
+
+    expect(emitted).toEqual(["helalo", "HELAbLO"]);
+  });
+
+  it("preserves the cursor when the owner rejects an edit", async () => {
+    const emitted: string[] = [];
+    render(<TextInput value="hello" onChange={(text) => emitted.push(text)} />);
+    await flush();
+
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("", { leftArrow: true });
+    inputHandler?.("x", {});
+    await settle();
+    inputHandler?.("y", {});
+    await settle();
+
+    expect(emitted).toEqual(["helxlo", "hellyo"]);
+  });
+
+  it("moves the cursor to the end on an external replacement while idle", async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <TextInput value="hello" onChange={onChange} />,
+    );
+    await flush();
+
+    rerender(<TextInput value="world" onChange={onChange} />);
+    await flush();
+    inputHandler?.("z", {});
+
+    expect(onChange).toHaveBeenLastCalledWith("worldz");
+  });
+
+  it("snaps a preserved cursor to a grapheme boundary", async () => {
+    const emitted: string[] = [];
+    const Emojify = () => {
+      const [value, setValue] = useState("");
+      return (
+        <TextInput
+          value={value}
+          onChange={(text) => {
+            emitted.push(text);
+            setValue("👍👍");
+          }}
+        />
+      );
+    };
+    render(<Emojify />);
+    await flush();
+
+    inputHandler?.("x", {});
+    await settle();
+    inputHandler?.("z", {});
+    await settle();
+
+    expect(emitted[0]).toBe("x");
+    expect(emitted[1]).toBe("z👍👍");
   });
 });

--- a/packages/react-ink/src/tests/useTextBuffer.test.ts
+++ b/packages/react-ink/src/tests/useTextBuffer.test.ts
@@ -213,6 +213,25 @@ describe("textBufferReducer", () => {
     expect(movedRight.cursorOffset).toBe(1 + skinToned.length);
   });
 
+  it("snaps set-cursor to a grapheme boundary", () => {
+    const midSurrogate = reduce(createTextBufferState("👍🏽b"), {
+      type: "set-cursor",
+      cursorOffset: 2,
+    });
+    const onBoundary = reduce(createTextBufferState("👍🏽b"), {
+      type: "set-cursor",
+      cursorOffset: 4,
+    });
+    const beyondEnd = reduce(createTextBufferState("👍🏽b"), {
+      type: "set-cursor",
+      cursorOffset: 99,
+    });
+
+    expect(midSurrogate.cursorOffset).toBe(0);
+    expect(onBoundary.cursorOffset).toBe(4);
+    expect(beyondEnd.cursorOffset).toBe(5);
+  });
+
   it("returns the full grapheme cluster at an offset", () => {
     expect(getGraphemeAt("ab", 0)).toBe("a");
     expect(getGraphemeAt("a😀b", 1)).toBe("😀");


### PR DESCRIPTION
## What

When a controlled owner transforms or rejects text in `onChange` (uppercase, mask, validation), `TextInput` now applies the corrected value while keeping the cursor at the edit position instead of jumping to the end. Follow-up to the #4658 

## Why

The sync effect treats every mismatched `value` as an external replacement and resets the cursor to `value.length`. For a normalizing owner that means the cursor jumps to the end on every transformed keystroke, making mid-string editing unusable. The echo-dedup map is keyed on the exact emitted string, so any owner transformation misses it.

## How

The pending-echo counter distinguishes the two sync cases, no string heuristics needed:

- Counter non-empty: we emitted an edit the owner has not acked, so a mismatched `value` is the owner correcting that edit. Apply the value and restore the previous cursor offset, clamped and snapped to a grapheme boundary.
- Counter empty: true external replacement (suggestion fill, programmatic set). Cursor to end, unchanged.

Mechanics:

- `set-cursor` in the reducer now snaps to a grapheme boundary (a preserved offset can land mid-grapheme in the transformed string); nothing dispatched `set-cursor` before, so no behavior change
- `ComposerPrimitive.Input` unaffected: the composer store accepts every change, so the correction path never fires there
- Submit stays optimistic-buffer; documented as a contract instead (validate in `onSubmit` too), since submitting the `value` prop would be stale by one render in the common case
- Tests: 4 new TextInput cases + 1 reducer case; 224/224 pass
- Patch changeset, docs updated in the same PR, no public API change

One accepted tradeoff: a genuine external replacement racing an in-flight keystroke (store set-text in the same render window as typing) now preserves the cursor instead of jumping to end. The race is rare and a preserved cursor is less jarring than a jump even there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

