### PR TITLE
fix(ui): scope badge hover styles to interactive anchors

### DIFF
--- a/packages/ui/src/components/assistant-ui/badge.tsx
+++ b/packages/ui/src/components/assistant-ui/badge.tsx
@@ -11,20 +11,20 @@ const badgeVariants = cva(
     variants: {
       variant: {
         outline:
-          "border-input text-muted-foreground hover:bg-accent hover:text-accent-foreground border bg-transparent",
+          "border-input text-muted-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground border bg-transparent",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/80",
         muted:
-          "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground",
+          "bg-muted text-muted-foreground [a&]:hover:bg-muted/80 [a&]:hover:text-foreground",
         ghost:
-          "text-muted-foreground hover:bg-accent hover:text-accent-foreground bg-transparent",
-        info: "bg-blue-100 text-blue-700 hover:bg-blue-100/80 dark:bg-blue-900/50 dark:text-blue-300",
+          "text-muted-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground bg-transparent",
+        info: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 [a&]:hover:bg-blue-100/80",
         warning:
-          "bg-amber-100 text-amber-700 hover:bg-amber-100/80 dark:bg-amber-900/50 dark:text-amber-300",
+          "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300 [a&]:hover:bg-amber-100/80",
         success:
-          "bg-emerald-100 text-emerald-700 hover:bg-emerald-100/80 dark:bg-emerald-900/50 dark:text-emerald-300",
+          "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300 [a&]:hover:bg-emerald-100/80",
         destructive:
-          "bg-red-100 text-red-700 hover:bg-red-100/80 dark:bg-red-900/50 dark:text-red-300",
+          "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300 [a&]:hover:bg-red-100/80",
       },
       size: {
         sm: "px-1.5 py-0.5",


### PR DESCRIPTION
## What
Every variant of the assistant-ui `Badge` carried unscoped `hover:` styles on a plain `<span>`, signaling interactivity where none exists.

## How
Each `hover:*` token in `badgeVariants` is now `[a&]:hover:*`, matching the convention already used in `packages/ui/src/components/ui/badge.tsx` and upstream shadcn/ui: hover feedback applies only when the badge renders as an anchor (e.g. `asChild` links, as in `sources.tsx`). Resting states, variants, sizes, and API are unchanged.

## Verification
- `pnpm --filter @assistant-ui/ui exec tsc --noEmit` green.
- Grep: no unscoped `hover:` tokens remain in either badge file.
- Browser check: static badges show no hover response; anchor badges keep their hover feedback.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

