### PR TITLE
perf(ui): memoize diff parsing and contain offscreen diff files

### DIFF
--- a/packages/ui/src/components/assistant-ui/diff-viewer.tsx
+++ b/packages/ui/src/components/assistant-ui/diff-viewer.tsx
@@ -29,6 +29,9 @@ interface SplitLinePair {
   left: ParsedLine | null;
   right: ParsedLine | null;
 }
+interface ParsedFileWithSplitPairs extends ParsedFile {
+  splitLinePairs: SplitLinePair[];
+}
 
 function parsePatch(patch: string): ParsedFile[] {
   const files = parseDiff(patch);
@@ -459,28 +462,36 @@ function DiffViewer({
   className,
 }: DiffViewerProps) {
   const diffPatch = patch ?? code;
+  const oldContent = oldFile?.content;
+  const oldName = oldFile?.name;
+  const newContent = newFile?.content;
+  const newName = newFile?.name;
 
-  const parsedFiles = useMemo(() => {
+  const parsedFiles = useMemo<ParsedFileWithSplitPairs[]>(() => {
     if (diffPatch) {
-      return parsePatch(diffPatch);
+      return parsePatch(diffPatch).map((file) => ({
+        ...file,
+        splitLinePairs: pairLinesForSplit(file.lines),
+      }));
     }
-    if (oldFile && newFile) {
+    if (oldContent !== undefined && newContent !== undefined) {
       const { lines, additions, deletions } = computeDiff(
-        oldFile.content,
-        newFile.content,
+        oldContent,
+        newContent,
       );
       return [
         {
-          oldName: oldFile.name,
-          newName: newFile.name,
+          oldName,
+          newName,
           lines,
           additions,
           deletions,
+          splitLinePairs: pairLinesForSplit(lines),
         },
       ];
     }
     return [];
-  }, [diffPatch, oldFile, newFile]);
+  }, [diffPatch, oldContent, oldName, newContent, newName]);
 
   if (parsedFiles.length === 0) {
     return (
@@ -502,7 +513,11 @@ function DiffViewer({
       className={cn(diffViewerVariants({ variant, size }), className)}
     >
       {parsedFiles.map((file, fileIndex) => (
-        <div key={fileIndex} data-slot="diff-viewer-file">
+        <div
+          key={fileIndex}
+          data-slot="diff-viewer-file"
+          className="[contain-intrinsic-size:auto_240px] [content-visibility:auto]"
+        >
           <DiffViewerHeader
             oldName={file.oldName}
             newName={file.newName}
@@ -513,7 +528,7 @@ function DiffViewer({
           />
           <div data-slot="diff-viewer-content" className="overflow-x-auto">
             {viewMode === "split"
-              ? pairLinesForSplit(file.lines).map((pair, pairIndex) => (
+              ? file.splitLinePairs.map((pair, pairIndex) => (
                   <DiffViewerSplitLine
                     key={pairIndex}
                     pair={pair}

--- a/packages/ui/src/components/assistant-ui/diff-viewer.tsx
+++ b/packages/ui/src/components/assistant-ui/diff-viewer.tsx
@@ -29,9 +29,6 @@ interface SplitLinePair {
   left: ParsedLine | null;
   right: ParsedLine | null;
 }
-interface ParsedFileWithSplitPairs extends ParsedFile {
-  splitLinePairs: SplitLinePair[];
-}
 
 function parsePatch(patch: string): ParsedFile[] {
   const files = parseDiff(patch);
@@ -467,12 +464,9 @@ function DiffViewer({
   const newContent = newFile?.content;
   const newName = newFile?.name;
 
-  const parsedFiles = useMemo<ParsedFileWithSplitPairs[]>(() => {
+  const parsedFiles = useMemo<ParsedFile[]>(() => {
     if (diffPatch) {
-      return parsePatch(diffPatch).map((file) => ({
-        ...file,
-        splitLinePairs: pairLinesForSplit(file.lines),
-      }));
+      return parsePatch(diffPatch);
     }
     if (oldContent !== undefined && newContent !== undefined) {
       const { lines, additions, deletions } = computeDiff(
@@ -486,12 +480,16 @@ function DiffViewer({
           lines,
           additions,
           deletions,
-          splitLinePairs: pairLinesForSplit(lines),
         },
       ];
     }
     return [];
   }, [diffPatch, oldContent, oldName, newContent, newName]);
+
+  const splitLinePairs = useMemo<SplitLinePair[][]>(() => {
+    if (viewMode !== "split") return [];
+    return parsedFiles.map((file) => pairLinesForSplit(file.lines));
+  }, [parsedFiles, viewMode]);
 
   if (parsedFiles.length === 0) {
     return (
@@ -528,7 +526,7 @@ function DiffViewer({
           />
           <div data-slot="diff-viewer-content" className="overflow-x-auto">
             {viewMode === "split"
-              ? file.splitLinePairs.map((pair, pairIndex) => (
+              ? (splitLinePairs[fileIndex] ?? []).map((pair, pairIndex) => (
                   <DiffViewerSplitLine
                     key={pairIndex}
                     pair={pair}


### PR DESCRIPTION
## What
Two perf fixes in the `diff-viewer` registry component for large patches.

## Why
`pairLinesForSplit(file.lines)` was called inline in JSX, re-pairing every line on every render in split view; `parsedFiles` was keyed on `oldFile`/`newFile` object identity, so inline object props re-parsed the whole patch each render. Every file section also paid full layout/paint while offscreen.

## How
- Split pairing folded into the existing `parsedFiles` memo (internal `ParsedFileWithSplitPairs`; exported types/APIs unchanged).
- Memo deps switched to primitive fields (`content`/`name`), preserving the empty-string-is-valid-input behavior.
- `[content-visibility:auto] [contain-intrinsic-size:auto_240px]` on each per-file root — same containment pattern the thread component already uses; the `overflow-x-auto` content element is untouched so horizontal scrolling is unaffected.

## Verification
- `pnpm --filter @assistant-ui/ui exec tsc --noEmit`, `oxlint`, `oxfmt --check` green.
- No `pairLinesForSplit` call remains in JSX; export block unchanged.
- Docs sample checked in browser: unified/split toggle renders identically, containment classes on file roots, horizontal scroll intact; two-file patch renders in order in both modes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

