### PR TITLE
fix(ui): harden markdown external links and wrap long urls

### DIFF
--- a/apps/docs/components/assistant-ui/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/markdown-text.tsx
@@ -142,15 +142,27 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, target, rel, ...props }) => {
+    const relTokens = rel?.split(/\s+/).filter(Boolean) ?? [];
+    const mergedRel =
+      target === "_blank"
+        ? Array.from(new Set([...relTokens, "noopener", "noreferrer"])).join(
+            " ",
+          )
+        : rel;
+
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 [overflow-wrap:anywhere] underline underline-offset-2",
+          className,
+        )}
+        {...props}
+        target={target}
+        rel={mergedRel}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -140,15 +140,27 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, target, rel, ...props }) => {
+    const relTokens = rel?.split(/\s+/).filter(Boolean) ?? [];
+    const mergedRel =
+      target === "_blank"
+        ? Array.from(new Set([...relTokens, "noopener", "noreferrer"])).join(
+            " ",
+          )
+        : rel;
+
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 [overflow-wrap:anywhere] underline underline-offset-2",
+          className,
+        )}
+        {...props}
+        target={target}
+        rel={mergedRel}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/scripts/sync-templates.sh
+++ b/scripts/sync-templates.sh
@@ -27,9 +27,6 @@ OVERRIDES=(
     # minimal intentionally ships a slim thread.tsx without GroupedParts /
     # reasoning / tool-group, since it doesn't bundle those companion files.
     "thread.tsx"
-    # minimal ships without react-shiki, so its markdown-text.tsx omits the
-    # SyntaxHighlighter wiring.
-    "markdown-text.tsx"
 )
 
 MODE="${1:-check}"

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -140,15 +140,27 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, target, rel, ...props }) => {
+    const relTokens = rel?.split(/\s+/).filter(Boolean) ?? [];
+    const mergedRel =
+      target === "_blank"
+        ? Array.from(new Set([...relTokens, "noopener", "noreferrer"])).join(
+            " ",
+          )
+        : rel;
+
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 [overflow-wrap:anywhere] underline underline-offset-2",
+          className,
+        )}
+        {...props}
+        target={target}
+        rel={mergedRel}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(


### PR DESCRIPTION
## What
Two fixes to the markdown `a` renderer, applied to the canonical `packages/ui` component, the minimal template copy, and the docs-app fork.

## Why
- When a consumer sets `target="_blank"` (via components config), nothing forced `rel="noopener noreferrer"` — reverse-tabnabbing exposure on untrusted markdown links.
- Long unbroken URLs overflowed the message bubble.

## How
- The renderer destructures `target`/`rel` and, when `target === "_blank"`, merges `noopener` and `noreferrer` into the consumer's rel tokens (order and spelling preserved, e.g. `nofollow` survives). The merged rel is applied after the prop spread so it cannot be clobbered. No target: rel passes through untouched.
- `[overflow-wrap:anywhere]` added to the anchor class for URL-safe wrapping.
- `scripts/sync-templates.sh`: removed the stale `markdown-text.tsx` OVERRIDES entry (the files were already byte-equal), so template sync now enforces this file's parity.

## Verification
- `pnpm sync-templates` green with byte-equal minimal copy (`cmp` exit 0); `pnpm lint` and `tsc --noEmit` green for ui and docs.
- Rendered checks: `_blank` + no rel → `noopener noreferrer`; `_blank` + `nofollow` → all three tokens; no target → no forced rel; 240-char URL wraps inside a 256px container.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

