### PR TITLE
fix(docs): move star count after GitHub icon and add nav spacing

### DIFF
--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -154,15 +154,15 @@ export function Header() {
             href="https://github.com/assistant-ui/assistant-ui"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-muted-foreground hover:text-foreground hidden items-center gap-2.5 transition-colors sm:flex"
+            className="text-muted-foreground hover:text-foreground ml-2 hidden items-center gap-2.5 transition-colors sm:flex"
             aria-label="GitHub"
           >
+            <GitHubIcon className="size-4" />
             {stars !== null && (
               <span className="text-sm tabular-nums">
                 {formatCompact(stars)}
               </span>
             )}
-            <GitHubIcon className="size-4" />
           </a>
 
           {!isHome && (


### PR DESCRIPTION
## What

Two small fixes to the shared marketing header (`apps/docs/components/shared/header.tsx`):

1. The GitHub star count rendered *before* the GitHub icon (`11k` → octocat). Swapped so the icon comes first, then the count.
2. The right-side nav container uses `gap-1`, which made the GitHub link sit tight against the Cloud button. Added `ml-2` on the GitHub link for clear separation.

The mobile menu variant (icon-only, no count) is unchanged.

## Screenshots

### Home

**Before**

![before-home](https://raw.githubusercontent.com/assistant-ui/assistant-ui/docs-nav-assets/nav-before-home.png)

**After**

![after-home](https://raw.githubusercontent.com/assistant-ui/assistant-ui/docs-nav-assets/nav-after-home.png)

### Marketing pages

**Before**

![before-marketing](https://raw.githubusercontent.com/assistant-ui/assistant-ui/docs-nav-assets/nav-before-marketing.png)

**After**

![after-marketing](https://raw.githubusercontent.com/assistant-ui/assistant-ui/docs-nav-assets/nav-after-marketing.png)