### PR TITLE
fix(cli): update package json errors

### DIFF
--- a/.changeset/cli-update-package-json-errors.md
+++ b/.changeset/cli-update-package-json-errors.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: clarify assistant-ui update package.json parse errors

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -23,7 +23,18 @@ export const update = new Command()
       process.exit(1);
     }
 
-    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    let pkg: Record<string, Record<string, string> | undefined>;
+    try {
+      pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    } catch {
+      logger.error("Could not parse package.json.");
+      logger.info(`Package path: ${packageJsonPath}`);
+      logger.info(
+        "Fix the JSON syntax in that file, then run: assistant-ui update",
+      );
+      logger.info("No changes were written.");
+      process.exit(1);
+    }
     const sections = ["dependencies", "devDependencies"];
     const targets: string[] = [];
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -5,6 +5,15 @@ import { sync as spawnSync } from "cross-spawn";
 import { logger } from "../lib/utils/logger";
 import { getInstallCommand } from "../lib/utils/package-manager";
 
+const logPackageJsonParseError = (packageJsonPath: string) => {
+  logger.error("Could not parse package.json.");
+  console.error(`Package path: ${packageJsonPath}`);
+  console.error(
+    "Fix the JSON syntax in that file, then run: assistant-ui update",
+  );
+  console.error("No changes were written.");
+};
+
 export const update = new Command()
   .name("update")
   .description(
@@ -23,16 +32,12 @@ export const update = new Command()
       process.exit(1);
     }
 
+    const packageJsonContent = fs.readFileSync(packageJsonPath, "utf-8");
     let pkg: Record<string, Record<string, string> | undefined>;
     try {
-      pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+      pkg = JSON.parse(packageJsonContent);
     } catch {
-      logger.error("Could not parse package.json.");
-      logger.info(`Package path: ${packageJsonPath}`);
-      logger.info(
-        "Fix the JSON syntax in that file, then run: assistant-ui update",
-      );
-      logger.info("No changes were written.");
+      logPackageJsonParseError(packageJsonPath);
       process.exit(1);
     }
     const sections = ["dependencies", "devDependencies"];

--- a/packages/cli/test/commands/update.test.ts
+++ b/packages/cli/test/commands/update.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { update } from "../../src/commands/update";
+
+describe("update command", () => {
+  let tempDir: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "assistant-ui-update-")),
+    );
+
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    exitSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("prints recovery details for invalid package.json", async () => {
+    const packageJsonPath = path.join(tempDir, "package.json");
+    fs.writeFileSync(packageJsonPath, "{ invalid json", "utf-8");
+
+    await expect(
+      update.parseAsync(["node", "update", "--cwd", tempDir], {
+        from: "node",
+      }),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    const output = [
+      ...consoleErrorSpy.mock.calls.flat(),
+      ...consoleLogSpy.mock.calls.flat(),
+    ].join("\n");
+
+    expect(output).toContain("Could not parse package.json.");
+    expect(output).toContain(`Package path: ${packageJsonPath}`);
+    expect(output).toContain(
+      "Fix the JSON syntax in that file, then run: assistant-ui update",
+    );
+    expect(output).toContain("No changes were written.");
+    expect(output).not.toContain("SyntaxError");
+  });
+});

--- a/packages/cli/test/commands/update.test.ts
+++ b/packages/cli/test/commands/update.test.ts
@@ -41,17 +41,16 @@ describe("update command", () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
 
-    const output = [
-      ...consoleErrorSpy.mock.calls.flat(),
-      ...consoleLogSpy.mock.calls.flat(),
-    ].join("\n");
+    const stderr = consoleErrorSpy.mock.calls.flat().join("\n");
+    const stdout = consoleLogSpy.mock.calls.flat().join("\n");
 
-    expect(output).toContain("Could not parse package.json.");
-    expect(output).toContain(`Package path: ${packageJsonPath}`);
-    expect(output).toContain(
+    expect(stderr).toContain("Could not parse package.json.");
+    expect(stderr).toContain(`Package path: ${packageJsonPath}`);
+    expect(stderr).toContain(
       "Fix the JSON syntax in that file, then run: assistant-ui update",
     );
-    expect(output).toContain("No changes were written.");
-    expect(output).not.toContain("SyntaxError");
+    expect(stderr).toContain("No changes were written.");
+    expect(stderr).not.toContain("SyntaxError");
+    expect(stdout).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

Clarifies the assistant-ui update failure path when the target project package.json is malformed.

Instead of surfacing a raw JSON parse error, the command now prints the package path, tells the user to fix the JSON syntax, and confirms that no changes were written.

## Why

assistant-ui update is often run while users are repairing or upgrading a project. If package.json has invalid JSON, the CLI should point directly at the broken file and recovery step instead of leaking a scary parser error.

## Validation

- pnpm --filter assistant-ui test -- update
- pnpm --filter assistant-ui build
- pnpm exec oxlint packages/cli/src/commands/update.ts packages/cli/test/commands/update.test.ts