### PR TITLE
feat(ui): thinking-steps trace UI for reasoning, tools, and sources

### DIFF
--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -66,6 +66,16 @@
   }
   --animate-shimmer: shimmer-sweep var(--shimmer-duration, 1000ms) linear
     infinite both;
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -71,10 +71,26 @@ export const registry: RegistryItem[] = [
       "https://r.assistant-ui.com/follow-up-suggestions.json",
       "https://r.assistant-ui.com/markdown-text.json",
       "https://r.assistant-ui.com/reasoning.json",
+      "https://r.assistant-ui.com/sources.json",
       "https://r.assistant-ui.com/tooltip-icon-button.json",
       "https://r.assistant-ui.com/tool-fallback.json",
       "https://r.assistant-ui.com/tool-group.json",
     ],
+    cssVars: {
+      theme: {
+        "--animate-working-dot": "working-dot 1.4s ease-in-out infinite",
+      },
+    },
+    css: {
+      "@keyframes working-dot": {
+        "0%, 100%": {
+          opacity: "0.2",
+        },
+        "40%": {
+          opacity: "1",
+        },
+      },
+    },
   },
   {
     name: "voice",
@@ -129,8 +145,10 @@ export const registry: RegistryItem[] = [
     ],
     dependencies: [
       "@assistant-ui/react",
+      "@assistant-ui/react-markdown",
       "lucide-react",
       "class-variance-authority",
+      "remark-gfm",
       "tw-shimmer",
     ],
     css: {

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -230,7 +230,7 @@ function ReasoningTrigger({
       <span className="aui-reasoning-trigger-line flex min-h-8 min-w-0 flex-1 items-center gap-1.5 py-1 pe-2 text-start">
         <span
           data-slot="reasoning-trigger-label"
-          className="aui-reasoning-trigger-label-wrapper text-muted-foreground group-hover/trigger:text-foreground relative shrink-0 text-sm leading-6 transition-colors motion-reduce:transition-none"
+          className="aui-reasoning-trigger-label-wrapper text-muted-foreground group-hover/trigger:text-foreground relative min-w-0 truncate text-sm leading-6 transition-colors motion-reduce:transition-none"
         >
           {label}
           {active ? (
@@ -345,6 +345,9 @@ function ReasoningText({
 export const stripReasoningMarkdown = (text: string) =>
   text.replace(/\*\*|__|`/g, "").trim();
 
+export const reasoningHeadline = (text: string) =>
+  stripReasoningMarkdown(text) || "Thinking";
+
 const ReasoningImpl: ReasoningMessagePartComponent = ({ text, status }) => {
   const running = status?.type === "running";
 
@@ -352,7 +355,7 @@ const ReasoningImpl: ReasoningMessagePartComponent = ({ text, status }) => {
     .split(/\n\s*\n/)
     .map((p) => p.trim())
     .filter((p) => stripReasoningMarkdown(p).length > 0);
-  const headline = stripReasoningMarkdown(paragraphs[0] ?? "") || "Thinking";
+  const headline = reasoningHeadline(paragraphs[0] ?? "");
   const thoughts = paragraphs.slice(1);
 
   if (thoughts.length === 0) {

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -347,7 +347,6 @@ export const stripReasoningMarkdown = (text: string) =>
 
 const ReasoningImpl: ReasoningMessagePartComponent = ({ text, status }) => {
   const running = status?.type === "running";
-  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
 
   const paragraphs = (text ?? "")
     .split(/\n\s*\n/)
@@ -370,11 +369,7 @@ const ReasoningImpl: ReasoningMessagePartComponent = ({ text, status }) => {
   }
 
   return (
-    <ReasoningRoot
-      variant="ghost"
-      open={userExpanded ?? running}
-      onOpenChange={setUserExpanded}
-    >
+    <ReasoningRoot variant="ghost" streaming={running}>
       <ReasoningTrigger label={headline} active={running} />
       <CollapsibleContent
         data-slot="reasoning-panel"

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -11,14 +11,15 @@ import {
   useState,
 } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
-import { BrainIcon, ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, LightbulbIcon } from "lucide-react";
 import {
   useScrollLock,
   useAuiState,
   type ReasoningMessagePartComponent,
   type ReasoningGroupComponent,
 } from "@assistant-ui/react";
-import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { MarkdownTextPrimitive } from "@assistant-ui/react-markdown";
+import remarkGfm from "remark-gfm";
 import {
   Collapsible,
   CollapsibleContent,
@@ -30,18 +31,24 @@ const ANIMATION_DURATION = 200;
 
 const ReasoningPreviewContext = createContext(false);
 
-const reasoningVariants = cva("aui-reasoning-root mb-4 w-full", {
-  variants: {
-    variant: {
-      outline: "rounded-lg border px-3 py-2",
-      ghost: "",
-      muted: "bg-muted/50 rounded-lg px-3 py-2",
+const reasoningVariants = cva(
+  cn(
+    "aui-reasoning-root relative w-full",
+    "animate-in fade-in-0 slide-in-from-top-1 duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
+  ),
+  {
+    variants: {
+      variant: {
+        outline: "mb-4 rounded-lg border px-3 py-2",
+        ghost: "",
+        muted: "bg-muted/50 mb-4 rounded-lg px-3 py-2",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
     },
   },
-  defaultVariants: {
-    variant: "outline",
-  },
-});
+);
 
 export type ReasoningRootProps = Omit<
   React.ComponentProps<typeof Collapsible>,
@@ -121,6 +128,11 @@ function ReasoningRoot({
       <ReasoningPreviewContext.Provider value={isPreview}>
         {children}
       </ReasoningPreviewContext.Provider>
+      <div
+        aria-hidden
+        data-slot="reasoning-connector"
+        className="aui-reasoning-connector bg-border absolute start-[11.5px] top-[26px] -bottom-1.5 hidden w-px"
+      />
     </Collapsible>
   );
 }
@@ -166,51 +178,80 @@ function ReasoningFade({
 function ReasoningTrigger({
   active,
   duration,
+  label = "Reasoning",
+  expandable = true,
   className,
   ...props
 }: React.ComponentProps<typeof CollapsibleTrigger> & {
   active?: boolean;
   duration?: number;
+  label?: React.ReactNode;
+  expandable?: boolean;
 }) {
-  const durationText = duration ? ` (${duration}s)` : "";
+  const durationText = duration ? `${duration}s` : "";
 
   return (
     <CollapsibleTrigger
       data-slot="reasoning-trigger"
       className={cn(
-        "aui-reasoning-trigger group/trigger text-muted-foreground hover:text-foreground flex max-w-[75%] origin-left items-center gap-2 py-1.5 text-sm transition-[color,scale] active:scale-[0.98]",
+        "aui-reasoning-trigger group/trigger flex w-full items-start",
         className,
       )}
       {...props}
     >
-      <BrainIcon
-        data-slot="reasoning-trigger-icon"
-        className="aui-reasoning-trigger-icon size-4 shrink-0"
-      />
       <span
-        data-slot="reasoning-trigger-label"
-        className="aui-reasoning-trigger-label-wrapper relative inline-block leading-none tabular-nums"
+        data-slot="reasoning-trigger-icon"
+        className="aui-reasoning-trigger-icon text-muted-foreground relative flex h-8 w-6 shrink-0 items-center justify-center"
       >
-        <span>Reasoning{durationText}</span>
-        {active ? (
+        <span
+          className={cn(
+            "aui-reasoning-trigger-glyph flex items-center justify-center [&>svg]:size-4",
+            expandable &&
+              "transition-opacity group-hover/trigger:opacity-0 motion-reduce:transition-none",
+          )}
+        >
+          <LightbulbIcon />
+        </span>
+        {expandable && (
           <span
-            aria-hidden
-            data-slot="reasoning-trigger-shimmer"
-            className="aui-reasoning-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            data-slot="reasoning-trigger-chevron"
+            className="aui-reasoning-trigger-chevron absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/trigger:opacity-100 motion-reduce:transition-none"
           >
-            Reasoning{durationText}
+            <ChevronDownIcon
+              className={cn(
+                "size-4 transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+                "group-data-[state=closed]/trigger:-rotate-90",
+                "group-data-[state=open]/trigger:rotate-0",
+              )}
+            />
           </span>
-        ) : null}
-      </span>
-      <ChevronDownIcon
-        data-slot="reasoning-trigger-chevron"
-        className={cn(
-          "aui-reasoning-trigger-chevron mt-0.5 size-4 shrink-0",
-          "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
         )}
-      />
+      </span>
+      <span className="aui-reasoning-trigger-line flex min-h-8 min-w-0 flex-1 items-center gap-1.5 py-1 pe-2 text-start">
+        <span
+          data-slot="reasoning-trigger-label"
+          className="aui-reasoning-trigger-label-wrapper text-muted-foreground group-hover/trigger:text-foreground relative shrink-0 text-sm leading-6 transition-colors motion-reduce:transition-none"
+        >
+          {label}
+          {active ? (
+            <span
+              aria-hidden
+              data-slot="reasoning-trigger-shimmer"
+              className="aui-reasoning-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {label}
+            </span>
+          ) : null}
+        </span>
+        {durationText && (
+          <span
+            data-slot="reasoning-trigger-meta"
+            className="aui-reasoning-trigger-meta text-muted-foreground ms-auto flex shrink-0 items-center gap-2 ps-2 text-xs tabular-nums"
+          >
+            {durationText}
+          </span>
+        )}
+      </span>
     </CollapsibleTrigger>
   );
 }
@@ -297,7 +338,90 @@ function ReasoningText({
   );
 }
 
-const ReasoningImpl: ReasoningMessagePartComponent = () => <MarkdownText />;
+/**
+ * Reasoning summaries stream as light markdown ("**Title**"); the step row
+ * renders plain text, so drop emphasis/code markers for display.
+ */
+export const stripReasoningMarkdown = (text: string) =>
+  text.replace(/\*\*|__|`/g, "").trim();
+
+const ReasoningImpl: ReasoningMessagePartComponent = ({ text, status }) => {
+  const running = status?.type === "running";
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+
+  const paragraphs = (text ?? "")
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter((p) => stripReasoningMarkdown(p).length > 0);
+  const headline = stripReasoningMarkdown(paragraphs[0] ?? "") || "Thinking";
+  const thoughts = paragraphs.slice(1);
+
+  if (thoughts.length === 0) {
+    return (
+      <ReasoningRoot variant="ghost">
+        <ReasoningTrigger
+          label={headline}
+          active={running}
+          expandable={false}
+          disabled
+        />
+      </ReasoningRoot>
+    );
+  }
+
+  return (
+    <ReasoningRoot
+      variant="ghost"
+      open={userExpanded ?? running}
+      onOpenChange={setUserExpanded}
+    >
+      <ReasoningTrigger label={headline} active={running} />
+      <CollapsibleContent
+        data-slot="reasoning-panel"
+        className={cn(
+          "aui-reasoning-panel relative overflow-hidden outline-none",
+          "ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
+          "data-[state=closed]:animate-collapsible-up",
+          "data-[state=open]:animate-collapsible-down",
+          "data-[state=closed]:fill-mode-forwards",
+          "data-[state=closed]:pointer-events-none",
+          "data-[state=open]:duration-(--animation-duration)",
+          "data-[state=closed]:duration-(--animation-duration)",
+        )}
+      >
+        <div
+          data-slot="reasoning-thoughts"
+          className="aui-reasoning-thoughts flex flex-col gap-2.5 ps-6 pe-2 pt-1 pb-2"
+        >
+          {thoughts.map((thought, i) => (
+            <div
+              key={i}
+              className={cn(
+                "aui-reasoning-thought relative",
+                "animate-in fade-in-0 slide-in-from-top-1 duration-(--animation-duration) motion-reduce:animate-none",
+                i === 0 &&
+                  "before:bg-border before:absolute before:-start-[12.5px] before:-top-2.5 before:h-5 before:w-px",
+                i < thoughts.length - 1 &&
+                  "after:bg-border after:absolute after:-start-[12.5px] after:top-[9px] after:-bottom-5 after:w-px",
+              )}
+            >
+              <span
+                aria-hidden
+                className="aui-reasoning-thought-dot border-border bg-background ring-background absolute -start-[16.5px] top-[5px] z-10 size-[9px] rounded-full border ring-4"
+              />
+              <MarkdownTextPrimitive
+                remarkPlugins={[remarkGfm]}
+                smooth={false}
+                preprocess={() => thought}
+                className="aui-reasoning-thought-text text-muted-foreground text-sm leading-snug"
+              />
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </ReasoningRoot>
+  );
+};
 
 const ReasoningGroupImpl: ReasoningGroupComponent = ({
   children,

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -7,14 +7,19 @@ import {
 } from "@/components/assistant-ui/attachment";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
+import { Sources } from "@/components/assistant-ui/sources";
 import {
   Reasoning,
   ReasoningContent,
   ReasoningRoot,
   ReasoningText,
   ReasoningTrigger,
+  stripReasoningMarkdown,
 } from "@/components/assistant-ui/reasoning";
-import { ToolFallback } from "@/components/assistant-ui/tool-fallback";
+import {
+  prettifyToolName,
+  ToolFallback,
+} from "@/components/assistant-ui/tool-fallback";
 import {
   ToolGroupContent,
   ToolGroupRoot,
@@ -22,6 +27,11 @@ import {
 } from "@/components/assistant-ui/tool-group";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import {
   ActionBarMorePrimitive,
@@ -37,11 +47,13 @@ import {
   ThreadPrimitive,
   type ToolCallMessagePartComponent,
   useAuiState,
+  useScrollLock,
 } from "@assistant-ui/react";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
   CheckIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   CopyIcon,
@@ -54,7 +66,11 @@ import {
 } from "lucide-react";
 import {
   createContext,
+  useCallback,
   useContext,
+  useEffect,
+  useRef,
+  useState,
   type ComponentType,
   type FC,
   type PropsWithChildren,
@@ -101,7 +117,9 @@ export const Thread: FC<ThreadProps> = ({ components = EMPTY_COMPONENTS }) => {
 
   return (
     <ThreadComponentsContext.Provider value={components}>
-      <ThreadRoot isEmpty={isEmpty} />
+      <RunStartProvider>
+        <ThreadRoot isEmpty={isEmpty} />
+      </RunStartProvider>
     </ThreadComponentsContext.Provider>
   );
 };
@@ -329,6 +347,291 @@ const MessageError: FC = () => {
   );
 };
 
+const ANIMATION_DURATION = 200;
+
+const RunStartAtContext = createContext<number | undefined>(undefined);
+
+// Message `createdAt` is re-stamped during message conversion, so the
+// wall-clock start of each run is stamped once at thread level to anchor
+// the working timer.
+const RunStartProvider: FC<PropsWithChildren> = ({ children }) => {
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+  const startRef = useRef<number | undefined>(undefined);
+  const prevRunning = useRef(false);
+  if (isRunning && !prevRunning.current) {
+    startRef.current = Date.now();
+  }
+  prevRunning.current = isRunning;
+  return (
+    <RunStartAtContext.Provider value={startRef.current}>
+      {children}
+    </RunStartAtContext.Provider>
+  );
+};
+
+const formatWorkingDuration = (ms: number) => {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 1) return null;
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+};
+
+const useWorkingElapsed = (running: boolean, startedAt?: number) => {
+  const startRef = useRef<number | null>(
+    running ? (startedAt ?? Date.now()) : null,
+  );
+  const [elapsedMs, setElapsedMs] = useState<number | null>(
+    running && startRef.current !== null ? Date.now() - startRef.current : null,
+  );
+
+  useEffect(() => {
+    if (!running) return;
+    startRef.current ??= startedAt ?? Date.now();
+    const start = startRef.current;
+    setElapsedMs(Date.now() - start);
+    const id = setInterval(() => setElapsedMs(Date.now() - start), 1000);
+    return () => clearInterval(id);
+  }, [running, startedAt]);
+
+  return elapsedMs;
+};
+
+const GLYPH_REST_OPACITY = [1, 1, 1, 0.85, 0.7, 0.2, 0.2, 0.2, 0.2];
+
+const WorkingGlyph: FC<{ active: boolean }> = ({ active }) => (
+  <span
+    aria-hidden
+    data-slot="aui_working-glyph"
+    className="aui-working-glyph grid grid-cols-3 gap-[2.5px]"
+  >
+    {GLYPH_REST_OPACITY.map((restOpacity, i) => (
+      <span
+        key={i}
+        className={cn(
+          "aui-working-glyph-dot size-[3px] rounded-full bg-current",
+          active && "animate-working-dot motion-reduce:animate-none",
+        )}
+        style={
+          active
+            ? {
+                animationDelay: `${(i % 3) * 140 + Math.floor(i / 3) * 70}ms`,
+              }
+            : { opacity: restOpacity }
+        }
+      />
+    ))}
+  </span>
+);
+
+const WorkingIndicator: FC = () => {
+  const startedAt = useContext(RunStartAtContext);
+  const elapsedMs = useWorkingElapsed(true, startedAt);
+  const duration = elapsedMs !== null ? formatWorkingDuration(elapsedMs) : null;
+
+  const label = (
+    <>
+      Working
+      {duration && (
+        <span className="whitespace-nowrap">
+          {" for "}
+          <span className="tabular-nums">{duration}</span>
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      data-slot="aui_assistant-message-indicator"
+      aria-label="Assistant is working"
+      className="aui-assistant-message-indicator text-muted-foreground flex items-center py-1 text-sm font-medium"
+    >
+      <span className="flex w-6 shrink-0 items-center justify-center">
+        <WorkingGlyph active />
+      </span>
+      <span className="relative leading-6">
+        {label}
+        <span
+          aria-hidden
+          className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+        >
+          {label}
+        </span>
+      </span>
+    </div>
+  );
+};
+
+const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
+  indices,
+  children,
+}) => {
+  const lastIndex = indices.at(-1) ?? 0;
+  const live = useAuiState(
+    (s) =>
+      s.message.status?.type === "running" &&
+      s.message.parts.length - 1 <= lastIndex,
+  );
+  const activeLabel = useAuiState((s) => {
+    if (s.message.status?.type !== "running") return undefined;
+    if (s.message.parts.length - 1 > lastIndex) return undefined;
+    const part = s.message.parts.at(-1);
+    if (part?.type === "tool-call") return prettifyToolName(part.toolName);
+    if (part?.type === "reasoning") {
+      const headline = stripReasoningMarkdown(
+        part.text.split("\n", 1)[0] ?? "",
+      );
+      return headline.length === 0 ? "Thinking" : headline;
+    }
+    return undefined;
+  });
+  const hasVisibleContent = useAuiState((s) =>
+    indices.some((i) => {
+      const part = s.message.parts[i];
+      if (part === undefined) return false;
+      return part.type !== "reasoning" || part.text.trim().length > 0;
+    }),
+  );
+  const sourcesOnly = useAuiState((s) =>
+    indices.every((i) => s.message.parts[i]?.type === "source"),
+  );
+  const startedAt = useContext(RunStartAtContext);
+
+  const collapsibleRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(live);
+  const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      lockScroll();
+      setOpen(next);
+    },
+    [lockScroll],
+  );
+
+  const prevLive = useRef(live);
+  useEffect(() => {
+    if (prevLive.current && !live) {
+      handleOpenChange(false);
+    }
+    prevLive.current = live;
+  }, [live, handleOpenChange]);
+
+  const elapsedMs = useWorkingElapsed(live, startedAt);
+  const duration = elapsedMs !== null ? formatWorkingDuration(elapsedMs) : null;
+
+  if (sourcesOnly) return <>{children}</>;
+  if (!hasVisibleContent && !live) return null;
+
+  let label: React.ReactNode;
+  let swapKey: string;
+  if (live && !open && activeLabel) {
+    label = `${activeLabel}…`;
+    swapKey = activeLabel;
+  } else if (live) {
+    label = (
+      <>
+        Working
+        {duration && (
+          <span className="whitespace-nowrap">
+            {" for "}
+            <span className="tabular-nums">{duration}</span>
+          </span>
+        )}
+      </>
+    );
+    swapKey = "working";
+  } else {
+    label = duration ? (
+      <>
+        Worked for <span className="tabular-nums">{duration}</span>
+      </>
+    ) : (
+      "Thought process"
+    );
+    swapKey = "done";
+  }
+
+  return (
+    <Collapsible
+      ref={collapsibleRef}
+      data-slot="aui_chain-of-thought"
+      data-streaming={live || undefined}
+      open={open}
+      onOpenChange={handleOpenChange}
+      className="aui-chain-of-thought w-full"
+      style={
+        {
+          "--animation-duration": `${ANIMATION_DURATION}ms`,
+        } as React.CSSProperties
+      }
+    >
+      <CollapsibleTrigger
+        data-slot="aui_chain-of-thought-header"
+        className="aui-chain-of-thought-header group/cot-header text-muted-foreground hover:text-foreground data-[state=open]:text-foreground flex w-fit items-center py-1 text-sm font-medium transition-colors"
+      >
+        {live && (
+          <span className="flex w-6 shrink-0 items-center justify-center">
+            <WorkingGlyph active={live} />
+          </span>
+        )}
+        <span
+          key={swapKey}
+          className={cn(
+            "aui-chain-of-thought-label relative leading-6",
+            "animate-in fade-in-0 slide-in-from-bottom-1 blur-in-[2px] duration-300 motion-reduce:animate-none",
+          )}
+        >
+          {label}
+          {live && (
+            <span
+              aria-hidden
+              className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {label}
+            </span>
+          )}
+        </span>
+        <ChevronDownIcon
+          data-slot="aui_chain-of-thought-chevron"
+          className={cn(
+            "aui-chain-of-thought-chevron ms-1.5 size-3.5 shrink-0",
+            "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+            "group-data-[state=closed]/cot-header:-rotate-90",
+            "group-data-[state=open]/cot-header:rotate-0",
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        data-slot="aui_chain-of-thought-content"
+        className={cn(
+          "aui-chain-of-thought-content relative overflow-hidden text-sm outline-none",
+          "ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
+          "data-[state=closed]:animate-collapsible-up",
+          "data-[state=open]:animate-collapsible-down",
+          "data-[state=closed]:fill-mode-forwards",
+          "data-[state=closed]:pointer-events-none",
+          "data-[state=open]:duration-(--animation-duration)",
+          "data-[state=closed]:duration-(--animation-duration)",
+        )}
+      >
+        <div
+          data-slot="aui_chain-of-thought-steps"
+          className={cn(
+            "aui-chain-of-thought-steps flex flex-col pt-1 pb-2",
+            "[&_[data-slot=tool-fallback-connector]]:block",
+            "[&_[data-slot=reasoning-connector]]:block",
+            "[&>*:last-child_[data-slot=tool-fallback-connector]]:hidden",
+            "[&>*:last-child_[data-slot=reasoning-connector]]:hidden",
+          )}
+        >
+          {children}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};
+
 const AssistantMessage: FC = () => {
   const {
     ToolFallback: ToolFallbackComponent = ToolFallback,
@@ -355,15 +658,21 @@ const AssistantMessage: FC = () => {
       >
         <MessagePrimitive.GroupedParts
           groupBy={groupPartByType({
-            reasoning: ["group-chainOfThought", "group-reasoning"],
-            "tool-call": ["group-chainOfThought", "group-tool"],
+            reasoning: ["group-chainOfThought"],
+            "tool-call": ["group-chainOfThought"],
+            source: ["group-chainOfThought", "group-sources"],
             "standalone-tool-call": [],
           })}
+          indicator="empty"
         >
           {({ part, children }) => {
             switch (part.type) {
               case "group-chainOfThought":
-                return <div data-slot="aui_chain-of-thought">{children}</div>;
+                return (
+                  <ChainOfThought indices={part.indices}>
+                    {children}
+                  </ChainOfThought>
+                );
               case "group-tool":
                 if (ToolGroup) {
                   return <ToolGroup group={part}>{children}</ToolGroup>;
@@ -385,7 +694,7 @@ const AssistantMessage: FC = () => {
                 }
                 const running = part.status.type === "running";
                 return (
-                  <ReasoningRoot streaming={running}>
+                  <ReasoningRoot variant="ghost" streaming={running}>
                     <ReasoningTrigger active={running} />
                     <ReasoningContent aria-busy={running}>
                       <ReasoningText>{children}</ReasoningText>
@@ -393,24 +702,27 @@ const AssistantMessage: FC = () => {
                   </ReasoningRoot>
                 );
               }
+              case "group-sources":
+                return (
+                  <div
+                    data-slot="aui_sources-row"
+                    className="aui-sources-row flex flex-wrap items-center gap-1.5 py-1 pe-2 in-[.aui-chain-of-thought-steps]:ps-6"
+                  >
+                    {children}
+                  </div>
+                );
               case "text":
                 return <MarkdownText />;
               case "reasoning":
                 return <Reasoning {...part} />;
+              case "source":
+                return <Sources {...part} />;
               case "tool-call":
                 return part.toolUI ?? <ToolFallbackComponent {...part} />;
               case "data":
                 return part.dataRendererUI;
               case "indicator":
-                return (
-                  <span
-                    data-slot="aui_assistant-message-indicator"
-                    className="animate-pulse font-sans"
-                    aria-label="Assistant is working"
-                  >
-                    {"●"}
-                  </span>
-                );
+                return <WorkingIndicator />;
               default:
                 return null;
             }

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -495,6 +495,7 @@ const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
   const sourcesOnly = useAuiState((s) =>
     indices.every((i) => s.message.parts[i]?.type === "source"),
   );
+  const isLast = useAuiState((s) => s.message.isLast);
   const startedAt = useContext(RunStartAtContext);
 
   const collapsibleRef = useRef<HTMLDivElement>(null);
@@ -509,13 +510,13 @@ const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
     [lockScroll],
   );
 
-  const prevLive = useRef(live);
+  const prevIsLast = useRef(isLast);
   useEffect(() => {
-    if (prevLive.current && !live) {
+    if (prevIsLast.current && !isLast) {
       handleOpenChange(false);
     }
-    prevLive.current = live;
-  }, [live, handleOpenChange]);
+    prevIsLast.current = isLast;
+  }, [isLast, handleOpenChange]);
 
   const elapsedMs = useWorkingElapsed(live, startedAt);
   const duration = elapsedMs !== null ? formatWorkingDuration(elapsedMs) : null;

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -11,14 +11,15 @@ import { Sources } from "@/components/assistant-ui/sources";
 import {
   Reasoning,
   ReasoningContent,
+  reasoningHeadline,
   ReasoningRoot,
   ReasoningText,
   ReasoningTrigger,
-  stripReasoningMarkdown,
 } from "@/components/assistant-ui/reasoning";
 import {
-  prettifyToolName,
+  formatToolDuration,
   ToolFallback,
+  toolRunningLabel,
 } from "@/components/assistant-ui/tool-fallback";
 import {
   ToolGroupContent,
@@ -356,24 +357,21 @@ const RunStartAtContext = createContext<number | undefined>(undefined);
 // the working timer.
 const RunStartProvider: FC<PropsWithChildren> = ({ children }) => {
   const isRunning = useAuiState((s) => s.thread.isRunning);
-  const startRef = useRef<number | undefined>(undefined);
-  const prevRunning = useRef(false);
-  if (isRunning && !prevRunning.current) {
-    startRef.current = Date.now();
+  const [runStart, setRunStart] = useState<{
+    running: boolean;
+    startedAt: number | undefined;
+  }>({ running: false, startedAt: undefined });
+  if (isRunning !== runStart.running) {
+    setRunStart({
+      running: isRunning,
+      startedAt: isRunning ? Date.now() : runStart.startedAt,
+    });
   }
-  prevRunning.current = isRunning;
   return (
-    <RunStartAtContext.Provider value={startRef.current}>
+    <RunStartAtContext.Provider value={runStart.startedAt}>
       {children}
     </RunStartAtContext.Provider>
   );
-};
-
-const formatWorkingDuration = (ms: number) => {
-  const seconds = Math.floor(ms / 1000);
-  if (seconds < 1) return null;
-  if (seconds < 60) return `${seconds}s`;
-  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 };
 
 const useWorkingElapsed = (running: boolean, startedAt?: number) => {
@@ -423,22 +421,24 @@ const WorkingGlyph: FC<{ active: boolean }> = ({ active }) => (
   </span>
 );
 
+const WorkingLabel: FC<{ duration: string | null }> = ({ duration }) => (
+  <>
+    Working
+    {duration && (
+      <span className="whitespace-nowrap">
+        {" for "}
+        <span className="tabular-nums">{duration}</span>
+      </span>
+    )}
+  </>
+);
+
 const WorkingIndicator: FC = () => {
   const startedAt = useContext(RunStartAtContext);
   const elapsedMs = useWorkingElapsed(true, startedAt);
-  const duration = elapsedMs !== null ? formatWorkingDuration(elapsedMs) : null;
+  const duration = elapsedMs !== null ? formatToolDuration(elapsedMs) : null;
 
-  const label = (
-    <>
-      Working
-      {duration && (
-        <span className="whitespace-nowrap">
-          {" for "}
-          <span className="tabular-nums">{duration}</span>
-        </span>
-      )}
-    </>
-  );
+  const label = <WorkingLabel duration={duration} />;
 
   return (
     <div
@@ -476,12 +476,9 @@ const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
     if (s.message.status?.type !== "running") return undefined;
     if (s.message.parts.length - 1 > lastIndex) return undefined;
     const part = s.message.parts.at(-1);
-    if (part?.type === "tool-call") return prettifyToolName(part.toolName);
+    if (part?.type === "tool-call") return toolRunningLabel(part.toolName);
     if (part?.type === "reasoning") {
-      const headline = stripReasoningMarkdown(
-        part.text.split("\n", 1)[0] ?? "",
-      );
-      return headline.length === 0 ? "Thinking" : headline;
+      return reasoningHeadline(part.text.split("\n", 1)[0] ?? "");
     }
     return undefined;
   });
@@ -519,7 +516,7 @@ const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
   }, [isLast, handleOpenChange]);
 
   const elapsedMs = useWorkingElapsed(live, startedAt);
-  const duration = elapsedMs !== null ? formatWorkingDuration(elapsedMs) : null;
+  const duration = elapsedMs !== null ? formatToolDuration(elapsedMs) : null;
 
   if (sourcesOnly) return <>{children}</>;
   if (!hasVisibleContent && !live) return null;
@@ -530,17 +527,7 @@ const ChainOfThought: FC<PropsWithChildren<{ indices: readonly number[] }>> = ({
     label = `${activeLabel}…`;
     swapKey = activeLabel;
   } else if (live) {
-    label = (
-      <>
-        Working
-        {duration && (
-          <span className="whitespace-nowrap">
-            {" for "}
-            <span className="tabular-nums">{duration}</span>
-          </span>
-        )}
-      </>
-    );
+    label = <WorkingLabel duration={duration} />;
     swapKey = "working";
   } else {
     label = duration ? (
@@ -668,6 +655,10 @@ const AssistantMessage: FC = () => {
             source: ["group-chainOfThought", "group-sources"],
             "standalone-tool-call": [],
           })}
+          // "empty" over the default "no-text": ChainOfThought renders its own
+          // live working header, so a trailing indicator would double up while
+          // a grouped part streams. Standalone tool calls carry their own
+          // running state via ToolFallback.
           indicator="empty"
         >
           {({ part, children }) => {

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -658,8 +658,12 @@ const AssistantMessage: FC = () => {
       >
         <MessagePrimitive.GroupedParts
           groupBy={groupPartByType({
-            reasoning: ["group-chainOfThought"],
-            "tool-call": ["group-chainOfThought"],
+            reasoning: ReasoningGroup
+              ? ["group-chainOfThought", "group-reasoning"]
+              : ["group-chainOfThought"],
+            "tool-call": ToolGroup
+              ? ["group-chainOfThought", "group-tool"]
+              : ["group-chainOfThought"],
             source: ["group-chainOfThought", "group-sources"],
             "standalone-tool-call": [],
           })}

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -156,9 +156,7 @@ const collectResults = (result: unknown) => {
 };
 
 type ToolPreset = {
-  /** Row label while the call is in flight, e.g. "Searching web". */
   running: string;
-  /** Row label once the call settled, e.g. "Searched web". */
   done: string;
   icon: React.ReactNode;
 };

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -103,7 +103,7 @@ const PREFERRED_ARG_KEYS = ["query", "path", "command", "code", "url", "file"];
 
 const primaryArg = (args: unknown, argsText: string | undefined) => {
   if (args && typeof args === "object") {
-    const record: Record<string, unknown> = { ...args };
+    const record = args as Record<string, unknown>;
     const candidates = [
       ...PREFERRED_ARG_KEYS.map((key) => record[key]),
       ...Object.values(record),
@@ -174,6 +174,11 @@ const TOOL_PRESETS: Record<string, ToolPreset> = {
   },
 };
 
+const toolRunningLabel = (toolName: string) =>
+  Object.hasOwn(TOOL_PRESETS, toolName)
+    ? TOOL_PRESETS[toolName]!.running
+    : prettifyToolName(toolName);
+
 const formatToolDuration = (ms: number) => {
   const seconds = Math.floor(ms / 1000);
   if (seconds < 1) return null;
@@ -204,26 +209,78 @@ function ToolFallbackDuration({
   );
 }
 
+const defaultFaviconUrl = (domain: string) =>
+  `https://icons.duckduckgo.com/ip3/${domain}.ico`;
+
+function ToolFallbackFavicon({
+  domain,
+  faviconUrl = defaultFaviconUrl,
+  className,
+  style,
+}: {
+  domain: string;
+  faviconUrl?: ((domain: string) => string) | undefined;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const src = faviconUrl(domain);
+  const [errorSrc, setErrorSrc] = useState<string | undefined>(undefined);
+
+  if (errorSrc === src) {
+    return (
+      <span
+        data-slot="tool-fallback-favicon-fallback"
+        className={cn(
+          "aui-tool-fallback-favicon bg-muted ring-background flex size-[18px] items-center justify-center rounded-full text-[9px] font-medium ring-2",
+          className,
+        )}
+        style={style}
+      >
+        {domain.charAt(0).toUpperCase() || "?"}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      data-slot="tool-fallback-favicon"
+      src={src}
+      alt=""
+      role="presentation"
+      className={cn(
+        "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
+        className,
+      )}
+      style={style}
+      onError={() => setErrorSrc(src)}
+    />
+  );
+}
+
 function ToolFallbackFavicons({
   urls,
   max = 3,
+  faviconUrl,
   className,
 }: {
   urls: readonly string[];
   max?: number;
+  faviconUrl?: ((domain: string) => string) | undefined;
   className?: string;
 }) {
-  const domains = urls
-    .map((url) => {
-      try {
-        return new URL(url).hostname;
-      } catch {
-        return null;
-      }
-    })
-    .filter((domain): domain is string => domain !== null)
-    .filter((domain, i, all) => all.indexOf(domain) === i)
-    .slice(0, max);
+  const domains = [
+    ...new Set(
+      urls
+        .map((url) => {
+          try {
+            return new URL(url).hostname.replace(/^www\./, "");
+          } catch {
+            return null;
+          }
+        })
+        .filter((domain): domain is string => domain !== null),
+    ),
+  ].slice(0, max);
 
   if (domains.length === 0) return null;
 
@@ -233,15 +290,11 @@ function ToolFallbackFavicons({
       className={cn("aui-tool-fallback-favicons flex items-center", className)}
     >
       {domains.map((domain, i) => (
-        <img
+        <ToolFallbackFavicon
           key={domain}
-          src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
-          alt=""
-          role="presentation"
-          className={cn(
-            "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
-            i > 0 && "-ms-2",
-          )}
+          domain={domain}
+          faviconUrl={faviconUrl}
+          className={cn(i > 0 && "-ms-2")}
           style={{ zIndex: domains.length - i }}
         />
       ))}
@@ -274,11 +327,12 @@ function ToolFallbackTrigger({
   const preset = Object.hasOwn(TOOL_PRESETS, toolName)
     ? TOOL_PRESETS[toolName]
     : undefined;
-  const label = preset
-    ? isRunning
-      ? preset.running
-      : preset.done
-    : prettifyToolName(toolName);
+  const label =
+    preset && !isCancelled && !isFailed
+      ? isRunning
+        ? preset.running
+        : preset.done
+      : prettifyToolName(toolName);
 
   return (
     <CollapsibleTrigger
@@ -860,7 +914,9 @@ ToolFallback.Error = ToolFallbackError;
 ToolFallback.Approval = ToolFallbackApproval;
 
 export {
+  formatToolDuration,
   prettifyToolName,
+  toolRunningLabel,
   ToolFallback,
   ToolFallbackRoot,
   ToolFallbackTrigger,

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -92,6 +92,7 @@ function ToolFallbackRoot({
 }
 
 const prettifyToolName = (toolName: string) => {
+  if (!toolName) return "Tool";
   const words = toolName.replace(/[_-]+/g, " ").trim();
   return words.length === 0
     ? toolName
@@ -769,7 +770,9 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
 
   let prettyArgs = argsText;
   if (args && typeof args === "object" && Object.keys(args).length > 0) {
-    prettyArgs = JSON.stringify(args, null, 2);
+    try {
+      prettyArgs = JSON.stringify(args, null, 2);
+    } catch {}
   }
   const showArgs = prettyArgs !== undefined && prettyArgs !== "{}";
 

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -3,10 +3,9 @@
 import { memo, useCallback, useRef, useState } from "react";
 import {
   AlertCircleIcon,
-  CheckIcon,
   ChevronDownIcon,
-  LoaderIcon,
-  XCircleIcon,
+  GlobeIcon,
+  WrenchIcon,
 } from "lucide-react";
 import {
   useScrollLock,
@@ -71,7 +70,8 @@ function ToolFallbackRoot({
       open={isOpen}
       onOpenChange={handleOpenChange}
       className={cn(
-        "aui-tool-fallback-root group/tool-fallback-root w-full",
+        "aui-tool-fallback-root group/tool-fallback-root relative w-full",
+        "animate-in fade-in-0 slide-in-from-top-1 duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
         className,
       )}
       style={
@@ -82,25 +82,104 @@ function ToolFallbackRoot({
       {...props}
     >
       {children}
+      <div
+        aria-hidden
+        data-slot="tool-fallback-connector"
+        className="aui-tool-fallback-connector bg-border absolute start-[11.5px] top-[26px] -bottom-1.5 hidden w-px"
+      />
     </Collapsible>
   );
 }
 
-type ToolStatus = ToolCallMessagePartStatus["type"];
+const prettifyToolName = (toolName: string) => {
+  const words = toolName.replace(/[_-]+/g, " ").trim();
+  return words.length === 0
+    ? toolName
+    : words[0]!.toUpperCase() + words.slice(1);
+};
 
-const statusIconMap: Record<ToolStatus, React.ElementType> = {
-  running: LoaderIcon,
-  complete: CheckIcon,
-  incomplete: XCircleIcon,
-  "requires-action": AlertCircleIcon,
+const PREFERRED_ARG_KEYS = ["query", "path", "command", "code", "url", "file"];
+
+const primaryArg = (args: unknown, argsText: string | undefined) => {
+  if (args && typeof args === "object") {
+    const record: Record<string, unknown> = { ...args };
+    const candidates = [
+      ...PREFERRED_ARG_KEYS.map((key) => record[key]),
+      ...Object.values(record),
+    ];
+    for (const value of candidates) {
+      if (typeof value === "string" && value.length > 0) {
+        const [firstLine] = value.split("\n", 1);
+        return firstLine;
+      }
+    }
+  }
+  if (argsText && argsText !== "{}") return argsText;
+  return undefined;
+};
+
+/** Provider-executed searches carry the query in the output's `action`. */
+const outputQuery = (result: unknown) => {
+  if (result && typeof result === "object" && "action" in result) {
+    const action = result.action;
+    if (action && typeof action === "object") {
+      if (
+        "query" in action &&
+        typeof action.query === "string" &&
+        action.query.length > 0
+      ) {
+        return action.query;
+      }
+      if ("queries" in action && Array.isArray(action.queries)) {
+        const queries = action.queries.filter(
+          (q): q is string => typeof q === "string",
+        );
+        if (queries.length > 0) return queries.join(", ");
+      }
+    }
+  }
+  return undefined;
+};
+
+const collectResults = (result: unknown) => {
+  if (Array.isArray(result)) return result;
+  if (result && typeof result === "object") {
+    if ("results" in result && Array.isArray(result.results)) {
+      return result.results;
+    }
+    if ("sources" in result && Array.isArray(result.sources)) {
+      return result.sources;
+    }
+  }
+  return undefined;
+};
+
+type ToolPreset = {
+  /** Row label while the call is in flight, e.g. "Searching web". */
+  running: string;
+  /** Row label once the call settled, e.g. "Searched web". */
+  done: string;
+  icon: React.ReactNode;
+};
+
+const TOOL_PRESETS: Record<string, ToolPreset> = {
+  web_search: {
+    running: "Searching web",
+    done: "Searched web",
+    icon: <GlobeIcon />,
+  },
+  web_search_preview: {
+    running: "Searching web",
+    done: "Searched web",
+    icon: <GlobeIcon />,
+  },
 };
 
 const formatToolDuration = (ms: number) => {
-  if (ms < 1000) return "<1s";
-  const seconds = ms / 1000;
-  if (seconds < 10) return `${(Math.floor(seconds * 10) / 10).toFixed(1)}s`;
-  if (seconds < 60) return `${Math.floor(seconds)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 1) return null;
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 };
 
 function ToolFallbackDuration({
@@ -109,6 +188,8 @@ function ToolFallbackDuration({
 }: React.ComponentProps<"span">) {
   const elapsedMs = useToolCallElapsed();
   if (elapsedMs === undefined) return null;
+  const duration = formatToolDuration(elapsedMs);
+  if (duration === null) return null;
 
   return (
     <span
@@ -119,7 +200,52 @@ function ToolFallbackDuration({
       )}
       {...props}
     >
-      {formatToolDuration(elapsedMs)}
+      {duration}
+    </span>
+  );
+}
+
+function ToolFallbackFavicons({
+  urls,
+  max = 3,
+  className,
+}: {
+  urls: readonly string[];
+  max?: number;
+  className?: string;
+}) {
+  const domains = urls
+    .map((url) => {
+      try {
+        return new URL(url).hostname;
+      } catch {
+        return null;
+      }
+    })
+    .filter((domain): domain is string => domain !== null)
+    .filter((domain, i, all) => all.indexOf(domain) === i)
+    .slice(0, max);
+
+  if (domains.length === 0) return null;
+
+  return (
+    <span
+      data-slot="tool-fallback-favicons"
+      className={cn("aui-tool-fallback-favicons flex items-center", className)}
+    >
+      {domains.map((domain, i) => (
+        <img
+          key={domain}
+          src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
+          alt=""
+          role="presentation"
+          className={cn(
+            "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
+            i > 0 && "-ms-2",
+          )}
+          style={{ zIndex: domains.length - i }}
+        />
+      ))}
     </span>
   );
 }
@@ -127,67 +253,117 @@ function ToolFallbackDuration({
 function ToolFallbackTrigger({
   toolName,
   status,
+  detail,
+  icon,
+  meta,
+  expandable = true,
   className,
   ...props
 }: React.ComponentProps<typeof CollapsibleTrigger> & {
   toolName: string;
   status?: ToolCallMessagePartStatus;
+  detail?: React.ReactNode;
+  icon?: React.ReactNode;
+  meta?: React.ReactNode;
+  expandable?: boolean;
 }) {
   const statusType = status?.type ?? "complete";
   const isRunning = statusType === "running";
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
-
-  const Icon = statusIconMap[statusType];
-  const label = isCancelled ? "Cancelled tool" : "Used tool";
+  const isFailed = status?.type === "incomplete" && !isCancelled;
+  const preset = Object.hasOwn(TOOL_PRESETS, toolName)
+    ? TOOL_PRESETS[toolName]
+    : undefined;
+  const label = preset
+    ? isRunning
+      ? preset.running
+      : preset.done
+    : prettifyToolName(toolName);
 
   return (
     <CollapsibleTrigger
       data-slot="tool-fallback-trigger"
       className={cn(
-        "aui-tool-fallback-trigger group/trigger text-muted-foreground hover:text-foreground flex w-fit origin-left items-center gap-2 py-1.5 text-sm transition-[color,scale] active:scale-[0.98]",
+        "aui-tool-fallback-trigger group/trigger flex w-full items-start",
         className,
       )}
       {...props}
     >
-      <Icon
+      <span
         data-slot="tool-fallback-trigger-icon"
         className={cn(
-          "aui-tool-fallback-trigger-icon size-4 shrink-0",
-          isCancelled && "text-muted-foreground",
-          isRunning && "animate-spin [animation-duration:0.6s]",
-        )}
-      />
-      <span
-        data-slot="tool-fallback-trigger-label"
-        className={cn(
-          "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
-          isCancelled && "text-muted-foreground line-through",
+          "aui-tool-fallback-trigger-icon relative flex h-8 w-6 shrink-0 items-center justify-center",
+          isFailed ? "text-destructive" : "text-muted-foreground",
         )}
       >
-        <span>
-          {label}: <b>{toolName}</b>
+        <span
+          className={cn(
+            "aui-tool-fallback-trigger-glyph flex items-center justify-center [&>svg]:size-4",
+            expandable &&
+              "transition-opacity group-hover/trigger:opacity-0 motion-reduce:transition-none",
+          )}
+        >
+          {icon ??
+            preset?.icon ??
+            (statusType === "requires-action" ? (
+              <AlertCircleIcon />
+            ) : (
+              <WrenchIcon />
+            ))}
         </span>
-        {isRunning && (
+        {expandable && (
           <span
-            aria-hidden
-            data-slot="tool-fallback-trigger-shimmer"
-            className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            data-slot="tool-fallback-trigger-chevron"
+            className="aui-tool-fallback-trigger-chevron absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/trigger:opacity-100 motion-reduce:transition-none"
           >
-            {label}: <b>{toolName}</b>
+            <ChevronDownIcon
+              className={cn(
+                "size-4 transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+                "group-data-[state=closed]/trigger:-rotate-90",
+                "group-data-[state=open]/trigger:rotate-0",
+              )}
+            />
           </span>
         )}
       </span>
-      <ToolFallbackDuration />
-      <ChevronDownIcon
-        data-slot="tool-fallback-trigger-chevron"
-        className={cn(
-          "aui-tool-fallback-trigger-chevron size-4 shrink-0",
-          "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+      <span className="aui-tool-fallback-trigger-line flex min-h-8 min-w-0 flex-1 items-center gap-1.5 py-1 pe-2 text-start">
+        <span
+          data-slot="tool-fallback-trigger-label"
+          className={cn(
+            "aui-tool-fallback-trigger-label-wrapper relative shrink-0 text-sm leading-6 transition-colors motion-reduce:transition-none",
+            isFailed
+              ? "text-destructive"
+              : "text-muted-foreground group-hover/trigger:text-foreground",
+            isCancelled && "line-through",
+          )}
+        >
+          {label}
+          {isRunning && (
+            <span
+              aria-hidden
+              data-slot="tool-fallback-trigger-shimmer"
+              className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {label}
+            </span>
+          )}
+        </span>
+        {detail && (
+          <span
+            data-slot="tool-fallback-trigger-detail"
+            className="aui-tool-fallback-trigger-detail text-muted-foreground/70 min-w-0 truncate font-mono text-xs"
+          >
+            {detail}
+          </span>
         )}
-      />
+        <span
+          data-slot="tool-fallback-trigger-meta"
+          className="aui-tool-fallback-trigger-meta text-muted-foreground ms-auto flex shrink-0 items-center gap-2 ps-2 text-xs"
+        >
+          {meta ?? <ToolFallbackDuration />}
+        </span>
+      </span>
     </CollapsibleTrigger>
   );
 }
@@ -215,7 +391,7 @@ function ToolFallbackContent({
     >
       <div
         className={cn(
-          "flex flex-col gap-2 ps-6 pt-1 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
+          "flex flex-col gap-2 ps-6 pe-2 pt-0.5 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
           "group-data-[state=open]/collapsible-content:animate-in group-data-[state=open]/collapsible-content:fade-in-0 group-data-[state=open]/collapsible-content:blur-in-[2px] group-data-[state=open]/collapsible-content:slide-in-from-top-1",
           "group-data-[state=closed]/collapsible-content:animate-out group-data-[state=closed]/collapsible-content:fade-out-0 group-data-[state=closed]/collapsible-content:blur-out-[2px] group-data-[state=closed]/collapsible-content:slide-out-to-top-1",
           "group-data-[state=closed]/collapsible-content:duration-(--animation-duration) group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
@@ -234,7 +410,7 @@ function ToolFallbackArgs({
 }: React.ComponentProps<"div"> & {
   argsText?: string;
 }) {
-  if (!argsText) return null;
+  if (!argsText || argsText === "{}") return null;
 
   return (
     <div
@@ -242,7 +418,16 @@ function ToolFallbackArgs({
       className={cn("aui-tool-fallback-args", className)}
       {...props}
     >
-      <pre className="aui-tool-fallback-args-value bg-muted/50 text-foreground/90 rounded-md p-2.5 text-xs whitespace-pre-wrap">
+      <p className="aui-tool-fallback-args-header text-muted-foreground mb-1 text-xs font-medium">
+        Request
+      </p>
+      <pre
+        className="aui-tool-fallback-args-value bg-muted/50 text-foreground/90 max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap"
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {argsText}
       </pre>
     </div>
@@ -264,10 +449,16 @@ function ToolFallbackResult({
       className={cn("aui-tool-fallback-result", className)}
       {...props}
     >
-      <p className="aui-tool-fallback-result-header text-muted-foreground text-xs font-medium">
-        Result:
+      <p className="aui-tool-fallback-result-header text-muted-foreground mb-1 text-xs font-medium">
+        Response
       </p>
-      <pre className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 mt-1 rounded-md p-2.5 text-xs whitespace-pre-wrap">
+      <pre
+        className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap"
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
       </pre>
     </div>
@@ -276,24 +467,33 @@ function ToolFallbackResult({
 
 function ToolFallbackError({
   status,
+  result,
+  isError,
   className,
   ...props
 }: React.ComponentProps<"div"> & {
   status?: ToolCallMessagePartStatus;
+  result?: unknown;
+  isError?: boolean | undefined;
 }) {
-  if (status?.type !== "incomplete") return null;
-
-  const error = status.error;
-  const errorText = error
-    ? typeof error === "string"
-      ? error
-      : JSON.stringify(error)
-    : null;
+  const isCancelled =
+    status?.type === "incomplete" && status.reason === "cancelled";
+  const statusError = status?.type === "incomplete" ? status.error : undefined;
+  const raw = statusError
+    ? statusError
+    : isError === true && result !== undefined
+      ? result
+      : undefined;
+  const errorText =
+    raw === undefined
+      ? null
+      : typeof raw === "string"
+        ? raw
+        : JSON.stringify(raw, null, 2);
 
   if (!errorText) return null;
 
-  const isCancelled = status.reason === "cancelled";
-  const headerText = isCancelled ? "Cancelled reason:" : "Error:";
+  const headerText = isCancelled ? "Cancelled" : "Error";
 
   return (
     <div
@@ -301,12 +501,28 @@ function ToolFallbackError({
       className={cn("aui-tool-fallback-error", className)}
       {...props}
     >
-      <p className="aui-tool-fallback-error-header text-muted-foreground font-semibold">
+      <p
+        className={cn(
+          "aui-tool-fallback-error-header mb-1 text-xs font-medium",
+          isCancelled ? "text-muted-foreground" : "text-destructive",
+        )}
+      >
         {headerText}
       </p>
-      <p className="aui-tool-fallback-error-reason text-muted-foreground">
+      <pre
+        className={cn(
+          "aui-tool-fallback-error-reason max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap",
+          isCancelled
+            ? "bg-muted/50 text-muted-foreground"
+            : "bg-destructive/5 text-destructive",
+        )}
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {errorText}
-      </p>
+      </pre>
     </div>
   );
 }
@@ -527,8 +743,10 @@ function ToolFallbackApproval({
 
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   toolName,
+  args,
   argsText,
   result,
+  isError,
   status,
   addResult,
   resume,
@@ -539,6 +757,7 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
   const isRequiresAction = status?.type === "requires-action";
+  const isRunning = status?.type === "running";
 
   const [open, setOpen] = useState(isRequiresAction);
   const [prevRequiresAction, setPrevRequiresAction] =
@@ -548,26 +767,72 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
     if (isRequiresAction) setOpen(true);
   }
 
+  let prettyArgs = argsText;
+  if (args && typeof args === "object" && Object.keys(args).length > 0) {
+    prettyArgs = JSON.stringify(args, null, 2);
+  }
+  const showArgs = prettyArgs !== undefined && prettyArgs !== "{}";
+
+  const results = isRunning ? undefined : collectResults(result);
+  const resultUrls =
+    results
+      ?.map((item: unknown) =>
+        item && typeof item === "object" && "url" in item
+          ? item.url
+          : undefined,
+      )
+      .filter((url): url is string => typeof url === "string") ?? [];
+
+  const hasError =
+    (status?.type === "incomplete" && Boolean(status.error)) ||
+    isError === true;
+  const expandable =
+    showArgs || hasError || result !== undefined || isRequiresAction;
+
   return (
-    <ToolFallbackRoot open={open} onOpenChange={setOpen}>
-      <ToolFallbackTrigger toolName={toolName} status={status} />
-      <ToolFallbackContent>
-        <ToolFallbackError status={status} />
-        <ToolFallbackArgs
-          argsText={argsText}
-          className={cn(isCancelled && "opacity-60")}
-        />
-        {isRequiresAction && (
-          <ToolFallbackApproval
-            addResult={addResult}
-            resume={resume}
-            interrupt={interrupt}
-            approval={approval}
-            respondToApproval={respondToApproval}
+    <ToolFallbackRoot open={expandable ? open : false} onOpenChange={setOpen}>
+      <ToolFallbackTrigger
+        toolName={toolName}
+        status={status}
+        detail={primaryArg(args, argsText) ?? outputQuery(result)}
+        expandable={expandable}
+        disabled={!expandable}
+        meta={
+          results ? (
+            <>
+              <span className="aui-tool-fallback-results whitespace-nowrap">
+                {results.length} {results.length === 1 ? "result" : "results"}
+              </span>
+              {resultUrls.length > 0 && (
+                <ToolFallbackFavicons urls={resultUrls} />
+              )}
+            </>
+          ) : undefined
+        }
+      />
+      {expandable && (
+        <ToolFallbackContent>
+          <ToolFallbackArgs
+            argsText={prettyArgs}
+            className={cn(isCancelled && "opacity-60")}
           />
-        )}
-        {!isCancelled && <ToolFallbackResult result={result} />}
-      </ToolFallbackContent>
+          <ToolFallbackError
+            status={status}
+            result={result}
+            isError={isError}
+          />
+          {isRequiresAction && (
+            <ToolFallbackApproval
+              addResult={addResult}
+              resume={resume}
+              interrupt={interrupt}
+              approval={approval}
+              respondToApproval={respondToApproval}
+            />
+          )}
+          {!isCancelled && !hasError && <ToolFallbackResult result={result} />}
+        </ToolFallbackContent>
+      )}
     </ToolFallbackRoot>
   );
 };
@@ -594,6 +859,7 @@ ToolFallback.Error = ToolFallbackError;
 ToolFallback.Approval = ToolFallbackApproval;
 
 export {
+  prettifyToolName,
   ToolFallback,
   ToolFallbackRoot,
   ToolFallbackTrigger,

--- a/templates/cloud-clerk/app/globals.css
+++ b/templates/cloud-clerk/app/globals.css
@@ -53,6 +53,16 @@
       background-position: -100% 0;
     }
   }
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/templates/cloud/app/globals.css
+++ b/templates/cloud/app/globals.css
@@ -53,6 +53,16 @@
       background-position: -100% 0;
     }
   }
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/templates/default/app/globals.css
+++ b/templates/default/app/globals.css
@@ -53,6 +53,16 @@
       background-position: -100% 0;
     }
   }
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/templates/mcp/app/globals.css
+++ b/templates/mcp/app/globals.css
@@ -53,6 +53,16 @@
       background-position: -100% 0;
     }
   }
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/templates/minimal/app/globals.css
+++ b/templates/minimal/app/globals.css
@@ -43,6 +43,16 @@
       background-position: -100% 0;
     }
   }
+  --animate-working-dot: working-dot 1.4s ease-in-out infinite;
+  @keyframes working-dot {
+    0%,
+    100% {
+      opacity: 0.2;
+    }
+    40% {
+      opacity: 1;
+    }
+  }
 }
 
 :root {

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -156,9 +156,7 @@ const collectResults = (result: unknown) => {
 };
 
 type ToolPreset = {
-  /** Row label while the call is in flight, e.g. "Searching web". */
   running: string;
-  /** Row label once the call settled, e.g. "Searched web". */
   done: string;
   icon: React.ReactNode;
 };

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -103,7 +103,7 @@ const PREFERRED_ARG_KEYS = ["query", "path", "command", "code", "url", "file"];
 
 const primaryArg = (args: unknown, argsText: string | undefined) => {
   if (args && typeof args === "object") {
-    const record: Record<string, unknown> = { ...args };
+    const record = args as Record<string, unknown>;
     const candidates = [
       ...PREFERRED_ARG_KEYS.map((key) => record[key]),
       ...Object.values(record),
@@ -174,6 +174,11 @@ const TOOL_PRESETS: Record<string, ToolPreset> = {
   },
 };
 
+const toolRunningLabel = (toolName: string) =>
+  Object.hasOwn(TOOL_PRESETS, toolName)
+    ? TOOL_PRESETS[toolName]!.running
+    : prettifyToolName(toolName);
+
 const formatToolDuration = (ms: number) => {
   const seconds = Math.floor(ms / 1000);
   if (seconds < 1) return null;
@@ -204,26 +209,78 @@ function ToolFallbackDuration({
   );
 }
 
+const defaultFaviconUrl = (domain: string) =>
+  `https://icons.duckduckgo.com/ip3/${domain}.ico`;
+
+function ToolFallbackFavicon({
+  domain,
+  faviconUrl = defaultFaviconUrl,
+  className,
+  style,
+}: {
+  domain: string;
+  faviconUrl?: ((domain: string) => string) | undefined;
+  className?: string;
+  style?: React.CSSProperties;
+}) {
+  const src = faviconUrl(domain);
+  const [errorSrc, setErrorSrc] = useState<string | undefined>(undefined);
+
+  if (errorSrc === src) {
+    return (
+      <span
+        data-slot="tool-fallback-favicon-fallback"
+        className={cn(
+          "aui-tool-fallback-favicon bg-muted ring-background flex size-[18px] items-center justify-center rounded-full text-[9px] font-medium ring-2",
+          className,
+        )}
+        style={style}
+      >
+        {domain.charAt(0).toUpperCase() || "?"}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      data-slot="tool-fallback-favicon"
+      src={src}
+      alt=""
+      role="presentation"
+      className={cn(
+        "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
+        className,
+      )}
+      style={style}
+      onError={() => setErrorSrc(src)}
+    />
+  );
+}
+
 function ToolFallbackFavicons({
   urls,
   max = 3,
+  faviconUrl,
   className,
 }: {
   urls: readonly string[];
   max?: number;
+  faviconUrl?: ((domain: string) => string) | undefined;
   className?: string;
 }) {
-  const domains = urls
-    .map((url) => {
-      try {
-        return new URL(url).hostname;
-      } catch {
-        return null;
-      }
-    })
-    .filter((domain): domain is string => domain !== null)
-    .filter((domain, i, all) => all.indexOf(domain) === i)
-    .slice(0, max);
+  const domains = [
+    ...new Set(
+      urls
+        .map((url) => {
+          try {
+            return new URL(url).hostname.replace(/^www\./, "");
+          } catch {
+            return null;
+          }
+        })
+        .filter((domain): domain is string => domain !== null),
+    ),
+  ].slice(0, max);
 
   if (domains.length === 0) return null;
 
@@ -233,15 +290,11 @@ function ToolFallbackFavicons({
       className={cn("aui-tool-fallback-favicons flex items-center", className)}
     >
       {domains.map((domain, i) => (
-        <img
+        <ToolFallbackFavicon
           key={domain}
-          src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
-          alt=""
-          role="presentation"
-          className={cn(
-            "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
-            i > 0 && "-ms-2",
-          )}
+          domain={domain}
+          faviconUrl={faviconUrl}
+          className={cn(i > 0 && "-ms-2")}
           style={{ zIndex: domains.length - i }}
         />
       ))}
@@ -274,11 +327,12 @@ function ToolFallbackTrigger({
   const preset = Object.hasOwn(TOOL_PRESETS, toolName)
     ? TOOL_PRESETS[toolName]
     : undefined;
-  const label = preset
-    ? isRunning
-      ? preset.running
-      : preset.done
-    : prettifyToolName(toolName);
+  const label =
+    preset && !isCancelled && !isFailed
+      ? isRunning
+        ? preset.running
+        : preset.done
+      : prettifyToolName(toolName);
 
   return (
     <CollapsibleTrigger
@@ -860,7 +914,9 @@ ToolFallback.Error = ToolFallbackError;
 ToolFallback.Approval = ToolFallbackApproval;
 
 export {
+  formatToolDuration,
   prettifyToolName,
+  toolRunningLabel,
   ToolFallback,
   ToolFallbackRoot,
   ToolFallbackTrigger,

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -92,6 +92,7 @@ function ToolFallbackRoot({
 }
 
 const prettifyToolName = (toolName: string) => {
+  if (!toolName) return "Tool";
   const words = toolName.replace(/[_-]+/g, " ").trim();
   return words.length === 0
     ? toolName
@@ -769,7 +770,9 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
 
   let prettyArgs = argsText;
   if (args && typeof args === "object" && Object.keys(args).length > 0) {
-    prettyArgs = JSON.stringify(args, null, 2);
+    try {
+      prettyArgs = JSON.stringify(args, null, 2);
+    } catch {}
   }
   const showArgs = prettyArgs !== undefined && prettyArgs !== "{}";
 

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -3,10 +3,9 @@
 import { memo, useCallback, useRef, useState } from "react";
 import {
   AlertCircleIcon,
-  CheckIcon,
   ChevronDownIcon,
-  LoaderIcon,
-  XCircleIcon,
+  GlobeIcon,
+  WrenchIcon,
 } from "lucide-react";
 import {
   useScrollLock,
@@ -71,7 +70,8 @@ function ToolFallbackRoot({
       open={isOpen}
       onOpenChange={handleOpenChange}
       className={cn(
-        "aui-tool-fallback-root group/tool-fallback-root w-full",
+        "aui-tool-fallback-root group/tool-fallback-root relative w-full",
+        "animate-in fade-in-0 slide-in-from-top-1 duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
         className,
       )}
       style={
@@ -82,25 +82,104 @@ function ToolFallbackRoot({
       {...props}
     >
       {children}
+      <div
+        aria-hidden
+        data-slot="tool-fallback-connector"
+        className="aui-tool-fallback-connector bg-border absolute start-[11.5px] top-[26px] -bottom-1.5 hidden w-px"
+      />
     </Collapsible>
   );
 }
 
-type ToolStatus = ToolCallMessagePartStatus["type"];
+const prettifyToolName = (toolName: string) => {
+  const words = toolName.replace(/[_-]+/g, " ").trim();
+  return words.length === 0
+    ? toolName
+    : words[0]!.toUpperCase() + words.slice(1);
+};
 
-const statusIconMap: Record<ToolStatus, React.ElementType> = {
-  running: LoaderIcon,
-  complete: CheckIcon,
-  incomplete: XCircleIcon,
-  "requires-action": AlertCircleIcon,
+const PREFERRED_ARG_KEYS = ["query", "path", "command", "code", "url", "file"];
+
+const primaryArg = (args: unknown, argsText: string | undefined) => {
+  if (args && typeof args === "object") {
+    const record: Record<string, unknown> = { ...args };
+    const candidates = [
+      ...PREFERRED_ARG_KEYS.map((key) => record[key]),
+      ...Object.values(record),
+    ];
+    for (const value of candidates) {
+      if (typeof value === "string" && value.length > 0) {
+        const [firstLine] = value.split("\n", 1);
+        return firstLine;
+      }
+    }
+  }
+  if (argsText && argsText !== "{}") return argsText;
+  return undefined;
+};
+
+/** Provider-executed searches carry the query in the output's `action`. */
+const outputQuery = (result: unknown) => {
+  if (result && typeof result === "object" && "action" in result) {
+    const action = result.action;
+    if (action && typeof action === "object") {
+      if (
+        "query" in action &&
+        typeof action.query === "string" &&
+        action.query.length > 0
+      ) {
+        return action.query;
+      }
+      if ("queries" in action && Array.isArray(action.queries)) {
+        const queries = action.queries.filter(
+          (q): q is string => typeof q === "string",
+        );
+        if (queries.length > 0) return queries.join(", ");
+      }
+    }
+  }
+  return undefined;
+};
+
+const collectResults = (result: unknown) => {
+  if (Array.isArray(result)) return result;
+  if (result && typeof result === "object") {
+    if ("results" in result && Array.isArray(result.results)) {
+      return result.results;
+    }
+    if ("sources" in result && Array.isArray(result.sources)) {
+      return result.sources;
+    }
+  }
+  return undefined;
+};
+
+type ToolPreset = {
+  /** Row label while the call is in flight, e.g. "Searching web". */
+  running: string;
+  /** Row label once the call settled, e.g. "Searched web". */
+  done: string;
+  icon: React.ReactNode;
+};
+
+const TOOL_PRESETS: Record<string, ToolPreset> = {
+  web_search: {
+    running: "Searching web",
+    done: "Searched web",
+    icon: <GlobeIcon />,
+  },
+  web_search_preview: {
+    running: "Searching web",
+    done: "Searched web",
+    icon: <GlobeIcon />,
+  },
 };
 
 const formatToolDuration = (ms: number) => {
-  if (ms < 1000) return "<1s";
-  const seconds = ms / 1000;
-  if (seconds < 10) return `${(Math.floor(seconds * 10) / 10).toFixed(1)}s`;
-  if (seconds < 60) return `${Math.floor(seconds)}s`;
-  return `${Math.floor(seconds / 60)}m ${Math.floor(seconds % 60)}s`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 1) return null;
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 };
 
 function ToolFallbackDuration({
@@ -109,6 +188,8 @@ function ToolFallbackDuration({
 }: React.ComponentProps<"span">) {
   const elapsedMs = useToolCallElapsed();
   if (elapsedMs === undefined) return null;
+  const duration = formatToolDuration(elapsedMs);
+  if (duration === null) return null;
 
   return (
     <span
@@ -119,7 +200,52 @@ function ToolFallbackDuration({
       )}
       {...props}
     >
-      {formatToolDuration(elapsedMs)}
+      {duration}
+    </span>
+  );
+}
+
+function ToolFallbackFavicons({
+  urls,
+  max = 3,
+  className,
+}: {
+  urls: readonly string[];
+  max?: number;
+  className?: string;
+}) {
+  const domains = urls
+    .map((url) => {
+      try {
+        return new URL(url).hostname;
+      } catch {
+        return null;
+      }
+    })
+    .filter((domain): domain is string => domain !== null)
+    .filter((domain, i, all) => all.indexOf(domain) === i)
+    .slice(0, max);
+
+  if (domains.length === 0) return null;
+
+  return (
+    <span
+      data-slot="tool-fallback-favicons"
+      className={cn("aui-tool-fallback-favicons flex items-center", className)}
+    >
+      {domains.map((domain, i) => (
+        <img
+          key={domain}
+          src={`https://www.google.com/s2/favicons?domain=${domain}&sz=64`}
+          alt=""
+          role="presentation"
+          className={cn(
+            "aui-tool-fallback-favicon bg-muted ring-background size-[18px] rounded-full ring-2",
+            i > 0 && "-ms-2",
+          )}
+          style={{ zIndex: domains.length - i }}
+        />
+      ))}
     </span>
   );
 }
@@ -127,67 +253,117 @@ function ToolFallbackDuration({
 function ToolFallbackTrigger({
   toolName,
   status,
+  detail,
+  icon,
+  meta,
+  expandable = true,
   className,
   ...props
 }: React.ComponentProps<typeof CollapsibleTrigger> & {
   toolName: string;
   status?: ToolCallMessagePartStatus;
+  detail?: React.ReactNode;
+  icon?: React.ReactNode;
+  meta?: React.ReactNode;
+  expandable?: boolean;
 }) {
   const statusType = status?.type ?? "complete";
   const isRunning = statusType === "running";
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
-
-  const Icon = statusIconMap[statusType];
-  const label = isCancelled ? "Cancelled tool" : "Used tool";
+  const isFailed = status?.type === "incomplete" && !isCancelled;
+  const preset = Object.hasOwn(TOOL_PRESETS, toolName)
+    ? TOOL_PRESETS[toolName]
+    : undefined;
+  const label = preset
+    ? isRunning
+      ? preset.running
+      : preset.done
+    : prettifyToolName(toolName);
 
   return (
     <CollapsibleTrigger
       data-slot="tool-fallback-trigger"
       className={cn(
-        "aui-tool-fallback-trigger group/trigger text-muted-foreground hover:text-foreground flex w-fit origin-left items-center gap-2 py-1.5 text-sm transition-[color,scale] active:scale-[0.98]",
+        "aui-tool-fallback-trigger group/trigger flex w-full items-start",
         className,
       )}
       {...props}
     >
-      <Icon
+      <span
         data-slot="tool-fallback-trigger-icon"
         className={cn(
-          "aui-tool-fallback-trigger-icon size-4 shrink-0",
-          isCancelled && "text-muted-foreground",
-          isRunning && "animate-spin [animation-duration:0.6s]",
-        )}
-      />
-      <span
-        data-slot="tool-fallback-trigger-label"
-        className={cn(
-          "aui-tool-fallback-trigger-label-wrapper relative inline-block text-start leading-none",
-          isCancelled && "text-muted-foreground line-through",
+          "aui-tool-fallback-trigger-icon relative flex h-8 w-6 shrink-0 items-center justify-center",
+          isFailed ? "text-destructive" : "text-muted-foreground",
         )}
       >
-        <span>
-          {label}: <b>{toolName}</b>
+        <span
+          className={cn(
+            "aui-tool-fallback-trigger-glyph flex items-center justify-center [&>svg]:size-4",
+            expandable &&
+              "transition-opacity group-hover/trigger:opacity-0 motion-reduce:transition-none",
+          )}
+        >
+          {icon ??
+            preset?.icon ??
+            (statusType === "requires-action" ? (
+              <AlertCircleIcon />
+            ) : (
+              <WrenchIcon />
+            ))}
         </span>
-        {isRunning && (
+        {expandable && (
           <span
-            aria-hidden
-            data-slot="tool-fallback-trigger-shimmer"
-            className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            data-slot="tool-fallback-trigger-chevron"
+            className="aui-tool-fallback-trigger-chevron absolute inset-0 flex items-center justify-center opacity-0 transition-opacity group-hover/trigger:opacity-100 motion-reduce:transition-none"
           >
-            {label}: <b>{toolName}</b>
+            <ChevronDownIcon
+              className={cn(
+                "size-4 transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+                "group-data-[state=closed]/trigger:-rotate-90",
+                "group-data-[state=open]/trigger:rotate-0",
+              )}
+            />
           </span>
         )}
       </span>
-      <ToolFallbackDuration />
-      <ChevronDownIcon
-        data-slot="tool-fallback-trigger-chevron"
-        className={cn(
-          "aui-tool-fallback-trigger-chevron size-4 shrink-0",
-          "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+      <span className="aui-tool-fallback-trigger-line flex min-h-8 min-w-0 flex-1 items-center gap-1.5 py-1 pe-2 text-start">
+        <span
+          data-slot="tool-fallback-trigger-label"
+          className={cn(
+            "aui-tool-fallback-trigger-label-wrapper relative shrink-0 text-sm leading-6 transition-colors motion-reduce:transition-none",
+            isFailed
+              ? "text-destructive"
+              : "text-muted-foreground group-hover/trigger:text-foreground",
+            isCancelled && "line-through",
+          )}
+        >
+          {label}
+          {isRunning && (
+            <span
+              aria-hidden
+              data-slot="tool-fallback-trigger-shimmer"
+              className="aui-tool-fallback-trigger-shimmer shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {label}
+            </span>
+          )}
+        </span>
+        {detail && (
+          <span
+            data-slot="tool-fallback-trigger-detail"
+            className="aui-tool-fallback-trigger-detail text-muted-foreground/70 min-w-0 truncate font-mono text-xs"
+          >
+            {detail}
+          </span>
         )}
-      />
+        <span
+          data-slot="tool-fallback-trigger-meta"
+          className="aui-tool-fallback-trigger-meta text-muted-foreground ms-auto flex shrink-0 items-center gap-2 ps-2 text-xs"
+        >
+          {meta ?? <ToolFallbackDuration />}
+        </span>
+      </span>
     </CollapsibleTrigger>
   );
 }
@@ -215,7 +391,7 @@ function ToolFallbackContent({
     >
       <div
         className={cn(
-          "flex flex-col gap-2 ps-6 pt-1 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
+          "flex flex-col gap-2 ps-6 pe-2 pt-0.5 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
           "group-data-[state=open]/collapsible-content:animate-in group-data-[state=open]/collapsible-content:fade-in-0 group-data-[state=open]/collapsible-content:blur-in-[2px] group-data-[state=open]/collapsible-content:slide-in-from-top-1",
           "group-data-[state=closed]/collapsible-content:animate-out group-data-[state=closed]/collapsible-content:fade-out-0 group-data-[state=closed]/collapsible-content:blur-out-[2px] group-data-[state=closed]/collapsible-content:slide-out-to-top-1",
           "group-data-[state=closed]/collapsible-content:duration-(--animation-duration) group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
@@ -234,7 +410,7 @@ function ToolFallbackArgs({
 }: React.ComponentProps<"div"> & {
   argsText?: string;
 }) {
-  if (!argsText) return null;
+  if (!argsText || argsText === "{}") return null;
 
   return (
     <div
@@ -242,7 +418,16 @@ function ToolFallbackArgs({
       className={cn("aui-tool-fallback-args", className)}
       {...props}
     >
-      <pre className="aui-tool-fallback-args-value bg-muted/50 text-foreground/90 rounded-md p-2.5 text-xs whitespace-pre-wrap">
+      <p className="aui-tool-fallback-args-header text-muted-foreground mb-1 text-xs font-medium">
+        Request
+      </p>
+      <pre
+        className="aui-tool-fallback-args-value bg-muted/50 text-foreground/90 max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap"
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {argsText}
       </pre>
     </div>
@@ -264,10 +449,16 @@ function ToolFallbackResult({
       className={cn("aui-tool-fallback-result", className)}
       {...props}
     >
-      <p className="aui-tool-fallback-result-header text-muted-foreground text-xs font-medium">
-        Result:
+      <p className="aui-tool-fallback-result-header text-muted-foreground mb-1 text-xs font-medium">
+        Response
       </p>
-      <pre className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 mt-1 rounded-md p-2.5 text-xs whitespace-pre-wrap">
+      <pre
+        className="aui-tool-fallback-result-content bg-muted/50 text-foreground/90 max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap"
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {typeof result === "string" ? result : JSON.stringify(result, null, 2)}
       </pre>
     </div>
@@ -276,24 +467,33 @@ function ToolFallbackResult({
 
 function ToolFallbackError({
   status,
+  result,
+  isError,
   className,
   ...props
 }: React.ComponentProps<"div"> & {
   status?: ToolCallMessagePartStatus;
+  result?: unknown;
+  isError?: boolean | undefined;
 }) {
-  if (status?.type !== "incomplete") return null;
-
-  const error = status.error;
-  const errorText = error
-    ? typeof error === "string"
-      ? error
-      : JSON.stringify(error)
-    : null;
+  const isCancelled =
+    status?.type === "incomplete" && status.reason === "cancelled";
+  const statusError = status?.type === "incomplete" ? status.error : undefined;
+  const raw = statusError
+    ? statusError
+    : isError === true && result !== undefined
+      ? result
+      : undefined;
+  const errorText =
+    raw === undefined
+      ? null
+      : typeof raw === "string"
+        ? raw
+        : JSON.stringify(raw, null, 2);
 
   if (!errorText) return null;
 
-  const isCancelled = status.reason === "cancelled";
-  const headerText = isCancelled ? "Cancelled reason:" : "Error:";
+  const headerText = isCancelled ? "Cancelled" : "Error";
 
   return (
     <div
@@ -301,12 +501,28 @@ function ToolFallbackError({
       className={cn("aui-tool-fallback-error", className)}
       {...props}
     >
-      <p className="aui-tool-fallback-error-header text-muted-foreground font-semibold">
+      <p
+        className={cn(
+          "aui-tool-fallback-error-header mb-1 text-xs font-medium",
+          isCancelled ? "text-muted-foreground" : "text-destructive",
+        )}
+      >
         {headerText}
       </p>
-      <p className="aui-tool-fallback-error-reason text-muted-foreground">
+      <pre
+        className={cn(
+          "aui-tool-fallback-error-reason max-h-64 overflow-auto rounded-md p-2.5 text-xs whitespace-pre-wrap",
+          isCancelled
+            ? "bg-muted/50 text-muted-foreground"
+            : "bg-destructive/5 text-destructive",
+        )}
+        style={{
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--border) transparent",
+        }}
+      >
         {errorText}
-      </p>
+      </pre>
     </div>
   );
 }
@@ -527,8 +743,10 @@ function ToolFallbackApproval({
 
 const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   toolName,
+  args,
   argsText,
   result,
+  isError,
   status,
   addResult,
   resume,
@@ -539,6 +757,7 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
   const isCancelled =
     status?.type === "incomplete" && status.reason === "cancelled";
   const isRequiresAction = status?.type === "requires-action";
+  const isRunning = status?.type === "running";
 
   const [open, setOpen] = useState(isRequiresAction);
   const [prevRequiresAction, setPrevRequiresAction] =
@@ -548,26 +767,72 @@ const ToolFallbackImpl: ToolCallMessagePartComponent = ({
     if (isRequiresAction) setOpen(true);
   }
 
+  let prettyArgs = argsText;
+  if (args && typeof args === "object" && Object.keys(args).length > 0) {
+    prettyArgs = JSON.stringify(args, null, 2);
+  }
+  const showArgs = prettyArgs !== undefined && prettyArgs !== "{}";
+
+  const results = isRunning ? undefined : collectResults(result);
+  const resultUrls =
+    results
+      ?.map((item: unknown) =>
+        item && typeof item === "object" && "url" in item
+          ? item.url
+          : undefined,
+      )
+      .filter((url): url is string => typeof url === "string") ?? [];
+
+  const hasError =
+    (status?.type === "incomplete" && Boolean(status.error)) ||
+    isError === true;
+  const expandable =
+    showArgs || hasError || result !== undefined || isRequiresAction;
+
   return (
-    <ToolFallbackRoot open={open} onOpenChange={setOpen}>
-      <ToolFallbackTrigger toolName={toolName} status={status} />
-      <ToolFallbackContent>
-        <ToolFallbackError status={status} />
-        <ToolFallbackArgs
-          argsText={argsText}
-          className={cn(isCancelled && "opacity-60")}
-        />
-        {isRequiresAction && (
-          <ToolFallbackApproval
-            addResult={addResult}
-            resume={resume}
-            interrupt={interrupt}
-            approval={approval}
-            respondToApproval={respondToApproval}
+    <ToolFallbackRoot open={expandable ? open : false} onOpenChange={setOpen}>
+      <ToolFallbackTrigger
+        toolName={toolName}
+        status={status}
+        detail={primaryArg(args, argsText) ?? outputQuery(result)}
+        expandable={expandable}
+        disabled={!expandable}
+        meta={
+          results ? (
+            <>
+              <span className="aui-tool-fallback-results whitespace-nowrap">
+                {results.length} {results.length === 1 ? "result" : "results"}
+              </span>
+              {resultUrls.length > 0 && (
+                <ToolFallbackFavicons urls={resultUrls} />
+              )}
+            </>
+          ) : undefined
+        }
+      />
+      {expandable && (
+        <ToolFallbackContent>
+          <ToolFallbackArgs
+            argsText={prettyArgs}
+            className={cn(isCancelled && "opacity-60")}
           />
-        )}
-        {!isCancelled && <ToolFallbackResult result={result} />}
-      </ToolFallbackContent>
+          <ToolFallbackError
+            status={status}
+            result={result}
+            isError={isError}
+          />
+          {isRequiresAction && (
+            <ToolFallbackApproval
+              addResult={addResult}
+              resume={resume}
+              interrupt={interrupt}
+              approval={approval}
+              respondToApproval={respondToApproval}
+            />
+          )}
+          {!isCancelled && !hasError && <ToolFallbackResult result={result} />}
+        </ToolFallbackContent>
+      )}
     </ToolFallbackRoot>
   );
 };
@@ -594,6 +859,7 @@ ToolFallback.Error = ToolFallbackError;
 ToolFallback.Approval = ToolFallbackApproval;
 
 export {
+  prettifyToolName,
   ToolFallback,
   ToolFallbackRoot,
   ToolFallbackTrigger,


### PR DESCRIPTION
## What

Reworks the assistant message trace in the shadcn/registry UI into a unified chain-of-thought "thinking steps" presentation:

- **thread.tsx** — groups reasoning, tool-call, and source parts into a collapsible chain-of-thought section with a step timeline and vertical connectors; sources render as a favicon row. `ToolGroup`/`ReasoningGroup` component overrides still dispatch through nested group keys when provided.
- **reasoning.tsx** — each reasoning part becomes a step: first paragraph is the headline, remaining paragraphs expand as a dotted thought timeline; auto-opens while streaming and collapses on completion (scroll-locked via `ReasoningRoot`'s `streaming` mode).
- **tool-fallback.tsx** — tool presets with running/done labels ("Searching web" → "Searched web"), globe/wrench icons, overlapping result favicons with counts, pretty-printed args, and cancelled/error states. Rendering is defensive: missing `toolName` falls back to "Tool", arg serialization never throws.
- **globals.css** (docs + 5 templates) — `working-dot` keyframe animation for the active-step indicator.
- **registry.ts** — thread now pulls in `sources.json` and ships the `working-dot` keyframes via `cssVars`/`css` so registry consumers get the animation.

## Why

Routine tool calls and reasoning are traces of what the model is doing, not standalone content. Folding them into a single chain-of-thought step list reads like the agent run it represents, instead of a flat stack of disconnected collapsibles.

## How

- Built on `MessagePrimitive.GroupedParts` + `groupPartByType` routing reasoning/tool-call/source into `group-chainOfThought`; `standalone-tool-call` parts stay ungrouped.
- `templates/minimal` `tool-fallback.tsx` copy kept byte-equal via `pnpm sync-templates`; minimal's `thread.tsx`/`markdown-text.tsx` remain declared OVERRIDES.
- No published npm package changes, so no changeset (packages/ui and templates are private).

## Screenshots

![Thinking-steps trace: chain-of-thought with reasoning steps, web-search tool calls with favicons and result counts, and an expanded tool response panel](https://gist.githubusercontent.com/ephraimduncan/9a8fa74d60b56aab5a098c5af227afe6/raw/thinking-steps-trace.png)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

