### PR TITLE
fix(ui): adapt syntax highlighter to light and dark mode

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -263,11 +263,12 @@ export const registry: RegistryItem[] = [
         type: "registry:component",
         path: "components/assistant-ui/syntax-highlighter.tsx",
         sourcePath:
-          "../../packages/ui/src/components/assistant-ui/syntax-highlighter.ts",
+          "../../packages/ui/src/components/assistant-ui/syntax-highlighter.tsx",
       },
     ],
     dependencies: [
       "@assistant-ui/react-syntax-highlighter",
+      "@assistant-ui/react-markdown",
       "react-syntax-highlighter",
       "@types/react-syntax-highlighter",
     ],

--- a/packages/ui/src/components/assistant-ui/syntax-highlighter.ts
+++ b/packages/ui/src/components/assistant-ui/syntax-highlighter.ts
@@ -1,4 +1,4 @@
-import { createElement, Fragment } from "react";
+import { createElement, Fragment, type ComponentProps } from "react";
 import { PrismAsyncLight } from "react-syntax-highlighter";
 import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
 
@@ -34,7 +34,7 @@ const DarkSyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
   className: "hidden dark:block",
 });
 
-type SyntaxHighlighterProps = Parameters<typeof LightSyntaxHighlighter>[0];
+type SyntaxHighlighterProps = ComponentProps<typeof LightSyntaxHighlighter>;
 
 export const SyntaxHighlighter = (props: SyntaxHighlighterProps) =>
   createElement(

--- a/packages/ui/src/components/assistant-ui/syntax-highlighter.ts
+++ b/packages/ui/src/components/assistant-ui/syntax-highlighter.ts
@@ -1,24 +1,45 @@
+import { createElement, Fragment } from "react";
 import { PrismAsyncLight } from "react-syntax-highlighter";
 import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
 
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
 
-import { coldarkDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import {
+  coldarkCold,
+  coldarkDark,
+} from "react-syntax-highlighter/dist/cjs/styles/prism";
 
-// register languages you want to support
 PrismAsyncLight.registerLanguage("js", tsx);
 PrismAsyncLight.registerLanguage("jsx", tsx);
 PrismAsyncLight.registerLanguage("ts", tsx);
 PrismAsyncLight.registerLanguage("tsx", tsx);
 PrismAsyncLight.registerLanguage("python", python);
 
-export const SyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
-  style: coldarkDark,
-  customStyle: {
-    margin: 0,
-    width: "100%",
-    background: "black",
-    padding: "1.5rem 1rem",
-  },
+const syntaxHighlighterCustomStyle = {
+  margin: 0,
+  width: "100%",
+  padding: "1.5rem 1rem",
+};
+
+const LightSyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
+  style: coldarkCold,
+  customStyle: syntaxHighlighterCustomStyle,
+  className: "dark:hidden",
 });
+
+const DarkSyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
+  style: coldarkDark,
+  customStyle: syntaxHighlighterCustomStyle,
+  className: "hidden dark:block",
+});
+
+type SyntaxHighlighterProps = Parameters<typeof LightSyntaxHighlighter>[0];
+
+export const SyntaxHighlighter = (props: SyntaxHighlighterProps) =>
+  createElement(
+    Fragment,
+    null,
+    createElement(LightSyntaxHighlighter, props),
+    createElement(DarkSyntaxHighlighter, props),
+  );

--- a/packages/ui/src/components/assistant-ui/syntax-highlighter.tsx
+++ b/packages/ui/src/components/assistant-ui/syntax-highlighter.tsx
@@ -1,6 +1,6 @@
-import { createElement, Fragment, type ComponentProps } from "react";
 import { PrismAsyncLight } from "react-syntax-highlighter";
 import { makePrismAsyncLightSyntaxHighlighter } from "@assistant-ui/react-syntax-highlighter";
+import type { SyntaxHighlighterProps } from "@assistant-ui/react-markdown";
 
 import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
 import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
@@ -34,12 +34,9 @@ const DarkSyntaxHighlighter = makePrismAsyncLightSyntaxHighlighter({
   className: "hidden dark:block",
 });
 
-type SyntaxHighlighterProps = ComponentProps<typeof LightSyntaxHighlighter>;
-
-export const SyntaxHighlighter = (props: SyntaxHighlighterProps) =>
-  createElement(
-    Fragment,
-    null,
-    createElement(LightSyntaxHighlighter, props),
-    createElement(DarkSyntaxHighlighter, props),
-  );
+export const SyntaxHighlighter = (props: SyntaxHighlighterProps) => (
+  <>
+    <LightSyntaxHighlighter {...props} />
+    <DarkSyntaxHighlighter {...props} />
+  </>
+);


### PR DESCRIPTION
## What
The registry `syntax-highlighter` component hard-wired the `coldarkDark` prism theme and `background: "black"`, rendering a black box with dark tokens in light-mode apps.

## Why
Light-mode apps get a visibly broken code block surface.

## How
The factory config in `@assistant-ui/react-syntax-highlighter` is static, so the component now creates two configured highlighters — `coldarkCold` with `dark:hidden` and `coldarkDark` with `hidden dark:block` — and renders both; CSS `.dark` selects the visible one. This is SSR-safe with no hydration mismatch and no first-paint theme flicker. The hard-coded black background is removed; the prism theme owns the surface (`#e3eaf2` light / `#111b27` dark).

Trade-off: duplicate hidden code-block DOM per block, chosen over a `MutationObserver`/`useSyncExternalStore` theme hook to keep the file free of client theme state and hydration risk.

## Verification
- `pnpm --filter @assistant-ui/ui exec tsc --noEmit`, `oxlint`, `oxfmt --check` green on the touched file.
- SSR + hydration harness: zero hydration errors in both modes; DOM asserts visible/hidden children, theme backgrounds, and preserved `margin/width/padding` inline styles; screenshots checked in both modes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

