### PR TITLE
fix(api-surface): stabilize top-level declaration order

### DIFF
--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -1,49 +1,22 @@
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
-
-type McpSamplingHandler = (request: McpSamplingRequest) => Promise<McpSamplingResponse>;
-
-type McpSamplingRequest = {
-  method: "sampling/createMessage";
-  params: {
-    messages: unknown[];
-    modelPreferences?: {
-      hints?: {
-        name?: string;
-      }[];
-    };
-    maxTokens?: number;
-    [key: string]: unknown;
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
   };
-};
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
 
-type McpSamplingResponse = {
-  model?: string;
-  content: unknown;
-  usage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    promptTokens?: number;
-    completionTokens?: number;
-    reasoningTokens?: number;
-    cachedInputTokens?: number;
-  };
-  [key: string]: unknown;
-};
-
-declare function wrapSamplingHandler(handler: McpSamplingHandler, onSamplingCall: (data: SamplingCallData) => void): McpSamplingHandler;
-
-declare function createSamplingCollector(): {
-  collect: (data: SamplingCallData) => number;
-  getCalls: () => SamplingCallData[];
-  reset: () => void;
-};
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
 
 type AssistantCloudAuthStrategy = {
   readonly strategy: "anon" | "api-key" | "jwt";
@@ -51,9 +24,14 @@ type AssistantCloudAuthStrategy = {
   readAuthHeaders(headers: Headers): void;
 };
 
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
 };
 
 type AssistantCloudConfig = ({
@@ -71,75 +49,145 @@ type AssistantCloudConfig = ({
   telemetry?: boolean | AssistantCloudTelemetryConfig;
 };
 
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
 }
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
 };
 
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
 };
 
-type PartInit = {
-  readonly type: "reasoning" | "text";
-  readonly parentId?: string;
-} | {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: ReadonlyJSONValue;
-  readonly parentId?: string;
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
 };
 
 type AssistantStreamChunk = {
@@ -193,80 +241,9 @@ type AssistantStreamChunk = {
   readonly operations: ObjectStreamOperation[];
 });
 
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
   headers?: Headers;
 };
-
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-};
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
 
 type CloudMessage = {
   id: string;
@@ -278,51 +255,17 @@ type CloudMessage = {
   content: ReadonlyJSONObject;
 };
 
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
+declare class CloudMessagePersistence {
   private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+  private idMapping;
+  constructor(cloud: AssistantCloud);
+  append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;
+  update(threadId: string, messageId: string, _format: string, content: ReadonlyJSONObject): Promise<void>;
+  isPersisted(messageId: string): boolean;
+  getRemoteId(messageId: string): Promise<string | undefined>;
+  load(threadId: string, format?: string): Promise<CloudMessage[]>;
+  reset(): void;
 }
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
 
 type CloudThread = {
   title: string;
@@ -337,50 +280,6 @@ type CloudThread = {
   is_archived: boolean;
 };
 
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
 type GeneratePresignedUploadUrlRequestBody = {
   filename: string;
 };
@@ -392,35 +291,42 @@ type GeneratePresignedUploadUrlResponse = {
   publicUrl: string;
 };
 
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
+};
 
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
+type McpSamplingHandler = (request: McpSamplingRequest) => Promise<McpSamplingResponse>;
+
+type McpSamplingRequest = {
+  method: "sampling/createMessage";
+  params: {
+    messages: unknown[];
+    modelPreferences?: {
+      hints?: {
+        name?: string;
+      }[];
+    };
+    maxTokens?: number;
+    [key: string]: unknown;
   };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
+};
 
-declare class CloudMessagePersistence {
-  private cloud;
-  private idMapping;
-  constructor(cloud: AssistantCloud);
-  append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;
-  update(threadId: string, messageId: string, _format: string, content: ReadonlyJSONObject): Promise<void>;
-  isPersisted(messageId: string): boolean;
-  getRemoteId(messageId: string): Promise<string | undefined>;
-  load(threadId: string, format?: string): Promise<CloudMessage[]>;
-  reset(): void;
-}
+type McpSamplingResponse = {
+  model?: string;
+  content: unknown;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    promptTokens?: number;
+    completionTokens?: number;
+    reasoningTokens?: number;
+    cachedInputTokens?: number;
+  };
+  [key: string]: unknown;
+};
 
 type MessageFormatAdapter<TMessage, TStorageFormat> = {
   format: string;
@@ -438,6 +344,92 @@ type MessageFormatAdapter<TMessage, TStorageFormat> = {
     message: TMessage;
   };
   getId(message: TMessage): string;
+};
+
+type ObjectStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
+type PartInit = {
+  readonly type: "reasoning" | "text";
+  readonly parentId?: string;
+} | {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: ReadonlyJSONValue;
+  readonly parentId?: string;
+};
+
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
 };
 
 declare const createFormattedPersistence: <TMessage, TStorageFormat>(persistence: {
@@ -463,8 +455,16 @@ declare const createFormattedPersistence: <TMessage, TStorageFormat>(persistence
   isPersisted: (messageId: string) => boolean;
 };
 
+declare function createSamplingCollector(): {
+  collect: (data: SamplingCallData) => number;
+  getCalls: () => SamplingCallData[];
+  reset: () => void;
+};
+
 declare namespace entry_root_exports {
   export { AssistantCloud, AssistantCloudRunReport, AssistantCloudTelemetryConfig, CloudMessage, CloudMessagePersistence, McpSamplingHandler, MessageFormatAdapter, SamplingCallData, createFormattedPersistence, createSamplingCollector, wrapSamplingHandler };
 }
+
+declare function wrapSamplingHandler(handler: McpSamplingHandler, onSamplingCall: (data: SamplingCallData) => void): McpSamplingHandler;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -1,126 +1,447 @@
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
+import Deque from "denque";
+
+import { SrvRecord } from "dns";
+
 import { EventEmitter } from "events";
 
 import { IpcNetConnectOpts, Socket, TcpNetConnectOpts } from "net";
 
-import { ConnectionOptions, TLSSocket } from "tls";
-
 import { Readable, ReadableOptions } from "stream";
 
-import { SrvRecord } from "dns";
+import { ConnectionOptions, TLSSocket } from "tls";
 
-import Deque from "denque";
-
-import { StandardSchemaV1 } from "@standard-schema/spec";
-
-type ResumableStreamRole = "consumer" | "producer";
-
-type ResumableStreamStatus = "done" | "error" | "missing" | "streaming";
-
-type ResumableStreamEntry = {
-  readonly cursor: string;
-  readonly chunk: Uint8Array;
-};
-
-type ResumableStreamAcquireOptions = {
-  readonly ttlMs?: number;
-};
-
-interface ResumableStreamStore {
-  acquire(streamId: string, options?: ResumableStreamAcquireOptions): Promise<ResumableStreamRole>;
-  append(streamId: string, chunk: Uint8Array): Promise<void>;
-  finalize(streamId: string, status: "done" | "error", error?: string): Promise<void>;
-  read(streamId: string, cursor: string, signal: AbortSignal): AsyncIterable<ResumableStreamEntry>;
-  status(streamId: string): Promise<ResumableStreamStatus>;
-  delete(streamId: string): Promise<void>;
+declare abstract class AbstractConnector {
+  firstError?: Error;
+  protected connecting: boolean;
+  protected stream: NetStream;
+  private disconnectTimeout;
+  constructor(disconnectTimeout: number);
+  check(info: any): boolean;
+  disconnect(): void;
+  abstract connect(_: ErrorEmitter): Promise<NetStream>;
 }
 
-type PipelineCommand = {
-  readonly type: "xAdd";
-  readonly key: string;
-  readonly fields: Record<string, string | Uint8Array>;
-} | {
-  readonly type: "expire";
-  readonly key: string;
-  readonly ttlSec: number;
-} | {
-  readonly type: "set";
-  readonly key: string;
-  readonly value: string;
-  readonly ttlSec: number;
-};
+declare type AddSet = CommandNameFlags["ENTER_SUBSCRIBER_MODE"][number];
 
-interface RedisLikeClient {
-  setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
-  set(key: string, value: string, ttlSec: number): Promise<void>;
-  get(key: string): Promise<string | null>;
-  expire(key: string, ttlSec: number): Promise<void>;
-  exists(key: string): Promise<boolean>;
-  del(keys: string[]): Promise<void>;
-  xAdd(key: string, fields: Record<string, string | Uint8Array>): Promise<string>;
-  xRange(key: string, start: string, end: string): Promise<Array<{
-    id: string;
-    fields: Record<string, string | Uint8Array>;
-  }>>;
-  pipeline(commands: readonly PipelineCommand[]): Promise<void>;
+interface AddressFromResponse {
+  port: string;
+  ip: string;
+  flags?: string | undefined;
 }
 
-type RedisResumableStreamStoreOptions = {
-  readonly keyPrefix?: string;
-  readonly defaultTtlMs?: number;
-  readonly pollIntervalMs?: number;
-  readonly maxChunkBytes?: number;
+declare type ArgumentTransformer = (args: any[]) => any[];
+
+declare type ArgumentType = string | Buffer | number | (string | Buffer | number | any[])[];
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantMessage = {
+  role: "assistant";
+  status: AssistantMessageStatus;
+  parts: AssistantMessagePart[];
+  content: AssistantMessagePart[];
+  metadata: {
+    unstable_state: ReadonlyJSONValue;
+    unstable_data: ReadonlyJSONValue[];
+    unstable_annotations: ReadonlyJSONValue[];
+    steps: AssistantMessageStepMetadata[];
+    custom: Record<string, unknown>;
+    timing?: AssistantMessageTiming;
+  };
 };
+
+declare class AssistantMessageAccumulator extends TransformStream<AssistantStreamChunk, AssistantMessage> {
+  constructor(_param0?: {
+    initialMessage?: AssistantMessage;
+    throttle?: boolean;
+    onError?: (error: string) => void;
+  });
+}
+
+type AssistantMessagePart = TextPart | ReasoningPart | ToolCallPart | SourcePart | FilePart | DataPart;
+
+type AssistantMessageStatus = {
+  type: "running";
+} | {
+  type: "requires-action";
+  reason: "tool-calls";
+} | {
+  type: "complete";
+  reason: "stop" | "unknown";
+} | {
+  type: "incomplete";
+  reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  error?: ReadonlyJSONValue;
+};
+
+type AssistantMessageStepMetadata = {
+  state: "started";
+  messageId: string;
+} | {
+  state: "finished";
+  messageId: string;
+  finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  usage?: AssistantMessageStepUsage;
+  isContinued: boolean;
+};
+
+type AssistantMessageStepUsage = {
+  inputTokens: number;
+  outputTokens: number;
+};
+
+declare class AssistantMessageStream {
+  readonly readable: ReadableStream<AssistantMessage>;
+  constructor(readable: ReadableStream<AssistantMessage>);
+  static fromAssistantStream(stream: AssistantStream): AssistantMessageStream;
+  unstable_result(): Promise<AssistantMessage>;
+  [Symbol.asyncIterator](): {
+    next(): Promise<IteratorResult<AssistantMessage, undefined>>;
+  };
+  tee(): [
+    AssistantMessageStream,
+    AssistantMessageStream
+  ];
+}
+
+type AssistantMessageTiming = {
+  streamStartTime: number;
+  firstTokenTime?: number;
+  totalStreamTime?: number;
+  tokenCount?: number;
+  tokensPerSecond?: number;
+  totalChunks: number;
+  toolCallCount: number;
+};
+
+type AssistantMetaStreamChunk = (AssistantStreamChunk & {
+  type: "part-finish" | "text-delta";
+  meta: PartInit;
+}) | (AssistantStreamChunk & {
+  type: "result" | "tool-call-args-text-finish";
+  meta: PartInit & {
+    type: "tool-call";
+  };
+}) | (AssistantStreamChunk & {
+  type: Exclude<AssistantStreamChunk["type"], "part-finish" | "result" | "text-delta" | "tool-call-args-text-finish">;
+});
+
+declare class AssistantMetaTransformStream extends TransformStream<AssistantStreamChunk, AssistantMetaStreamChunk> {
+  constructor();
+}
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamController = {
+  appendText(textDelta: string): void;
+  appendReasoning(reasoningDelta: string): void;
+  appendSource(options: SourcePart): void;
+  appendFile(options: FilePart): void;
+  appendData(options: DataPart): void;
+  addTextPart(): TextStreamController;
+  addToolCallPart(options: string): ToolCallStreamController;
+  addToolCallPart(options: ToolCallPartInit): ToolCallStreamController;
+  enqueue(chunk: AssistantStreamChunk): void;
+  merge(stream: AssistantStream): void;
+  close(): void;
+  withParentId(parentId: string): AssistantStreamController;
+};
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+declare class AssistantTransformStream<I> extends TransformStream<I, AssistantStreamChunk> {
+  constructor(transformer: AssistantTransformer<I>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<AssistantStreamChunk>);
+}
+
+type AssistantTransformer<I> = {
+  flush?: AssistantTransformerFlushCallback;
+  start?: AssistantTransformerStartCallback;
+  transform?: AssistantTransformerTransformCallback<I>;
+};
+
+type AssistantTransformerFlushCallback = (controller: AssistantStreamController) => void | PromiseLike<void>;
+
+type AssistantTransformerStartCallback = (controller: AssistantStreamController) => void | PromiseLike<void>;
+
+type AssistantTransformerTransformCallback<I> = (chunk: I, controller: AssistantStreamController) => void | PromiseLike<void>;
+
+declare class AssistantTransportDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
+  constructor();
+}
+
+declare class AssistantTransportEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
+  headers: Headers;
+  constructor();
+}
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type AttachmentLike = {
+  content: readonly MessagePartLike[];
+};
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: string | undefined;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+interface BatchOperationContext {
+  batchMode: "MULTI";
+  batchSize: number;
+  database: number;
+  serverAddress: string;
+  serverPort: number | undefined;
+}
 
 declare type Callback<T = any> = (err?: Error | null, result?: T) => void;
 
-declare type NetStream = Socket | TLSSocket;
-
-declare type CommandParameter = string | Buffer | number | any[];
-
-interface Respondable {
-  name: string;
-  args: CommandParameter[];
-  resolve(result: any): void;
-  reject(error: Error): void;
+interface ChainableCommander extends RedisCommander<{
+  type: "pipeline";
+}> {
+  length: number;
 }
 
-interface PipelineWriteableStream {
-  isPipeline: true;
-  write(data: string | Buffer): unknown;
-  destination: {
-    redis: {
-      stream: NetStream;
-    };
+declare type ClientContext = {
+  type: keyof ResultTypes<unknown, unknown>;
+};
+
+declare class Cluster extends Commander {
+  options: ClusterOptions;
+  slots: NodeKey[][];
+  status: ClusterStatus;
+  _groupsIds: {
+    [key: string]: number;
   };
+  _groupsBySlot: number[];
+  isCluster: boolean;
+  private startupNodes;
+  private connectionPool;
+  private manuallyClosing;
+  private retryAttempts;
+  private delayQueue;
+  private offlineQueue;
+  private subscriber;
+  private shardedSubscribers;
+  private slotsTimer;
+  private reconnectTimeout;
+  private isRefreshing;
+  private _refreshSlotsCacheCallbacks;
+  private _autoPipelines;
+  private _runningAutoPipelines;
+  private _readyDelayedCallbacks;
+  private subscriberGroupEmitter;
+  private connectionEpoch;
+  constructor(startupNodes: ClusterNode[], options?: ClusterOptions);
+  connect(): Promise<void>;
+  disconnect(reconnect?: boolean): void;
+  quit(callback?: Callback<"OK">): Promise<"OK">;
+  duplicate(overrideStartupNodes?: any[], overrideOptions?: {}): Cluster;
+  nodes(role?: NodeRole): Redis[];
+  delayUntilReady(callback: Callback): void;
+  get autoPipelineQueueSize(): number;
+  refreshSlotsCache(callback?: Callback<void>): void;
+  sendCommand(command: Command, stream?: WriteableStream, node?: any): unknown;
+  sscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  sscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  hscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  hscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  zscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  zscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  handleError(error: Error, ttl: {
+    value?: any;
+  }, handlers: any): void;
+  private resetOfflineQueue;
+  private clearNodesRefreshInterval;
+  private resetNodesRefreshInterval;
+  private setStatus;
+  private handleCloseEvent;
+  private flushQueue;
+  private executeOfflineCommands;
+  private natMapper;
+  private getInfoFromNode;
+  private invokeReadyDelayedCallbacks;
+  private readyCheck;
+  private resolveSrv;
+  private dnsLookup;
+  private resolveStartupNodeHostnames;
+  private createScanStream;
+  private createShardedSubscriberGroup;
 }
 
-declare type WriteableStream = NetStream | PipelineWriteableStream;
+interface Cluster extends EventEmitter {
+}
+
+interface Cluster extends Transaction {
+}
+
+declare type ClusterNode = string | number | {
+  host?: string | undefined;
+  port?: number | undefined;
+};
+
+declare type ClusterNodeRetryStrategy = RetryStrategy;
+
+interface ClusterOptions extends CommanderOptions {
+  clusterRetryStrategy?: ((times: number, reason?: Error) => number | void | null) | null | undefined;
+  enableOfflineQueue?: boolean | undefined;
+  enableReadyCheck?: boolean | undefined;
+  scaleReads?: NodeRole | Function | undefined;
+  maxRedirections?: number | undefined;
+  retryDelayOnFailover?: number | undefined;
+  retryDelayOnClusterDown?: number | undefined;
+  retryDelayOnTryAgain?: number | undefined;
+  retryDelayOnMoved?: number | undefined;
+  slotsRefreshTimeout?: number | undefined;
+  slotsRefreshInterval?: number | undefined;
+  shardedSubscribers?: boolean | undefined;
+  clusterNodeRetryStrategy?: ClusterNodeRetryStrategy;
+  redisOptions?: Omit<RedisOptions, "enableOfflineQueue" | "host" | "path" | "port" | "readOnly" | "retryStrategy" | "sentinels"> | undefined;
+  lazyConnect?: boolean | undefined;
+  useSRVRecords?: boolean | undefined;
+  resolveSrv?: DNSResolveSrvFunction | undefined;
+  dnsLookup?: DNSLookupFunction | undefined;
+  natMap?: NatMap | undefined;
+  enableAutoPipelining?: boolean | undefined;
+  autoPipeliningIgnoredCommands?: string[] | undefined;
+  scripts?: Record<string, {
+    lua: string;
+    numberOfKeys?: number;
+    readOnly?: boolean;
+  }> | undefined;
+}
+
+declare type ClusterStatus = "close" | "connect" | "connecting" | "disconnecting" | "end" | "ready" | "reconnecting" | "wait";
+
+declare class Command implements Respondable {
+  name: string;
+  static FLAGS: {
+    [key in keyof CommandNameFlags]: CommandNameFlags[key];
+  };
+  private static flagMap?;
+  private static _transformer;
+  static checkFlag<T extends keyof CommandNameFlags>(flagName: T, commandName: string): commandName is CommandNameFlags[T][number];
+  static setArgumentTransformer(name: string, func: ArgumentTransformer): void;
+  static setReplyTransformer(name: string, func: ReplyTransformer): void;
+  private static getFlagMap;
+  ignore?: boolean;
+  isReadOnly?: boolean;
+  args: CommandParameter[];
+  inTransaction: boolean;
+  pipelineIndex?: number;
+  isTraced: boolean;
+  isResolved: boolean;
+  reject: (err: Error) => void;
+  resolve: (result: any) => void;
+  promise: Promise<any>;
+  private replyEncoding;
+  private errorStack;
+  private bufferMode;
+  private callback;
+  private transformed;
+  private _commandTimeoutTimer?;
+  private _blockingTimeoutTimer?;
+  private _blockingDeadline?;
+  private slot?;
+  private keys?;
+  constructor(name: string, args?: Array<ArgumentType>, options?: CommandOptions, callback?: Callback);
+  getSlot(): number;
+  getKeys(): Array<string | Buffer>;
+  toWritable(_socket: object): string | Buffer;
+  stringifyArguments(): void;
+  transformReply(result: Buffer | Buffer[]): string | string[] | Buffer | Buffer[];
+  setTimeout(ms: number): void;
+  setBlockingTimeout(ms: number): void;
+  extractBlockingTimeout(): number | null | undefined;
+  private _clearTimers;
+  private initPromise;
+  private _iterateKeys;
+  private _convertValue;
+}
 
 interface CommandItem {
   command: Respondable;
   stream: WriteableStream;
   select: number;
 }
-
-interface ScanStreamOptions {
-  match?: string;
-  type?: string;
-  count?: number;
-  noValues?: boolean;
-}
-
-declare type ArgumentType = string | Buffer | number | (string | Buffer | number | any[])[];
-
-interface CommandOptions {
-  replyEncoding?: BufferEncoding | null;
-  errorStack?: Error;
-  keyPrefix?: string;
-  readOnly?: boolean;
-}
-
-declare type ArgumentTransformer = (args: any[]) => any[];
-
-declare type ReplyTransformer = (reply: any) => any;
 
 interface CommandNameFlags {
   VALID_IN_SUBSCRIBER_MODE: [
@@ -190,51 +511,446 @@ interface CommandNameFlags {
   ];
 }
 
-declare class Command implements Respondable {
-  name: string;
-  static FLAGS: {
-    [key in keyof CommandNameFlags]: CommandNameFlags[key];
-  };
-  private static flagMap?;
-  private static _transformer;
-  static checkFlag<T extends keyof CommandNameFlags>(flagName: T, commandName: string): commandName is CommandNameFlags[T][number];
-  static setArgumentTransformer(name: string, func: ArgumentTransformer): void;
-  static setReplyTransformer(name: string, func: ReplyTransformer): void;
-  private static getFlagMap;
-  ignore?: boolean;
-  isReadOnly?: boolean;
-  args: CommandParameter[];
-  inTransaction: boolean;
-  pipelineIndex?: number;
-  isTraced: boolean;
-  isResolved: boolean;
-  reject: (err: Error) => void;
-  resolve: (result: any) => void;
-  promise: Promise<any>;
-  private replyEncoding;
-  private errorStack;
-  private bufferMode;
-  private callback;
-  private transformed;
-  private _commandTimeoutTimer?;
-  private _blockingTimeoutTimer?;
-  private _blockingDeadline?;
-  private slot?;
-  private keys?;
-  constructor(name: string, args?: Array<ArgumentType>, options?: CommandOptions, callback?: Callback);
-  getSlot(): number;
-  getKeys(): Array<string | Buffer>;
-  toWritable(_socket: object): string | Buffer;
-  stringifyArguments(): void;
-  transformReply(result: Buffer | Buffer[]): string | string[] | Buffer | Buffer[];
-  setTimeout(ms: number): void;
-  setBlockingTimeout(ms: number): void;
-  extractBlockingTimeout(): number | null | undefined;
-  private _clearTimers;
-  private initPromise;
-  private _iterateKeys;
-  private _convertValue;
+interface CommandOptions {
+  replyEncoding?: BufferEncoding | null;
+  errorStack?: Error;
+  keyPrefix?: string;
+  readOnly?: boolean;
 }
+
+declare type CommandParameter = string | Buffer | number | any[];
+
+declare class Commander<Context extends ClientContext = {
+  type: "default";
+}> {
+  options: CommanderOptions;
+  scriptsSet: {};
+  addedBuiltinSet: Set<string>;
+  getBuiltinCommands(): string[];
+  createBuiltinCommand(commandName: string): {
+    string: any;
+    buffer: any;
+  };
+  addBuiltinCommand(commandName: string): void;
+  defineCommand(name: string, definition: {
+    lua: string;
+    numberOfKeys?: number;
+    readOnly?: boolean;
+  }): void;
+  sendCommand(command: Command, stream?: WriteableStream, node?: unknown): unknown;
+}
+
+interface Commander<Context> extends RedisCommander<Context> {
+}
+
+interface CommanderOptions {
+  keyPrefix?: string | undefined;
+  showFriendlyErrorStack?: boolean | undefined;
+}
+
+interface CommonRedisOptions extends CommanderOptions {
+  Connector?: ConnectorConstructor | undefined;
+  retryStrategy?: RetryStrategy;
+  commandTimeout?: number | undefined;
+  blockingTimeout?: number | undefined;
+  blockingTimeoutGrace?: number | undefined;
+  socketTimeout?: number | undefined;
+  keepAlive?: number | undefined;
+  noDelay?: boolean | undefined;
+  connectionName?: string | undefined;
+  disableClientInfo?: boolean | undefined;
+  clientInfoTag?: string | undefined;
+  username?: string | undefined;
+  password?: string | undefined;
+  db?: number | undefined;
+  autoResubscribe?: boolean | undefined;
+  autoResendUnfulfilledCommands?: boolean | undefined;
+  reconnectOnError?: ReconnectOnError | null | undefined;
+  readOnly?: boolean | undefined;
+  stringNumbers?: boolean | undefined;
+  connectTimeout?: number | undefined;
+  monitor?: boolean | undefined;
+  maxRetriesPerRequest?: number | null | undefined;
+  maxLoadingRetryTime?: number | undefined;
+  enableAutoPipelining?: boolean | undefined;
+  autoPipeliningIgnoredCommands?: string[] | undefined;
+  offlineQueue?: boolean | undefined;
+  commandQueue?: boolean | undefined;
+  enableOfflineQueue?: boolean | undefined;
+  enableReadyCheck?: boolean | undefined;
+  lazyConnect?: boolean | undefined;
+  scripts?: Record<string, {
+    lua: string;
+    numberOfKeys?: number | undefined;
+    readOnly?: boolean | undefined;
+  }> | undefined;
+}
+
+interface Condition {
+  select: number;
+  auth?: string | [
+    string,
+    string
+  ];
+  subscriber: false | SubscriptionSet;
+}
+
+interface ConnectorConstructor {
+  new (options: unknown): AbstractConnector;
+}
+
+type CreateObjectStreamOptions = {
+  execute: (controller: ObjectStreamController) => void | PromiseLike<void>;
+  defaultValue?: ReadonlyJSONValue;
+};
+
+type CreateResumableAssistantStreamResponseOptions = {
+  readonly context: ResumableStreamContext;
+  readonly streamId: string;
+  readonly callback: (controller: AssistantStreamController) => PromiseLike<void> | void;
+  readonly encoder?: () => AssistantStreamEncoder;
+  readonly headers?: HeadersInit;
+};
+
+type CreateResumeAssistantStreamResponseOptions = {
+  readonly context: ResumableStreamContext;
+  readonly streamId: string;
+  readonly encoder?: () => AssistantStreamEncoder;
+  readonly headers?: HeadersInit;
+  readonly missingResponse?: () => Response;
+};
+
+declare type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException | null | undefined, address: string, family?: number) => void) => void;
+
+declare type DNSResolveSrvFunction = (hostname: string, callback: (err: NodeJS.ErrnoException | null | undefined, records?: SrvRecord[]) => void) => void;
+
+interface DataHandledable extends EventEmitter {
+  stream: NetStream;
+  status: string;
+  condition: Condition | null;
+  commandQueue: Deque<CommandItem>;
+  disconnect(reconnect: boolean): void;
+  recoverFromFatalError(commandError: Error, err: Error, options: FlushQueueOptions): void;
+  handleReconnection(err: Error, item: CommandItem): void;
+}
+
+type DataPart = {
+  type: "data";
+  name: string;
+  data: ReadonlyJSONValue;
+  parentId?: string;
+};
+
+declare class DataStreamDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
+  constructor();
+}
+
+declare class DataStreamEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
+  headers: Headers;
+  constructor();
+}
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare type DelSet = CommandNameFlags["EXIT_SUBSCRIBER_MODE"][number];
+
+declare type ErrorEmitter = (type: string, err: Error) => void;
+
+type FieldState = "complete" | "partial";
+
+type FilePart = {
+  type: "file";
+  data: string;
+  mimeType: string;
+  parentId?: string;
+};
+
+type FinishReason = "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+
+declare type FlushQueueOptions = {
+  offlineQueue?: boolean;
+  commandQueue?: boolean;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenericAssistantMessage = {
+  role: "assistant";
+  content: (GenericTextPart | GenericToolCallPart)[];
+};
+
+type GenericFilePart = {
+  type: "file";
+  data: string | URL;
+  mediaType: string;
+};
+
+type GenericMessage = GenericSystemMessage | GenericUserMessage | GenericAssistantMessage | GenericToolMessage;
+
+type GenericSystemMessage = {
+  role: "system";
+  content: string;
+};
+
+type GenericTextPart = {
+  type: "text";
+  text: string;
+};
+
+type GenericToolCallPart = {
+  type: "tool-call";
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+};
+
+type GenericToolMessage = {
+  role: "tool";
+  content: GenericToolResultPart[];
+};
+
+type GenericToolResultPart = {
+  type: "tool-result";
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  isError?: boolean;
+};
+
+type GenericUserMessage = {
+  role: "user";
+  content: (GenericTextPart | GenericFilePart)[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type InMemoryResumableStreamStoreOptions = {
+  readonly defaultTtlMs?: number;
+  readonly now?: () => number;
+  readonly maxChunkBytes?: number;
+  readonly maxEntriesPerStream?: number;
+  readonly maxStreams?: number;
+  readonly gcIntervalMs?: number;
+};
+
+type IoRedisLike = Redis | Cluster;
+
+declare type IpcOptions = Pick<IpcNetConnectOpts, "path">;
+
+interface JSONSchema7 {
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  $schema?: JSONSchema7Version | undefined;
+  $comment?: string | undefined;
+  $defs?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
+  enum?: JSONSchema7Type[] | undefined;
+  const?: JSONSchema7Type | undefined;
+  multipleOf?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  minimum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  maxLength?: number | undefined;
+  minLength?: number | undefined;
+  pattern?: string | undefined;
+  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
+  additionalItems?: JSONSchema7Definition | undefined;
+  maxItems?: number | undefined;
+  minItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
+  contains?: JSONSchema7Definition | undefined;
+  maxProperties?: number | undefined;
+  minProperties?: number | undefined;
+  required?: string[] | undefined;
+  properties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  patternProperties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  additionalProperties?: JSONSchema7Definition | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7Definition | string[];
+  } | undefined;
+  propertyNames?: JSONSchema7Definition | undefined;
+  if?: JSONSchema7Definition | undefined;
+  then?: JSONSchema7Definition | undefined;
+  else?: JSONSchema7Definition | undefined;
+  allOf?: JSONSchema7Definition[] | undefined;
+  anyOf?: JSONSchema7Definition[] | undefined;
+  oneOf?: JSONSchema7Definition[] | undefined;
+  not?: JSONSchema7Definition | undefined;
+  format?: string | undefined;
+  contentMediaType?: string | undefined;
+  contentEncoding?: string | undefined;
+  definitions?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  default?: JSONSchema7Type | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchema7Type | undefined;
+}
+
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type McpServerConfig = {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
+} | {
+  type: "stdio";
+  command: string;
+  args?: readonly string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  connectionTimeout?: number | undefined;
+};
+
+type McpTool = ToolBase<Record<string, unknown>, unknown> & {
+  type: "mcp";
+  server: McpServerConfig;
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type MessagePartLike = {
+  type: string;
+  text?: string;
+  image?: string;
+  data?: string;
+  mimeType?: string;
+  toolCallId?: string;
+  toolName?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  isError?: boolean;
+};
+
+declare type NatMap = {
+  [key: string]: {
+    host: string;
+    port: number;
+  };
+} | NatMapFunction;
+
+declare type NatMapFunction = (key: string) => {
+  host: string;
+  port: number;
+} | null;
+
+declare type NetStream = Socket | TLSSocket;
+
+declare type NodeKey = string;
+
+type NodeRedisFields = Record<string, string | Buffer>;
+
+interface NodeRedisLike {
+  set(key: string, value: string, options: {
+    NX: true;
+    EX: number;
+  }): Promise<string | null>;
+  set(key: string, value: string, options: {
+    EX: number;
+  }): Promise<string | null>;
+  get(key: string): Promise<string | null>;
+  expire(key: string, seconds: number): Promise<unknown>;
+  exists(key: string): Promise<number>;
+  del(keys: string | string[]): Promise<unknown>;
+  xAdd(key: string, id: string, fields: NodeRedisFields): Promise<string>;
+  sendCommand<T = unknown>(args: ReadonlyArray<string | Buffer>, options?: {
+    typeMapping?: Record<number, unknown>;
+  }): Promise<T>;
+  multi(): NodeRedisMultiCommand;
+}
+
+interface NodeRedisMultiCommand {
+  xAdd(key: string, id: string, fields: NodeRedisFields): NodeRedisMultiCommand;
+  expire(key: string, seconds: number): NodeRedisMultiCommand;
+  set(key: string, value: string, options: {
+    EX: number;
+  }): NodeRedisMultiCommand;
+  execAsPipeline(): Promise<unknown>;
+  exec(): Promise<unknown>;
+}
+
+declare type NodeRole = "all" | "master" | "slave";
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type ObjectStreamChunk = {
+  readonly snapshot: ReadonlyJSONValue;
+  readonly operations: readonly ObjectStreamOperation[];
+};
+
+type ObjectStreamController = {
+  readonly abortSignal: AbortSignal;
+  enqueue(operations: readonly ObjectStreamOperation[]): void;
+};
+
+type ObjectStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
+declare class ObjectStreamResponse extends Response {
+  constructor(body: ReadableStream<ObjectStreamChunk>);
+}
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 interface Options extends ReadableOptions {
   key?: string;
@@ -246,35 +962,209 @@ interface Options extends ReadableOptions {
   noValues?: boolean;
 }
 
-declare class ScanStream extends Readable {
-  private opt;
-  private _redisCursor;
-  private _redisDrained;
-  constructor(opt: Options);
-  _read(): void;
-  close(): void;
-}
+declare const PARTIAL_JSON_OBJECT_META_SYMBOL: unique symbol;
 
-declare type RedisKey = string | Buffer;
-
-declare type RedisValue = string | Buffer | number;
-
-interface ResultTypes<Result, Context> {
-  default: Promise<Result>;
-  pipeline: ChainableCommander;
-}
-
-interface ChainableCommander extends RedisCommander<{
-  type: "pipeline";
-}> {
-  length: number;
-}
-
-declare type ClientContext = {
-  type: keyof ResultTypes<unknown, unknown>;
+type PartInit = {
+  readonly type: "reasoning" | "text";
+  readonly parentId?: string;
+} | {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: ReadonlyJSONValue;
+  readonly parentId?: string;
 };
 
-declare type Result<T, Context extends ClientContext> = ResultTypes<T, Context>[Context["type"]];
+type PartialJsonObjectMeta = {
+  state: "complete" | "partial";
+  partialPath: string[];
+};
+
+declare class PipeableTransformStream<I, O> extends TransformStream<I, O> {
+  constructor(transform: (readable: ReadableStream<I>) => ReadableStream<O>);
+}
+
+type PipelineCommand = {
+  readonly type: "xAdd";
+  readonly key: string;
+  readonly fields: Record<string, string | Uint8Array>;
+} | {
+  readonly type: "expire";
+  readonly key: string;
+  readonly ttlSec: number;
+} | {
+  readonly type: "set";
+  readonly key: string;
+  readonly value: string;
+  readonly ttlSec: number;
+};
+
+interface PipelineWriteableStream {
+  isPipeline: true;
+  write(data: string | Buffer): unknown;
+  destination: {
+    redis: {
+      stream: NetStream;
+    };
+  };
+}
+
+declare class PlainTextDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
+  constructor();
+}
+
+declare class PlainTextEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
+  headers: Headers;
+  constructor();
+}
+
+declare type PreferredSlaves = ((slaves: AddressFromResponse[]) => AddressFromResponse | null) | Array<{
+  port: string;
+  ip: string;
+  prio?: number | undefined;
+}> | {
+  port: string;
+  ip: string;
+  prio?: number | undefined;
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+declare const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+type ReasoningPart = {
+  type: "reasoning";
+  text: string;
+  status: TextStatus;
+  parentId?: string;
+};
+
+declare type ReconnectOnError = (err: Error) => boolean | 1 | 2;
+
+declare class Redis extends Commander implements DataHandledable {
+  static Cluster: typeof Cluster;
+  static Command: typeof Command;
+  private static defaultOptions;
+  static createClient(...args: ConstructorParameters<typeof Redis>): Redis;
+  options: RedisOptions;
+  status: RedisStatus;
+  stream: NetStream;
+  isCluster: boolean;
+  condition: Condition | null;
+  commandQueue: Deque<CommandItem>;
+  private connector;
+  private reconnectTimeout;
+  private offlineQueue;
+  private connectionEpoch;
+  private retryAttempts;
+  private manuallyClosing;
+  private socketTimeoutTimer;
+  private _autoPipelines;
+  private _runningAutoPipelines;
+  constructor(port: number, host: string, options: RedisOptions);
+  constructor(path: string, options: RedisOptions);
+  constructor(port: number, options: RedisOptions);
+  constructor(port: number, host: string);
+  constructor(options: RedisOptions);
+  constructor(port: number);
+  constructor(path: string);
+  constructor();
+  get autoPipelineQueueSize(): number;
+  connect(callback?: Callback<void>): Promise<void>;
+  private _connect;
+  disconnect(reconnect?: boolean): void;
+  end(): void;
+  duplicate(override?: Partial<RedisOptions>): Redis;
+  get mode(): "monitor" | "normal" | "subscriber";
+  monitor(callback?: Callback<Redis>): Promise<Redis>;
+  sendCommand(command: Command, stream?: WriteableStream): unknown;
+  private getBlockingTimeoutInMs;
+  private getConfiguredBlockingTimeout;
+  private setSocketTimeout;
+  scanStream(options?: ScanStreamOptions): ScanStream;
+  scanBufferStream(options?: ScanStreamOptions): ScanStream;
+  sscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  sscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  hscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  hscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  zscanStream(key: string, options?: ScanStreamOptions): ScanStream;
+  zscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
+  silentEmit(eventName: string, arg?: unknown): boolean;
+  recoverFromFatalError(_commandError: Error, err: Error, options: FlushQueueOptions): void;
+  handleReconnection(err: Error, item: CommandItem): void;
+  _getServerAddress(): {
+    address: string;
+    port: number | undefined;
+  };
+  private _buildCommandContext;
+  _buildBatchContext(batchSize: number): BatchOperationContext;
+  private _getDescription;
+  private resetCommandQueue;
+  private resetOfflineQueue;
+  private parseOptions;
+  private setStatus;
+  private createScanStream;
+  private flushQueue;
+  private _readyCheck;
+}
+
+interface Redis extends EventEmitter {
+  on(event: "message", cb: (channel: string, message: string) => void): this;
+  once(event: "message", cb: (channel: string, message: string) => void): this;
+  on(event: "messageBuffer", cb: (channel: Buffer, message: Buffer) => void): this;
+  once(event: "messageBuffer", cb: (channel: Buffer, message: Buffer) => void): this;
+  on(event: "pmessage", cb: (pattern: string, channel: string, message: string) => void): this;
+  once(event: "pmessage", cb: (pattern: string, channel: string, message: string) => void): this;
+  on(event: "pmessageBuffer", cb: (pattern: string, channel: Buffer, message: Buffer) => void): this;
+  once(event: "pmessageBuffer", cb: (pattern: string, channel: Buffer, message: Buffer) => void): this;
+  on(event: "error", cb: (error: Error) => void): this;
+  once(event: "error", cb: (error: Error) => void): this;
+  on(event: RedisStatus, cb: () => void): this;
+  once(event: RedisStatus, cb: () => void): this;
+  on(event: string | symbol, listener: (...args: any[]) => void): this;
+  once(event: string | symbol, listener: (...args: any[]) => void): this;
+}
+
+interface Redis extends Transaction {
+}
 
 interface RedisCommander<Context extends ClientContext = {
   type: "default";
@@ -10485,61 +11375,115 @@ interface RedisCommander<Context extends ClientContext = {
   ]): Result<number, Context>;
 }
 
-interface Transaction {
-  pipeline(commands?: unknown[][]): ChainableCommander;
-  multi(options: {
-    pipeline: false;
-  }): Promise<"OK">;
-  multi(): ChainableCommander;
-  multi(options: {
-    pipeline: true;
-  }): ChainableCommander;
-  multi(commands?: unknown[][]): ChainableCommander;
+declare type RedisKey = string | Buffer;
+
+interface RedisLikeClient {
+  setNX(key: string, value: string, ttlSec: number): Promise<boolean>;
+  set(key: string, value: string, ttlSec: number): Promise<void>;
+  get(key: string): Promise<string | null>;
+  expire(key: string, ttlSec: number): Promise<void>;
+  exists(key: string): Promise<boolean>;
+  del(keys: string[]): Promise<void>;
+  xAdd(key: string, fields: Record<string, string | Uint8Array>): Promise<string>;
+  xRange(key: string, start: string, end: string): Promise<Array<{
+    id: string;
+    fields: Record<string, string | Uint8Array>;
+  }>>;
+  pipeline(commands: readonly PipelineCommand[]): Promise<void>;
 }
 
-interface CommanderOptions {
-  keyPrefix?: string | undefined;
-  showFriendlyErrorStack?: boolean | undefined;
+declare type RedisOptions = CommonRedisOptions & SentinelConnectionOptions & StandaloneConnectionOptions;
+
+type RedisResumableStreamStoreOptions = {
+  readonly keyPrefix?: string;
+  readonly defaultTtlMs?: number;
+  readonly pollIntervalMs?: number;
+  readonly maxChunkBytes?: number;
+};
+
+declare type RedisStatus = "close" | "connect" | "connecting" | "end" | "ready" | "reconnecting" | "wait";
+
+declare type RedisValue = string | Buffer | number;
+
+declare type ReplyTransformer = (reply: any) => any;
+
+interface Respondable {
+  name: string;
+  args: CommandParameter[];
+  resolve(result: any): void;
+  reject(error: Error): void;
 }
 
-declare class Commander<Context extends ClientContext = {
-  type: "default";
-}> {
-  options: CommanderOptions;
-  scriptsSet: {};
-  addedBuiltinSet: Set<string>;
-  getBuiltinCommands(): string[];
-  createBuiltinCommand(commandName: string): {
-    string: any;
-    buffer: any;
-  };
-  addBuiltinCommand(commandName: string): void;
-  defineCommand(name: string, definition: {
-    lua: string;
-    numberOfKeys?: number;
-    readOnly?: boolean;
-  }): void;
-  sendCommand(command: Command, stream?: WriteableStream, node?: unknown): unknown;
+declare type Result<T, Context extends ClientContext> = ResultTypes<T, Context>[Context["type"]];
+
+interface ResultTypes<Result, Context> {
+  default: Promise<Result>;
+  pipeline: ChainableCommander;
 }
 
-interface Commander<Context> extends RedisCommander<Context> {
+type ResumableStreamAcquireOptions = {
+  readonly ttlMs?: number;
+};
+
+interface ResumableStreamContext {
+  run(streamId: string, makeStream: () => ReadableStream<Uint8Array>): Promise<ReadableStream<Uint8Array>>;
+  resume(streamId: string): Promise<ReadableStream<Uint8Array> | null>;
+  requireResume(streamId: string): Promise<ReadableStream<Uint8Array>>;
+  status(streamId: string): Promise<ResumableStreamStatus>;
+  delete(streamId: string): Promise<void>;
 }
 
-declare type ErrorEmitter = (type: string, err: Error) => void;
+type ResumableStreamContextOptions = {
+  readonly store: ResumableStreamStore;
+  readonly ttlMs?: number;
+  readonly waitUntil?: (promise: Promise<unknown>) => void;
+  readonly onAcquire?: (streamId: string, role: ResumableStreamRole) => void;
+  readonly onAppend?: (streamId: string, byteLength: number) => void;
+  readonly onFinalize?: (streamId: string, status: "done" | "error", error?: string) => void;
+  readonly onError?: (streamId: string, error: unknown) => void;
+};
 
-declare abstract class AbstractConnector {
-  firstError?: Error;
-  protected connecting: boolean;
-  protected stream: NetStream;
-  private disconnectTimeout;
-  constructor(disconnectTimeout: number);
-  check(info: any): boolean;
-  disconnect(): void;
-  abstract connect(_: ErrorEmitter): Promise<NetStream>;
+type ResumableStreamEntry = {
+  readonly cursor: string;
+  readonly chunk: Uint8Array;
+};
+
+declare class ResumableStreamError extends Error {
+  readonly code: ResumableStreamErrorCode;
+  constructor(code: ResumableStreamErrorCode, message: string);
 }
 
-interface ConnectorConstructor {
-  new (options: unknown): AbstractConnector;
+type ResumableStreamErrorCode = "exists" | "finalized" | "invalid-id" | "missing";
+
+type ResumableStreamRole = "consumer" | "producer";
+
+type ResumableStreamStatus = "done" | "error" | "missing" | "streaming";
+
+interface ResumableStreamStore {
+  acquire(streamId: string, options?: ResumableStreamAcquireOptions): Promise<ResumableStreamRole>;
+  append(streamId: string, chunk: Uint8Array): Promise<void>;
+  finalize(streamId: string, status: "done" | "error", error?: string): Promise<void>;
+  read(streamId: string, cursor: string, signal: AbortSignal): AsyncIterable<ResumableStreamEntry>;
+  status(streamId: string): Promise<ResumableStreamStatus>;
+  delete(streamId: string): Promise<void>;
+}
+
+declare type RetryStrategy = ((times: number) => number | void | null) | null | undefined;
+
+declare class ScanStream extends Readable {
+  private opt;
+  private _redisCursor;
+  private _redisDrained;
+  constructor(opt: Options);
+  _read(): void;
+  close(): void;
+}
+
+interface ScanStreamOptions {
+  match?: string;
+  type?: string;
+  count?: number;
+  noValues?: boolean;
 }
 
 interface SentinelAddress {
@@ -10547,22 +11491,6 @@ interface SentinelAddress {
   host: string;
   family?: number;
 }
-
-interface AddressFromResponse {
-  port: string;
-  ip: string;
-  flags?: string | undefined;
-}
-
-declare type PreferredSlaves = ((slaves: AddressFromResponse[]) => AddressFromResponse | null) | Array<{
-  port: string;
-  ip: string;
-  prio?: number | undefined;
-}> | {
-  port: string;
-  ip: string;
-  prio?: number | undefined;
-};
 
 interface SentinelConnectionOptions {
   name?: string | undefined;
@@ -10585,189 +11513,19 @@ interface SentinelConnectionOptions {
   failoverDetector?: boolean | undefined;
 }
 
-declare type TcpOptions = Pick<TcpNetConnectOpts, "family" | "host" | "port">;
-
-declare type IpcOptions = Pick<IpcNetConnectOpts, "path">;
+type SourcePart = {
+  type: "source";
+  sourceType: "url";
+  id: string;
+  url: string;
+  title?: string;
+  parentId?: string;
+};
 
 declare type StandaloneConnectionOptions = Partial<TcpOptions & IpcOptions> & {
   disconnectTimeout?: number | undefined;
   tls?: ConnectionOptions | undefined;
 };
-
-declare type ReconnectOnError = (err: Error) => boolean | 1 | 2;
-
-declare type RetryStrategy = ((times: number) => number | void | null) | null | undefined;
-
-interface CommonRedisOptions extends CommanderOptions {
-  Connector?: ConnectorConstructor | undefined;
-  retryStrategy?: RetryStrategy;
-  commandTimeout?: number | undefined;
-  blockingTimeout?: number | undefined;
-  blockingTimeoutGrace?: number | undefined;
-  socketTimeout?: number | undefined;
-  keepAlive?: number | undefined;
-  noDelay?: boolean | undefined;
-  connectionName?: string | undefined;
-  disableClientInfo?: boolean | undefined;
-  clientInfoTag?: string | undefined;
-  username?: string | undefined;
-  password?: string | undefined;
-  db?: number | undefined;
-  autoResubscribe?: boolean | undefined;
-  autoResendUnfulfilledCommands?: boolean | undefined;
-  reconnectOnError?: ReconnectOnError | null | undefined;
-  readOnly?: boolean | undefined;
-  stringNumbers?: boolean | undefined;
-  connectTimeout?: number | undefined;
-  monitor?: boolean | undefined;
-  maxRetriesPerRequest?: number | null | undefined;
-  maxLoadingRetryTime?: number | undefined;
-  enableAutoPipelining?: boolean | undefined;
-  autoPipeliningIgnoredCommands?: string[] | undefined;
-  offlineQueue?: boolean | undefined;
-  commandQueue?: boolean | undefined;
-  enableOfflineQueue?: boolean | undefined;
-  enableReadyCheck?: boolean | undefined;
-  lazyConnect?: boolean | undefined;
-  scripts?: Record<string, {
-    lua: string;
-    numberOfKeys?: number | undefined;
-    readOnly?: boolean | undefined;
-  }> | undefined;
-}
-
-declare type RedisOptions = CommonRedisOptions & SentinelConnectionOptions & StandaloneConnectionOptions;
-
-declare type NodeKey = string;
-
-declare type NodeRole = "all" | "master" | "slave";
-
-declare type DNSResolveSrvFunction = (hostname: string, callback: (err: NodeJS.ErrnoException | null | undefined, records?: SrvRecord[]) => void) => void;
-
-declare type DNSLookupFunction = (hostname: string, callback: (err: NodeJS.ErrnoException | null | undefined, address: string, family?: number) => void) => void;
-
-declare type NatMapFunction = (key: string) => {
-  host: string;
-  port: number;
-} | null;
-
-declare type NatMap = {
-  [key: string]: {
-    host: string;
-    port: number;
-  };
-} | NatMapFunction;
-
-declare type ClusterNodeRetryStrategy = RetryStrategy;
-
-interface ClusterOptions extends CommanderOptions {
-  clusterRetryStrategy?: ((times: number, reason?: Error) => number | void | null) | null | undefined;
-  enableOfflineQueue?: boolean | undefined;
-  enableReadyCheck?: boolean | undefined;
-  scaleReads?: NodeRole | Function | undefined;
-  maxRedirections?: number | undefined;
-  retryDelayOnFailover?: number | undefined;
-  retryDelayOnClusterDown?: number | undefined;
-  retryDelayOnTryAgain?: number | undefined;
-  retryDelayOnMoved?: number | undefined;
-  slotsRefreshTimeout?: number | undefined;
-  slotsRefreshInterval?: number | undefined;
-  shardedSubscribers?: boolean | undefined;
-  clusterNodeRetryStrategy?: ClusterNodeRetryStrategy;
-  redisOptions?: Omit<RedisOptions, "enableOfflineQueue" | "host" | "path" | "port" | "readOnly" | "retryStrategy" | "sentinels"> | undefined;
-  lazyConnect?: boolean | undefined;
-  useSRVRecords?: boolean | undefined;
-  resolveSrv?: DNSResolveSrvFunction | undefined;
-  dnsLookup?: DNSLookupFunction | undefined;
-  natMap?: NatMap | undefined;
-  enableAutoPipelining?: boolean | undefined;
-  autoPipeliningIgnoredCommands?: string[] | undefined;
-  scripts?: Record<string, {
-    lua: string;
-    numberOfKeys?: number;
-    readOnly?: boolean;
-  }> | undefined;
-}
-
-declare type ClusterNode = string | number | {
-  host?: string | undefined;
-  port?: number | undefined;
-};
-
-declare type ClusterStatus = "close" | "connect" | "connecting" | "disconnecting" | "end" | "ready" | "reconnecting" | "wait";
-
-declare class Cluster extends Commander {
-  options: ClusterOptions;
-  slots: NodeKey[][];
-  status: ClusterStatus;
-  _groupsIds: {
-    [key: string]: number;
-  };
-  _groupsBySlot: number[];
-  isCluster: boolean;
-  private startupNodes;
-  private connectionPool;
-  private manuallyClosing;
-  private retryAttempts;
-  private delayQueue;
-  private offlineQueue;
-  private subscriber;
-  private shardedSubscribers;
-  private slotsTimer;
-  private reconnectTimeout;
-  private isRefreshing;
-  private _refreshSlotsCacheCallbacks;
-  private _autoPipelines;
-  private _runningAutoPipelines;
-  private _readyDelayedCallbacks;
-  private subscriberGroupEmitter;
-  private connectionEpoch;
-  constructor(startupNodes: ClusterNode[], options?: ClusterOptions);
-  connect(): Promise<void>;
-  disconnect(reconnect?: boolean): void;
-  quit(callback?: Callback<"OK">): Promise<"OK">;
-  duplicate(overrideStartupNodes?: any[], overrideOptions?: {}): Cluster;
-  nodes(role?: NodeRole): Redis[];
-  delayUntilReady(callback: Callback): void;
-  get autoPipelineQueueSize(): number;
-  refreshSlotsCache(callback?: Callback<void>): void;
-  sendCommand(command: Command, stream?: WriteableStream, node?: any): unknown;
-  sscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  sscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  hscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  hscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  zscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  zscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  handleError(error: Error, ttl: {
-    value?: any;
-  }, handlers: any): void;
-  private resetOfflineQueue;
-  private clearNodesRefreshInterval;
-  private resetNodesRefreshInterval;
-  private setStatus;
-  private handleCloseEvent;
-  private flushQueue;
-  private executeOfflineCommands;
-  private natMapper;
-  private getInfoFromNode;
-  private invokeReadyDelayedCallbacks;
-  private readyCheck;
-  private resolveSrv;
-  private dnsLookup;
-  private resolveStartupNodeHostnames;
-  private createScanStream;
-  private createShardedSubscriberGroup;
-}
-
-interface Cluster extends EventEmitter {
-}
-
-interface Cluster extends Transaction {
-}
-
-declare type AddSet = CommandNameFlags["ENTER_SUBSCRIBER_MODE"][number];
-
-declare type DelSet = CommandNameFlags["EXIT_SUBSCRIBER_MODE"][number];
 
 declare class SubscriptionSet {
   private set;
@@ -10777,334 +11535,166 @@ declare class SubscriptionSet {
   isEmpty(): boolean;
 }
 
-interface Condition {
-  select: number;
-  auth?: string | [
-    string,
-    string
-  ];
-  subscriber: false | SubscriptionSet;
-}
-
-declare type FlushQueueOptions = {
-  offlineQueue?: boolean;
-  commandQueue?: boolean;
-};
-
-interface DataHandledable extends EventEmitter {
-  stream: NetStream;
-  status: string;
-  condition: Condition | null;
-  commandQueue: Deque<CommandItem>;
-  disconnect(reconnect: boolean): void;
-  recoverFromFatalError(commandError: Error, err: Error, options: FlushQueueOptions): void;
-  handleReconnection(err: Error, item: CommandItem): void;
-}
-
-interface BatchOperationContext {
-  batchMode: "MULTI";
-  batchSize: number;
-  database: number;
-  serverAddress: string;
-  serverPort: number | undefined;
-}
-
-declare type RedisStatus = "close" | "connect" | "connecting" | "end" | "ready" | "reconnecting" | "wait";
-
-declare class Redis extends Commander implements DataHandledable {
-  static Cluster: typeof Cluster;
-  static Command: typeof Command;
-  private static defaultOptions;
-  static createClient(...args: ConstructorParameters<typeof Redis>): Redis;
-  options: RedisOptions;
-  status: RedisStatus;
-  stream: NetStream;
-  isCluster: boolean;
-  condition: Condition | null;
-  commandQueue: Deque<CommandItem>;
-  private connector;
-  private reconnectTimeout;
-  private offlineQueue;
-  private connectionEpoch;
-  private retryAttempts;
-  private manuallyClosing;
-  private socketTimeoutTimer;
-  private _autoPipelines;
-  private _runningAutoPipelines;
-  constructor(port: number, host: string, options: RedisOptions);
-  constructor(path: string, options: RedisOptions);
-  constructor(port: number, options: RedisOptions);
-  constructor(port: number, host: string);
-  constructor(options: RedisOptions);
-  constructor(port: number);
-  constructor(path: string);
-  constructor();
-  get autoPipelineQueueSize(): number;
-  connect(callback?: Callback<void>): Promise<void>;
-  private _connect;
-  disconnect(reconnect?: boolean): void;
-  end(): void;
-  duplicate(override?: Partial<RedisOptions>): Redis;
-  get mode(): "monitor" | "normal" | "subscriber";
-  monitor(callback?: Callback<Redis>): Promise<Redis>;
-  sendCommand(command: Command, stream?: WriteableStream): unknown;
-  private getBlockingTimeoutInMs;
-  private getConfiguredBlockingTimeout;
-  private setSocketTimeout;
-  scanStream(options?: ScanStreamOptions): ScanStream;
-  scanBufferStream(options?: ScanStreamOptions): ScanStream;
-  sscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  sscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  hscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  hscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  zscanStream(key: string, options?: ScanStreamOptions): ScanStream;
-  zscanBufferStream(key: string, options?: ScanStreamOptions): ScanStream;
-  silentEmit(eventName: string, arg?: unknown): boolean;
-  recoverFromFatalError(_commandError: Error, err: Error, options: FlushQueueOptions): void;
-  handleReconnection(err: Error, item: CommandItem): void;
-  _getServerAddress(): {
-    address: string;
-    port: number | undefined;
-  };
-  private _buildCommandContext;
-  _buildBatchContext(batchSize: number): BatchOperationContext;
-  private _getDescription;
-  private resetCommandQueue;
-  private resetOfflineQueue;
-  private parseOptions;
-  private setStatus;
-  private createScanStream;
-  private flushQueue;
-  private _readyCheck;
-}
-
-interface Redis extends EventEmitter {
-  on(event: "message", cb: (channel: string, message: string) => void): this;
-  once(event: "message", cb: (channel: string, message: string) => void): this;
-  on(event: "messageBuffer", cb: (channel: Buffer, message: Buffer) => void): this;
-  once(event: "messageBuffer", cb: (channel: Buffer, message: Buffer) => void): this;
-  on(event: "pmessage", cb: (pattern: string, channel: string, message: string) => void): this;
-  once(event: "pmessage", cb: (pattern: string, channel: string, message: string) => void): this;
-  on(event: "pmessageBuffer", cb: (pattern: string, channel: Buffer, message: Buffer) => void): this;
-  once(event: "pmessageBuffer", cb: (pattern: string, channel: Buffer, message: Buffer) => void): this;
-  on(event: "error", cb: (error: Error) => void): this;
-  once(event: "error", cb: (error: Error) => void): this;
-  on(event: RedisStatus, cb: () => void): this;
-  once(event: RedisStatus, cb: () => void): this;
-  on(event: string | symbol, listener: (...args: any[]) => void): this;
-  once(event: string | symbol, listener: (...args: any[]) => void): this;
-}
-
-interface Redis extends Transaction {
-}
-
-declare namespace entry_resumable_ioredis_exports {
-  export { IoRedisLike, createIoredisResumableStreamStore };
-}
-
-type IoRedisLike = Redis | Cluster;
-
-declare function createIoredisResumableStreamStore(client: IoRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
-
-declare namespace entry_resumable_redis_exports {
-  export { NodeRedisLike, createRedisResumableStreamStore };
-}
-
-type NodeRedisFields = Record<string, string | Buffer>;
-
-interface NodeRedisMultiCommand {
-  xAdd(key: string, id: string, fields: NodeRedisFields): NodeRedisMultiCommand;
-  expire(key: string, seconds: number): NodeRedisMultiCommand;
-  set(key: string, value: string, options: {
-    EX: number;
-  }): NodeRedisMultiCommand;
-  execAsPipeline(): Promise<unknown>;
-  exec(): Promise<unknown>;
-}
-
-interface NodeRedisLike {
-  set(key: string, value: string, options: {
-    NX: true;
-    EX: number;
-  }): Promise<string | null>;
-  set(key: string, value: string, options: {
-    EX: number;
-  }): Promise<string | null>;
-  get(key: string): Promise<string | null>;
-  expire(key: string, seconds: number): Promise<unknown>;
-  exists(key: string): Promise<number>;
-  del(keys: string | string[]): Promise<unknown>;
-  xAdd(key: string, id: string, fields: NodeRedisFields): Promise<string>;
-  sendCommand<T = unknown>(args: ReadonlyArray<string | Buffer>, options?: {
-    typeMapping?: Record<number, unknown>;
-  }): Promise<T>;
-  multi(): NodeRedisMultiCommand;
-}
-
-declare function createRedisResumableStreamStore(client: NodeRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
-
-type ResumableStreamContextOptions = {
-  readonly store: ResumableStreamStore;
-  readonly ttlMs?: number;
-  readonly waitUntil?: (promise: Promise<unknown>) => void;
-  readonly onAcquire?: (streamId: string, role: ResumableStreamRole) => void;
-  readonly onAppend?: (streamId: string, byteLength: number) => void;
-  readonly onFinalize?: (streamId: string, status: "done" | "error", error?: string) => void;
-  readonly onError?: (streamId: string, error: unknown) => void;
-};
-
-interface ResumableStreamContext {
-  run(streamId: string, makeStream: () => ReadableStream<Uint8Array>): Promise<ReadableStream<Uint8Array>>;
-  resume(streamId: string): Promise<ReadableStream<Uint8Array> | null>;
-  requireResume(streamId: string): Promise<ReadableStream<Uint8Array>>;
-  status(streamId: string): Promise<ResumableStreamStatus>;
-  delete(streamId: string): Promise<void>;
-}
-
-declare function createResumableStreamContext(options: ResumableStreamContextOptions): ResumableStreamContext;
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
-
-declare function asAsyncIterableStream<T>(source: ReadableStream<T>): AsyncIterableStream<T>;
-
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
-
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
-
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
-}
-
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
-
-type JSONSchema7Version = string;
-
-type JSONSchema7Definition = JSONSchema7 | boolean;
-
-interface JSONSchema7 {
-  $id?: string | undefined;
-  $ref?: string | undefined;
-  $schema?: JSONSchema7Version | undefined;
-  $comment?: string | undefined;
-  $defs?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
-  enum?: JSONSchema7Type[] | undefined;
-  const?: JSONSchema7Type | undefined;
-  multipleOf?: number | undefined;
-  maximum?: number | undefined;
-  exclusiveMaximum?: number | undefined;
-  minimum?: number | undefined;
-  exclusiveMinimum?: number | undefined;
-  maxLength?: number | undefined;
-  minLength?: number | undefined;
-  pattern?: string | undefined;
-  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
-  additionalItems?: JSONSchema7Definition | undefined;
-  maxItems?: number | undefined;
-  minItems?: number | undefined;
-  uniqueItems?: boolean | undefined;
-  contains?: JSONSchema7Definition | undefined;
-  maxProperties?: number | undefined;
-  minProperties?: number | undefined;
-  required?: string[] | undefined;
-  properties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  patternProperties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  additionalProperties?: JSONSchema7Definition | undefined;
-  dependencies?: {
-    [key: string]: JSONSchema7Definition | string[];
-  } | undefined;
-  propertyNames?: JSONSchema7Definition | undefined;
-  if?: JSONSchema7Definition | undefined;
-  then?: JSONSchema7Definition | undefined;
-  else?: JSONSchema7Definition | undefined;
-  allOf?: JSONSchema7Definition[] | undefined;
-  anyOf?: JSONSchema7Definition[] | undefined;
-  oneOf?: JSONSchema7Definition[] | undefined;
-  not?: JSONSchema7Definition | undefined;
-  format?: string | undefined;
-  contentMediaType?: string | undefined;
-  contentEncoding?: string | undefined;
-  definitions?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  title?: string | undefined;
-  description?: string | undefined;
-  default?: JSONSchema7Type | undefined;
-  readOnly?: boolean | undefined;
-  writeOnly?: boolean | undefined;
-  examples?: JSONSchema7Type | undefined;
-}
-
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
 declare const TOOL_RESPONSE_SYMBOL: unique symbol;
 
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+declare type TcpOptions = Pick<TcpNetConnectOpts, "family" | "host" | "port">;
+
+type TextPart = {
+  type: "text";
+  text: string;
+  status: TextStatus;
+  parentId?: string;
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+type TextStatus = {
+  type: "running";
+} | {
+  type: "complete";
+  reason: "stop" | "unknown";
+} | {
+  type: "incomplete";
+  reason: "cancelled" | "content-filter" | "length" | "other";
+};
+
+type TextStreamController = {
+  append(textDelta: string): void;
+  close(): void;
+};
+
+type ThreadMessageLike = {
+  role: "assistant" | "system" | "user";
+  content: readonly MessagePartLike[];
+  attachments?: readonly AttachmentLike[];
+};
+
+type ToToolsJSONSchemaOptions = {
+  filter?: (name: string, tool: Tool) => boolean;
+};
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
+
+type ToolCallPart = ToolCallPartWithoutResult | ToolCallPartWithResult;
+
+type ToolCallPartBase = {
+  type: "tool-call";
+  status: ToolCallStatus;
+  toolCallId: string;
+  toolName: string;
+  argsText: string;
+  args: ReadonlyJSONObject;
+  timing?: ToolCallTiming;
+  artifact?: ReadonlyJSONValue;
+  result?: ReadonlyJSONValue;
+  modelContent?: readonly ToolModelContentPart[];
+  isError?: boolean;
+  parentId?: string;
+};
+
+type ToolCallPartInit = {
+  toolCallId?: string;
+  toolName: string;
+  argsText?: string;
+  args?: ReadonlyJSONObject;
+  response?: ToolResponseLike<ReadonlyJSONValue>;
+};
+
+type ToolCallPartWithResult = ToolCallPartBase & {
+  state: "result";
+  result: ReadonlyJSONValue;
+  artifact?: ReadonlyJSONValue;
+  modelContent?: readonly ToolModelContentPart[];
+  isError?: boolean;
+};
+
+type ToolCallPartWithoutResult = ToolCallPartBase & {
+  state: "call" | "partial-call";
+  result?: undefined;
+  modelContent?: undefined;
+};
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallStatus = {
+  type: "running";
+  isArgsComplete: boolean;
+} | {
+  type: "requires-action";
+  reason: "tool-call-result";
+} | {
+  type: "complete";
+  reason: "stop" | "unknown";
+} | {
+  type: "incomplete";
+  reason: "cancelled" | "content-filter" | "length" | "other";
+};
+
+type ToolCallStreamController = {
+  argsText: TextStreamController;
+  setResponse(response: ToolResponseLike<ReadonlyJSONValue>): void;
+  close(): void;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolCallback = (toolCall: {
+  toolCallId: string;
+  toolName: string;
+  args: ReadonlyJSONObject;
+}) => Promise<ToolResponse<ReadonlyJSONValue>> | ToolResponse<ReadonlyJSONValue> | undefined;
+
+type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionOptions = {
+  execute: ToolCallback;
+  streamCall: ToolStreamCallback;
+  onExecutionStart?: ((toolCallId: string, toolName: string) => void) | undefined;
+  onExecutionEnd?: ((toolCallId: string, toolName: string) => void) | undefined;
+};
+
+declare class ToolExecutionStream extends PipeableTransformStream<AssistantStreamChunk, AssistantStreamChunk> {
+  constructor(options: ToolExecutionOptions);
+}
+
+type ToolJSONSchema = {
+  description?: string;
+  parameters: JSONSchema7;
+  providerOptions?: ProviderOptions;
+};
 
 type ToolModelContentPart = {
   readonly type: "text";
@@ -11122,696 +11712,78 @@ type ToolModelOutputFunction<TArgs, TResult> = (options: {
   output: TResult;
 }) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
 
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+type ToolResultStreamOptions = {
+  onExecutionStart?: (toolCallId: string, toolName: string) => void;
+  onExecutionEnd?: (toolCallId: string, toolName: string) => void;
+};
 
 type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
 
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
-};
-
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: string | undefined;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type McpServerConfig = {
-  type: "http" | "sse";
-  url: string;
-  headers?: Record<string, string>;
-  redirect?: "error" | "follow";
-  connectionTimeout?: number | undefined;
-} | {
-  type: "stdio";
-  command: string;
-  args?: readonly string[];
-  env?: Record<string, string>;
-  cwd?: string;
-  connectionTimeout?: number | undefined;
-};
-
-type McpTool = ToolBase<Record<string, unknown>, unknown> & {
-  type: "mcp";
-  server: McpServerConfig;
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+type ToolStreamCallback = <TArgs extends ReadonlyJSONObject = ReadonlyJSONObject, TResult extends ReadonlyJSONValue = ReadonlyJSONValue>(toolCall: {
+  reader: ToolCallReader<TArgs, TResult>;
+  toolCallId: string;
+  toolName: string;
+}) => void;
 
 type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
   type?: undefined;
 };
 
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
-
-type ObjectStreamChunk = {
-  readonly snapshot: ReadonlyJSONValue;
-  readonly operations: readonly ObjectStreamOperation[];
-};
-
-type PartInit = {
-  readonly type: "reasoning" | "text";
-  readonly parentId?: string;
-} | {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: ReadonlyJSONValue;
-  readonly parentId?: string;
-};
-
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
-} | {
-  readonly type: "part-finish";
-} | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
-  readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
-};
-
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-};
-
-type TextStreamController = {
-  append(textDelta: string): void;
-  close(): void;
-};
-
-type ToolCallStreamController = {
-  argsText: TextStreamController;
-  setResponse(response: ToolResponseLike<ReadonlyJSONValue>): void;
-  close(): void;
-};
-
-type TextStatus = {
-  type: "running";
-} | {
-  type: "complete";
-  reason: "stop" | "unknown";
-} | {
-  type: "incomplete";
-  reason: "cancelled" | "content-filter" | "length" | "other";
-};
-
-type TextPart = {
-  type: "text";
-  text: string;
-  status: TextStatus;
-  parentId?: string;
-};
-
-type ReasoningPart = {
-  type: "reasoning";
-  text: string;
-  status: TextStatus;
-  parentId?: string;
-};
-
-type ToolCallStatus = {
-  type: "running";
-  isArgsComplete: boolean;
-} | {
-  type: "requires-action";
-  reason: "tool-call-result";
-} | {
-  type: "complete";
-  reason: "stop" | "unknown";
-} | {
-  type: "incomplete";
-  reason: "cancelled" | "content-filter" | "length" | "other";
-};
-
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type ToolCallPartBase = {
-  type: "tool-call";
-  status: ToolCallStatus;
-  toolCallId: string;
-  toolName: string;
-  argsText: string;
-  args: ReadonlyJSONObject;
-  timing?: ToolCallTiming;
-  artifact?: ReadonlyJSONValue;
-  result?: ReadonlyJSONValue;
-  modelContent?: readonly ToolModelContentPart[];
-  isError?: boolean;
-  parentId?: string;
-};
-
-type ToolCallPartWithoutResult = ToolCallPartBase & {
-  state: "call" | "partial-call";
-  result?: undefined;
-  modelContent?: undefined;
-};
-
-type ToolCallPartWithResult = ToolCallPartBase & {
-  state: "result";
-  result: ReadonlyJSONValue;
-  artifact?: ReadonlyJSONValue;
-  modelContent?: readonly ToolModelContentPart[];
-  isError?: boolean;
-};
-
-type ToolCallPart = ToolCallPartWithoutResult | ToolCallPartWithResult;
-
-type SourcePart = {
-  type: "source";
-  sourceType: "url";
-  id: string;
-  url: string;
-  title?: string;
-  parentId?: string;
-};
-
-type FilePart = {
-  type: "file";
-  data: string;
-  mimeType: string;
-  parentId?: string;
-};
-
-type DataPart = {
-  type: "data";
-  name: string;
-  data: ReadonlyJSONValue;
-  parentId?: string;
-};
-
-type AssistantMessagePart = TextPart | ReasoningPart | ToolCallPart | SourcePart | FilePart | DataPart;
-
-type AssistantMessageStepUsage = {
-  inputTokens: number;
-  outputTokens: number;
-};
-
-type AssistantMessageStepMetadata = {
-  state: "started";
-  messageId: string;
-} | {
-  state: "finished";
-  messageId: string;
-  finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  usage?: AssistantMessageStepUsage;
-  isContinued: boolean;
-};
-
-type AssistantMessageStatus = {
-  type: "running";
-} | {
-  type: "requires-action";
-  reason: "tool-calls";
-} | {
-  type: "complete";
-  reason: "stop" | "unknown";
-} | {
-  type: "incomplete";
-  reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  error?: ReadonlyJSONValue;
-};
-
-type AssistantMessageTiming = {
-  streamStartTime: number;
-  firstTokenTime?: number;
-  totalStreamTime?: number;
-  tokenCount?: number;
-  tokensPerSecond?: number;
-  totalChunks: number;
-  toolCallCount: number;
-};
-
-type AssistantMessage = {
-  role: "assistant";
-  status: AssistantMessageStatus;
-  parts: AssistantMessagePart[];
-  content: AssistantMessagePart[];
-  metadata: {
-    unstable_state: ReadonlyJSONValue;
-    unstable_data: ReadonlyJSONValue[];
-    unstable_annotations: ReadonlyJSONValue[];
-    steps: AssistantMessageStepMetadata[];
-    custom: Record<string, unknown>;
-    timing?: AssistantMessageTiming;
-  };
-};
-
-type ToolCallPartInit = {
-  toolCallId?: string;
-  toolName: string;
-  argsText?: string;
-  args?: ReadonlyJSONObject;
-  response?: ToolResponseLike<ReadonlyJSONValue>;
-};
-
-type AssistantStreamController = {
-  appendText(textDelta: string): void;
-  appendReasoning(reasoningDelta: string): void;
-  appendSource(options: SourcePart): void;
-  appendFile(options: FilePart): void;
-  appendData(options: DataPart): void;
-  addTextPart(): TextStreamController;
-  addToolCallPart(options: string): ToolCallStreamController;
-  addToolCallPart(options: ToolCallPartInit): ToolCallStreamController;
-  enqueue(chunk: AssistantStreamChunk): void;
-  merge(stream: AssistantStream): void;
-  close(): void;
-  withParentId(parentId: string): AssistantStreamController;
-};
-
-declare function createAssistantStream(callback: (controller: AssistantStreamController) => PromiseLike<void> | void): AssistantStream;
-
-declare function createAssistantStreamController(): readonly [
-  AssistantStream,
-  AssistantStreamController
-];
-
-declare function createAssistantStreamResponse(callback: (controller: AssistantStreamController) => PromiseLike<void> | void): Response;
-
-declare const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
-
-type CreateResumableAssistantStreamResponseOptions = {
-  readonly context: ResumableStreamContext;
-  readonly streamId: string;
-  readonly callback: (controller: AssistantStreamController) => PromiseLike<void> | void;
-  readonly encoder?: () => AssistantStreamEncoder;
-  readonly headers?: HeadersInit;
-};
-
-declare function createResumableAssistantStreamResponse(options: CreateResumableAssistantStreamResponseOptions): Promise<Response>;
-
-type CreateResumeAssistantStreamResponseOptions = {
-  readonly context: ResumableStreamContext;
-  readonly streamId: string;
-  readonly encoder?: () => AssistantStreamEncoder;
-  readonly headers?: HeadersInit;
-  readonly missingResponse?: () => Response;
-};
-
-declare function createResumeAssistantStreamResponse(options: CreateResumeAssistantStreamResponseOptions): Promise<Response>;
-
-type ResumableStreamErrorCode = "exists" | "finalized" | "invalid-id" | "missing";
-
-declare class ResumableStreamError extends Error {
-  readonly code: ResumableStreamErrorCode;
-  constructor(code: ResumableStreamErrorCode, message: string);
+interface Transaction {
+  pipeline(commands?: unknown[][]): ChainableCommander;
+  multi(options: {
+    pipeline: false;
+  }): Promise<"OK">;
+  multi(): ChainableCommander;
+  multi(options: {
+    pipeline: true;
+  }): ChainableCommander;
+  multi(commands?: unknown[][]): ChainableCommander;
 }
 
-type InMemoryResumableStreamStoreOptions = {
-  readonly defaultTtlMs?: number;
-  readonly now?: () => number;
-  readonly maxChunkBytes?: number;
-  readonly maxEntriesPerStream?: number;
-  readonly maxStreams?: number;
-  readonly gcIntervalMs?: number;
-};
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
 
-declare function createInMemoryResumableStreamStore(options?: InMemoryResumableStreamStoreOptions): ResumableStreamStore & {
-  dispose: () => void;
-};
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
 
-declare namespace entry_resumable_exports {
-  export { CreateResumableAssistantStreamResponseOptions, CreateResumeAssistantStreamResponseOptions, InMemoryResumableStreamStoreOptions, RESUMABLE_STREAM_ID_HEADER, RedisLikeClient, RedisResumableStreamStoreOptions, ResumableStreamAcquireOptions, ResumableStreamContext, ResumableStreamContextOptions, ResumableStreamEntry, ResumableStreamError, ResumableStreamErrorCode, ResumableStreamRole, ResumableStreamStatus, ResumableStreamStore, createInMemoryResumableStreamStore, createResumableAssistantStreamResponse, createResumableStreamContext, createResumeAssistantStreamResponse };
-}
-
-declare const PARTIAL_JSON_OBJECT_META_SYMBOL: unique symbol;
-
-type FieldState = "complete" | "partial";
-
-type PartialJsonObjectMeta = {
-  state: "complete" | "partial";
-  partialPath: string[];
-};
-
-declare const getPartialJsonObjectMeta: (obj: Record<symbol, unknown>) => PartialJsonObjectMeta | undefined;
-
-declare const parsePartialJsonObject: (json: string) => (ReadonlyJSONObject & {
-  [PARTIAL_JSON_OBJECT_META_SYMBOL]: PartialJsonObjectMeta;
-}) | undefined;
-
-declare const getPartialJsonObjectFieldState: (obj: Record<string, unknown>, fieldPath: (string | number)[]) => FieldState;
-
-type AssistantTransformerFlushCallback = (controller: AssistantStreamController) => void | PromiseLike<void>;
-
-type AssistantTransformerStartCallback = (controller: AssistantStreamController) => void | PromiseLike<void>;
-
-type AssistantTransformerTransformCallback<I> = (chunk: I, controller: AssistantStreamController) => void | PromiseLike<void>;
-
-type AssistantTransformer<I> = {
-  flush?: AssistantTransformerFlushCallback;
-  start?: AssistantTransformerStartCallback;
-  transform?: AssistantTransformerTransformCallback<I>;
-};
-
-declare class AssistantTransformStream<I> extends TransformStream<I, AssistantStreamChunk> {
-  constructor(transformer: AssistantTransformer<I>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<AssistantStreamChunk>);
-}
-
-type AssistantMetaStreamChunk = (AssistantStreamChunk & {
-  type: "part-finish" | "text-delta";
-  meta: PartInit;
-}) | (AssistantStreamChunk & {
-  type: "result" | "tool-call-args-text-finish";
-  meta: PartInit & {
-    type: "tool-call";
-  };
-}) | (AssistantStreamChunk & {
-  type: Exclude<AssistantStreamChunk["type"], "part-finish" | "result" | "text-delta" | "tool-call-args-text-finish">;
-});
-
-declare class AssistantMetaTransformStream extends TransformStream<AssistantStreamChunk, AssistantMetaStreamChunk> {
-  constructor();
-}
-
-declare namespace entry_utils_exports {
-  export { AssistantMetaTransformStream, AssistantTransformStream, AsyncIterableStream, ReadonlyJSONArray, ReadonlyJSONObject, ReadonlyJSONValue, asAsyncIterableStream, getPartialJsonObjectFieldState, getPartialJsonObjectMeta, parsePartialJsonObject };
-}
-
-declare class AssistantMessageStream {
-  readonly readable: ReadableStream<AssistantMessage>;
-  constructor(readable: ReadableStream<AssistantMessage>);
-  static fromAssistantStream(stream: AssistantStream): AssistantMessageStream;
-  unstable_result(): Promise<AssistantMessage>;
-  [Symbol.asyncIterator](): {
-    next(): Promise<IteratorResult<AssistantMessage, undefined>>;
-  };
-  tee(): [
-    AssistantMessageStream,
-    AssistantMessageStream
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
   ];
-}
-
-declare const createInitialMessage: (_param0?: {
-  unstable_state?: ReadonlyJSONValue;
-}) => AssistantMessage;
-
-declare class AssistantMessageAccumulator extends TransformStream<AssistantStreamChunk, AssistantMessage> {
-  constructor(_param1?: {
-    initialMessage?: AssistantMessage;
-    throttle?: boolean;
-    onError?: (error: string) => void;
-  });
-}
-
-type GenericTextPart = {
-  type: "text";
-  text: string;
-};
-
-type GenericFilePart = {
-  type: "file";
-  data: string | URL;
-  mediaType: string;
-};
-
-type GenericToolCallPart = {
-  type: "tool-call";
-  toolCallId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-};
-
-type GenericToolResultPart = {
-  type: "tool-result";
-  toolCallId: string;
-  toolName: string;
-  result: unknown;
-  isError?: boolean;
-};
-
-type GenericSystemMessage = {
-  role: "system";
-  content: string;
-};
-
-type GenericUserMessage = {
-  role: "user";
-  content: (GenericTextPart | GenericFilePart)[];
-};
-
-type GenericAssistantMessage = {
-  role: "assistant";
-  content: (GenericTextPart | GenericToolCallPart)[];
-};
-
-type GenericToolMessage = {
-  role: "tool";
-  content: GenericToolResultPart[];
-};
-
-type GenericMessage = GenericSystemMessage | GenericUserMessage | GenericAssistantMessage | GenericToolMessage;
-
-type MessagePartLike = {
-  type: string;
-  text?: string;
-  image?: string;
-  data?: string;
-  mimeType?: string;
-  toolCallId?: string;
-  toolName?: string;
-  args?: Record<string, unknown>;
-  result?: unknown;
-  isError?: boolean;
-};
-
-type AttachmentLike = {
-  content: readonly MessagePartLike[];
-};
-
-type ThreadMessageLike = {
-  role: "assistant" | "system" | "user";
-  content: readonly MessagePartLike[];
-  attachments?: readonly AttachmentLike[];
-};
-
-declare function toGenericMessages(messages: readonly ThreadMessageLike[]): GenericMessage[];
-
-declare class PipeableTransformStream<I, O> extends TransformStream<I, O> {
-  constructor(transform: (readable: ReadableStream<I>) => ReadableStream<O>);
-}
-
-declare class ObjectStreamResponse extends Response {
-  constructor(body: ReadableStream<ObjectStreamChunk>);
-}
-
-declare const fromObjectStreamResponse: (response: Response) => ReadableStream<ObjectStreamChunk>;
-
-type ObjectStreamController = {
-  readonly abortSignal: AbortSignal;
-  enqueue(operations: readonly ObjectStreamOperation[]): void;
-};
-
-type CreateObjectStreamOptions = {
-  execute: (controller: ObjectStreamController) => void | PromiseLike<void>;
-  defaultValue?: ReadonlyJSONValue;
-};
-
-declare const createObjectStream: (_param2: CreateObjectStreamOptions) => ReadableStream<ObjectStreamChunk>;
-
-declare class PlainTextEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
-  headers: Headers;
-  constructor();
-}
-
-declare class PlainTextDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
-  constructor();
-}
-
-declare class AssistantTransportEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
-  headers: Headers;
-  constructor();
-}
-
-declare class AssistantTransportDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
-  constructor();
-}
-
-declare class DataStreamEncoder extends PipeableTransformStream<AssistantStreamChunk, Uint8Array<ArrayBuffer>> implements AssistantStreamEncoder {
-  headers: Headers;
-  constructor();
-}
-
-declare class DataStreamDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
-  constructor();
-}
-
-type FinishReason = "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-
-type Usage = {
-  inputTokens: number;
-  outputTokens: number;
-};
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
 
 type UIMessageStreamChunk = {
   type: "start";
@@ -11886,6 +11858,10 @@ type UIMessageStreamDataChunk = {
   transient?: boolean;
 };
 
+declare class UIMessageStreamDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
+  constructor(options?: UIMessageStreamDecoderOptions);
+}
+
 type UIMessageStreamDecoderOptions = {
   onData?: (data: {
     type: string;
@@ -11895,42 +11871,71 @@ type UIMessageStreamDecoderOptions = {
   }) => void;
 };
 
-declare class UIMessageStreamDecoder extends PipeableTransformStream<Uint8Array<ArrayBuffer>, AssistantStreamChunk> {
-  constructor(options?: UIMessageStreamDecoderOptions);
+type Usage = {
+  inputTokens: number;
+  outputTokens: number;
+};
+
+declare type WriteableStream = NetStream | PipelineWriteableStream;
+
+declare function asAsyncIterableStream<T>(source: ReadableStream<T>): AsyncIterableStream<T>;
+
+declare function createAssistantStream(callback: (controller: AssistantStreamController) => PromiseLike<void> | void): AssistantStream;
+
+declare function createAssistantStreamController(): readonly [
+  AssistantStream,
+  AssistantStreamController
+];
+
+declare function createAssistantStreamResponse(callback: (controller: AssistantStreamController) => PromiseLike<void> | void): Response;
+
+declare function createInMemoryResumableStreamStore(options?: InMemoryResumableStreamStoreOptions): ResumableStreamStore & {
+  dispose: () => void;
+};
+
+declare const createInitialMessage: (_param1?: {
+  unstable_state?: ReadonlyJSONValue;
+}) => AssistantMessage;
+
+declare function createIoredisResumableStreamStore(client: IoRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
+
+declare const createObjectStream: (_param2: CreateObjectStreamOptions) => ReadableStream<ObjectStreamChunk>;
+
+declare function createRedisResumableStreamStore(client: NodeRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
+
+declare function createResumableAssistantStreamResponse(options: CreateResumableAssistantStreamResponseOptions): Promise<Response>;
+
+declare function createResumableStreamContext(options: ResumableStreamContextOptions): ResumableStreamContext;
+
+declare function createResumeAssistantStreamResponse(options: CreateResumeAssistantStreamResponseOptions): Promise<Response>;
+
+declare const fromObjectStreamResponse: (response: Response) => ReadableStream<ObjectStreamChunk>;
+
+declare const getPartialJsonObjectFieldState: (obj: Record<string, unknown>, fieldPath: (string | number)[]) => FieldState;
+
+declare const getPartialJsonObjectMeta: (obj: Record<symbol, unknown>) => PartialJsonObjectMeta | undefined;
+
+declare namespace entry_resumable_exports {
+  export { CreateResumableAssistantStreamResponseOptions, CreateResumeAssistantStreamResponseOptions, InMemoryResumableStreamStoreOptions, RESUMABLE_STREAM_ID_HEADER, RedisLikeClient, RedisResumableStreamStoreOptions, ResumableStreamAcquireOptions, ResumableStreamContext, ResumableStreamContextOptions, ResumableStreamEntry, ResumableStreamError, ResumableStreamErrorCode, ResumableStreamRole, ResumableStreamStatus, ResumableStreamStore, createInMemoryResumableStreamStore, createResumableAssistantStreamResponse, createResumableStreamContext, createResumeAssistantStreamResponse };
 }
 
-type ToolCallback = (toolCall: {
-  toolCallId: string;
-  toolName: string;
-  args: ReadonlyJSONObject;
-}) => Promise<ToolResponse<ReadonlyJSONValue>> | ToolResponse<ReadonlyJSONValue> | undefined;
-
-type ToolStreamCallback = <TArgs extends ReadonlyJSONObject = ReadonlyJSONObject, TResult extends ReadonlyJSONValue = ReadonlyJSONValue>(toolCall: {
-  reader: ToolCallReader<TArgs, TResult>;
-  toolCallId: string;
-  toolName: string;
-}) => void;
-
-type ToolExecutionOptions = {
-  execute: ToolCallback;
-  streamCall: ToolStreamCallback;
-  onExecutionStart?: ((toolCallId: string, toolName: string) => void) | undefined;
-  onExecutionEnd?: ((toolCallId: string, toolName: string) => void) | undefined;
-};
-
-declare class ToolExecutionStream extends PipeableTransformStream<AssistantStreamChunk, AssistantStreamChunk> {
-  constructor(options: ToolExecutionOptions);
+declare namespace entry_root_exports {
+  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, AssistantTransportEncoder, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createObjectStream, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
 }
 
-type ToolJSONSchema = {
-  description?: string;
-  parameters: JSONSchema7;
-  providerOptions?: ProviderOptions;
-};
+declare namespace entry_resumable_ioredis_exports {
+  export { IoRedisLike, createIoredisResumableStreamStore };
+}
 
-type ToToolsJSONSchemaOptions = {
-  filter?: (name: string, tool: Tool) => boolean;
-};
+declare const parsePartialJsonObject: (json: string) => (ReadonlyJSONObject & {
+  [PARTIAL_JSON_OBJECT_META_SYMBOL]: PartialJsonObjectMeta;
+}) | undefined;
+
+declare namespace entry_resumable_redis_exports {
+  export { NodeRedisLike, createRedisResumableStreamStore };
+}
+
+declare function toGenericMessages(messages: readonly ThreadMessageLike[]): GenericMessage[];
 
 declare function toJSONSchema(schema: StandardSchemaV1 | JSONSchema7): JSONSchema7;
 
@@ -11938,17 +11943,12 @@ declare function toPartialJSONSchema(schema: JSONSchema7): JSONSchema7;
 
 declare function toToolsJSONSchema(tools: Record<string, Tool> | undefined, options?: ToToolsJSONSchemaOptions): Record<string, ToolJSONSchema>;
 
-declare function unstable_runPendingTools(message: AssistantMessage, tools: Record<string, Tool> | undefined, abortSignal: AbortSignal, human: (toolCallId: string, payload: unknown) => Promise<unknown>): Promise<AssistantMessage>;
-
-type ToolResultStreamOptions = {
-  onExecutionStart?: (toolCallId: string, toolName: string) => void;
-  onExecutionEnd?: (toolCallId: string, toolName: string) => void;
-};
-
 declare function toolResultStream(tools: Record<string, Tool> | (() => Record<string, Tool> | undefined) | undefined, abortSignal: AbortSignal | (() => AbortSignal), human: (toolCallId: string, payload: unknown) => Promise<unknown>, options?: ToolResultStreamOptions): ToolExecutionStream;
 
-declare namespace entry_root_exports {
-  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, AssistantTransportEncoder, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createObjectStream, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
+declare function unstable_runPendingTools(message: AssistantMessage, tools: Record<string, Tool> | undefined, abortSignal: AbortSignal, human: (toolCallId: string, payload: unknown) => Promise<unknown>): Promise<AssistantMessage>;
+
+declare namespace entry_utils_exports {
+  export { AssistantMetaTransformStream, AssistantTransformStream, AsyncIterableStream, ReadonlyJSONArray, ReadonlyJSONObject, ReadonlyJSONValue, asAsyncIterableStream, getPartialJsonObjectFieldState, getPartialJsonObjectMeta, parsePartialJsonObject };
 }
 
 export { entry_resumable_exports as entry_resumable, entry_resumable_ioredis_exports as entry_resumable_ioredis, entry_resumable_redis_exports as entry_resumable_redis, entry_root_exports as entry_root, entry_utils_exports as entry_utils };

--- a/api-surface/assistant-ui__agent-launcher.ts
+++ b/api-surface/assistant-ui__agent-launcher.ts
@@ -5,10 +5,10 @@ interface LaunchOptions {
   dry?: boolean;
 }
 
-declare function launch(options: LaunchOptions): void;
-
 declare namespace entry_root_exports {
   export { LaunchOptions, launch };
 }
+
+declare function launch(options: LaunchOptions): void;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -1,15 +1,26 @@
-import { ChatInit } from "ai";
-
 import { UIMessage, UseChatHelpers } from "@ai-sdk/react";
 
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
+import { ChatInit } from "ai";
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
 
 type AssistantCloudAuthStrategy = {
   readonly strategy: "anon" | "api-key" | "jwt";
@@ -17,9 +28,14 @@ type AssistantCloudAuthStrategy = {
   readAuthHeaders(headers: Headers): void;
 };
 
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
 };
 
 type AssistantCloudConfig = ({
@@ -37,75 +53,145 @@ type AssistantCloudConfig = ({
   telemetry?: boolean | AssistantCloudTelemetryConfig;
 };
 
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
 }
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
 };
 
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
 };
 
-type PartInit = {
-  readonly type: "reasoning" | "text";
-  readonly parentId?: string;
-} | {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: ReadonlyJSONValue;
-  readonly parentId?: string;
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread$1>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread$1[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
 };
 
 type AssistantStreamChunk = {
@@ -159,80 +245,9 @@ type AssistantStreamChunk = {
   readonly operations: ObjectStreamOperation[];
 });
 
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
   headers?: Headers;
 };
-
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-};
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
 
 type CloudMessage = {
   id: string;
@@ -244,50 +259,14 @@ type CloudMessage = {
   content: ReadonlyJSONObject;
 };
 
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
+type CloudThread = {
+  id: string;
+  title: string;
+  status: ThreadStatus;
+  externalId: string | null;
+  lastMessageAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 type CloudThread$1 = {
@@ -303,38 +282,60 @@ type CloudThread$1 = {
   is_archived: boolean;
 };
 
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread$1[];
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
 };
 
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
 };
 
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
+type ObjectStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
 };
 
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread$1>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
+type PartInit = {
+  readonly type: "reasoning" | "text";
+  readonly parentId?: string;
+} | {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: ReadonlyJSONValue;
+  readonly parentId?: string;
+};
 
 type PdfToImagesRequestBody = {
   file_blob?: string | undefined;
@@ -347,45 +348,54 @@ type PdfToImagesResponse = {
   message: string;
 };
 
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
 
 type ThreadStatus = "archived" | "regular";
 
-type CloudThread = {
-  id: string;
-  title: string;
-  status: ThreadStatus;
-  externalId: string | null;
-  lastMessageAt: Date;
-  createdAt: Date;
-  updatedAt: Date;
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type UseCloudChatOptions = ChatInit<UIMessage> & {
+  threads?: UseThreadsResult;
+  cloud?: AssistantCloud;
+  onSyncError?: (error: Error) => void;
+};
+
+type UseCloudChatResult = UseChatHelpers<UIMessage> & {
+  threads: UseThreadsResult;
 };
 
 type UseThreadsOptions = {
@@ -413,22 +423,12 @@ type UseThreadsResult = {
   generateTitle: (threadId: string) => Promise<string | null>;
 };
 
-type UseCloudChatOptions = ChatInit<UIMessage> & {
-  threads?: UseThreadsResult;
-  cloud?: AssistantCloud;
-  onSyncError?: (error: Error) => void;
-};
-
-type UseCloudChatResult = UseChatHelpers<UIMessage> & {
-  threads: UseThreadsResult;
-};
+declare namespace entry_root_exports {
+  export { CloudThread, ThreadStatus, UseCloudChatOptions, UseCloudChatResult, UseThreadsOptions, UseThreadsResult, useCloudChat, useThreads };
+}
 
 declare function useCloudChat(options?: UseCloudChatOptions): UseCloudChatResult;
 
 declare function useThreads(options: UseThreadsOptions): UseThreadsResult;
-
-declare namespace entry_root_exports {
-  export { CloudThread, ThreadStatus, UseCloudChatOptions, UseCloudChatResult, UseThreadsOptions, UseThreadsResult, useCloudChat, useThreads };
-}
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1,380 +1,371 @@
-import { ComponentType, FC, PropsWithChildren, ReactNode, RefObject } from "react";
-
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
-};
+import { ComponentType, FC, PropsWithChildren, ReactNode, RefObject } from "react";
 
-type CompleteAttachmentStatus = {
-  type: "complete";
-};
-
-type AttachmentStatus = PendingAttachmentStatus | CompleteAttachmentStatus;
-
-type BaseAttachment = {
-  id: string;
-  type: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string | undefined;
-  file?: File;
-  content?: ThreadUserMessagePart[];
-};
-
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
-};
-
-type CompleteAttachment = BaseAttachment & {
-  status: CompleteAttachmentStatus;
-  content: ThreadUserMessagePart[];
-};
-
-type Attachment = PendingAttachment | CompleteAttachment;
-
-type CreateAttachment = {
-  id?: string;
-  type?: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string;
-  content: ThreadUserMessagePart[];
-};
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
-
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
-
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
-
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+interface ScopeRegistry {
+    threads: ThreadsClientSchema;
+    threadListItem: ThreadListItemClientSchema;
+    thread: ThreadClientSchema;
+    message: MessageClientSchema;
+    part: PartClientSchema;
+    composer: ComposerClientSchema;
+    attachment: AttachmentClientSchema;
+    modelContext: ModelContextClientSchema;
+    suggestions: SuggestionsClientSchema;
+    suggestion: SuggestionClientSchema;
+    chainOfThought: ChainOfThoughtClientSchema;
+    queueItem: QueueItemClientSchema;
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+interface ScopeRegistry {
+    tools: ToolsClientSchema;
+    dataRenderers: DataRenderersClientSchema;
+    interactables: InteractablesClientSchema;
+    unstable_interactables: Unstable_InteractablesClientSchema;
 }
 
-type JSONSchema7Version = string;
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-interface JSONSchema7 {
-  $id?: string | undefined;
-  $ref?: string | undefined;
-  $schema?: JSONSchema7Version | undefined;
-  $comment?: string | undefined;
-  $defs?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
-  enum?: JSONSchema7Type[] | undefined;
-  const?: JSONSchema7Type | undefined;
-  multipleOf?: number | undefined;
-  maximum?: number | undefined;
-  exclusiveMaximum?: number | undefined;
-  minimum?: number | undefined;
-  exclusiveMinimum?: number | undefined;
-  maxLength?: number | undefined;
-  minLength?: number | undefined;
-  pattern?: string | undefined;
-  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
-  additionalItems?: JSONSchema7Definition | undefined;
-  maxItems?: number | undefined;
-  minItems?: number | undefined;
-  uniqueItems?: boolean | undefined;
-  contains?: JSONSchema7Definition | undefined;
-  maxProperties?: number | undefined;
-  minProperties?: number | undefined;
-  required?: string[] | undefined;
-  properties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  patternProperties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  additionalProperties?: JSONSchema7Definition | undefined;
-  dependencies?: {
-    [key: string]: JSONSchema7Definition | string[];
-  } | undefined;
-  propertyNames?: JSONSchema7Definition | undefined;
-  if?: JSONSchema7Definition | undefined;
-  then?: JSONSchema7Definition | undefined;
-  else?: JSONSchema7Definition | undefined;
-  allOf?: JSONSchema7Definition[] | undefined;
-  anyOf?: JSONSchema7Definition[] | undefined;
-  oneOf?: JSONSchema7Definition[] | undefined;
-  not?: JSONSchema7Definition | undefined;
-  format?: string | undefined;
-  contentMediaType?: string | undefined;
-  contentEncoding?: string | undefined;
-  definitions?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  title?: string | undefined;
-  description?: string | undefined;
-  default?: JSONSchema7Type | undefined;
-  readOnly?: boolean | undefined;
-  writeOnly?: boolean | undefined;
-  examples?: JSONSchema7Type | undefined;
-}
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
 
 type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
 } | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+  source: null;
+  query: null;
+}) & {
+  name: K;
 };
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
   };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
 }
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
 
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: string | undefined;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type McpServerConfig = {
-  type: "http" | "sse";
-  url: string;
-  headers?: Record<string, string>;
-  redirect?: "error" | "follow";
-  connectionTimeout?: number | undefined;
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
 } | {
-  type: "stdio";
-  command: string;
-  args?: readonly string[];
-  env?: Record<string, string>;
-  cwd?: string;
-  connectionTimeout?: number | undefined;
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
 };
 
-type McpTool = ToolBase<Record<string, unknown>, unknown> & {
-  type: "mcp";
-  server: McpServerConfig;
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
 };
 
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
 };
 
-type PartInit = {
-  readonly type: "reasoning" | "text";
-  readonly parentId?: string;
-} | {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-} | {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: ReadonlyJSONValue;
-  readonly parentId?: string;
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantContextConfig = {
+  getContext: () => string;
+  disabled?: boolean | undefined;
+};
+
+type AssistantDataUI = FC & {
+  unstable_data: AssistantDataUIProps;
+};
+
+type AssistantDataUIProps<T = any> = {
+  name: string;
+  render: DataMessagePartComponent<T>;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+declare class AssistantFrameHost implements ModelContextProvider {
+  private _context;
+  private _subscribers;
+  private _pendingRequests;
+  private _requestCounter;
+  private _iframeWindow;
+  private _targetOrigin;
+  constructor(iframeWindow: Window, targetOrigin?: string);
+  private handleMessage;
+  private updateContext;
+  private callTool;
+  private sendRequest;
+  private requestContext;
+  private notifySubscribers;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  dispose(): void;
+}
+
+declare class AssistantFrameProvider {
+  private static _instance;
+  private _providers;
+  private _providerUnsubscribes;
+  private _targetOrigin;
+  private constructor();
+  private static getInstance;
+  private handleMessage;
+  private handleToolCall;
+  private sendMessage;
+  private getModelContext;
+  private broadcastUpdate;
+  static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
+  static dispose(): void;
+}
+
+type AssistantInstructionsConfig = {
+  disabled?: boolean | undefined;
+  instruction: string;
+};
+
+type AssistantInteractableProps = {
+  description: string;
+  stateSchema: InteractableStateSchema;
+  initialState: unknown;
+  id?: string;
+  selected?: boolean;
+};
+
+declare const AssistantProviderBase: FC<AssistantProviderBaseProps>;
+
+type AssistantProviderBaseProps = PropsWithChildren<{
+  runtime: AssistantRuntime;
+  aui?: AssistantClient | null;
+}>;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+};
+
+type AssistantRuntimeCore = {
+  readonly threads: ThreadListRuntimeCore;
+  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
+  getModelContextProvider: () => ModelContextProvider;
+  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
+};
+
+declare class AssistantRuntimeImpl implements AssistantRuntime {
+  private readonly _core;
+  readonly threads: ThreadListRuntimeImpl;
+  readonly _thread: ThreadRuntime;
+  constructor(_core: AssistantRuntimeCore);
+  protected __internal_bindMethods(): void;
+  get thread(): ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+}
+
+declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param0: {
+  runtime: AssistantRuntime;
+  aui?: AssistantClient | null;
+  children: ReactNode;
+}) => import("react").JSX.Element>;
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
 };
 
 type AssistantStreamChunk = {
@@ -428,312 +419,43 @@ type AssistantStreamChunk = {
   readonly operations: ObjectStreamOperation[];
 });
 
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
   headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type AssistantTool = FC & {
+  unstable_tool: AssistantToolProps<any, any>;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
+type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
+type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
+  toolName: string;
+  render?: unknown;
 };
 
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
+type AssistantToolUI = FC & {
+  unstable_tool: AssistantToolUIProps<any, any>;
 };
 
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
+type AssistantToolUIProps<TArgs, TResult> = {
+  toolName: string;
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+  display?: "inline" | "standalone";
 };
 
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type AsyncStorageLike = {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-declare const MCP_APP_URI_SCHEME = "ui://";
-
-declare const isMcpAppUri: (uri: string | undefined) => boolean;
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
+type Attachment = PendingAttachment | CompleteAttachment;
 
 type AttachmentAdapter = {
   accept: string;
@@ -744,480 +466,6 @@ type AttachmentAdapter = {
   send(attachment: PendingAttachment): Promise<CompleteAttachment>;
 };
 
-declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare const getFileDataURL: (file: File) => Promise<string>;
-
-declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
-  accept: string;
-  constructor(adapters: AttachmentAdapter[]);
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(attachment: Attachment): Promise<void>;
-}
-
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
-};
-
-type ThreadMessageLike = {
-  readonly role: "assistant" | "system" | "user";
-  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
-    readonly type: "tool-call";
-    readonly toolCallId?: string;
-    readonly toolName: string;
-    readonly args?: ReadonlyJSONObject;
-    readonly argsText?: string;
-    readonly artifact?: any;
-    readonly result?: any | undefined;
-    readonly isError?: boolean | undefined;
-    readonly parentId?: string | undefined;
-    readonly messages?: readonly ThreadMessage[] | undefined;
-    readonly interrupt?: {
-      type: "human";
-      payload: unknown;
-    };
-    readonly timing?: ToolCallTiming;
-    readonly approval?: {
-      readonly id: string;
-      readonly approved?: boolean;
-      readonly reason?: string;
-      readonly isAutomatic?: boolean;
-      readonly options?: readonly ToolApprovalOption[];
-      readonly optionId?: string;
-      readonly resolution?: "cancelled" | "expired";
-    };
-  })[];
-  readonly id?: string | undefined;
-  readonly createdAt?: Date | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
-    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
-  })[] | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly isOptimistic?: boolean | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  } | undefined;
-};
-
-declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
-
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
-  get headId(): string | null;
-  get canonicalHeadId(): string | null;
-  getMessages(headId?: string): readonly ThreadMessage[];
-  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
-  getMessage(messageId: string): {
-    parentId: string | null;
-    message: ThreadMessage;
-    index: number;
-  };
-  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
-  getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
-  switchToBranch(messageId: string): void;
-  resetHead(messageId: string | null): void;
-  clear(): void;
-  export(): ExportedMessageRepository;
-  import(_param0: ExportedMessageRepository): void;
-}
-
-type Unsubscribe$1 = () => void;
-
-declare const SKIP_UPDATE: unique symbol;
-
-type SKIP_UPDATE = typeof SKIP_UPDATE;
-
-type Subscribable = {
-  subscribe: (callback: () => void) => Unsubscribe$1;
-};
-
-type SubscribableWithState<TState, TPath> = Subscribable & {
-  path: TPath;
-  getState: () => TState;
-};
-
-type NestedSubscribable<TState extends Subscribable | undefined, TPath> = SubscribableWithState<TState, TPath>;
-
-type EventSubscribable<TEvent extends string> = {
-  event: TEvent;
-  binding: SubscribableWithState<{
-    unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
-  } | undefined, unknown>;
-};
-
-declare class BaseSubscribable {
-  private _subscribers;
-  subscribe(callback: () => void): Unsubscribe$1;
-  waitForUpdate(): Promise<void>;
-  protected _notifySubscribers(): void;
-}
-
-declare abstract class BaseSubject {
-  private _subscriptions;
-  private _connection;
-  protected get isConnected(): boolean;
-  protected abstract _connect(): Unsubscribe$1;
-  protected notifySubscribers(payload?: unknown): void;
-  private _updateConnection;
-  subscribe(callback: (payload?: unknown) => void): () => void;
-}
-
-declare class ShallowMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
-  private binding;
-  get path(): TPath;
-  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
-  private _previousState;
-  getState: () => TState;
-  private _syncState;
-  protected _connect(): Unsubscribe$1;
-}
-
-declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
-  private binding;
-  get path(): TPath;
-  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
-  private _previousStateDirty;
-  private _previousState;
-  getState: () => TState;
-  protected _connect(): Unsubscribe$1;
-}
-
-declare class NestedSubscriptionSubject<TState extends Subscribable | undefined, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath>, NestedSubscribable<TState, TPath> {
-  private binding;
-  get path(): TPath;
-  constructor(binding: NestedSubscribable<TState, TPath>);
-  getState(): TState;
-  outerSubscribe(callback: () => void): Unsubscribe$1;
-  protected _connect(): Unsubscribe$1;
-}
-
-declare class EventSubscriptionSubject<TEvent extends string> extends BaseSubject {
-  private config;
-  constructor(config: EventSubscribable<TEvent>);
-  getState(): {
-    unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
-  } | undefined;
-  outerSubscribe(callback: () => void): Unsubscribe$1;
-  protected _connect(): Unsubscribe$1;
-}
-
-declare const generateId: (size?: number) => string;
-
-declare const generateErrorMessageId: () => string;
-
-declare const isErrorMessageId: (id: string) => boolean;
-
-declare const getThreadMessageText: (message: ThreadMessage | AppendMessage) => string;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe$1;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe$1;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-declare class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
-  speak(text: string): SpeechSynthesisAdapter.Utterance;
-}
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-declare class WebSpeechDictationAdapter implements DictationAdapter {
-  private _language;
-  private _continuous;
-  private _interimResults;
-  constructor(options?: {
-    language?: string;
-    continuous?: boolean;
-    interimResults?: boolean;
-  });
-  static isSupported(): boolean;
-  listen(): DictationAdapter.Session;
-}
-
-declare namespace RealtimeVoiceAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Mode = "listening" | "speaking";
-  type TranscriptItem = {
-    role: "assistant" | "user";
-    text: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    isMuted: boolean;
-    disconnect: () => void;
-    mute: () => void;
-    unmute: () => void;
-    onStatusChange: (callback: (status: Status) => void) => Unsubscribe$1;
-    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe$1;
-    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe$1;
-    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe$1;
-  };
-}
-
-type RealtimeVoiceAdapter = {
-  connect: (options: {
-    abortSignal?: AbortSignal;
-  }) => RealtimeVoiceAdapter.Session;
-};
-
-type VoiceSessionControls = {
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
-};
-
-type VoiceSessionHelpers = {
-  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
-  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
-  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
-  emitVolume: (volume: number) => void;
-  isDisposed: () => boolean;
-};
-
-declare function createVoiceSession(options: {
-  abortSignal?: AbortSignal;
-}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
-};
-
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
-};
-
-type ModelContext$1 = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
-};
-
-type ModelContextProvider = {
-  getModelContext: () => ModelContext$1;
-  subscribe?: (callback: () => void) => Unsubscribe$1;
-};
-
-type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
-  toolName: string;
-  render?: unknown;
-};
-
-type AssistantInstructionsConfig = {
-  disabled?: boolean | undefined;
-  instruction: string;
-};
-
-type AssistantContextConfig = {
-  getContext: () => string;
-  disabled?: boolean | undefined;
-};
-
-declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
-
-type ChatModelRunUpdate = {
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly metadata?: Record<string, unknown>;
-};
-
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  };
-};
-
-type CoreChatModelRunResult = Omit<ChatModelRunResult, "content"> & {
-  readonly content: readonly (TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart)[];
-};
-
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext$1;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
-};
-
-type ChatModelAdapter = {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type QueueItemMethods = {
-  getState(): QueueItemState;
-  steer(): void;
-  remove(): void;
-};
-
-type QueueItemMeta = {
-  source: "composer";
-  query: {
-    index: number;
-  };
-};
-
-type QueueItemClientSchema = {
-  methods: QueueItemMethods;
-  meta: QueueItemMeta;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
 type AttachmentAddErrorEvent = {
   readonly reason: AttachmentAddErrorReason;
   readonly message: string;
@@ -1225,399 +473,62 @@ type AttachmentAddErrorEvent = {
   readonly error?: Error;
 };
 
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentClientSchema = {
+  methods: AttachmentMethods;
+  meta: AttachmentMeta;
 };
 
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type ComposerRuntimeCore = Readonly<{
-  isEditing: boolean;
-  canCancel: boolean;
-  canSend: boolean;
-  isEmpty: boolean;
-  attachments: readonly Attachment[];
-  attachmentAccept: string;
-  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
-  removeAttachment: (attachmentId: string) => Promise<void>;
-  text: string;
-  setText: (value: string) => void;
-  role: MessageRole;
-  setRole: (role: MessageRole) => void;
-  runConfig: RunConfig;
-  setRunConfig: (runConfig: RunConfig) => void;
-  quote: QuoteInfo | undefined;
-  setQuote: (quote: QuoteInfo | undefined) => void;
-  reset: () => Promise<void>;
-  clearAttachments: () => Promise<void>;
-  send: (options?: SendOptions) => void;
-  cancel: () => void;
-  queue: readonly QueueItemState[];
-  steerQueueItem: (queueItemId: string) => void;
-  removeQueueItem: (queueItemId: string) => void;
-  dictation: DictationState | undefined;
-  startDictation: () => void;
-  stopDictation: () => void;
-  subscribe: (callback: () => void) => Unsubscribe$1;
-  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
-}>;
-
-type ThreadComposerRuntimeCore = ComposerRuntimeCore;
-
-type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
-  parentId: string | null;
-  sourceId: string | null;
-}>;
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type ResumeToolCallOptions = {
-  toolCallId: string;
-  payload: unknown;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type SubmitFeedbackOptions = {
-  messageId: string;
-  type: "negative" | "positive";
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type SubmittedFeedback = {
-  readonly type: "negative" | "positive";
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ThreadRuntimeCore = Readonly<{
-  getMessageById: (messageId: string) => {
-    parentId: string | null;
-    message: ThreadMessage;
+type AttachmentMeta = {
+  source: "composer" | "message";
+  query: {
+    type: "index";
     index: number;
-  } | undefined;
-  getBranches: (messageId: string) => readonly string[];
-  switchToBranch: (branchId: string) => void;
-  append: (message: AppendMessage) => void;
-  deleteMessage: (messageId: string) => void | Promise<void>;
-  startRun: (config: StartRunConfig) => void;
-  resumeRun: (config: ResumeRunConfig) => void;
-  cancelRun: () => void;
-  addToolResult: (options: AddToolResultOptions) => void;
-  resumeToolCall: (options: ResumeToolCallOptions) => void;
-  respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
-  speak: (messageId: string) => void;
-  stopSpeaking: () => void;
-  connectVoice: () => void;
-  disconnectVoice: () => void;
-  muteVoice: () => void;
-  unmuteVoice: () => void;
-  submitFeedback: (feedback: SubmitFeedbackOptions) => void;
-  getModelContext: () => ModelContext$1;
-  composer: ThreadComposerRuntimeCore;
-  getEditComposer: (messageId: string) => EditComposerRuntimeCore | undefined;
-  beginEdit: (messageId: string) => void;
-  getQueueItems?: () => readonly QueueItemState[];
-  steerQueueItem?: (queueItemId: string) => void;
-  removeQueueItem?: (queueItemId: string) => void;
-  speech: SpeechState | undefined;
-  voice: VoiceSessionState | undefined;
-  capabilities: Readonly<RuntimeCapabilities>;
-  isDisabled: boolean;
-  isSendDisabled: boolean;
-  isLoading: boolean;
-  isRunning?: boolean | undefined;
-  messages: readonly ThreadMessage[];
-  state: ReadonlyJSONValue;
-  suggestions: readonly ThreadSuggestion[];
-  extras: unknown;
-  subscribe: (callback: () => void) => Unsubscribe$1;
-  getVoiceVolume: () => number;
-  subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
-  import(repository: ExportedMessageRepository): void;
-  export(): ExportedMessageRepository;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-}>;
-
-declare const resolveToolApprovalResponse: (approval: {
-  readonly id: string;
-  readonly options?: readonly ToolApprovalOption[];
-}, response: ToolApprovalResponse) => RespondToToolApprovalOptions;
-
-declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
-  getModelContext(): ModelContext$1;
-  registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
-  notifySubscribers(): void;
-  subscribe(callback: () => void): () => void;
-}
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
+  } | {
+    type: "id";
+    id: string;
   };
-  events: Record<`${E}.`, E>;
 };
 
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
+type AttachmentMethods = {
+  getState(): AttachmentState;
+  remove(): Promise<void>;
+  __internal_getRuntime?(): AttachmentRuntime;
 };
 
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
   };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
+  readonly source: TSource;
+  getState(): AttachmentState$1 & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
 };
 
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
+declare const AttachmentRuntimeClient: Resource<ClientOutput<"attachment">, [
+  {
+    runtime: AttachmentRuntime;
+  }
 ]>;
 
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
+declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  private _core;
+  get path(): AttachmentRuntimePath & {
+    attachmentSource: Source;
+  };
+  abstract get source(): Source;
+  constructor(_core: AttachmentSnapshotBinding<Source>);
+  protected __internal_bindMethods(): void;
+  getState(): AttachmentState$1 & {
+    source: Source;
+  };
+  abstract remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
 }
-
-type ScopesConfig = {
-  [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
-};
-
-type RuntimeExtras<T extends object> = {
-  provide: (value: T) => T;
-  is: (extras: unknown) => extras is T;
-  tryGet: (extras: unknown) => T | undefined;
-  get: (client: AssistantClient) => T;
-  use: {
-    (): T;
-    <S>(select: (extras: T) => S): S;
-    <S>(select: (extras: T) => S, fallback: S): S;
-  };
-};
-
-declare const createRuntimeExtras: <T extends object>(runtimeName: string) => RuntimeExtras<T>;
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
 
 type AttachmentRuntimePath = ((MessageRuntimePath & {
   readonly attachmentSource: "edit-composer" | "message";
@@ -1636,93 +547,44 @@ type AttachmentRuntimePath = ((MessageRuntimePath & {
   };
 };
 
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
+type AttachmentRuntimeSource = AttachmentState$1["source"];
 
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemCoreState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-  readonly runtime?: ThreadRuntimeCore | undefined;
-};
-
-type ThreadListRuntimeCore = {
-  readonly isLoading: boolean;
-  readonly isLoadingMore?: boolean;
-  readonly hasMore?: boolean;
-  mainThreadId: string;
-  newThreadId: string | undefined;
-  threadIds: readonly string[];
-  archivedThreadIds: readonly string[];
-  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
-  getMainThreadRuntimeCore(): ThreadRuntimeCore;
-  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
-  getItemById(threadId: string): ThreadListItemCoreState | undefined;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload?(): Promise<void>;
-  loadMore?(): Promise<void>;
-  detach(threadId: string): Promise<void>;
-  rename(threadId: string, newTitle: string): Promise<void>;
-  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(threadId: string): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
-
-type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "thread";
+type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
+  source: Source;
+}, AttachmentRuntimePath & {
+  attachmentSource: Source;
 }>;
 
-type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "edit";
-}>;
+type AttachmentState = Attachment;
 
-type MessageStateBinding = SubscribableWithState<ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-}, MessageRuntimePath>;
+type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
 
-type ThreadListItemState$1 = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
+type AttachmentStatus = PendingAttachmentStatus | CompleteAttachmentStatus;
+
+type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
+
+type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
-type AssistantRuntimeCore = {
-  readonly threads: ThreadListRuntimeCore;
-  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
-  getModelContextProvider: () => ModelContextProvider;
-  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
+type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: string | undefined;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
 };
 
 declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
@@ -1731,6 +593,15 @@ declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore 
   registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
   getModelContextProvider(): ModelContextProvider;
 }
+
+type BaseAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
 
 declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
   readonly isEditing = true;
@@ -1792,68 +663,60 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
 }
 
-declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
-  private _canCancel;
-  get canCancel(): boolean;
-  get canSend(): boolean;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected getDictationAdapter(): DictationAdapter | undefined;
-  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
-    adapters?: {
-      attachments?: AttachmentAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-    } | undefined;
-  });
-  connect(): Unsubscribe$1;
-  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
-  handleCancel(): Promise<void>;
-}
-
-declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
-  private runtime;
-  private endEditCallback;
-  get canCancel(): boolean;
-  get canSend(): boolean;
-  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected getDictationAdapter(): DictationAdapter | undefined;
-  private _previousText;
-  private _previousAttachments;
-  private _nonTextPassthrough;
-  private _parentId;
-  private _sourceId;
-  constructor(runtime: ThreadRuntimeCore & {
-    adapters?: {
-      attachments?: AttachmentAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-    } | undefined;
-  }, endEditCallback: () => void, _param1: {
-    parentId: string | null;
-    message: ThreadMessage;
-  });
-  get parentId(): string | null;
-  get sourceId(): string | null;
-  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
-  handleCancel(): void;
-}
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
 };
 
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
+declare abstract class BaseSubject {
+  private _subscriptions;
+  private _connection;
+  protected get isConnected(): boolean;
+  protected abstract _connect(): Unsubscribe$1;
+  protected notifySubscribers(payload?: unknown): void;
+  private _updateConnection;
+  subscribe(callback: (payload?: unknown) => void): () => void;
+}
+
+declare class BaseSubscribable {
+  private _subscribers;
+  subscribe(callback: () => void): Unsubscribe$1;
+  waitForUpdate(): Promise<void>;
+  protected _notifySubscribers(): void;
+}
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
   feedback?: FeedbackAdapter | undefined;
   attachments?: AttachmentAdapter | undefined;
   voice?: RealtimeVoiceAdapter | undefined;
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
 };
 
 declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
@@ -1903,7 +766,7 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   protected _notifySubscribers(): void;
   _notifyEventSubscribers<E extends ThreadRuntimeEventType>(event: E, payload: ThreadRuntimeEventPayload[E]): void;
   subscribe(callback: () => void): Unsubscribe$1;
-  submitFeedback(_param2: SubmitFeedbackOptions): void;
+  submitFeedback(_param1: SubmitFeedbackOptions): void;
   private _stopSpeaking;
   speech: SpeechState | undefined;
   speak(messageId: string): void;
@@ -1930,54 +793,204 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
+declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>>;
+
+declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
+  {
+    parts: readonly ChainOfThoughtPart[];
+    getMessagePart: (selector: {
+      index: number;
+    }) => PartMethods;
+  }
+]>;
+
+type ChainOfThoughtClientSchema = {
+  methods: ChainOfThoughtMethods;
+  meta: ChainOfThoughtMeta;
 };
 
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
+type ChainOfThoughtMeta = {
+  source: "message";
+  query: {
+    type: "chainOfThought";
+  };
 };
 
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
+type ChainOfThoughtMethods = {
+  getState(): ChainOfThoughtState;
+  setCollapsed(collapsed: boolean): void;
+  part(selector: {
+    index: number;
+  }): PartMethods;
 };
 
-type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
-  source: Source;
-}, AttachmentRuntimePath & {
-  attachmentSource: Source;
+type ChainOfThoughtPart = Extract<PartState, {
+  type: "tool-call";
+} | {
+  type: "reasoning";
 }>;
 
-type AttachmentRuntimeSource = AttachmentState$1["source"];
+declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
 
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
+type ChainOfThoughtPartsComponentConfig = {
+  Reasoning?: ReasoningMessagePartComponent | undefined;
+  tools?: {
+    Fallback?: ToolCallMessagePartComponent | undefined;
   };
-  readonly source: TSource;
-  getState(): AttachmentState$1 & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
+  Layout?: ComponentType<PropsWithChildren> | undefined;
 };
 
-declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
-  get path(): AttachmentRuntimePath & {
-    attachmentSource: Source;
+declare namespace ChainOfThoughtPrimitiveParts {
+  type Props = {
+    components?: ChainOfThoughtPartsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      part: PartState;
+    }) => ReactNode;
+    components?: never;
   };
-  abstract get source(): Source;
-  constructor(_core: AttachmentSnapshotBinding<Source>);
-  protected __internal_bindMethods(): void;
-  getState(): AttachmentState$1 & {
-    source: Source;
-  };
-  abstract remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
 }
+
+declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
+
+type ChainOfThoughtState = {
+  readonly parts: readonly ChainOfThoughtPart[];
+  readonly collapsed: boolean;
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type ChatModelAdapter = {
+  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext$1;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ChatModelRunUpdate = {
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly metadata?: Record<string, unknown>;
+};
+
+type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
+  private cloud;
+  accept: string;
+  constructor(cloud: AssistantCloud);
+  private uploadedUrls;
+  add(_param2: {
+    file: File;
+  }): AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+}
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
+};
+
+type CloudThreadListAdapterOptions = {
+  cloud?: AssistantCloud | undefined;
+  create?: (() => Promise<ThreadData>) | undefined;
+  delete?: ((threadId: string) => Promise<void>) | undefined;
+};
+
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
+
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
 
 declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
   private _composerApi;
@@ -1985,45 +998,126 @@ declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" 
   remove(): Promise<void>;
 }
 
-declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
-  get source(): "thread-composer";
-}
-
-declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
-  get source(): "edit-composer";
-}
-
-declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
-  get source(): "message";
-  remove(): never;
-}
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
+type ComposerAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
 };
 
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
+declare const ComposerClient: Resource<ClientOutput<"composer">, [
+  {
+    threadIdRef: {
+      current: string;
+    };
+    messageIdRef?: {
+      current: string;
+    };
+    runtime: ComposerRuntime;
+  }
+]>;
+
+type ComposerClientSchema = {
+  methods: ComposerMethods;
+  meta: ComposerMeta;
+  events: ComposerEvents;
 };
 
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
+type ComposerEvents = {
+  "composer.send": {
+    threadId: string;
+    messageId?: string;
+  };
+  "composer.attachmentAdd": {
+    threadId: string;
+    messageId?: string;
+  };
+  "composer.attachmentAddError": {
+    threadId: string;
+    messageId?: string;
+    attachmentId?: string;
+    reason: AttachmentAddErrorReason;
+    message: string;
+  };
 };
 
-type ComposerState$1 = ThreadComposerState | EditComposerState;
+type ComposerIfFilters = {
+  editing: boolean | undefined;
+  dictation: boolean | undefined;
+};
+
+type ComposerMeta = {
+  source: "message" | "thread";
+  query: Record<string, never>;
+};
+
+type ComposerMethods = {
+  getState(): ComposerState;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  clearAttachments(): Promise<void>;
+  attachment(selector: {
+    index: number;
+  } | {
+    id: string;
+  }): AttachmentMethods;
+  reset(): Promise<void>;
+  send(opts?: ComposerSendOptions): void;
+  cancel(): void;
+  beginEdit(): void;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  queueItem(selector: {
+    index: number;
+  }): QueueItemMethods;
+  __internal_getRuntime?(): ComposerRuntime;
+};
+
+declare namespace ComposerPrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: ComposerAttachmentsComponentConfig;
+  };
+}
+
+declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare namespace ComposerPrimitiveAttachments {
+  type Props = {
+    components: ComposerAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: Attachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
+
+declare namespace ComposerPrimitiveIf {
+  type Props = PropsWithChildren<UseComposerIfProps>;
+}
+
+declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
+
+declare namespace ComposerPrimitiveQueue {
+  type Props = {
+    children: (value: {
+      queueItem: QueueItemState;
+    }) => ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
+  children: (value: {
+    queueItem: QueueItemState;
+  }) => ReactNode;
+}>;
 
 type ComposerRuntime = {
   readonly path: ComposerRuntimePath;
@@ -2046,6 +1140,49 @@ type ComposerRuntime = {
   setQuote(quote: QuoteInfo | undefined): void;
   unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
 };
+
+type ComposerRuntimeCore = Readonly<{
+  isEditing: boolean;
+  canCancel: boolean;
+  canSend: boolean;
+  isEmpty: boolean;
+  attachments: readonly Attachment[];
+  attachmentAccept: string;
+  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
+  removeAttachment: (attachmentId: string) => Promise<void>;
+  text: string;
+  setText: (value: string) => void;
+  role: MessageRole;
+  setRole: (role: MessageRole) => void;
+  runConfig: RunConfig;
+  setRunConfig: (runConfig: RunConfig) => void;
+  quote: QuoteInfo | undefined;
+  setQuote: (quote: QuoteInfo | undefined) => void;
+  reset: () => Promise<void>;
+  clearAttachments: () => Promise<void>;
+  send: (options?: SendOptions) => void;
+  cancel: () => void;
+  queue: readonly QueueItemState[];
+  steerQueueItem: (queueItemId: string) => void;
+  removeQueueItem: (queueItemId: string) => void;
+  dictation: DictationState | undefined;
+  startDictation: () => void;
+  stopDictation: () => void;
+  subscribe: (callback: () => void) => Unsubscribe$1;
+  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
+}>;
+
+type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   protected _core: ComposerRuntimeCoreBinding;
@@ -2073,27 +1210,232 @@ declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
   abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
 }
 
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerSendOptions = SendOptions & {
+  steer?: boolean;
 };
 
-declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
-  get path(): ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  get type(): "thread";
-  private _getState;
-  constructor(core: ThreadComposerRuntimeCoreBinding);
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
+type ComposerState = {
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly isEditing: boolean;
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly attachmentAccept: string;
+  readonly isEmpty: boolean;
+  readonly type: "edit" | "thread";
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type ComposerState$1 = ThreadComposerState | EditComposerState;
+
+declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  private _adapters;
+  accept: string;
+  constructor(adapters: AttachmentAdapter[]);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(attachment: Attachment): Promise<void>;
 }
+
+declare class CompositeContextProvider implements ModelContextProvider {
+  private _providers;
+  getModelContext(): ModelContext$1;
+  registerModelContextProvider(provider: ModelContextProvider): () => void;
+  private _subscribers;
+  notifySubscribers(): void;
+  subscribe(callback: () => void): () => void;
+}
+
+type ConverterCallback<TIn> = (cache: ThreadMessage | undefined, message: TIn, idx: number) => ThreadMessage;
+
+type CoreChatModelRunResult = Omit<ChatModelRunResult, "content"> & {
+  readonly content: readonly (TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart)[];
+};
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
+
+type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};
+
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
+
+type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
+]>;
+
+type DataRenderersClientSchema = {
+  methods: DataRenderersMethods;
+};
+
+type DataRenderersMethods = {
+  getState(): DataRenderersState;
+  setDataUI(name: string, render: DataMessagePartComponent): Unsubscribe$1;
+  setFallbackDataUI(render: DataMessagePartComponent): Unsubscribe$1;
+};
+
+type DataRenderersState = {
+  renderers: Record<string, DataMessagePartComponent[]>;
+  fallbacks: DataMessagePartComponent[];
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
+  private runtime;
+  private endEditCallback;
+  get canCancel(): boolean;
+  get canSend(): boolean;
+  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected getDictationAdapter(): DictationAdapter | undefined;
+  private _previousText;
+  private _previousAttachments;
+  private _nonTextPassthrough;
+  private _parentId;
+  private _sourceId;
+  constructor(runtime: ThreadRuntimeCore & {
+    adapters?: {
+      attachments?: AttachmentAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+    } | undefined;
+  }, endEditCallback: () => void, _param3: {
+    parentId: string | null;
+    message: ThreadMessage;
+  });
+  get parentId(): string | null;
+  get sourceId(): string | null;
+  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
+  handleCancel(): void;
+}
+
+declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  private runtime;
+  private _canCancel;
+  get canCancel(): boolean;
+  get canSend(): boolean;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected getDictationAdapter(): DictationAdapter | undefined;
+  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: {
+      attachments?: AttachmentAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+    } | undefined;
+  });
+  connect(): Unsubscribe$1;
+  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
+  handleCancel(): Promise<void>;
+}
+
+declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
+  _config: Derived.Props<K>
+]>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
+}
+
+type DerivedElement<K extends ClientNames> = ResourceElement<null, [
+  Derived.Props<K>
+]>;
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe$1;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
+  };
+}
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+declare const EMPTY_THREAD_CORE: ThreadRuntimeCore;
+
+declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
+  get source(): "edit-composer";
+}
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
 
 type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
   readonly path: ComposerRuntimePath & {
@@ -2106,6 +1448,15 @@ type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getSt
     source: "edit-composer";
   };
 };
+
+type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
+  parentId: string | null;
+  sourceId: string | null;
+}>;
+
+type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "edit";
+}>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
   private _beginEdit;
@@ -2121,456 +1472,377 @@ declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements Edi
   getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
 }
 
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
 };
 
-type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
+type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
 
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe$1;
+type EmptyMessagePartProps = {
+  status: MessagePartStatus;
 };
 
-declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
-  get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
-  protected __internal_bindMethods(): void;
-  getState(): MessagePartState;
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  subscribe(callback: () => void): Unsubscribe$1;
+type EnrichedPartState = (Extract<PartState, {
+  type: "tool-call";
+}> & {
+  readonly toolUI: ReactNode;
+  addResult: ToolCallMessagePartProps["addResult"];
+  resume: ToolCallMessagePartProps["resume"];
+  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
+}) | (Extract<PartState, {
+  type: "data";
+}> & {
+  readonly dataRendererUI: ReactNode;
+}) | Exclude<PartState, {
+  type: "tool-call";
+} | {
+  type: "data";
+}>;
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type EventSubscribable<TEvent extends string> = {
+  event: TEvent;
+  binding: SubscribableWithState<{
+    unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
+  } | undefined, unknown>;
+};
+
+declare class EventSubscriptionSubject<TEvent extends string> extends BaseSubject {
+  private config;
+  constructor(config: EventSubscribable<TEvent>);
+  getState(): {
+    unstable_on: (event: TEvent, callback: (payload?: unknown) => void) => Unsubscribe$1;
+  } | undefined;
+  outerSubscribe(callback: () => void): Unsubscribe$1;
+  protected _connect(): Unsubscribe$1;
 }
 
-type MessageState$1 = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
 };
 
-type ReloadConfig = {
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
   runConfig?: RunConfig;
 };
 
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState$1;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param3: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param4: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
 };
 
-declare class MessageRuntimeImpl implements MessageRuntime {
-  private _core;
-  private _threadBinding;
-  get path(): MessageRuntimePath;
-  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
-  getState(): ThreadMessage & {
-    readonly parentId: string | null;
-    readonly index: number;
-    readonly isLast: boolean;
-    readonly branchNumber: number;
-    readonly branchCount: number;
-    readonly speech: SpeechState | undefined;
-  };
-  delete(): void | Promise<void>;
-  reload(reloadConfig?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param5: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param6: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
-  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+declare class ExternalStoreRuntimeCore extends BaseAssistantRuntimeCore {
+  readonly threads: ExternalStoreThreadListRuntimeCore;
+  constructor(adapter: ExternalStoreAdapter<any>);
+  setAdapter(adapter: ExternalStoreAdapter<any>): void;
 }
 
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
 
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadRuntimePath> & {
-  outerSubscribe(callback: () => void): Unsubscribe$1;
-};
-
-type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
-
-type ThreadState$1 = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState$1;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
-declare const getThreadState: (runtime: ThreadRuntimeCore, threadListItemState: ThreadListItemState$1) => ThreadState$1;
-
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState$1;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  cancelRun(): void;
-  getModelContext(): ModelContext$1;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-};
-
-declare class ThreadRuntimeImpl implements ThreadRuntime {
-  get path(): ThreadRuntimePath;
-  get __internal_threadBinding(): Subscribable & {
-    path: ThreadRuntimePath;
-    getState: () => Readonly<{
-      getMessageById: (messageId: string) => {
-        parentId: string | null;
-        message: ThreadMessage;
-        index: number;
-      } | undefined;
-      getBranches: (messageId: string) => readonly string[];
-      switchToBranch: (branchId: string) => void;
-      append: (message: AppendMessage) => void;
-      deleteMessage: (messageId: string) => void | Promise<void>;
-      startRun: (config: StartRunConfig) => void;
-      resumeRun: (config: ResumeRunConfig) => void;
-      cancelRun: () => void;
-      addToolResult: (options: AddToolResultOptions) => void;
-      resumeToolCall: (options: ResumeToolCallOptions) => void;
-      respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
-      speak: (messageId: string) => void;
-      stopSpeaking: () => void;
-      connectVoice: () => void;
-      disconnectVoice: () => void;
-      muteVoice: () => void;
-      unmuteVoice: () => void;
-      submitFeedback: (feedback: SubmitFeedbackOptions) => void;
-      getModelContext: () => ModelContext$1;
-      composer: Readonly<{
-        isEditing: boolean;
-        canCancel: boolean;
-        canSend: boolean;
-        isEmpty: boolean;
-        attachments: readonly Attachment[];
-        attachmentAccept: string;
-        addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
-        removeAttachment: (attachmentId: string) => Promise<void>;
-        text: string;
-        setText: (value: string) => void;
-        role: MessageRole;
-        setRole: (role: MessageRole) => void;
-        runConfig: RunConfig;
-        setRunConfig: (runConfig: RunConfig) => void;
-        quote: QuoteInfo | undefined;
-        setQuote: (quote: QuoteInfo | undefined) => void;
-        reset: () => Promise<void>;
-        clearAttachments: () => Promise<void>;
-        send: (options?: SendOptions) => void;
-        cancel: () => void;
-        queue: readonly QueueItemState[];
-        steerQueueItem: (queueItemId: string) => void;
-        removeQueueItem: (queueItemId: string) => void;
-        dictation: DictationState | undefined;
-        startDictation: () => void;
-        stopDictation: () => void;
-        subscribe: (callback: () => void) => Unsubscribe$1;
-        unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
-      }>;
-      getEditComposer: (messageId: string) => EditComposerRuntimeCore | undefined;
-      beginEdit: (messageId: string) => void;
-      getQueueItems?: () => readonly QueueItemState[];
-      steerQueueItem?: (queueItemId: string) => void;
-      removeQueueItem?: (queueItemId: string) => void;
-      speech: SpeechState | undefined;
-      voice: VoiceSessionState | undefined;
-      capabilities: Readonly<RuntimeCapabilities>;
-      isDisabled: boolean;
-      isSendDisabled: boolean;
-      isLoading: boolean;
-      isRunning?: boolean | undefined;
-      messages: readonly ThreadMessage[];
-      state: ReadonlyJSONValue;
-      suggestions: readonly ThreadSuggestion[];
-      extras: unknown;
-      subscribe: (callback: () => void) => Unsubscribe$1;
-      getVoiceVolume: () => number;
-      subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
-      import(repository: ExportedMessageRepository): void;
-      export(): ExportedMessageRepository;
-      exportExternalState(): any;
-      importExternalState(state: any): void;
-      reset(initialMessages?: readonly ThreadMessageLike[]): void;
-      unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-    }>;
-  } & {
-    outerSubscribe(callback: () => void): Unsubscribe$1;
-  } & {
-    getStateState(): ThreadState$1;
-  };
-  private readonly _threadBinding;
-  constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
-  protected __internal_bindMethods(): void;
-  readonly composer: ThreadComposerRuntimeImpl;
-  getState(): ThreadState$1;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getModelContext(): ModelContext$1;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  cancelRun(): void;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  export(): ExportedMessageRepository;
-  import(data: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntimeImpl;
-  getMessageById(messageId: string): MessageRuntimeImpl;
-  private _getMessageRuntime;
-  private _eventSubscriptionSubjects;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-}
-
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
-};
-
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
-
-type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
-
-declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _core;
-  private _runtimeFactory;
-  private _getState;
-  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
-  protected __internal_bindMethods(): void;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
-  readonly main: ThreadRuntime;
-  get mainItem(): ThreadListItemRuntimeImpl;
-  getById(threadId: string): ThreadRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getItemById(threadId: string): ThreadListItemRuntimeImpl;
-}
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState$1;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
-
-declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
-  private _core;
-  private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
-  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  getState(): ThreadListItemState$1;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  detach(): void;
-  __internal_getRuntime(): ThreadListItemRuntime;
-}
-
-declare const symbolInnerMessage: unique symbol;
-
-declare const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
-
-declare const getExternalStoreMessages: <T>(input: {
-  messages: readonly ThreadMessage[];
-} | ThreadMessage | ThreadMessage["content"][number]) => T[];
-
-declare const isAutoStatus: (status: MessageStatus) => boolean;
-
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
-
-type SuggestionAdapterGenerateOptions = {
-  messages: readonly ThreadMessage[];
-};
-
-type SuggestionAdapter = {
-  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
-};
-
-interface MessageStorageEntry<TPayload> {
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
   id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadFactory = () => ExternalStoreThreadRuntimeCore;
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
+  private threadFactory;
+  private _mainThreadId;
+  private _threads;
+  private _archivedThreads;
+  private _threadData;
+  private adapter;
+  get isLoading(): boolean;
+  get newThreadId(): undefined;
+  get threadIds(): readonly string[];
+  get archivedThreadIds(): readonly string[];
+  get threadItems(): Readonly<Record<string, ThreadListItemCoreState>>;
+  getLoadThreadsPromise(): Promise<void>;
+  private _mainThread;
+  get mainThreadId(): string;
+  constructor(adapter: ExternalStoreThreadListAdapter | undefined, threadFactory: ExternalStoreThreadFactory);
+  getMainThreadRuntimeCore(): ExternalStoreThreadRuntimeCore;
+  getThreadRuntimeCore(): never;
+  getItemById(threadId: string): ThreadListItemCoreState | undefined;
+  __internal_setAdapter(adapter: ExternalStoreThreadListAdapter, initialLoad?: boolean): void;
+  switchToThread(threadId: string, _options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  detach(): Promise<void>;
+  archive(threadId: string): Promise<void>;
+  unarchive(threadId: string): Promise<void>;
+  delete(threadId: string): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): never;
+  private _subscriptions;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _notifySubscribers;
 }
 
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
+declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
+  private _capabilities;
+  get capabilities(): RuntimeCapabilities;
+  private _messages;
+  isDisabled: boolean;
+  isSendDisabled: boolean;
+  get isLoading(): boolean;
+  get isRunning(): boolean | undefined;
+  protected _getBaseMessages(): readonly ThreadMessage[];
+  get state(): string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | null;
+  get adapters(): {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  suggestions: readonly ThreadSuggestion[];
+  extras: unknown;
+  private _converter;
+  private _store;
+  private _toolInvocations;
+  beginEdit(messageId: string): void;
+  constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);
+  __internal_setAdapter(store: ExternalStoreAdapter<any>): void;
+  private _driveToolInvocations;
+  private _toolCallToMessageId;
+  private _messagesForToolCallIndex;
+  private _findMessageIdForToolCall;
+  switchToBranch(branchId: string): void;
+  private _notifyBranchChange;
+  append(message: AppendMessage): Promise<void>;
+  deleteMessage(messageId: string): Promise<void>;
+  getQueueItems(): readonly QueueItemState[];
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  startRun(config: StartRunConfig): Promise<void>;
+  resumeRun(config: ResumeRunConfig): Promise<void>;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  cancelRun(): void;
+  addToolResult(options: AddToolResultOptions): void;
+  resumeToolCall(options: ResumeToolCallOptions): void;
+  respondToToolApproval(options: RespondToToolApprovalOptions): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  import(data: ExportedMessageRepository): void;
+  private updateMessages;
 }
 
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
+type ExternalThreadBranchAdapter = {
+  getBranches: (messageId: string) => readonly string[];
+  switchToBranch: (branchId: string) => void;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
+
+type FileMessagePartProps = MessagePartState & FileMessagePart;
+
+type FrameMessage = {
+  type: "model-context-request";
+} | {
+  type: "model-context-update";
+  context: SerializedModelContext;
+} | {
+  type: "tool-call";
+  id: string;
+  toolName: string;
+  args: unknown;
+} | {
+  type: "tool-result";
+  id: string;
+  result?: unknown;
+  error?: string;
+};
+
+type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUIMessagePartComponent = ComponentType<GenerativeUIMessagePartProps>;
+
+type GenerativeUIMessagePartProps = MessagePartState & GenerativeUIMessagePart;
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+declare const GenerativeUIRender: FC<GenerativeUIRenderProps>;
+
+declare class GenerativeUIRenderError extends Error {
+  readonly componentName: string;
+  constructor(componentName: string, message?: string);
 }
 
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
+type GenerativeUIRenderProps = {
+  spec: GenerativeUISpec;
+  components: GenerativeUIComponentRegistry;
+  Fallback?: ComponentType<{
+    component: string;
+    props?: unknown;
+  }> | undefined;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
 
 type GenericThreadHistoryAdapter<TMessage> = {
   load(): Promise<MessageFormatRepository<TMessage>>;
@@ -2586,15 +1858,222 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+type GroupByContext = {
+  readonly toolUIs?: ToolsState["toolUIs"];
+};
+
+type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
+
+type ImageMessagePartProps = MessagePartState & ImageMessagePart;
+
+declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
+  list(): Promise<RemoteThreadListResponse>;
+  rename(): Promise<void>;
+  updateCustom(): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(): Promise<AssistantStream>;
+  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
+}
+
+type InteractableDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: InteractableStateSchema;
+  state: unknown;
+  selected?: boolean | undefined;
+};
+
+type InteractablePersistedState = Record<string, {
+  name: string;
+  state: unknown;
+}>;
+
+type InteractablePersistenceAdapter = {
+  save(state: InteractablePersistedState): void | Promise<void>;
+};
+
+type InteractablePersistenceStatus = {
+  isPending: boolean;
+  error: unknown;
+};
+
+type InteractableRegistration = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: InteractableStateSchema;
+  initialState: unknown;
+  selected?: boolean | undefined;
+};
+
+type InteractableScope = "app" | "thread";
+
+type InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+declare const Interactables: Resource<ClientOutput<"interactables">, [
+]>;
+
+type InteractablesClientSchema = {
+  methods: InteractablesMethods;
+};
+
+type InteractablesMethods = {
+  getState(): InteractablesState;
+  register(def: InteractableRegistration): Unsubscribe$1;
+  setState(id: string, updater: (prev: unknown) => unknown): void;
+  setSelected(id: string, selected: boolean): void;
+  exportState(): InteractablePersistedState;
+  importState(saved: InteractablePersistedState): void;
+  setPersistenceAdapter(adapter: InteractablePersistenceAdapter | undefined): void;
+  flush(): Promise<void>;
+};
+
+type InteractablesState = {
+  definitions: Record<string, InteractableDefinition>;
+  persistence: Record<string, InteractablePersistenceStatus>;
+};
+
+interface JSONSchema7 {
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  $schema?: JSONSchema7Version | undefined;
+  $comment?: string | undefined;
+  $defs?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
+  enum?: JSONSchema7Type[] | undefined;
+  const?: JSONSchema7Type | undefined;
+  multipleOf?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  minimum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  maxLength?: number | undefined;
+  minLength?: number | undefined;
+  pattern?: string | undefined;
+  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
+  additionalItems?: JSONSchema7Definition | undefined;
+  maxItems?: number | undefined;
+  minItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
+  contains?: JSONSchema7Definition | undefined;
+  maxProperties?: number | undefined;
+  minProperties?: number | undefined;
+  required?: string[] | undefined;
+  properties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  patternProperties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  additionalProperties?: JSONSchema7Definition | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7Definition | string[];
+  } | undefined;
+  propertyNames?: JSONSchema7Definition | undefined;
+  if?: JSONSchema7Definition | undefined;
+  then?: JSONSchema7Definition | undefined;
+  else?: JSONSchema7Definition | undefined;
+  allOf?: JSONSchema7Definition[] | undefined;
+  anyOf?: JSONSchema7Definition[] | undefined;
+  oneOf?: JSONSchema7Definition[] | undefined;
+  not?: JSONSchema7Definition | undefined;
+  format?: string | undefined;
+  contentMediaType?: string | undefined;
+  contentEncoding?: string | undefined;
+  definitions?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  default?: JSONSchema7Type | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchema7Type | undefined;
+}
+
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type JoinStrategy = "concat-content" | "none";
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
+};
+
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
+
+declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
+  private binding;
+  get path(): TPath;
+  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
+  private _previousStateDirty;
+  private _previousState;
+  getState: () => TState;
+  protected _connect(): Unsubscribe$1;
+}
+
+declare class LocalRuntimeCore extends BaseAssistantRuntimeCore {
+  readonly threads: LocalThreadListRuntimeCore;
+  readonly Provider: undefined;
+  private _options;
+  constructor(options: LocalRuntimeOptionsBase, initialMessages: readonly ThreadMessageLike[] | undefined);
+}
+
+type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
+  cloud?: AssistantCloud | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
+  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
 };
 
 type LocalRuntimeOptionsBase = {
@@ -2612,6 +2091,56 @@ type LocalRuntimeOptionsBase = {
   unstable_humanToolNames?: string[] | undefined;
   unstable_enableMessageQueue?: boolean | undefined;
 };
+
+type LocalStorageAdapterOptions = {
+  storage: AsyncStorageLike;
+  prefix?: string | undefined;
+  titleGenerator?: TitleGenerationAdapter | undefined;
+};
+
+type LocalThreadFactory = () => LocalThreadRuntimeCore;
+
+declare class LocalThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
+  private _mainThread;
+  constructor(_threadFactory: LocalThreadFactory);
+  get isLoading(): boolean;
+  getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
+  get newThreadId(): string | undefined;
+  get threadIds(): readonly string[];
+  get archivedThreadIds(): readonly string[];
+  get mainThreadId(): string;
+  get threadItems(): Readonly<{
+    __DEFAULT_ID__: {
+      id: string;
+      remoteId: undefined;
+      externalId: undefined;
+      status: "regular";
+      title: undefined;
+    };
+  }>;
+  getThreadRuntimeCore(): never;
+  getLoadThreadsPromise(): Promise<void>;
+  getItemById(threadId: string): {
+    status: "regular";
+    id: string;
+    remoteId: string;
+    externalId: undefined;
+    title: undefined;
+    isMain: boolean;
+  };
+  switchToThread(): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  rename(): Promise<void>;
+  archive(): Promise<void>;
+  detach(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): never;
+}
 
 declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
   readonly capabilities: {
@@ -2666,278 +2195,892 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   removeQueueItem(queueItemId: string): void;
   private _runAppend;
   deleteMessage(messageId: string): Promise<void>;
-  resumeRun(_param7: ResumeRunConfig): Promise<void>;
+  resumeRun(_param4: ResumeRunConfig): Promise<void>;
   exportExternalState(): any;
   importExternalState(): void;
-  startRun(_param8: StartRunConfig, runCallback?: ChatModelAdapter["run"]): Promise<void>;
+  startRun(_param5: StartRunConfig, runCallback?: ChatModelAdapter["run"]): Promise<void>;
   private _runLoop;
   private performRoundtrip;
   detach(): void;
   cancelRun(): void;
-  addToolResult(_param9: AddToolResultOptions): void;
+  addToolResult(_param6: AddToolResultOptions): void;
   resumeToolCall(_options: ResumeToolCallOptions): void;
-  respondToToolApproval(_param10: RespondToToolApprovalOptions): void;
+  respondToToolApproval(_param7: RespondToToolApprovalOptions): void;
 }
 
-type LocalThreadFactory = () => LocalThreadRuntimeCore;
+declare const MCP_APP_URI_SCHEME = "ui://";
 
-declare class LocalThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
-  private _mainThread;
-  constructor(_threadFactory: LocalThreadFactory);
-  get isLoading(): boolean;
-  getMainThreadRuntimeCore(): LocalThreadRuntimeCore;
-  get newThreadId(): string | undefined;
-  get threadIds(): readonly string[];
-  get archivedThreadIds(): readonly string[];
-  get mainThreadId(): string;
-  get threadItems(): Readonly<{
-    __DEFAULT_ID__: {
-      id: string;
-      remoteId: undefined;
-      externalId: undefined;
-      status: "regular";
-      title: undefined;
-    };
-  }>;
-  getThreadRuntimeCore(): never;
-  getLoadThreadsPromise(): Promise<void>;
-  getItemById(threadId: string): {
-    status: "regular";
-    id: string;
-    remoteId: string;
-    externalId: undefined;
-    title: undefined;
-    isMain: boolean;
-  };
-  switchToThread(): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  rename(): Promise<void>;
-  archive(): Promise<void>;
-  detach(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): never;
-}
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
+};
 
-declare class LocalRuntimeCore extends BaseAssistantRuntimeCore {
-  readonly threads: LocalThreadListRuntimeCore;
-  readonly Provider: undefined;
-  private _options;
-  constructor(options: LocalRuntimeOptionsBase, initialMessages: readonly ThreadMessageLike[] | undefined);
-}
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
+};
 
-declare const shouldContinue: (result: ThreadAssistantMessage, humanToolNames: string[] | undefined) => boolean;
+type McpAppResourceOutput = {
+  readonly render: ToolCallMessagePartComponent;
+};
 
-type ToolExecutionStatus = {
-  type: "executing";
+type McpServerConfig = {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
 } | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
+  type: "stdio";
+  command: string;
+  args?: readonly string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  connectionTimeout?: number | undefined;
+};
+
+type McpTool = ToolBase<Record<string, unknown>, unknown> & {
+  type: "mcp";
+  server: McpServerConfig;
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type McpToolkitDefinition = Record<string, McpToolkitEntry>;
+
+type McpToolkitEntry = McpServerConfig | {
+  server: McpServerConfig;
+  disabled?: boolean | undefined;
+  tools?: Record<string, McpToolkitToolConfig> | undefined;
+};
+
+type McpToolkitToolConfig = {
+  disabled?: boolean | undefined;
+};
+
+declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
+  get source(): "message";
+  remove(): never;
+}
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+type MessageAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const MessageByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare const MessageClient: Resource<ClientOutput<"message">, [
+  {
+    runtime: MessageRuntime;
+    threadIdRef: {
+      current: string;
+    };
+  }
+]>;
+
+type MessageClientSchema = {
+  methods: MessageMethods;
+  meta: MessageMeta;
+};
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessageMeta = {
+  source: "thread";
+  query: {
+    type: "id";
+    id: string;
+  } | {
+    type: "index";
+    index: number;
   };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
+type MessageMethods = {
+  getState(): MessageState;
+  composer(): ComposerMethods;
+  delete(): void | Promise<void>;
+  reload(config?: {
+    runConfig?: RunConfig;
+  }): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(feedback: {
+    type: "negative" | "positive";
+  }): void;
+  switchToBranch(options: {
+    position?: "next" | "previous";
+    branchId?: string;
+  }): void;
+  getCopyText(): string;
+  part(selector: {
+    index: number;
+  } | {
+    toolCallId: string;
+  }): PartMethods;
+  attachment(selector: {
+    index: number;
+  } | {
+    id: string;
+  }): AttachmentMethods;
+  setIsCopied(value: boolean): void;
+  setIsHovering(value: boolean): void;
+  __internal_getRuntime?(): MessageRuntime;
+};
+
+declare const MessagePartClient: Resource<ClientOutput<"part">, [
+  {
+    runtime: MessagePartRuntime;
+  }
+]>;
+
+declare const MessagePartComponent: FC<MessagePartComponentProps>;
+
+type MessagePartComponentProps = {
+  components: MessagePrimitiveParts.Props["components"];
+};
+
+declare namespace MessagePartPrimitiveInProgress {
+  type Props = PropsWithChildren;
+}
+
+declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  private contentBinding;
+  private messageApi?;
+  private threadApi?;
+  get path(): MessagePartRuntimePath;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  protected __internal_bindMethods(): void;
+  getState(): MessagePartState;
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+}
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+declare namespace MessagePrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: MessageAttachmentsComponentConfig;
+  };
+}
+
+declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare namespace MessagePrimitiveAttachments {
+  type Props = {
+    components: MessageAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: CompleteAttachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
+
+declare namespace MessagePrimitiveGenerativeUI {
+  type Props = {
+    components: GenerativeUIComponentRegistry;
+    spec?: GenerativeUISpec | undefined;
+    Fallback?: ComponentType<{
+      component: string;
+      props?: unknown;
+    }> | undefined;
+  };
+}
+
+declare const MessagePrimitiveGenerativeUI: FC<MessagePrimitiveGenerativeUI.Props>;
+
+declare namespace MessagePrimitiveGroupedParts {
+  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly type: TKey;
+    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+    readonly indices: readonly number[];
+  };
+  type IndicatorPart = {
+    readonly type: "indicator";
+  };
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
+  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
+    readonly children: ReactNode;
+  };
+  type Props<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
+    readonly indicator?: IndicatorMode;
+    readonly children: (info: RenderInfo<TKey>) => ReactNode;
+  };
+}
+
+declare const MessagePrimitiveGroupedParts: {
+  <TKey extends `group-${string}`>(_param8: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
+  displayName: string;
+};
+
+declare namespace MessagePrimitivePartByIndex {
+  type Props = {
+    index: number;
+    components: MessagePrimitiveParts.Props["components"];
+  };
+}
+
+declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
+
+declare namespace MessagePrimitiveParts {
+  type DataConfig = {
+    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
+    Fallback?: DataMessagePartComponent | undefined;
+  };
+  type BaseComponents = {
+    Empty?: EmptyMessagePartComponent | undefined;
+    Text?: TextMessagePartComponent | undefined;
+    Source?: SourceMessagePartComponent | undefined;
+    Image?: ImageMessagePartComponent | undefined;
+    File?: FileMessagePartComponent | undefined;
+    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+    data?: DataConfig | undefined;
+    Quote?: QuoteMessagePartComponent | undefined;
+    generativeUI?: {
+      components: GenerativeUIComponentRegistry;
+      Fallback?: ComponentType<{
+        component: string;
+        props?: unknown;
+      }> | undefined;
+    } | undefined;
+  };
+  type ToolsConfig = {
+    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
+    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+  } | {
+    Override: ComponentType<ToolCallMessagePartProps>;
+  };
+  type StandardComponents = BaseComponents & {
+    Reasoning?: ReasoningMessagePartComponent | undefined;
+    tools?: ToolsConfig | undefined;
+    ToolGroup?: ComponentType<PropsWithChildren<{
+      startIndex: number;
+      endIndex: number;
+    }>>;
+    ReasoningGroup?: ReasoningGroupComponent;
+    ChainOfThought?: never;
+  };
+  type ChainOfThoughtComponents = BaseComponents & {
+    ChainOfThought: ComponentType;
+    Reasoning?: never;
+    tools?: never;
+    ToolGroup?: never;
+    ReasoningGroup?: never;
+  };
+  export type Props = {
+    components?: StandardComponents | ChainOfThoughtComponents | undefined;
+    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
+    children?: never;
+  } | {
+    children: (value: {
+      part: EnrichedPartState;
+    }) => ReactNode;
+    components?: never;
+    unstable_showEmptyOnNonTextEnd?: never;
+  };
+  export {};
+}
+
+declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
+
+declare namespace MessagePrimitiveQuote {
+  type Props = {
+    children: (value: QuoteInfo) => ReactNode;
+  };
+}
+
+declare const MessagePrimitiveQuote: import("react").NamedExoticComponent<MessagePrimitiveQuote.Props>;
+
+type MessageQueueController = {
+  readonly adapter: ExternalThreadQueueAdapter;
+  notifyBusy: () => void;
+  notifyIdle: () => void;
+  subscribe: (callback: () => void) => () => void;
+};
+
+type MessageQueueDriver = {
+  run: (message: AppendMessage, options: {
     steer: boolean;
   }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+  cancel?: (() => void) | undefined;
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type MessageQuoteState = {
+  message: {
+    metadata?: unknown;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
-};
-
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
-};
-
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
-
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
-    payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-declare const hasUpcomingMessage: (isRunning: boolean, messages: readonly ThreadMessage[]) => boolean;
-
-declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore implements ThreadRuntimeCore {
-  private _capabilities;
-  get capabilities(): RuntimeCapabilities;
+declare class MessageRepository {
+  private messages;
+  private head;
+  private root;
+  private updateLevels;
+  private performOp;
   private _messages;
-  isDisabled: boolean;
-  isSendDisabled: boolean;
-  get isLoading(): boolean;
-  get isRunning(): boolean | undefined;
-  protected _getBaseMessages(): readonly ThreadMessage[];
-  get state(): string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | null;
-  get adapters(): {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  suggestions: readonly ThreadSuggestion[];
-  extras: unknown;
-  private _converter;
-  private _store;
-  private _toolInvocations;
-  beginEdit(messageId: string): void;
-  constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);
-  __internal_setAdapter(store: ExternalStoreAdapter<any>): void;
-  private _driveToolInvocations;
-  private _toolCallToMessageId;
-  private _messagesForToolCallIndex;
-  private _findMessageIdForToolCall;
-  switchToBranch(branchId: string): void;
-  private _notifyBranchChange;
-  append(message: AppendMessage): Promise<void>;
-  deleteMessage(messageId: string): Promise<void>;
-  getQueueItems(): readonly QueueItemState[];
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  startRun(config: StartRunConfig): Promise<void>;
-  resumeRun(config: ResumeRunConfig): Promise<void>;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  cancelRun(): void;
-  addToolResult(options: AddToolResultOptions): void;
-  resumeToolCall(options: ResumeToolCallOptions): void;
-  respondToToolApproval(options: RespondToToolApprovalOptions): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  import(data: ExportedMessageRepository): void;
-  private updateMessages;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  private evictOffBranchOptimisticMessages;
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param9: ExportedMessageRepository): void;
 }
 
-type ExternalStoreThreadFactory = () => ExternalStoreThreadRuntimeCore;
+type MessageRole = ThreadMessage["role"];
 
-declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
-  private threadFactory;
-  private _mainThreadId;
-  private _threads;
-  private _archivedThreads;
-  private _threadData;
-  private adapter;
-  get isLoading(): boolean;
-  get newThreadId(): undefined;
-  get threadIds(): readonly string[];
-  get archivedThreadIds(): readonly string[];
-  get threadItems(): Readonly<Record<string, ThreadListItemCoreState>>;
-  getLoadThreadsPromise(): Promise<void>;
-  private _mainThread;
-  get mainThreadId(): string;
-  constructor(adapter: ExternalStoreThreadListAdapter | undefined, threadFactory: ExternalStoreThreadFactory);
-  getMainThreadRuntimeCore(): ExternalStoreThreadRuntimeCore;
-  getThreadRuntimeCore(): never;
-  getItemById(threadId: string): ThreadListItemCoreState | undefined;
-  __internal_setAdapter(adapter: ExternalStoreThreadListAdapter, initialLoad?: boolean): void;
-  switchToThread(threadId: string, _options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  rename(threadId: string, newTitle: string): Promise<void>;
-  updateCustom(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  detach(): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): never;
-  private _subscriptions;
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState$1;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param10: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param11: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
   subscribe(callback: () => void): Unsubscribe$1;
-  private _notifySubscribers;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+declare class MessageRuntimeImpl implements MessageRuntime {
+  private _core;
+  private _threadBinding;
+  get path(): MessageRuntimePath;
+  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  readonly composer: EditComposerRuntimeImpl;
+  private _getEditComposerRuntimeCore;
+  getState(): ThreadMessage & {
+    readonly parentId: string | null;
+    readonly index: number;
+    readonly isLast: boolean;
+    readonly branchNumber: number;
+    readonly branchCount: number;
+    readonly speech: SpeechState | undefined;
+  };
+  delete(): void | Promise<void>;
+  reload(reloadConfig?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param12: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param13: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
+  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
 }
 
-declare class ExternalStoreRuntimeCore extends BaseAssistantRuntimeCore {
-  readonly threads: ExternalStoreThreadListRuntimeCore;
-  constructor(adapter: ExternalStoreAdapter<any>);
-  setAdapter(adapter: ExternalStoreAdapter<any>): void;
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+  readonly composer: ComposerState;
+  readonly parts: readonly PartState[];
+  readonly isCopied: boolean;
+  readonly isHovering: boolean;
+  readonly index: number;
+};
+
+type MessageState$1 = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStateBinding = SubscribableWithState<ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+}, MessageRuntimePath>;
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
 }
 
-type ConverterCallback<TIn> = (cache: ThreadMessage | undefined, message: TIn, idx: number) => ThreadMessage;
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
 
-declare class ThreadMessageConverter {
-  private readonly cache;
-  convertMessages<TIn extends WeakKey>(messages: readonly TIn[], converter: ConverterCallback<TIn>): ThreadMessage[];
+type MessagesComponentConfig = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+declare const ModelContext: Resource<ClientOutput<"modelContext">, [
+]>;
+
+type ModelContext$1 = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextClientSchema = {
+  methods: ModelContextMethods;
+};
+
+type ModelContextMethods = ModelContextProvider & {
+  getState(): ModelContextState;
+  register: (provider: ModelContextProvider) => Unsubscribe$1;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext$1;
+  subscribe?: (callback: () => void) => Unsubscribe$1;
+};
+
+declare class ModelContextRegistry implements ModelContextProvider {
+  private _tools;
+  private _instructions;
+  private _providers;
+  private _subscribers;
+  private _providerUnsubscribes;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private notifySubscribers;
+  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
+  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
+  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
 }
+
+interface ModelContextRegistryInstructionHandle {
+  update(config: string | AssistantInstructionsConfig): void;
+  remove(): void;
+}
+
+interface ModelContextRegistryProviderHandle {
+  remove(): void;
+}
+
+interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
+  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
+  remove(): void;
+}
+
+type ModelContextState = {
+  readonly modelName?: string | undefined;
+  readonly toolNames: readonly string[];
+};
+
+type NestedSubscribable<TState extends Subscribable | undefined, TPath> = SubscribableWithState<TState, TPath>;
+
+declare class NestedSubscriptionSubject<TState extends Subscribable | undefined, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath>, NestedSubscribable<TState, TPath> {
+  private binding;
+  get path(): TPath;
+  constructor(binding: NestedSubscribable<TState, TPath>);
+  getState(): TState;
+  outerSubscribe(callback: () => void): Unsubscribe$1;
+  protected _connect(): Unsubscribe$1;
+}
+
+declare const NoOpComposerClient: Resource<ClientOutput<"composer">, [
+  {
+    type: "edit" | "thread";
+  }
+]>;
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type ObjectStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+declare class OptimisticState<TState> extends BaseSubscribable {
+  private readonly _pendingTransforms;
+  private readonly _completedOptimistics;
+  private _baseValue;
+  private _cachedValue;
+  constructor(initialState: TState);
+  private _updateState;
+  get baseValue(): TState;
+  get value(): TState;
+  update(state: TState): void;
+  optimisticUpdate<TResult>(transform: Transform<TState, TResult>): Promise<TResult>;
+}
+
+type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
+  [K in TKey]?: undefined;
+} : {
+  [K in TKey]?: TValue | undefined;
+} : {
+  [K in TKey]: TValue;
+};
+
+type OverrideToolDeclarationCallbacks<T extends {
+  streamCall?: unknown;
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
+  type?: never;
+} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+declare const PartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type PartClientSchema = {
+  methods: PartMethods;
+  meta: PartMeta;
+};
+
+type PartInit = {
+  readonly type: "reasoning" | "text";
+  readonly parentId?: string;
+} | {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+} | {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: ReadonlyJSONValue;
+  readonly parentId?: string;
+};
+
+type PartMeta = {
+  source: "message";
+  query: {
+    type: "index";
+    index: number;
+  } | {
+    type: "toolCallId";
+    toolCallId: string;
+  };
+} | {
+  source: "chainOfThought";
+  query: {
+    type: "index";
+    index: number;
+  };
+};
+
+type PartMethods = {
+  getState(): PartState;
+  addToolResult(result: unknown | ToolResponse<unknown>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  __internal_getRuntime?(): MessagePartRuntime;
+};
+
+declare namespace PartPrimitiveMessages {
+  type Props = {
+    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
+    children?: never;
+  } | {
+    children: (value: {
+      message: ThreadMessage;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
+
+declare const PartPrimitiveMessagesImpl: FC<PartPrimitiveMessages.Props>;
+
+type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type PropFieldStatus = "complete" | "streaming";
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
+
+type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
+  type: "provider";
+}>;
+
+declare const QueueItemByIndexProvider: FC<QueueItemByIndexProviderProps>;
+
+type QueueItemByIndexProviderProps = PropsWithChildren<{
+  index: number;
+}>;
+
+type QueueItemClientSchema = {
+  methods: QueueItemMethods;
+  meta: QueueItemMeta;
+};
+
+type QueueItemMeta = {
+  source: "composer";
+  query: {
+    index: number;
+  };
+};
+
+type QueueItemMethods = {
+  getState(): QueueItemState;
+  steer(): void;
+  remove(): void;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
+};
+
+type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
+
+type QuoteMessagePartProps = QuoteInfo;
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+declare namespace ReadonlyThreadProvider {
+  type Props = PropsWithChildren<{
+    messages: readonly ThreadMessage[];
+  }>;
+}
+
+declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
 
 declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements ThreadRuntimeCore {
   private _messages;
@@ -3036,87 +3179,58 @@ declare class ReadonlyThreadRuntimeCore extends BaseSubscribable implements Thre
   unstable_on(): Unsubscribe$1;
 }
 
-type Transform<TState, TResult> = {
-  execute: () => Promise<TResult>;
-  then?: (state: TState, result: TResult) => TState;
-  optimistic?: (state: TState) => TState;
-  loading?: (state: TState, task: Promise<TResult>) => TState;
-};
-
-declare class OptimisticState<TState> extends BaseSubscribable {
-  private readonly _pendingTransforms;
-  private readonly _completedOptimistics;
-  private _baseValue;
-  private _cachedValue;
-  constructor(initialState: TState);
-  private _updateState;
-  get baseValue(): TState;
-  get value(): TState;
-  update(state: TState): void;
-  optimisticUpdate<TResult>(transform: Transform<TState, TResult>): Promise<TResult>;
+declare namespace RealtimeVoiceAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Mode = "listening" | "speaking";
+  type TranscriptItem = {
+    role: "assistant" | "user";
+    text: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    isMuted: boolean;
+    disconnect: () => void;
+    mute: () => void;
+    unmute: () => void;
+    onStatusChange: (callback: (status: Status) => void) => Unsubscribe$1;
+    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe$1;
+    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe$1;
+    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe$1;
+  };
 }
 
-declare const EMPTY_THREAD_CORE: ThreadRuntimeCore;
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+type RealtimeVoiceAdapter = {
+  connect: (options: {
+    abortSignal?: AbortSignal;
+  }) => RealtimeVoiceAdapter.Session;
 };
 
-declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
-  readonly threads: ThreadListRuntimeImpl;
-  readonly _thread: ThreadRuntime;
-  constructor(_core: AssistantRuntimeCore);
-  protected __internal_bindMethods(): void;
-  get thread(): ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-}
+type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
 
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
+type ReasoningGroupProps = PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>;
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
+type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
 
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
+type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
 
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type RemoteThreadListOptions = {
-  runtimeHook: () => AssistantRuntime;
-  adapter: RemoteThreadListAdapter;
-  initialThreadId?: string | undefined;
-  threadId?: string | undefined;
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  allowNesting?: boolean | undefined;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
 type RemoteThreadData = {
@@ -3145,1243 +3259,23 @@ type RemoteThreadData = {
   readonly custom?: Record<string, unknown> | undefined;
 };
 
-type THREAD_MAPPING_ID = string & {
-  __brand: "THREAD_MAPPING_ID";
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
+};
+
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
-
-declare function createThreadMappingId(id: string): THREAD_MAPPING_ID;
-
-type RemoteThreadState = {
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly cursor: string | undefined;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly threadIdMap: Readonly<Record<string, THREAD_MAPPING_ID>>;
-  readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
-};
-
-declare const getThreadData: (state: RemoteThreadState, threadIdOrRemoteId: string) => RemoteThreadData | undefined;
-
-declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "archived" | "deleted" | "regular") => RemoteThreadState;
-
-declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
-}
-
-type ThreadListItemState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ThreadListItemMethods = {
-  getState(): ThreadListItemState;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): void;
-  rename(newTitle: string): void;
-  updateCustom(custom: Record<string, unknown> | undefined): void;
-  archive(): void;
-  unarchive(): void;
-  delete(): void;
-  generateTitle(): void;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  detach(): void;
-  __internal_getRuntime?(): ThreadListItemRuntime;
-};
-
-type ThreadListItemMeta = {
-  source: "threads";
-  query: {
-    type: "main";
-  } | {
-    type: "id";
-    id: string;
-  } | {
-    type: "index";
-    index: number;
-    archived?: boolean;
-  };
-};
-
-type ThreadListItemEvents = {
-  "threadListItem.switchedTo": {
-    threadId: string;
-  };
-  "threadListItem.switchedAway": {
-    threadId: string;
-  };
-};
-
-type ThreadListItemClientSchema = {
-  methods: ThreadListItemMethods;
-  meta: ThreadListItemMeta;
-  events: ThreadListItemEvents;
-};
-
-type AttachmentState = Attachment;
-
-type AttachmentMethods = {
-  getState(): AttachmentState;
-  remove(): Promise<void>;
-  __internal_getRuntime?(): AttachmentRuntime;
-};
-
-type AttachmentMeta = {
-  source: "composer" | "message";
-  query: {
-    type: "index";
-    index: number;
-  } | {
-    type: "id";
-    id: string;
-  };
-};
-
-type AttachmentClientSchema = {
-  methods: AttachmentMethods;
-  meta: AttachmentMeta;
-};
-
-type ComposerSendOptions = SendOptions & {
-  steer?: boolean;
-};
-
-type ComposerState = {
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly isEditing: boolean;
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly attachmentAccept: string;
-  readonly isEmpty: boolean;
-  readonly type: "edit" | "thread";
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ComposerMethods = {
-  getState(): ComposerState;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  clearAttachments(): Promise<void>;
-  attachment(selector: {
-    index: number;
-  } | {
-    id: string;
-  }): AttachmentMethods;
-  reset(): Promise<void>;
-  send(opts?: ComposerSendOptions): void;
-  cancel(): void;
-  beginEdit(): void;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  queueItem(selector: {
-    index: number;
-  }): QueueItemMethods;
-  __internal_getRuntime?(): ComposerRuntime;
-};
-
-type ComposerMeta = {
-  source: "message" | "thread";
-  query: Record<string, never>;
-};
-
-type ComposerEvents = {
-  "composer.send": {
-    threadId: string;
-    messageId?: string;
-  };
-  "composer.attachmentAdd": {
-    threadId: string;
-    messageId?: string;
-  };
-  "composer.attachmentAddError": {
-    threadId: string;
-    messageId?: string;
-    attachmentId?: string;
-    reason: AttachmentAddErrorReason;
-    message: string;
-  };
-};
-
-type ComposerClientSchema = {
-  methods: ComposerMethods;
-  meta: ComposerMeta;
-  events: ComposerEvents;
-};
-
-type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type PartMethods = {
-  getState(): PartState;
-  addToolResult(result: unknown | ToolResponse<unknown>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  __internal_getRuntime?(): MessagePartRuntime;
-};
-
-type PartMeta = {
-  source: "message";
-  query: {
-    type: "index";
-    index: number;
-  } | {
-    type: "toolCallId";
-    toolCallId: string;
-  };
-} | {
-  source: "chainOfThought";
-  query: {
-    type: "index";
-    index: number;
-  };
-};
-
-type PartClientSchema = {
-  methods: PartMethods;
-  meta: PartMeta;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-  readonly composer: ComposerState;
-  readonly parts: readonly PartState[];
-  readonly isCopied: boolean;
-  readonly isHovering: boolean;
-  readonly index: number;
-};
-
-type MessageMethods = {
-  getState(): MessageState;
-  composer(): ComposerMethods;
-  delete(): void | Promise<void>;
-  reload(config?: {
-    runConfig?: RunConfig;
-  }): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(feedback: {
-    type: "negative" | "positive";
-  }): void;
-  switchToBranch(options: {
-    position?: "next" | "previous";
-    branchId?: string;
-  }): void;
-  getCopyText(): string;
-  part(selector: {
-    index: number;
-  } | {
-    toolCallId: string;
-  }): PartMethods;
-  attachment(selector: {
-    index: number;
-  } | {
-    id: string;
-  }): AttachmentMethods;
-  setIsCopied(value: boolean): void;
-  setIsHovering(value: boolean): void;
-  __internal_getRuntime?(): MessageRuntime;
-};
-
-type MessageMeta = {
-  source: "thread";
-  query: {
-    type: "id";
-    id: string;
-  } | {
-    type: "index";
-    index: number;
-  };
-};
-
-type MessageClientSchema = {
-  methods: MessageMethods;
-  meta: MessageMeta;
-};
-
-type ThreadState = {
-  readonly isEmpty: boolean;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly MessageState[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-  readonly composer: ComposerState;
-};
-
-type ThreadMethods = {
-  getState(): ThreadState;
-  composer(): ComposerMethods;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  cancelRun(): void;
-  getModelContext(): ModelContext$1;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  message(selector: {
-    id: string;
-  } | {
-    index: number;
-  }): MessageMethods;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  __internal_getRuntime?(): ThreadRuntime;
-};
-
-type ThreadMeta = {
-  source: "threads";
-  query: {
-    type: "main";
-  };
-};
-
-type ThreadEvents = {
-  "thread.runStart": {
-    threadId: string;
-  };
-  "thread.runEnd": {
-    threadId: string;
-  };
-  "thread.initialize": {
-    threadId: string;
-  };
-  "thread.modelContextUpdate": {
-    threadId: string;
-  };
-};
-
-type ThreadClientSchema = {
-  methods: ThreadMethods;
-  meta: ThreadMeta;
-  events: ThreadEvents;
-};
-
-type ThreadsState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | null;
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly threadItems: readonly ThreadListItemState[];
-  readonly main: ThreadState;
-};
-
-type ThreadsMethods = {
-  getState(): ThreadsState;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): void;
-  switchToNewThread(): void;
-  item(threadIdOrOptions: "main" | {
-    id: string;
-  } | {
-    index: number;
-    archived?: boolean;
-  }): ThreadListItemMethods;
-  thread(selector: "main"): ThreadMethods;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-  __internal_getAssistantRuntime?(): AssistantRuntime;
-};
-
-type ThreadsClientSchema = {
-  methods: ThreadsMethods;
-};
-
-type SuggestionState = {
-  title: string;
-  label: string;
-  prompt: string;
-};
-
-type SuggestionMethods = {
-  getState(): SuggestionState;
-};
-
-type SuggestionMeta = {
-  source: "suggestions";
-  query: {
-    index: number;
-  };
-};
-
-type SuggestionClientSchema = {
-  methods: SuggestionMethods;
-  meta: SuggestionMeta;
-};
-
-type Suggestion = {
-  title: string;
-  label: string;
-  prompt: string;
-};
-
-type SuggestionsState = {
-  suggestions: Suggestion[];
-};
-
-type SuggestionsMethods = {
-  getState(): SuggestionsState;
-  suggestion(query: {
-    index: number;
-  }): SuggestionMethods;
-};
-
-type SuggestionsClientSchema = {
-  methods: SuggestionsMethods;
-};
-
-type ModelContextState = {
-  readonly modelName?: string | undefined;
-  readonly toolNames: readonly string[];
-};
-
-type ModelContextMethods = ModelContextProvider & {
-  getState(): ModelContextState;
-  register: (provider: ModelContextProvider) => Unsubscribe$1;
-};
-
-type ModelContextClientSchema = {
-  methods: ModelContextMethods;
-};
-
-type ChainOfThoughtPart = Extract<PartState, {
-  type: "tool-call";
-} | {
-  type: "reasoning";
-}>;
-
-type ChainOfThoughtState = {
-  readonly parts: readonly ChainOfThoughtPart[];
-  readonly collapsed: boolean;
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type ChainOfThoughtMethods = {
-  getState(): ChainOfThoughtState;
-  setCollapsed(collapsed: boolean): void;
-  part(selector: {
-    index: number;
-  }): PartMethods;
-};
-
-type ChainOfThoughtMeta = {
-  source: "message";
-  query: {
-    type: "chainOfThought";
-  };
-};
-
-type ChainOfThoughtClientSchema = {
-  methods: ChainOfThoughtMethods;
-  meta: ChainOfThoughtMeta;
-};
-
-interface ScopeRegistry {
-    threads: ThreadsClientSchema;
-    threadListItem: ThreadListItemClientSchema;
-    thread: ThreadClientSchema;
-    message: MessageClientSchema;
-    part: PartClientSchema;
-    composer: ComposerClientSchema;
-    attachment: AttachmentClientSchema;
-    modelContext: ModelContextClientSchema;
-    suggestions: SuggestionsClientSchema;
-    suggestion: SuggestionClientSchema;
-    chainOfThought: ChainOfThoughtClientSchema;
-    queueItem: QueueItemClientSchema;
-}
-
-type EmptyMessagePartProps = {
-  status: MessagePartStatus;
-};
-
-type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
-
-type TextMessagePartProps = MessagePartState & TextMessagePart;
-
-type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
-
-type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
-
-type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
-
-type ReasoningGroupProps = PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>;
-
-type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
-
-type SourceMessagePartProps = MessagePartState & SourceMessagePart;
-
-type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
-
-type ImageMessagePartProps = MessagePartState & ImageMessagePart;
-
-type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
-
-type FileMessagePartProps = MessagePartState & FileMessagePart;
-
-type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
-
-type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
-
-type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
-
-type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
-
-type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
-
-type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
-  addResult: (result: TResult | ToolResponse<TResult>) => void;
-  resume: (payload: unknown) => void;
-  respondToApproval: (response: ToolApprovalResponse) => void;
-};
-
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
-
-type QuoteMessagePartProps = QuoteInfo;
-
-type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
-
-type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
-
-type GenerativeUIMessagePartProps = MessagePartState & GenerativeUIMessagePart;
-
-type GenerativeUIMessagePartComponent = ComponentType<GenerativeUIMessagePartProps>;
-
-type GenerativeUIRenderProps = {
-  spec: GenerativeUISpec;
-  components: GenerativeUIComponentRegistry;
-  Fallback?: ComponentType<{
-    component: string;
-    props?: unknown;
-  }> | undefined;
-};
-
-type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type InteractableScope = "app" | "thread";
-
-type Unstable_InteractableDefinition = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  state: unknown;
-  initialState: unknown;
-  scope?: InteractableScope | undefined;
-};
-
-type Unstable_InteractableRegistration = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  initialState: unknown;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-type Unstable_InteractablePersistenceStatus = {
-  isPending: boolean;
-  error: unknown;
-};
-
-type Unstable_InteractablesState = {
-  definitions: Record<string, Unstable_InteractableDefinition>;
-  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
-};
-
-type Unstable_InteractablePersistedState = Record<string, {
-  name: string;
-  state: unknown;
-}>;
-
-type Unstable_InteractablePersistenceAdapter = {
-  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
-  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
-};
-
-type Unstable_InteractablesConfig = {
-  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
-};
-
-type Unstable_InteractablesMethods = {
-  getState(): Unstable_InteractablesState;
-  register(def: Unstable_InteractableRegistration): Unsubscribe$1;
-  setState(id: string, updater: (prev: unknown) => unknown): void;
-  exportState(): Unstable_InteractablePersistedState;
-  importState(saved: Unstable_InteractablePersistedState): void;
-  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
-  flush(): Promise<void>;
-};
-
-type Unstable_InteractablesClientSchema = {
-  methods: Unstable_InteractablesMethods;
-};
-
-type McpAppResourceOutput = {
-  readonly render: ToolCallMessagePartComponent;
-};
-
-type ToolRegistration = {
-  readonly render: ToolCallMessagePartComponent;
-  readonly standalone: boolean;
-};
-
-type ToolsState = {
-  toolUIs: Record<string, readonly ToolRegistration[]>;
-  mcpApp?: McpAppResourceOutput | undefined;
-  tools: Record<string, ToolCallMessagePartComponent[]>;
-};
-
-type ToolsMethods = {
-  getState(): ToolsState;
-  setToolUI(toolName: string, render: ToolCallMessagePartComponent, options?: {
-    standalone?: boolean;
-  }): Unsubscribe$1;
-};
-
-type ToolsClientSchema = {
-  methods: ToolsMethods;
-};
-
-type InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type InteractableDefinition = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: InteractableStateSchema;
-  state: unknown;
-  selected?: boolean | undefined;
-};
-
-type InteractableRegistration = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: InteractableStateSchema;
-  initialState: unknown;
-  selected?: boolean | undefined;
-};
-
-type InteractablePersistenceStatus = {
-  isPending: boolean;
-  error: unknown;
-};
-
-type InteractablesState = {
-  definitions: Record<string, InteractableDefinition>;
-  persistence: Record<string, InteractablePersistenceStatus>;
-};
-
-type InteractablePersistedState = Record<string, {
-  name: string;
-  state: unknown;
-}>;
-
-type InteractablePersistenceAdapter = {
-  save(state: InteractablePersistedState): void | Promise<void>;
-};
-
-type InteractablesMethods = {
-  getState(): InteractablesState;
-  register(def: InteractableRegistration): Unsubscribe$1;
-  setState(id: string, updater: (prev: unknown) => unknown): void;
-  setSelected(id: string, selected: boolean): void;
-  exportState(): InteractablePersistedState;
-  importState(saved: InteractablePersistedState): void;
-  setPersistenceAdapter(adapter: InteractablePersistenceAdapter | undefined): void;
-  flush(): Promise<void>;
-};
-
-type InteractablesClientSchema = {
-  methods: InteractablesMethods;
-};
-
-type DataRenderersState = {
-  renderers: Record<string, DataMessagePartComponent[]>;
-  fallbacks: DataMessagePartComponent[];
-};
-
-type DataRenderersMethods = {
-  getState(): DataRenderersState;
-  setDataUI(name: string, render: DataMessagePartComponent): Unsubscribe$1;
-  setFallbackDataUI(render: DataMessagePartComponent): Unsubscribe$1;
-};
-
-type DataRenderersClientSchema = {
-  methods: DataRenderersMethods;
-};
-
-interface ScopeRegistry {
-    tools: ToolsClientSchema;
-    dataRenderers: DataRenderersClientSchema;
-    interactables: InteractablesClientSchema;
-    unstable_interactables: Unstable_InteractablesClientSchema;
-}
-
-type StreamingTimingAccessors<TMessage> = {
-  readonly getAssistantMessageId: (messages: readonly TMessage[]) => string | undefined;
-  readonly getTextLength: (messages: readonly TMessage[], messageId: string) => number;
-  readonly getToolCallCount: (messages: readonly TMessage[], messageId: string) => number;
-};
-
-type StreamingTimingOptions = {
-  readonly estimateTokens?: (textLength: number) => number;
-};
-
-type StreamingTimingState = {
-  readonly messageId: string;
-  readonly startTime: number;
-  readonly firstTokenTime?: number;
-  readonly lastContentLength: number;
-  readonly totalChunks: number;
-};
-
-declare const stepStreamingTiming: <TMessage>(state: StreamingTimingState | null, messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options: StreamingTimingOptions | undefined, now?: () => number) => {
-  readonly state: StreamingTimingState | null;
-  readonly timings: Record<string, MessageTiming>;
-};
-
-declare const getRenderComponent: (runtime: AssistantRuntime) => ComponentType | undefined;
-
-type AssistantProviderBaseProps = PropsWithChildren<{
-  runtime: AssistantRuntime;
-  aui?: AssistantClient | null;
-}>;
-
-declare const AssistantProviderBase: FC<AssistantProviderBaseProps>;
-
-declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param11: {
-  runtime: AssistantRuntime;
-  aui?: AssistantClient | null;
-  children: ReactNode;
-}) => import("react").JSX.Element>;
-
-declare const RuntimeAdapter: Resource<ClientOutput<"threads">, [
-  runtime: AssistantRuntime
-]>;
-
-type TitleGenerationAdapter = {
-  generateTitle(messages: readonly ThreadMessage[]): Promise<string>;
-};
-
-declare const createSimpleTitleAdapter: () => TitleGenerationAdapter;
-
-type AsyncStorageLike = {
-  getItem(key: string): Promise<string | null>;
-  setItem(key: string, value: string): Promise<void>;
-  removeItem(key: string): Promise<void>;
-};
-
-type LocalStorageAdapterOptions = {
-  storage: AsyncStorageLike;
-  prefix?: string | undefined;
-  titleGenerator?: TitleGenerationAdapter | undefined;
-};
-
-declare const createLocalStorageAdapter: (options: LocalStorageAdapterOptions) => RemoteThreadListAdapter;
-
-declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
-]>;
-
-declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
-  (Unstable_InteractablesConfig | undefined)?
-]>;
-
-type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
-  type: "frontend" | "human";
-} ? T & (T extends {
-  type: "frontend";
-} ? {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-} | {
-  render?: ToolCallMessagePartComponent<TArgs, TResult>;
-  renderText: ToolCallText<TArgs, TResult>;
-} : {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-}) : T & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
-
-type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
-
-type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
-
-type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
-
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
-
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
-
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
-
-type Toolkit = Record<string, ToolDefinition<any, any>>;
-
-type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
-  [K in TKey]?: undefined;
-} : {
-  [K in TKey]?: TValue | undefined;
-} : {
-  [K in TKey]: TValue;
-};
-
-type OverrideToolDeclarationCallbacks<T extends {
-  streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
-  type?: never;
-} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
-
-type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
-  streamCall?: unknown;
-} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
-
-type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
-
-type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: NonNullable<ToolParameters<TArgs>>;
-};
-
-type ToolkitDefinition<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-} = Record<string, any>, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}> = {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
-};
-
-declare const Tools: Resource<ClientOutput<"tools">, [
-  {
-    toolkit?: Toolkit;
-    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
-  }
-]>;
-
-type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
-
-type AssistantTool = FC & {
-  unstable_tool: AssistantToolProps<any, any>;
-};
-
-declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
-
-type AssistantToolUIProps<TArgs, TResult> = {
-  toolName: string;
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "inline" | "standalone";
-};
-
-declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
-
-type AssistantToolUI = FC & {
-  unstable_tool: AssistantToolUIProps<any, any>;
-};
-
-declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
-
-type AssistantDataUIProps<T = any> = {
-  name: string;
-  render: DataMessagePartComponent<T>;
-};
-
-declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
-
-type AssistantDataUI = FC & {
-  unstable_data: AssistantDataUIProps;
-};
-
-declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
-
-declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
-
-declare const useAssistantContext: (config: AssistantContextConfig) => void;
-
-declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
-
-declare function defineToolkit<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-}, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}>(_definition: {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-}): Toolkit & {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-};
-
-declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
-
-declare function stubTool(): never;
-
-declare function externalTool(): never;
-
-type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
-
-type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
-
-declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
-
-declare function humanTool(): never;
-
-declare const hitlTool: typeof humanTool;
-
-declare const hitl: typeof humanTool;
-
-type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
-  type: "provider";
-}>;
-
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
-
-declare function providerTool(_config: ProviderToolConfig): never;
-
-type McpToolkitEntry = McpServerConfig | {
-  server: McpServerConfig;
-  disabled?: boolean | undefined;
-  tools?: Record<string, McpToolkitToolConfig> | undefined;
-};
-
-type McpToolkitToolConfig = {
-  disabled?: boolean | undefined;
-};
-
-type McpToolkitDefinition = Record<string, McpToolkitEntry>;
-
-declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
-
-type AssistantInteractableProps = {
-  description: string;
-  stateSchema: InteractableStateSchema;
-  initialState: unknown;
-  id?: string;
-  selected?: boolean;
-};
-
-declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
-
-type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
-
-declare const useInteractableState: <TState>(id: string, fallback: TState) => [
-  TState,
-  {
-    setState: (updater: StateUpdater$1<TState>) => void;
-    setSelected: (selected: boolean) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type Unstable_InferInteractableState<TSchema> = TSchema extends {
-  "~standard": {
-    types?: {
-      output: infer TOutput;
-    } | undefined;
-  };
-} ? TOutput : unknown;
-
-type Unstable_InteractableVersionInfo<TState> = {
-  state: TState;
-  isLatest: boolean;
-  restore: () => void;
-};
-
-type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  initialState: Unstable_InferInteractableState<TSchema>;
-  id?: string | undefined;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
-  Unstable_InferInteractableState<TSchema>,
-  {
-    id: string;
-    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
-    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type StateUpdater<TState> = TState | ((prev: TState) => TState);
-
-declare const unstable_useInteractableState: <TState>(id: string) => [
-  TState | undefined,
-  {
-    setState: (updater: StateUpdater<TState>) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type Unstable_InteractableSnapshotEntry = {
-  id: string;
-  name: string;
-  state: unknown;
-  partial?: boolean | undefined;
-};
-
-type SnapshotCarrierMessage = {
-  role: string;
-  metadata?: unknown;
-  content?: readonly unknown[] | undefined;
-};
-
-declare function unstable_getInteractableSnapshots(message: {
-  metadata?: unknown;
-}): Unstable_InteractableSnapshotEntry[] | undefined;
-
-declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
-
-type Unstable_InteractableVersion = {
-  state: unknown;
-  origin: "create" | "update" | "user-edit";
-  toolCallId?: string | undefined;
-};
-
-declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
-
-declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
-  state: TState;
-  restore: () => void;
-})[];
-
-type Unstable_InteractableToolRenderProps<TState> = {
-  state: TState;
-  setState: (updater: TState | ((prev: TState) => TState)) => void;
-  version: Unstable_InteractableVersionInfo<TState> | undefined;
-  id: string;
-  streaming: boolean;
-};
-
-type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
-};
-
-declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
-  success: true;
-}>;
-
-type PropFieldStatus = "complete" | "streaming";
-
-type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "complete" | "incomplete" | "requires-action" | "running";
-  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
-};
-
-declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
-
-declare const Interactables: Resource<ClientOutput<"interactables">, [
-]>;
-
-declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
-  runtime: ThreadListItemRuntime;
-}>>;
-
-declare const MessageByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const PartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const TextMessagePartProvider: FC<PropsWithChildren<{
-  text: string;
-  isRunning?: boolean;
-}>>;
-
-declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>>;
-
-declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-  archived: boolean;
-}>>;
-
-declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-type SuggestionByIndexProviderProps = PropsWithChildren<{
-  index: number;
-}>;
-
-declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
-
-type QueueItemByIndexProviderProps = PropsWithChildren<{
-  index: number;
-}>;
-
-declare const QueueItemByIndexProvider: FC<QueueItemByIndexProviderProps>;
-
-declare namespace ReadonlyThreadProvider {
-  type Props = PropsWithChildren<{
-    messages: readonly ThreadMessage[];
-  }>;
-}
-
-declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
-
-type RuntimeAdapters = {
-  modelContext?: ModelContextProvider | undefined;
-  history?: ThreadHistoryAdapter | undefined;
-  attachments?: AttachmentAdapter | undefined;
-};
-
-declare namespace RuntimeAdapterProvider {
-  type Props = {
-    adapters: RuntimeAdapters;
-    children: ReactNode;
-  };
-}
-
-declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
-
-declare const useRuntimeAdapters: () => RuntimeAdapters | null;
-
-declare const useExternalStoreRuntime: <T>(store: ExternalStoreAdapter<T>) => AssistantRuntime;
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
-
-declare const useExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
-
-type JoinStrategy = "concat-content" | "none";
-
-declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
-}
-
-declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
-
-declare const useExternalMessageConverter: <T extends WeakKey>(_param12: {
-  callback: useExternalMessageConverter.Callback<T>;
-  messages: T[];
-  isRunning: boolean;
-  joinStrategy?: JoinStrategy | undefined;
-  metadata?: useExternalMessageConverter.Metadata | undefined;
-}) => ThreadMessage[];
-
-declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
-  useThreadMessages: (_param13: {
-    messages: T[];
-    isRunning: boolean;
-    joinStrategy?: JoinStrategy | undefined;
-    metadata?: useExternalMessageConverter.Metadata;
-  }) => ThreadMessage[];
-  toThreadMessages: (messages: T[], isRunning?: boolean, metadata?: useExternalMessageConverter.Metadata) => ThreadMessage[];
-  toOriginalMessages: (input: ThreadState$1 | ThreadMessage | ThreadMessage["content"][number]) => unknown[];
-  toOriginalMessage: (input: ThreadState$1 | ThreadMessage | ThreadMessage["content"][number]) => {};
-  useOriginalMessage: () => {};
-  useOriginalMessages: () => unknown[];
-};
-
-declare const useStreamingTiming: <TMessage>(messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options?: StreamingTimingOptions) => Record<string, MessageTiming>;
 
 type RemoteThreadListHook = () => AssistantRuntime;
 
@@ -4501,6 +3395,24 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     provider: ComponentType<PropsWithChildren>;
   }>;
 }
+
+type RemoteThreadListOptions = {
+  runtimeHook: () => AssistantRuntime;
+  adapter: RemoteThreadListAdapter;
+  initialThreadId?: string | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  allowNesting?: boolean | undefined;
+};
+
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
+};
+
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
+};
 
 declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable implements ThreadListRuntimeCore {
   private _options;
@@ -4650,63 +3562,24 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   __internal_RenderComponent: FC;
 }
 
-declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
+type RemoteThreadState = {
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly cursor: string | undefined;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly threadIdMap: Readonly<Record<string, THREAD_MAPPING_ID>>;
+  readonly threadData: Readonly<Record<THREAD_MAPPING_ID, RemoteThreadData>>;
 };
 
 type ReportToolCall = {
@@ -4720,516 +3593,665 @@ type ReportToolCall = {
   sampling_calls?: SamplingCallData[];
 };
 
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
+  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+}[Keys];
+
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type ResumeToolCallOptions = {
+  toolCallId: string;
+  payload: unknown;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+declare const RuntimeAdapter: Resource<ClientOutput<"threads">, [
+  runtime: AssistantRuntime
+]>;
+
+declare namespace RuntimeAdapterProvider {
+  type Props = {
+    adapters: RuntimeAdapters;
+    children: ReactNode;
+  };
+}
+
+declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
+
+type RuntimeAdapters = {
+  modelContext?: ModelContextProvider | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  attachments?: AttachmentAdapter | undefined;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type RuntimeExtras<T extends object> = {
+  provide: (value: T) => T;
+  is: (extras: unknown) => extras is T;
+  tryGet: (extras: unknown) => T | undefined;
+  get: (client: AssistantClient) => T;
+  use: {
+    (): T;
+    <S>(select: (extras: T) => S): S;
+    <S>(select: (extras: T) => S, fallback: S): S;
+  };
+};
+
+declare const SKIP_UPDATE: unique symbol;
+
+type SKIP_UPDATE = typeof SKIP_UPDATE;
+
+type SamplingCallData = {
+  model_id?: string;
   input_tokens?: number;
   output_tokens?: number;
   reasoning_tokens?: number;
   cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
   duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
 };
 
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type ScopesConfig = {
+  [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SerializedModelContext = {
+  system?: string;
+  tools?: Record<string, SerializedTool>;
+};
+
+type SerializedTool = {
+  description?: string;
+  parameters: any;
+  disabled?: boolean;
+  type?: string;
+};
+
+declare class ShallowMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
+  private binding;
+  get path(): TPath;
+  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
+  private _previousState;
+  getState: () => TState;
+  private _syncState;
+  protected _connect(): Unsubscribe$1;
+}
+
+declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+type SnapshotCarrierMessage = {
+  role: string;
+  metadata?: unknown;
+  content?: readonly unknown[] | undefined;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
+
+type SourceMessagePartProps = MessagePartState & SourceMessagePart;
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
   };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe$1;
+  };
 }
 
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
 };
 
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
 };
 
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
+type StateUpdater<TState> = TState | ((prev: TState) => TState);
+
+type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
+
+type StreamingTimingAccessors<TMessage> = {
+  readonly getAssistantMessageId: (messages: readonly TMessage[]) => string | undefined;
+  readonly getTextLength: (messages: readonly TMessage[], messageId: string) => number;
+  readonly getToolCallCount: (messages: readonly TMessage[], messageId: string) => number;
 };
 
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
+type StreamingTimingOptions = {
+  readonly estimateTokens?: (textLength: number) => number;
 };
 
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
+type StreamingTimingState = {
+  readonly messageId: string;
+  readonly startTime: number;
+  readonly firstTokenTime?: number;
+  readonly lastContentLength: number;
+  readonly totalChunks: number;
 };
 
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
+type SubmitFeedbackOptions = {
+  messageId: string;
+  type: "negative" | "positive";
 };
 
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
+type SubmittedFeedback = {
+  readonly type: "negative" | "positive";
 };
 
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
+type Subscribable = {
+  subscribe: (callback: () => void) => Unsubscribe$1;
 };
 
-type CloudThread = {
+type SubscribableWithState<TState, TPath> = Subscribable & {
+  path: TPath;
+  getState: () => TState;
+};
+
+type Suggestion = {
   title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
+  label: string;
+  prompt: string;
 };
 
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
+type SuggestionAdapter = {
+  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
 };
 
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
+type SuggestionAdapterGenerateOptions = {
+  messages: readonly ThreadMessage[];
 };
 
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
+declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
+
+type SuggestionByIndexProviderProps = PropsWithChildren<{
+  index: number;
+}>;
+
+type SuggestionClientSchema = {
+  methods: SuggestionMethods;
+  meta: SuggestionMeta;
 };
 
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
+type SuggestionConfig = string | {
+  title: string;
+  label: string;
+  prompt: string;
 };
 
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
+type SuggestionMeta = {
+  source: "suggestions";
+  query: {
+    index: number;
   };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
+};
+
+type SuggestionMethods = {
+  getState(): SuggestionState;
+};
+
+type SuggestionState = {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const Suggestions: Resource<ClientOutput<"suggestions">, [
+  suggestions?: SuggestionConfig[] | undefined
+]>;
+
+type SuggestionsClientSchema = {
+  methods: SuggestionsMethods;
+};
+
+type SuggestionsComponentConfig = {
+  Suggestion: ComponentType;
+};
+
+type SuggestionsMethods = {
+  getState(): SuggestionsState;
+  suggestion(query: {
+    index: number;
+  }): SuggestionMethods;
+};
+
+type SuggestionsState = {
+  suggestions: Suggestion[];
+};
+
+type THREAD_MAPPING_ID = string & {
+  __brand: "THREAD_MAPPING_ID";
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
+
+type TextMessagePartProps = MessagePartState & TextMessagePart;
+
+declare const TextMessagePartProvider: FC<PropsWithChildren<{
+  text: string;
+  isRunning?: boolean;
+}>>;
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+declare const ThreadClient: Resource<ClientOutput<"thread">, [
+  {
+    runtime: ThreadRuntime;
+  }
+]>;
+
+type ThreadClientSchema = {
+  methods: ThreadMethods;
+  meta: ThreadMeta;
+  events: ThreadEvents;
+};
+
+declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
+  get source(): "thread-composer";
 }
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
+};
+
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
+};
+
+type ThreadComposerRuntimeCore = ComposerRuntimeCore;
+
+type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "thread";
+}>;
+
+declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  get path(): ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  get type(): "thread";
+  private _getState;
+  constructor(core: ThreadComposerRuntimeCoreBinding);
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
+}
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
 
 type ThreadData = {
   externalId: string | undefined;
 };
 
-type CloudThreadListAdapterOptions = {
-  cloud?: AssistantCloud | undefined;
-  create?: (() => Promise<ThreadData>) | undefined;
-  delete?: ((threadId: string) => Promise<void>) | undefined;
-};
-
-declare const useCloudThreadListAdapter: (adapter: CloudThreadListAdapterOptions) => RemoteThreadListAdapter;
-
-declare function useAssistantCloudThreadHistoryAdapter(cloudRef: RefObject<AssistantCloud>): ThreadHistoryAdapter;
-
-declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
-  private cloud;
-  accept: string;
-  constructor(cloud: AssistantCloud);
-  private uploadedUrls;
-  add(_param14: {
-    file: File;
-  }): AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-}
-
-type MessagesComponentConfig = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
-};
-
-declare namespace ThreadPrimitiveMessages {
-  type Props = {
-    components: MessagesComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      message: MessageState;
-    }) => ReactNode;
-    components?: never;
+type ThreadEvents = {
+  "thread.runStart": {
+    threadId: string;
   };
-}
+  "thread.runEnd": {
+    threadId: string;
+  };
+  "thread.initialize": {
+    threadId: string;
+  };
+  "thread.modelContextUpdate": {
+    threadId: string;
+  };
+};
 
-declare namespace ThreadPrimitiveMessageByIndex {
-  type Props = {
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+declare const ThreadListClient: Resource<ClientOutput<"threads">, [
+  {
+    runtime: ThreadListRuntime;
+    __internal_assistantRuntime: AssistantRuntime;
+  }
+]>;
+
+declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+  archived: boolean;
+}>>;
+
+declare const ThreadListItemClient: Resource<ClientOutput<"threadListItem">, [
+  {
+    runtime: ThreadListItemRuntime;
+  }
+]>;
+
+type ThreadListItemClientSchema = {
+  methods: ThreadListItemMethods;
+  meta: ThreadListItemMeta;
+  events: ThreadListItemEvents;
+};
+
+type ThreadListItemCoreState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+  readonly runtime?: ThreadRuntimeCore | undefined;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemEvents = {
+  "threadListItem.switchedTo": {
+    threadId: string;
+  };
+  "threadListItem.switchedAway": {
+    threadId: string;
+  };
+};
+
+type ThreadListItemMeta = {
+  source: "threads";
+  query: {
+    type: "main";
+  } | {
+    type: "id";
+    id: string;
+  } | {
+    type: "index";
     index: number;
-    components: MessagesComponentConfig;
+    archived?: boolean;
   };
-}
+};
 
-declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
+type ThreadListItemMethods = {
+  getState(): ThreadListItemState;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): void;
+  rename(newTitle: string): void;
+  updateCustom(custom: Record<string, unknown> | undefined): void;
+  archive(): void;
+  unarchive(): void;
+  delete(): void;
+  generateTitle(): void;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  detach(): void;
+  __internal_getRuntime?(): ThreadListItemRuntime;
+};
 
-declare namespace ThreadPrimitiveUnstable_MessageById {
+declare namespace ThreadListItemPrimitiveTitle {
   type Props = {
-    messageId: string;
-    components: MessagesComponentConfig;
+    fallback?: ReactNode;
   };
 }
 
-declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
+declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
 
-declare const ThreadPrimitiveMessagesImpl: FC<ThreadPrimitiveMessages.Props>;
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState$1;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
 
-declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
+type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
-declare namespace MessagePrimitiveParts {
-  type DataConfig = {
-    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
-    Fallback?: DataMessagePartComponent | undefined;
-  };
-  type BaseComponents = {
-    Empty?: EmptyMessagePartComponent | undefined;
-    Text?: TextMessagePartComponent | undefined;
-    Source?: SourceMessagePartComponent | undefined;
-    Image?: ImageMessagePartComponent | undefined;
-    File?: FileMessagePartComponent | undefined;
-    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
-    data?: DataConfig | undefined;
-    Quote?: QuoteMessagePartComponent | undefined;
-    generativeUI?: {
-      components: GenerativeUIComponentRegistry;
-      Fallback?: ComponentType<{
-        component: string;
-        props?: unknown;
-      }> | undefined;
-    } | undefined;
-  };
-  type ToolsConfig = {
-    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
-    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  private _core;
+  private _threadListBinding;
+  get path(): ThreadListItemRuntimePath;
+  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  getState(): ThreadListItemState$1;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  detach(): void;
+  __internal_getRuntime(): ThreadListItemRuntime;
+}
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
   } | {
-    Override: ComponentType<ToolCallMessagePartProps>;
-  };
-  type StandardComponents = BaseComponents & {
-    Reasoning?: ReasoningMessagePartComponent | undefined;
-    tools?: ToolsConfig | undefined;
-    ToolGroup?: ComponentType<PropsWithChildren<{
-      startIndex: number;
-      endIndex: number;
-    }>>;
-    ReasoningGroup?: ReasoningGroupComponent;
-    ChainOfThought?: never;
-  };
-  type ChainOfThoughtComponents = BaseComponents & {
-    ChainOfThought: ComponentType;
-    Reasoning?: never;
-    tools?: never;
-    ToolGroup?: never;
-    ReasoningGroup?: never;
-  };
-  export type Props = {
-    components?: StandardComponents | ChainOfThoughtComponents | undefined;
-    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
-    children?: never;
+    readonly type: "index";
+    readonly index: number;
   } | {
-    children: (value: {
-      part: EnrichedPartState;
-    }) => ReactNode;
-    components?: never;
-    unstable_showEmptyOnNonTextEnd?: never;
-  };
-  export {};
-}
-
-declare const defaultComponents: {
-  Text: () => null;
-  Reasoning: () => null;
-  Source: () => null;
-  Image: () => null;
-  File: () => null;
-  Unstable_Audio: () => null;
-  ToolGroup: (_param15: PropsWithChildren) => ReactNode;
-  ReasoningGroup: (_param16: PropsWithChildren) => ReactNode;
-};
-
-type MessagePartComponentProps = {
-  components: MessagePrimitiveParts.Props["components"];
-};
-
-declare const MessagePartComponent: FC<MessagePartComponentProps>;
-
-declare namespace MessagePrimitivePartByIndex {
-  type Props = {
-    index: number;
-    components: MessagePrimitiveParts.Props["components"];
-  };
-}
-
-declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
-
-type EnrichedPartState = (Extract<PartState, {
-  type: "tool-call";
-}> & {
-  readonly toolUI: ReactNode;
-  addResult: ToolCallMessagePartProps["addResult"];
-  resume: ToolCallMessagePartProps["resume"];
-  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
-}) | (Extract<PartState, {
-  type: "data";
-}> & {
-  readonly dataRendererUI: ReactNode;
-}) | Exclude<PartState, {
-  type: "tool-call";
-} | {
-  type: "data";
-}>;
-
-declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
-
-type GroupByContext = {
-  readonly toolUIs?: ToolsState["toolUIs"];
-};
-
-type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
-
-declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
-
-declare namespace MessagePrimitiveGroupedParts {
-  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly type: TKey;
-    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-    readonly indices: readonly number[];
-  };
-  type IndicatorPart = {
-    readonly type: "indicator";
-  };
-  type IndicatorMode = "always" | "empty" | "never" | "no-text";
-  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
-    readonly children: ReactNode;
-  };
-  type Props<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
-    readonly indicator?: IndicatorMode;
-    readonly children: (info: RenderInfo<TKey>) => ReactNode;
-  };
-}
-
-declare const MessagePrimitiveGroupedParts: {
-  <TKey extends `group-${string}`>(_param17: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
-  displayName: string;
-};
-
-declare class GenerativeUIRenderError extends Error {
-  readonly componentName: string;
-  constructor(componentName: string, message?: string);
-}
-
-declare const GenerativeUIRender: FC<GenerativeUIRenderProps>;
-
-declare namespace MessagePrimitiveGenerativeUI {
-  type Props = {
-    components: GenerativeUIComponentRegistry;
-    spec?: GenerativeUISpec | undefined;
-    Fallback?: ComponentType<{
-      component: string;
-      props?: unknown;
-    }> | undefined;
-  };
-}
-
-declare const MessagePrimitiveGenerativeUI: FC<MessagePrimitiveGenerativeUI.Props>;
-
-declare namespace MessagePrimitiveQuote {
-  type Props = {
-    children: (value: QuoteInfo) => ReactNode;
-  };
-}
-
-declare const MessagePrimitiveQuote: import("react").NamedExoticComponent<MessagePrimitiveQuote.Props>;
-
-type MessageAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace MessagePrimitiveAttachments {
-  type Props = {
-    components: MessageAttachmentsComponentConfig;
-    children?: never;
+    readonly type: "archiveIndex";
+    readonly index: number;
   } | {
-    children: (value: {
-      attachment: CompleteAttachment;
-    }) => ReactNode;
-    components?: never;
+    readonly type: "threadId";
+    readonly threadId: string;
   };
-}
-
-declare namespace MessagePrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: MessageAttachmentsComponentConfig;
-  };
-}
-
-declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
-
-type ComposerAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
 };
 
-declare namespace ComposerPrimitiveAttachments {
-  type Props = {
-    components: ComposerAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: Attachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
+declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
+  runtime: ThreadListItemRuntime;
+}>>;
 
-declare namespace ComposerPrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: ComposerAttachmentsComponentConfig;
-  };
-}
+type ThreadListItemState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly custom?: Record<string, unknown> | undefined;
+};
 
-declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
+type ThreadListItemState$1 = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
 
-declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
+type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
-declare namespace ComposerPrimitiveQueue {
-  type Props = {
-    children: (value: {
-      queueItem: QueueItemState;
-    }) => ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
-  children: (value: {
-    queueItem: QueueItemState;
-  }) => ReactNode;
-}>;
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
 
 type ThreadListItemsComponentConfig = {
   ThreadListItem: ComponentType;
 };
+
+declare namespace ThreadListPrimitiveItemByIndex {
+  type Props = {
+    index: number;
+    archived?: boolean | undefined;
+    components: ThreadListItemsComponentConfig;
+  };
+}
+
+declare const ThreadListPrimitiveItemByIndex: FC<ThreadListPrimitiveItemByIndex.Props>;
 
 declare namespace ThreadListPrimitiveItems {
   type Props = {
@@ -5245,73 +4267,230 @@ declare namespace ThreadListPrimitiveItems {
   });
 }
 
-declare namespace ThreadListPrimitiveItemByIndex {
-  type Props = {
-    index: number;
-    archived?: boolean | undefined;
-    components: ThreadListItemsComponentConfig;
-  };
-}
-
-declare const ThreadListPrimitiveItemByIndex: FC<ThreadListPrimitiveItemByIndex.Props>;
-
 declare const ThreadListPrimitiveItems: FC<ThreadListPrimitiveItems.Props>;
 
-type ChainOfThoughtPartsComponentConfig = {
-  Reasoning?: ReasoningMessagePartComponent | undefined;
-  tools?: {
-    Fallback?: ToolCallMessagePartComponent | undefined;
-  };
-  Layout?: ComponentType<PropsWithChildren> | undefined;
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
 };
 
-declare namespace ChainOfThoughtPrimitiveParts {
+type ThreadListRuntimeCore = {
+  readonly isLoading: boolean;
+  readonly isLoadingMore?: boolean;
+  readonly hasMore?: boolean;
+  mainThreadId: string;
+  newThreadId: string | undefined;
+  threadIds: readonly string[];
+  archivedThreadIds: readonly string[];
+  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
+  getMainThreadRuntimeCore(): ThreadRuntimeCore;
+  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  getItemById(threadId: string): ThreadListItemCoreState | undefined;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
+  loadMore?(): Promise<void>;
+  detach(threadId: string): Promise<void>;
+  rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(threadId: string): Promise<void>;
+  unarchive(threadId: string): Promise<void>;
+  delete(threadId: string): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(threadId: string): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
+
+declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _core;
+  private _runtimeFactory;
+  private _getState;
+  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
+  protected __internal_bindMethods(): void;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _mainThreadListItemRuntime;
+  readonly main: ThreadRuntime;
+  get mainItem(): ThreadListItemRuntimeImpl;
+  getById(threadId: string): ThreadRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getItemById(threadId: string): ThreadListItemRuntimeImpl;
+}
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+declare const ThreadMessageClient: Resource<ClientOutput<"message">, [
+  ThreadMessageClientProps
+]>;
+
+type ThreadMessageClientProps = {
+  message: ThreadMessage;
+  index: number;
+  isLast?: boolean;
+  branchNumber?: number;
+  branchCount?: number;
+};
+
+declare class ThreadMessageConverter {
+  private readonly cache;
+  convertMessages<TIn extends WeakKey>(messages: readonly TIn[], converter: ConverterCallback<TIn>): ThreadMessage[];
+}
+
+type ThreadMessageLike = {
+  readonly role: "assistant" | "system" | "user";
+  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
+    readonly type: "tool-call";
+    readonly toolCallId?: string;
+    readonly toolName: string;
+    readonly args?: ReadonlyJSONObject;
+    readonly argsText?: string;
+    readonly artifact?: any;
+    readonly result?: any | undefined;
+    readonly isError?: boolean | undefined;
+    readonly parentId?: string | undefined;
+    readonly messages?: readonly ThreadMessage[] | undefined;
+    readonly interrupt?: {
+      type: "human";
+      payload: unknown;
+    };
+    readonly timing?: ToolCallTiming;
+    readonly approval?: {
+      readonly id: string;
+      readonly approved?: boolean;
+      readonly reason?: string;
+      readonly isAutomatic?: boolean;
+      readonly options?: readonly ToolApprovalOption[];
+      readonly optionId?: string;
+      readonly resolution?: "cancelled" | "expired";
+    };
+  })[];
+  readonly id?: string | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
+    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
+  })[] | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly isOptimistic?: boolean | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  } | undefined;
+};
+
+type ThreadMeta = {
+  source: "threads";
+  query: {
+    type: "main";
+  };
+};
+
+type ThreadMethods = {
+  getState(): ThreadState;
+  composer(): ComposerMethods;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  cancelRun(): void;
+  getModelContext(): ModelContext$1;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  message(selector: {
+    id: string;
+  } | {
+    index: number;
+  }): MessageMethods;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  __internal_getRuntime?(): ThreadRuntime;
+};
+
+declare namespace ThreadPrimitiveMessageByIndex {
   type Props = {
-    components?: ChainOfThoughtPartsComponentConfig;
+    index: number;
+    components: MessagesComponentConfig;
+  };
+}
+
+declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
+
+declare namespace ThreadPrimitiveMessages {
+  type Props = {
+    components: MessagesComponentConfig;
     children?: never;
   } | {
     children: (value: {
-      part: PartState;
+      message: MessageState;
     }) => ReactNode;
     components?: never;
   };
 }
 
-declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
+declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
 
-declare namespace PartPrimitiveMessages {
+declare const ThreadPrimitiveMessagesImpl: FC<ThreadPrimitiveMessages.Props>;
+
+declare namespace ThreadPrimitiveSuggestionByIndex {
   type Props = {
-    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
-    children?: never;
-  } | {
-    children: (value: {
-      message: ThreadMessage;
-    }) => ReactNode;
-    components?: never;
+    index: number;
+    components: SuggestionsComponentConfig;
   };
 }
 
-declare const PartPrimitiveMessagesImpl: FC<PartPrimitiveMessages.Props>;
-
-declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
-
-declare namespace MessagePartPrimitiveInProgress {
-  type Props = PropsWithChildren;
-}
-
-declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
-
-declare namespace ThreadListItemPrimitiveTitle {
-  type Props = {
-    fallback?: ReactNode;
-  };
-}
-
-declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
-
-type SuggestionsComponentConfig = {
-  Suggestion: ComponentType;
-};
+declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
 
 declare namespace ThreadPrimitiveSuggestions {
   type Props = {
@@ -5325,145 +4504,807 @@ declare namespace ThreadPrimitiveSuggestions {
   };
 }
 
-declare namespace ThreadPrimitiveSuggestionByIndex {
-  type Props = {
-    index: number;
-    components: SuggestionsComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
+declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
 
 declare const ThreadPrimitiveSuggestionsImpl: FC<ThreadPrimitiveSuggestions.Props>;
 
-declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
-
-type ComposerIfFilters = {
-  editing: boolean | undefined;
-  dictation: boolean | undefined;
-};
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
-  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-}[Keys];
-
-type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
-
-declare namespace ComposerPrimitiveIf {
-  type Props = PropsWithChildren<UseComposerIfProps>;
+declare namespace ThreadPrimitiveUnstable_MessageById {
+  type Props = {
+    messageId: string;
+    components: MessagesComponentConfig;
+  };
 }
 
-declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
+declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
 
-type MessageQuoteState = {
-  message: {
-    metadata?: unknown;
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState$1;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  cancelRun(): void;
+  getModelContext(): ModelContext$1;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+};
+
+type ThreadRuntimeCore = Readonly<{
+  getMessageById: (messageId: string) => {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  } | undefined;
+  getBranches: (messageId: string) => readonly string[];
+  switchToBranch: (branchId: string) => void;
+  append: (message: AppendMessage) => void;
+  deleteMessage: (messageId: string) => void | Promise<void>;
+  startRun: (config: StartRunConfig) => void;
+  resumeRun: (config: ResumeRunConfig) => void;
+  cancelRun: () => void;
+  addToolResult: (options: AddToolResultOptions) => void;
+  resumeToolCall: (options: ResumeToolCallOptions) => void;
+  respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
+  speak: (messageId: string) => void;
+  stopSpeaking: () => void;
+  connectVoice: () => void;
+  disconnectVoice: () => void;
+  muteVoice: () => void;
+  unmuteVoice: () => void;
+  submitFeedback: (feedback: SubmitFeedbackOptions) => void;
+  getModelContext: () => ModelContext$1;
+  composer: ThreadComposerRuntimeCore;
+  getEditComposer: (messageId: string) => EditComposerRuntimeCore | undefined;
+  beginEdit: (messageId: string) => void;
+  getQueueItems?: () => readonly QueueItemState[];
+  steerQueueItem?: (queueItemId: string) => void;
+  removeQueueItem?: (queueItemId: string) => void;
+  speech: SpeechState | undefined;
+  voice: VoiceSessionState | undefined;
+  capabilities: Readonly<RuntimeCapabilities>;
+  isDisabled: boolean;
+  isSendDisabled: boolean;
+  isLoading: boolean;
+  isRunning?: boolean | undefined;
+  messages: readonly ThreadMessage[];
+  state: ReadonlyJSONValue;
+  suggestions: readonly ThreadSuggestion[];
+  extras: unknown;
+  subscribe: (callback: () => void) => Unsubscribe$1;
+  getVoiceVolume: () => number;
+  subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
+  import(repository: ExportedMessageRepository): void;
+  export(): ExportedMessageRepository;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+}>;
+
+type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadRuntimePath> & {
+  outerSubscribe(callback: () => void): Unsubscribe$1;
+};
+
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+declare class ThreadRuntimeImpl implements ThreadRuntime {
+  get path(): ThreadRuntimePath;
+  get __internal_threadBinding(): Subscribable & {
+    path: ThreadRuntimePath;
+    getState: () => Readonly<{
+      getMessageById: (messageId: string) => {
+        parentId: string | null;
+        message: ThreadMessage;
+        index: number;
+      } | undefined;
+      getBranches: (messageId: string) => readonly string[];
+      switchToBranch: (branchId: string) => void;
+      append: (message: AppendMessage) => void;
+      deleteMessage: (messageId: string) => void | Promise<void>;
+      startRun: (config: StartRunConfig) => void;
+      resumeRun: (config: ResumeRunConfig) => void;
+      cancelRun: () => void;
+      addToolResult: (options: AddToolResultOptions) => void;
+      resumeToolCall: (options: ResumeToolCallOptions) => void;
+      respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
+      speak: (messageId: string) => void;
+      stopSpeaking: () => void;
+      connectVoice: () => void;
+      disconnectVoice: () => void;
+      muteVoice: () => void;
+      unmuteVoice: () => void;
+      submitFeedback: (feedback: SubmitFeedbackOptions) => void;
+      getModelContext: () => ModelContext$1;
+      composer: Readonly<{
+        isEditing: boolean;
+        canCancel: boolean;
+        canSend: boolean;
+        isEmpty: boolean;
+        attachments: readonly Attachment[];
+        attachmentAccept: string;
+        addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
+        removeAttachment: (attachmentId: string) => Promise<void>;
+        text: string;
+        setText: (value: string) => void;
+        role: MessageRole;
+        setRole: (role: MessageRole) => void;
+        runConfig: RunConfig;
+        setRunConfig: (runConfig: RunConfig) => void;
+        quote: QuoteInfo | undefined;
+        setQuote: (quote: QuoteInfo | undefined) => void;
+        reset: () => Promise<void>;
+        clearAttachments: () => Promise<void>;
+        send: (options?: SendOptions) => void;
+        cancel: () => void;
+        queue: readonly QueueItemState[];
+        steerQueueItem: (queueItemId: string) => void;
+        removeQueueItem: (queueItemId: string) => void;
+        dictation: DictationState | undefined;
+        startDictation: () => void;
+        stopDictation: () => void;
+        subscribe: (callback: () => void) => Unsubscribe$1;
+        unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
+      }>;
+      getEditComposer: (messageId: string) => EditComposerRuntimeCore | undefined;
+      beginEdit: (messageId: string) => void;
+      getQueueItems?: () => readonly QueueItemState[];
+      steerQueueItem?: (queueItemId: string) => void;
+      removeQueueItem?: (queueItemId: string) => void;
+      speech: SpeechState | undefined;
+      voice: VoiceSessionState | undefined;
+      capabilities: Readonly<RuntimeCapabilities>;
+      isDisabled: boolean;
+      isSendDisabled: boolean;
+      isLoading: boolean;
+      isRunning?: boolean | undefined;
+      messages: readonly ThreadMessage[];
+      state: ReadonlyJSONValue;
+      suggestions: readonly ThreadSuggestion[];
+      extras: unknown;
+      subscribe: (callback: () => void) => Unsubscribe$1;
+      getVoiceVolume: () => number;
+      subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
+      import(repository: ExportedMessageRepository): void;
+      export(): ExportedMessageRepository;
+      exportExternalState(): any;
+      importExternalState(state: any): void;
+      reset(initialMessages?: readonly ThreadMessageLike[]): void;
+      unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+    }>;
+  } & {
+    outerSubscribe(callback: () => void): Unsubscribe$1;
+  } & {
+    getStateState(): ThreadState$1;
+  };
+  private readonly _threadBinding;
+  constructor(threadBinding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding);
+  protected __internal_bindMethods(): void;
+  readonly composer: ThreadComposerRuntimeImpl;
+  getState(): ThreadState$1;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getModelContext(): ModelContext$1;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  cancelRun(): void;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  export(): ExportedMessageRepository;
+  import(data: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntimeImpl;
+  getMessageById(messageId: string): MessageRuntimeImpl;
+  private _getMessageRuntime;
+  private _eventSubscriptionSubjects;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+}
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
   };
 };
 
-declare const getMessageQuote: (state: MessageQuoteState) => QuoteInfo | undefined;
-
-declare const useThreadMessages: () => readonly MessageState[];
-
-declare const unstable_useThreadMessageIds: () => readonly string[];
-
-declare const useThreadIsRunning: () => boolean;
-
-declare const useThreadIsEmpty: () => boolean;
-
-declare const useComposerSend: () => {
-  send: (opts?: ComposerSendOptions) => void;
-  disabled: boolean;
+type ThreadState = {
+  readonly isEmpty: boolean;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly MessageState[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+  readonly composer: ComposerState;
 };
 
-declare const useComposerCancel: () => {
-  cancel: () => void;
-  disabled: boolean;
+type ThreadState$1 = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState$1;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-declare const useComposerDictate: () => {
-  startDictation: () => void;
-  disabled: boolean;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-declare const useComposerAddAttachment: () => {
-  addAttachment: (file: File | CreateAttachment) => Promise<void>;
-  disabled: boolean;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-declare const useMessageReload: () => {
-  reload: () => void;
-  canReload: boolean;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-declare const useMessageBranching: () => {
-  branchNumber: number;
-  branchCount: number;
-  goToPrev: () => void;
-  goToNext: () => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type ThreadsClientSchema = {
+  methods: ThreadsMethods;
+};
+
+type ThreadsMethods = {
+  getState(): ThreadsState;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): void;
+  switchToNewThread(): void;
+  item(threadIdOrOptions: "main" | {
+    id: string;
+  } | {
+    index: number;
+    archived?: boolean;
+  }): ThreadListItemMethods;
+  thread(selector: "main"): ThreadMethods;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+  __internal_getAssistantRuntime?(): AssistantRuntime;
+};
+
+type ThreadsState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | null;
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly threadItems: readonly ThreadListItemState[];
+  readonly main: ThreadState;
+};
+
+type TitleGenerationAdapter = {
+  generateTitle(messages: readonly ThreadMessage[]): Promise<string>;
+};
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
+  status: "complete" | "incomplete" | "requires-action" | "running";
+  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
+  addResult: (result: TResult | ToolResponse<TResult>) => void;
+  resume: (payload: unknown) => void;
+  respondToApproval: (response: ToolApprovalResponse) => void;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
+
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
+
+type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
+
+type ToolRegistration = {
+  readonly render: ToolCallMessagePartComponent;
+  readonly standalone: boolean;
+};
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+
+type ToolkitDefinition<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+} = Record<string, any>, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}> = {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
+};
+
+type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
+
+type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
+  parameters: NonNullable<ToolParameters<TArgs>>;
+};
+
+type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
+  streamCall?: unknown;
+} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
+
+declare const Tools: Resource<ClientOutput<"tools">, [
+  {
+    toolkit?: Toolkit;
+    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
+  }
+]>;
+
+type ToolsClientSchema = {
+  methods: ToolsMethods;
+};
+
+type ToolsMethods = {
+  getState(): ToolsState;
+  setToolUI(toolName: string, render: ToolCallMessagePartComponent, options?: {
+    standalone?: boolean;
+  }): Unsubscribe$1;
+};
+
+type ToolsState = {
+  toolUIs: Record<string, readonly ToolRegistration[]>;
+  mcpApp?: McpAppResourceOutput | undefined;
+  tools: Record<string, ToolCallMessagePartComponent[]>;
+};
+
+type Transform<TState, TResult> = {
+  execute: () => Promise<TResult>;
+  then?: (state: TState, result: TResult) => TState;
+  optimistic?: (state: TState) => TState;
+  loading?: (state: TState, task: Promise<TResult>) => TState;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
+
+type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
+
+type Unstable_DirectiveFormatter = {
+  serialize(item: Unstable_TriggerItem): string;
+  parse(text: string): readonly Unstable_DirectiveSegment[];
+};
+
+type Unstable_DirectiveSegment = {
+  readonly kind: "text";
+  readonly text: string;
+} | {
+  readonly kind: "mention";
+  readonly type: string;
+  readonly label: string;
+  readonly id: string;
+};
+
+type Unstable_InferInteractableState<TSchema> = TSchema extends {
+  "~standard": {
+    types?: {
+      output: infer TOutput;
+    } | undefined;
+  };
+} ? TOutput : unknown;
+
+type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  initialState: Unstable_InferInteractableState<TSchema>;
+  id?: string | undefined;
+  updateRender?: ToolCallMessagePartComponent | undefined;
+};
+
+type Unstable_InteractableDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  state: unknown;
+  initialState: unknown;
+  scope?: InteractableScope | undefined;
+};
+
+type Unstable_InteractablePersistedState = Record<string, {
+  name: string;
+  state: unknown;
+}>;
+
+type Unstable_InteractablePersistenceAdapter = {
+  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
+  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
+};
+
+type Unstable_InteractablePersistenceStatus = {
+  isPending: boolean;
+  error: unknown;
+};
+
+type Unstable_InteractableRegistration = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  initialState: unknown;
+  updateRender?: ToolCallMessagePartComponent | undefined;
+};
+
+type Unstable_InteractableSnapshotEntry = {
+  id: string;
+  name: string;
+  state: unknown;
+  partial?: boolean | undefined;
+};
+
+type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
+};
+
+type Unstable_InteractableToolRenderProps<TState> = {
+  state: TState;
+  setState: (updater: TState | ((prev: TState) => TState)) => void;
+  version: Unstable_InteractableVersionInfo<TState> | undefined;
+  id: string;
+  streaming: boolean;
+};
+
+type Unstable_InteractableVersion = {
+  state: unknown;
+  origin: "create" | "update" | "user-edit";
+  toolCallId?: string | undefined;
+};
+
+type Unstable_InteractableVersionInfo<TState> = {
+  state: TState;
+  isLatest: boolean;
+  restore: () => void;
+};
+
+type Unstable_InteractablesClientSchema = {
+  methods: Unstable_InteractablesMethods;
+};
+
+type Unstable_InteractablesConfig = {
+  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
+};
+
+type Unstable_InteractablesMethods = {
+  getState(): Unstable_InteractablesState;
+  register(def: Unstable_InteractableRegistration): Unsubscribe$1;
+  setState(id: string, updater: (prev: unknown) => unknown): void;
+  exportState(): Unstable_InteractablePersistedState;
+  importState(saved: Unstable_InteractablePersistedState): void;
+  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
+  flush(): Promise<void>;
+};
+
+type Unstable_InteractablesState = {
+  definitions: Record<string, Unstable_InteractableDefinition>;
+  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
+};
+
+type Unstable_TriggerAdapter = {
+  categories(): readonly Unstable_TriggerCategory[];
+  categoryItems(categoryId: string): readonly Unstable_TriggerItem[];
+  search?(query: string): readonly Unstable_TriggerItem[];
+};
+
+type Unstable_TriggerCategory = {
+  readonly id: string;
+  readonly label: string;
+};
+
+type Unstable_TriggerItem = {
+  readonly id: string;
+  readonly type: string;
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly metadata?: ReadonlyJSONObject | undefined;
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
 
 type UseActionBarCopyOptions = {
   copiedDuration?: number | undefined;
   copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
 };
 
-declare const useActionBarCopy: (_param18?: UseActionBarCopyOptions) => {
-  copy: () => void;
-  disabled: boolean;
-  isCopied: boolean;
-};
-
-declare const useActionBarEdit: () => {
-  edit: () => void;
-  disabled: boolean;
-};
-
-declare const useActionBarReload: () => {
-  reload: () => void;
-  disabled: boolean;
-};
-
-declare const useActionBarFeedbackPositive: () => {
-  submit: () => void;
-  isSubmitted: boolean;
-};
-
-declare const useActionBarFeedbackNegative: () => {
-  submit: () => void;
-  isSubmitted: boolean;
-};
-
-declare const useActionBarSpeak: () => {
-  speak: () => Promise<void>;
-  disabled: boolean;
-};
-
-declare const useActionBarStopSpeaking: () => {
-  stopSpeaking: () => void;
-  disabled: boolean;
-};
-
-declare const useVoiceState: () => VoiceSessionState | undefined;
-
-declare const useVoiceVolume: () => number;
-
-declare const useVoiceControls: () => {
-  connect: () => void;
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
-};
-
-declare const useBranchPickerNext: () => {
-  next: () => void;
-  disabled: boolean;
-};
-
-declare const useBranchPickerPrevious: () => {
-  previous: () => void;
-  disabled: boolean;
-};
+type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
 
 type UseSuggestionTriggerOptions = {
   prompt: string;
@@ -5471,52 +5312,221 @@ type UseSuggestionTriggerOptions = {
   clearComposer?: boolean | undefined;
 };
 
-declare const useSuggestionTrigger: (_param19: UseSuggestionTriggerOptions) => {
-  trigger: () => void;
-  disabled: boolean;
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type VoiceSessionControls = {
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
 };
 
-declare const useThreadListItemArchive: () => {
-  archive: () => void;
+type VoiceSessionHelpers = {
+  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
+  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
+  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
+  emitVolume: (volume: number) => void;
+  isDisposed: () => boolean;
 };
 
-declare const useThreadListItemDelete: () => {
-  delete: () => void;
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
 };
 
-declare const useThreadListItemUnarchive: () => {
-  unarchive: () => void;
+declare class WebSpeechDictationAdapter implements DictationAdapter {
+  private _language;
+  private _continuous;
+  private _interimResults;
+  constructor(options?: {
+    language?: string;
+    continuous?: boolean;
+    interimResults?: boolean;
+  });
+  static isSupported(): boolean;
+  listen(): DictationAdapter.Session;
+}
+
+declare class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
+  speak(text: string): SpeechSynthesisAdapter.Utterance;
+}
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
+  type: "frontend" | "human";
+} ? T & (T extends {
+  type: "frontend";
+} ? {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+} | {
+  render?: ToolCallMessagePartComponent<TArgs, TResult>;
+  renderText: ToolCallText<TArgs, TResult>;
+} : {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+}) : T & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
-declare const useThreadListItemTrigger: () => {
-  switchTo: () => void;
+declare const baseRuntimeAdapterTransformScopes: (scopes: ScopesConfig, parent: AssistantClient) => void;
+
+declare const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
+
+declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
+
+declare const createLocalStorageAdapter: (options: LocalStorageAdapterOptions) => RemoteThreadListAdapter;
+
+declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
+  useThreadMessages: (_param14: {
+    messages: T[];
+    isRunning: boolean;
+    joinStrategy?: JoinStrategy | undefined;
+    metadata?: useExternalMessageConverter.Metadata;
+  }) => ThreadMessage[];
+  toThreadMessages: (messages: T[], isRunning?: boolean, metadata?: useExternalMessageConverter.Metadata) => ThreadMessage[];
+  toOriginalMessages: (input: ThreadState$1 | ThreadMessage | ThreadMessage["content"][number]) => unknown[];
+  toOriginalMessage: (input: ThreadState$1 | ThreadMessage | ThreadMessage["content"][number]) => {};
+  useOriginalMessage: () => {};
+  useOriginalMessages: () => unknown[];
 };
 
-declare const useThreadListNew: () => {
-  switchToNewThread: () => void;
+declare const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController;
+
+declare function createRequestHeaders(headersValue: Record<string, string> | Headers | (() => Promise<Record<string, string> | Headers>)): Promise<Headers>;
+
+declare const createRuntimeExtras: <T extends object>(runtimeName: string) => RuntimeExtras<T>;
+
+declare const createSimpleTitleAdapter: () => TitleGenerationAdapter;
+
+declare function createThreadMappingId(id: string): THREAD_MAPPING_ID;
+
+declare function createVoiceSession(options: {
+  abortSignal?: AbortSignal;
+}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
+
+declare const defaultComponents: {
+  Text: () => null;
+  Reasoning: () => null;
+  Source: () => null;
+  Image: () => null;
+  File: () => null;
+  Unstable_Audio: () => null;
+  ToolGroup: (_param15: PropsWithChildren) => ReactNode;
+  ReasoningGroup: (_param16: PropsWithChildren) => ReactNode;
 };
 
-declare const useThreadListLoadMore: () => {
-  loadMore: () => void;
-  disabled: boolean;
+declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
+
+declare function defineToolkit<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+}, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}>(_definition: {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
+}): Toolkit & {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
 };
 
-declare const useEditComposerCancel: () => {
-  cancel: () => void;
-};
+declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
 
-declare const useEditComposerSend: () => {
-  send: () => void;
-  disabled: boolean;
-};
+declare function externalTool(): never;
 
-declare const useMessageError: () => string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | undefined;
+declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
 
-type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  cloud?: AssistantCloud | undefined;
-  initialMessages?: readonly ThreadMessageLike[] | undefined;
-  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
-};
+declare const generateErrorMessageId: () => string;
+
+declare const generateId: (size?: number) => string;
+
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+
+declare const getExternalStoreMessages: <T>(input: {
+  messages: readonly ThreadMessage[];
+} | ThreadMessage | ThreadMessage["content"][number]) => T[];
+
+declare const getFileDataURL: (file: File) => Promise<string>;
+
+declare const getMessageQuote: (state: MessageQuoteState) => QuoteInfo | undefined;
+
+declare const getRenderComponent: (runtime: AssistantRuntime) => ComponentType | undefined;
+
+declare const getThreadData: (state: RemoteThreadState, threadIdOrRemoteId: string) => RemoteThreadData | undefined;
+
+declare const getThreadMessageText: (message: ThreadMessage | AppendMessage) => string;
+
+declare const getThreadState: (runtime: ThreadRuntimeCore, threadListItemState: ThreadListItemState$1) => ThreadState$1;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
+
+declare const hasUpcomingMessage: (isRunning: boolean, messages: readonly ThreadMessage[]) => boolean;
+
+declare const hitl: typeof humanTool;
+
+declare const hitlTool: typeof humanTool;
+
+declare function humanTool(): never;
+
+declare namespace entry_react_exports {
+  export { AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantInteractableProps, AssistantProviderBase, AssistantProviderBaseProps, AssistantRuntimeProvider, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, AsyncStorageLike, ChainOfThoughtByIndicesProvider, ChainOfThoughtPartByIndexProvider, ChainOfThoughtPrimitiveParts, CloudFileAttachmentAdapter, ComposerAttachmentByIndexProvider, ComposerPrimitiveAttachmentByIndex, ComposerPrimitiveAttachments, ComposerPrimitiveIf, ComposerPrimitiveQueue, DataMessagePartComponent, DataMessagePartProps, DataRenderers, DataRenderersClientSchema, DataRenderersMethods, DataRenderersState, EmptyMessagePartComponent, EmptyMessagePartProps, EnrichedPartState, FileMessagePartComponent, FileMessagePartProps, GenerativeUIComponentRegistry, GenerativeUIMessagePartComponent, GenerativeUIMessagePartProps, GenerativeUIRender, GenerativeUIRenderError, GenerativeUIRenderProps, GroupByContext, ImageMessagePartComponent, ImageMessagePartProps, InteractableDefinition, InteractablePersistedState, InteractablePersistenceAdapter, InteractablePersistenceStatus, InteractableRegistration, InteractableStateSchema, Interactables, InteractablesClientSchema, InteractablesMethods, InteractablesState, JoinStrategy, LocalRuntimeOptions, McpAppResourceOutput, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, MessagePartComponent, MessagePartPrimitiveInProgress, MessagePrimitiveAttachmentByIndex, MessagePrimitiveAttachments, MessagePrimitiveGenerativeUI, MessagePrimitiveGroupedParts, MessagePrimitivePartByIndex, MessagePrimitiveParts, MessagePrimitiveQuote, PartByIndexProvider, PartPrimitiveMessages, PartPrimitiveMessagesImpl, PartState, ProviderToolConfig, QueueItemByIndexProvider, QueueItemByIndexProviderProps, QuoteMessagePartComponent, QuoteMessagePartProps, ReadonlyThreadProvider, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListHookInstanceManager, RemoteThreadListThreadListRuntimeCore, RuntimeAdapter, RuntimeAdapterProvider, RuntimeAdapters, SourceMessagePartComponent, SourceMessagePartProps, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, SuggestionByIndexProvider, SuggestionByIndexProviderProps, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadListItemByIndexProvider, ThreadListItemPrimitiveTitle, ThreadListItemRuntimeProvider, ThreadListPrimitiveItemByIndex, ThreadListPrimitiveItems, ThreadPrimitiveMessageByIndex, ThreadPrimitiveMessages, ThreadPrimitiveMessagesImpl, ThreadPrimitiveSuggestionByIndex, ThreadPrimitiveSuggestions, ThreadPrimitiveSuggestionsImpl, ThreadPrimitiveUnstable_MessageById, TitleGenerationAdapter, ToolArgsStatus, ToolCallMessagePartComponent, ToolCallMessagePartProps, ToolCallText, ToolDefinition, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, ToolsClientSchema, ToolsMethods, ToolsState, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, UseActionBarCopyOptions, UseComposerIfProps, UseSuggestionTriggerOptions, convertExternalMessages, createLocalStorageAdapter, createMessageConverter, createSimpleTitleAdapter, defineMcpToolkit, defineToolkit, externalTool, getMessageQuote, getRenderComponent, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, defaultComponents as messagePartsDefaultComponents, providerTool, splitLocalRuntimeOptions, stubTool, unstable_Interactables, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useActionBarCopy, useActionBarEdit, useActionBarFeedbackNegative, useActionBarFeedbackPositive, useActionBarReload, useActionBarSpeak, useActionBarStopSpeaking, useAssistantCloudThreadHistoryAdapter, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAuiToolOverrides, useBranchPickerNext, useBranchPickerPrevious, useCloudThreadListAdapter, useComposerAddAttachment, useComposerCancel, useComposerDictate, useComposerSend, useEditComposerCancel, useEditComposerSend, useExternalMessageConverter, useExternalStoreRuntime, useExternalStoreSharedOptions, useInlineRender, useInteractableState, useLocalRuntime, useMessageBranching, useMessageError, useMessageReload, useRemoteThreadListRuntime, useRuntimeAdapters, useStreamingTiming, useSuggestionTrigger, useThreadIsEmpty, useThreadIsRunning, useThreadListItemArchive, useThreadListItemDelete, useThreadListItemTrigger, useThreadListItemUnarchive, useThreadListLoadMore, useThreadListNew, useThreadMessages, useToolArgsStatus, useVoiceControls, useVoiceState, useVoiceVolume };
+}
+
+declare namespace entry_root_exports {
+  export { AddToolResultOptions, AppendMessage, AssistantContextConfig, AssistantFrameHost, AssistantFrameProvider, AssistantInstructionsConfig, AssistantRuntime, AssistantRuntimeCore, AssistantToolProps$1 as AssistantToolProps, Attachment, AttachmentAdapter, AttachmentAddErrorEvent, AttachmentAddErrorReason, AttachmentRuntime, AttachmentRuntimePath, AttachmentState$1 as AttachmentState, AttachmentStatus, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChatModelRunUpdate, CompleteAttachment, CompleteAttachmentStatus, ComposerRuntime, ComposerRuntimeCore, ComposerRuntimeEventCallback, ComposerRuntimeEventPayload, ComposerRuntimeEventType, ComposerRuntimePath, ComposerState$1 as ComposerState, CompositeAttachmentAdapter, CoreChatModelRunResult, CreateAppendMessage, CreateAttachment, CreateResumeRunConfig, CreateStartRunConfig, DataMessagePart, DictationAdapter, DictationState, EditComposerRuntime, EditComposerRuntimeCore, EditComposerState, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreAdapter, ExternalStoreBranchChange, ExternalStoreMessageConverter, ExternalStoreSharedOptions, ExternalStoreThreadData, ExternalStoreThreadListAdapter, ExternalThreadBranchAdapter, ExternalThreadQueueAdapter, FRAME_MESSAGE_CHANNEL, FeedbackAdapter, FileMessagePart, FrameMessage, FrameMessageType, GenerativeUIMessagePart, GenerativeUINode, GenerativeUISpec, GenericThreadHistoryAdapter, ImageMessagePart, InMemoryThreadListAdapter, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptionsBase, MCP_APP_URI_SCHEME, McpAppMetadata, MessageFormatAdapter, MessageFormatItem, MessageFormatRepository, MessagePartRuntime, MessagePartRuntimePath, MessagePartState, MessagePartStatus, MessageQueueController, MessageQueueDriver, MessageRole, MessageRuntime, MessageRuntimePath, MessageState$1 as MessageState, MessageStatus, MessageStorageEntry, MessageTiming, ModelContext$1 as ModelContext, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PendingAttachment, PendingAttachmentStatus, QuoteInfo, RealtimeVoiceAdapter, ReasoningMessagePart, RemoteThreadInitializeResponse, RemoteThreadListAdapter, RemoteThreadListOptions, RemoteThreadListPageOptions, RemoteThreadListResponse, RemoteThreadMetadata, RespondToToolApprovalOptions, ResumeRunConfig, ResumeToolCallOptions, RunConfig, RuntimeCapabilities, SendOptions, SerializedModelContext, SerializedTool, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceProviderMetadata, SpeechState, SpeechSynthesisAdapter, StartRunConfig, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, SubmitFeedbackOptions, SubmittedFeedback, SuggestionAdapter, TextMessagePart, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadComposerRuntimeCore, ThreadComposerState, ThreadHistoryAdapter, ThreadListItemCoreState, ThreadListItemEventCallback, ThreadListItemEventPayload, ThreadListItemEventType, ThreadListItemRuntime, ThreadListItemRuntimePath, ThreadListItemState$1 as ThreadListItemState, ThreadListItemStatus, ThreadListRuntime, ThreadListRuntimeCore, ThreadListState, ThreadMessage, ThreadMessageLike, ThreadRuntime, ThreadRuntimeCore, ThreadRuntimeEventCallback, ThreadRuntimeEventPayload, ThreadRuntimeEventType, ThreadRuntimePath, ThreadState$1 as ThreadState, ThreadStep, ThreadSuggestion, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolCallMessagePart, ToolCallMessagePartMcpMetadata, ToolCallMessagePartStatus, ToolCallTiming, ToolExecutionStatus, ToolModelContentPart, Unstable_AudioMessagePart, Unstable_DirectiveFormatter, Unstable_DirectiveSegment, Unstable_InteractableSnapshotEntry, Unstable_InteractableVersion, Unstable_TriggerAdapter, Unstable_TriggerCategory, Unstable_TriggerItem, Unsubscribe$1 as Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, VoiceSessionState, WebSpeechDictationAdapter, WebSpeechSynthesisAdapter, bindExternalStoreMessage, createMessageQueue, createRequestHeaders, createVoiceSession, fromThreadMessageLike, generateId, getExternalStoreMessages, isMcpAppUri, mergeModelContexts, pickExternalStoreSharedOptions, stepStreamingTiming, tool, unstable_defaultDirectiveFormatter, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions };
+}
+
+declare namespace entry_store_exports {
+  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsMethods, ThreadsState };
+}
+
+declare namespace entry_internal_exports {
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
+}
+
+declare namespace entry_store_internal_exports {
+  export { AttachmentRuntimeClient, ComposerClient, MessageClient, MessagePartClient, ThreadClient, ThreadListClient, ThreadListItemClient, baseRuntimeAdapterTransformScopes };
+}
+
+declare const isAutoStatus: (status: MessageStatus) => boolean;
+
+declare const isErrorMessageId: (id: string) => boolean;
+
+declare const isMcpAppUri: (uri: string | undefined) => boolean;
+
+declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
+
+declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
+
+declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
+
+declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+
+declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
+
+declare function providerTool(_config: ProviderToolConfig): never;
+
+declare const resolveToolApprovalResponse: (approval: {
+  readonly id: string;
+  readonly options?: readonly ToolApprovalOption[];
+}, response: ToolApprovalResponse) => RespondToToolApprovalOptions;
+
+declare const shouldContinue: (result: ThreadAssistantMessage, humanToolNames: string[] | undefined) => boolean;
 
 declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options: T) => {
   localRuntimeOptions: {
@@ -5539,285 +5549,275 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
   otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
 };
 
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param20?: LocalRuntimeOptions) => AssistantRuntime;
-
-declare namespace entry_react_exports {
-  export { AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantInteractableProps, AssistantProviderBase, AssistantProviderBaseProps, AssistantRuntimeProvider, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, AsyncStorageLike, ChainOfThoughtByIndicesProvider, ChainOfThoughtPartByIndexProvider, ChainOfThoughtPrimitiveParts, CloudFileAttachmentAdapter, ComposerAttachmentByIndexProvider, ComposerPrimitiveAttachmentByIndex, ComposerPrimitiveAttachments, ComposerPrimitiveIf, ComposerPrimitiveQueue, DataMessagePartComponent, DataMessagePartProps, DataRenderers, DataRenderersClientSchema, DataRenderersMethods, DataRenderersState, EmptyMessagePartComponent, EmptyMessagePartProps, EnrichedPartState, FileMessagePartComponent, FileMessagePartProps, GenerativeUIComponentRegistry, GenerativeUIMessagePartComponent, GenerativeUIMessagePartProps, GenerativeUIRender, GenerativeUIRenderError, GenerativeUIRenderProps, GroupByContext, ImageMessagePartComponent, ImageMessagePartProps, InteractableDefinition, InteractablePersistedState, InteractablePersistenceAdapter, InteractablePersistenceStatus, InteractableRegistration, InteractableStateSchema, Interactables, InteractablesClientSchema, InteractablesMethods, InteractablesState, JoinStrategy, LocalRuntimeOptions, McpAppResourceOutput, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, MessagePartComponent, MessagePartPrimitiveInProgress, MessagePrimitiveAttachmentByIndex, MessagePrimitiveAttachments, MessagePrimitiveGenerativeUI, MessagePrimitiveGroupedParts, MessagePrimitivePartByIndex, MessagePrimitiveParts, MessagePrimitiveQuote, PartByIndexProvider, PartPrimitiveMessages, PartPrimitiveMessagesImpl, PartState, ProviderToolConfig, QueueItemByIndexProvider, QueueItemByIndexProviderProps, QuoteMessagePartComponent, QuoteMessagePartProps, ReadonlyThreadProvider, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListHookInstanceManager, RemoteThreadListThreadListRuntimeCore, RuntimeAdapter, RuntimeAdapterProvider, RuntimeAdapters, SourceMessagePartComponent, SourceMessagePartProps, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, SuggestionByIndexProvider, SuggestionByIndexProviderProps, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadListItemByIndexProvider, ThreadListItemPrimitiveTitle, ThreadListItemRuntimeProvider, ThreadListPrimitiveItemByIndex, ThreadListPrimitiveItems, ThreadPrimitiveMessageByIndex, ThreadPrimitiveMessages, ThreadPrimitiveMessagesImpl, ThreadPrimitiveSuggestionByIndex, ThreadPrimitiveSuggestions, ThreadPrimitiveSuggestionsImpl, ThreadPrimitiveUnstable_MessageById, TitleGenerationAdapter, ToolArgsStatus, ToolCallMessagePartComponent, ToolCallMessagePartProps, ToolCallText, ToolDefinition, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, ToolsClientSchema, ToolsMethods, ToolsState, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, UseActionBarCopyOptions, UseComposerIfProps, UseSuggestionTriggerOptions, convertExternalMessages, createLocalStorageAdapter, createMessageConverter, createSimpleTitleAdapter, defineMcpToolkit, defineToolkit, externalTool, getMessageQuote, getRenderComponent, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, defaultComponents as messagePartsDefaultComponents, providerTool, splitLocalRuntimeOptions, stubTool, unstable_Interactables, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useActionBarCopy, useActionBarEdit, useActionBarFeedbackNegative, useActionBarFeedbackPositive, useActionBarReload, useActionBarSpeak, useActionBarStopSpeaking, useAssistantCloudThreadHistoryAdapter, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAuiToolOverrides, useBranchPickerNext, useBranchPickerPrevious, useCloudThreadListAdapter, useComposerAddAttachment, useComposerCancel, useComposerDictate, useComposerSend, useEditComposerCancel, useEditComposerSend, useExternalMessageConverter, useExternalStoreRuntime, useExternalStoreSharedOptions, useInlineRender, useInteractableState, useLocalRuntime, useMessageBranching, useMessageError, useMessageReload, useRemoteThreadListRuntime, useRuntimeAdapters, useStreamingTiming, useSuggestionTrigger, useThreadIsEmpty, useThreadIsRunning, useThreadListItemArchive, useThreadListItemDelete, useThreadListItemTrigger, useThreadListItemUnarchive, useThreadListLoadMore, useThreadListNew, useThreadMessages, useToolArgsStatus, useVoiceControls, useVoiceState, useVoiceVolume };
-}
-
-declare const baseRuntimeAdapterTransformScopes: (scopes: ScopesConfig, parent: AssistantClient) => void;
-
-declare const AttachmentRuntimeClient: Resource<ClientOutput<"attachment">, [
-  {
-    runtime: AttachmentRuntime;
-  }
-]>;
-
-declare const MessagePartClient: Resource<ClientOutput<"part">, [
-  {
-    runtime: MessagePartRuntime;
-  }
-]>;
-
-declare const ComposerClient: Resource<ClientOutput<"composer">, [
-  {
-    threadIdRef: {
-      current: string;
-    };
-    messageIdRef?: {
-      current: string;
-    };
-    runtime: ComposerRuntime;
-  }
-]>;
-
-declare const MessageClient: Resource<ClientOutput<"message">, [
-  {
-    runtime: MessageRuntime;
-    threadIdRef: {
-      current: string;
-    };
-  }
-]>;
-
-declare const ThreadClient: Resource<ClientOutput<"thread">, [
-  {
-    runtime: ThreadRuntime;
-  }
-]>;
-
-declare const ThreadListItemClient: Resource<ClientOutput<"threadListItem">, [
-  {
-    runtime: ThreadListItemRuntime;
-  }
-]>;
-
-declare const ThreadListClient: Resource<ClientOutput<"threads">, [
-  {
-    runtime: ThreadListRuntime;
-    __internal_assistantRuntime: AssistantRuntime;
-  }
-]>;
-
-declare namespace entry_store_internal_exports {
-  export { AttachmentRuntimeClient, ComposerClient, MessageClient, MessagePartClient, ThreadClient, ThreadListClient, ThreadListItemClient, baseRuntimeAdapterTransformScopes };
-}
-
-declare const NoOpComposerClient: Resource<ClientOutput<"composer">, [
-  {
-    type: "edit" | "thread";
-  }
-]>;
-
-type SuggestionConfig = string | {
-  title: string;
-  label: string;
-  prompt: string;
+declare const stepStreamingTiming: <TMessage>(state: StreamingTimingState | null, messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options: StreamingTimingOptions | undefined, now?: () => number) => {
+  readonly state: StreamingTimingState | null;
+  readonly timings: Record<string, MessageTiming>;
 };
 
-declare const Suggestions: Resource<ClientOutput<"suggestions">, [
-  suggestions?: SuggestionConfig[] | undefined
-]>;
+declare function stubTool(): never;
 
-declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
-  {
-    parts: readonly ChainOfThoughtPart[];
-    getMessagePart: (selector: {
-      index: number;
-    }) => PartMethods;
-  }
-]>;
-
-type ThreadMessageClientProps = {
-  message: ThreadMessage;
-  index: number;
-  isLast?: boolean;
-  branchNumber?: number;
-  branchCount?: number;
-};
-
-declare const ThreadMessageClient: Resource<ClientOutput<"message">, [
-  ThreadMessageClientProps
-]>;
-
-declare const ModelContext: Resource<ClientOutput<"modelContext">, [
-]>;
-
-declare namespace entry_store_exports {
-  export { AttachmentClientSchema, AttachmentMeta, AttachmentMethods, AttachmentState, ChainOfThoughtClient, ChainOfThoughtClientSchema, ChainOfThoughtMeta, ChainOfThoughtMethods, ChainOfThoughtPart, ChainOfThoughtState, ComposerClientSchema, ComposerEvents, ComposerMeta, ComposerMethods, ComposerSendOptions, ComposerState, MessageClientSchema, MessageMeta, MessageMethods, MessageState, ModelContext, ModelContextClientSchema, ModelContextMethods, ModelContextState, NoOpComposerClient, PartClientSchema, PartMeta, PartMethods, PartState, QueueItemClientSchema, QueueItemMeta, QueueItemMethods, QueueItemState, Suggestion, SuggestionClientSchema, SuggestionConfig, SuggestionMeta, SuggestionMethods, SuggestionState, Suggestions, SuggestionsClientSchema, SuggestionsMethods, SuggestionsState, ThreadClientSchema, ThreadEvents, ThreadListItemClientSchema, ThreadListItemEvents, ThreadListItemMeta, ThreadListItemMethods, ThreadListItemState, ThreadMessageClient, ThreadMessageClientProps, ThreadMeta, ThreadMethods, ThreadState, ThreadsClientSchema, ThreadsMethods, ThreadsState };
-}
-
-type Unstable_TriggerItem = {
-  readonly id: string;
-  readonly type: string;
-  readonly label: string;
-  readonly description?: string | undefined;
-  readonly metadata?: ReadonlyJSONObject | undefined;
-};
-
-type Unstable_TriggerCategory = {
-  readonly id: string;
-  readonly label: string;
-};
-
-type Unstable_DirectiveSegment = {
-  readonly kind: "text";
-  readonly text: string;
-} | {
-  readonly kind: "mention";
-  readonly type: string;
-  readonly label: string;
-  readonly id: string;
-};
-
-type Unstable_DirectiveFormatter = {
-  serialize(item: Unstable_TriggerItem): string;
-  parse(text: string): readonly Unstable_DirectiveSegment[];
-};
-
-declare const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
-
-type Unstable_TriggerAdapter = {
-  categories(): readonly Unstable_TriggerCategory[];
-  categoryItems(categoryId: string): readonly Unstable_TriggerItem[];
-  search?(query: string): readonly Unstable_TriggerItem[];
-};
+declare const symbolInnerMessage: unique symbol;
 
 declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
 
-interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
-  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
-  remove(): void;
-}
+declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
+  (Unstable_InteractablesConfig | undefined)?
+]>;
 
-interface ModelContextRegistryInstructionHandle {
-  update(config: string | AssistantInstructionsConfig): void;
-  remove(): void;
-}
+declare const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
 
-interface ModelContextRegistryProviderHandle {
-  remove(): void;
-}
+declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
 
-declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
-  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
-  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
-  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
-}
+declare function unstable_getInteractableSnapshots(message: {
+  metadata?: unknown;
+}): Unstable_InteractableSnapshotEntry[] | undefined;
 
-declare class AssistantFrameHost implements ModelContextProvider {
-  private _context;
-  private _subscribers;
-  private _pendingRequests;
-  private _requestCounter;
-  private _iframeWindow;
-  private _targetOrigin;
-  constructor(iframeWindow: Window, targetOrigin?: string);
-  private handleMessage;
-  private updateContext;
-  private callTool;
-  private sendRequest;
-  private requestContext;
-  private notifySubscribers;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  dispose(): void;
-}
+declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
 
-declare class AssistantFrameProvider {
-  private static _instance;
-  private _providers;
-  private _providerUnsubscribes;
-  private _targetOrigin;
-  private constructor();
-  private static getInstance;
-  private handleMessage;
-  private handleToolCall;
-  private sendMessage;
-  private getModelContext;
-  private broadcastUpdate;
-  static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe$1;
-  static dispose(): void;
-}
+declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
+  success: true;
+}>;
 
-type SerializedTool = {
-  description?: string;
-  parameters: any;
-  disabled?: boolean;
-  type?: string;
+declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
+  Unstable_InferInteractableState<TSchema>,
+  {
+    id: string;
+    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
+    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableState: <TState>(id: string) => [
+  TState | undefined,
+  {
+    setState: (updater: StateUpdater<TState>) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
+  state: TState;
+  restore: () => void;
+})[];
+
+declare const unstable_useThreadMessageIds: () => readonly string[];
+
+declare const updateStatusReducer: (state: RemoteThreadState, threadIdOrRemoteId: string, newStatus: "archived" | "deleted" | "regular") => RemoteThreadState;
+
+declare const useActionBarCopy: (_param17?: UseActionBarCopyOptions) => {
+  copy: () => void;
+  disabled: boolean;
+  isCopied: boolean;
 };
 
-type SerializedModelContext = {
-  system?: string;
-  tools?: Record<string, SerializedTool>;
+declare const useActionBarEdit: () => {
+  edit: () => void;
+  disabled: boolean;
 };
 
-type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
-
-type FrameMessage = {
-  type: "model-context-request";
-} | {
-  type: "model-context-update";
-  context: SerializedModelContext;
-} | {
-  type: "tool-call";
-  id: string;
-  toolName: string;
-  args: unknown;
-} | {
-  type: "tool-result";
-  id: string;
-  result?: unknown;
-  error?: string;
+declare const useActionBarFeedbackNegative: () => {
+  submit: () => void;
+  isSubmitted: boolean;
 };
 
-declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";
-
-type ExternalThreadBranchAdapter = {
-  getBranches: (messageId: string) => readonly string[];
-  switchToBranch: (branchId: string) => void;
+declare const useActionBarFeedbackPositive: () => {
+  submit: () => void;
+  isSubmitted: boolean;
 };
 
-type MessageQueueDriver = {
-  run: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  cancel?: (() => void) | undefined;
+declare const useActionBarReload: () => {
+  reload: () => void;
+  disabled: boolean;
 };
 
-type MessageQueueController = {
-  readonly adapter: ExternalThreadQueueAdapter;
-  notifyBusy: () => void;
-  notifyIdle: () => void;
-  subscribe: (callback: () => void) => () => void;
+declare const useActionBarSpeak: () => {
+  speak: () => Promise<void>;
+  disabled: boolean;
 };
 
-declare const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController;
+declare const useActionBarStopSpeaking: () => {
+  stopSpeaking: () => void;
+  disabled: boolean;
+};
 
-declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
-  list(): Promise<RemoteThreadListResponse>;
-  rename(): Promise<void>;
-  updateCustom(): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(): Promise<AssistantStream>;
-  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
+declare function useAssistantCloudThreadHistoryAdapter(cloudRef: RefObject<AssistantCloud>): ThreadHistoryAdapter;
+
+declare const useAssistantContext: (config: AssistantContextConfig) => void;
+
+declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
+
+declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
+
+declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
+
+declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
+
+declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
+
+declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
+
+declare const useBranchPickerNext: () => {
+  next: () => void;
+  disabled: boolean;
+};
+
+declare const useBranchPickerPrevious: () => {
+  previous: () => void;
+  disabled: boolean;
+};
+
+declare const useCloudThreadListAdapter: (adapter: CloudThreadListAdapterOptions) => RemoteThreadListAdapter;
+
+declare const useComposerAddAttachment: () => {
+  addAttachment: (file: File | CreateAttachment) => Promise<void>;
+  disabled: boolean;
+};
+
+declare const useComposerCancel: () => {
+  cancel: () => void;
+  disabled: boolean;
+};
+
+declare const useComposerDictate: () => {
+  startDictation: () => void;
+  disabled: boolean;
+};
+
+declare const useComposerSend: () => {
+  send: (opts?: ComposerSendOptions) => void;
+  disabled: boolean;
+};
+
+declare const useEditComposerCancel: () => {
+  cancel: () => void;
+};
+
+declare const useEditComposerSend: () => {
+  send: () => void;
+  disabled: boolean;
+};
+
+declare namespace useExternalMessageConverter {
+  type Message = (ThreadMessageLike & {
+    readonly convertConfig?: {
+      readonly joinStrategy?: JoinStrategy;
+    };
+  }) | {
+    role: "tool";
+    toolCallId: string;
+    toolName?: string | undefined;
+    result: any;
+    artifact?: any;
+    isError?: boolean;
+    messages?: readonly ThreadMessage[];
+  };
+  type Metadata = {
+    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+    readonly error?: ReadonlyJSONValue;
+    readonly messageTiming?: Record<string, MessageTiming>;
+  };
+  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
 }
 
-declare function createRequestHeaders(headersValue: Record<string, string> | Headers | (() => Promise<Record<string, string> | Headers>)): Promise<Headers>;
+declare const useExternalMessageConverter: <T extends WeakKey>(_param18: {
+  callback: useExternalMessageConverter.Callback<T>;
+  messages: T[];
+  isRunning: boolean;
+  joinStrategy?: JoinStrategy | undefined;
+  metadata?: useExternalMessageConverter.Metadata | undefined;
+}) => ThreadMessage[];
 
-declare namespace entry_root_exports {
-  export { AddToolResultOptions, AppendMessage, AssistantContextConfig, AssistantFrameHost, AssistantFrameProvider, AssistantInstructionsConfig, AssistantRuntime, AssistantRuntimeCore, AssistantToolProps$1 as AssistantToolProps, Attachment, AttachmentAdapter, AttachmentAddErrorEvent, AttachmentAddErrorReason, AttachmentRuntime, AttachmentRuntimePath, AttachmentState$1 as AttachmentState, AttachmentStatus, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChatModelRunUpdate, CompleteAttachment, CompleteAttachmentStatus, ComposerRuntime, ComposerRuntimeCore, ComposerRuntimeEventCallback, ComposerRuntimeEventPayload, ComposerRuntimeEventType, ComposerRuntimePath, ComposerState$1 as ComposerState, CompositeAttachmentAdapter, CoreChatModelRunResult, CreateAppendMessage, CreateAttachment, CreateResumeRunConfig, CreateStartRunConfig, DataMessagePart, DictationAdapter, DictationState, EditComposerRuntime, EditComposerRuntimeCore, EditComposerState, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreAdapter, ExternalStoreBranchChange, ExternalStoreMessageConverter, ExternalStoreSharedOptions, ExternalStoreThreadData, ExternalStoreThreadListAdapter, ExternalThreadBranchAdapter, ExternalThreadQueueAdapter, FRAME_MESSAGE_CHANNEL, FeedbackAdapter, FileMessagePart, FrameMessage, FrameMessageType, GenerativeUIMessagePart, GenerativeUINode, GenerativeUISpec, GenericThreadHistoryAdapter, ImageMessagePart, InMemoryThreadListAdapter, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptionsBase, MCP_APP_URI_SCHEME, McpAppMetadata, MessageFormatAdapter, MessageFormatItem, MessageFormatRepository, MessagePartRuntime, MessagePartRuntimePath, MessagePartState, MessagePartStatus, MessageQueueController, MessageQueueDriver, MessageRole, MessageRuntime, MessageRuntimePath, MessageState$1 as MessageState, MessageStatus, MessageStorageEntry, MessageTiming, ModelContext$1 as ModelContext, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PendingAttachment, PendingAttachmentStatus, QuoteInfo, RealtimeVoiceAdapter, ReasoningMessagePart, RemoteThreadInitializeResponse, RemoteThreadListAdapter, RemoteThreadListOptions, RemoteThreadListPageOptions, RemoteThreadListResponse, RemoteThreadMetadata, RespondToToolApprovalOptions, ResumeRunConfig, ResumeToolCallOptions, RunConfig, RuntimeCapabilities, SendOptions, SerializedModelContext, SerializedTool, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceProviderMetadata, SpeechState, SpeechSynthesisAdapter, StartRunConfig, StreamingTimingAccessors, StreamingTimingOptions, StreamingTimingState, SubmitFeedbackOptions, SubmittedFeedback, SuggestionAdapter, TextMessagePart, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadComposerRuntimeCore, ThreadComposerState, ThreadHistoryAdapter, ThreadListItemCoreState, ThreadListItemEventCallback, ThreadListItemEventPayload, ThreadListItemEventType, ThreadListItemRuntime, ThreadListItemRuntimePath, ThreadListItemState$1 as ThreadListItemState, ThreadListItemStatus, ThreadListRuntime, ThreadListRuntimeCore, ThreadListState, ThreadMessage, ThreadMessageLike, ThreadRuntime, ThreadRuntimeCore, ThreadRuntimeEventCallback, ThreadRuntimeEventPayload, ThreadRuntimeEventType, ThreadRuntimePath, ThreadState$1 as ThreadState, ThreadStep, ThreadSuggestion, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolCallMessagePart, ToolCallMessagePartMcpMetadata, ToolCallMessagePartStatus, ToolCallTiming, ToolExecutionStatus, ToolModelContentPart, Unstable_AudioMessagePart, Unstable_DirectiveFormatter, Unstable_DirectiveSegment, Unstable_InteractableSnapshotEntry, Unstable_InteractableVersion, Unstable_TriggerAdapter, Unstable_TriggerCategory, Unstable_TriggerItem, Unsubscribe$1 as Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, VoiceSessionState, WebSpeechDictationAdapter, WebSpeechSynthesisAdapter, bindExternalStoreMessage, createMessageQueue, createRequestHeaders, createVoiceSession, fromThreadMessageLike, generateId, getExternalStoreMessages, isMcpAppUri, mergeModelContexts, pickExternalStoreSharedOptions, stepStreamingTiming, tool, unstable_defaultDirectiveFormatter, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions };
-}
+declare const useExternalStoreRuntime: <T>(store: ExternalStoreAdapter<T>) => AssistantRuntime;
+
+declare const useExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
+
+declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
+
+declare const useInteractableState: <TState>(id: string, fallback: TState) => [
+  TState,
+  {
+    setState: (updater: StateUpdater$1<TState>) => void;
+    setSelected: (selected: boolean) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param19?: LocalRuntimeOptions) => AssistantRuntime;
+
+declare const useMessageBranching: () => {
+  branchNumber: number;
+  branchCount: number;
+  goToPrev: () => void;
+  goToNext: () => void;
+};
+
+declare const useMessageError: () => string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | undefined;
+
+declare const useMessageReload: () => {
+  reload: () => void;
+  canReload: boolean;
+};
+
+declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
+
+declare const useRuntimeAdapters: () => RuntimeAdapters | null;
+
+declare const useStreamingTiming: <TMessage>(messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options?: StreamingTimingOptions) => Record<string, MessageTiming>;
+
+declare const useSuggestionTrigger: (_param20: UseSuggestionTriggerOptions) => {
+  trigger: () => void;
+  disabled: boolean;
+};
+
+declare const useThreadIsEmpty: () => boolean;
+
+declare const useThreadIsRunning: () => boolean;
+
+declare const useThreadListItemArchive: () => {
+  archive: () => void;
+};
+
+declare const useThreadListItemDelete: () => {
+  delete: () => void;
+};
+
+declare const useThreadListItemTrigger: () => {
+  switchTo: () => void;
+};
+
+declare const useThreadListItemUnarchive: () => {
+  unarchive: () => void;
+};
+
+declare const useThreadListLoadMore: () => {
+  loadMore: () => void;
+  disabled: boolean;
+};
+
+declare const useThreadListNew: () => {
+  switchToNewThread: () => void;
+};
+
+declare const useThreadMessages: () => readonly MessageState[];
+
+declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
+
+declare const useVoiceControls: () => {
+  connect: () => void;
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
+};
+
+declare const useVoiceState: () => VoiceSessionState | undefined;
+
+declare const useVoiceVolume: () => number;
 
 export { entry_internal_exports as entry_internal, entry_react_exports as entry_react, entry_root_exports as entry_root, entry_store_exports as entry_store, entry_store_internal_exports as entry_store_internal };

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1,23 +1,99 @@
-import { EveMessage, EveMessageData, UseEveAgentOptions } from "eve/react";
-
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { SendTurnPayload } from "eve/client";
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+import { EveMessage, EveMessageData, UseEveAgentOptions } from "eve/react";
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -29,9 +105,60 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -39,7 +166,66 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type ConvertEveMessagesOptions = {
+  readonly isRunning?: boolean | undefined;
+  readonly getCreatedAt?: ((message: EveMessage) => Date) | undefined;
+};
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -49,30 +235,261 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -134,164 +551,42 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -321,167 +616,37 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
+type MessageCommonProps = {
   readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
+  readonly createdAt: Date;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
 };
 
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
   };
 };
 
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
 
 type MessagePartStatus = {
   readonly type: "running";
@@ -493,10 +658,50 @@ type MessagePartStatus = {
   readonly error?: unknown;
 };
 
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
 
 type MessageStatus = {
   readonly type: "running";
@@ -522,185 +727,74 @@ type MessageTiming = {
   readonly toolCallCount: number;
 };
 
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
 };
 
-type MessageCommonProps = {
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
   readonly id: string;
-  readonly createdAt: Date;
+  readonly prompt: string;
 };
 
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
 };
 
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -735,65 +829,256 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -843,413 +1128,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1278,174 +1156,277 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-type ConvertEveMessagesOptions = {
-  readonly isRunning?: boolean | undefined;
-  readonly getCreatedAt?: ((message: EveMessage) => Date) | undefined;
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-declare const convertEveMessage: (message: EveMessage, index: number, messages: readonly EveMessage[], options?: ConvertEveMessagesOptions) => ThreadMessage;
+type ToolDisplay = "inline" | "standalone";
 
-declare const convertEveMessages: (data: EveMessageData, options?: ConvertEveMessagesOptions) => ThreadMessage[];
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
 
-declare const getEveMessageContent: (message: AppendMessage) => NonNullable<SendTurnPayload["message"]>;
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
 
 type UseEveAgentRuntimeOptions = Omit<UseEveAgentOptions<EveMessageData>, "reducer"> & ExternalStoreSharedOptions & {
   readonly adapters?: {
@@ -1457,10 +1438,29 @@ type UseEveAgentRuntimeOptions = Omit<UseEveAgentOptions<EveMessageData>, "reduc
   } | undefined;
 };
 
-declare const useEveAgentRuntime: (options?: UseEveAgentRuntimeOptions) => AssistantRuntime;
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+declare const convertEveMessage: (message: EveMessage, index: number, messages: readonly EveMessage[], options?: ConvertEveMessagesOptions) => ThreadMessage;
+
+declare const convertEveMessages: (data: EveMessageData, options?: ConvertEveMessagesOptions) => ThreadMessage[];
+
+declare const getEveMessageContent: (message: AppendMessage) => NonNullable<SendTurnPayload["message"]>;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
 declare namespace entry_root_exports {
   export { ConvertEveMessagesOptions, UseEveAgentRuntimeOptions, convertEveMessage, convertEveMessages, getEveMessageContent, useEveAgentRuntime };
 }
+
+declare const useEveAgentRuntime: (options?: UseEveAgentRuntimeOptions) => AssistantRuntime;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__gorp.ts
+++ b/api-surface/assistant-ui__gorp.ts
@@ -2,23 +2,6 @@ type DeepReadonly<T> = T extends ((...args: never[]) => unknown) ? T : T extends
   readonly [K in keyof T]: DeepReadonly<T[K]>;
 } : T;
 
-type GorpOperation = {
-  type: "set";
-  path: string[];
-  value: unknown;
-} | {
-  type: "append-text";
-  path: string[];
-  value: string;
-};
-
-type GorpMessage = {
-  ops: GorpOperation[];
-  ack?: number;
-};
-
-declare function appendText(value: string): string;
-
 declare class GorpClient<T extends Record<string, unknown>, C> {
   private readonly mutator;
   private readonly _send;
@@ -52,9 +35,26 @@ declare namespace GorpClient {
   };
 }
 
-type RelaySerializedState<T> = {
-  state: T;
+type GorpMessage = {
+  ops: GorpOperation[];
+  ack?: number;
 };
+
+type GorpOperation = {
+  type: "set";
+  path: string[];
+  value: unknown;
+} | {
+  type: "append-text";
+  path: string[];
+  value: string;
+};
+
+interface GorpPubsub<C> {
+  readonly state: unknown;
+  receive(command: C): void;
+  subscribe(callback: (env: GorpMessage) => void): () => void;
+}
 
 declare class GorpRelay<T extends Record<string, unknown>, C> {
   private readonly gorp;
@@ -96,21 +96,9 @@ declare namespace GorpServer {
   };
 }
 
-interface GorpPubsub<C> {
-  readonly state: unknown;
-  receive(command: C): void;
-  subscribe(callback: (env: GorpMessage) => void): () => void;
-}
-
 type GorpSession = {
   highWater: number;
   lastActivity: number;
-};
-
-type GorpSessionsState = {
-  sessions: Record<string, {
-    highWater: number;
-  }>;
 };
 
 declare class GorpSessions<C> {
@@ -136,6 +124,18 @@ declare namespace GorpSessions {
     remove(): void;
   }
 }
+
+type GorpSessionsState = {
+  sessions: Record<string, {
+    highWater: number;
+  }>;
+};
+
+type RelaySerializedState<T> = {
+  state: T;
+};
+
+declare function appendText(value: string): string;
 
 declare namespace entry_root_exports {
   export { GorpClient, GorpMessage, GorpRelay, GorpServer, GorpSessions, GorpSessionsState, RelaySerializedState, appendText };

--- a/api-surface/assistant-ui__mcp-docs-server.ts
+++ b/api-surface/assistant-ui__mcp-docs-server.ts
@@ -4,8 +4,8 @@ declare namespace entry_root_exports {
   export { runServer, server };
 }
 
-declare const server: McpServer;
-
 declare function runServer(): Promise<void>;
+
+declare const server: McpServer;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__metro.ts
+++ b/api-surface/assistant-ui__metro.ts
@@ -1,7 +1,3 @@
-declare namespace entry_transformer_exports {
-  export { getCacheKey, transform };
-}
-
 type BabelTransformer = {
   transform: (props: {
     filename: string;
@@ -17,14 +13,6 @@ type BabelTransformer = {
   [key: string]: unknown;
 };
 
-declare function transform(props: Parameters<BabelTransformer["transform"]>[0]): unknown;
-
-declare function getCacheKey(): string;
-
-declare namespace entry_root_exports {
-  export { MetroConfigLike, UPSTREAM_TRANSFORMER_ENV, withAui };
-}
-
 type MetroConfigLike = {
   transformer?: {
     babelTransformerPath?: string | undefined;
@@ -34,6 +22,18 @@ type MetroConfigLike = {
 };
 
 declare const UPSTREAM_TRANSFORMER_ENV = "AUI_METRO_UPSTREAM_TRANSFORMER";
+
+declare function getCacheKey(): string;
+
+declare namespace entry_root_exports {
+  export { MetroConfigLike, UPSTREAM_TRANSFORMER_ENV, withAui };
+}
+
+declare function transform(props: Parameters<BabelTransformer["transform"]>[0]): unknown;
+
+declare namespace entry_transformer_exports {
+  export { getCacheKey, transform };
+}
 
 declare function withAui<T extends MetroConfigLike>(config: T): T;
 

--- a/api-surface/assistant-ui__next.ts
+++ b/api-surface/assistant-ui__next.ts
@@ -1,7 +1,3 @@
-declare namespace entry_loader_exports {
-  export { generativeLoader as default };
-}
-
 interface GenerativeLoaderContext {
   resourcePath?: string;
   resourceQuery?: string;
@@ -12,12 +8,6 @@ interface GenerativeLoaderContext {
   async(): (err: unknown, code?: string, map?: object | null) => void;
 }
 
-declare function generativeLoader(this: GenerativeLoaderContext, source: string): void;
-
-interface WithAuiOptions {
-  rules?: string[];
-}
-
 type NextConfigLike = {
   turbopack?: {
     rules?: Record<string, unknown>;
@@ -25,10 +15,20 @@ type NextConfigLike = {
   webpack?: ((config: any, context: any) => any) | null | undefined;
 };
 
-declare function withAui<T extends NextConfigLike>(nextConfig?: T, options?: WithAuiOptions): T;
+interface WithAuiOptions {
+  rules?: string[];
+}
+
+declare function generativeLoader(this: GenerativeLoaderContext, source: string): void;
 
 declare namespace entry_root_exports {
   export { WithAuiOptions, withAui };
 }
+
+declare namespace entry_loader_exports {
+  export { generativeLoader as default };
+}
+
+declare function withAui<T extends NextConfigLike>(nextConfig?: T, options?: WithAuiOptions): T;
 
 export { entry_loader_exports as entry_loader, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1,20 +1,88 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type A2AClientOptions = {
-  baseUrl: string;
-  basePath?: string | undefined;
-  tenant?: string | undefined;
-  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
-  extensions?: string[] | undefined;
-  fetchOptions?: Omit<RequestInit, "body" | "headers" | "method" | "signal"> | undefined;
+type A2AAgentCapabilities = {
+  streaming?: boolean | undefined;
+  pushNotifications?: boolean | undefined;
+  extensions?: Array<{
+    uri: string;
+    description?: string | undefined;
+    required?: boolean | undefined;
+    params?: Record<string, unknown> | undefined;
+  }> | undefined;
+  extendedAgentCard?: boolean | undefined;
 };
 
-declare class A2AError extends Error {
-  code: number;
-  status: string;
-  details: unknown[] | undefined;
-  constructor(info: A2AErrorInfo);
-}
+type A2AAgentCard = {
+  name: string;
+  description: string;
+  supportedInterfaces: A2AAgentInterface[];
+  provider?: {
+    organization: string;
+    url: string;
+  } | undefined;
+  version: string;
+  documentationUrl?: string | undefined;
+  capabilities: A2AAgentCapabilities;
+  securitySchemes?: Record<string, A2ASecurityScheme> | undefined;
+  securityRequirements?: A2ASecurityRequirement[] | undefined;
+  defaultInputModes: string[];
+  defaultOutputModes: string[];
+  skills: A2AAgentSkill[];
+  signatures?: A2AAgentCardSignature[] | undefined;
+  iconUrl?: string | undefined;
+};
+
+type A2AAgentCardSignature = {
+  protected: string;
+  signature: string;
+  header?: Record<string, unknown> | undefined;
+};
+
+type A2AAgentInterface = {
+  url: string;
+  protocolBinding: string;
+  protocolVersion: string;
+  tenant?: string | undefined;
+};
+
+type A2AAgentSkill = {
+  id: string;
+  name: string;
+  description: string;
+  tags: string[];
+  examples?: string[] | undefined;
+  inputModes?: string[] | undefined;
+  outputModes?: string[] | undefined;
+  securityRequirements?: A2ASecurityRequirement[] | undefined;
+};
+
+type A2AApiKeySecurityScheme = {
+  description?: string | undefined;
+  location: string;
+  name: string;
+};
+
+type A2AArtifact = {
+  artifactId: string;
+  name?: string | undefined;
+  description?: string | undefined;
+  parts: A2APart[];
+  metadata?: Record<string, unknown> | undefined;
+  extensions?: string[] | undefined;
+};
+
+type A2AAuthenticationInfo = {
+  scheme: string;
+  credentials?: string | undefined;
+};
+
+type A2AAuthorizationCodeOAuthFlow = {
+  authorizationUrl: string;
+  tokenUrl: string;
+  refreshUrl?: string | undefined;
+  scopes: Record<string, string>;
+  pkceRequired?: boolean | undefined;
+};
 
 declare class A2AClient {
   private baseUrl;
@@ -46,20 +114,297 @@ declare class A2AClient {
   private parseSSE;
 }
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type A2AClientCredentialsOAuthFlow = {
+  tokenUrl: string;
+  refreshUrl?: string | undefined;
+  scopes: Record<string, string>;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type A2AClientOptions = {
+  baseUrl: string;
+  basePath?: string | undefined;
+  tenant?: string | undefined;
+  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
+  extensions?: string[] | undefined;
+  fetchOptions?: Omit<RequestInit, "body" | "headers" | "method" | "signal"> | undefined;
+};
+
+type A2ADeviceCodeOAuthFlow = {
+  deviceAuthorizationUrl: string;
+  tokenUrl: string;
+  refreshUrl?: string | undefined;
+  scopes: Record<string, string>;
+};
+
+declare class A2AError extends Error {
+  code: number;
+  status: string;
+  details: unknown[] | undefined;
+  constructor(info: A2AErrorInfo);
+}
+
+type A2AErrorInfo = {
+  code: number;
+  status: string;
+  message: string;
+  details?: unknown[] | undefined;
+};
+
+type A2AHttpAuthSecurityScheme = {
+  description?: string | undefined;
+  scheme: string;
+  bearerFormat?: string | undefined;
+};
+
+type A2AImplicitOAuthFlow = {
+  authorizationUrl?: string | undefined;
+  refreshUrl?: string | undefined;
+  scopes?: Record<string, string> | undefined;
+};
+
+type A2AListTaskPushNotificationConfigsResponse = {
+  configs: A2ATaskPushNotificationConfig[];
+  nextPageToken?: string | undefined;
+};
+
+type A2AListTasksRequest = {
+  contextId?: string | undefined;
+  status?: A2ATaskState | undefined;
+  pageSize?: number | undefined;
+  pageToken?: string | undefined;
+  historyLength?: number | undefined;
+  statusTimestampAfter?: string | undefined;
+  includeArtifacts?: boolean | undefined;
+};
+
+type A2AListTasksResponse = {
+  tasks: A2ATask[];
+  nextPageToken: string;
+  pageSize: number;
+  totalSize: number;
+};
+
+type A2AMessage = {
+  messageId: string;
+  contextId?: string | undefined;
+  taskId?: string | undefined;
+  role: A2ARole;
+  parts: A2APart[];
+  metadata?: Record<string, unknown> | undefined;
+  extensions?: string[] | undefined;
+  referenceTaskIds?: string[] | undefined;
+};
+
+type A2AMutualTlsSecurityScheme = {
+  description?: string | undefined;
+};
+
+type A2AOAuth2SecurityScheme = {
+  description?: string | undefined;
+  flows: A2AOAuthFlows;
+  oauth2MetadataUrl?: string | undefined;
+};
+
+type A2AOAuthFlows = {
+  authorizationCode?: A2AAuthorizationCodeOAuthFlow | undefined;
+  clientCredentials?: A2AClientCredentialsOAuthFlow | undefined;
+  implicit?: A2AImplicitOAuthFlow | undefined;
+  password?: A2APasswordOAuthFlow | undefined;
+  deviceCode?: A2ADeviceCodeOAuthFlow | undefined;
+};
+
+type A2AOpenIdConnectSecurityScheme = {
+  description?: string | undefined;
+  openIdConnectUrl: string;
+};
+
+type A2APart = {
+  text?: string | undefined;
+  raw?: string | undefined;
+  url?: string | undefined;
+  data?: unknown;
+  metadata?: Record<string, unknown> | undefined;
+  filename?: string | undefined;
+  mediaType?: string | undefined;
+};
+
+type A2APasswordOAuthFlow = {
+  tokenUrl?: string | undefined;
+  refreshUrl?: string | undefined;
+  scopes?: Record<string, string> | undefined;
+};
+
+type A2ARole = "agent" | "unspecified" | "user";
+
+type A2ASecurityRequirement = {
+  schemes: Record<string, {
+    list: string[];
+  }>;
+};
+
+type A2ASecurityScheme = {
+  apiKeySecurityScheme?: A2AApiKeySecurityScheme | undefined;
+  httpAuthSecurityScheme?: A2AHttpAuthSecurityScheme | undefined;
+  oauth2SecurityScheme?: A2AOAuth2SecurityScheme | undefined;
+  openIdConnectSecurityScheme?: A2AOpenIdConnectSecurityScheme | undefined;
+  mtlsSecurityScheme?: A2AMutualTlsSecurityScheme | undefined;
+};
+
+type A2ASendMessageConfiguration = {
+  acceptedOutputModes?: string[] | undefined;
+  taskPushNotificationConfig?: A2ATaskPushNotificationConfig | undefined;
+  historyLength?: number | undefined;
+  returnImmediately?: boolean | undefined;
+};
+
+type A2AStreamEvent = {
+  type: "task";
+  task: A2ATask;
+} | {
+  type: "message";
+  message: A2AMessage;
+} | {
+  type: "statusUpdate";
+  event: A2ATaskStatusUpdateEvent;
+} | {
+  type: "artifactUpdate";
+  event: A2ATaskArtifactUpdateEvent;
+};
+
+type A2ATask = {
+  id: string;
+  contextId?: string | undefined;
+  status: A2ATaskStatus;
+  artifacts?: A2AArtifact[] | undefined;
+  history?: A2AMessage[] | undefined;
+  metadata?: Record<string, unknown> | undefined;
+};
+
+type A2ATaskArtifactUpdateEvent = {
+  taskId: string;
+  contextId: string;
+  artifact: A2AArtifact;
+  append?: boolean | undefined;
+  lastChunk?: boolean | undefined;
+  metadata?: Record<string, unknown> | undefined;
+};
+
+type A2ATaskPushNotificationConfig = {
+  tenant?: string | undefined;
+  id?: string | undefined;
+  taskId?: string | undefined;
+  url: string;
+  token?: string | undefined;
+  authentication?: A2AAuthenticationInfo | undefined;
+};
+
+type A2ATaskState = "auth_required" | "canceled" | "completed" | "failed" | "input_required" | "rejected" | "submitted" | "unspecified" | "working";
+
+type A2ATaskStatus = {
+  state: A2ATaskState;
+  message?: A2AMessage | undefined;
+  timestamp?: string | undefined;
+};
+
+type A2ATaskStatusUpdateEvent = {
+  taskId: string;
+  contextId: string;
+  status: A2ATaskStatus;
+  metadata?: Record<string, unknown> | undefined;
+};
+
+declare const A2A_PROTOCOL_VERSION = "1.0";
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -71,9 +416,60 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -81,7 +477,61 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -91,30 +541,281 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -176,164 +877,42 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -363,167 +942,54 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
+type MessageCommonProps = {
   readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
+  readonly createdAt: Date;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
 };
 
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
   };
 };
 
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
 
 type MessagePartStatus = {
   readonly type: "running";
@@ -535,10 +1001,50 @@ type MessagePartStatus = {
   readonly error?: unknown;
 };
 
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
 
 type MessageStatus = {
   readonly type: "running";
@@ -554,6 +1060,13 @@ type MessageStatus = {
   readonly error?: ReadonlyJSONValue;
 };
 
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
 type MessageTiming = {
   readonly streamStartTime: number;
   readonly firstTokenTime?: number;
@@ -564,185 +1077,74 @@ type MessageTiming = {
   readonly toolCallCount: number;
 };
 
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
 };
 
-type MessageCommonProps = {
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
   readonly id: string;
-  readonly createdAt: Date;
+  readonly prompt: string;
 };
 
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
 };
 
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -777,65 +1179,267 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -885,468 +1489,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1375,440 +1517,277 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-declare const A2A_PROTOCOL_VERSION = "1.0";
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
 
-type A2ARole = "agent" | "unspecified" | "user";
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
 
-type A2APart = {
-  text?: string | undefined;
-  raw?: string | undefined;
-  url?: string | undefined;
-  data?: unknown;
-  metadata?: Record<string, unknown> | undefined;
-  filename?: string | undefined;
-  mediaType?: string | undefined;
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-type A2AMessage = {
-  messageId: string;
-  contextId?: string | undefined;
-  taskId?: string | undefined;
-  role: A2ARole;
-  parts: A2APart[];
-  metadata?: Record<string, unknown> | undefined;
-  extensions?: string[] | undefined;
-  referenceTaskIds?: string[] | undefined;
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
 };
 
-type A2ATaskState = "auth_required" | "canceled" | "completed" | "failed" | "input_required" | "rejected" | "submitted" | "unspecified" | "working";
-
-type A2ATaskStatus = {
-  state: A2ATaskState;
-  message?: A2AMessage | undefined;
-  timestamp?: string | undefined;
-};
-
-type A2AArtifact = {
-  artifactId: string;
-  name?: string | undefined;
-  description?: string | undefined;
-  parts: A2APart[];
-  metadata?: Record<string, unknown> | undefined;
-  extensions?: string[] | undefined;
-};
-
-type A2ATask = {
-  id: string;
-  contextId?: string | undefined;
-  status: A2ATaskStatus;
-  artifacts?: A2AArtifact[] | undefined;
-  history?: A2AMessage[] | undefined;
-  metadata?: Record<string, unknown> | undefined;
-};
-
-type A2ATaskStatusUpdateEvent = {
-  taskId: string;
-  contextId: string;
-  status: A2ATaskStatus;
-  metadata?: Record<string, unknown> | undefined;
-};
-
-type A2ATaskArtifactUpdateEvent = {
-  taskId: string;
-  contextId: string;
-  artifact: A2AArtifact;
-  append?: boolean | undefined;
-  lastChunk?: boolean | undefined;
-  metadata?: Record<string, unknown> | undefined;
-};
-
-type A2AStreamEvent = {
-  type: "task";
-  task: A2ATask;
+type ToolExecutionStatus = {
+  type: "executing";
 } | {
-  type: "message";
-  message: A2AMessage;
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
 } | {
-  type: "statusUpdate";
-  event: A2ATaskStatusUpdateEvent;
-} | {
-  type: "artifactUpdate";
-  event: A2ATaskArtifactUpdateEvent;
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
 };
 
-type A2AAuthenticationInfo = {
-  scheme: string;
-  credentials?: string | undefined;
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
 };
 
-type A2ATaskPushNotificationConfig = {
-  tenant?: string | undefined;
-  id?: string | undefined;
-  taskId?: string | undefined;
-  url: string;
-  token?: string | undefined;
-  authentication?: A2AAuthenticationInfo | undefined;
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
 };
 
-type A2AListTaskPushNotificationConfigsResponse = {
-  configs: A2ATaskPushNotificationConfig[];
-  nextPageToken?: string | undefined;
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
 };
 
-type A2ASendMessageConfiguration = {
-  acceptedOutputModes?: string[] | undefined;
-  taskPushNotificationConfig?: A2ATaskPushNotificationConfig | undefined;
-  historyLength?: number | undefined;
-  returnImmediately?: boolean | undefined;
-};
-
-type A2AListTasksRequest = {
-  contextId?: string | undefined;
-  status?: A2ATaskState | undefined;
-  pageSize?: number | undefined;
-  pageToken?: string | undefined;
-  historyLength?: number | undefined;
-  statusTimestampAfter?: string | undefined;
-  includeArtifacts?: boolean | undefined;
-};
-
-type A2AListTasksResponse = {
-  tasks: A2ATask[];
-  nextPageToken: string;
-  pageSize: number;
-  totalSize: number;
-};
-
-type A2AErrorInfo = {
-  code: number;
-  status: string;
-  message: string;
-  details?: unknown[] | undefined;
-};
-
-type A2AApiKeySecurityScheme = {
-  description?: string | undefined;
-  location: string;
-  name: string;
-};
-
-type A2AHttpAuthSecurityScheme = {
-  description?: string | undefined;
-  scheme: string;
-  bearerFormat?: string | undefined;
-};
-
-type A2AAuthorizationCodeOAuthFlow = {
-  authorizationUrl: string;
-  tokenUrl: string;
-  refreshUrl?: string | undefined;
-  scopes: Record<string, string>;
-  pkceRequired?: boolean | undefined;
-};
-
-type A2AClientCredentialsOAuthFlow = {
-  tokenUrl: string;
-  refreshUrl?: string | undefined;
-  scopes: Record<string, string>;
-};
-
-type A2ADeviceCodeOAuthFlow = {
-  deviceAuthorizationUrl: string;
-  tokenUrl: string;
-  refreshUrl?: string | undefined;
-  scopes: Record<string, string>;
-};
-
-type A2AImplicitOAuthFlow = {
-  authorizationUrl?: string | undefined;
-  refreshUrl?: string | undefined;
-  scopes?: Record<string, string> | undefined;
-};
-
-type A2APasswordOAuthFlow = {
-  tokenUrl?: string | undefined;
-  refreshUrl?: string | undefined;
-  scopes?: Record<string, string> | undefined;
-};
-
-type A2AOAuthFlows = {
-  authorizationCode?: A2AAuthorizationCodeOAuthFlow | undefined;
-  clientCredentials?: A2AClientCredentialsOAuthFlow | undefined;
-  implicit?: A2AImplicitOAuthFlow | undefined;
-  password?: A2APasswordOAuthFlow | undefined;
-  deviceCode?: A2ADeviceCodeOAuthFlow | undefined;
-};
-
-type A2AOAuth2SecurityScheme = {
-  description?: string | undefined;
-  flows: A2AOAuthFlows;
-  oauth2MetadataUrl?: string | undefined;
-};
-
-type A2AOpenIdConnectSecurityScheme = {
-  description?: string | undefined;
-  openIdConnectUrl: string;
-};
-
-type A2AMutualTlsSecurityScheme = {
-  description?: string | undefined;
-};
-
-type A2ASecurityScheme = {
-  apiKeySecurityScheme?: A2AApiKeySecurityScheme | undefined;
-  httpAuthSecurityScheme?: A2AHttpAuthSecurityScheme | undefined;
-  oauth2SecurityScheme?: A2AOAuth2SecurityScheme | undefined;
-  openIdConnectSecurityScheme?: A2AOpenIdConnectSecurityScheme | undefined;
-  mtlsSecurityScheme?: A2AMutualTlsSecurityScheme | undefined;
-};
-
-type A2ASecurityRequirement = {
-  schemes: Record<string, {
-    list: string[];
-  }>;
-};
-
-type A2AAgentCardSignature = {
-  protected: string;
-  signature: string;
-  header?: Record<string, unknown> | undefined;
-};
-
-type A2AAgentSkill = {
-  id: string;
-  name: string;
-  description: string;
-  tags: string[];
-  examples?: string[] | undefined;
-  inputModes?: string[] | undefined;
-  outputModes?: string[] | undefined;
-  securityRequirements?: A2ASecurityRequirement[] | undefined;
-};
-
-type A2AAgentCapabilities = {
-  streaming?: boolean | undefined;
-  pushNotifications?: boolean | undefined;
-  extensions?: Array<{
-    uri: string;
-    description?: string | undefined;
-    required?: boolean | undefined;
-    params?: Record<string, unknown> | undefined;
-  }> | undefined;
-  extendedAgentCard?: boolean | undefined;
-};
-
-type A2AAgentInterface = {
-  url: string;
-  protocolBinding: string;
-  protocolVersion: string;
-  tenant?: string | undefined;
-};
-
-type A2AAgentCard = {
-  name: string;
-  description: string;
-  supportedInterfaces: A2AAgentInterface[];
-  provider?: {
-    organization: string;
-    url: string;
-  } | undefined;
-  version: string;
-  documentationUrl?: string | undefined;
-  capabilities: A2AAgentCapabilities;
-  securitySchemes?: Record<string, A2ASecurityScheme> | undefined;
-  securityRequirements?: A2ASecurityRequirement[] | undefined;
-  defaultInputModes: string[];
-  defaultOutputModes: string[];
-  skills: A2AAgentSkill[];
-  signatures?: A2AAgentCardSignature[] | undefined;
-  iconUrl?: string | undefined;
-};
-
-type UseA2AThreadListAdapter = {
-  threadId?: string;
-  onSwitchToNewThread?: () => Promise<void> | void;
-  onSwitchToThread?: (threadId: string) => Promise<{
-    messages: readonly ThreadMessage[];
-  }>;
-};
+type Unsubscribe = () => void;
 
 type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
   client?: A2AClient;
@@ -1834,15 +1813,25 @@ type UseA2ARuntimeOptions = ExternalStoreSharedOptions & {
   };
 };
 
+type UseA2AThreadListAdapter = {
+  threadId?: string;
+  onSwitchToNewThread?: () => Promise<void> | void;
+  onSwitchToThread?: (threadId: string) => Promise<{
+    messages: readonly ThreadMessage[];
+  }>;
+};
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+declare function a2aMessageToContent(message: A2AMessage): ThreadAssistantMessage["content"];
+
 declare function a2aPartToContent(part: A2APart): ThreadAssistantMessage["content"][number];
 
 declare function a2aPartsToContent(parts: A2APart[]): ThreadAssistantMessage["content"];
-
-declare function isTerminalTaskState(state: A2ATaskState): boolean;
-
-declare function isInterruptedTaskState(state: A2ATaskState): boolean;
-
-declare function taskStateToMessageStatus(state: A2ATaskState): MessageStatus;
 
 declare function contentPartsToA2AParts(content: ReadonlyArray<{
   type: string;
@@ -1850,18 +1839,29 @@ declare function contentPartsToA2AParts(content: ReadonlyArray<{
   image?: string;
 }>): A2APart[];
 
-declare function a2aMessageToContent(message: A2AMessage): ThreadAssistantMessage["content"];
-
-declare const useA2ATask: () => A2ATask | undefined;
-
-declare const useA2AArtifacts: () => readonly A2AArtifact[];
-
-declare const useA2AAgentCard: () => A2AAgentCard | undefined;
-
-declare function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
 declare namespace entry_root_exports {
   export { A2AAgentCapabilities, A2AAgentCard, A2AAgentCardSignature, A2AAgentInterface, A2AAgentSkill, A2AApiKeySecurityScheme, A2AArtifact, A2AAuthenticationInfo, A2AAuthorizationCodeOAuthFlow, A2AClient, A2AClientCredentialsOAuthFlow, A2AClientOptions, A2ADeviceCodeOAuthFlow, A2AError, A2AErrorInfo, A2AHttpAuthSecurityScheme, A2AImplicitOAuthFlow, A2AListTaskPushNotificationConfigsResponse, A2AListTasksRequest, A2AListTasksResponse, A2AMessage, A2AMutualTlsSecurityScheme, A2AOAuth2SecurityScheme, A2AOAuthFlows, A2AOpenIdConnectSecurityScheme, A2APart, A2APasswordOAuthFlow, A2ARole, A2ASecurityRequirement, A2ASecurityScheme, A2ASendMessageConfiguration, A2AStreamEvent, A2ATask, A2ATaskArtifactUpdateEvent, A2ATaskPushNotificationConfig, A2ATaskState, A2ATaskStatus, A2ATaskStatusUpdateEvent, A2A_PROTOCOL_VERSION, UseA2ARuntimeOptions, UseA2AThreadListAdapter, a2aMessageToContent, a2aPartToContent, a2aPartsToContent, contentPartsToA2AParts, isInterruptedTaskState, isTerminalTaskState, taskStateToMessageStatus, useA2AAgentCard, useA2AArtifacts, useA2ARuntime, useA2ATask };
 }
+
+declare function isInterruptedTaskState(state: A2ATaskState): boolean;
+
+declare function isTerminalTaskState(state: A2ATaskState): boolean;
+
+declare function taskStateToMessageStatus(state: A2ATaskState): MessageStatus;
+
+declare const useA2AAgentCard: () => A2AAgentCard | undefined;
+
+declare const useA2AArtifacts: () => readonly A2AArtifact[];
+
+declare function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime;
+
+declare const useA2ATask: () => A2ATask | undefined;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1,26 +1,127 @@
-import { StandardSchemaV1 } from "@standard-schema/spec";
-
 import { AbstractAgent } from "@ag-ui/client";
 
-type Logger = {
-  debug: (...a: any[]) => void;
-  error: (...a: any[]) => void;
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
 };
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type AgUiAssistantRuntime = AssistantRuntime & {
+  unstable_getPendingInterrupts: () => readonly AgUiInterrupt[];
+  unstable_submitInterruptResponses: (responses: readonly AgUiResumeEntry[]) => Promise<void>;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AgUiInterrupt = {
+  id: string;
+  reason: AgUiInterruptReason;
+  message?: string;
+  toolCallId?: string;
+  responseSchema?: Record<string, unknown>;
+  expiresAt?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type AgUiInterruptReason = "tool_call" | "input_required" | "confirmation" | (string & {});
+
+type AgUiResumeEntry = {
+  interruptId: string;
+  status: "cancelled" | "resolved";
+  payload?: unknown;
+};
+
+type AgUiRunFinishedOutcome = {
+  type: "success";
+} | {
+  type: "interrupt";
+  interrupts: AgUiInterrupt[];
+};
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -32,9 +133,60 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -42,7 +194,61 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -52,30 +258,285 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FromAgUiMessagesOptions = {
+  showThinking?: boolean;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -137,164 +598,47 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type Logger = {
+  debug: (...a: any[]) => void;
+  error: (...a: any[]) => void;
 };
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -324,167 +668,54 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
+type MessageCommonProps = {
   readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
+  readonly createdAt: Date;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
 };
 
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
   };
 };
 
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
 
 type MessagePartStatus = {
   readonly type: "running";
@@ -496,10 +727,50 @@ type MessagePartStatus = {
   readonly error?: unknown;
 };
 
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
 
 type MessageStatus = {
   readonly type: "running";
@@ -515,6 +786,13 @@ type MessageStatus = {
   readonly error?: ReadonlyJSONValue;
 };
 
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
 type MessageTiming = {
   readonly streamStartTime: number;
   readonly firstTokenTime?: number;
@@ -525,185 +803,74 @@ type MessageTiming = {
   readonly toolCallCount: number;
 };
 
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
 };
 
-type MessageCommonProps = {
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
   readonly id: string;
-  readonly createdAt: Date;
+  readonly prompt: string;
 };
 
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
 };
 
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -738,65 +905,273 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+type SwitchToThreadResult = {
+  messages: readonly ThreadMessage[];
+  state?: ReadonlyJSONValue;
+  unstable_resume?: boolean;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -846,468 +1221,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1336,173 +1249,277 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-type SwitchToThreadResult = {
-  messages: readonly ThreadMessage[];
-  state?: ReadonlyJSONValue;
-  unstable_resume?: boolean;
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-type UseAgUiThreadListAdapter = Omit<ExternalStoreThreadListAdapter, "onSwitchToThread"> & {
-  onSwitchToThread?: ((threadId: string) => Promise<SwitchToThreadResult> | SwitchToThreadResult) | undefined;
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
 };
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
 
 type UseAgUiRuntimeAdapters = {
   attachments?: AttachmentAdapter;
@@ -1523,52 +1540,35 @@ type UseAgUiRuntimeOptions = ExternalStoreSharedOptions & {
   adapters?: UseAgUiRuntimeAdapters;
 };
 
-type AgUiInterruptReason = "tool_call" | "input_required" | "confirmation" | (string & {});
-
-type AgUiInterrupt = {
-  id: string;
-  reason: AgUiInterruptReason;
-  message?: string;
-  toolCallId?: string;
-  responseSchema?: Record<string, unknown>;
-  expiresAt?: string;
-  metadata?: Record<string, unknown>;
+type UseAgUiThreadListAdapter = Omit<ExternalStoreThreadListAdapter, "onSwitchToThread"> & {
+  onSwitchToThread?: ((threadId: string) => Promise<SwitchToThreadResult> | SwitchToThreadResult) | undefined;
 };
 
-type AgUiResumeEntry = {
-  interruptId: string;
-  status: "cancelled" | "resolved";
-  payload?: unknown;
-};
-
-type AgUiRunFinishedOutcome = {
-  type: "success";
-} | {
-  type: "interrupt";
-  interrupts: AgUiInterrupt[];
-};
-
-declare const useAgUiInterrupts: () => readonly AgUiInterrupt[];
-
-declare const useAgUiSubmitInterruptResponses: () => (responses: readonly AgUiResumeEntry[]) => Promise<void>;
-
-declare const useAgUiSteerAway: () => (message: CreateAppendMessage, responses?: readonly AgUiResumeEntry[]) => Promise<void>;
-
-type AgUiAssistantRuntime = AssistantRuntime & {
-  unstable_getPendingInterrupts: () => readonly AgUiInterrupt[];
-  unstable_submitInterruptResponses: (responses: readonly AgUiResumeEntry[]) => Promise<void>;
-};
-
-declare function useAgUiRuntime(options: UseAgUiRuntimeOptions): AgUiAssistantRuntime;
-
-type FromAgUiMessagesOptions = {
-  showThinking?: boolean;
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
 };
 
 declare function fromAgUiMessages(messages: readonly unknown[], options?: FromAgUiMessagesOptions): ThreadMessageLike[];
 
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
 declare namespace entry_root_exports {
   export { AgUiAssistantRuntime, AgUiInterrupt, AgUiInterruptReason, AgUiResumeEntry, AgUiRunFinishedOutcome, FromAgUiMessagesOptions, UseAgUiRuntimeAdapters, UseAgUiRuntimeOptions, UseAgUiThreadListAdapter, fromAgUiMessages, useAgUiInterrupts, useAgUiRuntime, useAgUiSteerAway, useAgUiSubmitInterruptResponses };
 }
+
+declare const useAgUiInterrupts: () => readonly AgUiInterrupt[];
+
+declare function useAgUiRuntime(options: UseAgUiRuntimeOptions): AgUiAssistantRuntime;
+
+declare const useAgUiSteerAway: () => (message: CreateAppendMessage, responses?: readonly AgUiResumeEntry[]) => Promise<void>;
+
+declare const useAgUiSubmitInterruptResponses: () => (responses: readonly AgUiResumeEntry[]) => Promise<void>;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1,37 +1,847 @@
-import { ChatInit, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
-
-import { ComponentType, ReactNode } from "react";
-
 import { CreateUIMessage, UIMessage as UIMessage$1, useChat } from "@ai-sdk/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type Unsubscribe = () => void;
+import { ChatInit, DefaultChatTransport, HttpChatTransportInitOptions, ToolSet, UIMessage } from "ai";
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+import { ComponentType, ReactNode } from "react";
 
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
+  adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
+    history?: ThreadHistoryAdapter | undefined;
+  }) | undefined;
+  toCreateMessage?: CustomToCreateMessageFunction;
+  cancelPendingToolCallsOnSend?: boolean | undefined;
+  onResume?: ExternalStoreAdapter["onResume"];
+  joinStrategy?: JoinStrategy | undefined;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+declare class AISDKToolkit {
+  #private;
+  constructor(options: AISDKToolkitOptions);
+  tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
+  close(): Promise<void>;
+}
+
+type AISDKToolkitOptions = {
+  toolkit: Toolkit;
+};
+
+type AISDKToolkitToolsOptions = {
+  frontend?: Record<string, ToolJSONSchema>;
+};
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantChatResumableOptions = {
+  storage: ResumableClientStorage;
+  resumeApi: string | ((streamId: string) => string);
+  isFinishEvent?: (chunk: Uint8Array, accumulator: string) => boolean;
+};
+
+declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
+  private runtime;
+  private getThreadListItem;
+  private readonly resumable;
+  constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
+  setRuntime(runtime: AssistantRuntime): void;
+  getResumableAdapter(): AssistantChatResumableOptions | undefined;
+  __internal_setGetThreadListItem(getter: () => InitializableThreadListItem | undefined): void;
+}
+
+type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatTransportInitOptions<UI_MESSAGE> & {
+  resumable?: AssistantChatResumableOptions;
+};
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type Attachment = PendingAttachment | CompleteAttachment;
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BaseAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
+};
+
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
+
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
+
+type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};
+
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
+
+type CustomToCreateMessageFunction = <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(message: AppendMessage) => CreateUIMessage<UI_MESSAGE>;
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+interface GenerativeToolsOptions {
+  toolkit: Toolkit;
+  frontendTools?: Record<string, ToolJSONSchema>;
 }
 
-type JSONSchema7Version = string;
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type InitializableThreadListItem = Pick<ThreadListItemRuntime, "initialize">;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -93,164 +903,51 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type JoinStrategy = "concat-content" | "none";
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -280,11 +977,156 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -295,6 +1137,8 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -323,110 +1167,20 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
-} | {
-  readonly type: "part-finish";
-} | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
-  readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type ToolJSONSchema = {
-  description?: string;
-  parameters: JSONSchema7;
-  providerOptions?: ProviderOptions;
-};
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
-};
-
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
-};
-
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
-};
-
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
 };
 
 type PendingAttachmentStatus = {
@@ -441,461 +1195,20 @@ type PendingAttachmentStatus = {
   reason: "error" | "upload-paused";
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
-};
+type ProviderOptions = Record<string, Record<string, unknown>>;
 
-type BaseAttachment = {
-  id: string;
-  type: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string | undefined;
-  file?: File;
-  content?: ThreadUserMessagePart[];
-};
-
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
-};
-
-type CompleteAttachment = BaseAttachment & {
-  status: CompleteAttachmentStatus;
-  content: ThreadUserMessagePart[];
-};
-
-type Attachment = PendingAttachment | CompleteAttachment;
-
-type CreateAttachment = {
-  id?: string;
-  type?: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string;
-  content: ThreadUserMessagePart[];
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
 };
 
 type QueueItemState = {
@@ -903,35 +1216,20 @@ type QueueItemState = {
   readonly prompt: string;
 };
 
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
 };
 
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
+declare const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -966,34 +1264,293 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
+};
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumableClientStorage = {
+  getStreamId(): string | null;
+  setStreamId(id: string): void;
+  clear(): void;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -1043,287 +1600,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1352,83 +1628,178 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
 };
 
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+type ThreadSuggestion = {
+  prompt: string;
+};
+
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadTokenUsage = {
+  totalTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cachedInputTokens?: number;
+};
+
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+interface TokenUsageExtractableMessage {
+  role?: string;
+  metadata?: unknown;
+}
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
 type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
@@ -1437,7 +1808,168 @@ type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState
   respondToApproval: (response: ToolApprovalResponse) => void;
 };
 
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
+
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolJSONSchema = {
+  description?: string;
+  parameters: JSONSchema7;
+  providerOptions?: ProviderOptions;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unstable_InteractableSnapshotEntry = {
+  id: string;
+  name: string;
+  state: unknown;
+  partial?: boolean | undefined;
+};
+
+type Unsubscribe = () => void;
+
+type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
+  cloud?: AssistantCloud | undefined;
+  adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
+  toCreateMessage?: CustomToCreateMessageFunction;
+  onResume?: AISDKRuntimeAdapter["onResume"];
+  onResumeError?: ((error: unknown) => void) | undefined;
+  joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+};
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
 
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
@@ -1455,567 +1987,35 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
-
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
-
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
-
-type Toolkit = Record<string, ToolDefinition<any, any>>;
-
-type Unstable_InteractableSnapshotEntry = {
-  id: string;
-  name: string;
-  state: unknown;
-  partial?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
-};
-
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
-};
-
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
-};
-
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
-};
-
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
-
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
-    payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-type JoinStrategy = "concat-content" | "none";
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
-
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type CustomToCreateMessageFunction = <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(message: AppendMessage) => CreateUIMessage<UI_MESSAGE>;
-
-type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
-  adapters?: (NonNullable<ExternalStoreAdapter["adapters"]> & {
-    history?: ThreadHistoryAdapter | undefined;
-  }) | undefined;
-  toCreateMessage?: CustomToCreateMessageFunction;
-  cancelPendingToolCallsOnSend?: boolean | undefined;
-  onResume?: ExternalStoreAdapter["onResume"];
-  joinStrategy?: JoinStrategy | undefined;
-};
-
-declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter) => AssistantRuntime;
-
-type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatInit<UI_MESSAGE> & ExternalStoreSharedOptions & {
-  cloud?: AssistantCloud | undefined;
-  adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
-  toCreateMessage?: CustomToCreateMessageFunction;
-  onResume?: AISDKRuntimeAdapter["onResume"];
-  onResumeError?: ((error: unknown) => void) | undefined;
-  joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-};
-
-declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
-
-declare const RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id";
-
-type ResumableClientStorage = {
-  getStreamId(): string | null;
-  setStreamId(id: string): void;
-  clear(): void;
-};
-
 declare function createResumableSessionStorage(options?: {
   key?: string;
 }): ResumableClientStorage;
 
-type AssistantChatResumableOptions = {
-  storage: ResumableClientStorage;
-  resumeApi: string | ((streamId: string) => string);
-  isFinishEvent?: (chunk: Uint8Array, accumulator: string) => boolean;
-};
-
-type InitializableThreadListItem = Pick<ThreadListItemRuntime, "initialize">;
-
-type AssistantChatTransportInitOptions<UI_MESSAGE extends UIMessage> = HttpChatTransportInitOptions<UI_MESSAGE> & {
-  resumable?: AssistantChatResumableOptions;
-};
-
-declare class AssistantChatTransport<UI_MESSAGE extends UIMessage> extends DefaultChatTransport<UI_MESSAGE> {
-  private runtime;
-  private getThreadListItem;
-  private readonly resumable;
-  constructor(initOptions?: AssistantChatTransportInitOptions<UI_MESSAGE>);
-  setRuntime(runtime: AssistantRuntime): void;
-  getResumableAdapter(): AssistantChatResumableOptions | undefined;
-  __internal_setGetThreadListItem(getter: () => InitializableThreadListItem | undefined): void;
-}
-
 declare const frontendTools: (tools: Record<string, ToolJSONSchema>) => ToolSet;
-
-declare function injectQuoteContext(messages: UIMessage[]): UIMessage[];
-
-declare function unstable_injectInteractableContext(messages: UIMessage[], format?: (item: Unstable_InteractableSnapshotEntry) => string): UIMessage[];
-
-type ThreadTokenUsage = {
-  totalTokens?: number;
-  inputTokens?: number;
-  outputTokens?: number;
-  reasoningTokens?: number;
-  cachedInputTokens?: number;
-};
-
-interface TokenUsageExtractableMessage {
-  role?: string;
-  metadata?: unknown;
-}
-
-declare function getThreadMessageTokenUsage(message: TokenUsageExtractableMessage | undefined): ThreadTokenUsage | undefined;
-
-declare function useThreadTokenUsage(): ThreadTokenUsage | undefined;
-
-interface GenerativeToolsOptions {
-  toolkit: Toolkit;
-  frontendTools?: Record<string, ToolJSONSchema>;
-}
-
-type AISDKToolkitOptions = {
-  toolkit: Toolkit;
-};
-
-type AISDKToolkitToolsOptions = {
-  frontend?: Record<string, ToolJSONSchema>;
-};
 
 declare const generativeTools: (options: GenerativeToolsOptions) => ToolSet;
 
-declare class AISDKToolkit {
-  #private;
-  constructor(options: AISDKToolkitOptions);
-  tools(options?: AISDKToolkitToolsOptions): Promise<ToolSet>;
-  close(): Promise<void>;
+declare function getThreadMessageTokenUsage(message: TokenUsageExtractableMessage | undefined): ThreadTokenUsage | undefined;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
 }
 
 declare namespace entry_root_exports {
   export { AISDKToolkit, AISDKToolkitOptions, AISDKToolkitToolsOptions, AssistantChatResumableOptions, AssistantChatTransport, GenerativeToolsOptions, RESUMABLE_STREAM_ID_HEADER, ResumableClientStorage, ThreadTokenUsage, TokenUsageExtractableMessage, UseChatRuntimeOptions, createResumableSessionStorage, frontendTools, generativeTools, getThreadMessageTokenUsage, injectQuoteContext, unstable_injectInteractableContext, useAISDKRuntime, useChatRuntime, useThreadTokenUsage };
 }
+
+declare function injectQuoteContext(messages: UIMessage[]): UIMessage[];
+
+declare function unstable_injectInteractableContext(messages: UIMessage[], format?: (item: Unstable_InteractableSnapshotEntry) => string): UIMessage[];
+
+declare const useAISDKRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(chatHelpers: ReturnType<typeof useChat<UI_MESSAGE>>, adapter?: AISDKRuntimeAdapter) => AssistantRuntime;
+
+declare const useChatRuntime: <UI_MESSAGE extends UIMessage$1 = UIMessage$1>(_param2?: UseChatRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
+
+declare function useThreadTokenUsage(): ThreadTokenUsage | undefined;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -2,20 +2,333 @@ import { LanguageModelV2Message } from "@ai-sdk/provider";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -27,9 +340,87 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelAdapter = {
+  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -37,7 +428,61 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -47,30 +492,204 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DataStreamProtocol = "data-stream" | "ui-message-stream";
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HeadersValue = Record<string, string> | Headers;
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -132,164 +751,71 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
 
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ObjectKey<T> = keyof T & (string | number);
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
 
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
+type JSONSchema7Version = string;
 
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
+  cloud?: AssistantCloud | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
+  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
+};
 
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+type LocalRuntimeOptionsBase = {
+  maxSteps?: number | undefined;
+  adapters: {
+    chatModel: ChatModelAdapter;
+    history?: ThreadHistoryAdapter | undefined;
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    suggestion?: SuggestionAdapter | undefined;
   };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+  unstable_humanToolNames?: string[] | undefined;
+  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -319,11 +845,156 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -334,6 +1005,8 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -362,444 +1035,67 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -834,69 +1130,278 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type SuggestionAdapter = {
+  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
+};
+
+type SuggestionAdapterGenerateOptions = {
+  messages: readonly ThreadMessage[];
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type ChatModelAdapter = {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
 };
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -946,439 +1451,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type SuggestionAdapterGenerateOptions = {
-  messages: readonly ThreadMessage[];
-};
-
-type SuggestionAdapter = {
-  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1407,356 +1479,272 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type LocalRuntimeOptionsBase = {
-  maxSteps?: number | undefined;
-  adapters: {
-    chatModel: ChatModelAdapter;
-    history?: ThreadHistoryAdapter | undefined;
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    suggestion?: SuggestionAdapter | undefined;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
   };
-  unstable_humanToolNames?: string[] | undefined;
-  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-declare function toLanguageModelMessages(messages: readonly ThreadMessage[], options?: {
-  unstable_includeId?: boolean | undefined;
-}): LanguageModelV2Message[];
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
 
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
 } | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
+  readonly optionId: string;
+  readonly reason?: string;
 } | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
   };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
   };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  cloud?: AssistantCloud | undefined;
-  initialMessages?: readonly ThreadMessageLike[] | undefined;
-  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type HeadersValue = Record<string, string> | Headers;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
 
-type DataStreamProtocol = "data-stream" | "ui-message-stream";
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
+
+type UseCloudRuntimeOptions = Omit<UseDataStreamRuntimeOptions, "api"> & {
+  cloud: AssistantCloud;
+  assistantId: string;
+};
 
 type UseDataStreamRuntimeOptions = {
   api: string;
@@ -1777,17 +1765,29 @@ type UseDataStreamRuntimeOptions = {
   sendExtraMessageFields?: boolean;
 } & LocalRuntimeOptions;
 
-declare const useDataStreamRuntime: (options: UseDataStreamRuntimeOptions) => AssistantRuntime;
-
-type UseCloudRuntimeOptions = Omit<UseDataStreamRuntimeOptions, "api"> & {
-  cloud: AssistantCloud;
-  assistantId: string;
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
 };
 
-declare const useCloudRuntime: (options: UseCloudRuntimeOptions) => AssistantRuntime;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
 declare namespace entry_root_exports {
   export { DataStreamProtocol, UseDataStreamRuntimeOptions, toLanguageModelMessages, useCloudRuntime, useDataStreamRuntime };
 }
+
+declare function toLanguageModelMessages(messages: readonly ThreadMessage[], options?: {
+  unstable_includeId?: boolean | undefined;
+}): LanguageModelV2Message[];
+
+declare const useCloudRuntime: (options: UseCloudRuntimeOptions) => AssistantRuntime;
+
+declare const useDataStreamRuntime: (options: UseDataStreamRuntimeOptions) => AssistantRuntime;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-devtools.ts
+++ b/api-surface/assistant-ui__react-devtools.ts
@@ -1,36 +1,8 @@
-import { CSSProperties, ComponentType, ReactNode } from "react";
-
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type NormalizedTool = {
-  name: string;
-  type?: string;
-  description?: string;
-  disabled?: boolean;
-  display?: string;
-  providerId?: string;
-  supportsDeferredResults?: boolean;
-  backendDefault?: unknown;
-  providerOptions?: unknown;
-  providerArgs?: unknown;
-  server?: unknown;
-  parameters?: unknown;
-};
+import { CSSProperties, ComponentType, ReactNode } from "react";
 
-declare const normalizeToolList: (value: unknown) => NormalizedTool[];
-
-interface SerializedModelContext {
-  system?: string;
-  tools?: NormalizedTool[];
-  callSettings?: Record<string, unknown>;
-  config?: Record<string, unknown>;
-}
-
-interface EventLogEntry {
-  readonly time: Date;
-  readonly event: string;
-  readonly data: unknown;
-}
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
 interface ApiInfo {
   id: number;
@@ -41,9 +13,98 @@ interface ApiInfo {
   threadSnapshots?: Readonly<Record<string, unknown>>;
 }
 
-interface DevToolsSnapshot {
-  apiIds: number[];
-  byId: ReadonlyMap<number, ApiInfo>;
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
 }
 
 interface DevToolsClient {
@@ -52,6 +113,42 @@ interface DevToolsClient {
   getServerSnapshot?(): DevToolsSnapshot;
   clearEvents(apiId: number): void;
   switchToThread?(apiId: number, threadId: string): void | Promise<void>;
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
+}
+
+declare const DevToolsModal: (props?: DevToolsModalProps) => import("react").JSX.Element | null;
+
+interface DevToolsModalProps {
+  plugins?: DevToolsPanelPlugin[];
+  theme?: "dark" | "light" | "system";
+  client?: DevToolsClient;
+}
+
+declare const DevToolsPanel: (_param0: DevToolsPanelProps) => import("react").JSX.Element;
+
+interface DevToolsPanelPlugin {
+  id: string;
+  label: string;
+  order?: number;
+  isAvailable?: (ctx: DevToolsTabContext) => boolean;
+  Component: ComponentType<DevToolsTabContext>;
+}
+
+interface DevToolsPanelProps {
+  plugins?: DevToolsPanelPlugin[] | undefined;
+  theme?: "dark" | "light";
+  onClose?: (() => void) | undefined;
+  client?: DevToolsClient | undefined;
+}
+
+interface DevToolsSnapshot {
+  apiIds: number[];
+  byId: ReadonlyMap<number, ApiInfo>;
 }
 
 interface DevToolsTabContext {
@@ -64,167 +161,42 @@ interface DevToolsTabContext {
   switchToThread?: ((threadId: string) => void | Promise<void>) | undefined;
 }
 
-interface DevToolsPanelPlugin {
-  id: string;
-  label: string;
-  order?: number;
-  isAvailable?: (ctx: DevToolsTabContext) => boolean;
-  Component: ComponentType<DevToolsTabContext>;
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
 }
 
-declare const createDevToolsPlugin: (plugin: DevToolsPanelPlugin) => DevToolsPanelPlugin;
-
-declare const builtinPlugins: DevToolsPanelPlugin[];
-
-interface DevToolsModalProps {
-  plugins?: DevToolsPanelPlugin[];
-  theme?: "dark" | "light" | "system";
-  client?: DevToolsClient;
+interface EventLogEntry {
+  readonly time: Date;
+  readonly event: string;
+  readonly data: unknown;
 }
-
-declare const DevToolsModal: (props?: DevToolsModalProps) => import("react").JSX.Element | null;
-
-declare const createInProcessClient: () => DevToolsClient;
-
-declare const inProcessClient: DevToolsClient;
-
-interface DevToolsPanelProps {
-  plugins?: DevToolsPanelPlugin[] | undefined;
-  theme?: "dark" | "light";
-  onClose?: (() => void) | undefined;
-  client?: DevToolsClient | undefined;
-}
-
-declare const DevToolsPanel: (_param0: DevToolsPanelProps) => import("react").JSX.Element;
-
-interface ShadowRootProps {
-  theme: "dark" | "light";
-  className?: string;
-  style?: CSSProperties;
-  children: ReactNode;
-}
-
-declare const ShadowRoot: (_param1: ShadowRootProps) => import("react").JSX.Element;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
 
 type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
 
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
 };
 
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
 };
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
-
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
-
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
-
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
-}
-
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
-
-type JSONSchema7Version = string;
-
-type JSONSchema7Definition = JSONSchema7 | boolean;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -286,164 +258,36 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
-};
-
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
 type McpServerConfig = {
@@ -473,11 +317,85 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
 };
+
+type NormalizedTool = {
+  name: string;
+  type?: string;
+  description?: string;
+  disabled?: boolean;
+  display?: string;
+  providerId?: string;
+  supportsDeferredResults?: boolean;
+  backendDefault?: unknown;
+  providerOptions?: unknown;
+  providerArgs?: unknown;
+  server?: unknown;
+  parameters?: unknown;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+interface SerializedModelContext {
+  system?: string;
+  tools?: NormalizedTool[];
+  callSettings?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+declare const ShadowRoot: (_param1: ShadowRootProps) => import("react").JSX.Element;
+
+interface ShadowRootProps {
+  theme: "dark" | "light";
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
 
 interface SpeechRecognitionInstance extends EventTarget {
   lang: string;
@@ -488,9 +406,130 @@ interface SpeechRecognitionInstance extends EventTarget {
   abort(): void;
 }
 
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unsubscribe = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+declare const builtinPlugins: DevToolsPanelPlugin[];
+
+declare const createDevToolsPlugin: (plugin: DevToolsPanelPlugin) => DevToolsPanelPlugin;
+
+declare const createInProcessClient: () => DevToolsClient;
 
 declare global {
   interface Window {
@@ -499,59 +538,20 @@ declare global {
   }
 }
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
-};
-
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
-};
-
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
-};
-
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
-
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
 declare global {
   interface Window {
     __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
   }
 }
 
-declare const serializeModelContext: (context: ModelContext | undefined) => SerializedModelContext | undefined;
+declare const inProcessClient: DevToolsClient;
 
 declare namespace entry_root_exports {
   export { ApiInfo, DevToolsClient, DevToolsModal, DevToolsModalProps, DevToolsPanel, DevToolsPanelPlugin, DevToolsPanelProps, DevToolsSnapshot, DevToolsTabContext, NormalizedTool, SerializedModelContext, ShadowRoot, builtinPlugins, createDevToolsPlugin, createInProcessClient, inProcessClient, normalizeToolList, serializeModelContext };
 }
+
+declare const normalizeToolList: (value: unknown) => NormalizedTool[];
+
+declare const serializeModelContext: (context: ModelContext | undefined) => SerializedModelContext | undefined;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -1,78 +1,8 @@
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
 import { ComponentType, ReactNode } from "react";
 
 import { ZodType } from "zod";
-
-import { StandardSchemaV1 } from "@standard-schema/spec";
-
-declare namespace entry_ir_exports {
-  export { ALERT_TONES, ALIGNS, Action, AlertTone, Align, BUTTON_STYLES, ButtonStyle, COLORS, Color, IMAGE_SIZE_TOKENS, ImageSize, JUSTIFIES, Justify, LegacyComponentNode, NormalizedUIElement, NormalizedUINode, TEXT_SIZES, TextSize, UIChildren, UIElement, UINode, UISpec, WEIGHTS, Weight, normalizeSpec, normalizeUINode };
-}
-
-declare const TEXT_SIZES: readonly [
-  "sm",
-  "md",
-  "lg",
-  "xl",
-  "2xl",
-  "3xl"
-];
-
-type TextSize = (typeof TEXT_SIZES)[number];
-
-declare const IMAGE_SIZE_TOKENS: readonly [
-  "sm",
-  "md",
-  "lg"
-];
-
-type ImageSize = (typeof IMAGE_SIZE_TOKENS)[number] | number;
-
-declare const WEIGHTS: readonly [
-  "normal",
-  "medium",
-  "semibold",
-  "bold"
-];
-
-type Weight = (typeof WEIGHTS)[number];
-
-declare const COLORS: readonly [
-  "emphasis",
-  "secondary",
-  "alpha-70",
-  "white",
-  "white-70",
-  "white-50"
-];
-
-type Color = (typeof COLORS)[number];
-
-declare const ALIGNS: readonly [
-  "start",
-  "center",
-  "end"
-];
-
-type Align = (typeof ALIGNS)[number];
-
-declare const JUSTIFIES: readonly [
-  "start",
-  "center",
-  "end",
-  "between"
-];
-
-type Justify = (typeof JUSTIFIES)[number];
-
-declare const BUTTON_STYLES: readonly [
-  "primary",
-  "secondary",
-  "outline",
-  "ghost",
-  "danger"
-];
-
-type ButtonStyle = (typeof BUTTON_STYLES)[number];
 
 declare const ALERT_TONES: readonly [
   "info",
@@ -81,49 +11,16 @@ declare const ALERT_TONES: readonly [
   "danger"
 ];
 
-type AlertTone = (typeof ALERT_TONES)[number];
+declare const ALIGNS: readonly [
+  "start",
+  "center",
+  "end"
+];
 
 interface Action {
   readonly type: string;
   readonly [payload: string]: unknown;
 }
-
-type UINode = string | number | UIElement | LegacyComponentNode;
-
-type UIChildren = UINode | readonly UINode[];
-
-interface UIElement {
-  readonly $type: string;
-  readonly $key?: string | number;
-  readonly children?: UIChildren;
-  readonly $action?: Action;
-  readonly [prop: string]: unknown;
-}
-
-interface LegacyComponentNode {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: UIChildren;
-  readonly key?: string;
-}
-
-type UISpec = UINode | readonly UINode[];
-
-interface NormalizedUIElement {
-  readonly type: string;
-  readonly props: Readonly<Record<string, unknown>>;
-  readonly children?: NormalizedUINode | undefined;
-  readonly key?: string | number | undefined;
-  readonly action?: Action | undefined;
-}
-
-type NormalizedUINode = string | number | readonly NormalizedUINode[] | NormalizedUIElement | null;
-
-declare function normalizeUINode(node: unknown, partialPath?: readonly string[] | undefined, depth?: number): NormalizedUINode;
-
-declare function normalizeSpec(spec: UISpec): {
-  readonly root: NormalizedUINode | readonly NormalizedUINode[];
-};
 
 type ActionDispatchContext = {
   readonly payload: Action;
@@ -136,45 +33,208 @@ type ActionRegistry = {
   has(type: string): boolean;
 };
 
-declare function createActionRegistry(handlers: Readonly<Record<string, ActionHandler>>): ActionRegistry;
+type AlertTone = (typeof ALERT_TONES)[number];
 
-declare const emptyActionRegistry: ActionRegistry;
+type Align = (typeof ALIGNS)[number];
 
-type GenerativeUIElement = NormalizedUIElement;
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type GenerativeUIProps = NormalizedUIElement["props"];
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type GenerativeUINode$1 = GenerativeUIElement | string | number | boolean | null | undefined | GenerativeUINode$1[];
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+declare const BUTTON_STYLES: readonly [
+  "primary",
+  "secondary",
+  "outline",
+  "ghost",
+  "danger"
+];
+
+type BackendDefaultMetadata = {
+  unstable_backendDefault?: {
+    parameters?: boolean;
+  };
+};
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BaseAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ButtonStyle = (typeof BUTTON_STYLES)[number];
+
+declare const COLORS: readonly [
+  "emphasis",
+  "secondary",
+  "alpha-70",
+  "white",
+  "white-70",
+  "white-50"
+];
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type Color = (typeof COLORS)[number];
+
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
+
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
+}
+
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
+}
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
 
 type GenerativeUIAction = Action;
-
-type GenerativeUIStatus = "done" | "streaming";
-
-type GenerativeUIDispatch = (action: Action) => unknown;
-
-type GenerativeUIRenderContext = {
-  status: GenerativeUIStatus;
-  dispatch?: GenerativeUIDispatch;
-};
-
-type StreamingRenderProps<P> = (Partial<P> & {
-  children?: ReactNode;
-  $status: "streaming";
-  $action?: Action;
-  $dispatch?: GenerativeUIDispatch;
-}) | (P & {
-  children?: ReactNode;
-  $status: "done";
-  $action?: Action;
-  $dispatch?: GenerativeUIDispatch;
-});
-
-type StaticRenderProps<P> = P & {
-  children?: ReactNode;
-  $status: "done";
-  $action?: Action;
-  $dispatch?: GenerativeUIDispatch;
-};
 
 type GenerativeUIComponent<P = any> = {
   description: string;
@@ -188,220 +248,88 @@ type GenerativeUIComponent<P = any> = {
   render: (props: StaticRenderProps<P>) => ReactNode;
 };
 
+type GenerativeUIDispatch = (action: Action) => unknown;
+
+type GenerativeUIElement = NormalizedUIElement;
+
 type GenerativeUILibrary = Record<string, GenerativeUIComponent>;
 
-type JSONSchema7TypeName$1 = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
 
-type JSONSchema7Type$1 = string | number | boolean | JSONSchema7Object$1 | JSONSchema7Array$1 | null;
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
 
-interface JSONSchema7Object$1 {
-  [key: string]: JSONSchema7Type$1;
-}
+type GenerativeUINode$1 = GenerativeUIElement | string | number | boolean | null | undefined | GenerativeUINode$1[];
 
-interface JSONSchema7Array$1 extends Array<JSONSchema7Type$1> {
-}
+type GenerativeUIProps = NormalizedUIElement["props"];
 
-type JSONSchema7Version$1 = string;
+type GenerativeUIRenderContext = {
+  status: GenerativeUIStatus;
+  dispatch?: GenerativeUIDispatch;
+};
 
-type JSONSchema7Definition$1 = JSONSchema7$1 | boolean;
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
 
-interface JSONSchema7$1 {
-  $id?: string | undefined;
-  $ref?: string | undefined;
-  $schema?: JSONSchema7Version$1 | undefined;
-  $comment?: string | undefined;
-  $defs?: {
-    [key: string]: JSONSchema7Definition$1;
-  } | undefined;
-  type?: JSONSchema7TypeName$1 | JSONSchema7TypeName$1[] | undefined;
-  enum?: JSONSchema7Type$1[] | undefined;
-  const?: JSONSchema7Type$1 | undefined;
-  multipleOf?: number | undefined;
-  maximum?: number | undefined;
-  exclusiveMaximum?: number | undefined;
-  minimum?: number | undefined;
-  exclusiveMinimum?: number | undefined;
-  maxLength?: number | undefined;
-  minLength?: number | undefined;
-  pattern?: string | undefined;
-  items?: JSONSchema7Definition$1 | JSONSchema7Definition$1[] | undefined;
-  additionalItems?: JSONSchema7Definition$1 | undefined;
-  maxItems?: number | undefined;
-  minItems?: number | undefined;
-  uniqueItems?: boolean | undefined;
-  contains?: JSONSchema7Definition$1 | undefined;
-  maxProperties?: number | undefined;
-  minProperties?: number | undefined;
-  required?: string[] | undefined;
-  properties?: {
-    [key: string]: JSONSchema7Definition$1;
-  } | undefined;
-  patternProperties?: {
-    [key: string]: JSONSchema7Definition$1;
-  } | undefined;
-  additionalProperties?: JSONSchema7Definition$1 | undefined;
-  dependencies?: {
-    [key: string]: JSONSchema7Definition$1 | string[];
-  } | undefined;
-  propertyNames?: JSONSchema7Definition$1 | undefined;
-  if?: JSONSchema7Definition$1 | undefined;
-  then?: JSONSchema7Definition$1 | undefined;
-  else?: JSONSchema7Definition$1 | undefined;
-  allOf?: JSONSchema7Definition$1[] | undefined;
-  anyOf?: JSONSchema7Definition$1[] | undefined;
-  oneOf?: JSONSchema7Definition$1[] | undefined;
-  not?: JSONSchema7Definition$1 | undefined;
-  format?: string | undefined;
-  contentMediaType?: string | undefined;
-  contentEncoding?: string | undefined;
-  definitions?: {
-    [key: string]: JSONSchema7Definition$1;
-  } | undefined;
-  title?: string | undefined;
+type GenerativeUIStatus = "done" | "streaming";
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
   description?: string | undefined;
-  default?: JSONSchema7Type$1 | undefined;
-  readOnly?: boolean | undefined;
-  writeOnly?: boolean | undefined;
-  examples?: JSONSchema7Type$1 | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+declare const IMAGE_SIZE_TOKENS: readonly [
+  "sm",
+  "md",
+  "lg"
+];
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type ImageSize = (typeof IMAGE_SIZE_TOKENS)[number] | number;
+
+declare class JSONGenerativeUI {
+  private readonly parameters;
+  constructor(options: JSONGenerativeUIOptions);
+  present(options?: PresentToolOptions): PresentTool;
+  promptUser(): PromptUserTool;
 }
 
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
+declare class JSONGenerativeUI$1 {
+  private readonly library;
+  private readonly parameters;
+  private readonly actions;
+  constructor(options: JSONGenerativeUIOptions);
+  private readonly render;
+  present(options?: PresentToolOptions): PresentTool;
+  promptUser(): PromptUserTool;
 }
 
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
+type JSONGenerativeUIOptions = {
+  library: GenerativeUILibrary;
+  actions?: ActionRegistry;
 };
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-type CompleteAttachmentStatus = {
-  type: "complete";
-};
-
-type BaseAttachment = {
-  id: string;
-  type: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string | undefined;
-  file?: File;
-  content?: ThreadUserMessagePart[];
-};
-
-type CompleteAttachment = BaseAttachment & {
-  status: CompleteAttachmentStatus;
-  content: ThreadUserMessagePart[];
-};
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
-
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
-
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
-
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
-}
-
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
-
-type JSONSchema7Version = string;
-
-type JSONSchema7Definition = JSONSchema7 | boolean;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -463,164 +391,116 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
-
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
-};
-
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
-};
-
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
+interface JSONSchema7$1 {
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  $schema?: JSONSchema7Version$1 | undefined;
+  $comment?: string | undefined;
+  $defs?: {
+    [key: string]: JSONSchema7Definition$1;
+  } | undefined;
+  type?: JSONSchema7TypeName$1 | JSONSchema7TypeName$1[] | undefined;
+  enum?: JSONSchema7Type$1[] | undefined;
+  const?: JSONSchema7Type$1 | undefined;
+  multipleOf?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  minimum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  maxLength?: number | undefined;
+  minLength?: number | undefined;
+  pattern?: string | undefined;
+  items?: JSONSchema7Definition$1 | JSONSchema7Definition$1[] | undefined;
+  additionalItems?: JSONSchema7Definition$1 | undefined;
+  maxItems?: number | undefined;
+  minItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
+  contains?: JSONSchema7Definition$1 | undefined;
+  maxProperties?: number | undefined;
+  minProperties?: number | undefined;
+  required?: string[] | undefined;
+  properties?: {
+    [key: string]: JSONSchema7Definition$1;
+  } | undefined;
+  patternProperties?: {
+    [key: string]: JSONSchema7Definition$1;
+  } | undefined;
+  additionalProperties?: JSONSchema7Definition$1 | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7Definition$1 | string[];
+  } | undefined;
+  propertyNames?: JSONSchema7Definition$1 | undefined;
+  if?: JSONSchema7Definition$1 | undefined;
+  then?: JSONSchema7Definition$1 | undefined;
+  else?: JSONSchema7Definition$1 | undefined;
+  allOf?: JSONSchema7Definition$1[] | undefined;
+  anyOf?: JSONSchema7Definition$1[] | undefined;
+  oneOf?: JSONSchema7Definition$1[] | undefined;
+  not?: JSONSchema7Definition$1 | undefined;
+  format?: string | undefined;
+  contentMediaType?: string | undefined;
+  contentEncoding?: string | undefined;
+  definitions?: {
+    [key: string]: JSONSchema7Definition$1;
+  } | undefined;
+  title?: string | undefined;
   description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
+  default?: JSONSchema7Type$1 | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchema7Type$1 | undefined;
+}
 
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
 
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+interface JSONSchema7Array$1 extends Array<JSONSchema7Type$1> {
+}
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+type JSONSchema7Definition$1 = JSONSchema7$1 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+interface JSONSchema7Object$1 {
+  [key: string]: JSONSchema7Type$1;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7Type$1 = string | number | boolean | JSONSchema7Object$1 | JSONSchema7Array$1 | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7TypeName$1 = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type JSONSchema7Version$1 = string;
+
+declare const JUSTIFIES: readonly [
+  "start",
+  "center",
+  "end",
+  "between"
+];
+
+type Justify = (typeof JUSTIFIES)[number];
+
+interface LegacyComponentNode {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: UIChildren;
+  readonly key?: string;
+}
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -650,167 +530,14 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
-};
-
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
+type MessageCommonProps = {
   readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
+  readonly createdAt: Date;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
 
 type MessagePartStatus = {
   readonly type: "running";
@@ -821,11 +548,6 @@ type MessagePartStatus = {
   readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
   readonly error?: unknown;
 };
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
 
 type MessageStatus = {
   readonly type: "running";
@@ -851,17 +573,171 @@ type MessageTiming = {
   readonly toolCallCount: number;
 };
 
+interface NormalizedUIElement {
+  readonly type: string;
+  readonly props: Readonly<Record<string, unknown>>;
+  readonly children?: NormalizedUINode | undefined;
+  readonly key?: string | number | undefined;
+  readonly action?: Action | undefined;
+}
+
+type NormalizedUINode = string | number | readonly NormalizedUINode[] | NormalizedUIElement | null;
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type PresentTool = ToolDefinition<Record<string, unknown>, Record<string, never>> & BackendDefaultMetadata;
+
+type PresentToolOptions = {
+  display?: "standalone";
+};
+
+type PromptUserTool = ToolDefinition<Record<string, unknown>, unknown> & BackendDefaultMetadata;
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type StaticRenderProps<P> = P & {
+  children?: ReactNode;
+  $status: "done";
+  $action?: Action;
+  $dispatch?: GenerativeUIDispatch;
+};
+
+type StreamingRenderProps<P> = (Partial<P> & {
+  children?: ReactNode;
+  $status: "streaming";
+  $action?: Action;
+  $dispatch?: GenerativeUIDispatch;
+}) | (P & {
+  children?: ReactNode;
+  $status: "done";
+  $action?: Action;
+  $dispatch?: GenerativeUIDispatch;
+});
+
+declare const TEXT_SIZES: readonly [
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+  "3xl"
+];
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+declare const TYPE_KEY = "$type";
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type TextSize = (typeof TEXT_SIZES)[number];
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
 type ThreadStep = {
   readonly messageId?: string;
   readonly usage?: {
     readonly inputTokens: number;
     readonly outputTokens: number;
   } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
 };
 
 type ThreadSystemMessage = MessageCommonProps & {
@@ -895,65 +771,86 @@ type ThreadUserMessage = MessageCommonProps & {
   };
 };
 
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
   };
 };
 
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
 
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
 
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
 
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
 type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
@@ -962,7 +859,163 @@ type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState
   respondToApproval: (response: ToolApprovalResponse) => void;
 };
 
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
+
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UIChildren = UINode | readonly UINode[];
+
+interface UIElement {
+  readonly $type: string;
+  readonly $key?: string | number;
+  readonly children?: UIChildren;
+  readonly $action?: Action;
+  readonly [prop: string]: unknown;
+}
+
+type UINode = string | number | UIElement | LegacyComponentNode;
+
+type UISpec = UINode | readonly UINode[];
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+declare const WEIGHTS: readonly [
+  "normal",
+  "medium",
+  "semibold",
+  "bold"
+];
+
+type Weight = (typeof WEIGHTS)[number];
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
 
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
@@ -980,40 +1033,23 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
+declare function buildPresentParameters(library: GenerativeUILibrary): JSONSchema7$1;
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
+declare function createActionRegistry(handlers: Readonly<Record<string, ActionHandler>>): ActionRegistry;
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
+declare const defaultGenerativeUILibrary: GenerativeUILibrary;
 
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+declare function defineGenerativeComponents(_library: GenerativeUILibrary): GenerativeUILibrary;
 
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
+declare const emptyActionRegistry: ActionRegistry;
 
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
+declare function generativeUIToJSX(node: unknown): string;
 
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
 }
 
 declare global {
@@ -1022,60 +1058,24 @@ declare global {
   }
 }
 
-type JSONGenerativeUIOptions = {
-  library: GenerativeUILibrary;
-  actions?: ActionRegistry;
-};
-
-type PresentToolOptions = {
-  display?: "standalone";
-};
-
-type BackendDefaultMetadata = {
-  unstable_backendDefault?: {
-    parameters?: boolean;
-  };
-};
-
-type PresentTool = ToolDefinition<Record<string, unknown>, Record<string, never>> & BackendDefaultMetadata;
-
-type PromptUserTool = ToolDefinition<Record<string, unknown>, unknown> & BackendDefaultMetadata;
-
-declare class JSONGenerativeUI$1 {
-  private readonly library;
-  private readonly parameters;
-  private readonly actions;
-  constructor(options: JSONGenerativeUIOptions);
-  private readonly render;
-  present(options?: PresentToolOptions): PresentTool;
-  promptUser(): PromptUserTool;
-}
-
-declare function buildPresentParameters(library: GenerativeUILibrary): JSONSchema7$1;
-
-declare const TYPE_KEY = "$type";
-
-declare function defineGenerativeComponents(_library: GenerativeUILibrary): GenerativeUILibrary;
-
-declare function generativeUIToJSX(node: unknown): string;
-
-declare function renderGenerativeUI(node: unknown, library: GenerativeUILibrary, context?: GenerativeUIRenderContext): ReactNode;
-
-declare const defaultGenerativeUILibrary: GenerativeUILibrary;
-
 declare namespace entry_root_default_exports {
   export { ALERT_TONES, ALIGNS, Action, ActionDispatchContext, ActionHandler, ActionRegistry, AlertTone, Align, BUTTON_STYLES, ButtonStyle, COLORS, Color, GenerativeUIAction, GenerativeUIComponent, GenerativeUIDispatch, GenerativeUIElement, GenerativeUILibrary, GenerativeUINode$1 as GenerativeUINode, GenerativeUIProps, GenerativeUIRenderContext, GenerativeUIStatus, IMAGE_SIZE_TOKENS, ImageSize, JSONGenerativeUI$1 as JSONGenerativeUI, JSONGenerativeUIOptions, JUSTIFIES, Justify, LegacyComponentNode, NormalizedUIElement, NormalizedUINode, PresentTool, PresentToolOptions, PromptUserTool, TEXT_SIZES, TYPE_KEY, TextSize, UIChildren, UIElement, UINode, UISpec, WEIGHTS, Weight, buildPresentParameters, createActionRegistry, defaultGenerativeUILibrary, defineGenerativeComponents, emptyActionRegistry, generativeUIToJSX, normalizeSpec, normalizeUINode, renderGenerativeUI };
-}
-
-declare class JSONGenerativeUI {
-  private readonly parameters;
-  constructor(options: JSONGenerativeUIOptions);
-  present(options?: PresentToolOptions): PresentTool;
-  promptUser(): PromptUserTool;
 }
 
 declare namespace entry_root_react_server_exports {
   export { ALERT_TONES, ALIGNS, Action, ActionDispatchContext, ActionHandler, ActionRegistry, AlertTone, Align, BUTTON_STYLES, ButtonStyle, COLORS, Color, GenerativeUIAction, GenerativeUIComponent, GenerativeUIDispatch, GenerativeUIElement, GenerativeUILibrary, GenerativeUINode$1 as GenerativeUINode, GenerativeUIProps, GenerativeUIRenderContext, GenerativeUIStatus, IMAGE_SIZE_TOKENS, ImageSize, JSONGenerativeUI, JSONGenerativeUIOptions, JUSTIFIES, Justify, LegacyComponentNode, NormalizedUIElement, NormalizedUINode, PresentTool, PresentToolOptions, PromptUserTool, TEXT_SIZES, TYPE_KEY, TextSize, UIChildren, UIElement, UINode, UISpec, WEIGHTS, Weight, buildPresentParameters, createActionRegistry, defaultGenerativeUILibrary, defineGenerativeComponents, emptyActionRegistry, generativeUIToJSX, normalizeSpec, normalizeUINode, renderGenerativeUI };
 }
+
+declare namespace entry_ir_exports {
+  export { ALERT_TONES, ALIGNS, Action, AlertTone, Align, BUTTON_STYLES, ButtonStyle, COLORS, Color, IMAGE_SIZE_TOKENS, ImageSize, JUSTIFIES, Justify, LegacyComponentNode, NormalizedUIElement, NormalizedUINode, TEXT_SIZES, TextSize, UIChildren, UIElement, UINode, UISpec, WEIGHTS, Weight, normalizeSpec, normalizeUINode };
+}
+
+declare function normalizeSpec(spec: UISpec): {
+  readonly root: NormalizedUINode | readonly NormalizedUINode[];
+};
+
+declare function normalizeUINode(node: unknown, partialPath?: readonly string[] | undefined, depth?: number): NormalizedUINode;
+
+declare function renderGenerativeUI(node: unknown, library: GenerativeUILibrary, context?: GenerativeUIRenderContext): ReactNode;
 
 export { entry_ir_exports as entry_ir, entry_root_default_exports as entry_root_default, entry_root_react_server_exports as entry_root_react_server };

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1,6 +1,262 @@
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
 import { ComponentType, PropsWithChildren } from "react";
 
-import { StandardSchemaV1 } from "@standard-schema/spec";
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AdkArtifactData = {
+  inlineData?: {
+    mimeType: string;
+    data: string;
+  } | undefined;
+  text?: string | undefined;
+};
+
+type AdkAuthCredential = {
+  authType: AdkAuthCredentialType;
+  resourceRef?: string | undefined;
+  apiKey?: string | undefined;
+  http?: {
+    scheme: string;
+    credentials: {
+      username?: string;
+      password?: string;
+      token?: string;
+    };
+  } | undefined;
+  oauth2?: {
+    clientId?: string;
+    clientSecret?: string;
+    authUri?: string;
+    state?: string;
+    redirectUri?: string;
+    authResponseUri?: string;
+    authCode?: string;
+    accessToken?: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    expiresIn?: number;
+  } | undefined;
+  serviceAccount?: unknown;
+};
+
+type AdkAuthCredentialType = "apiKey" | "http" | "oauth2" | "openIdConnect" | "serviceAccount";
+
+type AdkAuthRequest = {
+  toolCallId: string;
+  authConfig: unknown;
+};
+
+type AdkEvent = {
+  id: string;
+  invocationId?: string | undefined;
+  author?: string | undefined;
+  branch?: string | undefined;
+  partial?: boolean | undefined;
+  turnComplete?: boolean | undefined;
+  interrupted?: boolean | undefined;
+  finishReason?: string | undefined;
+  timestamp?: number | undefined;
+  content?: {
+    role?: string | undefined;
+    parts?: AdkEventPart[] | undefined;
+  } | undefined;
+  actions?: AdkEventActions | undefined;
+  longRunningToolIds?: string[] | undefined;
+  errorCode?: string | undefined;
+  errorMessage?: string | undefined;
+  groundingMetadata?: unknown;
+  citationMetadata?: unknown;
+  usageMetadata?: unknown;
+  customMetadata?: Record<string, unknown> | undefined;
+};
+
+declare class AdkEventAccumulator {
+  private messagesMap;
+  private currentMessageId;
+  private partialTextBuffer;
+  private partialReasoningBuffer;
+  private accumulatedStateDelta;
+  private accumulatedArtifactDelta;
+  private lastAgentInfo;
+  private lastTransferToAgent;
+  private pendingLongRunningToolIds;
+  private toolConfirmations;
+  private authRequests;
+  private escalated;
+  private messageMetadataMap;
+  constructor(initialMessages?: AdkMessage[]);
+  processEvent(rawEvent: AdkEvent): AdkMessage[];
+  private processPart;
+  private trackMessageMetadata;
+  private getContentArray;
+  private getOrCreateAiMessage;
+  private appendContent;
+  private replaceLastTextContent;
+  private replaceLastReasoningContent;
+  private finalizeCurrentMessage;
+  getMessages(): AdkMessage[];
+  getStateDelta(): Record<string, unknown>;
+  getArtifactDelta(): Record<string, number>;
+  getAgentInfo(): {
+    name?: string | undefined;
+    branch?: string | undefined;
+  };
+  getLastTransferToAgent(): string | undefined;
+  getLongRunningToolIds(): string[];
+  getToolConfirmations(): AdkToolConfirmation[];
+  getAuthRequests(): AdkAuthRequest[];
+  isEscalated(): boolean;
+  getMessageMetadata(): Map<string, AdkMessageMetadata>;
+}
+
+type AdkEventActions = {
+  stateDelta?: Record<string, unknown> | undefined;
+  artifactDelta?: Record<string, number> | undefined;
+  transferToAgent?: string | undefined;
+  escalate?: boolean | undefined;
+  skipSummarization?: boolean | undefined;
+  requestedAuthConfigs?: Record<string, unknown> | undefined;
+  requestedToolConfirmations?: Record<string, unknown> | undefined;
+};
+
+type AdkEventPart = {
+  text?: string;
+  thought?: boolean;
+  functionCall?: {
+    name: string;
+    id?: string;
+    args: Record<string, unknown>;
+  };
+  functionResponse?: {
+    name: string;
+    id?: string;
+    response: unknown;
+  };
+  executableCode?: {
+    code: string;
+    language?: string;
+  };
+  codeExecutionResult?: {
+    output: string;
+    outcome?: string;
+  };
+  inlineData?: {
+    mimeType: string;
+    data: string;
+  };
+  fileData?: {
+    fileUri: string;
+    mimeType?: string;
+  };
+};
+
+type AdkEventStreamOptions = {
+  onError?: (error: unknown) => void;
+};
+
+declare const AdkEventType: {
+  readonly THOUGHT: "thought";
+  readonly CONTENT: "content";
+  readonly TOOL_CALL: "tool_call";
+  readonly TOOL_RESULT: "tool_result";
+  readonly CALL_CODE: "call_code";
+  readonly CODE_RESULT: "code_result";
+  readonly ERROR: "error";
+  readonly ACTIVITY: "activity";
+  readonly TOOL_CONFIRMATION: "tool_confirmation";
+  readonly FINISHED: "finished";
+};
+
+type AdkMessage = {
+  id: string;
+  type: "human";
+  content: string | AdkMessageContentPart[];
+} | {
+  id: string;
+  type: "ai";
+  content: string | AdkMessageContentPart[];
+  tool_calls?: AdkToolCall[] | undefined;
+  author?: string | undefined;
+  branch?: string | undefined;
+  status?: MessageStatus | undefined;
+} | {
+  id: string;
+  type: "tool";
+  content: string;
+  tool_call_id: string;
+  name: string;
+  status?: "success" | "error" | undefined;
+  artifact?: unknown;
+};
+
+type AdkMessageContentPart = {
+  type: "text";
+  text: string;
+} | {
+  type: "reasoning";
+  text: string;
+} | {
+  type: "image";
+  mimeType: string;
+  data: string;
+} | {
+  type: "image_url";
+  url: string;
+} | {
+  type: "file";
+  mimeType: string;
+  data: string;
+  filename?: string | undefined;
+} | {
+  type: "file_url";
+  url: string;
+  mimeType?: string | undefined;
+} | {
+  type: "code";
+  code: string;
+  language: string;
+} | {
+  type: "code_result";
+  output: string;
+  outcome: string;
+} | {
+  type: "activity";
+  message: string;
+};
+
+type AdkMessageMetadata = {
+  groundingMetadata?: unknown;
+  citationMetadata?: unknown;
+  usageMetadata?: unknown;
+};
+
+type AdkRunConfig = {
+  streamingMode?: "none" | "sse" | "bidi" | undefined;
+  pauseOnToolCalls?: boolean | undefined;
+  maxLlmCalls?: number | undefined;
+  saveInputBlobsAsArtifacts?: boolean | undefined;
+  supportCfc?: boolean | undefined;
+  speechConfig?: unknown;
+  responseModalities?: string[] | undefined;
+  outputAudioTranscription?: unknown;
+  inputAudioTranscription?: unknown;
+  enableAffectiveDialog?: boolean | undefined;
+  proactivity?: unknown;
+  realtimeInputConfig?: unknown;
+};
+
+type AdkRunner = {
+  runAsync(options: Record<string, unknown>): AsyncGenerator<any, void, undefined>;
+};
 
 type AdkSdkEvent = {
   id?: string;
@@ -26,39 +282,429 @@ type AdkSdkEvent = {
   customMetadata?: Record<string, unknown>;
 };
 
-type AdkEventStreamOptions = {
-  onError?: (error: unknown) => void;
+type AdkSendMessageConfig = {
+  runConfig?: unknown;
+  checkpointId?: string | undefined;
+  stateDelta?: Record<string, unknown> | undefined;
 };
 
-declare const adkEventStream: (events: AsyncGenerator<AdkSdkEvent, void, undefined>, options?: AdkEventStreamOptions) => Response;
-
-type AdkRunner = {
-  runAsync(options: Record<string, unknown>): AsyncGenerator<any, void, undefined>;
+type AdkSessionAdapterOptions = {
+  apiUrl: string;
+  appName: string;
+  userId: string;
+  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
 };
 
-type CreateAdkApiRouteOptions = {
-  runner: AdkRunner;
-  userId: string | ((req: Request) => string | Promise<string>);
-  sessionId: string | ((req: Request) => string | Promise<string>);
-  onError?: AdkEventStreamOptions["onError"];
+type AdkSessionAdapterResult = {
+  adapter: RemoteThreadListAdapter;
+  load: (sessionId: string) => Promise<{
+    messages: AdkMessage[];
+  }>;
+  artifacts: {
+    list: (sessionId: string) => Promise<string[]>;
+    load: (sessionId: string, artifactName: string, version?: number) => Promise<AdkArtifactData>;
+    listVersions: (sessionId: string, artifactName: string) => Promise<number[]>;
+    delete: (sessionId: string, artifactName: string) => Promise<void>;
+  };
 };
 
-declare function createAdkApiRoute(options: CreateAdkApiRouteOptions): (req: Request) => Promise<Response>;
+type AdkStreamCallback = (messages: AdkMessage[], config: AdkSendMessageConfig & {
+  abortSignal: AbortSignal;
+  initialize: () => Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+}) => Promise<AsyncGenerator<AdkEvent>> | AsyncGenerator<AdkEvent>;
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
+type AdkStructuredEvent = {
+  type: "thought";
+  content: string;
 } | {
-  type: "requires-action";
-  reason: "composer-send";
+  type: "content";
+  content: string;
 } | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+  type: "tool_call";
+  call: {
+    name: string;
+    id?: string;
+    args: Record<string, unknown>;
+  };
+} | {
+  type: "tool_result";
+  result: {
+    name: string;
+    id?: string;
+    response: unknown;
+  };
+} | {
+  type: "call_code";
+  code: {
+    code: string;
+    language?: string;
+  };
+} | {
+  type: "code_result";
+  result: {
+    output: string;
+    outcome?: string;
+  };
+} | {
+  type: "error";
+  errorCode?: string;
+  errorMessage?: string;
+} | {
+  type: "activity";
+  message: string;
+} | {
+  type: "tool_confirmation";
+  confirmations: Record<string, unknown>;
+} | {
+  type: "finished";
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AdkToolCall = {
+  id: string;
+  name: string;
+  args: ReadonlyJSONObject;
+  argsText?: string;
+};
+
+type AdkToolConfirmation = {
+  toolCallId: string;
+  toolName: string;
+  args: Record<string, unknown>;
+  hint: string;
+  confirmed: boolean;
+  payload?: unknown;
+};
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -70,9 +716,83 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -80,7 +800,75 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAdkApiRouteOptions = {
+  runner: AdkRunner;
+  userId: string | ((req: Request) => string | Promise<string>);
+  sessionId: string | ((req: Request) => string | Promise<string>);
+  onError?: AdkEventStreamOptions["onError"];
+};
+
+type CreateAdkStreamOptions = {
+  api: string;
+  appName?: string | undefined;
+  userId?: string | undefined;
+  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
+};
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -90,30 +878,272 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -175,164 +1205,51 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type JoinStrategy = "concat-content" | "none";
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -362,11 +1279,132 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -376,6 +1414,30 @@ type ObjectStreamOperation = {
   readonly type: "append-text";
   readonly path: readonly string[];
   readonly value: string;
+};
+
+type OnAdkAgentTransferCallback = (toAgent: string) => void | Promise<void>;
+
+type OnAdkCustomEventCallback = (type: string, data: unknown) => void | Promise<void>;
+
+type OnAdkErrorCallback = (error: unknown) => void | Promise<void>;
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type ParsedAdkRequest = {
+  type: "message";
+  text: string;
+  parts?: Array<Record<string, unknown>> | undefined;
+  config: AdkSendMessageConfig;
+  stateDelta?: Record<string, unknown> | undefined;
+} | {
+  type: "tool-result";
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  isError: boolean;
+  config: AdkSendMessageConfig;
+  stateDelta?: Record<string, unknown> | undefined;
 };
 
 type PartInit = {
@@ -405,444 +1467,67 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -877,65 +1562,312 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
+};
+
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
+};
+
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -985,413 +1917,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1420,899 +1945,286 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-type AdkEventPart = {
-  text?: string;
-  thought?: boolean;
-  functionCall?: {
-    name: string;
-    id?: string;
-    args: Record<string, unknown>;
   };
-  functionResponse?: {
-    name: string;
-    id?: string;
-    response: unknown;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
   };
-  executableCode?: {
-    code: string;
-    language?: string;
-  };
-  codeExecutionResult?: {
-    output: string;
-    outcome?: string;
-  };
-  inlineData?: {
-    mimeType: string;
-    data: string;
-  };
-  fileData?: {
-    fileUri: string;
-    mimeType?: string;
-  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type AdkEventActions = {
-  stateDelta?: Record<string, unknown> | undefined;
-  artifactDelta?: Record<string, number> | undefined;
-  transferToAgent?: string | undefined;
-  escalate?: boolean | undefined;
-  skipSummarization?: boolean | undefined;
-  requestedAuthConfigs?: Record<string, unknown> | undefined;
-  requestedToolConfirmations?: Record<string, unknown> | undefined;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
-type AdkEvent = {
-  id: string;
-  invocationId?: string | undefined;
-  author?: string | undefined;
-  branch?: string | undefined;
-  partial?: boolean | undefined;
-  turnComplete?: boolean | undefined;
-  interrupted?: boolean | undefined;
-  finishReason?: string | undefined;
-  timestamp?: number | undefined;
-  content?: {
-    role?: string | undefined;
-    parts?: AdkEventPart[] | undefined;
-  } | undefined;
-  actions?: AdkEventActions | undefined;
-  longRunningToolIds?: string[] | undefined;
-  errorCode?: string | undefined;
-  errorMessage?: string | undefined;
-  groundingMetadata?: unknown;
-  citationMetadata?: unknown;
-  usageMetadata?: unknown;
-  customMetadata?: Record<string, unknown> | undefined;
-};
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-type AdkToolCall = {
-  id: string;
-  name: string;
-  args: ReadonlyJSONObject;
-  argsText?: string;
-};
-
-type AdkMessage = {
-  id: string;
-  type: "human";
-  content: string | AdkMessageContentPart[];
-} | {
-  id: string;
-  type: "ai";
-  content: string | AdkMessageContentPart[];
-  tool_calls?: AdkToolCall[] | undefined;
-  author?: string | undefined;
-  branch?: string | undefined;
-  status?: MessageStatus | undefined;
-} | {
-  id: string;
-  type: "tool";
-  content: string;
-  tool_call_id: string;
-  name: string;
-  status?: "success" | "error" | undefined;
-  artifact?: unknown;
-};
-
-type AdkMessageContentPart = {
-  type: "text";
-  text: string;
-} | {
-  type: "reasoning";
-  text: string;
-} | {
-  type: "image";
-  mimeType: string;
-  data: string;
-} | {
-  type: "image_url";
-  url: string;
-} | {
-  type: "file";
-  mimeType: string;
-  data: string;
-  filename?: string | undefined;
-} | {
-  type: "file_url";
-  url: string;
-  mimeType?: string | undefined;
-} | {
-  type: "code";
-  code: string;
-  language: string;
-} | {
-  type: "code_result";
-  output: string;
-  outcome: string;
-} | {
-  type: "activity";
-  message: string;
-};
-
-type AdkToolConfirmation = {
-  toolCallId: string;
-  toolName: string;
-  args: Record<string, unknown>;
-  hint: string;
-  confirmed: boolean;
-  payload?: unknown;
-};
-
-type AdkAuthCredentialType = "apiKey" | "http" | "oauth2" | "openIdConnect" | "serviceAccount";
-
-type AdkAuthCredential = {
-  authType: AdkAuthCredentialType;
-  resourceRef?: string | undefined;
-  apiKey?: string | undefined;
-  http?: {
-    scheme: string;
-    credentials: {
-      username?: string;
-      password?: string;
-      token?: string;
-    };
-  } | undefined;
-  oauth2?: {
-    clientId?: string;
-    clientSecret?: string;
-    authUri?: string;
-    state?: string;
-    redirectUri?: string;
-    authResponseUri?: string;
-    authCode?: string;
-    accessToken?: string;
-    refreshToken?: string;
-    expiresAt?: number;
-    expiresIn?: number;
-  } | undefined;
-  serviceAccount?: unknown;
-};
-
-type AdkAuthRequest = {
-  toolCallId: string;
-  authConfig: unknown;
-};
-
-type AdkMessageMetadata = {
-  groundingMetadata?: unknown;
-  citationMetadata?: unknown;
-  usageMetadata?: unknown;
-};
-
-type AdkRunConfig = {
-  streamingMode?: "none" | "sse" | "bidi" | undefined;
-  pauseOnToolCalls?: boolean | undefined;
-  maxLlmCalls?: number | undefined;
-  saveInputBlobsAsArtifacts?: boolean | undefined;
-  supportCfc?: boolean | undefined;
-  speechConfig?: unknown;
-  responseModalities?: string[] | undefined;
-  outputAudioTranscription?: unknown;
-  inputAudioTranscription?: unknown;
-  enableAffectiveDialog?: boolean | undefined;
-  proactivity?: unknown;
-  realtimeInputConfig?: unknown;
-};
-
-type AdkSendMessageConfig = {
-  runConfig?: unknown;
-  checkpointId?: string | undefined;
-  stateDelta?: Record<string, unknown> | undefined;
-};
-
-declare const AdkEventType: {
-  readonly THOUGHT: "thought";
-  readonly CONTENT: "content";
-  readonly TOOL_CALL: "tool_call";
-  readonly TOOL_RESULT: "tool_result";
-  readonly CALL_CODE: "call_code";
-  readonly CODE_RESULT: "code_result";
-  readonly ERROR: "error";
-  readonly ACTIVITY: "activity";
-  readonly TOOL_CONFIRMATION: "tool_confirmation";
-  readonly FINISHED: "finished";
-};
-
-type AdkStructuredEvent = {
-  type: "thought";
-  content: string;
-} | {
-  type: "content";
-  content: string;
-} | {
-  type: "tool_call";
-  call: {
-    name: string;
-    id?: string;
-    args: Record<string, unknown>;
-  };
-} | {
-  type: "tool_result";
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
   result: {
-    name: string;
-    id?: string;
-    response: unknown;
+    get: () => Promise<TResult>;
   };
-} | {
-  type: "call_code";
-  code: {
-    code: string;
-    language?: string;
-  };
-} | {
-  type: "code_result";
-  result: {
-    output: string;
-    outcome?: string;
-  };
-} | {
-  type: "error";
-  errorCode?: string;
-  errorMessage?: string;
-} | {
-  type: "activity";
-  message: string;
-} | {
-  type: "tool_confirmation";
-  confirmations: Record<string, unknown>;
-} | {
-  type: "finished";
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-type AdkStreamCallback = (messages: AdkMessage[], config: AdkSendMessageConfig & {
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
   abortSignal: AbortSignal;
-  initialize: () => Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-}) => Promise<AsyncGenerator<AdkEvent>> | AsyncGenerator<AdkEvent>;
+  human: (payload: unknown) => Promise<unknown>;
+};
 
-type OnAdkErrorCallback = (error: unknown) => void | Promise<void>;
-
-type OnAdkCustomEventCallback = (type: string, data: unknown) => void | Promise<void>;
-
-type OnAdkAgentTransferCallback = (toAgent: string) => void | Promise<void>;
-
-type ParsedAdkRequest = {
-  type: "message";
-  text: string;
-  parts?: Array<Record<string, unknown>> | undefined;
-  config: AdkSendMessageConfig;
-  stateDelta?: Record<string, unknown> | undefined;
+type ToolExecutionStatus = {
+  type: "executing";
 } | {
-  type: "tool-result";
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
   toolCallId: string;
-  toolName: string;
-  result: unknown;
-  isError: boolean;
-  config: AdkSendMessageConfig;
-  stateDelta?: Record<string, unknown> | undefined;
-};
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
 
-declare const parseAdkRequest: (request: Request) => Promise<ParsedAdkRequest>;
-
-declare const toAdkContent: (parsed: ParsedAdkRequest) => {
-  role: string;
-  parts: Array<Record<string, unknown>>;
-};
-
-declare namespace entry_server_exports {
-  export { AdkEventStreamOptions, CreateAdkApiRouteOptions, adkEventStream, createAdkApiRoute, parseAdkRequest, toAdkContent };
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
 }
 
-type CreateAdkStreamOptions = {
-  api: string;
-  appName?: string | undefined;
-  userId?: string | undefined;
-  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
 };
 
-declare function createAdkStream(options: CreateAdkStreamOptions): AdkStreamCallback;
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
 
-declare class AdkEventAccumulator {
-  private messagesMap;
-  private currentMessageId;
-  private partialTextBuffer;
-  private partialReasoningBuffer;
-  private accumulatedStateDelta;
-  private accumulatedArtifactDelta;
-  private lastAgentInfo;
-  private lastTransferToAgent;
-  private pendingLongRunningToolIds;
-  private toolConfirmations;
-  private authRequests;
-  private escalated;
-  private messageMetadataMap;
-  constructor(initialMessages?: AdkMessage[]);
-  processEvent(rawEvent: AdkEvent): AdkMessage[];
-  private processPart;
-  private trackMessageMetadata;
-  private getContentArray;
-  private getOrCreateAiMessage;
-  private appendContent;
-  private replaceLastTextContent;
-  private replaceLastReasoningContent;
-  private finalizeCurrentMessage;
-  getMessages(): AdkMessage[];
-  getStateDelta(): Record<string, unknown>;
-  getArtifactDelta(): Record<string, number>;
-  getAgentInfo(): {
-    name?: string | undefined;
-    branch?: string | undefined;
-  };
-  getLastTransferToAgent(): string | undefined;
-  getLongRunningToolIds(): string[];
-  getToolConfirmations(): AdkToolConfirmation[];
-  getAuthRequests(): AdkAuthRequest[];
-  isEscalated(): boolean;
-  getMessageMetadata(): Map<string, AdkMessageMetadata>;
-}
-
-type AdkSessionAdapterOptions = {
-  apiUrl: string;
-  appName: string;
-  userId: string;
-  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>) | undefined;
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
 };
 
-type AdkArtifactData = {
-  inlineData?: {
-    mimeType: string;
-    data: string;
-  } | undefined;
-  text?: string | undefined;
-};
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
 
-type AdkSessionAdapterResult = {
-  adapter: RemoteThreadListAdapter;
-  load: (sessionId: string) => Promise<{
-    messages: AdkMessage[];
-  }>;
-  artifacts: {
-    list: (sessionId: string) => Promise<string[]>;
-    load: (sessionId: string, artifactName: string, version?: number) => Promise<AdkArtifactData>;
-    listVersions: (sessionId: string, artifactName: string) => Promise<number[]>;
-    delete: (sessionId: string, artifactName: string) => Promise<void>;
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
   };
 };
 
-declare function createAdkSessionAdapter(options: AdkSessionAdapterOptions): AdkSessionAdapterResult;
+type Unsubscribe = () => void;
 
-type JoinStrategy = "concat-content" | "none";
-
-declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
+type UseAdkMessagesOptions = {
+  stream: AdkStreamCallback;
+  eventHandlers?: {
+    onError?: OnAdkErrorCallback;
+    onCustomEvent?: OnAdkCustomEventCallback;
+    onAgentTransfer?: OnAdkAgentTransferCallback;
   };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
-}
-
-declare const useExternalMessageConverter: <T extends WeakKey>(_param2: {
-  callback: useExternalMessageConverter.Callback<T>;
-  messages: T[];
-  isRunning: boolean;
-  joinStrategy?: JoinStrategy | undefined;
-  metadata?: useExternalMessageConverter.Metadata | undefined;
-}) => ThreadMessage[];
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
 };
-
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-declare const convertAdkMessage: useExternalMessageConverter.Callback<AdkMessage>;
-
-declare const useAdkAgentInfo: () => {
-  name?: string | undefined;
-  branch?: string | undefined;
-} | undefined;
-
-declare const useAdkSessionState: () => Record<string, unknown>;
-
-declare const useAdkSend: () => (messages: AdkMessage[], config: AdkSendMessageConfig) => Promise<void>;
-
-declare const useAdkLongRunningToolIds: () => string[];
-
-declare const useAdkToolConfirmations: () => AdkToolConfirmation[];
-
-declare const useAdkAuthRequests: () => AdkAuthRequest[];
-
-declare const useAdkArtifacts: () => Record<string, number>;
-
-declare const useAdkEscalation: () => boolean;
-
-declare const useAdkMessageMetadata: () => Map<string, AdkMessageMetadata>;
-
-declare const useAdkConfirmTool: () => (toolCallId: string, confirmed: boolean, payload?: ReadonlyJSONValue) => Promise<void>;
-
-declare const useAdkSubmitAuth: () => (toolCallId: string, credential: AdkAuthCredential) => Promise<void>;
-
-declare const useAdkSubmitInput: () => (toolCallId: string, result: ReadonlyJSONValue) => Promise<void>;
-
-declare const useAdkAppState: () => Record<string, unknown>;
-
-declare const useAdkUserState: () => Record<string, unknown>;
-
-declare const useAdkTempState: () => Record<string, unknown>;
 
 type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   stream: AdkStreamCallback;
@@ -2343,18 +2255,66 @@ type UseAdkRuntimeOptions = ExternalStoreSharedOptions & {
   sessionAdapter?: RemoteThreadListAdapter | undefined;
 };
 
-declare const useAdkRuntime: (_param3: UseAdkRuntimeOptions) => AssistantRuntime;
-
-type UseAdkMessagesOptions = {
-  stream: AdkStreamCallback;
-  eventHandlers?: {
-    onError?: OnAdkErrorCallback;
-    onCustomEvent?: OnAdkCustomEventCallback;
-    onAgentTransfer?: OnAdkAgentTransferCallback;
-  };
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
 };
 
-declare const useAdkMessages: (_param4: UseAdkMessagesOptions) => {
+declare const adkEventStream: (events: AsyncGenerator<AdkSdkEvent, void, undefined>, options?: AdkEventStreamOptions) => Response;
+
+declare const convertAdkMessage: useExternalMessageConverter.Callback<AdkMessage>;
+
+declare function createAdkApiRoute(options: CreateAdkApiRouteOptions): (req: Request) => Promise<Response>;
+
+declare function createAdkSessionAdapter(options: AdkSessionAdapterOptions): AdkSessionAdapterResult;
+
+declare function createAdkStream(options: CreateAdkStreamOptions): AdkStreamCallback;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { AdkArtifactData, AdkAuthCredential, AdkAuthCredentialType, AdkAuthRequest, AdkEvent, AdkEventAccumulator, AdkEventActions, AdkEventPart, AdkEventType, AdkMessage, AdkMessageContentPart, AdkMessageMetadata, AdkRunConfig, AdkSendMessageConfig, AdkSessionAdapterOptions, AdkStreamCallback, AdkStructuredEvent, AdkToolCall, AdkToolConfirmation, CreateAdkStreamOptions, OnAdkAgentTransferCallback, OnAdkCustomEventCallback, OnAdkErrorCallback, UseAdkMessagesOptions, UseAdkRuntimeOptions, convertAdkMessage, createAdkSessionAdapter, createAdkStream, toAdkStructuredEvents, useAdkAgentInfo, useAdkAppState, useAdkArtifacts, useAdkAuthRequests, useAdkConfirmTool, useAdkEscalation, useAdkLongRunningToolIds, useAdkMessageMetadata, useAdkMessages, useAdkRuntime, useAdkSend, useAdkSessionState, useAdkSubmitAuth, useAdkSubmitInput, useAdkTempState, useAdkToolConfirmations, useAdkUserState };
+}
+
+declare namespace entry_server_exports {
+  export { AdkEventStreamOptions, CreateAdkApiRouteOptions, adkEventStream, createAdkApiRoute, parseAdkRequest, toAdkContent };
+}
+
+declare const parseAdkRequest: (request: Request) => Promise<ParsedAdkRequest>;
+
+declare const toAdkContent: (parsed: ParsedAdkRequest) => {
+  role: string;
+  parts: Array<Record<string, unknown>>;
+};
+
+declare function toAdkStructuredEvents(event: AdkEvent): AdkStructuredEvent[];
+
+declare const useAdkAgentInfo: () => {
+  name?: string | undefined;
+  branch?: string | undefined;
+} | undefined;
+
+declare const useAdkAppState: () => Record<string, unknown>;
+
+declare const useAdkArtifacts: () => Record<string, number>;
+
+declare const useAdkAuthRequests: () => AdkAuthRequest[];
+
+declare const useAdkConfirmTool: () => (toolCallId: string, confirmed: boolean, payload?: ReadonlyJSONValue) => Promise<void>;
+
+declare const useAdkEscalation: () => boolean;
+
+declare const useAdkLongRunningToolIds: () => string[];
+
+declare const useAdkMessageMetadata: () => Map<string, AdkMessageMetadata>;
+
+declare const useAdkMessages: (_param2: UseAdkMessagesOptions) => {
   messages: AdkMessage[];
   stateDelta: Record<string, unknown>;
   agentInfo: {
@@ -2373,10 +2333,50 @@ declare const useAdkMessages: (_param4: UseAdkMessagesOptions) => {
   replaceMessages: (msgs: AdkMessage[]) => void;
 };
 
-declare function toAdkStructuredEvents(event: AdkEvent): AdkStructuredEvent[];
+declare const useAdkRuntime: (_param3: UseAdkRuntimeOptions) => AssistantRuntime;
 
-declare namespace entry_root_exports {
-  export { AdkArtifactData, AdkAuthCredential, AdkAuthCredentialType, AdkAuthRequest, AdkEvent, AdkEventAccumulator, AdkEventActions, AdkEventPart, AdkEventType, AdkMessage, AdkMessageContentPart, AdkMessageMetadata, AdkRunConfig, AdkSendMessageConfig, AdkSessionAdapterOptions, AdkStreamCallback, AdkStructuredEvent, AdkToolCall, AdkToolConfirmation, CreateAdkStreamOptions, OnAdkAgentTransferCallback, OnAdkCustomEventCallback, OnAdkErrorCallback, UseAdkMessagesOptions, UseAdkRuntimeOptions, convertAdkMessage, createAdkSessionAdapter, createAdkStream, toAdkStructuredEvents, useAdkAgentInfo, useAdkAppState, useAdkArtifacts, useAdkAuthRequests, useAdkConfirmTool, useAdkEscalation, useAdkLongRunningToolIds, useAdkMessageMetadata, useAdkMessages, useAdkRuntime, useAdkSend, useAdkSessionState, useAdkSubmitAuth, useAdkSubmitInput, useAdkTempState, useAdkToolConfirmations, useAdkUserState };
+declare const useAdkSend: () => (messages: AdkMessage[], config: AdkSendMessageConfig) => Promise<void>;
+
+declare const useAdkSessionState: () => Record<string, unknown>;
+
+declare const useAdkSubmitAuth: () => (toolCallId: string, credential: AdkAuthCredential) => Promise<void>;
+
+declare const useAdkSubmitInput: () => (toolCallId: string, result: ReadonlyJSONValue) => Promise<void>;
+
+declare const useAdkTempState: () => Record<string, unknown>;
+
+declare const useAdkToolConfirmations: () => AdkToolConfirmation[];
+
+declare const useAdkUserState: () => Record<string, unknown>;
+
+declare namespace useExternalMessageConverter {
+  type Message = (ThreadMessageLike & {
+    readonly convertConfig?: {
+      readonly joinStrategy?: JoinStrategy;
+    };
+  }) | {
+    role: "tool";
+    toolCallId: string;
+    toolName?: string | undefined;
+    result: any;
+    artifact?: any;
+    isError?: boolean;
+    messages?: readonly ThreadMessage[];
+  };
+  type Metadata = {
+    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+    readonly error?: ReadonlyJSONValue;
+    readonly messageTiming?: Record<string, MessageTiming>;
+  };
+  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
 }
+
+declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {
+  callback: useExternalMessageConverter.Callback<T>;
+  messages: T[];
+  isRunning: boolean;
+  joinStrategy?: JoinStrategy | undefined;
+  metadata?: useExternalMessageConverter.Metadata | undefined;
+}) => ThreadMessage[];
 
 export { entry_root_exports as entry_root, entry_server_exports as entry_server };

--- a/api-surface/assistant-ui__react-hook-form.ts
+++ b/api-surface/assistant-ui__react-hook-form.ts
@@ -1,75 +1,8 @@
-import { z } from "zod";
-
 import { ComponentType } from "react";
 
 import { FieldValues, UseFormProps, UseFormReturn } from "react-hook-form";
 
-declare const formTools: {
-  set_form_field: {
-    description: string;
-    parameters: z.ZodObject<{
-      name: z.ZodString;
-      value: z.ZodString;
-    }, z.core.$strip>;
-  };
-  submit_form: {
-    description: string;
-    parameters: z.ZodObject<{}, z.core.$strip>;
-  };
-  reset_form: {
-    description: string;
-    parameters: z.ZodObject<{}, z.core.$strip>;
-  };
-};
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
-
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type CompleteAttachmentStatus = {
-  type: "complete";
-};
+import { z } from "zod";
 
 type BaseAttachment = {
   id: string;
@@ -80,25 +13,131 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
 type CompleteAttachment = BaseAttachment & {
   status: CompleteAttachmentStatus;
   content: ThreadUserMessagePart[];
 };
 
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
   readonly parentId?: string;
 };
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
+};
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 type ReasoningMessagePart = {
   readonly type: "reasoning";
   readonly text: string;
   readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
 };
 
 type SourceMessagePart = {
@@ -121,63 +160,93 @@ type SourceMessagePart = {
   readonly parentId?: string;
 };
 
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
 };
 
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
   readonly parentId?: string;
 };
 
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
 
 type ToolApprovalOption = {
   readonly id: string;
@@ -190,6 +259,8 @@ type ToolApprovalOption = {
     description?: string;
   };
 };
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
 type ToolApprovalResponse = {
   readonly approved: boolean;
@@ -232,152 +303,10 @@ type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
   readonly messages?: readonly ThreadMessage[];
 };
 
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
 
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
 type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
@@ -386,7 +315,53 @@ type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState
   respondToApproval: (response: ToolApprovalResponse) => void;
 };
 
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
 
 type UseAssistantFormProps<TFieldValues extends FieldValues, TContext, TTransformedValues> = UseFormProps<TFieldValues, TContext, TTransformedValues> & {
   assistant?: {
@@ -404,10 +379,35 @@ type UseAssistantFormProps<TFieldValues extends FieldValues, TContext, TTransfor
   } | undefined;
 };
 
-declare const useAssistantForm: <TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseAssistantFormProps<TFieldValues, TContext, TTransformedValues>) => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
+declare const formTools: {
+  set_form_field: {
+    description: string;
+    parameters: z.ZodObject<{
+      name: z.ZodString;
+      value: z.ZodString;
+    }, z.core.$strip>;
+  };
+  submit_form: {
+    description: string;
+    parameters: z.ZodObject<{}, z.core.$strip>;
+  };
+  reset_form: {
+    description: string;
+    parameters: z.ZodObject<{}, z.core.$strip>;
+  };
+};
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
 declare namespace entry_root_exports {
   export { UseAssistantFormProps, formTools, useAssistantForm };
 }
+
+declare const useAssistantForm: <TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues>(props?: UseAssistantFormProps<TFieldValues, TContext, TTransformedValues>) => UseFormReturn<TFieldValues, TContext, TTransformedValues>;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-ink-markdown.ts
+++ b/api-surface/assistant-ui__react-ink-markdown.ts
@@ -1,5 +1,19 @@
 import { RenderOptions, Theme, Theme as Theme$1, ThemeName, ThemeName as ThemeName$1 } from "markdansi";
 
+declare const MarkdownText: {
+  (_param0: MarkdownTextProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+declare const MarkdownTextPrimitive: {
+  (_param1: MarkdownTextPrimitiveProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MarkdownTextPrimitiveProps = Omit<MarkdownTextProps, "text"> & {
+  preprocess?: ((text: string) => string) | undefined;
+};
+
 type MarkdownTextProps = {
   text: string;
   highlighter?: (code: string, lang?: string) => string;
@@ -17,29 +31,15 @@ type MarkdownTextProps = {
   listIndent?: number;
 };
 
-declare const MarkdownText: {
-  (_param0: MarkdownTextProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MarkdownTextPrimitiveProps = Omit<MarkdownTextProps, "text"> & {
-  preprocess?: ((text: string) => string) | undefined;
-};
-
-declare const MarkdownTextPrimitive: {
-  (_param1: MarkdownTextPrimitiveProps): import("react").JSX.Element;
-  displayName: string;
-};
-
 type UseShikiHighlighterOptions = {
   theme?: string;
   langs?: string[];
 };
 
-declare function useShikiHighlighter(options?: UseShikiHighlighterOptions): ((code: string, lang?: string) => string) | undefined;
-
 declare namespace entry_root_exports {
   export { MarkdownText, MarkdownTextPrimitive, MarkdownTextPrimitiveProps, MarkdownTextProps, RenderOptions, Theme$1 as Theme, ThemeName$1 as ThemeName, UseShikiHighlighterOptions, useShikiHighlighter };
 }
+
+declare function useShikiHighlighter(options?: UseShikiHighlighterOptions): ((code: string, lang?: string) => string) | undefined;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1,26 +1,584 @@
-import React, { ComponentProps, ComponentType, FC, PropsWithChildren, ReactElement, ReactNode } from "react";
+import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { Box, Text } from "ink";
 
 import Spinner from "ink-spinner";
 
-import { StandardSchemaV1 } from "@standard-schema/spec";
+import React, { ComponentProps, ComponentType, FC, PropsWithChildren, ReactElement, ReactNode } from "react";
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+declare const ActionBarCopy: (_param0: ActionBarCopyProps) => import("react").JSX.Element;
+
+type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
+  children: ReactNode | ((props: {
+    isCopied: boolean;
+  }) => ReactNode);
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+declare const ActionBarEdit: (_param1: ActionBarEditProps) => import("react").JSX.Element;
+
+type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
 };
+
+declare const ActionBarFeedbackNegative: (_param2: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
+
+type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: ReactNode | ((props: {
+    isSubmitted: boolean;
+  }) => ReactNode);
+};
+
+declare const ActionBarFeedbackPositive: (_param3: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
+
+type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: ReactNode | ((props: {
+    isSubmitted: boolean;
+  }) => ReactNode);
+};
+
+declare const ActionBarReload: (_param4: ActionBarReloadProps) => import("react").JSX.Element;
+
+type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantContextConfig = {
+  getContext: () => string;
+  disabled?: boolean | undefined;
+};
+
+type AssistantDataUI = FC & {
+  unstable_data: AssistantDataUIProps;
+};
+
+type AssistantDataUIProps<T = any> = {
+  name: string;
+  render: DataMessagePartComponent<T>;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AssistantInstructionsConfig = {
+  disabled?: boolean | undefined;
+  instruction: string;
+};
+
+type AssistantInteractableProps = {
+  description: string;
+  stateSchema: InteractableStateSchema;
+  initialState: unknown;
+  id?: string;
+  selected?: boolean;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+};
+
+type AssistantRuntimeCore = {
+  readonly threads: ThreadListRuntimeCore;
+  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
+  getModelContextProvider: () => ModelContextProvider;
+  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
+};
+
+declare class AssistantRuntimeImpl implements AssistantRuntime {
+  private readonly _core;
+  readonly threads: ThreadListRuntimeImpl;
+  readonly _thread: ThreadRuntime;
+  constructor(_core: AssistantRuntimeCore);
+  protected __internal_bindMethods(): void;
+  get thread(): ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+}
+
+declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param5: {
+  runtime: AssistantRuntime;
+  aui?: AssistantClient | null;
+  children: ReactNode;
+}) => import("react").JSX.Element>;
+
+type AssistantState = {
+  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
+    getState: () => infer S;
+  } ? S : never;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AssistantTool = FC & {
+  unstable_tool: AssistantToolProps<any, any>;
+};
+
+type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
+};
+
+type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
+  toolName: string;
+  render?: unknown;
+};
+
+type AssistantToolUI = FC & {
+  unstable_tool: AssistantToolUIProps<any, any>;
+};
+
+type AssistantToolUIProps<TArgs, TResult> = {
+  toolName: string;
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+  display?: "inline" | "standalone";
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+declare const AttachmentName: FC<AttachmentNameProps>;
+
+type AttachmentNameProps = ComponentProps<typeof Text>;
+
+declare const AttachmentRemove: (_param6: AttachmentRemoveProps) => import("react").JSX.Element;
+
+type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const AttachmentRoot: (_param7: AttachmentRootProps) => import("react").JSX.Element;
+
+type AttachmentRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState$1 & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  private _core;
+  get path(): AttachmentRuntimePath & {
+    attachmentSource: Source;
+  };
+  abstract get source(): Source;
+  constructor(_core: AttachmentSnapshotBinding<Source>);
+  protected __internal_bindMethods(): void;
+  getState(): AttachmentState$1 & {
+    source: Source;
+  };
+  abstract remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+}
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState$1["source"];
+
+type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
+  source: Source;
+}, AttachmentRuntimePath & {
+  attachmentSource: Source;
+}>;
+
+type AttachmentState = Attachment;
+
+type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+declare const AttachmentStatus: FC<AttachmentStatusProps>;
+
+type AttachmentStatusProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  showComplete?: boolean | undefined;
+};
+
+declare const AttachmentThumb: FC<AttachmentThumbProps>;
+
+type AttachmentThumbProps = ComponentProps<typeof Text>;
+
+declare namespace AuiIf {
+  type Props = PropsWithChildren<{
+    condition: AuiIf.Condition;
+  }>;
+  type Condition = (state: AssistantState) => boolean;
+}
+
+declare const AuiIf: FC<AuiIf.Props>;
+
+declare const AuiProvider: (_param8: {
+  value: AssistantClient;
+  children: React.ReactNode;
+}) => React.ReactElement;
+
+type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
+
+type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: string | undefined;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
+  protected readonly _contextProvider: CompositeContextProvider;
+  abstract get threads(): ThreadListRuntimeCore;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+  getModelContextProvider(): ModelContextProvider;
+}
 
 type BaseAttachment = {
   id: string;
@@ -31,9 +589,311 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  readonly isEditing = true;
+  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected abstract getDictationAdapter(): DictationAdapter | undefined;
+  protected enrichWithComposerMetadata<T extends {
+    metadata?: {
+      custom?: Record<string, unknown>;
+    };
+  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
+  get attachmentAccept(): string;
+  private _attachments;
+  get attachments(): readonly Attachment[];
+  protected setAttachments(value: readonly Attachment[]): void;
+  abstract get canCancel(): boolean;
+  abstract get canSend(): boolean;
+  get isEmpty(): boolean;
+  private _text;
+  get text(): string;
+  private _role;
+  get role(): "assistant" | "system" | "user";
+  private _runConfig;
+  get runConfig(): RunConfig;
+  private _quote;
+  get quote(): QuoteInfo | undefined;
+  setQuote(quote: QuoteInfo | undefined): void;
+  setText(value: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  private _emptyTextAndAttachments;
+  private _onClearAttachments;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): Promise<void>;
+  cancel(): void;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(_queueItemId: string): void;
+  removeQueueItem(_queueItemId: string): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleCancel(): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  private _safeEmitAttachmentAddError;
+  removeAttachment(attachmentId: string): Promise<void>;
+  private _dictation;
+  private _dictationSession;
+  private _dictationUnsubscribes;
+  private _dictationBaseText;
+  private _currentInterimText;
+  private _dictationSessionIdCounter;
+  private _activeDictationSessionId;
+  private _isCleaningDictation;
+  get dictation(): DictationState | undefined;
+  private _isActiveSession;
+  startDictation(): void;
+  stopDictation(): void;
+  private _cleanupDictation;
+  private _eventSubscribers;
+  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
+}
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+declare class BaseSubscribable {
+  private _subscribers;
+  subscribe(callback: () => void): Unsubscribe$1;
+  waitForUpdate(): Promise<void>;
+  protected _notifySubscribers(): void;
+}
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+declare const BranchPickerCount: (props: BranchPickerCountProps) => import("react").JSX.Element;
+
+type BranchPickerCountProps = ComponentProps<typeof Text>;
+
+declare const BranchPickerNext: (_param9: BranchPickerNextProps) => import("react").JSX.Element;
+
+type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
+
+type BranchPickerNumberProps = ComponentProps<typeof Text>;
+
+declare const BranchPickerPrevious: (_param10: BranchPickerPreviousProps) => import("react").JSX.Element;
+
+type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ChainOfThoughtAccordionTrigger: (_param11: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
+
+type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>>;
+
+declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
+  {
+    parts: readonly ChainOfThoughtPart[];
+    getMessagePart: (selector: {
+      index: number;
+    }) => PartMethods;
+  }
+]>;
+
+type ChainOfThoughtPart = Extract<PartState, {
+  type: "tool-call";
+} | {
+  type: "reasoning";
+}>;
+
+declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type ChainOfThoughtPartsComponentConfig = {
+  Reasoning?: ReasoningMessagePartComponent | undefined;
+  tools?: {
+    Fallback?: ToolCallMessagePartComponent | undefined;
+  };
+  Layout?: ComponentType<PropsWithChildren> | undefined;
+};
+
+declare namespace ChainOfThoughtPrimitiveParts {
+  type Props = {
+    components?: ChainOfThoughtPartsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      part: PartState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
+
+declare const ChainOfThoughtRoot: (_param12: ChainOfThoughtRootProps) => import("react").JSX.Element;
+
+type ChainOfThoughtRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type ChatModelAdapter = {
+  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext$1;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+declare const ChecklistItem: {
+  (_param13: ChecklistItemProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type ChecklistItemData = {
+  id: string;
+  text: string;
+  status: ChecklistItemStatus;
+  detail?: string;
+  children?: ChecklistItemData[];
+};
+
+type ChecklistItemProps = ComponentProps<typeof Box> & {
+  item: ChecklistItemData;
+  depth?: number | undefined;
+  maxDepth?: number | undefined;
+};
+
+type ChecklistItemStatus = "complete" | "error" | "pending" | "running";
+
+declare const ChecklistProgress: {
+  (_param14: ChecklistProgressProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type ChecklistProgressProps = ComponentProps<typeof Box> & {
+  items: ChecklistItemData[];
+};
+
+declare const ChecklistRoot: {
+  (_param15: ChecklistRootProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type ChecklistRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -41,7 +901,277 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+declare const ComposerAddAttachment: (_param16: ComposerAddAttachmentProps) => import("react").JSX.Element;
+
+type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  private _composerApi;
+  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
+  remove(): Promise<void>;
+}
+
+declare const ComposerAttachments: import("react").FC<ComposerPrimitiveAttachments.Props>;
+
+type ComposerAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const ComposerCancel: (_param17: ComposerCancelProps) => import("react").JSX.Element;
+
+type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ComposerIfFilters = {
+  editing: boolean | undefined;
+  dictation: boolean | undefined;
+};
+
+declare const ComposerInput: (_param18: ComposerInputProps) => import("react").JSX.Element;
+
+type ComposerInputProps = ComponentProps<typeof Box> & {
+  submitOnEnter?: boolean | undefined;
+  placeholder?: string | undefined;
+  autoFocus?: boolean | undefined;
+  multiLine?: boolean | undefined;
+  onSubmit?: ((text: string) => void) | undefined;
+};
+
+declare namespace ComposerPrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: ComposerAttachmentsComponentConfig;
+  };
+}
+
+declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare namespace ComposerPrimitiveAttachments {
+  type Props = {
+    components: ComposerAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: Attachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
+
+declare namespace ComposerPrimitiveIf {
+  type Props = PropsWithChildren<UseComposerIfProps>;
+}
+
+declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
+
+declare namespace ComposerPrimitiveQueue {
+  type Props = {
+    children: (value: {
+      queueItem: QueueItemState;
+    }) => ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
+  children: (value: {
+    queueItem: QueueItemState;
+  }) => ReactNode;
+}>;
+
+declare const ComposerQuote: (_param19: ComposerQuoteProps) => import("react").JSX.Element | null;
+
+declare const ComposerQuoteDismiss: (_param20: ComposerQuoteDismissProps) => import("react").JSX.Element;
+
+type ComposerQuoteDismissProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ComposerQuoteProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+declare const ComposerQuoteText: (_param21: ComposerQuoteTextProps) => import("react").JSX.Element | null;
+
+type ComposerQuoteTextProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+declare const ComposerRoot: (_param22: ComposerRootProps) => import("react").JSX.Element;
+
+type ComposerRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState$1;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
+};
+
+type ComposerRuntimeCore = Readonly<{
+  isEditing: boolean;
+  canCancel: boolean;
+  canSend: boolean;
+  isEmpty: boolean;
+  attachments: readonly Attachment[];
+  attachmentAccept: string;
+  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
+  removeAttachment: (attachmentId: string) => Promise<void>;
+  text: string;
+  setText: (value: string) => void;
+  role: MessageRole;
+  setRole: (role: MessageRole) => void;
+  runConfig: RunConfig;
+  setRunConfig: (runConfig: RunConfig) => void;
+  quote: QuoteInfo | undefined;
+  setQuote: (quote: QuoteInfo | undefined) => void;
+  reset: () => Promise<void>;
+  clearAttachments: () => Promise<void>;
+  send: (options?: SendOptions) => void;
+  cancel: () => void;
+  queue: readonly QueueItemState[];
+  steerQueueItem: (queueItemId: string) => void;
+  removeQueueItem: (queueItemId: string) => void;
+  dictation: DictationState | undefined;
+  startDictation: () => void;
+  stopDictation: () => void;
+  subscribe: (callback: () => void) => Unsubscribe$1;
+  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
+}>;
+
+type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  protected _core: ComposerRuntimeCoreBinding;
+  get path(): ComposerRuntimePath;
+  abstract get type(): "edit" | "thread";
+  constructor(_core: ComposerRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  abstract getState(): ComposerState$1;
+  setText(text: string): void;
+  setRunConfig(runConfig: RunConfig): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  setRole(role: MessageRole): void;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _eventSubscriptionSubjects;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
+  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
+}
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+declare const ComposerSend: (_param23: ComposerSendProps) => import("react").JSX.Element;
+
+type ComposerSendProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ComposerState = {
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly isEditing: boolean;
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly attachmentAccept: string;
+  readonly isEmpty: boolean;
+  readonly type: "edit" | "thread";
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type ComposerState$1 = ThreadComposerState | EditComposerState;
+
+declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  private _adapters;
+  accept: string;
+  constructor(adapters: AttachmentAdapter[]);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(attachment: Attachment): Promise<void>;
+}
+
+declare class CompositeContextProvider implements ModelContextProvider {
+  private _providers;
+  getModelContext(): ModelContext$1;
+  registerModelContextProvider(provider: ModelContextProvider): () => void;
+  private _subscribers;
+  notifySubscribers(): void;
+  subscribe(callback: () => void): () => void;
+}
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -51,30 +1181,437 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateFileStorageAdapterOptions = {
+  dir: string;
+  prefix?: string | undefined;
+  titleGenerator?: TitleGenerationAdapter | undefined;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
+]>;
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  private runtime;
+  private _canCancel;
+  get canCancel(): boolean;
+  get canSend(): boolean;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected getDictationAdapter(): DictationAdapter | undefined;
+  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: {
+      attachments?: AttachmentAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+    } | undefined;
+  });
+  connect(): Unsubscribe$1;
+  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
+  handleCancel(): Promise<void>;
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
+  _config: Derived.Props<K>
+]>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
 }
 
-type JSONSchema7Version = string;
+type DerivedElement<K extends ClientNames> = ResourceElement<null, [
+  Derived.Props<K>
+]>;
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe$1;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
+  };
+}
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+declare const DiffContent: {
+  (_param24: DiffContentProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type DiffContentProps = ComponentProps<typeof Box> & {
+  fileIndex?: number | undefined;
+  showLineNumbers?: boolean | undefined;
+  contextLines?: number | undefined;
+  maxLines?: number | undefined;
+  renderLine?: ((props: {
+    line: ParsedLine;
+    index: number;
+  }) => ReactNode) | undefined;
+  renderFold?: ((props: {
+    region: FoldedRegion;
+    index: number;
+  }) => ReactNode) | undefined;
+};
+
+interface DiffFileInput {
+  content: string;
+  name?: string | undefined;
+}
+
+declare const DiffHeader: {
+  (_param25: DiffHeaderProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type DiffHeaderProps = ComponentProps<typeof Box> & {
+  fileIndex?: number;
+};
+
+declare const DiffLine: {
+  (_param26: DiffLineProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type DiffLineProps = ComponentProps<typeof Box> & {
+  line: ParsedLine;
+  showLineNumbers?: boolean;
+  lineNumberWidth?: number;
+};
+
+type DiffLineType = "add" | "del" | "normal";
+
+declare const DiffRoot: {
+  (_param27: DiffRootProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type DiffRootProps = ComponentProps<typeof Box> & {
+  files?: ParsedFile[] | undefined;
+  children: ReactNode;
+};
+
+declare const DiffStats: {
+  (_param28: DiffStatsProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type DiffStatsProps = ComponentProps<typeof Box> & {
+  fileIndex?: number;
+};
+
+declare const DiffView: (_param29: DiffViewProps) => import("react").JSX.Element;
+
+type DiffViewProps = Omit<ComponentProps<typeof Box>, "children"> & {
+  patch?: string | undefined;
+  oldFile?: DiffFileInput | undefined;
+  newFile?: DiffFileInput | undefined;
+  showLineNumbers?: boolean | undefined;
+  contextLines?: number | undefined;
+  maxLines?: number | undefined;
+};
+
+type DisplayLine = ParsedLine | FoldedRegion;
+
+declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
+  get source(): "edit-composer";
+}
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
+  parentId: string | null;
+  sourceId: string | null;
+}>;
+
+type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "edit";
+}>;
+
+declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  private _beginEdit;
+  get path(): ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  get type(): "edit";
+  private _getState;
+  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
+  __internal_bindMethods(): void;
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
+}
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
+
+type EmptyMessagePartProps = {
+  status: MessagePartStatus;
+};
+
+type EnrichedPartState = (Extract<PartState, {
+  type: "tool-call";
+}> & {
+  readonly toolUI: ReactNode;
+  addResult: ToolCallMessagePartProps["addResult"];
+  resume: ToolCallMessagePartProps["resume"];
+  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
+}) | (Extract<PartState, {
+  type: "data";
+}> & {
+  readonly dataRendererUI: ReactNode;
+}) | Exclude<PartState, {
+  type: "tool-call";
+} | {
+  type: "data";
+}>;
+
+declare const ErrorMessage: {
+  (_param30: ErrorMessageProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type ErrorMessageProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+declare const ErrorRoot: {
+  (_param31: ErrorRootProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type ErrorRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
+
+type FileMessagePartProps = MessagePartState & FileMessagePart;
+
+interface FoldedRegion {
+  type: "fold";
+  hiddenCount: number;
+}
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
+
+type ImageMessagePartProps = MessagePartState & ImageMessagePart;
+
+declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
+  list(): Promise<RemoteThreadListResponse>;
+  rename(): Promise<void>;
+  updateCustom(): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(): Promise<AssistantStream>;
+  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
+}
+
+type IncompleteReason = Extract<MessageStatus, {
+  type: "incomplete";
+}>["reason"];
+
+type InteractableScope = "app" | "thread";
+
+type InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+declare const Interactables: Resource<ClientOutput<"interactables">, [
+]>;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -136,175 +1673,157 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
 
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ObjectKey<T> = keyof T & (string | number);
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
 
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+declare const LOADING_FRAMES: {
+  readonly dots: readonly [
+    ".  ",
+    ".. ",
+    "..."
   ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
+  readonly pulse: readonly [
+    "*--",
+    "-*-",
+    "--*"
   ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+  readonly bar: readonly [
+    "[=   ]",
+    "[==  ]",
+    "[=== ]",
+    "[ ===]",
+    "[  ==]",
+    "[   =]"
+  ];
+  readonly bounce: readonly [
+    "[*   ]",
+    "[ *  ]",
+    "[  * ]",
+    "[   *]",
+    "[  * ]",
+    "[ *  ]"
+  ];
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
 
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
+declare const LiveChecklist: {
+  (_param32: LiveChecklistProps): import("react").JSX.Element;
+  displayName: string;
+};
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type LiveChecklistProps = ComponentProps<typeof Box> & {
+  items?: ChecklistItemData[] | undefined;
+  formatToolName?: ((toolName: string) => string) | undefined;
+  title?: string | undefined;
+  showProgress?: boolean | undefined;
+  maxDepth?: number | undefined;
+};
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+declare const LoadingElapsedTime: {
+  (_param33: LoadingElapsedTimeProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type LoadingElapsedTimeProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  format?: (seconds: number) => string;
+};
+
+declare const LoadingRoot: {
+  (_param34: LoadingRootProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type LoadingRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+declare const LoadingSpinner: {
+  (_param35: LoadingSpinnerProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type LoadingSpinnerProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  variant?: LoadingSpinnerVariant;
+  type?: ComponentProps<typeof Spinner>["type"];
+  intervalMs?: number;
+};
+
+type LoadingSpinnerVariant = "spinner" | keyof typeof LOADING_FRAMES;
+
+declare const LoadingText: {
+  (_param36: LoadingTextProps): import("react").JSX.Element;
+  displayName: string;
+};
+
+type LoadingTextProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
+  cloud?: AssistantCloud | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
+  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
+};
+
+type LocalRuntimeOptionsBase = {
+  maxSteps?: number | undefined;
+  adapters: {
+    chatModel: ChatModelAdapter;
+    history?: ThreadHistoryAdapter | undefined;
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    suggestion?: SuggestionAdapter | undefined;
   };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+  unstable_humanToolNames?: string[] | undefined;
+  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
-type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: string | undefined;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppResourceOutput = {
+  readonly render: ToolCallMessagePartComponent;
 };
 
 type McpServerConfig = {
@@ -334,13 +1853,635 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+type McpToolkitDefinition = Record<string, McpToolkitEntry>;
 
-type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type McpToolkitEntry = McpServerConfig | {
+  server: McpServerConfig;
+  disabled?: boolean | undefined;
+  tools?: Record<string, McpToolkitToolConfig> | undefined;
 };
+
+type McpToolkitToolConfig = {
+  disabled?: boolean | undefined;
+};
+
+declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
+  get source(): "message";
+  remove(): never;
+}
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+declare const MessageAttachments: import("react").FC<MessagePrimitiveAttachments.Props>;
+
+type MessageAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const MessageByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessageComponents = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+declare const MessageContent: (_param37: MessageContentProps) => import("react").JSX.Element;
+
+type MessageContentPart = ThreadUserMessagePart | ThreadAssistantMessagePart;
+
+type MessageContentProps = {
+  renderText?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "text";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderToolCall?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "tool-call";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderImage?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "image";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderReasoning?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "reasoning";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderSource?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "source";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderFile?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "file";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderData?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "data";
+    }>;
+    index: number;
+  }) => ReactElement;
+};
+
+declare const MessageError: FC<PropsWithChildren>;
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+declare const MessageIf: (_param38: MessageIfProps) => import("react").JSX.Element | null;
+
+type MessageIfProps = {
+  children: ReactNode;
+  user?: boolean | undefined;
+  assistant?: boolean | undefined;
+  running?: boolean | undefined;
+  last?: boolean | undefined;
+};
+
+declare namespace MessagePartPrimitiveData {
+  type Props = MessagePartPrimitiveDataProps;
+}
+
+declare const MessagePartPrimitiveData: {
+  (props: MessagePartPrimitiveData.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveDataProps = Omit<ComponentProps<typeof Text>, "children">;
+
+declare namespace MessagePartPrimitiveFile {
+  type Props = MessagePartPrimitiveFileProps;
+}
+
+declare const MessagePartPrimitiveFile: {
+  (props: MessagePartPrimitiveFile.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveFileProps = Omit<ComponentProps<typeof Text>, "children">;
+
+declare namespace MessagePartPrimitiveImage {
+  type Props = MessagePartPrimitiveImageProps;
+}
+
+declare const MessagePartPrimitiveImage: {
+  (props: MessagePartPrimitiveImage.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveImageProps = Omit<ComponentProps<typeof Text>, "children">;
+
+declare namespace MessagePartPrimitiveInProgress {
+  type Props = PropsWithChildren;
+}
+
+declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
+
+declare namespace MessagePartPrimitiveReasoning {
+  type Props = MessagePartPrimitiveReasoningProps;
+}
+
+declare const MessagePartPrimitiveReasoning: {
+  (props: MessagePartPrimitiveReasoning.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveReasoningProps = Omit<ComponentProps<typeof Text>, "children">;
+
+declare namespace MessagePartPrimitiveSource {
+  type Props = MessagePartPrimitiveSourceProps;
+}
+
+declare const MessagePartPrimitiveSource: {
+  (props: MessagePartPrimitiveSource.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveSourceProps = Omit<ComponentProps<typeof Text>, "children">;
+
+declare namespace MessagePartPrimitiveText {
+  type Props = MessagePartPrimitiveTextProps;
+}
+
+declare const MessagePartPrimitiveText: {
+  (props: MessagePartPrimitiveText.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type MessagePartPrimitiveTextProps = Omit<ComponentProps<typeof Text>, "children">;
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  private contentBinding;
+  private messageApi?;
+  private threadApi?;
+  get path(): MessagePartRuntimePath;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  protected __internal_bindMethods(): void;
+  getState(): MessagePartState;
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+}
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+declare namespace MessagePrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: MessageAttachmentsComponentConfig;
+  };
+}
+
+declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare namespace MessagePrimitiveAttachments {
+  type Props = {
+    components: MessageAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: CompleteAttachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
+
+declare namespace MessagePrimitivePartByIndex {
+  type Props = {
+    index: number;
+    components: MessagePrimitiveParts$1.Props["components"];
+  };
+}
+
+declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
+
+declare namespace MessagePrimitiveParts {
+  type Props = MessagePrimitiveParts$1.Props;
+}
+
+declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
+
+declare namespace MessagePrimitiveParts$1 {
+  type DataConfig = {
+    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
+    Fallback?: DataMessagePartComponent | undefined;
+  };
+  type BaseComponents = {
+    Empty?: EmptyMessagePartComponent | undefined;
+    Text?: TextMessagePartComponent | undefined;
+    Source?: SourceMessagePartComponent | undefined;
+    Image?: ImageMessagePartComponent | undefined;
+    File?: FileMessagePartComponent | undefined;
+    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+    data?: DataConfig | undefined;
+    Quote?: QuoteMessagePartComponent | undefined;
+    generativeUI?: {
+      components: GenerativeUIComponentRegistry;
+      Fallback?: ComponentType<{
+        component: string;
+        props?: unknown;
+      }> | undefined;
+    } | undefined;
+  };
+  type ToolsConfig = {
+    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
+    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+  } | {
+    Override: ComponentType<ToolCallMessagePartProps>;
+  };
+  type StandardComponents = BaseComponents & {
+    Reasoning?: ReasoningMessagePartComponent | undefined;
+    tools?: ToolsConfig | undefined;
+    ToolGroup?: ComponentType<PropsWithChildren<{
+      startIndex: number;
+      endIndex: number;
+    }>>;
+    ReasoningGroup?: ReasoningGroupComponent;
+    ChainOfThought?: never;
+  };
+  type ChainOfThoughtComponents = BaseComponents & {
+    ChainOfThought: ComponentType;
+    Reasoning?: never;
+    tools?: never;
+    ToolGroup?: never;
+    ReasoningGroup?: never;
+  };
+  export type Props = {
+    components?: StandardComponents | ChainOfThoughtComponents | undefined;
+    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
+    children?: never;
+  } | {
+    children: (value: {
+      part: EnrichedPartState;
+    }) => ReactNode;
+    components?: never;
+    unstable_showEmptyOnNonTextEnd?: never;
+  };
+  export {};
+}
+
+declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
+
+declare class MessageRepository {
+  private messages;
+  private head;
+  private root;
+  private updateLevels;
+  private performOp;
+  private _messages;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  private evictOffBranchOptimisticMessages;
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param39: ExportedMessageRepository): void;
+}
+
+type MessageRole = ThreadMessage["role"];
+
+declare const MessageRoot: (_param40: MessageRootProps) => import("react").JSX.Element;
+
+type MessageRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState$1;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param41: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param42: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+declare class MessageRuntimeImpl implements MessageRuntime {
+  private _core;
+  private _threadBinding;
+  get path(): MessageRuntimePath;
+  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  readonly composer: EditComposerRuntimeImpl;
+  private _getEditComposerRuntimeCore;
+  getState(): ThreadMessage & {
+    readonly parentId: string | null;
+    readonly index: number;
+    readonly isLast: boolean;
+    readonly branchNumber: number;
+    readonly branchCount: number;
+    readonly speech: SpeechState | undefined;
+  };
+  delete(): void | Promise<void>;
+  reload(reloadConfig?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param43: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param44: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
+  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
+}
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+  readonly composer: ComposerState;
+  readonly parts: readonly PartState[];
+  readonly isCopied: boolean;
+  readonly isHovering: boolean;
+  readonly index: number;
+};
+
+type MessageState$1 = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStateBinding = SubscribableWithState<ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+}, MessageRuntimePath>;
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type MessagesComponentConfig = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+declare const ModelContext: Resource<ClientOutput<"modelContext">, [
+]>;
+
+type ModelContext$1 = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext$1;
+  subscribe?: (callback: () => void) => Unsubscribe$1;
+};
+
+declare class ModelContextRegistry implements ModelContextProvider {
+  private _tools;
+  private _instructions;
+  private _providers;
+  private _subscribers;
+  private _providerUnsubscribes;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private notifySubscribers;
+  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
+  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
+  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
+}
+
+interface ModelContextRegistryInstructionHandle {
+  update(config: string | AssistantInstructionsConfig): void;
+  remove(): void;
+}
+
+interface ModelContextRegistryProviderHandle {
+  remove(): void;
+}
+
+interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
+  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
+  remove(): void;
+}
+
+type NotificationConfig = {
+  enabled?: boolean;
+  onTaskComplete?: NotificationHandler<"task-complete"> | false;
+  onTaskIncomplete?: NotificationHandler<"task-incomplete"> | false;
+  onNeedsInput?: NotificationHandler<"needs-input"> | false;
+};
+
+type NotificationEvent = {
+  type: "task-complete";
+  threadId: string;
+  messageId: string;
+  title: string;
+} | {
+  type: "task-incomplete";
+  threadId: string;
+  messageId: string;
+  title: string;
+  reason: IncompleteReason;
+} | {
+  type: "needs-input";
+  threadId: string;
+  messageId: string;
+  title: string;
+  reason: "interrupt";
+};
+
+type NotificationHandler<T extends NotificationEvent["type"] = NotificationEvent["type"]> = {
+  bell?: boolean;
+  osc?: boolean | OSCVariant;
+  custom?: (event: Extract<NotificationEvent, {
+    type: T;
+  }>) => void;
+};
+
+type OSCVariant = "osc777" | "osc9" | "osc99";
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -351,6 +2492,45 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
+  [K in TKey]?: undefined;
+} : {
+  [K in TKey]?: TValue | undefined;
+} : {
+  [K in TKey]: TValue;
+};
+
+type OverrideToolDeclarationCallbacks<T extends {
+  streamCall?: unknown;
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
+  type?: never;
+} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+interface ParsedFile {
+  oldName?: string | undefined;
+  newName?: string | undefined;
+  lines: ParsedLine[];
+  additions: number;
+  deletions: number;
+}
+
+interface ParsedLine {
+  type: DiffLineType;
+  content: string;
+  oldLineNumber?: number;
+  newLineNumber?: number;
+}
+
+declare const PartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -379,473 +2559,132 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PartMethods = {
+  getState(): PartState;
+  addToolResult(result: unknown | ToolResponse<unknown>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  __internal_getRuntime?(): MessagePartRuntime;
+};
+
+declare namespace PartPrimitiveMessages {
+  type Props = {
+    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
+    children?: never;
+  } | {
+    children: (value: {
+      message: ThreadMessage;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
+
+type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type PressableProps = Omit<ComponentProps<typeof Box>, "children"> & {
+  children: ReactNode | ((state: PressableState) => ReactNode);
+  onPress?: (() => void) | undefined;
+  disabled?: boolean | undefined;
+};
+
+type PressableState = {
+  isFocused: boolean;
+  disabled: boolean;
+};
+
+type PropFieldStatus = "complete" | "streaming";
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
+
+type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
+  type: "provider";
+}>;
+
+declare const QueueItemRemove: (_param45: QueueItemRemoveProps) => import("react").JSX.Element;
+
+type QueueItemRemoveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+declare const QueueItemSteer: (_param46: QueueItemSteerProps) => import("react").JSX.Element;
+
+type QueueItemSteerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const QueueItemText: (_param47: QueueItemTextProps) => import("react").JSX.Element;
+
+type QueueItemTextProps = ComponentProps<typeof Text>;
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
+
+type QuoteMessagePartProps = QuoteInfo;
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
-  accept: string;
-  constructor(adapters: AttachmentAdapter[]);
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(attachment: Attachment): Promise<void>;
-}
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe$1 = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe$1;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe$1;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -880,105 +2719,794 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type VoiceSessionControls = {
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
+type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
+
+type ReasoningGroupProps = PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>;
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type VoiceSessionHelpers = {
-  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
-  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
-  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
-  emitVolume: (volume: number) => void;
-  isDisposed: () => boolean;
+type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
+
+type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-declare function createVoiceSession(options: {
-  abortSignal?: AbortSignal;
-}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ModelContext$1 = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadListOptions = {
+  runtimeHook: () => AssistantRuntime;
+  adapter: RemoteThreadListAdapter;
+  initialThreadId?: string | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  allowNesting?: boolean | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext$1;
-  subscribe?: (callback: () => void) => Unsubscribe$1;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
 };
 
-type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
-  toolName: string;
-  render?: unknown;
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
 };
 
-type AssistantInstructionsConfig = {
-  disabled?: boolean | undefined;
-  instruction: string;
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
-type AssistantContextConfig = {
-  getContext: () => string;
-  disabled?: boolean | undefined;
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
-declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
+  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+}[Keys];
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type ResumeToolCallOptions = {
+  toolCallId: string;
+  payload: unknown;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+declare namespace RuntimeAdapterProvider {
+  type Props = {
+    adapters: RuntimeAdapters;
+    children: ReactNode;
+  };
+}
+
+declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
+
+type RuntimeAdapters = {
+  modelContext?: ModelContextProvider | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  attachments?: AttachmentAdapter | undefined;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+type SnapshotCarrierMessage = {
+  role: string;
+  metadata?: unknown;
+  content?: readonly unknown[] | undefined;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
+
+type SourceMessagePartProps = MessagePartState & SourceMessagePart;
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe$1;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+type StateUpdater<TState> = TState | ((prev: TState) => TState);
+
+type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
+
+declare namespace StatusBarPrimitiveLatency {
+  type Props = StatusBarPrimitiveLatencyProps;
+}
+
+declare const StatusBarPrimitiveLatency: {
+  (_param48: StatusBarPrimitiveLatency.Props): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type StatusBarPrimitiveLatencyProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  format?: (tokensPerSecond: number) => string;
+};
+
+declare namespace StatusBarPrimitiveMessageCount {
+  type Props = StatusBarPrimitiveMessageCountProps;
+}
+
+declare const StatusBarPrimitiveMessageCount: {
+  (_param49: StatusBarPrimitiveMessageCount.Props): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type StatusBarPrimitiveMessageCountProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  format?: (count: number) => string;
+};
+
+declare namespace StatusBarPrimitiveModelName {
+  type Props = StatusBarPrimitiveModelNameProps;
+}
+
+declare const StatusBarPrimitiveModelName: {
+  (_param50: StatusBarPrimitiveModelName.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type StatusBarPrimitiveModelNameProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  name?: ReactNode;
+};
+
+declare namespace StatusBarPrimitiveRoot {
+  type Props = StatusBarPrimitiveRootProps;
+}
+
+declare const StatusBarPrimitiveRoot: {
+  (_param51: StatusBarPrimitiveRoot.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type StatusBarPrimitiveRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+declare namespace StatusBarPrimitiveStatus {
+  type Props = StatusBarPrimitiveStatusProps;
+}
+
+declare const StatusBarPrimitiveStatus: {
+  (_param52: StatusBarPrimitiveStatus.Props): import("react").JSX.Element;
+  displayName: string;
+};
+
+type StatusBarPrimitiveStatusProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  format?: (status: StatusType) => string;
+};
+
+declare namespace StatusBarPrimitiveTokenCount {
+  type Props = StatusBarPrimitiveTokenCountProps;
+}
+
+declare const StatusBarPrimitiveTokenCount: {
+  (_param53: StatusBarPrimitiveTokenCount.Props): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type StatusBarPrimitiveTokenCountProps = Omit<ComponentProps<typeof Text>, "children"> & {
+  format?: (tokens: number) => string;
+};
+
+type StatusType = "cancelled" | "error" | "idle" | "running";
+
+type SubmitFeedbackOptions = {
+  messageId: string;
+  type: "negative" | "positive";
+};
+
+type Subscribable = {
+  subscribe: (callback: () => void) => Unsubscribe$1;
+};
+
+type SubscribableWithState<TState, TPath> = Subscribable & {
+  path: TPath;
+  getState: () => TState;
+};
+
+type SuggestionAdapter = {
+  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion$1[]> | AsyncGenerator<readonly ThreadSuggestion$1[], void>;
+};
+
+type SuggestionAdapterGenerateOptions = {
+  messages: readonly ThreadMessage[];
+};
+
+declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
+
+type SuggestionByIndexProviderProps = PropsWithChildren<{
+  index: number;
+}>;
+
+type SuggestionConfig = string | {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const SuggestionDescription: (_param54: SuggestionDescriptionProps) => import("react").JSX.Element;
+
+type SuggestionDescriptionProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+type SuggestionState = {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const SuggestionTitle: (_param55: SuggestionTitleProps) => import("react").JSX.Element;
+
+type SuggestionTitleProps = ComponentProps<typeof Text> & {
+  children?: ReactNode;
+};
+
+declare const SuggestionTrigger: (_param56: SuggestionTriggerProps) => import("react").JSX.Element;
+
+type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+};
+
+declare const Suggestions: Resource<ClientOutput<"suggestions">, [
+  suggestions?: SuggestionConfig[] | undefined
+]>;
+
+type SuggestionsComponentConfig = {
+  Suggestion: ComponentType;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+declare const TextInput: (_param57: TextInputProps) => import("react").JSX.Element;
+
+type TextInputProps = ComponentProps<typeof Box> & {
+  value: string;
+  onChange: (text: string) => void;
+  onSubmit?: ((text: string) => void) | undefined;
+  submitOnEnter?: boolean | undefined;
+  placeholder?: string | undefined;
+  autoFocus?: boolean | undefined;
+  multiLine?: boolean | undefined;
+};
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
+
+type TextMessagePartProps = MessagePartState & TextMessagePart;
+
+declare const TextMessagePartProvider: FC<PropsWithChildren<{
+  text: string;
+  isRunning?: boolean;
+}>>;
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext$1;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
+  get source(): "thread-composer";
+}
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type ChatModelAdapter = {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntimeCore = ComposerRuntimeCore;
+
+type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "thread";
+}>;
+
+declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  get path(): ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  get type(): "thread";
+  private _getState;
+  constructor(core: ThreadComposerRuntimeCoreBinding);
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
+}
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
 };
+
+declare const ThreadEmpty: (_param58: ThreadEmptyProps) => import("react").JSX.Element | null;
+
+type ThreadEmptyProps = {
+  children: ReactNode;
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+declare const ThreadIf: (_param59: ThreadIfProps) => import("react").JSX.Element | null;
+
+type ThreadIfProps = {
+  children: ReactNode;
+  empty?: boolean | undefined;
+  running?: boolean | undefined;
+};
+
+declare const ThreadListItemArchive: (_param60: ThreadListItemArchiveProps) => import("react").JSX.Element;
+
+type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+  archived: boolean;
+}>>;
+
+type ThreadListItemCoreState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+  readonly runtime?: ThreadRuntimeCore | undefined;
+};
+
+declare const ThreadListItemDelete: (_param61: ThreadListItemDeleteProps) => import("react").JSX.Element;
+
+type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+declare namespace ThreadListItemPrimitiveTitle {
+  type Props = {
+    fallback?: ReactNode;
+  };
+}
+
+declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
+
+declare const ThreadListItemRoot: (_param62: ThreadListItemRootProps) => import("react").JSX.Element;
+
+type ThreadListItemRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState$1;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  private _core;
+  private _threadListBinding;
+  get path(): ThreadListItemRuntimePath;
+  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  getState(): ThreadListItemState$1;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  detach(): void;
+  __internal_getRuntime(): ThreadListItemRuntime;
+}
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
+  runtime: ThreadListItemRuntime;
+}>>;
+
+type ThreadListItemState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemState$1 = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+declare const ThreadListItemTrigger: (_param63: ThreadListItemTriggerProps) => import("react").JSX.Element;
+
+type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItemUnarchive: (_param64: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
+
+type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItems: (_param65: ThreadListItemsProps) => import("react").JSX.Element;
+
+type ThreadListItemsProps = {
+  renderItem: (props: {
+    threadId: string;
+    index: number;
+  }) => ReactElement;
+};
+
+declare const ThreadListNew: (_param66: ThreadListNewProps) => import("react").JSX.Element;
+
+type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListRoot: (_param67: ThreadListRootProps) => import("react").JSX.Element;
+
+type ThreadListRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
+};
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListRuntimeCore = {
+  readonly isLoading: boolean;
+  readonly isLoadingMore?: boolean;
+  readonly hasMore?: boolean;
+  mainThreadId: string;
+  newThreadId: string | undefined;
+  threadIds: readonly string[];
+  archivedThreadIds: readonly string[];
+  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
+  getMainThreadRuntimeCore(): ThreadRuntimeCore;
+  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  getItemById(threadId: string): ThreadListItemCoreState | undefined;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
+  loadMore?(): Promise<void>;
+  detach(threadId: string): Promise<void>;
+  rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(threadId: string): Promise<void>;
+  unarchive(threadId: string): Promise<void>;
+  delete(threadId: string): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(threadId: string): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
+
+declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _core;
+  private _runtimeFactory;
+  private _getState;
+  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
+  protected __internal_bindMethods(): void;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _mainThreadListItemRuntime;
+  readonly main: ThreadRuntime;
+  get mainItem(): ThreadListItemRuntimeImpl;
+  getById(threadId: string): ThreadRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getItemById(threadId: string): ThreadListItemRuntimeImpl;
+}
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -1028,214 +3556,105 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
+declare const ThreadMessages: FC<ThreadMessagesProps>;
 
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
+type ThreadMessagesProps = ({
+  components: MessageComponents;
+  children?: never;
+} & WindowingProps) | ({
+  children: (value: {
     message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
+  }) => ReactNode;
+  components?: never;
+} & WindowingProps);
 
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
-  get headId(): string | null;
-  get canonicalHeadId(): string | null;
-  getMessages(headId?: string): readonly ThreadMessage[];
-  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
-  getMessage(messageId: string): {
-    parentId: string | null;
-    message: ThreadMessage;
+declare namespace ThreadPrimitiveMessageByIndex {
+  type Props = {
     index: number;
+    components: MessagesComponentConfig;
   };
-  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
-  getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
-  switchToBranch(messageId: string): void;
-  resetHead(messageId: string | null): void;
-  clear(): void;
-  export(): ExportedMessageRepository;
-  import(_param0: ExportedMessageRepository): void;
 }
 
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
+declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
+
+declare namespace ThreadPrimitiveMessages {
+  type Props = {
+    components: MessagesComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      message: MessageState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
+
+declare namespace ThreadPrimitiveSuggestionByIndex {
+  type Props = {
+    index: number;
+    components: SuggestionsComponentConfig;
+  };
+}
+
+declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
+
+declare namespace ThreadPrimitiveSuggestions {
+  type Props = {
+    components: SuggestionsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      suggestion: SuggestionState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
+
+declare namespace ThreadPrimitiveUnstable_MessageById {
+  type Props = {
+    messageId: string;
+    components: MessagesComponentConfig;
+  };
+}
+
+declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
+
+declare const ThreadRoot: (_param68: ThreadRootProps) => import("react").JSX.Element;
+
+type ThreadRootProps = ComponentProps<typeof Box> & {
+  children: ReactNode;
 };
 
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type ComposerRuntimeCore = Readonly<{
-  isEditing: boolean;
-  canCancel: boolean;
-  canSend: boolean;
-  isEmpty: boolean;
-  attachments: readonly Attachment[];
-  attachmentAccept: string;
-  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
-  removeAttachment: (attachmentId: string) => Promise<void>;
-  text: string;
-  setText: (value: string) => void;
-  role: MessageRole;
-  setRole: (role: MessageRole) => void;
-  runConfig: RunConfig;
-  setRunConfig: (runConfig: RunConfig) => void;
-  quote: QuoteInfo | undefined;
-  setQuote: (quote: QuoteInfo | undefined) => void;
-  reset: () => Promise<void>;
-  clearAttachments: () => Promise<void>;
-  send: (options?: SendOptions) => void;
-  cancel: () => void;
-  queue: readonly QueueItemState[];
-  steerQueueItem: (queueItemId: string) => void;
-  removeQueueItem: (queueItemId: string) => void;
-  dictation: DictationState | undefined;
-  startDictation: () => void;
-  stopDictation: () => void;
-  subscribe: (callback: () => void) => Unsubscribe$1;
-  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
-}>;
-
-type ThreadComposerRuntimeCore = ComposerRuntimeCore;
-
-type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
-  parentId: string | null;
-  sourceId: string | null;
-}>;
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type ResumeToolCallOptions = {
-  toolCallId: string;
-  payload: unknown;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type SubmitFeedbackOptions = {
-  messageId: string;
-  type: "negative" | "positive";
-};
-
-type ThreadSuggestion$1 = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState$1;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  cancelRun(): void;
+  getModelContext(): ModelContext$1;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 };
 
 type ThreadRuntimeCore = Readonly<{
@@ -1290,651 +3709,20 @@ type ThreadRuntimeCore = Readonly<{
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }>;
 
-type SuggestionAdapterGenerateOptions = {
-  messages: readonly ThreadMessage[];
-};
-
-type SuggestionAdapter = {
-  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion$1[]> | AsyncGenerator<readonly ThreadSuggestion$1[], void>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
-
-type Unstable_InteractableSnapshotEntry = {
-  id: string;
-  name: string;
-  state: unknown;
-  partial?: boolean | undefined;
-};
-
-type SnapshotCarrierMessage = {
-  role: string;
-  metadata?: unknown;
-  content?: readonly unknown[] | undefined;
-};
-
-declare function unstable_getInteractableSnapshots(message: {
-  metadata?: unknown;
-}): Unstable_InteractableSnapshotEntry[] | undefined;
-
-declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
-
-type Unstable_InteractableVersion = {
-  state: unknown;
-  origin: "create" | "update" | "user-edit";
-  toolCallId?: string | undefined;
-};
-
-declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
-
-interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
-  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryInstructionHandle {
-  update(config: string | AssistantInstructionsConfig): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryProviderHandle {
-  remove(): void;
-}
-
-declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
-  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
-  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
-  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
-}
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemCoreState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-  readonly runtime?: ThreadRuntimeCore | undefined;
-};
-
-type ThreadListRuntimeCore = {
-  readonly isLoading: boolean;
-  readonly isLoadingMore?: boolean;
-  readonly hasMore?: boolean;
-  mainThreadId: string;
-  newThreadId: string | undefined;
-  threadIds: readonly string[];
-  archivedThreadIds: readonly string[];
-  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
-  getMainThreadRuntimeCore(): ThreadRuntimeCore;
-  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
-  getItemById(threadId: string): ThreadListItemCoreState | undefined;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload?(): Promise<void>;
-  loadMore?(): Promise<void>;
-  detach(threadId: string): Promise<void>;
-  rename(threadId: string, newTitle: string): Promise<void>;
-  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(threadId: string): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-type AssistantRuntimeCore = {
-  readonly threads: ThreadListRuntimeCore;
-  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
-  getModelContextProvider: () => ModelContextProvider;
-  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
-};
-
-declare const generateId: (size?: number) => string;
-
-type Subscribable = {
-  subscribe: (callback: () => void) => Unsubscribe$1;
-};
-
-type SubscribableWithState<TState, TPath> = Subscribable & {
-  path: TPath;
-  getState: () => TState;
-};
-
-declare class BaseSubscribable {
-  private _subscribers;
-  subscribe(callback: () => void): Unsubscribe$1;
-  waitForUpdate(): Promise<void>;
-  protected _notifySubscribers(): void;
-}
-
-type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
-
-type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "thread";
-}>;
-
-type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "edit";
-}>;
-
-type MessageStateBinding = SubscribableWithState<ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-}, MessageRuntimePath>;
-
-type ThreadListItemState$1 = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
-  source: Source;
-}, AttachmentRuntimePath & {
-  attachmentSource: Source;
-}>;
-
-type AttachmentRuntimeSource = AttachmentState$1["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState$1 & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
-  get path(): AttachmentRuntimePath & {
-    attachmentSource: Source;
-  };
-  abstract get source(): Source;
-  constructor(_core: AttachmentSnapshotBinding<Source>);
-  protected __internal_bindMethods(): void;
-  getState(): AttachmentState$1 & {
-    source: Source;
-  };
-  abstract remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-}
-
-declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
-  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
-  remove(): Promise<void>;
-}
-
-declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
-  get source(): "thread-composer";
-}
-
-declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
-  get source(): "edit-composer";
-}
-
-declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
-  get source(): "message";
-  remove(): never;
-}
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState$1 = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState$1;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
-};
-
-declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
-  get path(): ComposerRuntimePath;
-  abstract get type(): "edit" | "thread";
-  constructor(_core: ComposerRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  abstract getState(): ComposerState$1;
-  setText(text: string): void;
-  setRunConfig(runConfig: RunConfig): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  setRole(role: MessageRole): void;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
-  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
-}
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
-  get path(): ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  get type(): "thread";
-  private _getState;
-  constructor(core: ThreadComposerRuntimeCoreBinding);
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
-}
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
-  get path(): ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  get type(): "edit";
-  private _getState;
-  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
-  __internal_bindMethods(): void;
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
-}
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
-  get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
-  protected __internal_bindMethods(): void;
-  getState(): MessagePartState;
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-}
-
-type MessageState$1 = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState$1;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param1: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param2: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-declare class MessageRuntimeImpl implements MessageRuntime {
-  private _core;
-  private _threadBinding;
-  get path(): MessageRuntimePath;
-  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
-  getState(): ThreadMessage & {
-    readonly parentId: string | null;
-    readonly index: number;
-    readonly isLast: boolean;
-    readonly branchNumber: number;
-    readonly branchCount: number;
-    readonly speech: SpeechState | undefined;
-  };
-  delete(): void | Promise<void>;
-  reload(reloadConfig?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param3: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param4: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
-  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
-}
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
 type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadRuntimePath> & {
   outerSubscribe(callback: () => void): Unsubscribe$1;
 };
 
-type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
-type ThreadState$1 = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState$1;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion$1[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
 };
 
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState$1;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  cancelRun(): void;
-  getModelContext(): ModelContext$1;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-};
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
   get path(): ThreadRuntimePath;
@@ -2056,1724 +3844,58 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
-};
-
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
-
-type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
-
-declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _core;
-  private _runtimeFactory;
-  private _getState;
-  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
-  protected __internal_bindMethods(): void;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
-  readonly main: ThreadRuntime;
-  get mainItem(): ThreadListItemRuntimeImpl;
-  getById(threadId: string): ThreadRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getItemById(threadId: string): ThreadListItemRuntimeImpl;
-}
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState$1;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
-
-declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
-  private _core;
-  private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
-  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  getState(): ThreadListItemState$1;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  detach(): void;
-  __internal_getRuntime(): ThreadListItemRuntime;
-}
-
-type LocalRuntimeOptionsBase = {
-  maxSteps?: number | undefined;
-  adapters: {
-    chatModel: ChatModelAdapter;
-    history?: ThreadHistoryAdapter | undefined;
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    suggestion?: SuggestionAdapter | undefined;
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
   };
-  unstable_humanToolNames?: string[] | undefined;
-  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-};
-
-declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
-  readonly threads: ThreadListRuntimeImpl;
-  readonly _thread: ThreadRuntime;
-  constructor(_core: AssistantRuntimeCore);
-  protected __internal_bindMethods(): void;
-  get thread(): ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-}
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type RemoteThreadListOptions = {
-  runtimeHook: () => AssistantRuntime;
-  adapter: RemoteThreadListAdapter;
-  initialThreadId?: string | undefined;
-  threadId?: string | undefined;
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  allowNesting?: boolean | undefined;
-};
-
-declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
-  list(): Promise<RemoteThreadListResponse>;
-  rename(): Promise<void>;
-  updateCustom(): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(): Promise<AssistantStream>;
-  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
-}
-
-declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
-  getModelContext(): ModelContext$1;
-  registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
-  notifySubscribers(): void;
-  subscribe(callback: () => void): () => void;
-}
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
-
-type Unsubscribe = () => void;
-
-type AssistantState = {
-  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
-    getState: () => infer S;
-  } ? S : never;
-};
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-declare namespace AuiIf {
-  type Props = PropsWithChildren<{
-    condition: AuiIf.Condition;
-  }>;
-  type Condition = (state: AssistantState) => boolean;
-}
-
-declare const AuiIf: FC<AuiIf.Props>;
-
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-declare namespace useAui {
-  type Props = {
-    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
-  };
-}
-
-declare function useAui(): AssistantClient;
-
-declare function useAui(clients: useAui.Props): AssistantClient;
-
-declare function useAui(clients: useAui.Props, config: {
-  parent: null | AssistantClient;
-}): AssistantClient;
-
-declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
-
-declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
-
-declare const AuiProvider: (_param5: {
-  value: AssistantClient;
-  children: React.ReactNode;
-}) => React.ReactElement;
-
-declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
-  protected readonly _contextProvider: CompositeContextProvider;
-  abstract get threads(): ThreadListRuntimeCore;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-  getModelContextProvider(): ModelContextProvider;
-}
-
-declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
-  readonly isEditing = true;
-  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected abstract getDictationAdapter(): DictationAdapter | undefined;
-  protected enrichWithComposerMetadata<T extends {
-    metadata?: {
-      custom?: Record<string, unknown>;
-    };
-  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
-  get attachmentAccept(): string;
-  private _attachments;
-  get attachments(): readonly Attachment[];
-  protected setAttachments(value: readonly Attachment[]): void;
-  abstract get canCancel(): boolean;
-  abstract get canSend(): boolean;
-  get isEmpty(): boolean;
-  private _text;
-  get text(): string;
-  private _role;
-  get role(): "assistant" | "system" | "user";
-  private _runConfig;
-  get runConfig(): RunConfig;
-  private _quote;
-  get quote(): QuoteInfo | undefined;
-  setQuote(quote: QuoteInfo | undefined): void;
-  setText(value: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): Promise<void>;
-  cancel(): void;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(_queueItemId: string): void;
-  removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
-  protected abstract handleCancel(): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
-  removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
-  get dictation(): DictationState | undefined;
-  private _isActiveSession;
-  startDictation(): void;
-  stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
-  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
-}
-
-declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
-  private _canCancel;
-  get canCancel(): boolean;
-  get canSend(): boolean;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected getDictationAdapter(): DictationAdapter | undefined;
-  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
-    adapters?: {
-      attachments?: AttachmentAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-    } | undefined;
-  });
-  connect(): Unsubscribe$1;
-  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
-  handleCancel(): Promise<void>;
-}
-
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
-
-declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, getAutoStatus };
-}
-
-type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type PartMethods = {
-  getState(): PartState;
-  addToolResult(result: unknown | ToolResponse<unknown>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  __internal_getRuntime?(): MessagePartRuntime;
-};
-
-declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param6: {
-  runtime: AssistantRuntime;
-  aui?: AssistantClient | null;
-  children: ReactNode;
-}) => import("react").JSX.Element>;
-
-type TitleGenerationAdapter = {
-  generateTitle(messages: readonly ThreadMessage[]): Promise<string>;
-};
-
-declare const createSimpleTitleAdapter: () => TitleGenerationAdapter;
-
-declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
-]>;
-
-type EmptyMessagePartProps = {
-  status: MessagePartStatus;
-};
-
-type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
-
-type TextMessagePartProps = MessagePartState & TextMessagePart;
-
-type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
-
-type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
-
-type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
-
-type ReasoningGroupProps = PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>;
-
-type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
-
-type SourceMessagePartProps = MessagePartState & SourceMessagePart;
-
-type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
-
-type ImageMessagePartProps = MessagePartState & ImageMessagePart;
-
-type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
-
-type FileMessagePartProps = MessagePartState & FileMessagePart;
-
-type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
-
-type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
-
-type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
-
-type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
-
-type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
-
-type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
-  addResult: (result: TResult | ToolResponse<TResult>) => void;
-  resume: (payload: unknown) => void;
-  respondToApproval: (response: ToolApprovalResponse) => void;
-};
-
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
-
-type QuoteMessagePartProps = QuoteInfo;
-
-type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
-
-type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
-
-type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type InteractableScope = "app" | "thread";
-
-type Unstable_InteractableDefinition = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  state: unknown;
-  initialState: unknown;
-  scope?: InteractableScope | undefined;
-};
-
-type Unstable_InteractableRegistration = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  initialState: unknown;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-type Unstable_InteractablePersistenceStatus = {
-  isPending: boolean;
-  error: unknown;
-};
-
-type Unstable_InteractablesState = {
-  definitions: Record<string, Unstable_InteractableDefinition>;
-  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
-};
-
-type Unstable_InteractablePersistedState = Record<string, {
-  name: string;
-  state: unknown;
-}>;
-
-type Unstable_InteractablePersistenceAdapter = {
-  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
-  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
-};
-
-type Unstable_InteractablesConfig = {
-  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
-};
-
-type Unstable_InteractablesMethods = {
-  getState(): Unstable_InteractablesState;
-  register(def: Unstable_InteractableRegistration): Unsubscribe$1;
-  setState(id: string, updater: (prev: unknown) => unknown): void;
-  exportState(): Unstable_InteractablePersistedState;
-  importState(saved: Unstable_InteractablePersistedState): void;
-  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
-  flush(): Promise<void>;
-};
-
-type Unstable_InteractablesClientSchema = {
-  methods: Unstable_InteractablesMethods;
-};
-
-declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
-  (Unstable_InteractablesConfig | undefined)?
-]>;
-
-type McpAppResourceOutput = {
-  readonly render: ToolCallMessagePartComponent;
-};
-
-type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
-  type: "frontend" | "human";
-} ? T & (T extends {
-  type: "frontend";
-} ? {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-} | {
-  render?: ToolCallMessagePartComponent<TArgs, TResult>;
-  renderText: ToolCallText<TArgs, TResult>;
-} : {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-}) : T & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
-
-type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
-
-type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
-
-type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
-
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
-
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
-
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
-
-type Toolkit = Record<string, ToolDefinition<any, any>>;
-
-type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
-  [K in TKey]?: undefined;
-} : {
-  [K in TKey]?: TValue | undefined;
-} : {
-  [K in TKey]: TValue;
-};
-
-type OverrideToolDeclarationCallbacks<T extends {
-  streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
-  type?: never;
-} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
-
-type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
-  streamCall?: unknown;
-} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
-
-type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
-
-type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: NonNullable<ToolParameters<TArgs>>;
-};
-
-type ToolkitDefinition<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-} = Record<string, any>, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}> = {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
-};
-
-declare const Tools: Resource<ClientOutput<"tools">, [
-  {
-    toolkit?: Toolkit;
-    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
-  }
-]>;
-
-type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
-
-type AssistantTool = FC & {
-  unstable_tool: AssistantToolProps<any, any>;
-};
-
-declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
-
-type AssistantToolUIProps<TArgs, TResult> = {
-  toolName: string;
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "inline" | "standalone";
-};
-
-declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
-
-type AssistantToolUI = FC & {
-  unstable_tool: AssistantToolUIProps<any, any>;
-};
-
-declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
-
-type AssistantDataUIProps<T = any> = {
-  name: string;
-  render: DataMessagePartComponent<T>;
-};
-
-declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
-
-type AssistantDataUI = FC & {
-  unstable_data: AssistantDataUIProps;
-};
-
-declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
-
-declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
-
-declare const useAssistantContext: (config: AssistantContextConfig) => void;
-
-declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
-
-declare function defineToolkit$1<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-}, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}>(_definition: {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-}): Toolkit & {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-};
-
-declare function defineToolkit$1<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
-
-type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
-
-type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
-
-declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
-
-type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
-  type: "provider";
-}>;
-
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
-
-type McpToolkitEntry = McpServerConfig | {
-  server: McpServerConfig;
-  disabled?: boolean | undefined;
-  tools?: Record<string, McpToolkitToolConfig> | undefined;
-};
-
-type McpToolkitToolConfig = {
-  disabled?: boolean | undefined;
-};
-
-type McpToolkitDefinition = Record<string, McpToolkitEntry>;
-
-declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
-
-type InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type AssistantInteractableProps = {
-  description: string;
-  stateSchema: InteractableStateSchema;
-  initialState: unknown;
-  id?: string;
-  selected?: boolean;
-};
-
-declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
-
-type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
-
-declare const useInteractableState: <TState>(id: string, fallback: TState) => [
-  TState,
-  {
-    setState: (updater: StateUpdater$1<TState>) => void;
-    setSelected: (selected: boolean) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type Unstable_InferInteractableState<TSchema> = TSchema extends {
-  "~standard": {
-    types?: {
-      output: infer TOutput;
-    } | undefined;
-  };
-} ? TOutput : unknown;
-
-type Unstable_InteractableVersionInfo<TState> = {
-  state: TState;
-  isLatest: boolean;
-  restore: () => void;
-};
-
-type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  initialState: Unstable_InferInteractableState<TSchema>;
-  id?: string | undefined;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
-  Unstable_InferInteractableState<TSchema>,
-  {
-    id: string;
-    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
-    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type StateUpdater<TState> = TState | ((prev: TState) => TState);
-
-declare const unstable_useInteractableState: <TState>(id: string) => [
-  TState | undefined,
-  {
-    setState: (updater: StateUpdater<TState>) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
-  state: TState;
-  restore: () => void;
-})[];
-
-type Unstable_InteractableToolRenderProps<TState> = {
-  state: TState;
-  setState: (updater: TState | ((prev: TState) => TState)) => void;
-  version: Unstable_InteractableVersionInfo<TState> | undefined;
-  id: string;
-  streaming: boolean;
-};
-
-type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
-};
-
-declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
-  success: true;
-}>;
-
-type PropFieldStatus = "complete" | "streaming";
-
-type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "complete" | "incomplete" | "requires-action" | "running";
-  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
-};
-
-declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
-
-declare const Interactables: Resource<ClientOutput<"interactables">, [
-]>;
-
-declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
-  runtime: ThreadListItemRuntime;
-}>>;
-
-declare const MessageByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const PartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const TextMessagePartProvider: FC<PropsWithChildren<{
-  text: string;
-  isRunning?: boolean;
-}>>;
-
-declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>>;
-
-declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-  archived: boolean;
-}>>;
-
-declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-type SuggestionByIndexProviderProps = PropsWithChildren<{
-  index: number;
-}>;
-
-declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
-
-type RuntimeAdapters = {
-  modelContext?: ModelContextProvider | undefined;
-  history?: ThreadHistoryAdapter | undefined;
-  attachments?: AttachmentAdapter | undefined;
-};
-
-declare namespace RuntimeAdapterProvider {
-  type Props = {
-    adapters: RuntimeAdapters;
-    children: ReactNode;
-  };
-}
-
-declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
-
-declare const useRuntimeAdapters: () => RuntimeAdapters | null;
-
-declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
-
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type AttachmentState = Attachment;
-
-type ComposerState = {
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly isEditing: boolean;
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly attachmentAccept: string;
+type ThreadState = {
   readonly isEmpty: boolean;
-  readonly type: "edit" | "thread";
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly MessageState[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion$1[];
+  readonly extras: unknown;
   readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
   readonly composer: ComposerState;
-  readonly parts: readonly PartState[];
-  readonly isCopied: boolean;
-  readonly isHovering: boolean;
-  readonly index: number;
 };
 
-type MessagesComponentConfig = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
+type ThreadState$1 = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState$1;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion$1[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-declare namespace ThreadPrimitiveMessages {
-  type Props = {
-    components: MessagesComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      message: MessageState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ThreadPrimitiveMessageByIndex {
-  type Props = {
-    index: number;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
-
-declare namespace ThreadPrimitiveUnstable_MessageById {
-  type Props = {
-    messageId: string;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
-
-declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
-
-declare namespace MessagePrimitiveParts$1 {
-  type DataConfig = {
-    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
-    Fallback?: DataMessagePartComponent | undefined;
-  };
-  type BaseComponents = {
-    Empty?: EmptyMessagePartComponent | undefined;
-    Text?: TextMessagePartComponent | undefined;
-    Source?: SourceMessagePartComponent | undefined;
-    Image?: ImageMessagePartComponent | undefined;
-    File?: FileMessagePartComponent | undefined;
-    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
-    data?: DataConfig | undefined;
-    Quote?: QuoteMessagePartComponent | undefined;
-    generativeUI?: {
-      components: GenerativeUIComponentRegistry;
-      Fallback?: ComponentType<{
-        component: string;
-        props?: unknown;
-      }> | undefined;
-    } | undefined;
-  };
-  type ToolsConfig = {
-    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
-    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
-  } | {
-    Override: ComponentType<ToolCallMessagePartProps>;
-  };
-  type StandardComponents = BaseComponents & {
-    Reasoning?: ReasoningMessagePartComponent | undefined;
-    tools?: ToolsConfig | undefined;
-    ToolGroup?: ComponentType<PropsWithChildren<{
-      startIndex: number;
-      endIndex: number;
-    }>>;
-    ReasoningGroup?: ReasoningGroupComponent;
-    ChainOfThought?: never;
-  };
-  type ChainOfThoughtComponents = BaseComponents & {
-    ChainOfThought: ComponentType;
-    Reasoning?: never;
-    tools?: never;
-    ToolGroup?: never;
-    ReasoningGroup?: never;
-  };
-  export type Props = {
-    components?: StandardComponents | ChainOfThoughtComponents | undefined;
-    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
-    children?: never;
-  } | {
-    children: (value: {
-      part: EnrichedPartState;
-    }) => ReactNode;
-    components?: never;
-    unstable_showEmptyOnNonTextEnd?: never;
-  };
-  export {};
-}
-
-declare namespace MessagePrimitivePartByIndex {
-  type Props = {
-    index: number;
-    components: MessagePrimitiveParts$1.Props["components"];
-  };
-}
-
-declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
-
-type EnrichedPartState = (Extract<PartState, {
-  type: "tool-call";
-}> & {
-  readonly toolUI: ReactNode;
-  addResult: ToolCallMessagePartProps["addResult"];
-  resume: ToolCallMessagePartProps["resume"];
-  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
-}) | (Extract<PartState, {
-  type: "data";
-}> & {
-  readonly dataRendererUI: ReactNode;
-}) | Exclude<PartState, {
-  type: "tool-call";
-} | {
-  type: "data";
-}>;
-
-declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
-
-type MessageAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-declare namespace MessagePrimitiveAttachments {
-  type Props = {
-    components: MessageAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: CompleteAttachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
+declare const ThreadSuggestion: (_param69: ThreadSuggestionProps) => import("react").JSX.Element;
 
-declare namespace MessagePrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: MessageAttachmentsComponentConfig;
-  };
-}
-
-declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
-
-type ComposerAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace ComposerPrimitiveAttachments {
-  type Props = {
-    components: ComposerAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: Attachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ComposerPrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: ComposerAttachmentsComponentConfig;
-  };
-}
-
-declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
-
-declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
-
-declare namespace ComposerPrimitiveQueue {
-  type Props = {
-    children: (value: {
-      queueItem: QueueItemState;
-    }) => ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
-  children: (value: {
-    queueItem: QueueItemState;
-  }) => ReactNode;
-}>;
-
-type ThreadListItemState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ChainOfThoughtPartsComponentConfig = {
-  Reasoning?: ReasoningMessagePartComponent | undefined;
-  tools?: {
-    Fallback?: ToolCallMessagePartComponent | undefined;
-  };
-  Layout?: ComponentType<PropsWithChildren> | undefined;
-};
-
-declare namespace ChainOfThoughtPrimitiveParts {
-  type Props = {
-    components?: ChainOfThoughtPartsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      part: PartState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
-
-declare namespace PartPrimitiveMessages {
-  type Props = {
-    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
-    children?: never;
-  } | {
-    children: (value: {
-      message: ThreadMessage;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
-
-declare namespace MessagePartPrimitiveInProgress {
-  type Props = PropsWithChildren;
-}
-
-declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
-
-declare namespace ThreadListItemPrimitiveTitle {
-  type Props = {
-    fallback?: ReactNode;
-  };
-}
-
-declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
-
-type SuggestionState = {
-  title: string;
-  label: string;
+type ThreadSuggestion$1 = {
   prompt: string;
-};
-
-type SuggestionsComponentConfig = {
-  Suggestion: ComponentType;
-};
-
-declare namespace ThreadPrimitiveSuggestions {
-  type Props = {
-    components: SuggestionsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      suggestion: SuggestionState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ThreadPrimitiveSuggestionByIndex {
-  type Props = {
-    index: number;
-    components: SuggestionsComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
-
-declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
-
-type ComposerIfFilters = {
-  editing: boolean | undefined;
-  dictation: boolean | undefined;
-};
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
-  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-}[Keys];
-
-type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
-
-declare namespace ComposerPrimitiveIf {
-  type Props = PropsWithChildren<UseComposerIfProps>;
-}
-
-declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
-
-declare const unstable_useThreadMessageIds: () => readonly string[];
-
-type UseActionBarCopyOptions = {
-  copiedDuration?: number | undefined;
-  copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
-};
-
-declare const useVoiceState: () => VoiceSessionState | undefined;
-
-declare const useVoiceVolume: () => number;
-
-declare const useVoiceControls: () => {
-  connect: () => void;
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
-};
-
-type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  cloud?: AssistantCloud | undefined;
-  initialMessages?: readonly ThreadMessageLike[] | undefined;
-  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
-};
-
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param7?: LocalRuntimeOptions) => AssistantRuntime;
-
-type CreateFileStorageAdapterOptions = {
-  dir: string;
-  prefix?: string | undefined;
-  titleGenerator?: TitleGenerationAdapter | undefined;
-};
-
-declare const createFileStorageAdapter: (options: CreateFileStorageAdapterOptions) => RemoteThreadListAdapter;
-
-type OSCVariant = "osc777" | "osc9" | "osc99";
-
-declare const ringBell: () => void;
-
-declare const sendOSCNotification: (title: string, body?: string, variant?: OSCVariant) => void;
-
-type IncompleteReason = Extract<MessageStatus, {
-  type: "incomplete";
-}>["reason"];
-
-type NotificationEvent = {
-  type: "task-complete";
-  threadId: string;
-  messageId: string;
-  title: string;
-} | {
-  type: "task-incomplete";
-  threadId: string;
-  messageId: string;
-  title: string;
-  reason: IncompleteReason;
-} | {
-  type: "needs-input";
-  threadId: string;
-  messageId: string;
-  title: string;
-  reason: "interrupt";
-};
-
-type NotificationHandler<T extends NotificationEvent["type"] = NotificationEvent["type"]> = {
-  bell?: boolean;
-  osc?: boolean | OSCVariant;
-  custom?: (event: Extract<NotificationEvent, {
-    type: T;
-  }>) => void;
-};
-
-type NotificationConfig = {
-  enabled?: boolean;
-  onTaskComplete?: NotificationHandler<"task-complete"> | false;
-  onTaskIncomplete?: NotificationHandler<"task-incomplete"> | false;
-  onNeedsInput?: NotificationHandler<"needs-input"> | false;
-};
-
-declare const useNotification: (config?: NotificationConfig) => void;
-
-type ThreadRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const ThreadRoot: (_param8: ThreadRootProps) => import("react").JSX.Element;
-
-type MessageComponents = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
-};
-
-type WindowingProps = {
-  windowSize?: number | undefined;
-  windowOverscan?: number | undefined;
-};
-
-type ThreadMessagesProps = ({
-  components: MessageComponents;
-  children?: never;
-} & WindowingProps) | ({
-  children: (value: {
-    message: ThreadMessage;
-  }) => ReactNode;
-  components?: never;
-} & WindowingProps);
-
-declare const ThreadMessages: FC<ThreadMessagesProps>;
-
-type ThreadEmptyProps = {
-  children: ReactNode;
-};
-
-declare const ThreadEmpty: (_param9: ThreadEmptyProps) => import("react").JSX.Element | null;
-
-type ThreadIfProps = {
-  children: ReactNode;
-  empty?: boolean | undefined;
-  running?: boolean | undefined;
-};
-
-declare const ThreadIf: (_param10: ThreadIfProps) => import("react").JSX.Element | null;
-
-type PressableState = {
-  isFocused: boolean;
-  disabled: boolean;
-};
-
-type PressableProps = Omit<ComponentProps<typeof Box>, "children"> & {
-  children: ReactNode | ((state: PressableState) => ReactNode);
-  onPress?: (() => void) | undefined;
-  disabled?: boolean | undefined;
 };
 
 type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
@@ -3783,367 +3905,201 @@ type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
   clearComposer?: boolean | undefined;
 };
 
-declare const ThreadSuggestion: (_param11: ThreadSuggestionProps) => import("react").JSX.Element;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
 
-declare namespace thread_d_exports {
-  export { ThreadEmpty as Empty, ThreadEmptyProps as EmptyProps, ThreadIf as If, ThreadIfProps as IfProps, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadMessages as Messages, ThreadMessagesProps as MessagesProps, ThreadRoot as Root, ThreadRootProps as RootProps, ThreadSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadSuggestionProps as SuggestionProps, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById };
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type ThreadsState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | null;
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly threadItems: readonly ThreadListItemState[];
+  readonly main: ThreadState;
+};
+
+type TitleGenerationAdapter = {
+  generateTitle(messages: readonly ThreadMessage[]): Promise<string>;
+};
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
+  status: "complete" | "incomplete" | "requires-action" | "running";
+  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
 }
 
-type ComposerRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-declare const ComposerRoot: (_param12: ComposerRootProps) => import("react").JSX.Element;
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
 
-declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
-
-declare const ComposerAttachments: import("react").FC<ComposerPrimitiveAttachments.Props>;
-
-type ComposerInputProps = ComponentProps<typeof Box> & {
-  submitOnEnter?: boolean | undefined;
-  placeholder?: string | undefined;
-  autoFocus?: boolean | undefined;
-  multiLine?: boolean | undefined;
-  onSubmit?: ((text: string) => void) | undefined;
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
 
-declare const ComposerInput: (_param13: ComposerInputProps) => import("react").JSX.Element;
-
-type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
+type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
+  addResult: (result: TResult | ToolResponse<TResult>) => void;
+  resume: (payload: unknown) => void;
+  respondToApproval: (response: ToolApprovalResponse) => void;
 };
 
-declare const ComposerSend: (_param14: ComposerSendProps) => import("react").JSX.Element;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerCancel: (_param15: ComposerCancelProps) => import("react").JSX.Element;
-
-type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerAddAttachment: (_param16: ComposerAddAttachmentProps) => import("react").JSX.Element;
-
-type ComposerQuoteProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const ComposerQuote: (_param17: ComposerQuoteProps) => import("react").JSX.Element | null;
-
-type ComposerQuoteTextProps = ComponentProps<typeof Text> & {
-  children?: ReactNode;
-};
-
-declare const ComposerQuoteText: (_param18: ComposerQuoteTextProps) => import("react").JSX.Element | null;
-
-type ComposerQuoteDismissProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerQuoteDismiss: (_param19: ComposerQuoteDismissProps) => import("react").JSX.Element;
-
-declare namespace composer_d_exports {
-  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerPrimitiveQueue as Queue, ComposerQuote as Quote, ComposerQuoteDismiss as QuoteDismiss, ComposerQuoteDismissProps as QuoteDismissProps, ComposerQuoteProps as QuoteProps, ComposerQuoteText as QuoteText, ComposerQuoteTextProps as QuoteTextProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
 }
 
-type QueueItemTextProps = ComponentProps<typeof Text>;
-
-declare const QueueItemText: (_param20: QueueItemTextProps) => import("react").JSX.Element;
-
-type QueueItemRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const QueueItemRemove: (_param21: QueueItemRemoveProps) => import("react").JSX.Element;
-
-type QueueItemSteerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const QueueItemSteer: (_param22: QueueItemSteerProps) => import("react").JSX.Element;
-
-declare namespace queueItem_d_exports {
-  export { QueueItemRemove as Remove, QueueItemRemoveProps as RemoveProps, QueueItemSteer as Steer, QueueItemSteerProps as SteerProps, QueueItemText as Text, QueueItemTextProps as TextProps };
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
 }
 
-type MessageRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const MessageRoot: (_param23: MessageRootProps) => import("react").JSX.Element;
-
-type MessageContentPart = ThreadUserMessagePart | ThreadAssistantMessagePart;
-
-type MessageContentProps = {
-  renderText?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "text";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderToolCall?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "tool-call";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderImage?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "image";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderReasoning?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "reasoning";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderSource?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "source";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderFile?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "file";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderData?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "data";
-    }>;
-    index: number;
-  }) => ReactElement;
-};
-
-declare const MessageContent: (_param24: MessageContentProps) => import("react").JSX.Element;
-
-declare namespace MessagePrimitiveParts {
-  type Props = MessagePrimitiveParts$1.Props;
-}
-
-declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
-
-type MessageIfProps = {
-  children: ReactNode;
-  user?: boolean | undefined;
-  assistant?: boolean | undefined;
-  running?: boolean | undefined;
-  last?: boolean | undefined;
-};
-
-declare const MessageIf: (_param25: MessageIfProps) => import("react").JSX.Element | null;
-
-declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessageAttachments: import("react").FC<MessagePrimitiveAttachments.Props>;
-
-declare const MessageError: FC<PropsWithChildren>;
-
-declare namespace message_d_exports {
-  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessageError as Error, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
-}
-
-type ThreadListRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const ThreadListRoot: (_param26: ThreadListRootProps) => import("react").JSX.Element;
-
-type ThreadListItemsProps = {
-  renderItem: (props: {
-    threadId: string;
-    index: number;
-  }) => ReactElement;
-};
-
-declare const ThreadListItems: (_param27: ThreadListItemsProps) => import("react").JSX.Element;
-
-type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListNew: (_param28: ThreadListNewProps) => import("react").JSX.Element;
-
-declare namespace threadList_d_exports {
-  export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
-}
-
-type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
-  children: ReactNode | ((props: {
-    isCopied: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarCopy: (_param29: ActionBarCopyProps) => import("react").JSX.Element;
-
-type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ActionBarEdit: (_param30: ActionBarEditProps) => import("react").JSX.Element;
-
-type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ActionBarReload: (_param31: ActionBarReloadProps) => import("react").JSX.Element;
-
-type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
-  children: ReactNode | ((props: {
-    isSubmitted: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarFeedbackPositive: (_param32: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
-
-type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
-  children: ReactNode | ((props: {
-    isSubmitted: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarFeedbackNegative: (_param33: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
-
-declare namespace actionBar_d_exports {
-  export { ActionBarCopy as Copy, ActionBarCopyProps as CopyProps, ActionBarEdit as Edit, ActionBarEditProps as EditProps, ActionBarFeedbackNegative as FeedbackNegative, ActionBarFeedbackNegativeProps as FeedbackNegativeProps, ActionBarFeedbackPositive as FeedbackPositive, ActionBarFeedbackPositiveProps as FeedbackPositiveProps, ActionBarReload as Reload, ActionBarReloadProps as ReloadProps };
-}
-
-type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const BranchPickerPrevious: (_param34: BranchPickerPreviousProps) => import("react").JSX.Element;
-
-type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const BranchPickerNext: (_param35: BranchPickerNextProps) => import("react").JSX.Element;
-
-type BranchPickerNumberProps = ComponentProps<typeof Text>;
-
-declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
-
-type BranchPickerCountProps = ComponentProps<typeof Text>;
-
-declare const BranchPickerCount: (props: BranchPickerCountProps) => import("react").JSX.Element;
-
-declare namespace branchPicker_d_exports {
-  export { BranchPickerCount as Count, BranchPickerCountProps as CountProps, BranchPickerNext as Next, BranchPickerNextProps as NextProps, BranchPickerNumber as Number, BranchPickerNumberProps as NumberProps, BranchPickerPrevious as Previous, BranchPickerPreviousProps as PreviousProps };
-}
-
-type AttachmentRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const AttachmentRoot: (_param36: AttachmentRootProps) => import("react").JSX.Element;
-
-type AttachmentNameProps = ComponentProps<typeof Text>;
-
-declare const AttachmentName: FC<AttachmentNameProps>;
-
-type AttachmentThumbProps = ComponentProps<typeof Text>;
-
-declare const AttachmentThumb: FC<AttachmentThumbProps>;
-
-type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const AttachmentRemove: (_param37: AttachmentRemoveProps) => import("react").JSX.Element;
-
-type AttachmentStatusProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  showComplete?: boolean | undefined;
-};
-
-declare const AttachmentStatus: FC<AttachmentStatusProps>;
-
-declare namespace attachment_d_exports {
-  export { AttachmentName as Name, AttachmentNameProps as NameProps, AttachmentRemove as Remove, AttachmentRemoveProps as RemoveProps, AttachmentRoot as Root, AttachmentRootProps as RootProps, AttachmentStatus as Status, AttachmentStatusProps as StatusProps, AttachmentThumb as Thumb, AttachmentThumbProps as ThumbProps };
-}
-
-type ThreadListItemRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemRoot: (_param38: ThreadListItemRootProps) => import("react").JSX.Element;
-
-type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemTrigger: (_param39: ThreadListItemTriggerProps) => import("react").JSX.Element;
-
-type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemDelete: (_param40: ThreadListItemDeleteProps) => import("react").JSX.Element;
-
-type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemArchive: (_param41: ThreadListItemArchiveProps) => import("react").JSX.Element;
-
-type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemUnarchive: (_param42: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
-
-declare namespace threadListItem_d_exports {
-  export { ThreadListItemArchive as Archive, ThreadListItemArchiveProps as ArchiveProps, ThreadListItemDelete as Delete, ThreadListItemDeleteProps as DeleteProps, ThreadListItemRoot as Root, ThreadListItemRootProps as RootProps, ThreadListItemPrimitiveTitle as Title, ThreadListItemTrigger as Trigger, ThreadListItemTriggerProps as TriggerProps, ThreadListItemUnarchive as Unarchive, ThreadListItemUnarchiveProps as UnarchiveProps };
-}
-
-type ChainOfThoughtRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const ChainOfThoughtRoot: (_param43: ChainOfThoughtRootProps) => import("react").JSX.Element;
-
-type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ChainOfThoughtAccordionTrigger: (_param44: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
-
-declare namespace chainOfThought_d_exports {
-  export { ChainOfThoughtAccordionTrigger as AccordionTrigger, ChainOfThoughtAccordionTriggerProps as AccordionTriggerProps, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtRoot as Root, ChainOfThoughtRootProps as RootProps };
-}
-
-type SuggestionTitleProps = ComponentProps<typeof Text> & {
-  children?: ReactNode;
-};
-
-declare const SuggestionTitle: (_param45: SuggestionTitleProps) => import("react").JSX.Element;
-
-type SuggestionDescriptionProps = ComponentProps<typeof Text> & {
-  children?: ReactNode;
-};
-
-declare const SuggestionDescription: (_param46: SuggestionDescriptionProps) => import("react").JSX.Element;
-
-type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-};
-
-declare const SuggestionTrigger: (_param47: SuggestionTriggerProps) => import("react").JSX.Element;
-
-declare namespace suggestion_d_exports {
-  export { SuggestionDescription as Description, SuggestionDescriptionProps as DescriptionProps, SuggestionTitle as Title, SuggestionTitleProps as TitleProps, SuggestionTrigger as Trigger, SuggestionTriggerProps as TriggerProps };
-}
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
 
 type ToolCallStatus = "complete" | "error" | "requires-action" | "running";
+
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
+
+type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+declare const ToolFallback: (_param70: ToolFallbackProps) => import("react").JSX.Element;
 
 type ToolFallbackBaseProps = Omit<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume"> & Partial<Pick<ToolCallMessagePartProps, "addResult" | "respondToApproval" | "resume">>;
 
@@ -4167,507 +4123,551 @@ type ToolFallbackProps = ToolFallbackBaseProps & {
   }) => ReactNode;
 };
 
-declare const ToolFallback: (_param48: ToolFallbackProps) => import("react").JSX.Element;
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
 
-declare namespace toolCall_d_exports {
-  export { ToolFallback as Fallback, ToolFallbackProps as FallbackProps, ToolCallStatus };
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
 }
 
-type ErrorRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
 };
 
-declare const ErrorRoot: {
-  (_param49: ErrorRootProps): import("react").JSX.Element | null;
-  displayName: string;
+type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
 };
 
-type ErrorMessageProps = ComponentProps<typeof Text> & {
-  children?: ReactNode;
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+
+type ToolkitDefinition<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+} = Record<string, any>, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}> = {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
 };
 
-declare const ErrorMessage: {
-  (_param50: ErrorMessageProps): import("react").JSX.Element | null;
-  displayName: string;
+type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
+
+type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
+  parameters: NonNullable<ToolParameters<TArgs>>;
 };
 
-declare namespace index_d_exports$2 {
-  export { ErrorMessage as Message, ErrorMessageProps as MessageProps, ErrorRoot as Root, ErrorRootProps as RootProps };
-}
+type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
+  streamCall?: unknown;
+} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
 
-type DiffLineType = "add" | "del" | "normal";
+declare const Tools: Resource<ClientOutput<"tools">, [
+  {
+    toolkit?: Toolkit;
+    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
+  }
+]>;
 
-interface ParsedLine {
-  type: DiffLineType;
-  content: string;
-  oldLineNumber?: number;
-  newLineNumber?: number;
-}
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
 
-interface ParsedFile {
-  oldName?: string | undefined;
-  newName?: string | undefined;
-  lines: ParsedLine[];
-  additions: number;
-  deletions: number;
-}
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
 
-interface FoldedRegion {
-  type: "fold";
-  hiddenCount: number;
-}
-
-type DisplayLine = ParsedLine | FoldedRegion;
-
-interface DiffFileInput {
-  content: string;
-  name?: string | undefined;
-}
-
-type DiffRootProps = ComponentProps<typeof Box> & {
-  files?: ParsedFile[] | undefined;
-  children: ReactNode;
-};
-
-declare const DiffRoot: {
-  (_param51: DiffRootProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type DiffHeaderProps = ComponentProps<typeof Box> & {
-  fileIndex?: number;
-};
-
-declare const DiffHeader: {
-  (_param52: DiffHeaderProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type DiffContentProps = ComponentProps<typeof Box> & {
-  fileIndex?: number | undefined;
-  showLineNumbers?: boolean | undefined;
-  contextLines?: number | undefined;
-  maxLines?: number | undefined;
-  renderLine?: ((props: {
-    line: ParsedLine;
-    index: number;
-  }) => ReactNode) | undefined;
-  renderFold?: ((props: {
-    region: FoldedRegion;
-    index: number;
-  }) => ReactNode) | undefined;
-};
-
-declare const DiffContent: {
-  (_param53: DiffContentProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type DiffLineProps = ComponentProps<typeof Box> & {
-  line: ParsedLine;
-  showLineNumbers?: boolean;
-  lineNumberWidth?: number;
-};
-
-declare const DiffLine: {
-  (_param54: DiffLineProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type DiffStatsProps = ComponentProps<typeof Box> & {
-  fileIndex?: number;
-};
-
-declare const DiffStats: {
-  (_param55: DiffStatsProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-declare namespace diff_d_exports {
-  export { DiffContent as Content, DiffContentProps as ContentProps, DiffFileInput, DiffLineType, DisplayLine, FoldedRegion, DiffHeader as Header, DiffHeaderProps as HeaderProps, DiffLine as Line, DiffLineProps as LineProps, ParsedFile, ParsedLine, DiffRoot as Root, DiffRootProps as RootProps, DiffStats as Stats, DiffStatsProps as StatsProps };
-}
-
-type MessagePartPrimitiveTextProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveText {
-  type Props = MessagePartPrimitiveTextProps;
-}
-
-declare const MessagePartPrimitiveText: {
-  (props: MessagePartPrimitiveText.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MessagePartPrimitiveImageProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveImage {
-  type Props = MessagePartPrimitiveImageProps;
-}
-
-declare const MessagePartPrimitiveImage: {
-  (props: MessagePartPrimitiveImage.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MessagePartPrimitiveFileProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveFile {
-  type Props = MessagePartPrimitiveFileProps;
-}
-
-declare const MessagePartPrimitiveFile: {
-  (props: MessagePartPrimitiveFile.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MessagePartPrimitiveSourceProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveSource {
-  type Props = MessagePartPrimitiveSourceProps;
-}
-
-declare const MessagePartPrimitiveSource: {
-  (props: MessagePartPrimitiveSource.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MessagePartPrimitiveReasoningProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveReasoning {
-  type Props = MessagePartPrimitiveReasoningProps;
-}
-
-declare const MessagePartPrimitiveReasoning: {
-  (props: MessagePartPrimitiveReasoning.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type MessagePartPrimitiveDataProps = Omit<ComponentProps<typeof Text>, "children">;
-
-declare namespace MessagePartPrimitiveData {
-  type Props = MessagePartPrimitiveDataProps;
-}
-
-declare const MessagePartPrimitiveData: {
-  (props: MessagePartPrimitiveData.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-declare namespace messagePart_d_exports {
-  export { MessagePartPrimitiveData as Data, MessagePartPrimitiveFile as File, MessagePartPrimitiveImage as Image, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveReasoning as Reasoning, MessagePartPrimitiveSource as Source, MessagePartPrimitiveText as Text };
-}
-
-type LoadingRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare const LoadingRoot: {
-  (_param56: LoadingRootProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-declare const LOADING_FRAMES: {
-  readonly dots: readonly [
-    ".  ",
-    ".. ",
-    "..."
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
   ];
-  readonly pulse: readonly [
-    "*--",
-    "-*-",
-    "--*"
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
   ];
-  readonly bar: readonly [
-    "[=   ]",
-    "[==  ]",
-    "[=== ]",
-    "[ ===]",
-    "[  ==]",
-    "[   =]"
-  ];
-  readonly bounce: readonly [
-    "[*   ]",
-    "[ *  ]",
-    "[  * ]",
-    "[   *]",
-    "[  * ]",
-    "[ *  ]"
-  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
 };
 
-type LoadingSpinnerVariant = "spinner" | keyof typeof LOADING_FRAMES;
+type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
 
-type LoadingSpinnerProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  variant?: LoadingSpinnerVariant;
-  type?: ComponentProps<typeof Spinner>["type"];
-  intervalMs?: number;
+type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
+
+type Unstable_InferInteractableState<TSchema> = TSchema extends {
+  "~standard": {
+    types?: {
+      output: infer TOutput;
+    } | undefined;
+  };
+} ? TOutput : unknown;
+
+type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  initialState: Unstable_InferInteractableState<TSchema>;
+  id?: string | undefined;
+  updateRender?: ToolCallMessagePartComponent | undefined;
 };
 
-declare const LoadingSpinner: {
-  (_param57: LoadingSpinnerProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type LoadingTextProps = ComponentProps<typeof Text> & {
-  children?: ReactNode;
-};
-
-declare const LoadingText: {
-  (_param58: LoadingTextProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type LoadingElapsedTimeProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  format?: (seconds: number) => string;
-};
-
-declare const LoadingElapsedTime: {
-  (_param59: LoadingElapsedTimeProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-declare namespace index_d_exports$1 {
-  export { LoadingElapsedTime as ElapsedTime, LoadingElapsedTimeProps as ElapsedTimeProps, LoadingRoot as Root, LoadingRootProps as RootProps, LoadingSpinner as Spinner, LoadingSpinnerProps as SpinnerProps, LoadingText as Text, LoadingTextProps as TextProps };
-}
-
-type StatusBarPrimitiveRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
-};
-
-declare namespace StatusBarPrimitiveRoot {
-  type Props = StatusBarPrimitiveRootProps;
-}
-
-declare const StatusBarPrimitiveRoot: {
-  (_param60: StatusBarPrimitiveRoot.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type StatusBarPrimitiveModelNameProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  name?: ReactNode;
-};
-
-declare namespace StatusBarPrimitiveModelName {
-  type Props = StatusBarPrimitiveModelNameProps;
-}
-
-declare const StatusBarPrimitiveModelName: {
-  (_param61: StatusBarPrimitiveModelName.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-type StatusBarPrimitiveMessageCountProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  format?: (count: number) => string;
-};
-
-declare namespace StatusBarPrimitiveMessageCount {
-  type Props = StatusBarPrimitiveMessageCountProps;
-}
-
-declare const StatusBarPrimitiveMessageCount: {
-  (_param62: StatusBarPrimitiveMessageCount.Props): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type StatusBarPrimitiveTokenCountProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  format?: (tokens: number) => string;
-};
-
-declare namespace StatusBarPrimitiveTokenCount {
-  type Props = StatusBarPrimitiveTokenCountProps;
-}
-
-declare const StatusBarPrimitiveTokenCount: {
-  (_param63: StatusBarPrimitiveTokenCount.Props): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type StatusBarPrimitiveLatencyProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  format?: (tokensPerSecond: number) => string;
-};
-
-declare namespace StatusBarPrimitiveLatency {
-  type Props = StatusBarPrimitiveLatencyProps;
-}
-
-declare const StatusBarPrimitiveLatency: {
-  (_param64: StatusBarPrimitiveLatency.Props): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type StatusType = "cancelled" | "error" | "idle" | "running";
-
-type StatusBarPrimitiveStatusProps = Omit<ComponentProps<typeof Text>, "children"> & {
-  format?: (status: StatusType) => string;
-};
-
-declare namespace StatusBarPrimitiveStatus {
-  type Props = StatusBarPrimitiveStatusProps;
-}
-
-declare const StatusBarPrimitiveStatus: {
-  (_param65: StatusBarPrimitiveStatus.Props): import("react").JSX.Element;
-  displayName: string;
-};
-
-declare namespace statusBar_d_exports {
-  export { StatusBarPrimitiveLatency as Latency, StatusBarPrimitiveMessageCount as MessageCount, StatusBarPrimitiveModelName as ModelName, StatusBarPrimitiveRoot as Root, StatusBarPrimitiveStatus as Status, StatusType, StatusBarPrimitiveTokenCount as TokenCount };
-}
-
-type DiffViewProps = Omit<ComponentProps<typeof Box>, "children"> & {
-  patch?: string | undefined;
-  oldFile?: DiffFileInput | undefined;
-  newFile?: DiffFileInput | undefined;
-  showLineNumbers?: boolean | undefined;
-  contextLines?: number | undefined;
-  maxLines?: number | undefined;
-};
-
-declare const DiffView: (_param66: DiffViewProps) => import("react").JSX.Element;
-
-type TextInputProps = ComponentProps<typeof Box> & {
-  value: string;
-  onChange: (text: string) => void;
-  onSubmit?: ((text: string) => void) | undefined;
-  submitOnEnter?: boolean | undefined;
-  placeholder?: string | undefined;
-  autoFocus?: boolean | undefined;
-  multiLine?: boolean | undefined;
-};
-
-declare const TextInput: (_param67: TextInputProps) => import("react").JSX.Element;
-
-type ChecklistItemStatus = "complete" | "error" | "pending" | "running";
-
-type ChecklistItemData = {
+type Unstable_InteractableDefinition = {
   id: string;
-  text: string;
-  status: ChecklistItemStatus;
-  detail?: string;
-  children?: ChecklistItemData[];
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  state: unknown;
+  initialState: unknown;
+  scope?: InteractableScope | undefined;
 };
 
-type ChecklistRootProps = ComponentProps<typeof Box> & {
-  children: ReactNode;
+type Unstable_InteractablePersistedState = Record<string, {
+  name: string;
+  state: unknown;
+}>;
+
+type Unstable_InteractablePersistenceAdapter = {
+  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
+  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
 };
 
-declare const ChecklistRoot: {
-  (_param68: ChecklistRootProps): import("react").JSX.Element;
-  displayName: string;
+type Unstable_InteractablePersistenceStatus = {
+  isPending: boolean;
+  error: unknown;
 };
 
-type ChecklistItemProps = ComponentProps<typeof Box> & {
-  item: ChecklistItemData;
-  depth?: number | undefined;
-  maxDepth?: number | undefined;
+type Unstable_InteractableRegistration = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  initialState: unknown;
+  updateRender?: ToolCallMessagePartComponent | undefined;
 };
 
-declare const ChecklistItem: {
-  (_param69: ChecklistItemProps): import("react").JSX.Element;
-  displayName: string;
+type Unstable_InteractableSnapshotEntry = {
+  id: string;
+  name: string;
+  state: unknown;
+  partial?: boolean | undefined;
 };
 
-type ChecklistProgressProps = ComponentProps<typeof Box> & {
-  items: ChecklistItemData[];
+type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
 };
 
-declare const ChecklistProgress: {
-  (_param70: ChecklistProgressProps): import("react").JSX.Element;
-  displayName: string;
+type Unstable_InteractableToolRenderProps<TState> = {
+  state: TState;
+  setState: (updater: TState | ((prev: TState) => TState)) => void;
+  version: Unstable_InteractableVersionInfo<TState> | undefined;
+  id: string;
+  streaming: boolean;
 };
 
-declare namespace checklist_d_exports {
-  export { ChecklistItem as Item, ChecklistItemProps as ItemProps, ChecklistProgress as Progress, ChecklistProgressProps as ProgressProps, ChecklistRoot as Root, ChecklistRootProps as RootProps };
-}
-
-type LiveChecklistProps = ComponentProps<typeof Box> & {
-  items?: ChecklistItemData[] | undefined;
-  formatToolName?: ((toolName: string) => string) | undefined;
-  title?: string | undefined;
-  showProgress?: boolean | undefined;
-  maxDepth?: number | undefined;
+type Unstable_InteractableVersion = {
+  state: unknown;
+  origin: "create" | "update" | "user-edit";
+  toolCallId?: string | undefined;
 };
 
-declare const LiveChecklist: {
-  (_param71: LiveChecklistProps): import("react").JSX.Element;
-  displayName: string;
+type Unstable_InteractableVersionInfo<TState> = {
+  state: TState;
+  isLatest: boolean;
+  restore: () => void;
 };
+
+type Unstable_InteractablesClientSchema = {
+  methods: Unstable_InteractablesMethods;
+};
+
+type Unstable_InteractablesConfig = {
+  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
+};
+
+type Unstable_InteractablesMethods = {
+  getState(): Unstable_InteractablesState;
+  register(def: Unstable_InteractableRegistration): Unsubscribe$1;
+  setState(id: string, updater: (prev: unknown) => unknown): void;
+  exportState(): Unstable_InteractablePersistedState;
+  importState(saved: Unstable_InteractablePersistedState): void;
+  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
+  flush(): Promise<void>;
+};
+
+type Unstable_InteractablesState = {
+  definitions: Record<string, Unstable_InteractableDefinition>;
+  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
+
+type UseActionBarCopyOptions = {
+  copiedDuration?: number | undefined;
+  copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
+};
+
+type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
 
 type UseToolCallChecklistOptions = {
   formatToolName?: ((toolName: string) => string) | undefined;
 };
 
-declare const useToolCallChecklist: (options?: UseToolCallChecklistOptions) => ChecklistItemData[];
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
 
-declare function humanTool(): never;
+type VoiceSessionControls = {
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
+};
 
-declare const hitlTool: typeof humanTool;
+type VoiceSessionHelpers = {
+  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
+  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
+  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
+  emitVolume: (volume: number) => void;
+  isDisposed: () => boolean;
+};
 
-declare const hitl: typeof humanTool;
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
 
-declare function stubTool(): never;
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
 
-declare function providerTool(config: ProviderToolConfig): never;
+type WindowingProps = {
+  windowSize?: number | undefined;
+  windowOverscan?: number | undefined;
+};
+
+type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
+  type: "frontend" | "human";
+} ? T & (T extends {
+  type: "frontend";
+} ? {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+} | {
+  render?: ToolCallMessagePartComponent<TArgs, TResult>;
+  renderText: ToolCallText<TArgs, TResult>;
+} : {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+}) : T & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
+};
+
+declare namespace actionBar_d_exports {
+  export { ActionBarCopy as Copy, ActionBarCopyProps as CopyProps, ActionBarEdit as Edit, ActionBarEditProps as EditProps, ActionBarFeedbackNegative as FeedbackNegative, ActionBarFeedbackNegativeProps as FeedbackNegativeProps, ActionBarFeedbackPositive as FeedbackPositive, ActionBarFeedbackPositiveProps as FeedbackPositiveProps, ActionBarReload as Reload, ActionBarReloadProps as ReloadProps };
+}
+
+declare namespace attachment_d_exports {
+  export { AttachmentName as Name, AttachmentNameProps as NameProps, AttachmentRemove as Remove, AttachmentRemoveProps as RemoveProps, AttachmentRoot as Root, AttachmentRootProps as RootProps, AttachmentStatus as Status, AttachmentStatusProps as StatusProps, AttachmentThumb as Thumb, AttachmentThumbProps as ThumbProps };
+}
+
+declare namespace branchPicker_d_exports {
+  export { BranchPickerCount as Count, BranchPickerCountProps as CountProps, BranchPickerNext as Next, BranchPickerNextProps as NextProps, BranchPickerNumber as Number, BranchPickerNumberProps as NumberProps, BranchPickerPrevious as Previous, BranchPickerPreviousProps as PreviousProps };
+}
+
+declare namespace chainOfThought_d_exports {
+  export { ChainOfThoughtAccordionTrigger as AccordionTrigger, ChainOfThoughtAccordionTriggerProps as AccordionTriggerProps, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtRoot as Root, ChainOfThoughtRootProps as RootProps };
+}
+
+declare namespace checklist_d_exports {
+  export { ChecklistItem as Item, ChecklistItemProps as ItemProps, ChecklistProgress as Progress, ChecklistProgressProps as ProgressProps, ChecklistRoot as Root, ChecklistRootProps as RootProps };
+}
+
+declare namespace composer_d_exports {
+  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerPrimitiveQueue as Queue, ComposerQuote as Quote, ComposerQuoteDismiss as QuoteDismiss, ComposerQuoteDismissProps as QuoteDismissProps, ComposerQuoteProps as QuoteProps, ComposerQuoteText as QuoteText, ComposerQuoteTextProps as QuoteTextProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
+}
+
+declare const createFileStorageAdapter: (options: CreateFileStorageAdapterOptions) => RemoteThreadListAdapter;
+
+declare const createSimpleTitleAdapter: () => TitleGenerationAdapter;
+
+declare function createVoiceSession(options: {
+  abortSignal?: AbortSignal;
+}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
+
+declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
 
 declare const defineToolkit: typeof defineToolkit$1;
 
-type ThreadState = {
-  readonly isEmpty: boolean;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly MessageState[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion$1[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-  readonly composer: ComposerState;
+declare function defineToolkit$1<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+}, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}>(_definition: {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
+}): Toolkit & {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
 };
 
-type ThreadsState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | null;
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly threadItems: readonly ThreadListItemState[];
-  readonly main: ThreadState;
-};
+declare function defineToolkit$1<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
 
-type ChainOfThoughtPart = Extract<PartState, {
-  type: "tool-call";
-} | {
-  type: "reasoning";
-}>;
+declare namespace diff_d_exports {
+  export { DiffContent as Content, DiffContentProps as ContentProps, DiffFileInput, DiffLineType, DisplayLine, FoldedRegion, DiffHeader as Header, DiffHeaderProps as HeaderProps, DiffLine as Line, DiffLineProps as LineProps, ParsedFile, ParsedLine, DiffRoot as Root, DiffRootProps as RootProps, DiffStats as Stats, DiffStatsProps as StatsProps };
+}
 
-type SuggestionConfig = string | {
-  title: string;
-  label: string;
-  prompt: string;
-};
+declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
 
-declare const Suggestions: Resource<ClientOutput<"suggestions">, [
-  suggestions?: SuggestionConfig[] | undefined
-]>;
+declare const generateId: (size?: number) => string;
 
-declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
-  {
-    parts: readonly ChainOfThoughtPart[];
-    getMessagePart: (selector: {
-      index: number;
-    }) => PartMethods;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
   }
-]>;
+}
 
-declare const ModelContext: Resource<ClientOutput<"modelContext">, [
-]>;
+declare const hitl: typeof humanTool;
+
+declare const hitlTool: typeof humanTool;
+
+declare function humanTool(): never;
 
 declare namespace entry_root_exports {
   export { actionBar_d_exports as ActionBarPrimitive, AppendMessage, AssistantClient, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantInteractableProps, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, ChainOfThoughtPartByIndexProvider, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChecklistItemData, ChecklistItemStatus, checklist_d_exports as ChecklistPrimitive, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerState, CompositeAttachmentAdapter, CreateAttachment, CreateFileStorageAdapterOptions, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, diff_d_exports as DiffPrimitive, DiffView, DiffViewProps, EditComposerRuntime, EmptyMessagePartComponent, EmptyMessagePartProps, index_d_exports$2 as ErrorPrimitive, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadListAdapter, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LiveChecklist, LiveChecklistProps, index_d_exports$1 as LoadingPrimitive, LocalRuntimeOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, messagePart_d_exports as MessagePartPrimitive, message_d_exports as MessagePrimitive, MessageRole, MessageRuntime, MessageState, MessageStatus, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, NotificationConfig, NotificationEvent, NotificationHandler, OSCVariant, PartByIndexProvider, PendingAttachment, ProviderToolConfig, queueItem_d_exports as QueueItemPrimitive, QueueItemState, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RemoteThreadListOptions, RunConfig, RuntimeAdapterProvider, RuntimeAdapters, RuntimeCapabilities, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, statusBar_d_exports as StatusBarPrimitive, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextInput, TextInputProps, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadsState, TitleGenerationAdapter, Tool, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartProps, toolCall_d_exports as ToolCallPrimitive, ToolCallText, ToolDefinition, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unsubscribe$1 as Unsubscribe, UseToolCallChecklistOptions, VoiceSessionControls, VoiceSessionHelpers, createFileStorageAdapter, createSimpleTitleAdapter, createVoiceSession, defineMcpToolkit, defineToolkit, fromThreadMessageLike, generateId, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, mergeModelContexts, providerTool, ringBell, sendOSCNotification, stubTool, tool, unstable_Interactables, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useInlineRender, useInteractableState, useLocalRuntime, useNotification, useRemoteThreadListRuntime, useRuntimeAdapters, useToolArgsStatus, useToolCallChecklist, useVoiceControls, useVoiceState, useVoiceVolume };
 }
+
+declare namespace index_d_exports$1 {
+  export { LoadingElapsedTime as ElapsedTime, LoadingElapsedTimeProps as ElapsedTimeProps, LoadingRoot as Root, LoadingRootProps as RootProps, LoadingSpinner as Spinner, LoadingSpinnerProps as SpinnerProps, LoadingText as Text, LoadingTextProps as TextProps };
+}
+
+declare namespace index_d_exports$2 {
+  export { ErrorMessage as Message, ErrorMessageProps as MessageProps, ErrorRoot as Root, ErrorRootProps as RootProps };
+}
+
+declare namespace entry_internal_exports {
+  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, getAutoStatus };
+}
+
+declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
+
+declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
+
+declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
+
+declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+
+declare namespace messagePart_d_exports {
+  export { MessagePartPrimitiveData as Data, MessagePartPrimitiveFile as File, MessagePartPrimitiveImage as Image, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveReasoning as Reasoning, MessagePartPrimitiveSource as Source, MessagePartPrimitiveText as Text };
+}
+
+declare namespace message_d_exports {
+  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessageError as Error, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
+}
+
+declare function providerTool(config: ProviderToolConfig): never;
+
+declare namespace queueItem_d_exports {
+  export { QueueItemRemove as Remove, QueueItemRemoveProps as RemoveProps, QueueItemSteer as Steer, QueueItemSteerProps as SteerProps, QueueItemText as Text, QueueItemTextProps as TextProps };
+}
+
+declare const ringBell: () => void;
+
+declare const sendOSCNotification: (title: string, body?: string, variant?: OSCVariant) => void;
+
+declare namespace statusBar_d_exports {
+  export { StatusBarPrimitiveLatency as Latency, StatusBarPrimitiveMessageCount as MessageCount, StatusBarPrimitiveModelName as ModelName, StatusBarPrimitiveRoot as Root, StatusBarPrimitiveStatus as Status, StatusType, StatusBarPrimitiveTokenCount as TokenCount };
+}
+
+declare function stubTool(): never;
+
+declare namespace suggestion_d_exports {
+  export { SuggestionDescription as Description, SuggestionDescriptionProps as DescriptionProps, SuggestionTitle as Title, SuggestionTitleProps as TitleProps, SuggestionTrigger as Trigger, SuggestionTriggerProps as TriggerProps };
+}
+
+declare namespace threadListItem_d_exports {
+  export { ThreadListItemArchive as Archive, ThreadListItemArchiveProps as ArchiveProps, ThreadListItemDelete as Delete, ThreadListItemDeleteProps as DeleteProps, ThreadListItemRoot as Root, ThreadListItemRootProps as RootProps, ThreadListItemPrimitiveTitle as Title, ThreadListItemTrigger as Trigger, ThreadListItemTriggerProps as TriggerProps, ThreadListItemUnarchive as Unarchive, ThreadListItemUnarchiveProps as UnarchiveProps };
+}
+
+declare namespace threadList_d_exports {
+  export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
+}
+
+declare namespace thread_d_exports {
+  export { ThreadEmpty as Empty, ThreadEmptyProps as EmptyProps, ThreadIf as If, ThreadIfProps as IfProps, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadMessages as Messages, ThreadMessagesProps as MessagesProps, ThreadRoot as Root, ThreadRootProps as RootProps, ThreadSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadSuggestionProps as SuggestionProps, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById };
+}
+
+declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
+
+declare namespace toolCall_d_exports {
+  export { ToolFallback as Fallback, ToolFallbackProps as FallbackProps, ToolCallStatus };
+}
+
+declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
+  (Unstable_InteractablesConfig | undefined)?
+]>;
+
+declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
+
+declare function unstable_getInteractableSnapshots(message: {
+  metadata?: unknown;
+}): Unstable_InteractableSnapshotEntry[] | undefined;
+
+declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
+
+declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
+  success: true;
+}>;
+
+declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
+  Unstable_InferInteractableState<TSchema>,
+  {
+    id: string;
+    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
+    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableState: <TState>(id: string) => [
+  TState | undefined,
+  {
+    setState: (updater: StateUpdater<TState>) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
+  state: TState;
+  restore: () => void;
+})[];
+
+declare const unstable_useThreadMessageIds: () => readonly string[];
+
+declare const useAssistantContext: (config: AssistantContextConfig) => void;
+
+declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
+
+declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
+
+declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
+
+declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
+
+declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
+
+declare namespace useAui {
+  type Props = {
+    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
+  };
+}
+
+declare function useAui(): AssistantClient;
+
+declare function useAui(clients: useAui.Props): AssistantClient;
+
+declare function useAui(clients: useAui.Props, config: {
+  parent: null | AssistantClient;
+}): AssistantClient;
+
+declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
+
+declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
+
+declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
+
+declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
+
+declare const useInteractableState: <TState>(id: string, fallback: TState) => [
+  TState,
+  {
+    setState: (updater: StateUpdater$1<TState>) => void;
+    setSelected: (selected: boolean) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param71?: LocalRuntimeOptions) => AssistantRuntime;
+
+declare const useNotification: (config?: NotificationConfig) => void;
+
+declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
+
+declare const useRuntimeAdapters: () => RuntimeAdapters | null;
+
+declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
+
+declare const useToolCallChecklist: (options?: UseToolCallChecklistOptions) => ChecklistItemData[];
+
+declare const useVoiceControls: () => {
+  connect: () => void;
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
+};
+
+declare const useVoiceState: () => VoiceSessionState | undefined;
+
+declare const useVoiceVolume: () => number;
 
 export { entry_internal_exports as entry_internal, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1,23 +1,346 @@
-import { ComponentType, PropsWithChildren } from "react";
-
 import { AssembledToolCall, SubagentDiscoverySnapshot, SubagentDiscoverySnapshot as SubagentDiscoverySnapshot$1, SubgraphDiscoverySnapshot, SubgraphDiscoverySnapshot as SubgraphDiscoverySnapshot$1, UseStreamOptions } from "@langchain/react";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+import { ComponentType, PropsWithChildren } from "react";
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -29,9 +352,83 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -39,7 +436,61 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -49,30 +500,272 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -134,164 +827,127 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type JoinStrategy = "concat-content" | "none";
+
+type LangChainBaseMessage = {
+  _getType: () => string;
+  content: unknown;
+  id?: string | undefined;
+  name?: string | undefined;
+  additional_kwargs?: Record<string, unknown> | undefined;
+  tool_calls?: readonly LangChainToolCall[] | undefined;
+  tool_call_id?: string | undefined;
+  status?: MessageStatus | "success" | "error" | undefined;
+  artifact?: unknown;
+};
+
+type LangChainContentBlock = {
+  type: "text";
+  text: string;
 } | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
-
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+  type: "text_delta";
+  text: string;
+} | {
+  type: "image_url";
+  image_url: string | {
+    url?: string;
   };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+} | {
+  type: "thinking";
+  thinking: string;
+} | {
+  type: "reasoning";
+  summary?: Array<{
+    type: "summary_text";
+    text?: string;
+  }>;
+  reasoning?: string;
+} | {
+  type: "file";
+  data: string;
+  mime_type: string;
+  source_type?: "base64";
+  metadata?: {
+    filename?: string;
+  };
+} | {
+  type: "input_json_delta" | "tool_use";
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LangChainMessageConverterMetadata = useExternalMessageConverter.Metadata & {
+  uiMessagesByParent?: Map<string, UIMessage[]>;
+  messageTiming?: Record<string, MessageTiming>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  cloud?: AssistantCloud | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+  } | undefined;
+  autoCancelPendingToolCalls?: boolean | undefined;
+  unstable_allowCancellation?: boolean | undefined;
+  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
+  create?: (() => Promise<{
+    externalId: string | undefined;
+  }>) | undefined;
+  delete?: ((threadId: string) => Promise<void>) | undefined;
+  uiStateKey?: string | undefined;
 };
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+type LangChainToolCall = {
+  id: string;
+  name: string;
   args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+};
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
+};
+
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
+
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
+};
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -321,11 +977,132 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -336,6 +1113,8 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -364,444 +1143,67 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -836,65 +1238,317 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
+};
+
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
+};
+
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type RemoveUIMessage = {
+  type: "remove-ui";
+  id: string;
+};
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -944,413 +1598,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1379,493 +1626,267 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
-
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
   };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
   };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
 }
 
-type LangChainContentBlock = {
-  type: "text";
-  text: string;
-} | {
-  type: "text_delta";
-  text: string;
-} | {
-  type: "image_url";
-  image_url: string | {
-    url?: string;
-  };
-} | {
-  type: "thinking";
-  thinking: string;
-} | {
-  type: "reasoning";
-  summary?: Array<{
-    type: "summary_text";
-    text?: string;
-  }>;
-  reasoning?: string;
-} | {
-  type: "file";
-  data: string;
-  mime_type: string;
-  source_type?: "base64";
-  metadata?: {
-    filename?: string;
-  };
-} | {
-  type: "input_json_delta" | "tool_use";
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-type LangChainToolCall = {
-  id: string;
-  name: string;
-  args: Record<string, unknown>;
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
 };
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
 
 type UIMessage<TName extends string = string, TProps extends Record<string, unknown> = Record<string, unknown>> = {
   type: "ui";
@@ -1883,46 +1904,36 @@ type UIMessage<TName extends string = string, TProps extends Record<string, unkn
   };
 };
 
-type RemoveUIMessage = {
-  type: "remove-ui";
-  id: string;
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
 };
 
-type LangChainBaseMessage = {
-  _getType: () => string;
-  content: unknown;
-  id?: string | undefined;
-  name?: string | undefined;
-  additional_kwargs?: Record<string, unknown> | undefined;
-  tool_calls?: readonly LangChainToolCall[] | undefined;
-  tool_call_id?: string | undefined;
-  status?: MessageStatus | "success" | "error" | undefined;
-  artifact?: unknown;
-};
-
-type LangChainRuntimeExtraOptions = ExternalStoreSharedOptions & {
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  cloud?: AssistantCloud | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-  } | undefined;
-  autoCancelPendingToolCalls?: boolean | undefined;
-  unstable_allowCancellation?: boolean | undefined;
-  unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
-  create?: (() => Promise<{
-    externalId: string | undefined;
-  }>) | undefined;
-  delete?: ((threadId: string) => Promise<void>) | undefined;
-  uiStateKey?: string | undefined;
-};
+type Unsubscribe = () => void;
 
 type UseStreamRuntimeOptions = UseStreamOptions extends infer O ? O extends UseStreamOptions ? O & LangChainRuntimeExtraOptions : never : never;
 
-type JoinStrategy = "concat-content" | "none";
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metadata?: LangChainMessageConverterMetadata) => useExternalMessageConverter.Message;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { LangChainBaseMessage, LangChainContentBlock, LangChainToolCall, RemoveUIMessage, SubagentDiscoverySnapshot$1 as SubagentDiscoverySnapshot, SubgraphDiscoverySnapshot$1 as SubgraphDiscoverySnapshot, UIMessage, UseStreamRuntimeOptions, convertLangChainBaseMessage, useLangChainError, useLangChainInterruptState, useLangChainInterrupts, useLangChainRespond, useLangChainRespondAll, useLangChainSend, useLangChainSendCommand, useLangChainState, useLangChainStream, useLangChainStreamingTiming, useLangChainSubagents, useLangChainSubgraphs, useLangChainSubmit, useLangChainToolCalls, useStreamRuntime };
+}
 
 declare namespace useExternalMessageConverter {
   type Message = (ThreadMessageLike & {
@@ -1954,12 +1965,7 @@ declare const useExternalMessageConverter: <T extends WeakKey>(_param2: {
   metadata?: useExternalMessageConverter.Metadata | undefined;
 }) => ThreadMessage[];
 
-type LangChainMessageConverterMetadata = useExternalMessageConverter.Metadata & {
-  uiMessagesByParent?: Map<string, UIMessage[]>;
-  messageTiming?: Record<string, MessageTiming>;
-};
-
-declare const convertLangChainBaseMessage: (message: LangChainBaseMessage, metadata?: LangChainMessageConverterMetadata) => useExternalMessageConverter.Message;
+declare const useLangChainError: () => unknown;
 
 declare const useLangChainInterruptState: () => {
   value?: unknown;
@@ -1969,18 +1975,6 @@ declare const useLangChainInterrupts: () => readonly {
   id?: string;
   value?: unknown;
 }[];
-
-declare const useLangChainError: () => unknown;
-
-declare const useLangChainToolCalls: () => readonly AssembledToolCall<string, unknown, unknown>[];
-
-declare const useLangChainSubagents: () => ReadonlyMap<string, SubagentDiscoverySnapshot>;
-
-declare const useLangChainSubgraphs: () => ReadonlyMap<string, SubgraphDiscoverySnapshot>;
-
-declare const useLangChainStream: () => import("@langchain/react").AnyStream | undefined;
-
-declare const useLangChainSubmit: () => (values: Record<string, unknown> | null | undefined, options?: Record<string, unknown>) => Promise<void>;
 
 declare const useLangChainRespond: () => (response: unknown, options?: Record<string, unknown>) => Promise<void>;
 
@@ -1994,12 +1988,18 @@ declare function useLangChainState<T>(key: string): T | undefined;
 
 declare function useLangChainState<T>(key: string, defaultValue: T): T;
 
-declare const useStreamRuntime: (rawOptions: UseStreamRuntimeOptions) => AssistantRuntime;
+declare const useLangChainStream: () => import("@langchain/react").AnyStream | undefined;
 
 declare const useLangChainStreamingTiming: (messages: readonly LangChainBaseMessage[], isRunning: boolean) => Record<string, MessageTiming>;
 
-declare namespace entry_root_exports {
-  export { LangChainBaseMessage, LangChainContentBlock, LangChainToolCall, RemoveUIMessage, SubagentDiscoverySnapshot$1 as SubagentDiscoverySnapshot, SubgraphDiscoverySnapshot$1 as SubgraphDiscoverySnapshot, UIMessage, UseStreamRuntimeOptions, convertLangChainBaseMessage, useLangChainError, useLangChainInterruptState, useLangChainInterrupts, useLangChainRespond, useLangChainRespondAll, useLangChainSend, useLangChainSendCommand, useLangChainState, useLangChainStream, useLangChainStreamingTiming, useLangChainSubagents, useLangChainSubgraphs, useLangChainSubmit, useLangChainToolCalls, useStreamRuntime };
-}
+declare const useLangChainSubagents: () => ReadonlyMap<string, SubagentDiscoverySnapshot>;
+
+declare const useLangChainSubgraphs: () => ReadonlyMap<string, SubgraphDiscoverySnapshot>;
+
+declare const useLangChainSubmit: () => (values: Record<string, unknown> | null | undefined, options?: Record<string, unknown>) => Promise<void>;
+
+declare const useLangChainToolCalls: () => readonly AssembledToolCall<string, unknown, unknown>[];
+
+declare const useStreamRuntime: (rawOptions: UseStreamRuntimeOptions) => AssistantRuntime;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1,33 +1,790 @@
-import { ComponentType, PropsWithChildren } from "react";
+import { Client, StreamMode } from "@langchain/langgraph-sdk";
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-import { Client, StreamMode } from "@langchain/langgraph-sdk";
+import { ComponentType, PropsWithChildren } from "react";
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantMessageContent = string | AssistantMessageContentComplex[];
+
+type AssistantMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentToolUse | MessageContentFile | MessageContentReasoning | MessageContentThinking | MessageContentComputerCall;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
 
 type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type Attachment = PendingAttachment | CompleteAttachment;
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BaseAttachment = {
+  id: string;
+  type: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
+};
+
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
+
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
+
+type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};
+
+type CreateLangGraphStreamOptions = {
+  client: LangGraphStreamClient;
+  assistantId: string;
+  streamMode?: StreamMode | StreamMode[];
+  onDisconnect?: StreamPayload["onDisconnect"];
+};
+
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
+
+type CustomEventType = string;
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
+
+type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-type JSONSchema7Version = string;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type EventType = LangGraphKnownEventTypes | CustomEventType;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -89,164 +846,185 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type JoinStrategy = "concat-content" | "none";
+
+type LangChainEvent = {
+  event: LangGraphKnownEventTypes.MessagesPartial | LangGraphKnownEventTypes.MessagesComplete;
+  data: LangChainMessage[];
+};
+
+type LangChainMessage = {
+  id?: string;
+  type: "system";
+  content: string;
+  additional_kwargs?: Record<string, unknown>;
 } | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
-
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
-};
-
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
-};
-
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  id?: string;
   type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+  content: UserMessageContent;
+  additional_kwargs?: Record<string, unknown>;
+} | {
+  id?: string;
+  type: "tool";
+  content: string;
+  tool_call_id: string;
+  name: string;
+  artifact?: any;
+  status: "error" | "success";
+} | {
+  id?: string;
+  type: "ai";
+  content: AssistantMessageContent;
+  tool_call_chunks?: LangChainToolCallChunk[];
+  tool_calls?: LangChainToolCall[];
+  status?: MessageStatus;
+  additional_kwargs?: {
+    reasoning?: MessageContentReasoning;
+    tool_outputs?: MessageContentComputerCall[];
+    metadata?: Record<string, unknown>;
+  };
 };
 
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type LangChainMessageChunk = {
+  id?: string | undefined;
+  type: "AIMessageChunk";
+  content?: AssistantMessageContent | undefined;
+  tool_call_chunks?: LangChainToolCallChunk[] | undefined;
+};
+
+type LangChainToolCall = {
+  index?: number;
+  id: string;
+  name: string;
+  args: ReadonlyJSONObject;
+  partial_json?: string;
+};
+
+type LangChainToolCallChunk = {
+  index: number;
+  id: string;
+  name: string;
+  args?: string;
+  args_json?: string;
+};
+
+type LangGraphCommand = {
+  resume: string;
+};
+
+type LangGraphInterruptState = {
+  value?: any;
+  resumable?: boolean;
+  when?: string;
+  ns?: string[];
+};
+
+declare enum LangGraphKnownEventTypes {
+  Messages = "messages",
+  MessagesPartial = "messages/partial",
+  MessagesComplete = "messages/complete",
+  Metadata = "metadata",
+  Updates = "updates",
+  Values = "values",
+  Info = "info",
+  Error = "error"
+}
+
+declare class LangGraphMessageAccumulator<TMessage extends {
+  id?: string;
+}> {
+  private messagesMap;
+  private metadataMap;
+  private uiMessages;
+  private appendMessage;
+  constructor(_param0?: LangGraphStateAccumulatorConfig<TMessage>);
+  private ensureMessageId;
+  addMessages(newMessages: TMessage[]): TMessage[];
+  addMessageWithMetadata(message: TMessage, metadata: LangGraphTupleMetadata): TMessage[];
+  getMessages(): TMessage[];
+  getMetadataMap(): Map<string, LangGraphTupleMetadata>;
+  replaceMessages(newMessages: TMessage[]): TMessage[];
+  reconcileMessages(serverMessages: TMessage[]): TMessage[];
+  applyUIUpdate(update: UIMessage | RemoveUIMessage | readonly (UIMessage | RemoveUIMessage)[]): UIMessage[];
+  replaceUIMessages(newUIMessages: UIMessage[]): UIMessage[];
+  getUIMessages(): UIMessage[];
+  clear(): void;
+}
+
+type LangGraphMessagesEvent<TMessage> = {
+  event: EventType;
+  data: TMessage[] | any;
+};
+
+type LangGraphSendMessageConfig = {
+  command?: LangGraphCommand;
+  runConfig?: unknown;
+  checkpointId?: string;
+};
+
+type LangGraphStateAccumulatorConfig<TMessage> = {
+  initialMessages?: TMessage[];
+  initialUIMessages?: UIMessage[];
+  appendMessage?: (prev: TMessage | undefined, curr: TMessage) => TMessage;
+};
+
+type LangGraphStreamCallback<TMessage> = (messages: TMessage[], config: LangGraphSendMessageConfig & {
+  abortSignal: AbortSignal;
+  initialize: () => Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+}) => Promise<AsyncGenerator<LangGraphMessagesEvent<TMessage>>> | AsyncGenerator<LangGraphMessagesEvent<TMessage>>;
+
+type LangGraphStreamClient = {
+  runs: Pick<Client["runs"], "stream">;
+};
+
+type LangGraphTupleMetadata = Record<string, unknown>;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
+};
+
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
+
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
+};
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -276,11 +1054,183 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessageContentComputerCall = {
+  type: "computer_call";
+  call_id: string;
+  id: string;
+  action: unknown;
+  pending_safety_checks: unknown[];
+  index: number;
+};
+
+type MessageContentFile = {
+  type: "file";
+  data: string;
+  mime_type: string;
+  source_type?: "base64";
+  metadata?: {
+    filename?: string;
+  };
+};
+
+type MessageContentImageUrl = {
+  type: "image_url";
+  image_url: string | {
+    url?: string;
+  };
+};
+
+type MessageContentReasoning = {
+  type: "reasoning";
+  summary?: MessageContentReasoningSummaryText[];
+  reasoning?: string;
+};
+
+type MessageContentReasoningSummaryText = {
+  type: "summary_text";
+  text?: string;
+};
+
+type MessageContentText = {
+  type: "text" | "text_delta";
+  text: string;
+};
+
+type MessageContentThinking = {
+  type: "thinking";
+  thinking: string;
+};
+
+type MessageContentToolUse = {
+  type: "input_json_delta" | "tool_use";
+};
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param1: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param2: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -291,6 +1241,28 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnCustomEventCallback = (type: string, data: unknown) => void | Promise<void>;
+
+type OnErrorEventCallback = (error: unknown) => void | Promise<void>;
+
+type OnInfoEventCallback = (info: unknown) => void | Promise<void>;
+
+type OnMessageChunkCallback = (chunk: LangChainMessageChunk, metadata: LangGraphTupleMetadata) => void | Promise<void>;
+
+type OnMetadataEventCallback = (metadata: unknown) => void | Promise<void>;
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type OnSubgraphErrorEventCallback = (namespace: string, error: unknown) => void | Promise<void>;
+
+type OnSubgraphUpdatesEventCallback = (namespace: string, updates: unknown) => void | Promise<void>;
+
+type OnSubgraphValuesEventCallback = (namespace: string, values: unknown) => void | Promise<void>;
+
+type OnUpdatesEventCallback = (updates: unknown) => void | Promise<void>;
+
+type OnValuesEventCallback = (values: unknown) => void | Promise<void>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -319,73 +1291,20 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
-} | {
-  readonly type: "part-finish";
-} | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
-  readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
 };
 
 type PendingAttachmentStatus = {
@@ -400,408 +1319,39 @@ type PendingAttachmentStatus = {
   reason: "error" | "upload-paused";
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
 };
 
-type BaseAttachment = {
-  id: string;
-  type: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string | undefined;
-  file?: File;
-  content?: ThreadUserMessagePart[];
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
-};
-
-type CompleteAttachment = BaseAttachment & {
-  status: CompleteAttachmentStatus;
-  content: ThreadUserMessagePart[];
-};
-
-type Attachment = PendingAttachment | CompleteAttachment;
-
-type CreateAttachment = {
-  id?: string;
-  type?: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string;
-  content: ThreadUserMessagePart[];
-};
-
-type TextMessagePart = {
-  readonly type: "text";
+type QuoteInfo = {
   readonly text: string;
-  readonly parentId?: string;
+  readonly messageId: string;
 };
 
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -836,65 +1386,319 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
+};
+
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
+};
+
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type RemoveUIMessage = {
+  type: "remove-ui";
+  id: string;
+};
+
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+type StreamPayload = NonNullable<Parameters<LangGraphStreamClient["runs"]["stream"]>[2]>;
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -944,413 +1748,6 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
 type ThreadRuntime = {
   readonly path: ThreadRuntimePath;
   readonly composer: ThreadComposerRuntime;
@@ -1379,626 +1776,267 @@ type ThreadRuntime = {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
+type ThreadSuggestion = {
+  prompt: string;
 };
 
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
 };
 
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
 
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
 };
 
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
     payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
-
-type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
-
-type JoinStrategy = "concat-content" | "none";
-
-declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
   };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
   };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
 }
 
-declare const useExternalMessageConverter: <T extends WeakKey>(_param2: {
-  callback: useExternalMessageConverter.Callback<T>;
-  messages: T[];
-  isRunning: boolean;
-  joinStrategy?: JoinStrategy | undefined;
-  metadata?: useExternalMessageConverter.Metadata | undefined;
-}) => ThreadMessage[];
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
 
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
 };
 
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
 };
 
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
+type ToolExecutionStatus = {
+  type: "executing";
 } | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
 } | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
 };
 
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
 
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
 }
 
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
 };
 
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
 };
 
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
 
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
 
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type LangChainToolCallChunk = {
-  index: number;
-  id: string;
-  name: string;
-  args?: string;
-  args_json?: string;
-};
-
-type LangChainToolCall = {
-  index?: number;
-  id: string;
-  name: string;
-  args: ReadonlyJSONObject;
-  partial_json?: string;
-};
-
-type MessageContentText = {
-  type: "text" | "text_delta";
-  text: string;
-};
-
-type MessageContentImageUrl = {
-  type: "image_url";
-  image_url: string | {
-    url?: string;
-  };
-};
-
-type MessageContentThinking = {
-  type: "thinking";
-  thinking: string;
-};
-
-type MessageContentReasoningSummaryText = {
-  type: "summary_text";
-  text?: string;
-};
-
-type MessageContentReasoning = {
-  type: "reasoning";
-  summary?: MessageContentReasoningSummaryText[];
-  reasoning?: string;
-};
-
-type MessageContentToolUse = {
-  type: "input_json_delta" | "tool_use";
-};
-
-type MessageContentComputerCall = {
-  type: "computer_call";
-  call_id: string;
-  id: string;
-  action: unknown;
-  pending_safety_checks: unknown[];
-  index: number;
-};
-
-declare enum LangGraphKnownEventTypes {
-  Messages = "messages",
-  MessagesPartial = "messages/partial",
-  MessagesComplete = "messages/complete",
-  Metadata = "metadata",
-  Updates = "updates",
-  Values = "values",
-  Info = "info",
-  Error = "error"
-}
-
-type CustomEventType = string;
-
-type EventType = LangGraphKnownEventTypes | CustomEventType;
-
-type MessageContentFile = {
-  type: "file";
-  data: string;
-  mime_type: string;
-  source_type?: "base64";
-  metadata?: {
-    filename?: string;
-  };
-};
-
-type UserMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentFile;
-
-type AssistantMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentToolUse | MessageContentFile | MessageContentReasoning | MessageContentThinking | MessageContentComputerCall;
-
-type UserMessageContent = string | UserMessageContentComplex[];
-
-type AssistantMessageContent = string | AssistantMessageContentComplex[];
-
-type LangChainMessage = {
-  id?: string;
-  type: "system";
-  content: string;
-  additional_kwargs?: Record<string, unknown>;
-} | {
-  id?: string;
-  type: "human";
-  content: UserMessageContent;
-  additional_kwargs?: Record<string, unknown>;
-} | {
-  id?: string;
-  type: "tool";
-  content: string;
-  tool_call_id: string;
-  name: string;
-  artifact?: any;
-  status: "error" | "success";
-} | {
-  id?: string;
-  type: "ai";
-  content: AssistantMessageContent;
-  tool_call_chunks?: LangChainToolCallChunk[];
-  tool_calls?: LangChainToolCall[];
-  status?: MessageStatus;
-  additional_kwargs?: {
-    reasoning?: MessageContentReasoning;
-    tool_outputs?: MessageContentComputerCall[];
-    metadata?: Record<string, unknown>;
-  };
-};
-
-type LangChainMessageChunk = {
-  id?: string | undefined;
-  type: "AIMessageChunk";
-  content?: AssistantMessageContent | undefined;
-  tool_call_chunks?: LangChainToolCallChunk[] | undefined;
-};
-
-type LangChainEvent = {
-  event: LangGraphKnownEventTypes.MessagesPartial | LangGraphKnownEventTypes.MessagesComplete;
-  data: LangChainMessage[];
-};
-
-type LangGraphTupleMetadata = Record<string, unknown>;
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
 
 type UIMessage<TName extends string = string, TProps extends Record<string, unknown> = Record<string, unknown>> = {
   type: "ui";
@@ -2015,30 +2053,15 @@ type UIMessage<TName extends string = string, TProps extends Record<string, unkn
   };
 };
 
-type RemoveUIMessage = {
-  type: "remove-ui";
-  id: string;
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
 };
 
-type OnMessageChunkCallback = (chunk: LangChainMessageChunk, metadata: LangGraphTupleMetadata) => void | Promise<void>;
-
-type OnValuesEventCallback = (values: unknown) => void | Promise<void>;
-
-type OnUpdatesEventCallback = (updates: unknown) => void | Promise<void>;
-
-type OnSubgraphValuesEventCallback = (namespace: string, values: unknown) => void | Promise<void>;
-
-type OnSubgraphUpdatesEventCallback = (namespace: string, updates: unknown) => void | Promise<void>;
-
-type OnMetadataEventCallback = (metadata: unknown) => void | Promise<void>;
-
-type OnInfoEventCallback = (info: unknown) => void | Promise<void>;
-
-type OnErrorEventCallback = (error: unknown) => void | Promise<void>;
-
-type OnSubgraphErrorEventCallback = (namespace: string, error: unknown) => void | Promise<void>;
-
-type OnCustomEventCallback = (type: string, data: unknown) => void | Promise<void>;
+type Unsubscribe = () => void;
 
 type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
@@ -2086,39 +2109,70 @@ type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
   unstable_threadListAdapter?: RemoteThreadListAdapter | undefined;
 };
 
-type LangGraphCommand = {
-  resume: string;
+type UserMessageContent = string | UserMessageContentComplex[];
+
+type UserMessageContentComplex = MessageContentText | MessageContentImageUrl | MessageContentFile;
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
 };
 
-type LangGraphSendMessageConfig = {
-  command?: LangGraphCommand;
-  runConfig?: unknown;
-  checkpointId?: string;
-};
+declare const appendLangChainChunk: (prev: LangChainMessage | undefined, curr: LangChainMessage | LangChainMessageChunk) => LangChainMessage;
 
-type LangGraphMessagesEvent<TMessage> = {
-  event: EventType;
-  data: TMessage[] | any;
-};
+declare const convertLangChainMessages: useExternalMessageConverter.Callback<LangChainMessage>;
 
-type LangGraphStreamCallback<TMessage> = (messages: TMessage[], config: LangGraphSendMessageConfig & {
-  abortSignal: AbortSignal;
-  initialize: () => Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-}) => Promise<AsyncGenerator<LangGraphMessagesEvent<TMessage>>> | AsyncGenerator<LangGraphMessagesEvent<TMessage>>;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
-type LangGraphInterruptState = {
-  value?: any;
-  resumable?: boolean;
-  when?: string;
-  ns?: string[];
-};
+declare namespace entry_root_exports {
+  export { CreateLangGraphStreamOptions, LangChainEvent, LangChainMessage, LangChainMessageChunk, LangChainToolCall, LangChainToolCallChunk, LangGraphCommand, LangGraphInterruptState, LangGraphMessageAccumulator, LangGraphMessagesEvent, LangGraphSendMessageConfig, LangGraphStreamCallback, LangGraphStreamClient, LangGraphTupleMetadata, OnCustomEventCallback, OnErrorEventCallback, OnInfoEventCallback, OnMessageChunkCallback, OnMetadataEventCallback, OnSubgraphErrorEventCallback, OnSubgraphUpdatesEventCallback, OnSubgraphValuesEventCallback, OnUpdatesEventCallback, OnValuesEventCallback, RemoveUIMessage, UIMessage, UseLangGraphRuntimeOptions, appendLangChainChunk, convertLangChainMessages, unstable_createLangGraphStream, useLangGraphInterruptState, useLangGraphMessageMetadata, useLangGraphMessages, useLangGraphRuntime, useLangGraphSend, useLangGraphSendCommand, useLangGraphStreamingTiming, useLangGraphUIMessages };
+}
+
+declare const unstable_createLangGraphStream: (_param3: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
+
+declare namespace useExternalMessageConverter {
+  type Message = (ThreadMessageLike & {
+    readonly convertConfig?: {
+      readonly joinStrategy?: JoinStrategy;
+    };
+  }) | {
+    role: "tool";
+    toolCallId: string;
+    toolName?: string | undefined;
+    result: any;
+    artifact?: any;
+    isError?: boolean;
+    messages?: readonly ThreadMessage[];
+  };
+  type Metadata = {
+    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+    readonly error?: ReadonlyJSONValue;
+    readonly messageTiming?: Record<string, MessageTiming>;
+  };
+  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+}
+
+declare const useExternalMessageConverter: <T extends WeakKey>(_param4: {
+  callback: useExternalMessageConverter.Callback<T>;
+  messages: T[];
+  isRunning: boolean;
+  joinStrategy?: JoinStrategy | undefined;
+  metadata?: useExternalMessageConverter.Metadata | undefined;
+}) => ThreadMessage[];
+
+declare const useLangGraphInterruptState: () => LangGraphInterruptState | undefined;
+
+declare const useLangGraphMessageMetadata: () => Map<string, LangGraphTupleMetadata>;
 
 declare const useLangGraphMessages: <TMessage extends {
   id?: string;
-}>(_param3: {
+}>(_param5: {
   stream: LangGraphStreamCallback<TMessage>;
   appendMessage?: (prev: TMessage | undefined, curr: TMessage) => TMessage;
   uiStateKey?: string;
@@ -2146,68 +2200,14 @@ declare const useLangGraphMessages: <TMessage extends {
   setUIMessages: (next: UIMessage[]) => void;
 };
 
-type LangGraphStateAccumulatorConfig<TMessage> = {
-  initialMessages?: TMessage[];
-  initialUIMessages?: UIMessage[];
-  appendMessage?: (prev: TMessage | undefined, curr: TMessage) => TMessage;
-};
-
-declare class LangGraphMessageAccumulator<TMessage extends {
-  id?: string;
-}> {
-  private messagesMap;
-  private metadataMap;
-  private uiMessages;
-  private appendMessage;
-  constructor(_param4?: LangGraphStateAccumulatorConfig<TMessage>);
-  private ensureMessageId;
-  addMessages(newMessages: TMessage[]): TMessage[];
-  addMessageWithMetadata(message: TMessage, metadata: LangGraphTupleMetadata): TMessage[];
-  getMessages(): TMessage[];
-  getMetadataMap(): Map<string, LangGraphTupleMetadata>;
-  replaceMessages(newMessages: TMessage[]): TMessage[];
-  reconcileMessages(serverMessages: TMessage[]): TMessage[];
-  applyUIUpdate(update: UIMessage | RemoveUIMessage | readonly (UIMessage | RemoveUIMessage)[]): UIMessage[];
-  replaceUIMessages(newUIMessages: UIMessage[]): UIMessage[];
-  getUIMessages(): UIMessage[];
-  clear(): void;
-}
-
-declare const appendLangChainChunk: (prev: LangChainMessage | undefined, curr: LangChainMessage | LangChainMessageChunk) => LangChainMessage;
-
-declare const convertLangChainMessages: useExternalMessageConverter.Callback<LangChainMessage>;
-
-type LangGraphStreamClient = {
-  runs: Pick<Client["runs"], "stream">;
-};
-
-type StreamPayload = NonNullable<Parameters<LangGraphStreamClient["runs"]["stream"]>[2]>;
-
-type CreateLangGraphStreamOptions = {
-  client: LangGraphStreamClient;
-  assistantId: string;
-  streamMode?: StreamMode | StreamMode[];
-  onDisconnect?: StreamPayload["onDisconnect"];
-};
-
-declare const unstable_createLangGraphStream: (_param5: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
-
-declare const useLangGraphInterruptState: () => LangGraphInterruptState | undefined;
+declare const useLangGraphRuntime: (_param6: UseLangGraphRuntimeOptions) => AssistantRuntime;
 
 declare const useLangGraphSend: () => (messages: LangChainMessage[], config: LangGraphSendMessageConfig) => Promise<void>;
 
 declare const useLangGraphSendCommand: () => (command: LangGraphCommand) => Promise<void>;
 
-declare const useLangGraphMessageMetadata: () => Map<string, LangGraphTupleMetadata>;
-
-declare const useLangGraphUIMessages: () => readonly UIMessage<string, Record<string, unknown>>[];
-
-declare const useLangGraphRuntime: (_param6: UseLangGraphRuntimeOptions) => AssistantRuntime;
-
 declare const useLangGraphStreamingTiming: (messages: readonly LangChainMessage[], isRunning: boolean) => Record<string, MessageTiming>;
 
-declare namespace entry_root_exports {
-  export { CreateLangGraphStreamOptions, LangChainEvent, LangChainMessage, LangChainMessageChunk, LangChainToolCall, LangChainToolCallChunk, LangGraphCommand, LangGraphInterruptState, LangGraphMessageAccumulator, LangGraphMessagesEvent, LangGraphSendMessageConfig, LangGraphStreamCallback, LangGraphStreamClient, LangGraphTupleMetadata, OnCustomEventCallback, OnErrorEventCallback, OnInfoEventCallback, OnMessageChunkCallback, OnMetadataEventCallback, OnSubgraphErrorEventCallback, OnSubgraphUpdatesEventCallback, OnSubgraphValuesEventCallback, OnUpdatesEventCallback, OnValuesEventCallback, RemoveUIMessage, UIMessage, UseLangGraphRuntimeOptions, appendLangChainChunk, convertLangChainMessages, unstable_createLangGraphStream, useLangGraphInterruptState, useLangGraphMessageMetadata, useLangGraphMessages, useLangGraphRuntime, useLangGraphSend, useLangGraphSendCommand, useLangGraphStreamingTiming, useLangGraphUIMessages };
-}
+declare const useLangGraphUIMessages: () => readonly UIMessage<string, Record<string, unknown>>[];
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-lexical.ts
+++ b/api-surface/assistant-ui__react-lexical.ts
@@ -1,57 +1,12 @@
-import { ComponentPropsWithoutRef, FC, ReactNode } from "react";
-
 import { DOMConversionMap, DOMExportOutput, DecoratorNode, EditorConfig, LexicalEditor, LexicalNode, NodeKey, SerializedLexicalNode, Spread } from "lexical";
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+import { ComponentPropsWithoutRef, FC, ReactNode } from "react";
 
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
+declare function $createDirectiveNode(item: Unstable_TriggerItem, directiveText?: string | undefined): DirectiveNode;
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+declare function $createDirectiveNodeWithFormatter(item: Unstable_TriggerItem, formatter: Unstable_DirectiveFormatter): DirectiveNode;
 
-type Unstable_TriggerItem = {
-  readonly id: string;
-  readonly type: string;
-  readonly label: string;
-  readonly description?: string | undefined;
-  readonly metadata?: ReadonlyJSONObject | undefined;
-};
-
-type Unstable_DirectiveSegment = {
-  readonly kind: "text";
-  readonly text: string;
-} | {
-  readonly kind: "mention";
-  readonly type: string;
-  readonly label: string;
-  readonly id: string;
-};
-
-type Unstable_DirectiveFormatter = {
-  serialize(item: Unstable_TriggerItem): string;
-  parse(text: string): readonly Unstable_DirectiveSegment[];
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+declare function $isDirectiveNode(node: LexicalNode | null | undefined): node is DirectiveNode;
 
 type DirectiveChipProps = {
   directiveId: string;
@@ -60,15 +15,6 @@ type DirectiveChipProps = {
 };
 
 declare const DirectiveChipProvider: import("react").Provider<FC<DirectiveChipProps> | null>;
-
-type SerializedDirectiveNode = Spread<{
-  directiveId: string;
-  directiveType: string;
-  label: string;
-  description?: string | undefined;
-  metadata?: Unstable_TriggerItem["metadata"];
-  directiveText?: string;
-}, SerializedLexicalNode>;
 
 declare class DirectiveNode extends DecoratorNode<ReactNode> {
   __directiveId: string;
@@ -95,26 +41,10 @@ declare class DirectiveNode extends DecoratorNode<ReactNode> {
   getDirectiveItem(): Unstable_TriggerItem;
 }
 
-declare function $createDirectiveNode(item: Unstable_TriggerItem, directiveText?: string | undefined): DirectiveNode;
-
-declare function $createDirectiveNodeWithFormatter(item: Unstable_TriggerItem, formatter: Unstable_DirectiveFormatter): DirectiveNode;
-
-declare function $isDirectiveNode(node: LexicalNode | null | undefined): node is DirectiveNode;
+declare function DirectivePlugin(_param0?: DirectivePluginProps): null;
 
 type DirectivePluginProps = {
   onDirectiveSelect?: ((item: Unstable_TriggerItem) => void) | undefined;
-};
-
-declare function DirectivePlugin(_param0?: DirectivePluginProps): null;
-
-type LexicalComposerInputProps = Omit<ComponentPropsWithoutRef<"div">, "autoFocus"> & {
-  submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
-  cancelOnEscape?: boolean | undefined;
-  placeholder?: string | undefined;
-  autoFocus?: boolean | undefined;
-  directivePluginProps?: DirectivePluginProps | undefined;
-  directiveChip?: FC<DirectiveChipProps> | undefined;
-  formatter?: Unstable_DirectiveFormatter | undefined;
 };
 
 declare const LexicalComposerInput: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref">, "autoFocus"> & {
@@ -126,6 +56,76 @@ declare const LexicalComposerInput: import("react").ForwardRefExoticComponent<Om
   directiveChip?: FC<DirectiveChipProps> | undefined;
   formatter?: Unstable_DirectiveFormatter | undefined;
 } & import("react").RefAttributes<HTMLDivElement>>;
+
+type LexicalComposerInputProps = Omit<ComponentPropsWithoutRef<"div">, "autoFocus"> & {
+  submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
+  cancelOnEscape?: boolean | undefined;
+  placeholder?: string | undefined;
+  autoFocus?: boolean | undefined;
+  directivePluginProps?: DirectivePluginProps | undefined;
+  directiveChip?: FC<DirectiveChipProps> | undefined;
+  formatter?: Unstable_DirectiveFormatter | undefined;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+type SerializedDirectiveNode = Spread<{
+  directiveId: string;
+  directiveType: string;
+  label: string;
+  description?: string | undefined;
+  metadata?: Unstable_TriggerItem["metadata"];
+  directiveText?: string;
+}, SerializedLexicalNode>;
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type Unstable_DirectiveFormatter = {
+  serialize(item: Unstable_TriggerItem): string;
+  parse(text: string): readonly Unstable_DirectiveSegment[];
+};
+
+type Unstable_DirectiveSegment = {
+  readonly kind: "text";
+  readonly text: string;
+} | {
+  readonly kind: "mention";
+  readonly type: string;
+  readonly label: string;
+  readonly id: string;
+};
+
+type Unstable_TriggerItem = {
+  readonly id: string;
+  readonly type: string;
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly metadata?: ReadonlyJSONObject | undefined;
+};
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
 declare namespace entry_root_exports {
   export { $createDirectiveNode, $createDirectiveNodeWithFormatter, $isDirectiveNode, DirectiveChipProps, DirectiveChipProvider, DirectiveNode, DirectivePlugin, DirectivePluginProps, LexicalComposerInput, LexicalComposerInputProps };

--- a/api-surface/assistant-ui__react-markdown.ts
+++ b/api-surface/assistant-ui__react-markdown.ts
@@ -1,64 +1,88 @@
+import { Primitive } from "@radix-ui/react-primitive";
+
 import { ComponentProps, ComponentPropsWithoutRef, ComponentType, ElementType, ForwardRefExoticComponent, RefAttributes } from "react";
 
 import { Options } from "react-markdown";
 
-import { Primitive } from "@radix-ui/react-primitive";
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-interface Data$1 {
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
 }
 
-interface Point {
-  line: number;
-  column: number;
-  offset?: number | undefined;
-}
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
-interface Position {
-  start: Point;
-  end: Point;
-}
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
 
-interface Node$1 {
-  type: string;
-  data?: Data$1 | undefined;
-  position?: Position | undefined;
-}
+type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {
+  node?: Element | undefined;
+}>;
 
-interface Data extends Data$1 {
-}
-
-interface Properties {
-  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
-}
-
-type ElementContent = ElementContentMap[keyof ElementContentMap];
-
-interface ElementContentMap {
-  comment: Comment;
-  element: Element;
-  text: Text;
-}
-
-type RootContent = RootContentMap[keyof RootContentMap];
-
-interface RootContentMap {
-  comment: Comment;
-  doctype: Doctype;
-  element: Element;
-  text: Text;
-}
-
-interface Node extends Node$1 {
-  data?: Data | undefined;
-}
-
-interface Literal extends Node {
-  value: string;
-}
-
-interface Parent extends Node {
-  children: RootContent[];
-}
+type CodeHeaderProps = {
+  node?: Element | undefined;
+  language: string | undefined;
+  code: string;
+};
 
 interface Comment extends Literal {
   type: "comment";
@@ -66,6 +90,30 @@ interface Comment extends Literal {
 }
 
 interface CommentData extends Data {
+}
+
+type Components = {
+  [Key in Extract<ElementType, string>]?: ComponentType<ComponentProps<Key>>;
+} & {
+  SyntaxHighlighter?: ComponentType<Omit<SyntaxHighlighterProps, "node">> | undefined;
+  CodeHeader?: ComponentType<Omit<CodeHeaderProps, "node">> | undefined;
+};
+
+interface Data extends Data$1 {
+}
+
+interface Data$1 {
+}
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
 }
 
 interface Doctype extends Node$1 {
@@ -85,163 +133,15 @@ interface Element extends Parent {
   data?: ElementData | undefined;
 }
 
+type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+interface ElementContentMap {
+  comment: Comment;
+  element: Element;
+  text: Text;
+}
+
 interface ElementData extends Data {
-}
-
-interface Root extends Parent {
-  type: "root";
-  children: RootContent[];
-  data?: RootData | undefined;
-}
-
-interface RootData extends Data {
-}
-
-interface Text extends Literal {
-  type: "text";
-  data?: TextData | undefined;
-}
-
-interface TextData extends Data {
-}
-
-type PreComponent = ComponentType<ComponentPropsWithoutRef<"pre"> & {
-  node?: Element | undefined;
-}>;
-
-type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {
-  node?: Element | undefined;
-}>;
-
-type CodeHeaderProps = {
-  node?: Element | undefined;
-  language: string | undefined;
-  code: string;
-};
-
-type SyntaxHighlighterProps = {
-  node?: Element | undefined;
-  components: {
-    Pre: PreComponent;
-    Code: CodeComponent;
-  };
-  language: string;
-  code: string;
-};
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
 }
 
 interface EventLog {
@@ -250,31 +150,13 @@ interface EventLog {
   data: unknown;
 }
 
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+interface Literal extends Node {
+  value: string;
 }
 
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
-declare global {
-  interface Window {
-    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
-  }
-}
-
-type SmoothOptions = {
-  drainMs?: number | undefined;
-  maxCharIntervalMs?: number | undefined;
-  maxCharsPerFrame?: number | undefined;
-  minCommitMs?: number | undefined;
-};
-
-type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+declare const MarkdownTextPrimitive: ForwardRefExoticComponent<MarkdownTextPrimitiveProps> & RefAttributes<HTMLDivElement>;
 
 type MarkdownTextPrimitiveProps = Omit<Options, "children" | "components"> & {
   className?: string | undefined;
@@ -293,16 +175,138 @@ type MarkdownTextPrimitiveProps = Omit<Options, "children" | "components"> & {
   preprocess?: (text: string) => string;
 };
 
-declare const MarkdownTextPrimitive: ForwardRefExoticComponent<MarkdownTextPrimitiveProps> & RefAttributes<HTMLDivElement>;
+interface Node extends Node$1 {
+  data?: Data | undefined;
+}
 
-declare const useIsMarkdownCodeBlock: () => boolean;
+interface Node$1 {
+  type: string;
+  data?: Data$1 | undefined;
+  position?: Position | undefined;
+}
 
-type Components = {
-  [Key in Extract<ElementType, string>]?: ComponentType<ComponentProps<Key>>;
-} & {
-  SyntaxHighlighter?: ComponentType<Omit<SyntaxHighlighterProps, "node">> | undefined;
-  CodeHeader?: ComponentType<Omit<CodeHeaderProps, "node">> | undefined;
+interface Parent extends Node {
+  children: RootContent[];
+}
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+interface Point {
+  line: number;
+  column: number;
+  offset?: number | undefined;
+}
+
+interface Position {
+  start: Point;
+  end: Point;
+}
+
+type PreComponent = ComponentType<ComponentPropsWithoutRef<"pre"> & {
+  node?: Element | undefined;
+}>;
+
+type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive.div>;
+
+interface Properties {
+  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
+}
+
+interface Root extends Parent {
+  type: "root";
+  children: RootContent[];
+  data?: RootData | undefined;
+}
+
+type RootContent = RootContentMap[keyof RootContentMap];
+
+interface RootContentMap {
+  comment: Comment;
+  doctype: Doctype;
+  element: Element;
+  text: Text;
+}
+
+interface RootData extends Data {
+}
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SmoothOptions = {
+  drainMs?: number | undefined;
+  maxCharIntervalMs?: number | undefined;
+  maxCharsPerFrame?: number | undefined;
+  minCommitMs?: number | undefined;
 };
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SyntaxHighlighterProps = {
+  node?: Element | undefined;
+  components: {
+    Pre: PreComponent;
+    Code: CodeComponent;
+  };
+  language: string;
+  code: string;
+};
+
+interface Text extends Literal {
+  type: "text";
+  data?: TextData | undefined;
+}
+
+interface TextData extends Data {
+}
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unsubscribe = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+declare function escapeCurrencyDollars(text: string): string;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare global {
+  interface Window {
+    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { CodeHeaderProps, MarkdownTextPrimitive, MarkdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, normalizeMathDelimiters, rewriteCustomMathTags, rewriteLatexBracketDelimiters, memoizeMarkdownComponents as unstable_memoizeMarkdownComponents, useIsMarkdownCodeBlock };
+}
 
 declare const memoizeMarkdownComponents: (components?: Components) => {
   [k: string]: import("react").MemoExoticComponent<(_param0: {
@@ -310,16 +314,12 @@ declare const memoizeMarkdownComponents: (components?: Components) => {
   }) => import("react").JSX.Element> | undefined;
 };
 
-declare function rewriteLatexBracketDelimiters(text: string): string;
+declare function normalizeMathDelimiters(text: string): string;
 
 declare function rewriteCustomMathTags(text: string): string;
 
-declare function normalizeMathDelimiters(text: string): string;
+declare function rewriteLatexBracketDelimiters(text: string): string;
 
-declare function escapeCurrencyDollars(text: string): string;
-
-declare namespace entry_root_exports {
-  export { CodeHeaderProps, MarkdownTextPrimitive, MarkdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, normalizeMathDelimiters, rewriteCustomMathTags, rewriteLatexBracketDelimiters, memoizeMarkdownComponents as unstable_memoizeMarkdownComponents, useIsMarkdownCodeBlock };
-}
+declare const useIsMarkdownCodeBlock: () => boolean;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -1,8 +1,53 @@
-import { ComponentPropsWithoutRef, ComponentRef, FC, PropsWithChildren, ReactNode } from "react";
+import { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 
 import { Primitive } from "@radix-ui/react-primitive";
 
-import { OAuthClientInformationFull, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { ComponentPropsWithoutRef, ComponentRef, FC, PropsWithChildren, ReactNode } from "react";
+
+interface ScopeRegistry {
+    mcp: {
+      methods: MCPManagerMethods;
+    };
+    mcpServer: {
+      methods: MCPServerMethods;
+      meta: {
+        source: "mcp";
+        query: MCPServerQuery;
+      };
+    };
+}
+
+type AddFormAuthType = MCPAuthConfig["type"];
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
 
 type MCPAuthConfig = {
   type: "none";
@@ -18,6 +63,8 @@ type MCPAuthConfig = {
   clientId?: string | undefined;
   clientSecret?: string | undefined;
 };
+
+type MCPConnectionState = "authPending" | "authRequired" | "connected" | "connecting" | "disconnected" | "error";
 
 type MCPConnector = {
   id: string;
@@ -37,28 +84,22 @@ type MCPCustomServerRecord = {
   createdAt: number;
 };
 
-type MCPServerKind = "connector" | "custom";
-
-type MCPConnectionState = "authPending" | "authRequired" | "connected" | "connecting" | "disconnected" | "error";
-
-type MCPToolInfo = {
-  name: string;
-  description?: string | undefined;
-  inputSchema: unknown;
-};
-
-type MCPServerState = {
-  id: string;
-  kind: MCPServerKind;
-  name: string;
-  url: string;
-  icon?: string | undefined;
-  connectionState: MCPConnectionState;
-  lastError: {
-    message: string;
-  } | null;
-  tools: MCPToolInfo[];
-  authorizationUrl: string | null;
+type MCPManagerMethods = {
+  getState: () => MCPManagerState;
+  server: (query: MCPServerQuery) => MCPServerMethods;
+  connector: (query: {
+    index: number;
+  }) => MCPServerMethods;
+  customServer: (query: {
+    index: number;
+  }) => MCPServerMethods;
+  addCustomServer: (input: {
+    name: string;
+    url: string;
+    auth: MCPAuthConfig;
+    connectionTimeout?: number | undefined;
+  }) => Promise<string>;
+  removeServer: (id: string) => Promise<void>;
 };
 
 type MCPManagerState = {
@@ -67,6 +108,15 @@ type MCPManagerState = {
   customServers: MCPServerState[];
   isHydrated: boolean;
 };
+
+type MCPPersistedAuthState = {
+  tokens?: OAuthTokens;
+  clientInformation?: OAuthClientInformationFull;
+  codeVerifier?: string;
+  token?: string;
+};
+
+type MCPServerKind = "connector" | "custom";
 
 type MCPServerMethods = {
   getState: () => MCPServerState;
@@ -88,52 +138,19 @@ type MCPServerQuery = {
   index: number;
 };
 
-type MCPManagerMethods = {
-  getState: () => MCPManagerState;
-  server: (query: MCPServerQuery) => MCPServerMethods;
-  connector: (query: {
-    index: number;
-  }) => MCPServerMethods;
-  customServer: (query: {
-    index: number;
-  }) => MCPServerMethods;
-  addCustomServer: (input: {
-    name: string;
-    url: string;
-    auth: MCPAuthConfig;
-    connectionTimeout?: number | undefined;
-  }) => Promise<string>;
-  removeServer: (id: string) => Promise<void>;
+type MCPServerState = {
+  id: string;
+  kind: MCPServerKind;
+  name: string;
+  url: string;
+  icon?: string | undefined;
+  connectionState: MCPConnectionState;
+  lastError: {
+    message: string;
+  } | null;
+  tools: MCPToolInfo[];
+  authorizationUrl: string | null;
 };
-
-interface ScopeRegistry {
-    mcp: {
-      methods: MCPManagerMethods;
-    };
-    mcpServer: {
-      methods: MCPServerMethods;
-      meta: {
-        source: "mcp";
-        query: MCPServerQuery;
-      };
-    };
-}
-
-type MCPPersistedAuthState = {
-  tokens?: OAuthTokens;
-  clientInformation?: OAuthClientInformationFull;
-  codeVerifier?: string;
-  token?: string;
-};
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
 
 type MCPStorage = {
   loadCustomServers: () => Promise<MCPCustomServerRecord[]>;
@@ -145,7 +162,84 @@ type MCPStorage = {
 
 type MCPStorageElement = ResourceElement<MCPStorage>;
 
-declare function defineConnector(connector: MCPConnector): MCPConnector;
+type MCPToolInfo = {
+  name: string;
+  description?: string | undefined;
+  inputSchema: unknown;
+};
+
+declare namespace McpAddFormPrimitiveAuthFields {
+  type Props = {
+    children?: FC<{
+      authType: AddFormAuthType;
+    }>;
+  };
+}
+
+declare const McpAddFormPrimitiveAuthFields: FC<McpAddFormPrimitiveAuthFields.Props>;
+
+declare namespace McpAddFormPrimitiveAuthSelect {
+  type Element = ComponentRef<typeof Primitive.select>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.select>, "onChange" | "value">;
+}
+
+declare const McpAddFormPrimitiveAuthSelect: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveAuthSelect.Props & import("react").RefAttributes<HTMLSelectElement>>;
+
+declare namespace McpAddFormPrimitiveCancel {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+declare const McpAddFormPrimitiveCancel: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpAddFormPrimitiveError {
+  type Element = ComponentRef<typeof Primitive.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+declare const McpAddFormPrimitiveError: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace McpAddFormPrimitiveNameField {
+  type Element = ComponentRef<typeof Primitive.input>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
+}
+
+declare const McpAddFormPrimitiveNameField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveNameField.Props & import("react").RefAttributes<HTMLInputElement>>;
+
+declare namespace McpAddFormPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive.form>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.form>, "onSubmit"> & {
+    onSubmitted?: (id: string) => void;
+    onCancel?: () => void;
+  };
+}
+
+declare const McpAddFormPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
+  asChild?: boolean;
+}, "ref">, "onSubmit"> & {
+  onSubmitted?: (id: string) => void;
+  onCancel?: () => void;
+} & import("react").RefAttributes<HTMLFormElement>>;
+
+declare namespace McpAddFormPrimitiveSubmit {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+declare const McpAddFormPrimitiveSubmit: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpAddFormPrimitiveUrlField {
+  type Element = ComponentRef<typeof Primitive.input>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
+}
+
+declare const McpAddFormPrimitiveUrlField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveUrlField.Props & import("react").RefAttributes<HTMLInputElement>>;
 
 declare const McpConnectorByIndexProvider: FC<PropsWithChildren<{
   index: number;
@@ -155,94 +249,12 @@ declare const McpCustomServerByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
 
-declare const McpServerByIdProvider: FC<PropsWithChildren<{
-  id: string;
-}>>;
-
-type UseMcpOAuthCallbackOptions = {
-  url?: string;
-  onComplete?: (serverId: string) => void;
-  onError?: (err: Error) => void;
-};
-
-type UseMcpOAuthCallbackResult = {
-  status: "done" | "error" | "idle" | "running";
-  serverId: string | null;
-  error: Error | null;
-};
-
-declare function useMcpOAuthCallback(opts?: UseMcpOAuthCallbackOptions): UseMcpOAuthCallbackResult;
-
-declare const McpOAuthCallback: FC<UseMcpOAuthCallbackOptions & {
-  children?: (result: UseMcpOAuthCallbackResult) => ReactNode;
-}>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type McpManagerResourceProps = {
-  connectors?: MCPConnector[] | undefined;
-  storage?: MCPStorageElement | undefined;
-  oauthRedirectUri?: string | undefined;
-  autoConnect?: boolean | undefined;
-  connectionTimeout?: number | undefined;
-};
-
-declare const McpManagerResource: Resource<ClientOutput<"mcp">, [
-  props: McpManagerResourceProps
+declare const McpCustomStorage: Resource<MCPStorage, [
+  impl: MCPStorage
 ]>;
 
-type McpServerResourceProps = {
-  id: string;
-  kind: MCPServerKind;
-  name: string;
-  url: string;
-  icon?: string | undefined;
-  auth: MCPAuthConfig;
-  storage: MCPStorage;
-  redirectUri: string;
-  autoConnect: boolean;
-  connectionTimeout?: number | undefined;
-  onRemove: () => Promise<void>;
-};
-
-declare const McpServerResource: Resource<ClientOutput<"mcpServer">, [
-  props: McpServerResourceProps
+declare const McpLocalStorage: Resource<MCPStorage, [
+  opts?: McpLocalStorageOptions | undefined
 ]>;
 
 type McpLocalStorageOptions = {
@@ -250,25 +262,14 @@ type McpLocalStorageOptions = {
   storage?: Storage;
 };
 
-declare const McpLocalStorage: Resource<MCPStorage, [
-  opts?: McpLocalStorageOptions | undefined
-]>;
-
-declare const McpMemoryStorage: Resource<MCPStorage, [
-]>;
-
-declare const McpCustomStorage: Resource<MCPStorage, [
-  impl: MCPStorage
-]>;
-
-declare namespace McpManagerPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+declare namespace McpManagerPrimitiveAddCustomTrigger {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
 }
 
-declare const McpManagerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+declare const McpManagerPrimitiveAddCustomTrigger: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
   asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
 
 declare namespace McpManagerPrimitiveConnectors {
   type Props = {
@@ -290,45 +291,55 @@ declare namespace McpManagerPrimitiveCustomServers {
 
 declare const McpManagerPrimitiveCustomServers: FC<McpManagerPrimitiveCustomServers.Props>;
 
-declare namespace McpManagerPrimitiveAddCustomTrigger {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
-}
-
-declare const McpManagerPrimitiveAddCustomTrigger: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace manager_d_exports {
-  export { McpManagerPrimitiveAddCustomTrigger as AddCustomTrigger, McpManagerPrimitiveConnectors as Connectors, McpManagerPrimitiveCustomServers as CustomServers, McpManagerPrimitiveRoot as Root };
-}
-
-declare namespace McpServerPrimitiveRoot {
+declare namespace McpManagerPrimitiveRoot {
   type Element = ComponentRef<typeof Primitive.div>;
   type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
 }
 
-declare const McpServerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+declare const McpManagerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
   asChild?: boolean;
 }, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
 
-declare namespace McpServerPrimitiveName {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+declare const McpManagerResource: Resource<ClientOutput<"mcp">, [
+  props: McpManagerResourceProps
+]>;
+
+type McpManagerResourceProps = {
+  connectors?: MCPConnector[] | undefined;
+  storage?: MCPStorageElement | undefined;
+  oauthRedirectUri?: string | undefined;
+  autoConnect?: boolean | undefined;
+  connectionTimeout?: number | undefined;
+};
+
+declare const McpMemoryStorage: Resource<MCPStorage, [
+]>;
+
+declare const McpOAuthCallback: FC<UseMcpOAuthCallbackOptions & {
+  children?: (result: UseMcpOAuthCallbackResult) => ReactNode;
+}>;
+
+declare const McpServerByIdProvider: FC<PropsWithChildren<{
+  id: string;
+}>>;
+
+declare namespace McpServerPrimitiveConnectButton {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
 }
 
-declare const McpServerPrimitiveName: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+declare const McpServerPrimitiveConnectButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
   asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
 
-declare namespace McpServerPrimitiveStatus {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+declare namespace McpServerPrimitiveDisconnectButton {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
 }
 
-declare const McpServerPrimitiveStatus: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+declare const McpServerPrimitiveDisconnectButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
   asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
 
 declare namespace McpServerPrimitiveError {
   type Element = ComponentRef<typeof Primitive.div>;
@@ -354,32 +365,14 @@ declare const McpServerPrimitiveIcon: import("react").ForwardRefExoticComponent<
   alt?: string;
 } & import("react").RefAttributes<HTMLImageElement>>;
 
-declare namespace McpServerPrimitiveConnectButton {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+declare namespace McpServerPrimitiveName {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
 }
 
-declare const McpServerPrimitiveConnectButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+declare const McpServerPrimitiveName: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
   asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace McpServerPrimitiveDisconnectButton {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
-}
-
-declare const McpServerPrimitiveDisconnectButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace McpServerPrimitiveRemoveButton {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
-}
-
-declare const McpServerPrimitiveRemoveButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
 declare namespace McpServerPrimitiveOAuthLink {
   type Element = ComponentRef<typeof Primitive.a>;
@@ -394,15 +387,32 @@ declare const McpServerPrimitiveOAuthLink: import("react").ForwardRefExoticCompo
   href?: string;
 } & import("react").RefAttributes<HTMLAnchorElement>>;
 
-declare const useMcpServerTool: () => MCPToolInfo;
-
-declare namespace McpServerPrimitiveTools {
-  type Props = {
-    children: ReactNode | ((tool: MCPToolInfo) => ReactNode);
-  };
+declare namespace McpServerPrimitiveRemoveButton {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
 }
 
-declare const McpServerPrimitiveTools: FC<McpServerPrimitiveTools.Props>;
+declare const McpServerPrimitiveRemoveButton: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpServerPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+declare const McpServerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace McpServerPrimitiveStatus {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+declare const McpServerPrimitiveStatus: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
 declare namespace McpServerPrimitiveToolName {
   type Element = ComponentRef<typeof Primitive.span>;
@@ -413,91 +423,81 @@ declare const McpServerPrimitiveToolName: import("react").ForwardRefExoticCompon
   asChild?: boolean;
 }, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
-declare namespace server_d_exports {
-  export { McpServerPrimitiveConnectButton as ConnectButton, McpServerPrimitiveDisconnectButton as DisconnectButton, McpServerPrimitiveError as Error, McpServerPrimitiveIcon as Icon, McpServerPrimitiveName as Name, McpServerPrimitiveOAuthLink as OAuthLink, McpServerPrimitiveRemoveButton as RemoveButton, McpServerPrimitiveRoot as Root, McpServerPrimitiveStatus as Status, McpServerPrimitiveToolName as ToolName, McpServerPrimitiveTools as Tools, useMcpServerTool };
-}
-
-declare namespace McpAddFormPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive.form>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.form>, "onSubmit"> & {
-    onSubmitted?: (id: string) => void;
-    onCancel?: () => void;
-  };
-}
-
-declare const McpAddFormPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
-  asChild?: boolean;
-}, "ref">, "onSubmit"> & {
-  onSubmitted?: (id: string) => void;
-  onCancel?: () => void;
-} & import("react").RefAttributes<HTMLFormElement>>;
-
-declare namespace McpAddFormPrimitiveNameField {
-  type Element = ComponentRef<typeof Primitive.input>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
-}
-
-declare const McpAddFormPrimitiveNameField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveNameField.Props & import("react").RefAttributes<HTMLInputElement>>;
-
-declare namespace McpAddFormPrimitiveUrlField {
-  type Element = ComponentRef<typeof Primitive.input>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.input>, "onChange" | "type" | "value">;
-}
-
-declare const McpAddFormPrimitiveUrlField: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveUrlField.Props & import("react").RefAttributes<HTMLInputElement>>;
-
-declare namespace McpAddFormPrimitiveAuthSelect {
-  type Element = ComponentRef<typeof Primitive.select>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive.select>, "onChange" | "value">;
-}
-
-declare const McpAddFormPrimitiveAuthSelect: import("react").ForwardRefExoticComponent<McpAddFormPrimitiveAuthSelect.Props & import("react").RefAttributes<HTMLSelectElement>>;
-
-type AddFormAuthType = MCPAuthConfig["type"];
-
-declare namespace McpAddFormPrimitiveAuthFields {
+declare namespace McpServerPrimitiveTools {
   type Props = {
-    children?: FC<{
-      authType: AddFormAuthType;
-    }>;
+    children: ReactNode | ((tool: MCPToolInfo) => ReactNode);
   };
 }
 
-declare const McpAddFormPrimitiveAuthFields: FC<McpAddFormPrimitiveAuthFields.Props>;
+declare const McpServerPrimitiveTools: FC<McpServerPrimitiveTools.Props>;
 
-declare namespace McpAddFormPrimitiveSubmit {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+declare const McpServerResource: Resource<ClientOutput<"mcpServer">, [
+  props: McpServerResourceProps
+]>;
+
+type McpServerResourceProps = {
+  id: string;
+  kind: MCPServerKind;
+  name: string;
+  url: string;
+  icon?: string | undefined;
+  auth: MCPAuthConfig;
+  storage: MCPStorage;
+  redirectUri: string;
+  autoConnect: boolean;
+  connectionTimeout?: number | undefined;
+  onRemove: () => Promise<void>;
+};
+
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
 }
 
-declare const McpAddFormPrimitiveSubmit: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+type UseMcpOAuthCallbackOptions = {
+  url?: string;
+  onComplete?: (serverId: string) => void;
+  onError?: (err: Error) => void;
+};
 
-declare namespace McpAddFormPrimitiveCancel {
-  type Element = ComponentRef<typeof Primitive.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
-}
+type UseMcpOAuthCallbackResult = {
+  status: "done" | "error" | "idle" | "running";
+  serverId: string | null;
+  error: Error | null;
+};
 
-declare const McpAddFormPrimitiveCancel: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace McpAddFormPrimitiveError {
-  type Element = ComponentRef<typeof Primitive.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
-}
-
-declare const McpAddFormPrimitiveError: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
 
 declare namespace addForm_d_exports {
   export { McpAddFormPrimitiveAuthFields as AuthFields, McpAddFormPrimitiveAuthSelect as AuthSelect, McpAddFormPrimitiveCancel as Cancel, McpAddFormPrimitiveError as Error, McpAddFormPrimitiveNameField as NameField, McpAddFormPrimitiveRoot as Root, McpAddFormPrimitiveSubmit as Submit, McpAddFormPrimitiveUrlField as UrlField };
 }
 
+declare function defineConnector(connector: MCPConnector): MCPConnector;
+
 declare namespace entry_root_exports {
   export { MCPAuthConfig, MCPConnectionState, MCPConnector, MCPCustomServerRecord, MCPManagerMethods, MCPManagerState, MCPPersistedAuthState, MCPServerKind, MCPServerMethods, MCPServerQuery, MCPServerState, MCPStorage, MCPStorageElement, MCPToolInfo, addForm_d_exports as McpAddFormPrimitive, McpConnectorByIndexProvider, McpCustomServerByIndexProvider, McpCustomStorage, McpLocalStorage, McpLocalStorageOptions, manager_d_exports as McpManagerPrimitive, McpManagerResource, McpManagerResourceProps, McpMemoryStorage, McpOAuthCallback, McpServerByIdProvider, server_d_exports as McpServerPrimitive, McpServerResource, McpServerResourceProps, UseMcpOAuthCallbackOptions, UseMcpOAuthCallbackResult, defineConnector, useMcpOAuthCallback };
 }
+
+declare namespace manager_d_exports {
+  export { McpManagerPrimitiveAddCustomTrigger as AddCustomTrigger, McpManagerPrimitiveConnectors as Connectors, McpManagerPrimitiveCustomServers as CustomServers, McpManagerPrimitiveRoot as Root };
+}
+
+declare namespace server_d_exports {
+  export { McpServerPrimitiveConnectButton as ConnectButton, McpServerPrimitiveDisconnectButton as DisconnectButton, McpServerPrimitiveError as Error, McpServerPrimitiveIcon as Icon, McpServerPrimitiveName as Name, McpServerPrimitiveOAuthLink as OAuthLink, McpServerPrimitiveRemoveButton as RemoveButton, McpServerPrimitiveRoot as Root, McpServerPrimitiveStatus as Status, McpServerPrimitiveToolName as ToolName, McpServerPrimitiveTools as Tools, useMcpServerTool };
+}
+
+declare function useMcpOAuthCallback(opts?: UseMcpOAuthCallbackOptions): UseMcpOAuthCallbackResult;
+
+declare const useMcpServerTool: () => MCPToolInfo;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1,24 +1,576 @@
+import { StandardSchemaV1 } from "@standard-schema/spec";
+
 import React, { ComponentType, FC, PropsWithChildren, ReactElement, ReactNode } from "react";
 
 import { FlatListProps, PressableProps, TextInputProps, TextProps, ViewProps } from "react-native";
 
-import { StandardSchemaV1 } from "@standard-schema/spec";
+declare const ActionBarCopy: (_param0: ActionBarCopyProps) => import("react").JSX.Element;
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
+  children: ReactNode | ((props: {
+    isCopied: boolean;
+  }) => ReactNode);
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+declare const ActionBarEdit: (_param1: ActionBarEditProps) => import("react").JSX.Element;
+
+type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
 };
+
+declare const ActionBarFeedbackNegative: (_param2: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
+
+type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: ReactNode | ((props: {
+    isSubmitted: boolean;
+  }) => ReactNode);
+};
+
+declare const ActionBarFeedbackPositive: (_param3: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
+
+type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
+  children: ReactNode | ((props: {
+    isSubmitted: boolean;
+  }) => ReactNode);
+};
+
+declare const ActionBarReload: (_param4: ActionBarReloadProps) => import("react").JSX.Element;
+
+type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
+};
+
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
+
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
+
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
+  };
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantContextConfig = {
+  getContext: () => string;
+  disabled?: boolean | undefined;
+};
+
+type AssistantDataUI = FC & {
+  unstable_data: AssistantDataUIProps;
+};
+
+type AssistantDataUIProps<T = any> = {
+  name: string;
+  render: DataMessagePartComponent<T>;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AssistantInstructionsConfig = {
+  disabled?: boolean | undefined;
+  instruction: string;
+};
+
+type AssistantInteractableProps = {
+  description: string;
+  stateSchema: InteractableStateSchema;
+  initialState: unknown;
+  id?: string;
+  selected?: boolean;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+};
+
+type AssistantRuntimeCore = {
+  readonly threads: ThreadListRuntimeCore;
+  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
+  getModelContextProvider: () => ModelContextProvider;
+  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
+};
+
+declare class AssistantRuntimeImpl implements AssistantRuntime {
+  private readonly _core;
+  readonly threads: ThreadListRuntimeImpl;
+  readonly _thread: ThreadRuntime;
+  constructor(_core: AssistantRuntimeCore);
+  protected __internal_bindMethods(): void;
+  get thread(): ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+}
+
+declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param5: {
+  runtime: AssistantRuntime;
+  aui?: AssistantClient | null;
+  children: ReactNode;
+}) => import("react").JSX.Element>;
+
+type AssistantState = {
+  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
+    getState: () => infer S;
+  } ? S : never;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AssistantTool = FC & {
+  unstable_tool: AssistantToolProps<any, any>;
+};
+
+type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
+};
+
+type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
+  toolName: string;
+  render?: unknown;
+};
+
+type AssistantToolUI = FC & {
+  unstable_tool: AssistantToolUIProps<any, any>;
+};
+
+type AssistantToolUIProps<TArgs, TResult> = {
+  toolName: string;
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+  display?: "inline" | "standalone";
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+declare const AttachmentName: FC<AttachmentNameProps>;
+
+type AttachmentNameProps = TextProps;
+
+declare const AttachmentRemove: (_param6: AttachmentRemoveProps) => import("react").JSX.Element;
+
+type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const AttachmentRoot: (_param7: AttachmentRootProps) => import("react").JSX.Element;
+
+type AttachmentRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState$1 & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  private _core;
+  get path(): AttachmentRuntimePath & {
+    attachmentSource: Source;
+  };
+  abstract get source(): Source;
+  constructor(_core: AttachmentSnapshotBinding<Source>);
+  protected __internal_bindMethods(): void;
+  getState(): AttachmentState$1 & {
+    source: Source;
+  };
+  abstract remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+}
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState$1["source"];
+
+type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
+  source: Source;
+}, AttachmentRuntimePath & {
+  attachmentSource: Source;
+}>;
+
+type AttachmentState = Attachment;
+
+type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+declare const AttachmentThumb: FC<AttachmentThumbProps>;
+
+type AttachmentThumbProps = TextProps;
+
+declare namespace AuiIf {
+  type Props = PropsWithChildren<{
+    condition: AuiIf.Condition;
+  }>;
+  type Condition = (state: AssistantState) => boolean;
+}
+
+declare const AuiIf: FC<AuiIf.Props>;
+
+declare const AuiProvider: (_param8: {
+  value: AssistantClient;
+  children: React.ReactNode;
+}) => React.ReactElement;
+
+type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
+
+type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: string | undefined;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
+  protected readonly _contextProvider: CompositeContextProvider;
+  abstract get threads(): ThreadListRuntimeCore;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
+  getModelContextProvider(): ModelContextProvider;
+}
 
 type BaseAttachment = {
   id: string;
@@ -29,9 +581,272 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  readonly isEditing = true;
+  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected abstract getDictationAdapter(): DictationAdapter | undefined;
+  protected enrichWithComposerMetadata<T extends {
+    metadata?: {
+      custom?: Record<string, unknown>;
+    };
+  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
+  get attachmentAccept(): string;
+  private _attachments;
+  get attachments(): readonly Attachment[];
+  protected setAttachments(value: readonly Attachment[]): void;
+  abstract get canCancel(): boolean;
+  abstract get canSend(): boolean;
+  get isEmpty(): boolean;
+  private _text;
+  get text(): string;
+  private _role;
+  get role(): "assistant" | "system" | "user";
+  private _runConfig;
+  get runConfig(): RunConfig;
+  private _quote;
+  get quote(): QuoteInfo | undefined;
+  setQuote(quote: QuoteInfo | undefined): void;
+  setText(value: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  private _emptyTextAndAttachments;
+  private _onClearAttachments;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): Promise<void>;
+  cancel(): void;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(_queueItemId: string): void;
+  removeQueueItem(_queueItemId: string): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleCancel(): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  private _safeEmitAttachmentAddError;
+  removeAttachment(attachmentId: string): Promise<void>;
+  private _dictation;
+  private _dictationSession;
+  private _dictationUnsubscribes;
+  private _dictationBaseText;
+  private _currentInterimText;
+  private _dictationSessionIdCounter;
+  private _activeDictationSessionId;
+  private _isCleaningDictation;
+  get dictation(): DictationState | undefined;
+  private _isActiveSession;
+  startDictation(): void;
+  stopDictation(): void;
+  private _cleanupDictation;
+  private _eventSubscribers;
+  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
+}
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+declare class BaseSubscribable {
+  private _subscribers;
+  subscribe(callback: () => void): Unsubscribe$1;
+  waitForUpdate(): Promise<void>;
+  protected _notifySubscribers(): void;
+}
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+declare const BranchPickerCount: (props: BranchPickerCountProps) => import("react").JSX.Element;
+
+type BranchPickerCountProps = TextProps;
+
+declare const BranchPickerNext: (_param9: BranchPickerNextProps) => import("react").JSX.Element;
+
+type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
+
+type BranchPickerNumberProps = TextProps;
+
+declare const BranchPickerPrevious: (_param10: BranchPickerPreviousProps) => import("react").JSX.Element;
+
+type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ChainOfThoughtAccordionTrigger: (_param11: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
+
+type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>>;
+
+declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
+  {
+    parts: readonly ChainOfThoughtPart[];
+    getMessagePart: (selector: {
+      index: number;
+    }) => PartMethods;
+  }
+]>;
+
+type ChainOfThoughtPart = Extract<PartState, {
+  type: "tool-call";
+} | {
+  type: "reasoning";
+}>;
+
+declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type ChainOfThoughtPartsComponentConfig = {
+  Reasoning?: ReasoningMessagePartComponent | undefined;
+  tools?: {
+    Fallback?: ToolCallMessagePartComponent | undefined;
+  };
+  Layout?: ComponentType<PropsWithChildren> | undefined;
+};
+
+declare namespace ChainOfThoughtPrimitiveParts {
+  type Props = {
+    components?: ChainOfThoughtPartsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      part: PartState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
+
+declare const ChainOfThoughtRoot: (_param12: ChainOfThoughtRootProps) => import("react").JSX.Element;
+
+type ChainOfThoughtRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type ChatModelAdapter = {
+  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext$1;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -39,7 +854,241 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+declare const ComposerAddAttachment: (_param13: ComposerAddAttachmentProps) => import("react").JSX.Element;
+
+type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  private _composerApi;
+  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
+  remove(): Promise<void>;
+}
+
+declare const ComposerAttachments: import("react").FC<ComposerPrimitiveAttachments.Props>;
+
+type ComposerAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const ComposerCancel: (_param14: ComposerCancelProps) => import("react").JSX.Element;
+
+type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ComposerIfFilters = {
+  editing: boolean | undefined;
+  dictation: boolean | undefined;
+};
+
+declare const ComposerInput: (_param15: ComposerInputProps) => import("react").JSX.Element;
+
+type ComposerInputProps = Omit<TextInputProps, "onChangeText" | "value"> & {
+  submitMode?: "enter" | "none";
+};
+
+declare namespace ComposerPrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: ComposerAttachmentsComponentConfig;
+  };
+}
+
+declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare namespace ComposerPrimitiveAttachments {
+  type Props = {
+    components: ComposerAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: Attachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
+
+declare namespace ComposerPrimitiveIf {
+  type Props = PropsWithChildren<UseComposerIfProps>;
+}
+
+declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
+
+declare const ComposerRoot: (_param16: ComposerRootProps) => import("react").JSX.Element;
+
+type ComposerRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState$1;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
+};
+
+type ComposerRuntimeCore = Readonly<{
+  isEditing: boolean;
+  canCancel: boolean;
+  canSend: boolean;
+  isEmpty: boolean;
+  attachments: readonly Attachment[];
+  attachmentAccept: string;
+  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
+  removeAttachment: (attachmentId: string) => Promise<void>;
+  text: string;
+  setText: (value: string) => void;
+  role: MessageRole;
+  setRole: (role: MessageRole) => void;
+  runConfig: RunConfig;
+  setRunConfig: (runConfig: RunConfig) => void;
+  quote: QuoteInfo | undefined;
+  setQuote: (quote: QuoteInfo | undefined) => void;
+  reset: () => Promise<void>;
+  clearAttachments: () => Promise<void>;
+  send: (options?: SendOptions) => void;
+  cancel: () => void;
+  queue: readonly QueueItemState[];
+  steerQueueItem: (queueItemId: string) => void;
+  removeQueueItem: (queueItemId: string) => void;
+  dictation: DictationState | undefined;
+  startDictation: () => void;
+  stopDictation: () => void;
+  subscribe: (callback: () => void) => Unsubscribe$1;
+  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
+}>;
+
+type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  protected _core: ComposerRuntimeCoreBinding;
+  get path(): ComposerRuntimePath;
+  abstract get type(): "edit" | "thread";
+  constructor(_core: ComposerRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  abstract getState(): ComposerState$1;
+  setText(text: string): void;
+  setRunConfig(runConfig: RunConfig): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  setRole(role: MessageRole): void;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _eventSubscriptionSubjects;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
+  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
+}
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+declare const ComposerSend: (_param17: ComposerSendProps) => import("react").JSX.Element;
+
+type ComposerSendProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ComposerState = {
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly isEditing: boolean;
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly attachmentAccept: string;
+  readonly isEmpty: boolean;
+  readonly type: "edit" | "thread";
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type ComposerState$1 = ThreadComposerState | EditComposerState;
+
+declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  private _adapters;
+  accept: string;
+  constructor(adapters: AttachmentAdapter[]);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(attachment: Attachment): Promise<void>;
+}
+
+declare class CompositeContextProvider implements ModelContextProvider {
+  private _providers;
+  getModelContext(): ModelContext$1;
+  registerModelContextProvider(provider: ModelContextProvider): () => void;
+  private _subscribers;
+  notifySubscribers(): void;
+  subscribe(callback: () => void): () => void;
+}
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -49,30 +1098,349 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
+]>;
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  private runtime;
+  private _canCancel;
+  get canCancel(): boolean;
+  get canSend(): boolean;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected getDictationAdapter(): DictationAdapter | undefined;
+  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: {
+      attachments?: AttachmentAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+    } | undefined;
+  });
+  connect(): Unsubscribe$1;
+  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
+  handleCancel(): Promise<void>;
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
+  _config: Derived.Props<K>
+]>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
 }
 
-type JSONSchema7Version = string;
+type DerivedElement<K extends ClientNames> = ResourceElement<null, [
+  Derived.Props<K>
+]>;
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe$1;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
+  };
+}
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
+  get source(): "edit-composer";
+}
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
+  parentId: string | null;
+  sourceId: string | null;
+}>;
+
+type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "edit";
+}>;
+
+declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  private _beginEdit;
+  get path(): ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  get type(): "edit";
+  private _getState;
+  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
+  __internal_bindMethods(): void;
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
+}
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
+
+type EmptyMessagePartProps = {
+  status: MessagePartStatus;
+};
+
+type EnrichedPartState = (Extract<PartState, {
+  type: "tool-call";
+}> & {
+  readonly toolUI: ReactNode;
+  addResult: ToolCallMessagePartProps["addResult"];
+  resume: ToolCallMessagePartProps["resume"];
+  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
+}) | (Extract<PartState, {
+  type: "data";
+}> & {
+  readonly dataRendererUI: ReactNode;
+}) | Exclude<PartState, {
+  type: "tool-call";
+} | {
+  type: "data";
+}>;
+
+declare const ErrorMessage: {
+  (_param18: ErrorMessageProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type ErrorMessageProps = TextProps & {
+  children?: ReactNode;
+};
+
+declare const ErrorRoot: {
+  (_param19: ErrorRootProps): import("react").JSX.Element | null;
+  displayName: string;
+};
+
+type ErrorRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
+
+type FileMessagePartProps = MessagePartState & FileMessagePart;
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type GroupByContext = {
+  readonly toolUIs?: ToolsState["toolUIs"];
+};
+
+type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
+
+type ImageMessagePartProps = MessagePartState & ImageMessagePart;
+
+declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
+  list(): Promise<RemoteThreadListResponse>;
+  rename(): Promise<void>;
+  updateCustom(): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(): Promise<AssistantStream>;
+  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
+}
+
+type InteractableScope = "app" | "thread";
+
+type InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+declare const Interactables: Resource<ClientOutput<"interactables">, [
+]>;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -134,175 +1502,75 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
 
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ObjectKey<T> = keyof T & (string | number);
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
 
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
+type JSONSchema7Version = string;
 
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
+  cloud?: AssistantCloud | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
+  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
+};
 
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+type LocalRuntimeOptionsBase = {
+  maxSteps?: number | undefined;
+  adapters: {
+    chatModel: ChatModelAdapter;
+    history?: ThreadHistoryAdapter | undefined;
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    suggestion?: SuggestionAdapter | undefined;
   };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+  unstable_humanToolNames?: string[] | undefined;
+  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
-type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: string | undefined;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppResourceOutput = {
+  readonly render: ToolCallMessagePartComponent;
 };
 
 type McpServerConfig = {
@@ -332,13 +1600,561 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+type McpToolkitDefinition = Record<string, McpToolkitEntry>;
 
-type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type McpToolkitEntry = McpServerConfig | {
+  server: McpServerConfig;
+  disabled?: boolean | undefined;
+  tools?: Record<string, McpToolkitToolConfig> | undefined;
 };
+
+type McpToolkitToolConfig = {
+  disabled?: boolean | undefined;
+};
+
+declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
+  get source(): "message";
+  remove(): never;
+}
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+declare const MessageAttachments: import("react").FC<MessagePrimitiveAttachments.Props>;
+
+type MessageAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const MessageByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessageComponents = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+declare const MessageContent: (_param20: MessageContentProps) => import("react").JSX.Element;
+
+type MessageContentPart = ThreadUserMessagePart | ThreadAssistantMessagePart;
+
+type MessageContentProps = {
+  renderText?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "text";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderToolCall?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "tool-call";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderImage?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "image";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderReasoning?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "reasoning";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderSource?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "source";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderFile?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "file";
+    }>;
+    index: number;
+  }) => ReactElement;
+  renderData?: (props: {
+    part: Extract<MessageContentPart, {
+      type: "data";
+    }>;
+    index: number;
+  }) => ReactElement;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+declare const MessageIf: (_param21: MessageIfProps) => import("react").JSX.Element | null;
+
+type MessageIfProps = {
+  children: ReactNode;
+  user?: boolean | undefined;
+  assistant?: boolean | undefined;
+  running?: boolean | undefined;
+  last?: boolean | undefined;
+};
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  private contentBinding;
+  private messageApi?;
+  private threadApi?;
+  get path(): MessagePartRuntimePath;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  protected __internal_bindMethods(): void;
+  getState(): MessagePartState;
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+}
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+declare namespace MessagePrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: MessageAttachmentsComponentConfig;
+  };
+}
+
+declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare namespace MessagePrimitiveAttachments {
+  type Props = {
+    components: MessageAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: CompleteAttachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
+
+declare namespace MessagePrimitiveGroupedParts {
+  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly type: TKey;
+    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+    readonly indices: readonly number[];
+  };
+  type IndicatorPart = {
+    readonly type: "indicator";
+  };
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
+  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
+    readonly children: ReactNode;
+  };
+  type Props<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
+    readonly indicator?: IndicatorMode;
+    readonly children: (info: RenderInfo<TKey>) => ReactNode;
+  };
+}
+
+declare const MessagePrimitiveGroupedParts: {
+  <TKey extends `group-${string}`>(_param22: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
+  displayName: string;
+};
+
+declare namespace MessagePrimitivePartByIndex {
+  type Props = {
+    index: number;
+    components: MessagePrimitiveParts$1.Props["components"];
+  };
+}
+
+declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
+
+declare namespace MessagePrimitiveParts {
+  type Props = MessagePrimitiveParts$1.Props;
+}
+
+declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
+
+declare namespace MessagePrimitiveParts$1 {
+  type DataConfig = {
+    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
+    Fallback?: DataMessagePartComponent | undefined;
+  };
+  type BaseComponents = {
+    Empty?: EmptyMessagePartComponent | undefined;
+    Text?: TextMessagePartComponent | undefined;
+    Source?: SourceMessagePartComponent | undefined;
+    Image?: ImageMessagePartComponent | undefined;
+    File?: FileMessagePartComponent | undefined;
+    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+    data?: DataConfig | undefined;
+    Quote?: QuoteMessagePartComponent | undefined;
+    generativeUI?: {
+      components: GenerativeUIComponentRegistry;
+      Fallback?: ComponentType<{
+        component: string;
+        props?: unknown;
+      }> | undefined;
+    } | undefined;
+  };
+  type ToolsConfig = {
+    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
+    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+  } | {
+    Override: ComponentType<ToolCallMessagePartProps>;
+  };
+  type StandardComponents = BaseComponents & {
+    Reasoning?: ReasoningMessagePartComponent | undefined;
+    tools?: ToolsConfig | undefined;
+    ToolGroup?: ComponentType<PropsWithChildren<{
+      startIndex: number;
+      endIndex: number;
+    }>>;
+    ReasoningGroup?: ReasoningGroupComponent;
+    ChainOfThought?: never;
+  };
+  type ChainOfThoughtComponents = BaseComponents & {
+    ChainOfThought: ComponentType;
+    Reasoning?: never;
+    tools?: never;
+    ToolGroup?: never;
+    ReasoningGroup?: never;
+  };
+  export type Props = {
+    components?: StandardComponents | ChainOfThoughtComponents | undefined;
+    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
+    children?: never;
+  } | {
+    children: (value: {
+      part: EnrichedPartState;
+    }) => ReactNode;
+    components?: never;
+    unstable_showEmptyOnNonTextEnd?: never;
+  };
+  export {};
+}
+
+declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
+
+declare class MessageRepository {
+  private messages;
+  private head;
+  private root;
+  private updateLevels;
+  private performOp;
+  private _messages;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  private evictOffBranchOptimisticMessages;
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param23: ExportedMessageRepository): void;
+}
+
+type MessageRole = ThreadMessage["role"];
+
+declare const MessageRoot: (_param24: MessageRootProps) => import("react").JSX.Element;
+
+type MessageRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState$1;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param25: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param26: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+declare class MessageRuntimeImpl implements MessageRuntime {
+  private _core;
+  private _threadBinding;
+  get path(): MessageRuntimePath;
+  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  readonly composer: EditComposerRuntimeImpl;
+  private _getEditComposerRuntimeCore;
+  getState(): ThreadMessage & {
+    readonly parentId: string | null;
+    readonly index: number;
+    readonly isLast: boolean;
+    readonly branchNumber: number;
+    readonly branchCount: number;
+    readonly speech: SpeechState | undefined;
+  };
+  delete(): void | Promise<void>;
+  reload(reloadConfig?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param27: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param28: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe$1;
+  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
+  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
+}
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+  readonly composer: ComposerState;
+  readonly parts: readonly PartState[];
+  readonly isCopied: boolean;
+  readonly isHovering: boolean;
+  readonly index: number;
+};
+
+type MessageState$1 = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStateBinding = SubscribableWithState<ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+}, MessageRuntimePath>;
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type MessagesComponentConfig = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+type MessagesContent = {
+  components: MessageComponents;
+  children?: never;
+} | {
+  children: (value: {
+    message: MessageState$1;
+  }) => ReactNode;
+  components?: never;
+};
+
+declare const ModelContext: Resource<ClientOutput<"modelContext">, [
+]>;
+
+type ModelContext$1 = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext$1;
+  subscribe?: (callback: () => void) => Unsubscribe$1;
+};
+
+declare class ModelContextRegistry implements ModelContextProvider {
+  private _tools;
+  private _instructions;
+  private _providers;
+  private _subscribers;
+  private _providerUnsubscribes;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private notifySubscribers;
+  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
+  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
+  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
+}
+
+interface ModelContextRegistryInstructionHandle {
+  update(config: string | AssistantInstructionsConfig): void;
+  remove(): void;
+}
+
+interface ModelContextRegistryProviderHandle {
+  remove(): void;
+}
+
+interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
+  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
+  remove(): void;
+}
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -349,6 +2165,30 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
+  [K in TKey]?: undefined;
+} : {
+  [K in TKey]?: TValue | undefined;
+} : {
+  [K in TKey]: TValue;
+};
+
+type OverrideToolDeclarationCallbacks<T extends {
+  streamCall?: unknown;
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
+  type?: never;
+} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+declare const PartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -377,473 +2217,91 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PartMethods = {
+  getState(): PartState;
+  addToolResult(result: unknown | ToolResponse<unknown>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  __internal_getRuntime?(): MessagePartRuntime;
+};
+
+type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type PropFieldStatus = "complete" | "streaming";
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
+
+type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
+  type: "provider";
+}>;
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
+
+type QuoteMessagePartProps = QuoteInfo;
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
-  accept: string;
-  constructor(adapters: AttachmentAdapter[]);
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(attachment: Attachment): Promise<void>;
-}
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe$1 = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe$1;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe$1;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe$1;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe$1;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -878,105 +2336,702 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type VoiceSessionControls = {
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
+type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
+
+type ReasoningGroupProps = PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>;
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type VoiceSessionHelpers = {
-  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
-  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
-  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
-  emitVolume: (volume: number) => void;
-  isDisposed: () => boolean;
+type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
+
+type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-declare function createVoiceSession(options: {
-  abortSignal?: AbortSignal;
-}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ModelContext$1 = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadListOptions = {
+  runtimeHook: () => AssistantRuntime;
+  adapter: RemoteThreadListAdapter;
+  initialThreadId?: string | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  allowNesting?: boolean | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext$1;
-  subscribe?: (callback: () => void) => Unsubscribe$1;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
 };
 
-type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
-  toolName: string;
-  render?: unknown;
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
 };
 
-type AssistantInstructionsConfig = {
-  disabled?: boolean | undefined;
-  instruction: string;
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
-type AssistantContextConfig = {
-  getContext: () => string;
-  disabled?: boolean | undefined;
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
 };
 
-declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
+  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+}[Keys];
 
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type ResumeToolCallOptions = {
+  toolCallId: string;
+  payload: unknown;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+declare namespace RuntimeAdapterProvider {
+  type Props = {
+    adapters: RuntimeAdapters;
+    children: ReactNode;
+  };
+}
+
+declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
+
+type RuntimeAdapters = {
+  modelContext?: ModelContextProvider | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  attachments?: AttachmentAdapter | undefined;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+type SnapshotCarrierMessage = {
+  role: string;
+  metadata?: unknown;
+  content?: readonly unknown[] | undefined;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
+
+type SourceMessagePartProps = MessagePartState & SourceMessagePart;
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe$1;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+type StateUpdater<TState> = TState | ((prev: TState) => TState);
+
+type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
+
+type SubmitFeedbackOptions = {
+  messageId: string;
+  type: "negative" | "positive";
+};
+
+type Subscribable = {
+  subscribe: (callback: () => void) => Unsubscribe$1;
+};
+
+type SubscribableWithState<TState, TPath> = Subscribable & {
+  path: TPath;
+  getState: () => TState;
+};
+
+type SuggestionAdapter = {
+  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion$1[]> | AsyncGenerator<readonly ThreadSuggestion$1[], void>;
+};
+
+type SuggestionAdapterGenerateOptions = {
+  messages: readonly ThreadMessage[];
+};
+
+declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
+
+type SuggestionByIndexProviderProps = PropsWithChildren<{
+  index: number;
+}>;
+
+type SuggestionConfig = string | {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const SuggestionDescription: (_param29: SuggestionDescriptionProps) => import("react").JSX.Element;
+
+type SuggestionDescriptionProps = TextProps & {
+  children?: ReactNode;
+};
+
+type SuggestionState = {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const SuggestionTitle: (_param30: SuggestionTitleProps) => import("react").JSX.Element;
+
+type SuggestionTitleProps = TextProps & {
+  children?: ReactNode;
+};
+
+declare const SuggestionTrigger: (_param31: SuggestionTriggerProps) => import("react").JSX.Element;
+
+type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+};
+
+declare const Suggestions: Resource<ClientOutput<"suggestions">, [
+  suggestions?: SuggestionConfig[] | undefined
+]>;
+
+type SuggestionsComponentConfig = {
+  Suggestion: ComponentType;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
+
+type TextMessagePartProps = MessagePartState & TextMessagePart;
+
+declare const TextMessagePartProvider: FC<PropsWithChildren<{
+  text: string;
+  isRunning?: boolean;
+}>>;
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext$1;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
+  get source(): "thread-composer";
+}
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type ChatModelAdapter = {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntimeCore = ComposerRuntimeCore;
+
+type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "thread";
+}>;
+
+declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  get path(): ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  get type(): "thread";
+  private _getState;
+  constructor(core: ThreadComposerRuntimeCoreBinding);
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
+}
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
 };
+
+declare const ThreadEmpty: (_param32: ThreadEmptyProps) => import("react").JSX.Element | null;
+
+type ThreadEmptyProps = {
+  children: ReactNode;
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+declare const ThreadIf: (_param33: ThreadIfProps) => import("react").JSX.Element | null;
+
+type ThreadIfProps = {
+  children: ReactNode;
+  empty?: boolean | undefined;
+  running?: boolean | undefined;
+};
+
+declare const ThreadListItemArchive: (_param34: ThreadListItemArchiveProps) => import("react").JSX.Element;
+
+type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+  archived: boolean;
+}>>;
+
+type ThreadListItemCoreState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+  readonly runtime?: ThreadRuntimeCore | undefined;
+};
+
+declare const ThreadListItemDelete: (_param35: ThreadListItemDeleteProps) => import("react").JSX.Element;
+
+type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+declare namespace ThreadListItemPrimitiveTitle {
+  type Props = {
+    fallback?: ReactNode;
+  };
+}
+
+declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
+
+declare const ThreadListItemRoot: (_param36: ThreadListItemRootProps) => import("react").JSX.Element;
+
+type ThreadListItemRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState$1;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  private _core;
+  private _threadListBinding;
+  get path(): ThreadListItemRuntimePath;
+  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  getState(): ThreadListItemState$1;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
+  subscribe(callback: () => void): Unsubscribe$1;
+  detach(): void;
+  __internal_getRuntime(): ThreadListItemRuntime;
+}
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
+  runtime: ThreadListItemRuntime;
+}>>;
+
+type ThreadListItemState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemState$1 = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+declare const ThreadListItemTrigger: (_param37: ThreadListItemTriggerProps) => import("react").JSX.Element;
+
+type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItemUnarchive: (_param38: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
+
+type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListItems: (_param39: ThreadListItemsProps) => import("react").JSX.Element;
+
+type ThreadListItemsProps = Omit<FlatListProps<string>, "data" | "renderItem"> & {
+  renderItem: (props: {
+    threadId: string;
+    index: number;
+  }) => ReactElement;
+};
+
+declare const ThreadListNew: (_param40: ThreadListNewProps) => import("react").JSX.Element;
+
+type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+};
+
+declare const ThreadListRoot: (_param41: ThreadListRootProps) => import("react").JSX.Element;
+
+type ThreadListRootProps = ViewProps & {
+  children: ReactNode;
+};
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListRuntimeCore = {
+  readonly isLoading: boolean;
+  readonly isLoadingMore?: boolean;
+  readonly hasMore?: boolean;
+  mainThreadId: string;
+  newThreadId: string | undefined;
+  threadIds: readonly string[];
+  archivedThreadIds: readonly string[];
+  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
+  getMainThreadRuntimeCore(): ThreadRuntimeCore;
+  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  getItemById(threadId: string): ThreadListItemCoreState | undefined;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
+  loadMore?(): Promise<void>;
+  detach(threadId: string): Promise<void>;
+  rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(threadId: string): Promise<void>;
+  unarchive(threadId: string): Promise<void>;
+  delete(threadId: string): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(threadId: string): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe$1;
+};
+
+type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
+
+declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _core;
+  private _runtimeFactory;
+  private _getState;
+  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
+  protected __internal_bindMethods(): void;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe$1;
+  private _mainThreadListItemRuntime;
+  readonly main: ThreadRuntime;
+  get mainItem(): ThreadListItemRuntimeImpl;
+  getById(threadId: string): ThreadRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getItemById(threadId: string): ThreadListItemRuntimeImpl;
+}
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
 
 type ThreadMessageLike = {
   readonly role: "assistant" | "system" | "user";
@@ -1026,214 +3081,86 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
-
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
+declare const ThreadMessages: {
+  (_param42: ThreadMessagesProps): import("react").JSX.Element;
+  displayName: string;
 };
 
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
+type ThreadMessagesProps = Omit<FlatListProps<ThreadMessage>, "children" | "data" | "renderItem"> & MessagesContent;
 
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
-  get headId(): string | null;
-  get canonicalHeadId(): string | null;
-  getMessages(headId?: string): readonly ThreadMessage[];
-  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
-  getMessage(messageId: string): {
-    parentId: string | null;
-    message: ThreadMessage;
+declare namespace ThreadPrimitiveMessageByIndex {
+  type Props = {
     index: number;
+    components: MessagesComponentConfig;
   };
-  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
-  getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
-  switchToBranch(messageId: string): void;
-  resetHead(messageId: string | null): void;
-  clear(): void;
-  export(): ExportedMessageRepository;
-  import(_param0: ExportedMessageRepository): void;
 }
 
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
+declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
+
+declare namespace ThreadPrimitiveSuggestionByIndex {
+  type Props = {
+    index: number;
+    components: SuggestionsComponentConfig;
+  };
+}
+
+declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
+
+declare namespace ThreadPrimitiveSuggestions {
+  type Props = {
+    components: SuggestionsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      suggestion: SuggestionState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
+
+declare namespace ThreadPrimitiveUnstable_MessageById {
+  type Props = {
+    messageId: string;
+    components: MessagesComponentConfig;
+  };
+}
+
+declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
+
+declare const ThreadRoot: (_param43: ThreadRootProps) => import("react").JSX.Element;
+
+type ThreadRootProps = ViewProps & {
+  children: ReactNode;
 };
 
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type ComposerRuntimeCore = Readonly<{
-  isEditing: boolean;
-  canCancel: boolean;
-  canSend: boolean;
-  isEmpty: boolean;
-  attachments: readonly Attachment[];
-  attachmentAccept: string;
-  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
-  removeAttachment: (attachmentId: string) => Promise<void>;
-  text: string;
-  setText: (value: string) => void;
-  role: MessageRole;
-  setRole: (role: MessageRole) => void;
-  runConfig: RunConfig;
-  setRunConfig: (runConfig: RunConfig) => void;
-  quote: QuoteInfo | undefined;
-  setQuote: (quote: QuoteInfo | undefined) => void;
-  reset: () => Promise<void>;
-  clearAttachments: () => Promise<void>;
-  send: (options?: SendOptions) => void;
-  cancel: () => void;
-  queue: readonly QueueItemState[];
-  steerQueueItem: (queueItemId: string) => void;
-  removeQueueItem: (queueItemId: string) => void;
-  dictation: DictationState | undefined;
-  startDictation: () => void;
-  stopDictation: () => void;
-  subscribe: (callback: () => void) => Unsubscribe$1;
-  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe$1;
-}>;
-
-type ThreadComposerRuntimeCore = ComposerRuntimeCore;
-
-type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
-  parentId: string | null;
-  sourceId: string | null;
-}>;
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type ResumeToolCallOptions = {
-  toolCallId: string;
-  payload: unknown;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type SubmitFeedbackOptions = {
-  messageId: string;
-  type: "negative" | "positive";
-};
-
-type ThreadSuggestion$1 = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState$1;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe$1;
+  cancelRun(): void;
+  getModelContext(): ModelContext$1;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 };
 
 type ThreadRuntimeCore = Readonly<{
@@ -1288,651 +3215,20 @@ type ThreadRuntimeCore = Readonly<{
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }>;
 
-type SuggestionAdapterGenerateOptions = {
-  messages: readonly ThreadMessage[];
-};
-
-type SuggestionAdapter = {
-  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion$1[]> | AsyncGenerator<readonly ThreadSuggestion$1[], void>;
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
-
-type Unstable_InteractableSnapshotEntry = {
-  id: string;
-  name: string;
-  state: unknown;
-  partial?: boolean | undefined;
-};
-
-type SnapshotCarrierMessage = {
-  role: string;
-  metadata?: unknown;
-  content?: readonly unknown[] | undefined;
-};
-
-declare function unstable_getInteractableSnapshots(message: {
-  metadata?: unknown;
-}): Unstable_InteractableSnapshotEntry[] | undefined;
-
-declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
-
-type Unstable_InteractableVersion = {
-  state: unknown;
-  origin: "create" | "update" | "user-edit";
-  toolCallId?: string | undefined;
-};
-
-declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
-
-interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
-  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryInstructionHandle {
-  update(config: string | AssistantInstructionsConfig): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryProviderHandle {
-  remove(): void;
-}
-
-declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private notifySubscribers;
-  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
-  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
-  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
-}
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemCoreState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-  readonly runtime?: ThreadRuntimeCore | undefined;
-};
-
-type ThreadListRuntimeCore = {
-  readonly isLoading: boolean;
-  readonly isLoadingMore?: boolean;
-  readonly hasMore?: boolean;
-  mainThreadId: string;
-  newThreadId: string | undefined;
-  threadIds: readonly string[];
-  archivedThreadIds: readonly string[];
-  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
-  getMainThreadRuntimeCore(): ThreadRuntimeCore;
-  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
-  getItemById(threadId: string): ThreadListItemCoreState | undefined;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload?(): Promise<void>;
-  loadMore?(): Promise<void>;
-  detach(threadId: string): Promise<void>;
-  rename(threadId: string, newTitle: string): Promise<void>;
-  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(threadId: string): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-type AssistantRuntimeCore = {
-  readonly threads: ThreadListRuntimeCore;
-  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe$1;
-  getModelContextProvider: () => ModelContextProvider;
-  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
-};
-
-declare const generateId: (size?: number) => string;
-
-type Subscribable = {
-  subscribe: (callback: () => void) => Unsubscribe$1;
-};
-
-type SubscribableWithState<TState, TPath> = Subscribable & {
-  path: TPath;
-  getState: () => TState;
-};
-
-declare class BaseSubscribable {
-  private _subscribers;
-  subscribe(callback: () => void): Unsubscribe$1;
-  waitForUpdate(): Promise<void>;
-  protected _notifySubscribers(): void;
-}
-
-type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
-
-type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "thread";
-}>;
-
-type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "edit";
-}>;
-
-type MessageStateBinding = SubscribableWithState<ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-}, MessageRuntimePath>;
-
-type ThreadListItemState$1 = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState$1 = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState$1 & {
-  source: Source;
-}, AttachmentRuntimePath & {
-  attachmentSource: Source;
-}>;
-
-type AttachmentRuntimeSource = AttachmentState$1["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState$1 & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
-  get path(): AttachmentRuntimePath & {
-    attachmentSource: Source;
-  };
-  abstract get source(): Source;
-  constructor(_core: AttachmentSnapshotBinding<Source>);
-  protected __internal_bindMethods(): void;
-  getState(): AttachmentState$1 & {
-    source: Source;
-  };
-  abstract remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe$1;
-}
-
-declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
-  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
-  remove(): Promise<void>;
-}
-
-declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
-  get source(): "thread-composer";
-}
-
-declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
-  get source(): "edit-composer";
-}
-
-declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
-  get source(): "message";
-  remove(): never;
-}
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState$1 = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState$1;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
-};
-
-declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
-  get path(): ComposerRuntimePath;
-  abstract get type(): "edit" | "thread";
-  constructor(_core: ComposerRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  abstract getState(): ComposerState$1;
-  setText(text: string): void;
-  setRunConfig(runConfig: RunConfig): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  setRole(role: MessageRole): void;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private _eventSubscriptionSubjects;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe$1;
-  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
-}
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
-  get path(): ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  get type(): "thread";
-  private _getState;
-  constructor(core: ThreadComposerRuntimeCoreBinding);
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
-}
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
-  get path(): ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  get type(): "edit";
-  private _getState;
-  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
-  __internal_bindMethods(): void;
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
-}
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe$1;
-};
-
-declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
-  get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
-  protected __internal_bindMethods(): void;
-  getState(): MessagePartState;
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-}
-
-type MessageState$1 = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState$1;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param1: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param2: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-declare class MessageRuntimeImpl implements MessageRuntime {
-  private _core;
-  private _threadBinding;
-  get path(): MessageRuntimePath;
-  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
-  getState(): ThreadMessage & {
-    readonly parentId: string | null;
-    readonly index: number;
-    readonly isLast: boolean;
-    readonly branchNumber: number;
-    readonly branchCount: number;
-    readonly speech: SpeechState | undefined;
-  };
-  delete(): void | Promise<void>;
-  reload(reloadConfig?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param3: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param4: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe$1;
-  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
-  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
-}
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
 type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadRuntimePath> & {
   outerSubscribe(callback: () => void): Unsubscribe$1;
 };
 
-type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
-type ThreadState$1 = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState$1;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion$1[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
 };
 
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState$1;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  cancelRun(): void;
-  getModelContext(): ModelContext$1;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe$1;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
-};
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
   get path(): ThreadRuntimePath;
@@ -2054,533 +3350,196 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
 }
 
-type ThreadListState = {
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly isEmpty: boolean;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly MessageState[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion$1[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+  readonly composer: ComposerState;
+};
+
+type ThreadState$1 = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState$1;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion$1[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+};
+
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
+};
+
+declare const ThreadSuggestion: (_param44: ThreadSuggestionProps) => import("react").JSX.Element;
+
+type ThreadSuggestion$1 = {
+  prompt: string;
+};
+
+type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
+  children: ReactNode;
+  prompt: string;
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+};
+
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type ThreadsState = {
   readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+  readonly newThreadId: string | null;
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly threadItems: readonly ThreadListItemState[];
+  readonly main: ThreadState;
 };
 
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
 
-type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
-
-declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _core;
-  private _runtimeFactory;
-  private _getState;
-  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
-  protected __internal_bindMethods(): void;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe$1;
-  private _mainThreadListItemRuntime;
-  readonly main: ThreadRuntime;
-  get mainItem(): ThreadListItemRuntimeImpl;
-  getById(threadId: string): ThreadRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getItemById(threadId: string): ThreadListItemRuntimeImpl;
-}
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState$1;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe$1;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
-
-declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
-  private _core;
-  private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
-  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  getState(): ThreadListItemState$1;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe$1;
-  subscribe(callback: () => void): Unsubscribe$1;
-  detach(): void;
-  __internal_getRuntime(): ThreadListItemRuntime;
-}
-
-type LocalRuntimeOptionsBase = {
-  maxSteps?: number | undefined;
-  adapters: {
-    chatModel: ChatModelAdapter;
-    history?: ThreadHistoryAdapter | undefined;
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    suggestion?: SuggestionAdapter | undefined;
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
   };
-  unstable_humanToolNames?: string[] | undefined;
-  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-};
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
 
-declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
-  readonly threads: ThreadListRuntimeImpl;
-  readonly _thread: ThreadRuntime;
-  constructor(_core: AssistantRuntimeCore);
-  protected __internal_bindMethods(): void;
-  get thread(): ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-}
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type RemoteThreadListOptions = {
-  runtimeHook: () => AssistantRuntime;
-  adapter: RemoteThreadListAdapter;
-  initialThreadId?: string | undefined;
-  threadId?: string | undefined;
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  allowNesting?: boolean | undefined;
-};
-
-declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
-  list(): Promise<RemoteThreadListResponse>;
-  rename(): Promise<void>;
-  updateCustom(): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(): Promise<AssistantStream>;
-  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
-}
-
-declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
-  getModelContext(): ModelContext$1;
-  registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
-  notifySubscribers(): void;
-  subscribe(callback: () => void): () => void;
-}
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
-
-type Unsubscribe = () => void;
-
-type AssistantState = {
-  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
-    getState: () => infer S;
-  } ? S : never;
-};
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
 } | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
 };
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
+  status: "complete" | "incomplete" | "requires-action" | "running";
+  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
 };
 
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
 
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
 
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
   };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-declare namespace AuiIf {
-  type Props = PropsWithChildren<{
-    condition: AuiIf.Condition;
-  }>;
-  type Condition = (state: AssistantState) => boolean;
-}
-
-declare const AuiIf: FC<AuiIf.Props>;
-
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-declare namespace useAui {
-  type Props = {
-    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
   };
-}
-
-declare function useAui(): AssistantClient;
-
-declare function useAui(clients: useAui.Props): AssistantClient;
-
-declare function useAui(clients: useAui.Props, config: {
-  parent: null | AssistantClient;
-}): AssistantClient;
-
-declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
-
-declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
-
-declare const AuiProvider: (_param5: {
-  value: AssistantClient;
-  children: React.ReactNode;
-}) => React.ReactElement;
-
-declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
-  protected readonly _contextProvider: CompositeContextProvider;
-  abstract get threads(): ThreadListRuntimeCore;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe$1;
-  getModelContextProvider(): ModelContextProvider;
-}
-
-declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
-  readonly isEditing = true;
-  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected abstract getDictationAdapter(): DictationAdapter | undefined;
-  protected enrichWithComposerMetadata<T extends {
-    metadata?: {
-      custom?: Record<string, unknown>;
-    };
-  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
-  get attachmentAccept(): string;
-  private _attachments;
-  get attachments(): readonly Attachment[];
-  protected setAttachments(value: readonly Attachment[]): void;
-  abstract get canCancel(): boolean;
-  abstract get canSend(): boolean;
-  get isEmpty(): boolean;
-  private _text;
-  get text(): string;
-  private _role;
-  get role(): "assistant" | "system" | "user";
-  private _runConfig;
-  get runConfig(): RunConfig;
-  private _quote;
-  get quote(): QuoteInfo | undefined;
-  setQuote(quote: QuoteInfo | undefined): void;
-  setText(value: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): Promise<void>;
-  cancel(): void;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(_queueItemId: string): void;
-  removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
-  protected abstract handleCancel(): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
-  removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
-  get dictation(): DictationState | undefined;
-  private _isActiveSession;
-  startDictation(): void;
-  stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
-  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
-}
-
-declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
-  private _canCancel;
-  get canCancel(): boolean;
-  get canSend(): boolean;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected getDictationAdapter(): DictationAdapter | undefined;
-  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
-    adapters?: {
-      attachments?: AttachmentAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-    } | undefined;
-  });
-  connect(): Unsubscribe$1;
-  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
-  handleCancel(): Promise<void>;
-}
-
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
-
-declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, getAutoStatus };
-}
-
-type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
 };
 
-type PartMethods = {
-  getState(): PartState;
-  addToolResult(result: unknown | ToolResponse<unknown>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  __internal_getRuntime?(): MessagePartRuntime;
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
 };
-
-declare const AssistantRuntimeProvider: import("react").MemoExoticComponent<(_param6: {
-  runtime: AssistantRuntime;
-  aui?: AssistantClient | null;
-  children: ReactNode;
-}) => import("react").JSX.Element>;
-
-declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
-]>;
-
-type EmptyMessagePartProps = {
-  status: MessagePartStatus;
-};
-
-type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
-
-type TextMessagePartProps = MessagePartState & TextMessagePart;
-
-type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
-
-type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
-
-type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
-
-type ReasoningGroupProps = PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>;
-
-type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
-
-type SourceMessagePartProps = MessagePartState & SourceMessagePart;
-
-type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
-
-type ImageMessagePartProps = MessagePartState & ImageMessagePart;
-
-type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
-
-type FileMessagePartProps = MessagePartState & FileMessagePart;
-
-type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
-
-type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
-
-type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
-
-type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
-
-type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
 
 type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
   addResult: (result: TResult | ToolResponse<TResult>) => void;
@@ -2588,19 +3547,197 @@ type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState
   respondToApproval: (response: ToolApprovalResponse) => void;
 };
 
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
 
-type QuoteMessagePartProps = QuoteInfo;
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
 
-type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
 
-type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
 
-type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
 
-type InteractableScope = "app" | "thread";
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
+
+type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
+
+type ToolRegistration = {
+  readonly render: ToolCallMessagePartComponent;
+  readonly standalone: boolean;
+};
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+
+type ToolkitDefinition<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+} = Record<string, any>, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}> = {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
+};
+
+type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
+
+type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
+  parameters: NonNullable<ToolParameters<TArgs>>;
+};
+
+type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
+  streamCall?: unknown;
+} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
+
+declare const Tools: Resource<ClientOutput<"tools">, [
+  {
+    toolkit?: Toolkit;
+    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
+  }
+]>;
+
+type ToolsState = {
+  toolUIs: Record<string, readonly ToolRegistration[]>;
+  mcpApp?: McpAppResourceOutput | undefined;
+  tools: Record<string, ToolCallMessagePartComponent[]>;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
+
+type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
+
+type Unstable_InferInteractableState<TSchema> = TSchema extends {
+  "~standard": {
+    types?: {
+      output: infer TOutput;
+    } | undefined;
+  };
+} ? TOutput : unknown;
+
+type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  initialState: Unstable_InferInteractableState<TSchema>;
+  id?: string | undefined;
+  updateRender?: ToolCallMessagePartComponent | undefined;
+};
 
 type Unstable_InteractableDefinition = {
   id: string;
@@ -2612,6 +3749,21 @@ type Unstable_InteractableDefinition = {
   scope?: InteractableScope | undefined;
 };
 
+type Unstable_InteractablePersistedState = Record<string, {
+  name: string;
+  state: unknown;
+}>;
+
+type Unstable_InteractablePersistenceAdapter = {
+  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
+  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
+};
+
+type Unstable_InteractablePersistenceStatus = {
+  isPending: boolean;
+  error: unknown;
+};
+
 type Unstable_InteractableRegistration = {
   id: string;
   name: string;
@@ -2621,24 +3773,45 @@ type Unstable_InteractableRegistration = {
   updateRender?: ToolCallMessagePartComponent | undefined;
 };
 
-type Unstable_InteractablePersistenceStatus = {
-  isPending: boolean;
-  error: unknown;
-};
-
-type Unstable_InteractablesState = {
-  definitions: Record<string, Unstable_InteractableDefinition>;
-  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
-};
-
-type Unstable_InteractablePersistedState = Record<string, {
+type Unstable_InteractableSnapshotEntry = {
+  id: string;
   name: string;
   state: unknown;
-}>;
+  partial?: boolean | undefined;
+};
 
-type Unstable_InteractablePersistenceAdapter = {
-  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
-  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
+type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
+};
+
+type Unstable_InteractableToolRenderProps<TState> = {
+  state: TState;
+  setState: (updater: TState | ((prev: TState) => TState)) => void;
+  version: Unstable_InteractableVersionInfo<TState> | undefined;
+  id: string;
+  streaming: boolean;
+};
+
+type Unstable_InteractableVersion = {
+  state: unknown;
+  origin: "create" | "update" | "user-edit";
+  toolCallId?: string | undefined;
+};
+
+type Unstable_InteractableVersionInfo<TState> = {
+  state: TState;
+  isLatest: boolean;
+  restore: () => void;
+};
+
+type Unstable_InteractablesClientSchema = {
+  methods: Unstable_InteractablesMethods;
 };
 
 type Unstable_InteractablesConfig = {
@@ -2655,28 +3828,53 @@ type Unstable_InteractablesMethods = {
   flush(): Promise<void>;
 };
 
-type Unstable_InteractablesClientSchema = {
-  methods: Unstable_InteractablesMethods;
+type Unstable_InteractablesState = {
+  definitions: Record<string, Unstable_InteractableDefinition>;
+  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
 };
 
-declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
-  (Unstable_InteractablesConfig | undefined)?
-]>;
+type Unsubscribe = () => void;
 
-type McpAppResourceOutput = {
-  readonly render: ToolCallMessagePartComponent;
+type Unsubscribe$1 = () => void;
+
+type UseActionBarCopyOptions = {
+  copiedDuration?: number | undefined;
+  copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
 };
 
-type ToolRegistration = {
-  readonly render: ToolCallMessagePartComponent;
-  readonly standalone: boolean;
+type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type VoiceSessionControls = {
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
 };
 
-type ToolsState = {
-  toolUIs: Record<string, readonly ToolRegistration[]>;
-  mcpApp?: McpAppResourceOutput | undefined;
-  tools: Record<string, ToolCallMessagePartComponent[]>;
+type VoiceSessionHelpers = {
+  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
+  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
+  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
+  emitVolume: (volume: number) => void;
+  isDisposed: () => boolean;
 };
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
 
 type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   type: "frontend" | "human";
@@ -2694,121 +3892,31 @@ type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
   renderText?: ToolCallText<TArgs, TResult> | undefined;
 };
 
-type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
+declare namespace actionBar_d_exports {
+  export { ActionBarCopy as Copy, ActionBarCopyProps as CopyProps, ActionBarEdit as Edit, ActionBarEditProps as EditProps, ActionBarFeedbackNegative as FeedbackNegative, ActionBarFeedbackNegativeProps as FeedbackNegativeProps, ActionBarFeedbackPositive as FeedbackPositive, ActionBarFeedbackPositiveProps as FeedbackPositiveProps, ActionBarReload as Reload, ActionBarReloadProps as ReloadProps };
+}
 
-type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
+declare namespace attachment_d_exports {
+  export { AttachmentName as Name, AttachmentNameProps as NameProps, AttachmentRemove as Remove, AttachmentRemoveProps as RemoveProps, AttachmentRoot as Root, AttachmentRootProps as RootProps, AttachmentThumb as Thumb, AttachmentThumbProps as ThumbProps };
+}
 
-type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
+declare namespace branchPicker_d_exports {
+  export { BranchPickerCount as Count, BranchPickerCountProps as CountProps, BranchPickerNext as Next, BranchPickerNextProps as NextProps, BranchPickerNumber as Number, BranchPickerNumberProps as NumberProps, BranchPickerPrevious as Previous, BranchPickerPreviousProps as PreviousProps };
+}
 
-type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
+declare namespace chainOfThought_d_exports {
+  export { ChainOfThoughtAccordionTrigger as AccordionTrigger, ChainOfThoughtAccordionTriggerProps as AccordionTriggerProps, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtRoot as Root, ChainOfThoughtRootProps as RootProps };
+}
 
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
+declare namespace composer_d_exports {
+  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
+}
 
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
+declare function createVoiceSession(options: {
+  abortSignal?: AbortSignal;
+}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
 
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
-
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
-
-type Toolkit = Record<string, ToolDefinition<any, any>>;
-
-type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
-  [K in TKey]?: undefined;
-} : {
-  [K in TKey]?: TValue | undefined;
-} : {
-  [K in TKey]: TValue;
-};
-
-type OverrideToolDeclarationCallbacks<T extends {
-  streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
-  type?: never;
-} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
-
-type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
-  streamCall?: unknown;
-} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
-
-type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
-
-type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: NonNullable<ToolParameters<TArgs>>;
-};
-
-type ToolkitDefinition<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-} = Record<string, any>, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}> = {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
-};
-
-declare const Tools: Resource<ClientOutput<"tools">, [
-  {
-    toolkit?: Toolkit;
-    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
-  }
-]>;
-
-type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
-
-type AssistantTool = FC & {
-  unstable_tool: AssistantToolProps<any, any>;
-};
-
-declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
-
-type AssistantToolUIProps<TArgs, TResult> = {
-  toolName: string;
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "inline" | "standalone";
-};
-
-declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
-
-type AssistantToolUI = FC & {
-  unstable_tool: AssistantToolUIProps<any, any>;
-};
-
-declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
-
-type AssistantDataUIProps<T = any> = {
-  name: string;
-  render: DataMessagePartComponent<T>;
-};
-
-declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
-
-type AssistantDataUI = FC & {
-  unstable_data: AssistantDataUIProps;
-};
-
-declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
-
-declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
-
-declare const useAssistantContext: (config: AssistantContextConfig) => void;
-
-declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
+declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
 
 declare function defineToolkit<TArgsByName extends {
   [K in keyof TArgsByName]: Record<string, unknown>;
@@ -2824,92 +3932,90 @@ declare function defineToolkit<TArgsByName extends {
 
 declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
 
-declare function stubTool(): never;
-
 declare function externalTool(): never;
 
-type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
+declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
 
-type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
+declare const generateId: (size?: number) => string;
 
-declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
 
-declare function humanTool(): never;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
 
-declare const hitlTool: typeof humanTool;
+declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
 
 declare const hitl: typeof humanTool;
 
-type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
-  type: "provider";
-}>;
+declare const hitlTool: typeof humanTool;
 
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
+declare function humanTool(): never;
+
+declare namespace entry_root_exports {
+  export { actionBar_d_exports as ActionBarPrimitive, AppendMessage, AssistantClient, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantInteractableProps, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, ChainOfThoughtPartByIndexProvider, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerState, CompositeAttachmentAdapter, CreateAttachment, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, EditComposerRuntime, EmptyMessagePartComponent, EmptyMessagePartProps, index_d_exports$1 as ErrorPrimitive, ExportedMessageRepository, ExportedMessageRepositoryItem, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, GroupByContext, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadListAdapter, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, message_d_exports as MessagePrimitive, MessageRole, MessageRuntime, MessageState, MessageStatus, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PartByIndexProvider, PendingAttachment, ProviderToolConfig, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RemoteThreadListOptions, RespondToToolApprovalOptions, RunConfig, RuntimeAdapterProvider, RuntimeAdapters, RuntimeCapabilities, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadsState, Tool, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartProps, ToolCallText, ToolCallTiming, ToolDefinition, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unsubscribe$1 as Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, createVoiceSession, defineMcpToolkit, defineToolkit, externalTool, fromThreadMessageLike, generateId, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, mergeModelContexts, providerTool, stubTool, tool, unstable_Interactables, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useInlineRender, useInteractableState, useLocalRuntime, useRemoteThreadListRuntime, useRuntimeAdapters, useToolArgsStatus, useVoiceControls, useVoiceState, useVoiceVolume };
+}
+
+declare namespace index_d_exports$1 {
+  export { ErrorMessage as Message, ErrorMessageProps as MessageProps, ErrorRoot as Root, ErrorRootProps as RootProps };
+}
+
+declare namespace entry_internal_exports {
+  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, getAutoStatus };
+}
+
+declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
+
+declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
+
+declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
+
+declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+
+declare namespace message_d_exports {
+  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessagePrimitiveGroupedParts as GroupedParts, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
+}
 
 declare function providerTool(_config: ProviderToolConfig): never;
 
-type McpToolkitEntry = McpServerConfig | {
-  server: McpServerConfig;
-  disabled?: boolean | undefined;
-  tools?: Record<string, McpToolkitToolConfig> | undefined;
-};
+declare function stubTool(): never;
 
-type McpToolkitToolConfig = {
-  disabled?: boolean | undefined;
-};
+declare namespace suggestion_d_exports {
+  export { SuggestionDescription as Description, SuggestionDescriptionProps as DescriptionProps, SuggestionTitle as Title, SuggestionTitleProps as TitleProps, SuggestionTrigger as Trigger, SuggestionTriggerProps as TriggerProps };
+}
 
-type McpToolkitDefinition = Record<string, McpToolkitEntry>;
+declare namespace threadListItem_d_exports {
+  export { ThreadListItemArchive as Archive, ThreadListItemArchiveProps as ArchiveProps, ThreadListItemDelete as Delete, ThreadListItemDeleteProps as DeleteProps, ThreadListItemRoot as Root, ThreadListItemRootProps as RootProps, ThreadListItemPrimitiveTitle as Title, ThreadListItemTrigger as Trigger, ThreadListItemTriggerProps as TriggerProps, ThreadListItemUnarchive as Unarchive, ThreadListItemUnarchiveProps as UnarchiveProps };
+}
 
-declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
+declare namespace threadList_d_exports {
+  export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
+}
 
-type InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
+declare namespace thread_d_exports {
+  export { ThreadEmpty as Empty, ThreadEmptyProps as EmptyProps, ThreadIf as If, ThreadIfProps as IfProps, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadMessages as Messages, ThreadMessagesProps as MessagesProps, ThreadRoot as Root, ThreadRootProps as RootProps, ThreadSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadSuggestionProps as SuggestionProps, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById };
+}
 
-type AssistantInteractableProps = {
-  description: string;
-  stateSchema: InteractableStateSchema;
-  initialState: unknown;
-  id?: string;
-  selected?: boolean;
-};
+declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
 
-declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
+declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
+  (Unstable_InteractablesConfig | undefined)?
+]>;
 
-type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
+declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
 
-declare const useInteractableState: <TState>(id: string, fallback: TState) => [
-  TState,
-  {
-    setState: (updater: StateUpdater$1<TState>) => void;
-    setSelected: (selected: boolean) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
+declare function unstable_getInteractableSnapshots(message: {
+  metadata?: unknown;
+}): Unstable_InteractableSnapshotEntry[] | undefined;
 
-type Unstable_InferInteractableState<TSchema> = TSchema extends {
-  "~standard": {
-    types?: {
-      output: infer TOutput;
-    } | undefined;
-  };
-} ? TOutput : unknown;
+declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
 
-type Unstable_InteractableVersionInfo<TState> = {
-  state: TState;
-  isLatest: boolean;
-  restore: () => void;
-};
-
-type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  initialState: Unstable_InferInteractableState<TSchema>;
-  id?: string | undefined;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
+declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
+  success: true;
+}>;
 
 declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
   Unstable_InferInteractableState<TSchema>,
@@ -2922,8 +4028,6 @@ declare const unstable_useInteractable: <TSchema extends Unstable_InteractableSt
     flush: () => Promise<void>;
   }
 ];
-
-type StateUpdater<TState> = TState | ((prev: TState) => TState);
 
 declare const unstable_useInteractableState: <TState>(id: string) => [
   TState | undefined,
@@ -2940,705 +4044,60 @@ declare const unstable_useInteractableVersions: <TState = unknown>(id: string, n
   restore: () => void;
 })[];
 
-type Unstable_InteractableToolRenderProps<TState> = {
-  state: TState;
-  setState: (updater: TState | ((prev: TState) => TState)) => void;
-  version: Unstable_InteractableVersionInfo<TState> | undefined;
-  id: string;
-  streaming: boolean;
-};
+declare const unstable_useThreadMessageIds: () => readonly string[];
 
-type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
-};
+declare const useAssistantContext: (config: AssistantContextConfig) => void;
 
-declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
-  success: true;
-}>;
+declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
 
-type PropFieldStatus = "complete" | "streaming";
+declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
 
-type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "complete" | "incomplete" | "requires-action" | "running";
-  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
-};
+declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
 
-declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
+declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
 
-declare const Interactables: Resource<ClientOutput<"interactables">, [
-]>;
+declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
 
-declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
-  runtime: ThreadListItemRuntime;
-}>>;
-
-declare const MessageByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const PartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const TextMessagePartProvider: FC<PropsWithChildren<{
-  text: string;
-  isRunning?: boolean;
-}>>;
-
-declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>>;
-
-declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-  archived: boolean;
-}>>;
-
-declare const ChainOfThoughtPartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-type SuggestionByIndexProviderProps = PropsWithChildren<{
-  index: number;
-}>;
-
-declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
-
-type RuntimeAdapters = {
-  modelContext?: ModelContextProvider | undefined;
-  history?: ThreadHistoryAdapter | undefined;
-  attachments?: AttachmentAdapter | undefined;
-};
-
-declare namespace RuntimeAdapterProvider {
+declare namespace useAui {
   type Props = {
-    adapters: RuntimeAdapters;
-    children: ReactNode;
+    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
   };
 }
 
-declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
+declare function useAui(): AssistantClient;
 
-declare const useRuntimeAdapters: () => RuntimeAdapters | null;
+declare function useAui(clients: useAui.Props): AssistantClient;
+
+declare function useAui(clients: useAui.Props, config: {
+  parent: null | AssistantClient;
+}): AssistantClient;
+
+declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
+
+declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
+
+declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
+
+declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
+
+declare const useInteractableState: <TState>(id: string, fallback: TState) => [
+  TState,
+  {
+    setState: (updater: StateUpdater$1<TState>) => void;
+    setSelected: (selected: boolean) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param45?: LocalRuntimeOptions) => AssistantRuntime;
 
 declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
 
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
+declare const useRuntimeAdapters: () => RuntimeAdapters | null;
 
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type AttachmentState = Attachment;
-
-type ComposerState = {
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly isEditing: boolean;
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly attachmentAccept: string;
-  readonly isEmpty: boolean;
-  readonly type: "edit" | "thread";
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-  readonly composer: ComposerState;
-  readonly parts: readonly PartState[];
-  readonly isCopied: boolean;
-  readonly isHovering: boolean;
-  readonly index: number;
-};
-
-type MessagesComponentConfig = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
-};
-
-declare namespace ThreadPrimitiveMessageByIndex {
-  type Props = {
-    index: number;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
-
-declare namespace ThreadPrimitiveUnstable_MessageById {
-  type Props = {
-    messageId: string;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
-
-declare namespace MessagePrimitiveParts$1 {
-  type DataConfig = {
-    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
-    Fallback?: DataMessagePartComponent | undefined;
-  };
-  type BaseComponents = {
-    Empty?: EmptyMessagePartComponent | undefined;
-    Text?: TextMessagePartComponent | undefined;
-    Source?: SourceMessagePartComponent | undefined;
-    Image?: ImageMessagePartComponent | undefined;
-    File?: FileMessagePartComponent | undefined;
-    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
-    data?: DataConfig | undefined;
-    Quote?: QuoteMessagePartComponent | undefined;
-    generativeUI?: {
-      components: GenerativeUIComponentRegistry;
-      Fallback?: ComponentType<{
-        component: string;
-        props?: unknown;
-      }> | undefined;
-    } | undefined;
-  };
-  type ToolsConfig = {
-    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
-    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
-  } | {
-    Override: ComponentType<ToolCallMessagePartProps>;
-  };
-  type StandardComponents = BaseComponents & {
-    Reasoning?: ReasoningMessagePartComponent | undefined;
-    tools?: ToolsConfig | undefined;
-    ToolGroup?: ComponentType<PropsWithChildren<{
-      startIndex: number;
-      endIndex: number;
-    }>>;
-    ReasoningGroup?: ReasoningGroupComponent;
-    ChainOfThought?: never;
-  };
-  type ChainOfThoughtComponents = BaseComponents & {
-    ChainOfThought: ComponentType;
-    Reasoning?: never;
-    tools?: never;
-    ToolGroup?: never;
-    ReasoningGroup?: never;
-  };
-  export type Props = {
-    components?: StandardComponents | ChainOfThoughtComponents | undefined;
-    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
-    children?: never;
-  } | {
-    children: (value: {
-      part: EnrichedPartState;
-    }) => ReactNode;
-    components?: never;
-    unstable_showEmptyOnNonTextEnd?: never;
-  };
-  export {};
-}
-
-declare namespace MessagePrimitivePartByIndex {
-  type Props = {
-    index: number;
-    components: MessagePrimitiveParts$1.Props["components"];
-  };
-}
-
-declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
-
-type EnrichedPartState = (Extract<PartState, {
-  type: "tool-call";
-}> & {
-  readonly toolUI: ReactNode;
-  addResult: ToolCallMessagePartProps["addResult"];
-  resume: ToolCallMessagePartProps["resume"];
-  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
-}) | (Extract<PartState, {
-  type: "data";
-}> & {
-  readonly dataRendererUI: ReactNode;
-}) | Exclude<PartState, {
-  type: "tool-call";
-} | {
-  type: "data";
-}>;
-
-declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
-
-type GroupByContext = {
-  readonly toolUIs?: ToolsState["toolUIs"];
-};
-
-type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
-
-declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
-
-declare namespace MessagePrimitiveGroupedParts {
-  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly type: TKey;
-    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-    readonly indices: readonly number[];
-  };
-  type IndicatorPart = {
-    readonly type: "indicator";
-  };
-  type IndicatorMode = "always" | "empty" | "never" | "no-text";
-  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
-    readonly children: ReactNode;
-  };
-  type Props<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
-    readonly indicator?: IndicatorMode;
-    readonly children: (info: RenderInfo<TKey>) => ReactNode;
-  };
-}
-
-declare const MessagePrimitiveGroupedParts: {
-  <TKey extends `group-${string}`>(_param7: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
-  displayName: string;
-};
-
-type MessageAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace MessagePrimitiveAttachments {
-  type Props = {
-    components: MessageAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: CompleteAttachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace MessagePrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: MessageAttachmentsComponentConfig;
-  };
-}
-
-declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
-
-type ComposerAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace ComposerPrimitiveAttachments {
-  type Props = {
-    components: ComposerAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: Attachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ComposerPrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: ComposerAttachmentsComponentConfig;
-  };
-}
-
-declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
-
-declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
-
-type ThreadListItemState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ChainOfThoughtPartsComponentConfig = {
-  Reasoning?: ReasoningMessagePartComponent | undefined;
-  tools?: {
-    Fallback?: ToolCallMessagePartComponent | undefined;
-  };
-  Layout?: ComponentType<PropsWithChildren> | undefined;
-};
-
-declare namespace ChainOfThoughtPrimitiveParts {
-  type Props = {
-    components?: ChainOfThoughtPartsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      part: PartState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
-
-declare namespace ThreadListItemPrimitiveTitle {
-  type Props = {
-    fallback?: ReactNode;
-  };
-}
-
-declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
-
-type SuggestionState = {
-  title: string;
-  label: string;
-  prompt: string;
-};
-
-type SuggestionsComponentConfig = {
-  Suggestion: ComponentType;
-};
-
-declare namespace ThreadPrimitiveSuggestions {
-  type Props = {
-    components: SuggestionsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      suggestion: SuggestionState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ThreadPrimitiveSuggestionByIndex {
-  type Props = {
-    index: number;
-    components: SuggestionsComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
-
-declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
-
-type ComposerIfFilters = {
-  editing: boolean | undefined;
-  dictation: boolean | undefined;
-};
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
-  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-}[Keys];
-
-type UseComposerIfProps = RequireAtLeastOne<ComposerIfFilters>;
-
-declare namespace ComposerPrimitiveIf {
-  type Props = PropsWithChildren<UseComposerIfProps>;
-}
-
-declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
-
-declare const unstable_useThreadMessageIds: () => readonly string[];
-
-type UseActionBarCopyOptions = {
-  copiedDuration?: number | undefined;
-  copyToClipboard?: ((text: string) => void | Promise<void>) | undefined;
-};
-
-declare const useVoiceState: () => VoiceSessionState | undefined;
-
-declare const useVoiceVolume: () => number;
+declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
 
 declare const useVoiceControls: () => {
   connect: () => void;
@@ -3647,467 +4106,8 @@ declare const useVoiceControls: () => {
   unmute: () => void;
 };
 
-type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  cloud?: AssistantCloud | undefined;
-  initialMessages?: readonly ThreadMessageLike[] | undefined;
-  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
-};
+declare const useVoiceState: () => VoiceSessionState | undefined;
 
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param8?: LocalRuntimeOptions) => AssistantRuntime;
-
-type ThreadRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ThreadRoot: (_param9: ThreadRootProps) => import("react").JSX.Element;
-
-type MessageComponents = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
-};
-
-type MessagesContent = {
-  components: MessageComponents;
-  children?: never;
-} | {
-  children: (value: {
-    message: MessageState$1;
-  }) => ReactNode;
-  components?: never;
-};
-
-type ThreadMessagesProps = Omit<FlatListProps<ThreadMessage>, "children" | "data" | "renderItem"> & MessagesContent;
-
-declare const ThreadMessages: {
-  (_param10: ThreadMessagesProps): import("react").JSX.Element;
-  displayName: string;
-};
-
-type ThreadEmptyProps = {
-  children: ReactNode;
-};
-
-declare const ThreadEmpty: (_param11: ThreadEmptyProps) => import("react").JSX.Element | null;
-
-type ThreadIfProps = {
-  children: ReactNode;
-  empty?: boolean | undefined;
-  running?: boolean | undefined;
-};
-
-declare const ThreadIf: (_param12: ThreadIfProps) => import("react").JSX.Element | null;
-
-type ThreadSuggestionProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-  prompt: string;
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-};
-
-declare const ThreadSuggestion: (_param13: ThreadSuggestionProps) => import("react").JSX.Element;
-
-declare namespace thread_d_exports {
-  export { ThreadEmpty as Empty, ThreadEmptyProps as EmptyProps, ThreadIf as If, ThreadIfProps as IfProps, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadMessages as Messages, ThreadMessagesProps as MessagesProps, ThreadRoot as Root, ThreadRootProps as RootProps, ThreadSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadSuggestionProps as SuggestionProps, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById };
-}
-
-type ComposerRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ComposerRoot: (_param14: ComposerRootProps) => import("react").JSX.Element;
-
-declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
-
-declare const ComposerAttachments: import("react").FC<ComposerPrimitiveAttachments.Props>;
-
-type ComposerInputProps = Omit<TextInputProps, "onChangeText" | "value"> & {
-  submitMode?: "enter" | "none";
-};
-
-declare const ComposerInput: (_param15: ComposerInputProps) => import("react").JSX.Element;
-
-type ComposerSendProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerSend: (_param16: ComposerSendProps) => import("react").JSX.Element;
-
-type ComposerCancelProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerCancel: (_param17: ComposerCancelProps) => import("react").JSX.Element;
-
-type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ComposerAddAttachment: (_param18: ComposerAddAttachmentProps) => import("react").JSX.Element;
-
-declare namespace composer_d_exports {
-  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
-}
-
-type MessageRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const MessageRoot: (_param19: MessageRootProps) => import("react").JSX.Element;
-
-type MessageContentPart = ThreadUserMessagePart | ThreadAssistantMessagePart;
-
-type MessageContentProps = {
-  renderText?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "text";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderToolCall?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "tool-call";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderImage?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "image";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderReasoning?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "reasoning";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderSource?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "source";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderFile?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "file";
-    }>;
-    index: number;
-  }) => ReactElement;
-  renderData?: (props: {
-    part: Extract<MessageContentPart, {
-      type: "data";
-    }>;
-    index: number;
-  }) => ReactElement;
-};
-
-declare const MessageContent: (_param20: MessageContentProps) => import("react").JSX.Element;
-
-declare namespace MessagePrimitiveParts {
-  type Props = MessagePrimitiveParts$1.Props;
-}
-
-declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
-
-type MessageIfProps = {
-  children: ReactNode;
-  user?: boolean | undefined;
-  assistant?: boolean | undefined;
-  running?: boolean | undefined;
-  last?: boolean | undefined;
-};
-
-declare const MessageIf: (_param21: MessageIfProps) => import("react").JSX.Element | null;
-
-declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessageAttachments: import("react").FC<MessagePrimitiveAttachments.Props>;
-
-declare namespace message_d_exports {
-  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessagePrimitiveGroupedParts as GroupedParts, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
-}
-
-type ThreadListRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ThreadListRoot: (_param22: ThreadListRootProps) => import("react").JSX.Element;
-
-type ThreadListItemsProps = Omit<FlatListProps<string>, "data" | "renderItem"> & {
-  renderItem: (props: {
-    threadId: string;
-    index: number;
-  }) => ReactElement;
-};
-
-declare const ThreadListItems: (_param23: ThreadListItemsProps) => import("react").JSX.Element;
-
-type ThreadListNewProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListNew: (_param24: ThreadListNewProps) => import("react").JSX.Element;
-
-declare namespace threadList_d_exports {
-  export { ThreadListItems as Items, ThreadListItemsProps as ItemsProps, ThreadListNew as New, ThreadListNewProps as NewProps, ThreadListRoot as Root, ThreadListRootProps as RootProps };
-}
-
-type ActionBarCopyProps = Omit<PressableProps, "children" | "onPress"> & UseActionBarCopyOptions & {
-  children: ReactNode | ((props: {
-    isCopied: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarCopy: (_param25: ActionBarCopyProps) => import("react").JSX.Element;
-
-type ActionBarEditProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ActionBarEdit: (_param26: ActionBarEditProps) => import("react").JSX.Element;
-
-type ActionBarReloadProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ActionBarReload: (_param27: ActionBarReloadProps) => import("react").JSX.Element;
-
-type ActionBarFeedbackPositiveProps = Omit<PressableProps, "children" | "onPress"> & {
-  children: ReactNode | ((props: {
-    isSubmitted: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarFeedbackPositive: (_param28: ActionBarFeedbackPositiveProps) => import("react").JSX.Element;
-
-type ActionBarFeedbackNegativeProps = Omit<PressableProps, "children" | "onPress"> & {
-  children: ReactNode | ((props: {
-    isSubmitted: boolean;
-  }) => ReactNode);
-};
-
-declare const ActionBarFeedbackNegative: (_param29: ActionBarFeedbackNegativeProps) => import("react").JSX.Element;
-
-declare namespace actionBar_d_exports {
-  export { ActionBarCopy as Copy, ActionBarCopyProps as CopyProps, ActionBarEdit as Edit, ActionBarEditProps as EditProps, ActionBarFeedbackNegative as FeedbackNegative, ActionBarFeedbackNegativeProps as FeedbackNegativeProps, ActionBarFeedbackPositive as FeedbackPositive, ActionBarFeedbackPositiveProps as FeedbackPositiveProps, ActionBarReload as Reload, ActionBarReloadProps as ReloadProps };
-}
-
-type BranchPickerPreviousProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const BranchPickerPrevious: (_param30: BranchPickerPreviousProps) => import("react").JSX.Element;
-
-type BranchPickerNextProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const BranchPickerNext: (_param31: BranchPickerNextProps) => import("react").JSX.Element;
-
-type BranchPickerNumberProps = TextProps;
-
-declare const BranchPickerNumber: (props: BranchPickerNumberProps) => import("react").JSX.Element;
-
-type BranchPickerCountProps = TextProps;
-
-declare const BranchPickerCount: (props: BranchPickerCountProps) => import("react").JSX.Element;
-
-declare namespace branchPicker_d_exports {
-  export { BranchPickerCount as Count, BranchPickerCountProps as CountProps, BranchPickerNext as Next, BranchPickerNextProps as NextProps, BranchPickerNumber as Number, BranchPickerNumberProps as NumberProps, BranchPickerPrevious as Previous, BranchPickerPreviousProps as PreviousProps };
-}
-
-type AttachmentRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const AttachmentRoot: (_param32: AttachmentRootProps) => import("react").JSX.Element;
-
-type AttachmentNameProps = TextProps;
-
-declare const AttachmentName: FC<AttachmentNameProps>;
-
-type AttachmentThumbProps = TextProps;
-
-declare const AttachmentThumb: FC<AttachmentThumbProps>;
-
-type AttachmentRemoveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const AttachmentRemove: (_param33: AttachmentRemoveProps) => import("react").JSX.Element;
-
-declare namespace attachment_d_exports {
-  export { AttachmentName as Name, AttachmentNameProps as NameProps, AttachmentRemove as Remove, AttachmentRemoveProps as RemoveProps, AttachmentRoot as Root, AttachmentRootProps as RootProps, AttachmentThumb as Thumb, AttachmentThumbProps as ThumbProps };
-}
-
-type ThreadListItemRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemRoot: (_param34: ThreadListItemRootProps) => import("react").JSX.Element;
-
-type ThreadListItemTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemTrigger: (_param35: ThreadListItemTriggerProps) => import("react").JSX.Element;
-
-type ThreadListItemDeleteProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemDelete: (_param36: ThreadListItemDeleteProps) => import("react").JSX.Element;
-
-type ThreadListItemArchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemArchive: (_param37: ThreadListItemArchiveProps) => import("react").JSX.Element;
-
-type ThreadListItemUnarchiveProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ThreadListItemUnarchive: (_param38: ThreadListItemUnarchiveProps) => import("react").JSX.Element;
-
-declare namespace threadListItem_d_exports {
-  export { ThreadListItemArchive as Archive, ThreadListItemArchiveProps as ArchiveProps, ThreadListItemDelete as Delete, ThreadListItemDeleteProps as DeleteProps, ThreadListItemRoot as Root, ThreadListItemRootProps as RootProps, ThreadListItemPrimitiveTitle as Title, ThreadListItemTrigger as Trigger, ThreadListItemTriggerProps as TriggerProps, ThreadListItemUnarchive as Unarchive, ThreadListItemUnarchiveProps as UnarchiveProps };
-}
-
-type ChainOfThoughtRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ChainOfThoughtRoot: (_param39: ChainOfThoughtRootProps) => import("react").JSX.Element;
-
-type ChainOfThoughtAccordionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-};
-
-declare const ChainOfThoughtAccordionTrigger: (_param40: ChainOfThoughtAccordionTriggerProps) => import("react").JSX.Element;
-
-declare namespace chainOfThought_d_exports {
-  export { ChainOfThoughtAccordionTrigger as AccordionTrigger, ChainOfThoughtAccordionTriggerProps as AccordionTriggerProps, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtRoot as Root, ChainOfThoughtRootProps as RootProps };
-}
-
-type SuggestionTitleProps = TextProps & {
-  children?: ReactNode;
-};
-
-declare const SuggestionTitle: (_param41: SuggestionTitleProps) => import("react").JSX.Element;
-
-type SuggestionDescriptionProps = TextProps & {
-  children?: ReactNode;
-};
-
-declare const SuggestionDescription: (_param42: SuggestionDescriptionProps) => import("react").JSX.Element;
-
-type SuggestionTriggerProps = Omit<PressableProps, "onPress"> & {
-  children: ReactNode;
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-};
-
-declare const SuggestionTrigger: (_param43: SuggestionTriggerProps) => import("react").JSX.Element;
-
-declare namespace suggestion_d_exports {
-  export { SuggestionDescription as Description, SuggestionDescriptionProps as DescriptionProps, SuggestionTitle as Title, SuggestionTitleProps as TitleProps, SuggestionTrigger as Trigger, SuggestionTriggerProps as TriggerProps };
-}
-
-type ErrorRootProps = ViewProps & {
-  children: ReactNode;
-};
-
-declare const ErrorRoot: {
-  (_param44: ErrorRootProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-type ErrorMessageProps = TextProps & {
-  children?: ReactNode;
-};
-
-declare const ErrorMessage: {
-  (_param45: ErrorMessageProps): import("react").JSX.Element | null;
-  displayName: string;
-};
-
-declare namespace index_d_exports$1 {
-  export { ErrorMessage as Message, ErrorMessageProps as MessageProps, ErrorRoot as Root, ErrorRootProps as RootProps };
-}
-
-type ThreadState = {
-  readonly isEmpty: boolean;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly MessageState[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion$1[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-  readonly composer: ComposerState;
-};
-
-type ThreadsState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | null;
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly threadItems: readonly ThreadListItemState[];
-  readonly main: ThreadState;
-};
-
-type ChainOfThoughtPart = Extract<PartState, {
-  type: "tool-call";
-} | {
-  type: "reasoning";
-}>;
-
-type SuggestionConfig = string | {
-  title: string;
-  label: string;
-  prompt: string;
-};
-
-declare const Suggestions: Resource<ClientOutput<"suggestions">, [
-  suggestions?: SuggestionConfig[] | undefined
-]>;
-
-declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
-  {
-    parts: readonly ChainOfThoughtPart[];
-    getMessagePart: (selector: {
-      index: number;
-    }) => PartMethods;
-  }
-]>;
-
-declare const ModelContext: Resource<ClientOutput<"modelContext">, [
-]>;
-
-declare namespace entry_root_exports {
-  export { actionBar_d_exports as ActionBarPrimitive, AppendMessage, AssistantClient, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantInteractableProps, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, ChainOfThoughtPartByIndexProvider, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerState, CompositeAttachmentAdapter, CreateAttachment, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, EditComposerRuntime, EmptyMessagePartComponent, EmptyMessagePartProps, index_d_exports$1 as ErrorPrimitive, ExportedMessageRepository, ExportedMessageRepositoryItem, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, GroupByContext, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadListAdapter, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, message_d_exports as MessagePrimitive, MessageRole, MessageRuntime, MessageState, MessageStatus, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PartByIndexProvider, PendingAttachment, ProviderToolConfig, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RemoteThreadListOptions, RespondToToolApprovalOptions, RunConfig, RuntimeAdapterProvider, RuntimeAdapters, RuntimeCapabilities, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadsState, Tool, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartProps, ToolCallText, ToolCallTiming, ToolDefinition, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unsubscribe$1 as Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, createVoiceSession, defineMcpToolkit, defineToolkit, externalTool, fromThreadMessageLike, generateId, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, mergeModelContexts, providerTool, stubTool, tool, unstable_Interactables, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useThreadMessageIds, useAssistantContext, useAssistantDataUI, useAssistantInstructions, useAssistantInteractable, useAssistantTool, useAssistantToolUI, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useInlineRender, useInteractableState, useLocalRuntime, useRemoteThreadListRuntime, useRuntimeAdapters, useToolArgsStatus, useVoiceControls, useVoiceState, useVoiceVolume };
-}
+declare const useVoiceVolume: () => number;
 
 export { entry_internal_exports as entry_internal, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-o11y.ts
+++ b/api-surface/assistant-ui__react-o11y.ts
@@ -1,10 +1,75 @@
+import { Primitive } from "@radix-ui/react-primitive";
+
 import { ComponentPropsWithoutRef, ComponentRef, ComponentType, FC, PropsWithChildren, ReactNode } from "react";
 
-import { Primitive } from "@radix-ui/react-primitive";
+interface ScopeRegistry {
+    span: {
+      methods: SpanMethods;
+      meta: SpanMeta;
+    };
+}
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
 
 declare const SpanByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
+
+type SpanChildrenComponentConfig = {
+  Span: ComponentType;
+};
+
+type SpanData = {
+  id: string;
+  parentSpanId: string | null;
+  name: string;
+  type: string;
+  status: "completed" | "failed" | "running" | "skipped";
+  startedAt: number;
+  endedAt: number | null;
+  latencyMs: number | null;
+};
 
 type SpanItemState = {
   id: string;
@@ -20,20 +85,6 @@ type SpanItemState = {
   isCollapsed: boolean;
 };
 
-type SpanState = SpanItemState & {
-  children: SpanItemState[];
-  timeRange: {
-    min: number;
-    max: number;
-  };
-};
-
-type SpanMethods = {
-  getState: () => SpanState;
-  child: (lookup: SpanMeta["query"]) => SpanMethods;
-  toggleCollapse: () => void;
-};
-
 type SpanMeta = {
   source: "span";
   query: {
@@ -43,48 +94,25 @@ type SpanMeta = {
   };
 };
 
-interface ScopeRegistry {
-    span: {
-      methods: SpanMethods;
-      meta: SpanMeta;
-    };
+type SpanMethods = {
+  getState: () => SpanState;
+  child: (lookup: SpanMeta["query"]) => SpanMethods;
+  toggleCollapse: () => void;
+};
+
+declare namespace SpanPrimitiveChildren {
+  type Props = {
+    components: SpanChildrenComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      span: SpanState;
+    }) => ReactNode;
+    components?: never;
+  };
 }
 
-declare namespace SpanPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
-}
-
-declare const SpanPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace SpanPrimitiveName {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
-}
-
-declare const SpanPrimitiveName: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace SpanPrimitiveTypeBadge {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
-}
-
-declare const SpanPrimitiveTypeBadge: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace SpanPrimitiveStatusIndicator {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
-}
-
-declare const SpanPrimitiveStatusIndicator: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+declare const SpanPrimitiveChildren: FC<SpanPrimitiveChildren.Props>;
 
 declare namespace SpanPrimitiveCollapseToggle {
   type Element = ComponentRef<typeof Primitive.button>;
@@ -110,28 +138,32 @@ declare const SpanPrimitiveIndent: import("react").ForwardRefExoticComponent<Omi
   indentPerLevel?: number;
 } & import("react").RefAttributes<HTMLDivElement>>;
 
-type SpanChildrenComponentConfig = {
-  Span: ComponentType;
-};
-
-declare namespace SpanPrimitiveChildren {
-  type Props = {
-    components: SpanChildrenComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      span: SpanState;
-    }) => ReactNode;
-    components?: never;
-  };
+declare namespace SpanPrimitiveName {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
 }
 
-declare const SpanPrimitiveChildren: FC<SpanPrimitiveChildren.Props>;
+declare const SpanPrimitiveName: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
-type SpanTimelineRange = {
-  min: number;
-  max: number;
-};
+declare namespace SpanPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+declare const SpanPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace SpanPrimitiveStatusIndicator {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+declare const SpanPrimitiveStatusIndicator: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
 declare namespace SpanPrimitiveTimeline {
   type Element = ComponentRef<typeof Primitive.div>;
@@ -163,67 +195,14 @@ declare const SpanPrimitiveTimelineBar: import("react").ForwardRefExoticComponen
   timeRange?: SpanTimelineRange | undefined;
 } & import("react").RefAttributes<HTMLDivElement>>;
 
-declare namespace span_d_exports {
-  export { SpanPrimitiveChildren as Children, SpanPrimitiveCollapseToggle as CollapseToggle, SpanPrimitiveIndent as Indent, SpanPrimitiveName as Name, SpanPrimitiveRoot as Root, SpanTimelineRange, SpanPrimitiveStatusIndicator as StatusIndicator, SpanPrimitiveTimeline as Timeline, SpanPrimitiveTimelineBar as TimelineBar, SpanPrimitiveTypeBadge as TypeBadge };
+declare namespace SpanPrimitiveTypeBadge {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
 }
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type SpanData = {
-  id: string;
-  parentSpanId: string | null;
-  name: string;
-  type: string;
-  status: "completed" | "failed" | "running" | "skipped";
-  startedAt: number;
-  endedAt: number | null;
-  latencyMs: number | null;
-};
+declare const SpanPrimitiveTypeBadge: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
 declare const SpanResource: Resource<ClientOutput<"span">, [
   {
@@ -231,8 +210,29 @@ declare const SpanResource: Resource<ClientOutput<"span">, [
   }
 ]>;
 
+type SpanState = SpanItemState & {
+  children: SpanItemState[];
+  timeRange: {
+    min: number;
+    max: number;
+  };
+};
+
+type SpanTimelineRange = {
+  min: number;
+  max: number;
+};
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
 declare namespace entry_root_exports {
   export { SpanByIndexProvider, SpanData, SpanItemState, span_d_exports as SpanPrimitive, SpanResource, SpanState };
+}
+
+declare namespace span_d_exports {
+  export { SpanPrimitiveChildren as Children, SpanPrimitiveCollapseToggle as CollapseToggle, SpanPrimitiveIndent as Indent, SpanPrimitiveName as Name, SpanPrimitiveRoot as Root, SpanTimelineRange, SpanPrimitiveStatusIndicator as StatusIndicator, SpanPrimitiveTimeline as Timeline, SpanPrimitiveTimelineBar as TimelineBar, SpanPrimitiveTypeBadge as TypeBadge };
 }
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -2,47 +2,34 @@ import { AssistantMessage, Event, FilePart, GlobalSession, Message as Message$1,
 
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
 };
 
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
 };
 
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe$1;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
 };
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe$1 = () => void;
 
 type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
   source: "root";
@@ -54,39 +41,13 @@ type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["m
   name: K;
 };
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe$1;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
-};
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
 
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
+type AssistantEventName = keyof AssistantEventPayload;
 
 type AssistantEventPayload = ClientEventMap & {
   "*": WildcardPayload;
 };
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
 type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
 
@@ -95,22 +56,76 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
   event: TEvent;
 };
 
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
 type BaseAttachment = {
@@ -122,9 +137,96 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -132,7 +234,61 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -142,30 +298,280 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
 }
 
-type JSONSchema7Version = string;
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
+}
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
+}
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -227,164 +633,44 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
 }
 
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
 }
 
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
+type Listener = (event: OpenCodeServerEvent) => void;
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
 type McpServerConfig = {
@@ -414,213 +700,8 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
-};
-
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
 };
 
 type MessageCommonProps = {
@@ -628,486 +709,13 @@ type MessageCommonProps = {
   readonly createdAt: Date;
 };
 
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-declare namespace RealtimeVoiceAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Mode = "listening" | "speaking";
-  type TranscriptItem = {
-    role: "assistant" | "user";
-    text: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    isMuted: boolean;
-    disconnect: () => void;
-    mute: () => void;
-    unmute: () => void;
-    onStatusChange: (callback: (status: Status) => void) => Unsubscribe;
-    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe;
-    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe;
-    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe;
-  };
-}
-
-type RealtimeVoiceAdapter = {
-  connect: (options: {
-    abortSignal?: AbortSignal;
-  }) => RealtimeVoiceAdapter.Session;
-};
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
-};
-
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
-};
-
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
-};
-
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
-};
-
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  };
-};
-
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
-};
-
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
-};
-
-type ThreadMessageLike = {
-  readonly role: "assistant" | "system" | "user";
-  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
-    readonly type: "tool-call";
-    readonly toolCallId?: string;
-    readonly toolName: string;
-    readonly args?: ReadonlyJSONObject;
-    readonly argsText?: string;
-    readonly artifact?: any;
-    readonly result?: any | undefined;
-    readonly isError?: boolean | undefined;
-    readonly parentId?: string | undefined;
-    readonly messages?: readonly ThreadMessage[] | undefined;
-    readonly interrupt?: {
-      type: "human";
-      payload: unknown;
-    };
-    readonly timing?: ToolCallTiming;
-    readonly approval?: {
-      readonly id: string;
-      readonly approved?: boolean;
-      readonly reason?: string;
-      readonly isAutomatic?: boolean;
-      readonly options?: readonly ToolApprovalOption[];
-      readonly optionId?: string;
-      readonly resolution?: "cancelled" | "expired";
-    };
-  })[];
-  readonly id?: string | undefined;
-  readonly createdAt?: Date | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
-    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
-  })[] | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly isOptimistic?: boolean | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  } | undefined;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
 };
 
 type MessagePartRuntimePath = MessageRuntimePath & {
@@ -1120,167 +728,21 @@ type MessagePartRuntimePath = MessageRuntimePath & {
   };
 };
 
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
 type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
 
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
 };
 
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
+type MessageRole = ThreadMessage["role"];
 
 type MessageRuntime = {
   readonly path: MessageRuntimePath;
@@ -1306,258 +768,108 @@ type MessageRuntime = {
   };
 };
 
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
 };
 
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
   readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
 };
 
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe;
-  cancelRun(): void;
-  getModelContext(): ModelContext;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
 };
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
 };
-
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
-};
-
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
-};
-
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
-};
-
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
-};
-
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
-
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
-    payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
-
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
-declare global {
-  interface Window {
-    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
-  }
-}
 
 type MessageWithParts = {
   info: Message$1;
   parts: Part[];
 };
 
-type OpenCodePermissionResponse = "always" | "once" | "reject";
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+declare class OpenCodeEventSource {
+  private readonly client;
+  private readonly listeners;
+  private readonly reconnectDelayMs;
+  private readonly maxReconnectDelayMs;
+  private abortController;
+  private connectionPromise;
+  private stopped;
+  private nextReconnectDelayMs;
+  private hadConnection;
+  constructor(client: OpencodeClient);
+  subscribe(listener: Listener): () => void;
+  dispose(): void;
+  private emit;
+  private connect;
+  private disconnect;
+  private run;
+}
+
+type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
+
+type OpenCodeLoadState = {
+  type: "idle";
+} | {
+  type: "loading";
+} | {
+  type: "ready";
+} | {
+  type: "error";
+  error: unknown;
+};
+
+type OpenCodePartPayload = {
+  readonly name: string;
+  readonly data: Record<string, unknown>;
+};
 
 type OpenCodePermissionRequest = {
   id: string;
@@ -1574,39 +886,12 @@ type OpenCodePermissionRequest = {
   raw: PermissionRequest;
 };
 
+type OpenCodePermissionResponse = "always" | "once" | "reject";
+
+type OpenCodeProjectedThreadMessage = ThreadMessageLike;
+
 type OpenCodeQuestionRequest = QuestionRequest & {
   askedAt: number;
-};
-
-type PendingUserMessage = {
-  clientId: string;
-  sessionId: string;
-  createdAt: number;
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: unknown;
-  contentText: string;
-  parts: readonly ThreadUserMessagePart[];
-  status: "failed" | "pending";
-  error?: unknown;
-};
-
-type OpenCodeServerMessage = {
-  id: string;
-  info: Message$1 | undefined;
-  parts: readonly Part[];
-  shadowParts: readonly ThreadUserMessagePart[] | undefined;
-};
-
-type OpenCodeLoadState = {
-  type: "idle";
-} | {
-  type: "loading";
-} | {
-  type: "ready";
-} | {
-  type: "error";
-  error: unknown;
 };
 
 type OpenCodeRunState = {
@@ -1622,59 +907,21 @@ type OpenCodeRunState = {
   error: unknown;
 };
 
-type OpenCodeUnhandledEvent = {
-  type: string;
-  sessionId: string | undefined;
-  properties: Record<string, unknown>;
-  seenAt: number;
-};
+type OpenCodeRuntime = AssistantRuntime;
 
-type OpenCodeThreadState = {
-  sessionId: string;
+type OpenCodeRuntimeExtras = {
   session: Session | null;
-  sessionStatus: SessionStatus | null;
-  loadState: OpenCodeLoadState;
-  runState: OpenCodeRunState;
-  messageOrder: readonly string[];
-  messagesById: Readonly<Record<string, OpenCodeServerMessage>>;
-  pendingUserMessages: Readonly<Record<string, PendingUserMessage>>;
-  interactions: {
-    permissions: {
-      pending: Readonly<Record<string, OpenCodePermissionRequest>>;
-      resolved: Readonly<Record<string, {
-        request: OpenCodePermissionRequest;
-        reply: OpenCodePermissionResponse;
-        respondedAt: number;
-      }>>;
-    };
-    questions: {
-      pending: Readonly<Record<string, OpenCodeQuestionRequest>>;
-      answered: Readonly<Record<string, {
-        request: OpenCodeQuestionRequest;
-        answers: readonly QuestionAnswer[];
-        respondedAt: number;
-      }>>;
-      rejected: Readonly<Record<string, {
-        request: OpenCodeQuestionRequest;
-        rejectedAt: number;
-      }>>;
-    };
-  };
-  unhandledEvents: readonly OpenCodeUnhandledEvent[];
-  sync: {
-    lastHistoryLoadAt?: number;
-    lastEventAt?: number;
-    lastCompactionAt?: number;
-  };
-};
-
-type OpenCodeUserMessageOptions = {
-  model?: {
-    providerID: string;
-    modelID: string;
-  } | undefined;
-  agent?: string | undefined;
-  noReply?: boolean | undefined;
+  state: OpenCodeThreadState;
+  permissions: OpenCodeThreadState["interactions"]["permissions"]["pending"];
+  questions: OpenCodeThreadState["interactions"]["questions"]["pending"];
+  fork: (messageId: string) => Promise<string>;
+  revert: (messageId: string) => Promise<void>;
+  unrevert: () => Promise<void>;
+  cancel: () => Promise<void>;
+  refresh: () => Promise<void>;
+  replyToPermission: (permissionId: string, response: OpenCodePermissionResponse) => Promise<void>;
+  replyToQuestion: (questionId: string, answers: readonly QuestionAnswer[]) => Promise<void>;
+  rejectQuestion: (questionId: string) => Promise<void>;
 };
 
 type OpenCodeRuntimeOptions = ExternalStoreSharedOptions & {
@@ -1697,30 +944,18 @@ type OpenCodeRuntimeOptions = ExternalStoreSharedOptions & {
   } | undefined;
 };
 
-type OpenCodeRuntimeExtras = {
-  session: Session | null;
-  state: OpenCodeThreadState;
-  permissions: OpenCodeThreadState["interactions"]["permissions"]["pending"];
-  questions: OpenCodeThreadState["interactions"]["questions"]["pending"];
-  fork: (messageId: string) => Promise<string>;
-  revert: (messageId: string) => Promise<void>;
-  unrevert: () => Promise<void>;
-  cancel: () => Promise<void>;
-  refresh: () => Promise<void>;
-  replyToPermission: (permissionId: string, response: OpenCodePermissionResponse) => Promise<void>;
-  replyToQuestion: (questionId: string, answers: readonly QuestionAnswer[]) => Promise<void>;
-  rejectQuestion: (questionId: string) => Promise<void>;
-};
-
-type OpenCodeRuntime = AssistantRuntime;
-
-type OpenCodeThreadStateSelector<T> = (state: OpenCodeThreadState) => T;
-
 type OpenCodeServerEvent = {
   type: string;
   sessionId: string | undefined;
   raw: unknown;
   properties: Record<string, unknown>;
+};
+
+type OpenCodeServerMessage = {
+  id: string;
+  info: Message$1 | undefined;
+  parts: readonly Part[];
+  shadowParts: readonly ThreadUserMessagePart[] | undefined;
 };
 
 type OpenCodeStateEvent = {
@@ -1806,57 +1041,6 @@ type OpenCodeStateEvent = {
   error: unknown;
 };
 
-type OpenCodeThreadControllerSnapshot = OpenCodeThreadState;
-
-type OpenCodeThreadControllerLike = {
-  getState(): OpenCodeThreadControllerSnapshot;
-  subscribe(listener: () => void): () => void;
-  load(force?: boolean): Promise<void>;
-  refresh(): Promise<void>;
-  sendMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
-  stageMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
-  sendStagedMessage(parentId: string, options?: OpenCodeUserMessageOptions): Promise<boolean>;
-  cancel(): Promise<void>;
-  revert(messageId: string): Promise<void>;
-  unrevert(): Promise<void>;
-  fork(messageId: string): Promise<string>;
-  replyToPermission(permissionId: string, response: OpenCodePermissionResponse): Promise<void>;
-  replyToQuestion(questionId: string, answers: readonly QuestionAnswer[]): Promise<void>;
-  rejectQuestion(questionId: string): Promise<void>;
-};
-
-type OpenCodePartPayload = {
-  readonly name: string;
-  readonly data: Record<string, unknown>;
-};
-
-type OpenCodeProjectedThreadMessage = ThreadMessageLike;
-
-type Listener = (event: OpenCodeServerEvent) => void;
-
-declare const STREAM_RECONNECTED_EVENT_TYPE = "stream.reconnected";
-
-declare class OpenCodeEventSource {
-  private readonly client;
-  private readonly listeners;
-  private readonly reconnectDelayMs;
-  private readonly maxReconnectDelayMs;
-  private abortController;
-  private connectionPromise;
-  private stopped;
-  private nextReconnectDelayMs;
-  private hadConnection;
-  constructor(client: OpencodeClient);
-  subscribe(listener: Listener): () => void;
-  dispose(): void;
-  private emit;
-  private connect;
-  private disconnect;
-  private run;
-}
-
-type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
-
 declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private readonly client;
   private readonly sessionId;
@@ -1892,13 +1076,831 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private dispatch;
 }
 
-declare const useOpenCodeRuntimeExtras: () => OpenCodeRuntimeExtras;
+type OpenCodeThreadControllerLike = {
+  getState(): OpenCodeThreadControllerSnapshot;
+  subscribe(listener: () => void): () => void;
+  load(force?: boolean): Promise<void>;
+  refresh(): Promise<void>;
+  sendMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
+  stageMessage(message: AppendMessage, options?: OpenCodeUserMessageOptions): Promise<void>;
+  sendStagedMessage(parentId: string, options?: OpenCodeUserMessageOptions): Promise<boolean>;
+  cancel(): Promise<void>;
+  revert(messageId: string): Promise<void>;
+  unrevert(): Promise<void>;
+  fork(messageId: string): Promise<string>;
+  replyToPermission(permissionId: string, response: OpenCodePermissionResponse): Promise<void>;
+  replyToQuestion(questionId: string, answers: readonly QuestionAnswer[]): Promise<void>;
+  rejectQuestion(questionId: string): Promise<void>;
+};
 
-declare const useOpenCodeSession: () => import("@opencode-ai/sdk/v2/client").Session | null;
+type OpenCodeThreadControllerSnapshot = OpenCodeThreadState;
 
-declare function useOpenCodeThreadState(): OpenCodeThreadState;
+type OpenCodeThreadState = {
+  sessionId: string;
+  session: Session | null;
+  sessionStatus: SessionStatus | null;
+  loadState: OpenCodeLoadState;
+  runState: OpenCodeRunState;
+  messageOrder: readonly string[];
+  messagesById: Readonly<Record<string, OpenCodeServerMessage>>;
+  pendingUserMessages: Readonly<Record<string, PendingUserMessage>>;
+  interactions: {
+    permissions: {
+      pending: Readonly<Record<string, OpenCodePermissionRequest>>;
+      resolved: Readonly<Record<string, {
+        request: OpenCodePermissionRequest;
+        reply: OpenCodePermissionResponse;
+        respondedAt: number;
+      }>>;
+    };
+    questions: {
+      pending: Readonly<Record<string, OpenCodeQuestionRequest>>;
+      answered: Readonly<Record<string, {
+        request: OpenCodeQuestionRequest;
+        answers: readonly QuestionAnswer[];
+        respondedAt: number;
+      }>>;
+      rejected: Readonly<Record<string, {
+        request: OpenCodeQuestionRequest;
+        rejectedAt: number;
+      }>>;
+    };
+  };
+  unhandledEvents: readonly OpenCodeUnhandledEvent[];
+  sync: {
+    lastHistoryLoadAt?: number;
+    lastEventAt?: number;
+    lastCompactionAt?: number;
+  };
+};
 
-declare function useOpenCodeThreadState<T>(selector: (state: OpenCodeThreadState) => T): T;
+type OpenCodeThreadStateSelector<T> = (state: OpenCodeThreadState) => T;
+
+type OpenCodeUnhandledEvent = {
+  type: string;
+  sessionId: string | undefined;
+  properties: Record<string, unknown>;
+  seenAt: number;
+};
+
+type OpenCodeUserMessageOptions = {
+  model?: {
+    providerID: string;
+    modelID: string;
+  } | undefined;
+  agent?: string | undefined;
+  noReply?: boolean | undefined;
+};
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type PendingUserMessage = {
+  clientId: string;
+  sessionId: string;
+  createdAt: number;
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: unknown;
+  contentText: string;
+  parts: readonly ThreadUserMessagePart[];
+  status: "failed" | "pending";
+  error?: unknown;
+};
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+declare namespace RealtimeVoiceAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Mode = "listening" | "speaking";
+  type TranscriptItem = {
+    role: "assistant" | "user";
+    text: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    isMuted: boolean;
+    disconnect: () => void;
+    mute: () => void;
+    unmute: () => void;
+    onStatusChange: (callback: (status: Status) => void) => Unsubscribe;
+    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe;
+    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe;
+    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe;
+  };
+}
+
+type RealtimeVoiceAdapter = {
+  connect: (options: {
+    abortSignal?: AbortSignal;
+  }) => RealtimeVoiceAdapter.Session;
+};
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+declare const STREAM_RECONNECTED_EVENT_TYPE = "stream.reconnected";
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
+};
+
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
+};
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+type ThreadMessageLike = {
+  readonly role: "assistant" | "system" | "user";
+  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
+    readonly type: "tool-call";
+    readonly toolCallId?: string;
+    readonly toolName: string;
+    readonly args?: ReadonlyJSONObject;
+    readonly argsText?: string;
+    readonly artifact?: any;
+    readonly result?: any | undefined;
+    readonly isError?: boolean | undefined;
+    readonly parentId?: string | undefined;
+    readonly messages?: readonly ThreadMessage[] | undefined;
+    readonly interrupt?: {
+      type: "human";
+      payload: unknown;
+    };
+    readonly timing?: ToolCallTiming;
+    readonly approval?: {
+      readonly id: string;
+      readonly approved?: boolean;
+      readonly reason?: string;
+      readonly isAutomatic?: boolean;
+      readonly options?: readonly ToolApprovalOption[];
+      readonly optionId?: string;
+      readonly resolution?: "cancelled" | "expired";
+    };
+  })[];
+  readonly id?: string | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
+    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
+  })[] | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly isOptimistic?: boolean | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  } | undefined;
+};
+
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe;
+  cancelRun(): void;
+  getModelContext(): ModelContext;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+};
+
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
+};
+
+type ThreadSuggestion = {
+  prompt: string;
+};
+
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+declare const createOpenCodeThreadState: (sessionId: string) => OpenCodeThreadState;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare global {
+  interface Window {
+    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
+}
+
+declare const projectOpenCodeThreadMessages: (state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>) => OpenCodeProjectedThreadMessage[];
+
+declare const reduceOpenCodeThreadState: (state: OpenCodeThreadState, event: OpenCodeStateEvent) => OpenCodeThreadState;
 
 declare const useOpenCodePermissions: () => {
   pending: OpenCodePermissionRequest[];
@@ -1909,16 +1911,14 @@ declare const useOpenCodeQuestions: () => OpenCodeQuestionRequest[];
 
 declare const useOpenCodeRuntime: (options?: OpenCodeRuntimeOptions) => AssistantRuntime;
 
+declare const useOpenCodeRuntimeExtras: () => OpenCodeRuntimeExtras;
+
+declare const useOpenCodeSession: () => import("@opencode-ai/sdk/v2/client").Session | null;
+
 declare const useOpenCodeStreamingTiming: (state: OpenCodeThreadState, isRunning: boolean) => Record<string, MessageTiming>;
 
-declare const createOpenCodeThreadState: (sessionId: string) => OpenCodeThreadState;
+declare function useOpenCodeThreadState(): OpenCodeThreadState;
 
-declare const reduceOpenCodeThreadState: (state: OpenCodeThreadState, event: OpenCodeStateEvent) => OpenCodeThreadState;
-
-declare const projectOpenCodeThreadMessages: (state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>) => OpenCodeProjectedThreadMessage[];
-
-declare namespace entry_root_exports {
-  export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
-}
+declare function useOpenCodeThreadState<T>(selector: (state: OpenCodeThreadState) => T): T;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1,63 +1,860 @@
 import { createAgentSession } from "@earendil-works/pi-coding-agent";
 
-
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-interface PiTextContent {
-  type: "text";
-  text: string;
-  textSignature?: string;
-}
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
 
-interface PiThinkingContent {
-  type: "thinking";
-  thinking: string;
-  thinkingSignature?: string;
-  redacted?: boolean;
-}
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-interface PiImageContent {
-  type: "image";
-  data: string;
-  mimeType: string;
-}
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
 
-interface PiToolCall {
-  type: "toolCall";
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe$1;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type BaseAttachment = {
   id: string;
+  type: "image" | "document" | "file" | (string & {});
   name: string;
-  arguments: Record<string, unknown>;
-  thoughtSignature?: string;
+  contentType?: string | undefined;
+  file?: File;
+  content?: ThreadUserMessagePart[];
+};
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
 }
 
-type PiAssistantContent = PiTextContent | PiThinkingContent | PiToolCall;
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
-type PiUserContent = PiTextContent | PiImageContent;
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
 
-type PiToolResultContent = PiTextContent | PiImageContent;
+type CompleteAttachment = BaseAttachment & {
+  status: CompleteAttachmentStatus;
+  content: ThreadUserMessagePart[];
+};
 
-interface PiUsage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  totalTokens: number;
-  cost: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-    total: number;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerState = ThreadComposerState | EditComposerState;
+
+type ContentPart = Exclude<ThreadMessageLike["content"], string>[number];
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
+
+type CreateAttachment = {
+  id?: string;
+  type?: "image" | "document" | "file" | (string & {});
+  name: string;
+  contentType?: string;
+  content: ThreadUserMessagePart[];
+};
+
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
+
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
+
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
+}
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
   };
 }
 
-type PiStopReason = "aborted" | "error" | "length" | "stop" | "toolUse";
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
 
-interface PiUserMessage {
-  role: "user";
-  content: string | PiUserContent[];
-  timestamp: number;
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
 }
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+interface JSONSchema7 {
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  $schema?: JSONSchema7Version | undefined;
+  $comment?: string | undefined;
+  $defs?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
+  enum?: JSONSchema7Type[] | undefined;
+  const?: JSONSchema7Type | undefined;
+  multipleOf?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  minimum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  maxLength?: number | undefined;
+  minLength?: number | undefined;
+  pattern?: string | undefined;
+  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
+  additionalItems?: JSONSchema7Definition | undefined;
+  maxItems?: number | undefined;
+  minItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
+  contains?: JSONSchema7Definition | undefined;
+  maxProperties?: number | undefined;
+  minProperties?: number | undefined;
+  required?: string[] | undefined;
+  properties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  patternProperties?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  additionalProperties?: JSONSchema7Definition | undefined;
+  dependencies?: {
+    [key: string]: JSONSchema7Definition | string[];
+  } | undefined;
+  propertyNames?: JSONSchema7Definition | undefined;
+  if?: JSONSchema7Definition | undefined;
+  then?: JSONSchema7Definition | undefined;
+  else?: JSONSchema7Definition | undefined;
+  allOf?: JSONSchema7Definition[] | undefined;
+  anyOf?: JSONSchema7Definition[] | undefined;
+  oneOf?: JSONSchema7Definition[] | undefined;
+  not?: JSONSchema7Definition | undefined;
+  format?: string | undefined;
+  contentMediaType?: string | undefined;
+  contentEncoding?: string | undefined;
+  definitions?: {
+    [key: string]: JSONSchema7Definition;
+  } | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  default?: JSONSchema7Type | undefined;
+  readOnly?: boolean | undefined;
+  writeOnly?: boolean | undefined;
+  examples?: JSONSchema7Type | undefined;
+}
+
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
+
+type JSONSchema7Definition = JSONSchema7 | boolean;
+
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
+
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+
+type JSONSchema7Version = string;
+
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
+};
+
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
+};
+
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
+};
+
+type McpServerConfig = {
+  type: "http" | "sse";
+  url: string;
+  headers?: Record<string, string>;
+  redirect?: "error" | "follow";
+  connectionTimeout?: number | undefined;
+} | {
+  type: "stdio";
+  command: string;
+  args?: readonly string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  connectionTimeout?: number | undefined;
+};
+
+type McpTool = ToolBase<Record<string, unknown>, unknown> & {
+  type: "mcp";
+  server: McpServerConfig;
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
+};
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param0: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param1: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type ModelContext = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+type ObjectKey<T> = keyof T & (string | number);
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
+} | {
+  type: "requires-action";
+  reason: "composer-send";
+} | {
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+type PiAgentMessage = PiKnownAgentMessage | PiUnknownAgentMessage;
+
+type PiAnyClientEvent = PiClientEvent | (PiUnknownClientEventBody & PiClientEventEnvelope);
+
+type PiAssistantContent = PiTextContent | PiThinkingContent | PiToolCall;
 
 interface PiAssistantMessage {
   role: "assistant";
@@ -72,63 +869,6 @@ interface PiAssistantMessage {
   errorMessage?: string;
   timestamp: number;
 }
-
-interface PiToolResultMessage {
-  role: "toolResult";
-  toolCallId: string;
-  toolName: string;
-  content: PiToolResultContent[];
-  details?: unknown;
-  isError: boolean;
-  timestamp: number;
-}
-
-interface PiBashExecutionMessage {
-  role: "bashExecution";
-  command: string;
-  output: string;
-  exitCode: number | undefined;
-  cancelled: boolean;
-  truncated: boolean;
-  fullOutputPath?: string;
-  timestamp: number;
-  excludeFromContext?: boolean;
-}
-
-interface PiCustomMessage {
-  role: "custom";
-  customType: string;
-  content: string | PiUserContent[];
-  display: boolean;
-  details?: unknown;
-  timestamp: number;
-}
-
-interface PiBranchSummaryMessage {
-  role: "branchSummary";
-  summary: string;
-  fromId: string;
-  timestamp: number;
-}
-
-interface PiCompactionSummaryMessage {
-  role: "compactionSummary";
-  summary: string;
-  tokensBefore: number;
-  timestamp: number;
-}
-
-type PiKnownAgentMessage = PiUserMessage | PiAssistantMessage | PiToolResultMessage | PiBashExecutionMessage | PiCustomMessage | PiBranchSummaryMessage | PiCompactionSummaryMessage;
-
-interface PiUnknownAgentMessage {
-  role: string;
-  timestamp?: number;
-  [key: string]: unknown;
-}
-
-type PiAgentMessage = PiKnownAgentMessage | PiUnknownAgentMessage;
-
-type PiTranscriptMessage = PiAgentMessage;
 
 type PiAssistantMessageDelta = {
   type: "start";
@@ -185,124 +925,61 @@ type PiAssistantMessageDelta = {
   error: PiAssistantMessage;
 };
 
-interface PiContextUsage {
-  tokens: number | null;
-  contextWindow: number;
-  percent: number | null;
+interface PiBashExecutionMessage {
+  role: "bashExecution";
+  command: string;
+  output: string;
+  exitCode: number | undefined;
+  cancelled: boolean;
+  truncated: boolean;
+  fullOutputPath?: string;
+  timestamp: number;
+  excludeFromContext?: boolean;
 }
 
-type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
+interface PiBranchSummaryMessage {
+  role: "branchSummary";
+  summary: string;
+  fromId: string;
+  timestamp: number;
+}
 
-type PiModelInfo = {
-  provider: string;
-  modelId: string;
-  name?: string;
-  supportsThinking?: boolean;
-  availableThinkingLevels?: readonly PiThinkingLevel[];
-};
-
-type PiRuntimeReadiness = {
-  state: "ready";
-  selection: {
+interface PiClient {
+  listThreads(input?: {
+    workspacePath?: string;
+    includeArchived?: boolean;
+  }): Promise<PiThreadMetadata[]>;
+  createThread(input?: {
+    workspacePath?: string;
+    title?: string;
+    initialMessage?: PiSendMessageInput;
+  }): Promise<PiThreadSnapshot>;
+  getThread(threadId: string): Promise<PiThreadSnapshot>;
+  sendMessage(threadId: string, input: PiSendMessageInput): Promise<void>;
+  cancelRun(threadId: string): Promise<void>;
+  clearQueue(threadId: string): Promise<{
+    steering: string[];
+    followUp: string[];
+  }>;
+  getAvailableModels(input?: {
+    workspacePath?: string;
+  }): Promise<PiModelInfo[]>;
+  setModel(threadId: string, input: {
     provider: string;
     modelId: string;
-  };
-  source: "env" | "pi-default" | "session";
-} | {
-  state: "missing-model";
-  message: string;
-} | {
-  state: "missing-credentials";
-  provider?: string;
-  message: string;
-} | {
-  state: "unavailable-model";
-  selection: {
-    provider: string;
-    modelId: string;
-  };
-  message: string;
-};
+  }): Promise<void>;
+  setThinkingLevel(threadId: string, level: PiThinkingLevel): Promise<void>;
+  renameThread(threadId: string, title: string): Promise<void>;
+  archiveThread(threadId: string): Promise<void>;
+  unarchiveThread(threadId: string): Promise<void>;
+  deleteThread(threadId: string): Promise<void>;
+  respondToHostUiRequest(threadId: string, response: PiHostUiResponse): Promise<void>;
+  subscribe(threadId: string, listener: (event: PiClientEvent) => void, options?: {
+    includeSnapshot?: boolean;
+  }): () => void;
+}
 
-type PiThreadStatus = "failed" | "idle" | "running";
-
-type PiQueuedMessage = {
-  id: string;
-  mode: "followUp" | "steer";
-  content: string;
-};
-
-type PiThreadMetadata = {
-  id: string;
-  title?: string;
-  workspacePath?: string;
-  archived?: boolean;
-  status: PiThreadStatus;
-  runningRunId?: string;
-  queuedMessages?: readonly PiQueuedMessage[];
-  config?: {
-    provider?: string;
-    modelId?: string;
-    thinkingLevel?: PiThinkingLevel | string;
-  };
-  contextUsage?: PiContextUsage;
-  sessionFile?: string;
-  parentSessionPath?: string;
-  messageCount?: number;
-  createdAt?: string;
-  updatedAt?: string;
-};
-
-type PiInputAttachment = PiImageContent;
-
-type PiSendMessageInput = {
-  content: string;
-  attachments?: PiInputAttachment[];
-  streamingBehavior?: "followUp" | "steer";
-};
-
-type PiHostUiRequestKind = "confirm" | "editor" | "input" | "select";
-
-type PiHostUiRequest = {
-  id: string;
-  kind: "confirm";
-  title: string;
-  message: string;
-  toolCallId?: string;
-  timeoutMs?: number;
-} | {
-  id: string;
-  kind: "select";
-  title: string;
-  options: readonly string[];
-  toolCallId?: string;
-  timeoutMs?: number;
-} | {
-  id: string;
-  kind: "input";
-  title: string;
-  placeholder?: string;
-  toolCallId?: string;
-  timeoutMs?: number;
-} | {
-  id: string;
-  kind: "editor";
-  title: string;
-  prefill?: string;
-  toolCallId?: string;
-  timeoutMs?: number;
-};
-
-type PiHostUiResponse = {
-  requestId: string;
-  confirmed: boolean;
-} | {
-  requestId: string;
-  value: string;
-} | {
-  requestId: string;
-  dismissed: true;
-};
+type PiClientEvent = PiClientEventBody & PiClientEventEnvelope;
 
 type PiClientEventBody = {
   type: "snapshot";
@@ -381,158 +1058,32 @@ type PiClientEventBody = {
   error: string;
 };
 
-type PiUnknownClientEventBody = {
-  type: string;
-  [key: string]: unknown;
-};
-
 type PiClientEventEnvelope = {
   threadId: string;
   seq: number;
 };
 
-type PiClientEvent = PiClientEventBody & PiClientEventEnvelope;
-
-type PiAnyClientEvent = PiClientEvent | (PiUnknownClientEventBody & PiClientEventEnvelope);
-
-type PiThreadSnapshot = {
-  metadata: PiThreadMetadata;
-  messages: PiTranscriptMessage[];
-  hostUiRequests?: readonly PiHostUiRequest[];
-  readiness?: PiRuntimeReadiness;
-  lastError?: string;
-};
-
-interface PiClient {
-  listThreads(input?: {
-    workspacePath?: string;
-    includeArchived?: boolean;
-  }): Promise<PiThreadMetadata[]>;
-  createThread(input?: {
-    workspacePath?: string;
-    title?: string;
-    initialMessage?: PiSendMessageInput;
-  }): Promise<PiThreadSnapshot>;
-  getThread(threadId: string): Promise<PiThreadSnapshot>;
-  sendMessage(threadId: string, input: PiSendMessageInput): Promise<void>;
-  cancelRun(threadId: string): Promise<void>;
-  clearQueue(threadId: string): Promise<{
-    steering: string[];
-    followUp: string[];
-  }>;
-  getAvailableModels(input?: {
-    workspacePath?: string;
-  }): Promise<PiModelInfo[]>;
-  setModel(threadId: string, input: {
-    provider: string;
-    modelId: string;
-  }): Promise<void>;
-  setThinkingLevel(threadId: string, level: PiThinkingLevel): Promise<void>;
-  renameThread(threadId: string, title: string): Promise<void>;
-  archiveThread(threadId: string): Promise<void>;
-  unarchiveThread(threadId: string): Promise<void>;
-  deleteThread(threadId: string): Promise<void>;
-  respondToHostUiRequest(threadId: string, response: PiHostUiResponse): Promise<void>;
-  subscribe(threadId: string, listener: (event: PiClientEvent) => void, options?: {
-    includeSnapshot?: boolean;
-  }): () => void;
+interface PiCompactionSummaryMessage {
+  role: "compactionSummary";
+  summary: string;
+  tokensBefore: number;
+  timestamp: number;
 }
 
-type PiSessionModel = NonNullable<Parameters<typeof createAgentSession>[0]>["model"];
-
-interface PiThreadSupervisorOptions {
-  workspacePath?: string;
-  agentDir?: string;
-  model?: PiSessionModel;
+interface PiContextUsage {
+  tokens: number | null;
+  contextWindow: number;
+  percent: number | null;
 }
 
-declare class PiThreadSupervisor {
-  private readonly records;
-  private readonly pendingOpens;
-  private readonly recordsBySessionFile;
-  private readonly workspacePath;
-  private readonly agentDir;
-  private readonly model;
-  private readonly modelRegistry;
-  private readonly archivedSessionFiles;
-  private readonly catalogCache;
-  private readonly catalogInfoByThreadId;
-  constructor(options?: PiThreadSupervisorOptions);
-  listThreads(input?: {
-    workspacePath?: string;
-    includeArchived?: boolean;
-  }): Promise<PiThreadMetadata[]>;
-  createThread(input?: {
-    workspacePath?: string;
-    title?: string;
-    initialMessage?: PiSendMessageInput;
-  }): Promise<PiThreadSnapshot>;
-  getThread(threadId: string): Promise<PiThreadSnapshot>;
-  sendMessage(threadId: string, input: PiSendMessageInput): Promise<void>;
-  cancelRun(threadId: string): Promise<void>;
-  clearQueue(threadId: string): Promise<{
-    steering: string[];
-    followUp: string[];
-  }>;
-  getAvailableModels(): Promise<PiModelInfo[]>;
-  setModel(threadId: string, input: {
-    provider: string;
-    modelId: string;
-  }): Promise<void>;
-  setThinkingLevel(threadId: string, level: PiThinkingLevel): Promise<void>;
-  renameThread(threadId: string, title: string): Promise<void>;
-  archiveThread(threadId: string): Promise<void>;
-  unarchiveThread(threadId: string): Promise<void>;
-  deleteThread(threadId: string): Promise<void>;
-  respondToHostUiRequest(threadId: string, response: PiHostUiResponse): Promise<void>;
-  subscribe(threadId: string, listener: (event: PiClientEvent) => void, options?: {
-    includeSnapshot?: boolean;
-  }): () => void;
-  dispose(): Promise<void>;
-  private openSession;
-  private ensureOpen;
-  private openCold;
-  private listSessionInfos;
-  private invalidateCatalog;
-  private findSessionInfo;
-  private rememberSessionInfos;
-  private send;
-  private onSessionEvent;
-  private emitContextUsage;
-  private emit;
-  private liveStatusFor;
-  private runStatus;
-  private readinessOf;
-  private queuedMessagesOf;
-  private metadataOf;
-  private snapshotOf;
-  private snapshotFromSessionFile;
+interface PiCustomMessage {
+  role: "custom";
+  customType: string;
+  content: string | PiUserContent[];
+  display: boolean;
+  details?: unknown;
+  timestamp: number;
 }
-
-type PiNodeClientOptions = PiThreadSupervisorOptions;
-
-declare const getPiThreadSupervisor: (options?: PiNodeClientOptions) => PiThreadSupervisor;
-
-declare const createPiNodeClient: (options?: PiNodeClientOptions) => PiClient;
-
-declare class PiUnsupportedHostUiError extends Error {
-  readonly method: string;
-  constructor(method: string);
-}
-
-declare namespace entry_node_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
-}
-
-interface SseFrame {
-  event?: string;
-  data: string;
-  id?: string;
-}
-
-declare const createSseDecoder: () => {
-  push(chunk: string): SseFrame[];
-};
 
 interface PiEventStreamOptions {
   url: string;
@@ -543,17 +1094,48 @@ interface PiEventStreamOptions {
   reconnectDelay?: () => Promise<void>;
 }
 
-declare const openPiEventStream: (options: PiEventStreamOptions) => (() => void);
-
-type SharedStream = {
-  listeners: Set<(event: PiClientEvent) => void>;
-  close: () => void;
-  closeTimer: ReturnType<typeof setTimeout> | undefined;
+type PiHostUiRequest = {
+  id: string;
+  kind: "confirm";
+  title: string;
+  message: string;
+  toolCallId?: string;
+  timeoutMs?: number;
+} | {
+  id: string;
+  kind: "select";
+  title: string;
+  options: readonly string[];
+  toolCallId?: string;
+  timeoutMs?: number;
+} | {
+  id: string;
+  kind: "input";
+  title: string;
+  placeholder?: string;
+  toolCallId?: string;
+  timeoutMs?: number;
+} | {
+  id: string;
+  kind: "editor";
+  title: string;
+  prefill?: string;
+  toolCallId?: string;
+  timeoutMs?: number;
 };
 
-declare global {
-  var __assistantUiPiHttpStreams: Map<string, SharedStream> | undefined;
-}
+type PiHostUiRequestKind = "confirm" | "editor" | "input" | "select";
+
+type PiHostUiResponse = {
+  requestId: string;
+  confirmed: boolean;
+} | {
+  requestId: string;
+  value: string;
+} | {
+  requestId: string;
+  dismissed: true;
+};
 
 interface PiHttpClientOptions {
   baseUrl?: string;
@@ -564,1608 +1146,34 @@ interface PiHttpClientOptions {
   streamCloseDelayMs?: number;
 }
 
-declare const createPiHttpClient: (options?: PiHttpClientOptions) => PiClient;
+interface PiImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
 
-type PiQueueMode = "followUp" | "steer";
+type PiInputAttachment = PiImageContent;
 
-declare const piQueueItemId: (mode: PiQueueMode, index: number) => string;
+type PiInterruptAnswer = string | {
+  value?: string | null;
+  dismissed?: boolean;
+} | null | undefined;
 
-declare const isPiSteerQueueItemId: (id: string) => boolean;
-
-type PiRunStatus = "failed" | "idle" | "running";
+type PiKnownAgentMessage = PiUserMessage | PiAssistantMessage | PiToolResultMessage | PiBashExecutionMessage | PiCustomMessage | PiBranchSummaryMessage | PiCompactionSummaryMessage;
 
 type PiLoadState = "loaded" | "loading" | "pending";
 
-interface PiToolExecutionState {
-  toolCallId: string;
-  toolName?: string;
-  args?: unknown;
-  partialResult?: unknown;
-  status: "complete" | "error" | "running";
-}
-
-interface PiThreadState {
-  threadId: string;
-  metadata: PiThreadMetadata;
-  messages: readonly PiAgentMessage[];
-  streamingMessageIndex: number | undefined;
-  toolExecutions: Readonly<Record<string, PiToolExecutionState>>;
-  runStatus: PiRunStatus;
-  queue: {
-    steering: readonly string[];
-    followUp: readonly string[];
-  };
-  contextUsage: PiContextUsage | undefined;
-  compaction: {
-    active: boolean;
-    reason?: "manual" | "overflow" | "threshold";
-  };
-  retry: {
-    active: boolean;
-    attempt: number;
-  };
-  hostUiRequests: readonly PiHostUiRequest[];
-  readiness: PiRuntimeReadiness | undefined;
-  lastError: string | undefined;
-  loadState: PiLoadState;
-  lastSeq: number;
-}
-
-declare const createPiThreadState: (threadId: string) => PiThreadState;
-
-declare const reducePiThreadState: (state: PiThreadState, event: PiClientEvent) => PiThreadState;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe$1 = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe$1;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
-};
-
-type CompleteAttachmentStatus = {
-  type: "complete";
-};
-
-type BaseAttachment = {
-  id: string;
-  type: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string | undefined;
-  file?: File;
-  content?: ThreadUserMessagePart[];
-};
-
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
-};
-
-type CompleteAttachment = BaseAttachment & {
-  status: CompleteAttachmentStatus;
-  content: ThreadUserMessagePart[];
-};
-
-type Attachment = PendingAttachment | CompleteAttachment;
-
-type CreateAttachment = {
-  id?: string;
-  type?: "image" | "document" | "file" | (string & {});
-  name: string;
-  contentType?: string;
-  content: ThreadUserMessagePart[];
-};
-
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
-};
-
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
-
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
-
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
-
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
-
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
-}
-
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
-}
-
-type JSONSchema7Version = string;
-
-type JSONSchema7Definition = JSONSchema7 | boolean;
-
-interface JSONSchema7 {
-  $id?: string | undefined;
-  $ref?: string | undefined;
-  $schema?: JSONSchema7Version | undefined;
-  $comment?: string | undefined;
-  $defs?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  type?: JSONSchema7TypeName | JSONSchema7TypeName[] | undefined;
-  enum?: JSONSchema7Type[] | undefined;
-  const?: JSONSchema7Type | undefined;
-  multipleOf?: number | undefined;
-  maximum?: number | undefined;
-  exclusiveMaximum?: number | undefined;
-  minimum?: number | undefined;
-  exclusiveMinimum?: number | undefined;
-  maxLength?: number | undefined;
-  minLength?: number | undefined;
-  pattern?: string | undefined;
-  items?: JSONSchema7Definition | JSONSchema7Definition[] | undefined;
-  additionalItems?: JSONSchema7Definition | undefined;
-  maxItems?: number | undefined;
-  minItems?: number | undefined;
-  uniqueItems?: boolean | undefined;
-  contains?: JSONSchema7Definition | undefined;
-  maxProperties?: number | undefined;
-  minProperties?: number | undefined;
-  required?: string[] | undefined;
-  properties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  patternProperties?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  additionalProperties?: JSONSchema7Definition | undefined;
-  dependencies?: {
-    [key: string]: JSONSchema7Definition | string[];
-  } | undefined;
-  propertyNames?: JSONSchema7Definition | undefined;
-  if?: JSONSchema7Definition | undefined;
-  then?: JSONSchema7Definition | undefined;
-  else?: JSONSchema7Definition | undefined;
-  allOf?: JSONSchema7Definition[] | undefined;
-  anyOf?: JSONSchema7Definition[] | undefined;
-  oneOf?: JSONSchema7Definition[] | undefined;
-  not?: JSONSchema7Definition | undefined;
-  format?: string | undefined;
-  contentMediaType?: string | undefined;
-  contentEncoding?: string | undefined;
-  definitions?: {
-    [key: string]: JSONSchema7Definition;
-  } | undefined;
-  title?: string | undefined;
-  description?: string | undefined;
-  default?: JSONSchema7Type | undefined;
-  readOnly?: boolean | undefined;
-  writeOnly?: boolean | undefined;
-  examples?: JSONSchema7Type | undefined;
-}
-
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
-
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
-
-type ObjectKey<T> = keyof T & (string | number);
-
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
-
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
-
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
-
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
-
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
-};
-
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-};
-
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
-
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
-  };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
-};
-
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
-
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
-};
-
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
-};
-
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
-};
-
-type McpServerConfig = {
-  type: "http" | "sse";
-  url: string;
-  headers?: Record<string, string>;
-  redirect?: "error" | "follow";
-  connectionTimeout?: number | undefined;
-} | {
-  type: "stdio";
-  command: string;
-  args?: readonly string[];
-  env?: Record<string, string>;
-  cwd?: string;
-  connectionTimeout?: number | undefined;
-};
-
-type McpTool = ToolBase<Record<string, unknown>, unknown> & {
-  type: "mcp";
-  server: McpServerConfig;
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
-};
-
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
-};
-
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
-
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-declare namespace RealtimeVoiceAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Mode = "listening" | "speaking";
-  type TranscriptItem = {
-    role: "assistant" | "user";
-    text: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    isMuted: boolean;
-    disconnect: () => void;
-    mute: () => void;
-    unmute: () => void;
-    onStatusChange: (callback: (status: Status) => void) => Unsubscribe;
-    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe;
-    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe;
-    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe;
-  };
-}
-
-type RealtimeVoiceAdapter = {
-  connect: (options: {
-    abortSignal?: AbortSignal;
-  }) => RealtimeVoiceAdapter.Session;
-};
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
-};
-
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
-};
-
-type ModelContext = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
-};
-
-type ModelContextProvider = {
-  getModelContext: () => ModelContext;
-  subscribe?: (callback: () => void) => Unsubscribe;
-};
-
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  };
-};
-
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
-};
-
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
-};
-
-type ThreadMessageLike = {
-  readonly role: "assistant" | "system" | "user";
-  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
-    readonly type: "tool-call";
-    readonly toolCallId?: string;
-    readonly toolName: string;
-    readonly args?: ReadonlyJSONObject;
-    readonly argsText?: string;
-    readonly artifact?: any;
-    readonly result?: any | undefined;
-    readonly isError?: boolean | undefined;
-    readonly parentId?: string | undefined;
-    readonly messages?: readonly ThreadMessage[] | undefined;
-    readonly interrupt?: {
-      type: "human";
-      payload: unknown;
-    };
-    readonly timing?: ToolCallTiming;
-    readonly approval?: {
-      readonly id: string;
-      readonly approved?: boolean;
-      readonly reason?: string;
-      readonly isAutomatic?: boolean;
-      readonly options?: readonly ToolApprovalOption[];
-      readonly optionId?: string;
-      readonly resolution?: "cancelled" | "expired";
-    };
-  })[];
-  readonly id?: string | undefined;
-  readonly createdAt?: Date | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
-    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
-  })[] | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly isOptimistic?: boolean | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
-  } | undefined;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
-
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
-
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
-
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
-
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
-
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
-
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
-
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
-
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type ThreadSuggestion = {
-  prompt: string;
-};
-
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
-
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
-
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
-
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
-
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
-
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
-
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
+type PiModelInfo = {
+  provider: string;
+  modelId: string;
+  name?: string;
+  supportsThinking?: boolean;
+  availableThinkingLevels?: readonly PiThinkingLevel[];
 };
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemState = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param0: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param1: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
-};
-
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe;
-  cancelRun(): void;
-  getModelContext(): ModelContext;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
-};
-
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
-  readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
-};
-
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
-};
-
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
-};
-
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
-};
-
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
-};
-
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
-
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
-    payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
-
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
 
-declare global {
-  interface Window {
-    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
-  }
-}
+type PiNodeClientOptions = PiThreadSupervisorOptions;
 
-type ContentPart = Exclude<ThreadMessageLike["content"], string>[number];
+type PiNotificationScheduler = (flush: () => void) => void;
 
 interface PiProjectionInput {
   messages: readonly PiAgentMessage[];
@@ -2174,61 +1182,106 @@ interface PiProjectionInput {
   hostUiRequests: readonly PiHostUiRequest[];
 }
 
-declare const projectPiThreadMessages: (input: PiProjectionInput) => ThreadMessageLike[];
+type PiQueueMode = "followUp" | "steer";
 
-declare const projectPiThreadRepository: (input: PiProjectionInput) => ExportedMessageRepository;
+type PiQueuedMessage = {
+  id: string;
+  mode: "followUp" | "steer";
+  content: string;
+};
 
-interface SplitHostUiRequests {
-  toolAssociated: Map<string, PiHostUiRequest>;
-  freeStanding: PiHostUiRequest[];
+type PiRunStatus = "failed" | "idle" | "running";
+
+interface PiRuntimeExtras {
+  state: PiThreadState;
+  metadata: PiThreadMetadata;
+  status: PiThreadStatus;
+  readiness: PiRuntimeReadiness | undefined;
+  contextUsage: PiContextUsage | undefined;
+  hostUiRequests: readonly PiHostUiRequest[];
+  allHostUiRequests: readonly PiHostUiRequest[];
+  queue: PiThreadState["queue"];
+  compaction: PiThreadState["compaction"];
+  retry: PiThreadState["retry"];
+  lastError: string | undefined;
+  cancel: () => Promise<void>;
+  refresh: () => Promise<void>;
+  clearQueue: () => Promise<{
+    steering: string[];
+    followUp: string[];
+  }>;
+  setModel: (input: {
+    provider: string;
+    modelId: string;
+  }) => Promise<void>;
+  setThinkingLevel: (level: PiThinkingLevel) => Promise<void>;
+  respondToHostUiRequest: (response: PiHostUiResponse) => Promise<void>;
+  respondToToolApproval: (id: string, approved: boolean) => Promise<void>;
+  resumeToolCall: (toolCallId: string, payload: PiInterruptAnswer) => Promise<void>;
 }
 
-declare const splitHostUiRequests: (requests: readonly PiHostUiRequest[]) => SplitHostUiRequests;
+type PiRuntimeOptions = ExternalStoreSharedOptions & {
+  client: PiClient;
+  workspacePath?: string;
+  includeArchived?: boolean;
+  initialThreadId?: string;
+  threadId?: string;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  onError?: (error: unknown) => void;
+  adapters?: ExternalStoreAdapter<ThreadMessageLike>["adapters"];
+};
 
-declare const responseForApproval: (requestId: string, approved: boolean) => PiHostUiResponse;
+type PiRuntimeReadiness = {
+  state: "ready";
+  selection: {
+    provider: string;
+    modelId: string;
+  };
+  source: "env" | "pi-default" | "session";
+} | {
+  state: "missing-model";
+  message: string;
+} | {
+  state: "missing-credentials";
+  provider?: string;
+  message: string;
+} | {
+  state: "unavailable-model";
+  selection: {
+    provider: string;
+    modelId: string;
+  };
+  message: string;
+};
 
-type PiInterruptAnswer = string | {
-  value?: string | null;
-  dismissed?: boolean;
-} | null | undefined;
-
-declare const responseForInterrupt: (requestId: string, answer: PiInterruptAnswer) => PiHostUiResponse;
-
-declare const responseForRequest: (request: PiHostUiRequest, answer: boolean | PiInterruptAnswer) => PiHostUiResponse;
+type PiSendMessageInput = {
+  content: string;
+  attachments?: PiInputAttachment[];
+  streamingBehavior?: "followUp" | "steer";
+};
 
 type PiSendOptions = {
   streamingBehavior?: "followUp" | "steer";
 };
 
-type PiNotificationScheduler = (flush: () => void) => void;
+type PiSessionModel = NonNullable<Parameters<typeof createAgentSession>[0]>["model"];
 
-interface PiThreadControllerLike {
-  getState(): PiThreadState;
-  getProjectedMessages(): readonly ThreadMessageLike[];
-  getMessageRepository(): ExportedMessageRepository;
-  getVersion(): number;
-  connect(): () => void;
-  subscribe(listener: () => void): () => void;
-  subscribeMetadata(listener: () => void): () => void;
-  subscribeMessages(listener: () => void): () => void;
-  load(force?: boolean): Promise<void>;
-  refresh(): Promise<void>;
-  sendMessage(message: AppendMessage, options?: PiSendOptions): Promise<void>;
-  cancel(): Promise<void>;
-  clearQueue(): Promise<{
-    steering: string[];
-    followUp: string[];
-  }>;
-  setModel(input: {
-    provider: string;
-    modelId: string;
-  }): Promise<void>;
-  setThinkingLevel(level: PiThinkingLevel): Promise<void>;
-  respondToToolApproval(approvalId: string, approved: boolean): Promise<void>;
-  resumeToolCall(toolCallId: string, payload: unknown): Promise<void>;
-  respondToHostUiRequest(response: PiHostUiResponse): Promise<void>;
-  dispose(): void;
+type PiStopReason = "aborted" | "error" | "length" | "stop" | "toolUse";
+
+interface PiTextContent {
+  type: "text";
+  text: string;
+  textSignature?: string;
 }
+
+interface PiThinkingContent {
+  type: "thinking";
+  thinking: string;
+  thinkingSignature?: string;
+  redacted?: boolean;
+}
+
+type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
 
 declare class PiThreadController implements PiThreadControllerLike {
   private readonly client;
@@ -2296,44 +1349,999 @@ declare class PiThreadController implements PiThreadControllerLike {
   private notifyMessageListeners;
 }
 
-type PiRuntimeOptions = ExternalStoreSharedOptions & {
-  client: PiClient;
-  workspacePath?: string;
-  includeArchived?: boolean;
-  initialThreadId?: string;
-  threadId?: string;
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  onError?: (error: unknown) => void;
-  adapters?: ExternalStoreAdapter<ThreadMessageLike>["adapters"];
-};
-
-interface PiRuntimeExtras {
-  state: PiThreadState;
-  metadata: PiThreadMetadata;
-  status: PiThreadStatus;
-  readiness: PiRuntimeReadiness | undefined;
-  contextUsage: PiContextUsage | undefined;
-  hostUiRequests: readonly PiHostUiRequest[];
-  allHostUiRequests: readonly PiHostUiRequest[];
-  queue: PiThreadState["queue"];
-  compaction: PiThreadState["compaction"];
-  retry: PiThreadState["retry"];
-  lastError: string | undefined;
-  cancel: () => Promise<void>;
-  refresh: () => Promise<void>;
-  clearQueue: () => Promise<{
+interface PiThreadControllerLike {
+  getState(): PiThreadState;
+  getProjectedMessages(): readonly ThreadMessageLike[];
+  getMessageRepository(): ExportedMessageRepository;
+  getVersion(): number;
+  connect(): () => void;
+  subscribe(listener: () => void): () => void;
+  subscribeMetadata(listener: () => void): () => void;
+  subscribeMessages(listener: () => void): () => void;
+  load(force?: boolean): Promise<void>;
+  refresh(): Promise<void>;
+  sendMessage(message: AppendMessage, options?: PiSendOptions): Promise<void>;
+  cancel(): Promise<void>;
+  clearQueue(): Promise<{
     steering: string[];
     followUp: string[];
   }>;
-  setModel: (input: {
+  setModel(input: {
     provider: string;
     modelId: string;
-  }) => Promise<void>;
-  setThinkingLevel: (level: PiThinkingLevel) => Promise<void>;
-  respondToHostUiRequest: (response: PiHostUiResponse) => Promise<void>;
-  respondToToolApproval: (id: string, approved: boolean) => Promise<void>;
-  resumeToolCall: (toolCallId: string, payload: PiInterruptAnswer) => Promise<void>;
+  }): Promise<void>;
+  setThinkingLevel(level: PiThinkingLevel): Promise<void>;
+  respondToToolApproval(approvalId: string, approved: boolean): Promise<void>;
+  resumeToolCall(toolCallId: string, payload: unknown): Promise<void>;
+  respondToHostUiRequest(response: PiHostUiResponse): Promise<void>;
+  dispose(): void;
 }
+
+type PiThreadMetadata = {
+  id: string;
+  title?: string;
+  workspacePath?: string;
+  archived?: boolean;
+  status: PiThreadStatus;
+  runningRunId?: string;
+  queuedMessages?: readonly PiQueuedMessage[];
+  config?: {
+    provider?: string;
+    modelId?: string;
+    thinkingLevel?: PiThinkingLevel | string;
+  };
+  contextUsage?: PiContextUsage;
+  sessionFile?: string;
+  parentSessionPath?: string;
+  messageCount?: number;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type PiThreadSnapshot = {
+  metadata: PiThreadMetadata;
+  messages: PiTranscriptMessage[];
+  hostUiRequests?: readonly PiHostUiRequest[];
+  readiness?: PiRuntimeReadiness;
+  lastError?: string;
+};
+
+interface PiThreadState {
+  threadId: string;
+  metadata: PiThreadMetadata;
+  messages: readonly PiAgentMessage[];
+  streamingMessageIndex: number | undefined;
+  toolExecutions: Readonly<Record<string, PiToolExecutionState>>;
+  runStatus: PiRunStatus;
+  queue: {
+    steering: readonly string[];
+    followUp: readonly string[];
+  };
+  contextUsage: PiContextUsage | undefined;
+  compaction: {
+    active: boolean;
+    reason?: "manual" | "overflow" | "threshold";
+  };
+  retry: {
+    active: boolean;
+    attempt: number;
+  };
+  hostUiRequests: readonly PiHostUiRequest[];
+  readiness: PiRuntimeReadiness | undefined;
+  lastError: string | undefined;
+  loadState: PiLoadState;
+  lastSeq: number;
+}
+
+type PiThreadStatus = "failed" | "idle" | "running";
+
+declare class PiThreadSupervisor {
+  private readonly records;
+  private readonly pendingOpens;
+  private readonly recordsBySessionFile;
+  private readonly workspacePath;
+  private readonly agentDir;
+  private readonly model;
+  private readonly modelRegistry;
+  private readonly archivedSessionFiles;
+  private readonly catalogCache;
+  private readonly catalogInfoByThreadId;
+  constructor(options?: PiThreadSupervisorOptions);
+  listThreads(input?: {
+    workspacePath?: string;
+    includeArchived?: boolean;
+  }): Promise<PiThreadMetadata[]>;
+  createThread(input?: {
+    workspacePath?: string;
+    title?: string;
+    initialMessage?: PiSendMessageInput;
+  }): Promise<PiThreadSnapshot>;
+  getThread(threadId: string): Promise<PiThreadSnapshot>;
+  sendMessage(threadId: string, input: PiSendMessageInput): Promise<void>;
+  cancelRun(threadId: string): Promise<void>;
+  clearQueue(threadId: string): Promise<{
+    steering: string[];
+    followUp: string[];
+  }>;
+  getAvailableModels(): Promise<PiModelInfo[]>;
+  setModel(threadId: string, input: {
+    provider: string;
+    modelId: string;
+  }): Promise<void>;
+  setThinkingLevel(threadId: string, level: PiThinkingLevel): Promise<void>;
+  renameThread(threadId: string, title: string): Promise<void>;
+  archiveThread(threadId: string): Promise<void>;
+  unarchiveThread(threadId: string): Promise<void>;
+  deleteThread(threadId: string): Promise<void>;
+  respondToHostUiRequest(threadId: string, response: PiHostUiResponse): Promise<void>;
+  subscribe(threadId: string, listener: (event: PiClientEvent) => void, options?: {
+    includeSnapshot?: boolean;
+  }): () => void;
+  dispose(): Promise<void>;
+  private openSession;
+  private ensureOpen;
+  private openCold;
+  private listSessionInfos;
+  private invalidateCatalog;
+  private findSessionInfo;
+  private rememberSessionInfos;
+  private send;
+  private onSessionEvent;
+  private emitContextUsage;
+  private emit;
+  private liveStatusFor;
+  private runStatus;
+  private readinessOf;
+  private queuedMessagesOf;
+  private metadataOf;
+  private snapshotOf;
+  private snapshotFromSessionFile;
+}
+
+interface PiThreadSupervisorOptions {
+  workspacePath?: string;
+  agentDir?: string;
+  model?: PiSessionModel;
+}
+
+interface PiToolCall {
+  type: "toolCall";
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  thoughtSignature?: string;
+}
+
+interface PiToolExecutionState {
+  toolCallId: string;
+  toolName?: string;
+  args?: unknown;
+  partialResult?: unknown;
+  status: "complete" | "error" | "running";
+}
+
+type PiToolResultContent = PiTextContent | PiImageContent;
+
+interface PiToolResultMessage {
+  role: "toolResult";
+  toolCallId: string;
+  toolName: string;
+  content: PiToolResultContent[];
+  details?: unknown;
+  isError: boolean;
+  timestamp: number;
+}
+
+type PiTranscriptMessage = PiAgentMessage;
+
+interface PiUnknownAgentMessage {
+  role: string;
+  timestamp?: number;
+  [key: string]: unknown;
+}
+
+type PiUnknownClientEventBody = {
+  type: string;
+  [key: string]: unknown;
+};
+
+declare class PiUnsupportedHostUiError extends Error {
+  readonly method: string;
+  constructor(method: string);
+}
+
+interface PiUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+}
+
+type PiUserContent = PiTextContent | PiImageContent;
+
+interface PiUserMessage {
+  role: "user";
+  content: string | PiUserContent[];
+  timestamp: number;
+}
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QuoteInfo = {
+  readonly text: string;
+  readonly messageId: string;
+};
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
+};
+
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
+
+declare namespace RealtimeVoiceAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Mode = "listening" | "speaking";
+  type TranscriptItem = {
+    role: "assistant" | "user";
+    text: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    isMuted: boolean;
+    disconnect: () => void;
+    mute: () => void;
+    unmute: () => void;
+    onStatusChange: (callback: (status: Status) => void) => Unsubscribe;
+    onTranscript: (callback: (transcript: TranscriptItem) => void) => Unsubscribe;
+    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe;
+    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe;
+  };
+}
+
+type RealtimeVoiceAdapter = {
+  connect: (options: {
+    abortSignal?: AbortSignal;
+  }) => RealtimeVoiceAdapter.Session;
+};
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ReloadConfig = {
+  runConfig?: RunConfig;
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SharedStream = {
+  listeners: Set<(event: PiClientEvent) => void>;
+  close: () => void;
+  closeTimer: ReturnType<typeof setTimeout> | undefined;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+interface SplitHostUiRequests {
+  toolAssociated: Map<string, PiHostUiRequest>;
+  freeStanding: PiHostUiRequest[];
+}
+
+interface SseFrame {
+  event?: string;
+  data: string;
+  id?: string;
+}
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
+};
+
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
+};
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadListItemState = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+type ThreadMessageLike = {
+  readonly role: "assistant" | "system" | "user";
+  readonly content: string | readonly (TextMessagePart | ReasoningMessagePart | SourceMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | GenerativeUIMessagePart | Unstable_AudioMessagePart | DataPrefixedPart | {
+    readonly type: "tool-call";
+    readonly toolCallId?: string;
+    readonly toolName: string;
+    readonly args?: ReadonlyJSONObject;
+    readonly argsText?: string;
+    readonly artifact?: any;
+    readonly result?: any | undefined;
+    readonly isError?: boolean | undefined;
+    readonly parentId?: string | undefined;
+    readonly messages?: readonly ThreadMessage[] | undefined;
+    readonly interrupt?: {
+      type: "human";
+      payload: unknown;
+    };
+    readonly timing?: ToolCallTiming;
+    readonly approval?: {
+      readonly id: string;
+      readonly approved?: boolean;
+      readonly reason?: string;
+      readonly isAutomatic?: boolean;
+      readonly options?: readonly ToolApprovalOption[];
+      readonly optionId?: string;
+      readonly resolution?: "cancelled" | "expired";
+    };
+  })[];
+  readonly id?: string | undefined;
+  readonly createdAt?: Date | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly attachments?: readonly (Omit<CompleteAttachment, "content"> & {
+    readonly content: readonly (ThreadUserMessagePart | DataPrefixedPart)[];
+  })[] | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly isOptimistic?: boolean | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  } | undefined;
+};
+
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe;
+  cancelRun(): void;
+  getModelContext(): ModelContext;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
+};
+
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState;
+  readonly isDisabled: boolean;
+  readonly isLoading: boolean;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
+  readonly speech: SpeechState | undefined;
+  readonly voice: VoiceSessionState | undefined;
+};
+
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
+};
+
+type ThreadSuggestion = {
+  prompt: string;
+};
+
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
+  };
+};
+
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
+
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
+};
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+declare const createPiHttpClient: (options?: PiHttpClientOptions) => PiClient;
+
+declare const createPiNodeClient: (options?: PiNodeClientOptions) => PiClient;
+
+declare const createPiThreadState: (threadId: string) => PiThreadState;
+
+declare const createSseDecoder: () => {
+  push(chunk: string): SseFrame[];
+};
+
+declare const getPiThreadSupervisor: (options?: PiNodeClientOptions) => PiThreadSupervisor;
+
+declare global {
+  var __assistantUiPiHttpStreams: Map<string, SharedStream> | undefined;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare global {
+  interface Window {
+    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
+  }
+}
+
+declare namespace entry_root_exports {
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
+}
+
+declare const isPiSteerQueueItemId: (id: string) => boolean;
+
+declare namespace entry_node_exports {
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
+}
+
+declare const openPiEventStream: (options: PiEventStreamOptions) => (() => void);
+
+declare const piQueueItemId: (mode: PiQueueMode, index: number) => string;
+
+declare const projectPiThreadMessages: (input: PiProjectionInput) => ThreadMessageLike[];
+
+declare const projectPiThreadRepository: (input: PiProjectionInput) => ExportedMessageRepository;
+
+declare const reducePiThreadState: (state: PiThreadState, event: PiClientEvent) => PiThreadState;
+
+declare const responseForApproval: (requestId: string, approved: boolean) => PiHostUiResponse;
+
+declare const responseForInterrupt: (requestId: string, answer: PiInterruptAnswer) => PiHostUiResponse;
+
+declare const responseForRequest: (request: PiHostUiRequest, answer: boolean | PiInterruptAnswer) => PiHostUiResponse;
+
+declare const splitHostUiRequests: (requests: readonly PiHostUiRequest[]) => SplitHostUiRequests;
+
+declare const usePiHostUiRequests: () => {
+  requests: readonly PiHostUiRequest[];
+  respond: (response: PiHostUiResponse) => Promise<void>;
+};
 
 declare const usePiRuntime: (options: PiRuntimeOptions) => AssistantRuntime;
 
@@ -2344,14 +2352,5 @@ declare const usePiSession: () => PiThreadMetadata | null;
 declare function usePiThreadState(): PiThreadState;
 
 declare function usePiThreadState<T>(selector: (state: PiThreadState) => T): T;
-
-declare const usePiHostUiRequests: () => {
-  requests: readonly PiHostUiRequest[];
-  respond: (response: PiHostUiResponse) => Promise<void>;
-};
-
-declare namespace entry_root_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
-}
 
 export { entry_node_exports as entry_node, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-streamdown.ts
+++ b/api-surface/assistant-ui__react-streamdown.ts
@@ -1,66 +1,100 @@
 import { ComponentPropsWithoutRef, ComponentType, ReactNode } from "react";
 
+import { Options as RemarkRehypeOptions } from "remark-rehype";
+
 import { RemendOptions } from "remend";
 
 import { BundledLanguage, BundledTheme, BundledTheme as BundledTheme$1, CjkPlugin, CodeHighlighterPlugin, DiagramPlugin, HighlightOptions, MathPlugin, MermaidErrorComponentProps, MermaidOptions, StreamdownContext, StreamdownProps, StreamdownProps as StreamdownProps$1, StreamdownProps as StreamdownProps$2, parseMarkdownIntoBlocks } from "streamdown";
 
-import { Options as RemarkRehypeOptions } from "remark-rehype";
+type AllowedTags = Record<string, string[]>;
 
-interface Data$1 {
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type BlockProps = {
+  content: string;
+  shouldParseIncompleteMarkdown: boolean;
+  index: number;
+  components?: StreamdownProps$2["components"];
+  rehypePlugins?: StreamdownProps$2["rehypePlugins"];
+  remarkPlugins?: StreamdownProps$2["remarkPlugins"];
+  remarkRehypeOptions?: RemarkRehypeOptions;
+};
+
+type CaretStyle = "block" | "circle";
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
 }
 
-interface Point {
-  line: number;
-  column: number;
-  offset?: number | undefined;
-}
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
-interface Position {
-  start: Point;
-  end: Point;
-}
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
 
-interface Node$1 {
-  type: string;
-  data?: Data$1 | undefined;
-  position?: Position | undefined;
-}
-
-interface Data extends Data$1 {
-}
-
-interface Properties {
-  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
-}
-
-type ElementContent = ElementContentMap[keyof ElementContentMap];
-
-interface ElementContentMap {
-  comment: Comment;
-  element: Element;
-  text: Text;
-}
-
-type RootContent = RootContentMap[keyof RootContentMap];
-
-interface RootContentMap {
-  comment: Comment;
-  doctype: Doctype;
-  element: Element;
-  text: Text;
-}
-
-interface Node extends Node$1 {
-  data?: Data | undefined;
-}
-
-interface Literal extends Node {
-  value: string;
-}
-
-interface Parent extends Node {
-  children: RootContent[];
-}
+type CodeHeaderProps = {
+  node?: Element | undefined;
+  language: string | undefined;
+  code: string;
+};
 
 interface Comment extends Literal {
   type: "comment";
@@ -68,6 +102,44 @@ interface Comment extends Literal {
 }
 
 interface CommentData extends Data {
+}
+
+type ComponentsByLanguage = Record<string, {
+  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
+  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
+}>;
+
+type ControlsConfig = boolean | {
+  table?: boolean;
+  code?: boolean;
+  mermaid?: boolean | {
+    download?: boolean;
+    copy?: boolean;
+    fullscreen?: boolean;
+    panZoom?: boolean;
+  };
+};
+
+declare const DEFAULT_SHIKI_THEME: [
+  BundledTheme,
+  BundledTheme
+];
+
+interface Data extends Data$1 {
+}
+
+interface Data$1 {
+}
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
 }
 
 interface Doctype extends Node$1 {
@@ -87,147 +159,15 @@ interface Element extends Parent {
   data?: ElementData | undefined;
 }
 
+type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+interface ElementContentMap {
+  comment: Comment;
+  element: Element;
+  text: Text;
+}
+
 interface ElementData extends Data {
-}
-
-interface Root extends Parent {
-  type: "root";
-  children: RootContent[];
-  data?: RootData | undefined;
-}
-
-interface RootData extends Data {
-}
-
-interface Text extends Literal {
-  type: "text";
-  data?: TextData | undefined;
-}
-
-interface TextData extends Data {
-}
-
-type PreOverrideProps = ComponentPropsWithoutRef<"pre"> & {
-  node?: Element | undefined;
-};
-
-declare function useIsStreamdownCodeBlock(): boolean;
-
-declare function useStreamdownPreProps(): PreOverrideProps | null;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
-
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
 }
 
 interface EventLog {
@@ -236,41 +176,12 @@ interface EventLog {
   data: unknown;
 }
 
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
 
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
-declare global {
-  interface Window {
-    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
-  }
-}
-
-type SmoothOptions = {
-  drainMs?: number | undefined;
-  maxCharIntervalMs?: number | undefined;
-  maxCharsPerFrame?: number | undefined;
-  minCommitMs?: number | undefined;
-};
-
-type CaretStyle = "block" | "circle";
-
-type ControlsConfig = boolean | {
-  table?: boolean;
-  code?: boolean;
-  mermaid?: boolean | {
-    download?: boolean;
-    copy?: boolean;
-    fullscreen?: boolean;
-    panZoom?: boolean;
-  };
+type LinkSafetyConfig = {
+  enabled: boolean;
+  onLinkCheck?: (url: string) => Promise<boolean> | boolean;
+  renderModal?: (props: LinkSafetyModalProps) => ReactNode;
 };
 
 type LinkSafetyModalProps = {
@@ -280,17 +191,53 @@ type LinkSafetyModalProps = {
   onConfirm: () => void;
 };
 
-type LinkSafetyConfig = {
-  enabled: boolean;
-  onLinkCheck?: (url: string) => Promise<boolean> | boolean;
-  renderModal?: (props: LinkSafetyModalProps) => ReactNode;
+interface Literal extends Node {
+  value: string;
+}
+
+interface Node extends Node$1 {
+  data?: Data | undefined;
+}
+
+interface Node$1 {
+  type: string;
+  data?: Data$1 | undefined;
+  position?: Position | undefined;
+}
+
+interface Parent extends Node {
+  children: RootContent[];
+}
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+type PluginConfig = {
+  code?: unknown | false | undefined;
+  math?: unknown | false | undefined;
+  cjk?: unknown | false | undefined;
+  mermaid?: unknown | false | undefined;
 };
 
-type RemendHandler = {
-  name: string;
-  handle: (text: string) => string;
-  priority?: number;
+interface Point {
+  line: number;
+  column: number;
+  offset?: number | undefined;
+}
+
+interface Position {
+  start: Point;
+  end: Point;
+}
+
+type PreOverrideProps = ComponentPropsWithoutRef<"pre"> & {
+  node?: Element | undefined;
 };
+
+interface Properties {
+  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
+}
 
 type RemendConfig = {
   links?: boolean;
@@ -306,46 +253,35 @@ type RemendConfig = {
   handlers?: RemendHandler[];
 };
 
-type SyntaxHighlighterProps = {
-  node?: Element | undefined;
-  components: {
-    Pre: ComponentType<ComponentPropsWithoutRef<"pre"> & {
-      node?: Element | undefined;
-    }>;
-    Code: ComponentType<ComponentPropsWithoutRef<"code"> & {
-      node?: Element | undefined;
-    }>;
-  };
-  language: string;
-  code: string;
-};
-
-type CodeHeaderProps = {
-  node?: Element | undefined;
-  language: string | undefined;
-  code: string;
-};
-
-type ComponentsByLanguage = Record<string, {
-  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
-  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
-}>;
-
-type StreamdownTextComponents = NonNullable<StreamdownProps$2["components"]> & {
-  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
-  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
-};
-
-type PluginConfig = {
-  code?: unknown | false | undefined;
-  math?: unknown | false | undefined;
-  cjk?: unknown | false | undefined;
-  mermaid?: unknown | false | undefined;
+type RemendHandler = {
+  name: string;
+  handle: (text: string) => string;
+  priority?: number;
 };
 
 type ResolvedPluginConfig = NonNullable<StreamdownProps$2["plugins"]>;
 
-type AllowedTags = Record<string, string[]>;
+interface Root extends Parent {
+  type: "root";
+  children: RootContent[];
+  data?: RootData | undefined;
+}
+
+type RootContent = RootContentMap[keyof RootContentMap];
+
+interface RootContentMap {
+  comment: Comment;
+  doctype: Doctype;
+  element: Element;
+  text: Text;
+}
+
+interface RootData extends Data {
+}
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
 
 type SecurityConfig = {
   allowedLinkPrefixes?: string[];
@@ -357,42 +293,30 @@ type SecurityConfig = {
   blockedImageClass?: string;
 };
 
-type BlockProps = {
-  content: string;
-  shouldParseIncompleteMarkdown: boolean;
-  index: number;
-  components?: StreamdownProps$2["components"];
-  rehypePlugins?: StreamdownProps$2["rehypePlugins"];
-  remarkPlugins?: StreamdownProps$2["remarkPlugins"];
-  remarkRehypeOptions?: RemarkRehypeOptions;
+type SmoothOptions = {
+  drainMs?: number | undefined;
+  maxCharIntervalMs?: number | undefined;
+  maxCharsPerFrame?: number | undefined;
+  minCommitMs?: number | undefined;
 };
 
-type StreamdownTextPrimitiveProps = Omit<StreamdownProps$2, "BlockComponent" | "caret" | "children" | "components" | "controls" | "linkSafety" | "mermaid" | "parseMarkdownIntoBlocksFn" | "plugins" | "remend"> & {
-  components?: StreamdownTextComponents | undefined;
-  componentsByLanguage?: ComponentsByLanguage | undefined;
-  plugins?: PluginConfig | undefined;
-  preprocess?: ((text: string) => string) | undefined;
-  defer?: boolean | undefined;
-  smooth?: boolean | SmoothOptions | undefined;
-  containerProps?: Omit<ComponentPropsWithoutRef<"div">, "children"> | undefined;
-  containerClassName?: string | undefined;
-  caret?: CaretStyle | undefined;
-  controls?: ControlsConfig | undefined;
-  linkSafety?: LinkSafetyConfig | undefined;
-  remend?: RemendConfig | undefined;
-  mermaid?: MermaidOptions | undefined;
-  parseIncompleteMarkdown?: boolean | undefined;
-  allowedTags?: AllowedTags | undefined;
-  remarkRehypeOptions?: RemarkRehypeOptions | undefined;
-  security?: SecurityConfig | undefined;
-  BlockComponent?: StreamdownProps$2["BlockComponent"] | undefined;
-  parseMarkdownIntoBlocksFn?: ((markdown: string) => string[]) | undefined;
-};
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
 
-declare const DEFAULT_SHIKI_THEME: [
-  BundledTheme,
-  BundledTheme
-];
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type StreamdownTextComponents = NonNullable<StreamdownProps$2["components"]> & {
+  SyntaxHighlighter?: ComponentType<SyntaxHighlighterProps> | undefined;
+  CodeHeader?: ComponentType<CodeHeaderProps> | undefined;
+};
 
 declare const StreamdownTextPrimitive: import("react").ForwardRefExoticComponent<Omit<StreamdownProps, "BlockComponent" | "caret" | "children" | "components" | "controls" | "linkSafety" | "mermaid" | "parseMarkdownIntoBlocksFn" | "plugins" | "remend"> & {
   components?: StreamdownTextComponents | undefined;
@@ -416,25 +340,101 @@ declare const StreamdownTextPrimitive: import("react").ForwardRefExoticComponent
   parseMarkdownIntoBlocksFn?: ((markdown: string) => string[]) | undefined;
 } & import("react").RefAttributes<HTMLDivElement>>;
 
-declare function memoCompareNodes<T extends {
-  children?: ReactNode;
-  [key: string]: unknown;
-}>(prev: Readonly<T>, next: Readonly<T>): boolean;
+type StreamdownTextPrimitiveProps = Omit<StreamdownProps$2, "BlockComponent" | "caret" | "children" | "components" | "controls" | "linkSafety" | "mermaid" | "parseMarkdownIntoBlocksFn" | "plugins" | "remend"> & {
+  components?: StreamdownTextComponents | undefined;
+  componentsByLanguage?: ComponentsByLanguage | undefined;
+  plugins?: PluginConfig | undefined;
+  preprocess?: ((text: string) => string) | undefined;
+  defer?: boolean | undefined;
+  smooth?: boolean | SmoothOptions | undefined;
+  containerProps?: Omit<ComponentPropsWithoutRef<"div">, "children"> | undefined;
+  containerClassName?: string | undefined;
+  caret?: CaretStyle | undefined;
+  controls?: ControlsConfig | undefined;
+  linkSafety?: LinkSafetyConfig | undefined;
+  remend?: RemendConfig | undefined;
+  mermaid?: MermaidOptions | undefined;
+  parseIncompleteMarkdown?: boolean | undefined;
+  allowedTags?: AllowedTags | undefined;
+  remarkRehypeOptions?: RemarkRehypeOptions | undefined;
+  security?: SecurityConfig | undefined;
+  BlockComponent?: StreamdownProps$2["BlockComponent"] | undefined;
+  parseMarkdownIntoBlocksFn?: ((markdown: string) => string[]) | undefined;
+};
 
-declare function rewriteLatexBracketDelimiters(text: string): string;
+type SyntaxHighlighterProps = {
+  node?: Element | undefined;
+  components: {
+    Pre: ComponentType<ComponentPropsWithoutRef<"pre"> & {
+      node?: Element | undefined;
+    }>;
+    Code: ComponentType<ComponentPropsWithoutRef<"code"> & {
+      node?: Element | undefined;
+    }>;
+  };
+  language: string;
+  code: string;
+};
 
-declare function rewriteCustomMathTags(text: string): string;
+interface Text extends Literal {
+  type: "text";
+  data?: TextData | undefined;
+}
 
-declare function normalizeMathDelimiters(text: string): string;
+interface TextData extends Data {
+}
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unsubscribe = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
 
 declare function escapeCurrencyDollars(text: string): string;
 
 declare function findRemendWindowStart(text: string): number;
 
-declare function tailBoundedRemend(text: string, options?: RemendOptions): string;
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare global {
+  interface Window {
+    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
+  }
+}
 
 declare namespace entry_root_exports {
   export { AllowedTags, BlockProps, BundledLanguage, BundledTheme$1 as BundledTheme, CaretStyle, CjkPlugin, CodeHeaderProps, CodeHighlighterPlugin, ComponentsByLanguage, ControlsConfig, DEFAULT_SHIKI_THEME, DiagramPlugin, HighlightOptions, LinkSafetyConfig, LinkSafetyModalProps, MathPlugin, MermaidErrorComponentProps, MermaidOptions, PluginConfig, RemarkRehypeOptions, RemendConfig, RemendHandler, ResolvedPluginConfig, SecurityConfig, StreamdownContext, StreamdownProps$1 as StreamdownProps, StreamdownTextComponents, StreamdownTextPrimitive, StreamdownTextPrimitiveProps, SyntaxHighlighterProps, escapeCurrencyDollars, findRemendWindowStart, memoCompareNodes, normalizeMathDelimiters, parseMarkdownIntoBlocks, rewriteCustomMathTags, rewriteLatexBracketDelimiters, tailBoundedRemend, useIsStreamdownCodeBlock, useStreamdownPreProps };
 }
+
+declare function memoCompareNodes<T extends {
+  children?: ReactNode;
+  [key: string]: unknown;
+}>(prev: Readonly<T>, next: Readonly<T>): boolean;
+
+declare function normalizeMathDelimiters(text: string): string;
+
+declare function rewriteCustomMathTags(text: string): string;
+
+declare function rewriteLatexBracketDelimiters(text: string): string;
+
+declare function tailBoundedRemend(text: string, options?: RemendOptions): string;
+
+declare function useIsStreamdownCodeBlock(): boolean;
+
+declare function useStreamdownPreProps(): PreOverrideProps | null;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react-syntax-highlighter.ts
+++ b/api-surface/assistant-ui__react-syntax-highlighter.ts
@@ -1,60 +1,78 @@
 import { ComponentPropsWithoutRef, ComponentType } from "react";
 
-interface Data$1 {
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
+};
+
+type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
+  source: "root";
+  query: Record<string, never>;
+} | {
+  source: null;
+  query: null;
+}) & {
+  name: K;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
+
+type AssistantEventPayload = ClientEventMap & {
+  "*": WildcardPayload;
+};
+
+type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
+
+type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
 }
 
-interface Point {
-  line: number;
-  column: number;
-  offset?: number | undefined;
-}
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
 
-interface Position {
-  start: Point;
-  end: Point;
-}
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
 
-interface Node$1 {
-  type: string;
-  data?: Data$1 | undefined;
-  position?: Position | undefined;
-}
-
-interface Data extends Data$1 {
-}
-
-interface Properties {
-  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
-}
-
-type ElementContent = ElementContentMap[keyof ElementContentMap];
-
-interface ElementContentMap {
-  comment: Comment;
-  element: Element;
-  text: Text;
-}
-
-type RootContent = RootContentMap[keyof RootContentMap];
-
-interface RootContentMap {
-  comment: Comment;
-  doctype: Doctype;
-  element: Element;
-  text: Text;
-}
-
-interface Node extends Node$1 {
-  data?: Data | undefined;
-}
-
-interface Literal extends Node {
-  value: string;
-}
-
-interface Parent extends Node {
-  children: RootContent[];
-}
+type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {
+  node?: Element | undefined;
+}>;
 
 interface Comment extends Literal {
   type: "comment";
@@ -62,6 +80,23 @@ interface Comment extends Literal {
 }
 
 interface CommentData extends Data {
+}
+
+interface Data extends Data$1 {
+}
+
+interface Data$1 {
+}
+
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
 }
 
 interface Doctype extends Node$1 {
@@ -81,7 +116,64 @@ interface Element extends Parent {
   data?: ElementData | undefined;
 }
 
+type ElementContent = ElementContentMap[keyof ElementContentMap];
+
+interface ElementContentMap {
+  comment: Comment;
+  element: Element;
+  text: Text;
+}
+
 interface ElementData extends Data {
+}
+
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
+}
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+interface Literal extends Node {
+  value: string;
+}
+
+interface Node extends Node$1 {
+  data?: Data | undefined;
+}
+
+interface Node$1 {
+  type: string;
+  data?: Data$1 | undefined;
+  position?: Position | undefined;
+}
+
+interface Parent extends Node {
+  children: RootContent[];
+}
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+interface Point {
+  line: number;
+  column: number;
+  offset?: number | undefined;
+}
+
+interface Position {
+  start: Point;
+  end: Point;
+}
+
+type PreComponent = ComponentType<ComponentPropsWithoutRef<"pre"> & {
+  node?: Element | undefined;
+}>;
+
+interface Properties {
+  [PropertyName: string]: boolean | number | string | null | undefined | Array<string | number>;
 }
 
 interface Root extends Parent {
@@ -90,24 +182,34 @@ interface Root extends Parent {
   data?: RootData | undefined;
 }
 
+type RootContent = RootContentMap[keyof RootContentMap];
+
+interface RootContentMap {
+  comment: Comment;
+  doctype: Doctype;
+  element: Element;
+  text: Text;
+}
+
 interface RootData extends Data {
 }
 
-interface Text extends Literal {
-  type: "text";
-  data?: TextData | undefined;
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
 }
 
-interface TextData extends Data {
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
 }
 
-type PreComponent = ComponentType<ComponentPropsWithoutRef<"pre"> & {
-  node?: Element | undefined;
-}>;
-
-type CodeComponent = ComponentType<ComponentPropsWithoutRef<"code"> & {
-  node?: Element | undefined;
-}>;
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
 
 type SyntaxHighlighterProps = {
   node?: Element | undefined;
@@ -119,70 +221,21 @@ type SyntaxHighlighterProps = {
   code: string;
 };
 
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
+interface Text extends Literal {
+  type: "text";
+  data?: TextData | undefined;
 }
 
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
+interface TextData extends Data {
 }
 
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
 
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
+type Unsubscribe = () => void;
 
 type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
   methods: ClientMethods;
 } ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type Unsubscribe = () => void;
-
-type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
-  source: "root";
-  query: Record<string, never>;
-} | {
-  source: null;
-  query: null;
-}) & {
-  name: K;
-};
-
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
-
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
 
 type WildcardPayload = {
   [K in keyof ClientEventMap]: {
@@ -191,40 +244,8 @@ type WildcardPayload = {
   };
 }[Extract<keyof ClientEventMap, string>];
 
-type AssistantEventPayload = ClientEventMap & {
-  "*": WildcardPayload;
-};
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
-
-type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
-
-type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
-};
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
+declare namespace entry_full_exports {
+  export { makePrismAsyncSyntaxHighlighter, makePrismSyntaxHighlighter, makeSyntaxHighlighter };
 }
 
 declare global {
@@ -234,49 +255,28 @@ declare global {
   }
 }
 
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
-
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
 declare global {
   interface Window {
     __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
   }
 }
 
-declare const makeSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare const makePrismSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare const makePrismAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare namespace entry_full_exports {
-  export { makePrismAsyncSyntaxHighlighter, makePrismSyntaxHighlighter, makeSyntaxHighlighter };
-}
-
-declare const makePrismAsyncLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare const makePrismLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare const makeLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
-declare const makeLightAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
-
 declare namespace entry_root_exports {
   export { makeLightAsyncSyntaxHighlighter, makeLightSyntaxHighlighter, makePrismAsyncLightSyntaxHighlighter, makePrismLightSyntaxHighlighter };
 }
+
+declare const makeLightAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makeLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makePrismAsyncLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makePrismAsyncSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makePrismLightSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makePrismSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
+
+declare const makeSyntaxHighlighter: (config: Omit<import("react-syntax-highlighter").SyntaxHighlighterProps, "children" | "language">) => import("react").FC<SyntaxHighlighterProps>;
 
 export { entry_full_exports as entry_full, entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1,14 +1,215 @@
-import React, { CSSProperties, ComponentPropsWithoutRef, ComponentRef, ComponentType, ElementRef, ElementType, FC, ForwardRefExoticComponent, KeyboardEventHandler, PropsWithChildren, ReactElement, ReactNode, RefAttributes, RefCallback, RefObject } from "react";
-
-import { StoreApi } from "zustand";
-
 import { Primitive } from "@radix-ui/react-primitive";
+
+import { StandardSchemaV1 } from "@standard-schema/spec";
 
 import { DropdownMenu, Popover } from "radix-ui";
 
+import React, { CSSProperties, ComponentPropsWithoutRef, ComponentRef, ComponentType, ElementRef, ElementType, FC, ForwardRefExoticComponent, KeyboardEventHandler, PropsWithChildren, ReactElement, ReactNode, RefAttributes, RefCallback, RefObject } from "react";
+
 import { TextareaAutosizeProps } from "react-textarea-autosize";
 
-import { StandardSchemaV1 } from "@standard-schema/spec";
+import { StoreApi } from "zustand";
+
+declare namespace ActionBarMorePrimitiveContent {
+  type Element = ComponentRef<typeof DropdownMenu.Content>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Content> & {
+    portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
+  };
+}
+
+declare const ActionBarMorePrimitiveContent: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & {
+  portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ActionBarMorePrimitiveItem {
+  type Element = ComponentRef<typeof DropdownMenu.Item>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Item>;
+}
+
+declare const ActionBarMorePrimitiveItem: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuItemProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ActionBarMorePrimitiveRoot {
+  type Props = DropdownMenu.DropdownMenuProps;
+}
+
+declare const ActionBarMorePrimitiveRoot: FC<ActionBarMorePrimitiveRoot.Props>;
+
+declare namespace ActionBarMorePrimitiveSeparator {
+  type Element = ComponentRef<typeof DropdownMenu.Separator>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Separator>;
+}
+
+declare const ActionBarMorePrimitiveSeparator: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuSeparatorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ActionBarMorePrimitiveTrigger {
+  type Element = ComponentRef<typeof DropdownMenu.Trigger>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Trigger>;
+}
+
+declare const ActionBarMorePrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveCopy {
+  type Element = HTMLButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarPrimitiveCopy>;
+}
+
+declare const ActionBarPrimitiveCopy: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  copiedDuration?: number | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveEdit {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarEdit>;
+}
+
+declare const ActionBarPrimitiveEdit: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveExportMarkdown {
+  type Element = HTMLButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarExportMarkdown>;
+}
+
+declare const ActionBarPrimitiveExportMarkdown: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  filename?: string | undefined;
+  onExport?: ((content: string) => void | Promise<void>) | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveFeedbackNegative {
+  type Element = HTMLButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarFeedbackNegative>;
+}
+
+declare const ActionBarPrimitiveFeedbackNegative: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveFeedbackPositive {
+  type Element = HTMLButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarFeedbackPositive>;
+}
+
+declare const ActionBarPrimitiveFeedbackPositive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveReload {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarReload>;
+}
+
+declare const ActionBarPrimitiveReload: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps$5 & {
+    hideWhenRunning?: boolean | undefined;
+    autohide?: "always" | "not-last" | "never" | undefined;
+    autohideFloat?: "always" | "single-branch" | "never" | undefined;
+  };
+}
+
+declare const ActionBarPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  hideWhenRunning?: boolean | undefined;
+  autohide?: "always" | "not-last" | "never" | undefined;
+  autohideFloat?: "always" | "single-branch" | "never" | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ActionBarPrimitiveSpeak {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarSpeak>;
+}
+
+declare const ActionBarPrimitiveSpeak: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ActionBarPrimitiveStopSpeaking {
+  type Element = HTMLButtonElement;
+  type Props = ActionButtonProps<typeof useActionBarStopSpeaking>;
+}
+
+declare const ActionBarPrimitiveStopSpeaking: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+type ActionButtonElement = ComponentRef<typeof Primitive$1.button>;
+
+type ActionButtonProps<THook> = PrimitiveButtonProps & (THook extends ((props: infer TProps) => unknown) ? TProps : never);
+
+type AddMessageCommand = {
+  readonly type: "add-message";
+  readonly message: UserMessage | AssistantMessage;
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type AddToolResultCommand = {
+  readonly type: "add-tool-result";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly modelContent?: readonly ToolModelContentPart[];
+};
+
+type AddToolResultOptions = {
+  messageId: string;
+  toolName: string;
+  toolCallId: string;
+  result: ReadonlyJSONValue;
+  isError: boolean;
+  artifact?: ReadonlyJSONValue | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+};
+
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
+
+type AppendMessage = Omit<ThreadMessage, "id"> & {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig | undefined;
+  startRun?: boolean | undefined;
+  steer?: boolean | undefined;
+};
+
+type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
 
 declare namespace Assistant {
   interface Commands {
@@ -17,69 +218,11 @@ declare namespace Assistant {
   }
 }
 
-type UserCommands = Assistant.Commands[keyof Assistant.Commands];
-
-type UserExternalState = keyof Assistant.ExternalState extends never ? Record<string, unknown> : Assistant.ExternalState[keyof Assistant.ExternalState];
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
-
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
-
-type Unsubscribe$1 = () => void;
-
-type AssistantState = {
-  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
-    getState: () => infer S;
-  } ? S : never;
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe$1;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
 };
 
 type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
@@ -92,39 +235,210 @@ type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["m
   name: K;
 };
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe$1;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe$1;
+declare class AssistantCloud {
+  readonly threads: AssistantCloudThreads;
+  readonly auth: {
+    tokens: AssistantCloudAuthTokens;
+  };
+  readonly runs: AssistantCloudRuns;
+  readonly files: AssistantCloudFiles;
+  readonly telemetry: AssistantCloudTelemetryConfig;
+  constructor(config: AssistantCloudConfig);
+}
+
+declare class AssistantCloudAPI {
+  _auth: AssistantCloudAuthStrategy;
+  _baseUrl: string;
+  constructor(config: AssistantCloudConfig);
+  initializeAuth(): Promise<boolean>;
+  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
+  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
+}
+
+type AssistantCloudAuthStrategy = {
+  readonly strategy: "anon" | "api-key" | "jwt";
+  getAuthHeaders(): Promise<Record<string, string> | false>;
+  readAuthHeaders(headers: Headers): void;
 };
 
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+declare class AssistantCloudAuthTokens {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
+}
 
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
+type AssistantCloudAuthTokensCreateResponse = {
+  token: string;
+};
 
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
+type AssistantCloudConfig = ({
+  baseUrl: string;
+  authToken: () => Promise<string | null>;
+} | {
+  baseUrl?: string;
+  apiKey: string;
+  userId: string;
+  workspaceId: string;
+} | {
+  baseUrl: string;
+  anonymous: true;
+}) & {
+  telemetry?: boolean | AssistantCloudTelemetryConfig;
+};
+
+declare class AssistantCloudFiles {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
+  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
+}
+
+type AssistantCloudMessageCreateResponse = {
+  message_id: string;
+};
+
+type AssistantCloudRunReport = {
+  thread_id: string;
+  status: "completed" | "error" | "incomplete";
+  total_steps?: number;
+  tool_calls?: ReportToolCall[];
+  steps?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    reasoning_tokens?: number;
+    cached_input_tokens?: number;
+    tool_calls?: ReportToolCall[];
+    start_ms?: number;
+    end_ms?: number;
+  }[];
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  model_id?: string;
+  provider_type?: string;
+  duration_ms?: number;
+  output_text?: string;
+  metadata?: Record<string, unknown>;
+};
+
+declare class AssistantCloudRuns {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  __internal_getAssistantOptions(assistantId: string): {
+    api: string;
+    headers: () => Promise<{
+      Accept: string;
+    }>;
+    body: {
+      assistant_id: string;
+      response_format: string;
+      thread_id: string;
+    };
   };
-}[Extract<keyof ClientEventMap, string>];
+  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
+  report(body: AssistantCloudRunReport): Promise<{
+    run_id: string;
+  }>;
+}
+
+type AssistantCloudRunsStreamBody = {
+  thread_id: string;
+  assistant_id: "system/thread_title";
+  messages: readonly unknown[];
+};
+
+type AssistantCloudTelemetryConfig = {
+  enabled?: boolean;
+  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
+};
+
+type AssistantCloudThreadMessageCreateBody = {
+  parent_id: string | null;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type AssistantCloudThreadMessageListQuery = {
+  format?: string;
+};
+
+type AssistantCloudThreadMessageListResponse = {
+  messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageUpdateBody = {
+  content: ReadonlyJSONObject;
+};
+
+declare class AssistantCloudThreadMessages {
+  private cloud;
+  constructor(cloud: AssistantCloudAPI);
+  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
+  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
+  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
+}
+
+declare class AssistantCloudThreads {
+  private cloud;
+  readonly messages: AssistantCloudThreadMessages;
+  constructor(cloud: AssistantCloudAPI);
+  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
+  get(threadId: string): Promise<CloudThread>;
+  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
+  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
+  delete(threadId: string): Promise<void>;
+}
+
+type AssistantCloudThreadsCreateBody = {
+  title?: string | undefined;
+  last_message_at: Date;
+  metadata?: unknown | undefined;
+  external_id?: string | undefined;
+};
+
+type AssistantCloudThreadsCreateResponse = {
+  thread_id: string;
+};
+
+type AssistantCloudThreadsListQuery = {
+  is_archived?: boolean;
+  limit?: number;
+  after?: string;
+};
+
+type AssistantCloudThreadsListResponse = {
+  threads: CloudThread[];
+};
+
+type AssistantCloudThreadsUpdateBody = {
+  title?: string | undefined;
+  last_message_at?: Date | undefined;
+  metadata?: unknown | undefined;
+  is_archived?: boolean | undefined;
+};
+
+type AssistantContextConfig = {
+  getContext: () => string;
+  disabled?: boolean | undefined;
+};
+
+type AssistantDataUI = FC & {
+  unstable_data: AssistantDataUIProps;
+};
+
+type AssistantDataUIProps<T = any> = {
+  name: string;
+  render: DataMessagePartComponent<T>;
+};
+
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+
+type AssistantEventName = keyof AssistantEventPayload;
 
 type AssistantEventPayload = ClientEventMap & {
   "*": WildcardPayload;
 };
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
 type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
 
@@ -133,7 +447,383 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
   event: TEvent;
 };
 
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
+declare class AssistantFrameHost implements ModelContextProvider {
+  private _context;
+  private _subscribers;
+  private _pendingRequests;
+  private _requestCounter;
+  private _iframeWindow;
+  private _targetOrigin;
+  constructor(iframeWindow: Window, targetOrigin?: string);
+  private handleMessage;
+  private updateContext;
+  private callTool;
+  private sendRequest;
+  private requestContext;
+  private notifySubscribers;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe;
+  dispose(): void;
+}
+
+declare class AssistantFrameProvider {
+  private static _instance;
+  private _providers;
+  private _providerUnsubscribes;
+  private _targetOrigin;
+  private constructor();
+  private static getInstance;
+  private handleMessage;
+  private handleToolCall;
+  private sendMessage;
+  private getModelContext;
+  private broadcastUpdate;
+  static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe;
+  static dispose(): void;
+}
+
+type AssistantInstructionsConfig = {
+  disabled?: boolean | undefined;
+  instruction: string;
+};
+
+type AssistantInteractableProps = {
+  description: string;
+  stateSchema: InteractableStateSchema;
+  initialState: unknown;
+  id?: string;
+  selected?: boolean;
+};
+
+type AssistantMessage = {
+  readonly role: "assistant";
+  readonly parts: readonly TextPart[];
+};
+
+declare namespace AssistantModalPrimitiveAnchor {
+  type Element = ComponentRef<typeof Popover.Anchor>;
+  type Props = ComponentPropsWithoutRef<typeof Popover.Anchor>;
+}
+
+declare const AssistantModalPrimitiveAnchor: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverAnchorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace AssistantModalPrimitiveContent {
+  type Element = ComponentRef<typeof Popover.Content>;
+  type Props = ComponentPropsWithoutRef<typeof Popover.Content> & {
+    portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
+    dissmissOnInteractOutside?: boolean | undefined;
+  };
+}
+
+declare const AssistantModalPrimitiveContent: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
+  dissmissOnInteractOutside?: boolean | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace AssistantModalPrimitiveRoot {
+  type Props = Popover.PopoverProps & {
+    unstable_openOnRunStart?: boolean | undefined;
+  };
+}
+
+declare const AssistantModalPrimitiveRoot: FC<AssistantModalPrimitiveRoot.Props>;
+
+declare namespace AssistantModalPrimitiveTrigger {
+  type Element = ComponentRef<typeof Popover.Trigger>;
+  type Props = ComponentPropsWithoutRef<typeof Popover.Trigger>;
+}
+
+declare const AssistantModalPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+type AssistantRuntime = {
+  readonly threads: ThreadListRuntime;
+  readonly thread: ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+};
+
+type AssistantRuntimeCore = {
+  readonly threads: ThreadListRuntimeCore;
+  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe;
+  getModelContextProvider: () => ModelContextProvider;
+  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
+};
+
+declare class AssistantRuntimeImpl implements AssistantRuntime {
+  private readonly _core;
+  readonly threads: ThreadListRuntimeImpl;
+  readonly _thread: ThreadRuntime;
+  constructor(_core: AssistantRuntimeCore);
+  protected __internal_bindMethods(): void;
+  get thread(): ThreadRuntime;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+}
+
+declare namespace AssistantRuntimeProvider {
+  type Props = PropsWithChildren<{
+    runtime: AssistantRuntime;
+    aui?: AssistantClient;
+  }>;
+}
+
+declare const AssistantRuntimeProvider: import("react").NamedExoticComponent<AssistantRuntimeProvider.Props>;
+
+type AssistantState = {
+  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
+    getState: () => infer S;
+  } ? S : never;
+};
+
+type AssistantStream = ReadableStream<AssistantStreamChunk>;
+
+declare const AssistantStream: {
+  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
+  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
+  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+};
+
+type AssistantStreamChunk = {
+  readonly path: readonly number[];
+} & ({
+  readonly type: "part-start";
+  readonly part: PartInit;
+} | {
+  readonly type: "part-finish";
+} | {
+  readonly type: "tool-call-args-text-finish";
+} | {
+  readonly type: "text-delta";
+  readonly textDelta: string;
+} | {
+  readonly type: "annotations";
+  readonly annotations: ReadonlyJSONValue[];
+} | {
+  readonly type: "data";
+  readonly data: ReadonlyJSONValue[];
+} | {
+  readonly type: "step-start";
+  readonly messageId: string;
+} | {
+  readonly type: "step-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+  readonly isContinued: boolean;
+} | {
+  readonly type: "message-finish";
+  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  };
+} | {
+  readonly type: "result";
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+} | {
+  readonly type: "error";
+  readonly error: string;
+} | {
+  readonly type: "update-state";
+  readonly operations: ObjectStreamOperation[];
+});
+
+type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
+  headers?: Headers;
+};
+
+type AssistantTool = FC & {
+  unstable_tool: AssistantToolProps<any, any>;
+};
+
+type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
+};
+
+type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
+  toolName: string;
+  render?: unknown;
+};
+
+type AssistantToolUI = FC & {
+  unstable_tool: AssistantToolUIProps<any, any>;
+};
+
+type AssistantToolUIProps<TArgs, TResult> = {
+  toolName: string;
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+  display?: "inline" | "standalone";
+};
+
+type AssistantTransportCommand = AddMessageCommand | AddToolResultCommand | UserCommands;
+
+type AssistantTransportConnectionMetadata = {
+  pendingCommands: AssistantTransportCommand[];
+  isSending: boolean;
+  toolStatuses: Record<string, ToolExecutionStatus>;
+};
+
+type AssistantTransportOptions<T> = {
+  initialState: T;
+  api: string;
+  resumeApi?: string;
+  protocol?: AssistantTransportProtocol;
+  converter: AssistantTransportStateConverter<T>;
+  headers: HeadersValue | (() => Promise<HeadersValue>);
+  body?: object | (() => Promise<object | undefined>);
+  prepareSendCommandsRequest?: (body: SendCommandsRequestBody) => Record<string, unknown> | Promise<Record<string, unknown>>;
+  onResponse?: (response: Response) => void;
+  onFinish?: () => void;
+  onError?: (error: Error, params: {
+    commands: AssistantTransportCommand[];
+    updateState: (updater: (state: T) => T) => void;
+  }) => void | Promise<void>;
+  onCancel?: (params: {
+    commands: AssistantTransportCommand[];
+    updateState: (updater: (state: T) => T) => void;
+    error?: Error;
+  }) => void;
+  capabilities?: {
+    edit?: boolean;
+  };
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    history?: ThreadHistoryAdapter | undefined;
+  };
+};
+
+type AssistantTransportProtocol = "assistant-transport" | "data-stream";
+
+type AssistantTransportState = {
+  readonly messages: readonly ThreadMessage[];
+  readonly state?: ReadonlyJSONValue;
+  readonly isRunning: boolean;
+};
+
+type AssistantTransportStateConverter<T> = (state: T, connectionMetadata: AssistantTransportConnectionMetadata) => AssistantTransportState;
+
+type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+
+type Attachment = PendingAttachment | CompleteAttachment;
+
+type AttachmentAdapter = {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+};
+
+type AttachmentAddErrorEvent = {
+  readonly reason: AttachmentAddErrorReason;
+  readonly message: string;
+  readonly attachmentId?: string;
+  readonly error?: Error;
+};
+
+type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+
+declare namespace AttachmentPrimitiveName {
+  type Props = Record<string, never>;
+}
+
+declare const AttachmentPrimitiveName: FC<AttachmentPrimitiveName.Props>;
+
+declare namespace AttachmentPrimitiveRemove {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useAttachmentRemove>;
+}
+
+declare const AttachmentPrimitiveRemove: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace AttachmentPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps$4;
+}
+
+declare const AttachmentPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace AttachmentPrimitiveThumb {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps$3;
+}
+
+declare const AttachmentPrimitiveThumb: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
+  readonly path: AttachmentRuntimePath & {
+    attachmentSource: TSource;
+  };
+  readonly source: TSource;
+  getState(): AttachmentState & {
+    source: TSource;
+  };
+  remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
+  private _core;
+  get path(): AttachmentRuntimePath & {
+    attachmentSource: Source;
+  };
+  abstract get source(): Source;
+  constructor(_core: AttachmentSnapshotBinding<Source>);
+  protected __internal_bindMethods(): void;
+  getState(): AttachmentState & {
+    source: Source;
+  };
+  abstract remove(): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+}
+
+type AttachmentRuntimePath = ((MessageRuntimePath & {
+  readonly attachmentSource: "edit-composer" | "message";
+}) | (ThreadRuntimePath & {
+  readonly attachmentSource: "thread-composer";
+})) & {
+  readonly attachmentSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type AttachmentRuntimeSource = AttachmentState["source"];
+
+type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState & {
+  source: Source;
+}, AttachmentRuntimePath & {
+  attachmentSource: Source;
+}>;
+
+type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
+
+type AttachmentStatus = PendingAttachmentStatus | CompleteAttachmentStatus;
 
 declare namespace AuiIf {
   type Props = PropsWithChildren<{
@@ -144,60 +834,43 @@ declare namespace AuiIf {
 
 declare const AuiIf: FC<AuiIf.Props>;
 
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-declare namespace useAui {
-  type Props = {
-    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
-  };
-}
-
-declare function useAui(): AssistantClient;
-
-declare function useAui(clients: useAui.Props): AssistantClient;
-
-declare function useAui(clients: useAui.Props, config: {
-  parent: null | AssistantClient;
-}): AssistantClient;
-
-declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
-
-declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
-
 declare const AuiProvider: (_param0: {
   value: AssistantClient;
   children: React.ReactNode;
 }) => React.ReactElement;
 
-type PendingAttachmentStatus = {
-  type: "running";
-  reason: "uploading";
-  progress: number;
-} | {
-  type: "requires-action";
-  reason: "composer-send";
-} | {
-  type: "incomplete";
-  reason: "error" | "upload-paused";
+type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
+
+type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
+
+type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: undefined;
+  parameters?: undefined;
+  disabled?: undefined;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: undefined;
 };
 
-type CompleteAttachmentStatus = {
-  type: "complete";
+type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "backend";
+  description?: string | undefined;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
 };
 
-type AttachmentStatus = PendingAttachmentStatus | CompleteAttachmentStatus;
+declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
+  protected readonly _contextProvider: CompositeContextProvider;
+  abstract get threads(): ThreadListRuntimeCore;
+  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
+  getModelContextProvider(): ModelContextProvider;
+}
 
 type BaseAttachment = {
   id: string;
@@ -208,9 +881,337 @@ type BaseAttachment = {
   content?: ThreadUserMessagePart[];
 };
 
-type PendingAttachment = BaseAttachment & {
-  status: PendingAttachmentStatus;
-  file: File;
+declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
+  readonly isEditing = true;
+  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected abstract getDictationAdapter(): DictationAdapter | undefined;
+  protected enrichWithComposerMetadata<T extends {
+    metadata?: {
+      custom?: Record<string, unknown>;
+    };
+  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
+  get attachmentAccept(): string;
+  private _attachments;
+  get attachments(): readonly Attachment[];
+  protected setAttachments(value: readonly Attachment[]): void;
+  abstract get canCancel(): boolean;
+  abstract get canSend(): boolean;
+  get isEmpty(): boolean;
+  private _text;
+  get text(): string;
+  private _role;
+  get role(): "assistant" | "system" | "user";
+  private _runConfig;
+  get runConfig(): RunConfig;
+  private _quote;
+  get quote(): QuoteInfo | undefined;
+  setQuote(quote: QuoteInfo | undefined): void;
+  setText(value: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  private _emptyTextAndAttachments;
+  private _onClearAttachments;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): Promise<void>;
+  cancel(): void;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(_queueItemId: string): void;
+  removeQueueItem(_queueItemId: string): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleCancel(): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  private _safeEmitAttachmentAddError;
+  removeAttachment(attachmentId: string): Promise<void>;
+  private _dictation;
+  private _dictationSession;
+  private _dictationUnsubscribes;
+  private _dictationBaseText;
+  private _currentInterimText;
+  private _dictationSessionIdCounter;
+  private _activeDictationSessionId;
+  private _isCleaningDictation;
+  get dictation(): DictationState | undefined;
+  private _isActiveSession;
+  startDictation(): void;
+  stopDictation(): void;
+  private _cleanupDictation;
+  private _eventSubscribers;
+  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
+}
+
+type BaseComposerState = {
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly isEditing: boolean;
+  readonly isEmpty: boolean;
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly attachmentAccept: string;
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+declare class BaseSubscribable {
+  private _subscribers;
+  subscribe(callback: () => void): Unsubscribe;
+  waitForUpdate(): Promise<void>;
+  protected _notifySubscribers(): void;
+}
+
+type BaseThreadMessage = {
+  readonly status?: ThreadAssistantMessage["status"];
+  readonly metadata: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
+    readonly unstable_data?: readonly ReadonlyJSONValue[];
+    readonly steps?: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
+  };
+  readonly attachments?: ThreadUserMessage["attachments"];
+};
+
+declare namespace BranchPickerPrimitiveCount {
+  type Props = Record<string, never>;
+}
+
+declare const BranchPickerPrimitiveCount: FC<BranchPickerPrimitiveCount.Props>;
+
+declare namespace BranchPickerPrimitiveNext {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useBranchPickerNext>;
+}
+
+declare const BranchPickerPrimitiveNext: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace BranchPickerPrimitiveNumber {
+  type Props = Record<string, never>;
+}
+
+declare const BranchPickerPrimitiveNumber: FC<BranchPickerPrimitiveNumber.Props>;
+
+declare namespace BranchPickerPrimitivePrevious {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useBranchPickerPrevious>;
+}
+
+declare const BranchPickerPrimitivePrevious: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace BranchPickerPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div> & {
+    hideWhenSingleBranch?: boolean | undefined;
+  };
+}
+
+declare const BranchPickerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  hideWhenSingleBranch?: boolean | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>>;
+
+declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
+  {
+    parts: readonly ChainOfThoughtPart[];
+    getMessagePart: (selector: {
+      index: number;
+    }) => PartMethods;
+  }
+]>;
+
+type ChainOfThoughtPart = Extract<PartState, {
+  type: "tool-call";
+} | {
+  type: "reasoning";
+}>;
+
+type ChainOfThoughtPartsComponentConfig = {
+  Reasoning?: ReasoningMessagePartComponent | undefined;
+  tools?: {
+    Fallback?: ToolCallMessagePartComponent | undefined;
+  };
+  Layout?: ComponentType<PropsWithChildren> | undefined;
+};
+
+declare namespace ChainOfThoughtPrimitiveAccordionTrigger {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useChainOfThoughtAccordionTrigger>;
+}
+
+declare const ChainOfThoughtPrimitiveAccordionTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ChainOfThoughtPrimitiveParts {
+  type Props = {
+    components?: ChainOfThoughtPartsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      part: PartState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
+
+declare namespace ChainOfThoughtPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps$2;
+}
+
+declare const ChainOfThoughtPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+type ChatModelAdapter = {
+  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+};
+
+type ChatModelRunOptions = {
+  readonly messages: readonly ThreadMessage[];
+  readonly runConfig: RunConfig;
+  readonly abortSignal: AbortSignal;
+  readonly context: ModelContext$1;
+  readonly unstable_assistantMessageId?: string | undefined;
+  readonly unstable_threadId?: string | undefined;
+  readonly unstable_parentId?: string | null | undefined;
+  unstable_getMessage(): ThreadMessage;
+};
+
+type ChatModelRunResult = {
+  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
+  readonly status?: MessageStatus | undefined;
+  readonly metadata?: {
+    readonly unstable_state?: ReadonlyJSONValue;
+    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
+    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
+    readonly steps?: readonly ThreadStep[] | undefined;
+    readonly timing?: MessageTiming | undefined;
+    readonly custom?: Record<string, unknown> | undefined;
+  };
+};
+
+type ChatModelRunUpdate = {
+  readonly content: readonly ThreadAssistantMessagePart[];
+  readonly metadata?: Record<string, unknown>;
+};
+
+type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
+  private cloud;
+  accept: string;
+  constructor(cloud: AssistantCloud);
+  private uploadedUrls;
+  add(_param1: {
+    file: File;
+  }): AsyncGenerator<PendingAttachment, void>;
+  remove(attachment: Attachment): Promise<void>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+}
+
+type CloudMessage = {
+  id: string;
+  parent_id: string | null;
+  height: number;
+  created_at: Date;
+  updated_at: Date;
+  format: "aui/v0" | string;
+  content: ReadonlyJSONObject;
+};
+
+type CloudThread = {
+  title: string;
+  last_message_at: Date;
+  metadata: unknown;
+  external_id: string | null;
+  id: string;
+  project_id: string;
+  created_at: Date;
+  updated_at: Date;
+  workspace_id: string;
+  is_archived: boolean;
+};
+
+type CloudThreadListAdapter = {
+  cloud: AssistantCloud;
+  runtimeHook: () => AssistantRuntime;
+  create?(): Promise<ThreadData>;
+  delete?(threadId: string): Promise<void>;
+};
+
+type CloudThreadListAdapterOptions = {
+  cloud?: AssistantCloud | undefined;
+  create?: (() => Promise<ThreadData$1>) | undefined;
+  delete?: ((threadId: string) => Promise<void>) | undefined;
 };
 
 type CompleteAttachment = BaseAttachment & {
@@ -218,7 +1219,513 @@ type CompleteAttachment = BaseAttachment & {
   content: ThreadUserMessagePart[];
 };
 
-type Attachment = PendingAttachment | CompleteAttachment;
+type CompleteAttachmentStatus = {
+  type: "complete";
+};
+
+declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
+  private _composerApi;
+  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
+  remove(): Promise<void>;
+}
+
+type ComposerAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+type ComposerIfFilters = {
+  editing: boolean | undefined;
+  dictation: boolean | undefined;
+};
+
+type ComposerInputPlugin = {
+  handleKeyDown(e: {
+    readonly key: string;
+    readonly shiftKey: boolean;
+    readonly ctrlKey?: boolean;
+    readonly metaKey?: boolean;
+    readonly nativeEvent?: {
+      isComposing?: boolean;
+    };
+    preventDefault(): void;
+  }): boolean;
+  setCursorPosition(pos: number): void;
+};
+
+type ComposerInputPluginRegisterOptions = {
+  priority?: number;
+};
+
+type ComposerInputPluginRegistry = {
+  register(plugin: ComposerInputPlugin, opts?: ComposerInputPluginRegisterOptions): () => void;
+  getPlugins(): readonly ComposerInputPlugin[];
+};
+
+declare namespace ComposerPrimitiveAddAttachment {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useComposerAddAttachment>;
+}
+
+declare const ComposerPrimitiveAddAttachment: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  multiple?: boolean | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: ComposerAttachmentsComponentConfig;
+  };
+}
+
+declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
+
+declare namespace ComposerPrimitiveAttachmentDropzone {
+  type Element = HTMLDivElement;
+  type Props = React.HTMLAttributes<HTMLDivElement> & {
+    asChild?: boolean | undefined;
+    render?: ReactElement | undefined;
+    disabled?: boolean | undefined;
+  };
+}
+
+declare const ComposerPrimitiveAttachmentDropzone: React.ForwardRefExoticComponent<React.HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean | undefined;
+  render?: ReactElement | undefined;
+  disabled?: boolean | undefined;
+} & React.RefAttributes<HTMLDivElement>>;
+
+declare namespace ComposerPrimitiveAttachments {
+  type Props = {
+    components: ComposerAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: Attachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
+
+declare namespace ComposerPrimitiveCancel {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useComposerCancel>;
+}
+
+declare const ComposerPrimitiveCancel: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveDictate {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useComposerDictate>;
+}
+
+declare const ComposerPrimitiveDictate: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveDictationTranscript {
+  type Element = ComponentRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const ComposerPrimitiveDictationTranscript: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace ComposerPrimitiveIf {
+  type Props = PropsWithChildren<UseComposerIfProps>;
+}
+
+declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
+
+declare namespace ComposerPrimitiveInput {
+  export type Element = HTMLTextAreaElement;
+  type BaseProps = {
+    asChild?: boolean | undefined;
+    render?: ReactElement | undefined;
+    cancelOnEscape?: boolean | undefined;
+    unstable_focusOnRunStart?: boolean | undefined;
+    unstable_focusOnScrollToBottom?: boolean | undefined;
+    unstable_focusOnThreadSwitched?: boolean | undefined;
+    unstable_insertNewlineOnTouchEnter?: boolean | undefined;
+    addAttachmentOnPaste?: boolean | undefined;
+  };
+  type SubmitModeProps = {
+    submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
+    submitOnEnter?: never;
+  } | {
+    submitMode?: never;
+    submitOnEnter?: boolean | undefined;
+  };
+  export type Props = TextareaAutosizeProps & BaseProps & SubmitModeProps;
+  export {};
+}
+
+declare const ComposerPrimitiveInput: import("react").ForwardRefExoticComponent<ComposerPrimitiveInput.Props & import("react").RefAttributes<HTMLTextAreaElement>>;
+
+declare namespace ComposerPrimitiveQueue {
+  type Props = {
+    children: (value: {
+      queueItem: QueueItemState;
+    }) => ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
+  children: (value: {
+    queueItem: QueueItemState;
+  }) => ReactNode;
+}>;
+
+declare namespace ComposerPrimitiveQuote {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
+
+declare const ComposerPrimitiveQuote: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ComposerPrimitiveQuoteDismiss {
+  type Element = ComponentRef<typeof Primitive$1.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
+}
+
+declare const ComposerPrimitiveQuoteDismiss: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveQuoteText {
+  type Element = ComponentRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const ComposerPrimitiveQuoteText: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace ComposerPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.form>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.form>;
+}
+
+declare const ComposerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLFormElement>, "ref"> & import("react").RefAttributes<HTMLFormElement>>;
+
+declare namespace ComposerPrimitiveSend {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useComposerSend>;
+}
+
+declare const ComposerPrimitiveSend: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveStopDictation {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useComposerStopDictation>;
+}
+
+declare const ComposerPrimitiveStopDictation: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare const ComposerPrimitiveTriggerPopover: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref">, "onSelect"> & {
+  readonly char: string;
+  readonly adapter?: Unstable_TriggerAdapter | undefined;
+  readonly isLoading?: boolean | undefined;
+} & import("react").RefAttributes<HTMLDivElement>> & {
+  Directive: import("react").FC<ComposerPrimitiveTriggerPopoverDirective.Props>;
+  Action: import("react").FC<ComposerPrimitiveTriggerPopoverAction.Props>;
+};
+
+declare namespace ComposerPrimitiveTriggerPopoverAction {
+  type Props = {
+    readonly formatter?: Unstable_DirectiveFormatter | undefined;
+    readonly onExecute: (item: Unstable_TriggerItem) => void;
+    readonly removeOnExecute?: boolean | undefined;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverAction: FC<ComposerPrimitiveTriggerPopoverAction.Props>;
+
+declare namespace ComposerPrimitiveTriggerPopoverBack {
+  type Element = ComponentRef<typeof Primitive$1.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
+}
+
+declare const ComposerPrimitiveTriggerPopoverBack: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveTriggerPopoverCategories {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.div>, "children"> & {
+    children: (categories: readonly Unstable_TriggerCategory[]) => ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverCategories: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
+  children: (categories: readonly Unstable_TriggerCategory[]) => ReactNode;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ComposerPrimitiveTriggerPopoverCategoryItem {
+  type Element = ComponentRef<typeof Primitive$1.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button> & {
+    categoryId: string;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverCategoryItem: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  categoryId: string;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveTriggerPopoverDirective {
+  type Props = {
+    readonly formatter?: Unstable_DirectiveFormatter | undefined;
+    readonly onInserted?: ((item: Unstable_TriggerItem) => void) | undefined;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverDirective: FC<ComposerPrimitiveTriggerPopoverDirective.Props>;
+
+declare namespace ComposerPrimitiveTriggerPopoverItem {
+  type Element = ComponentRef<typeof Primitive$1.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button> & {
+    item: Unstable_TriggerItem;
+    index?: number | undefined;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverItem: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  item: Unstable_TriggerItem;
+  index?: number | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ComposerPrimitiveTriggerPopoverItems {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.div>, "children"> & {
+    children: (items: readonly Unstable_TriggerItem[]) => ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverItems: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
+  children: (items: readonly Unstable_TriggerItem[]) => ReactNode;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ComposerPrimitiveTriggerPopoverRoot {
+  type Props = {
+    children: ReactNode;
+  };
+}
+
+declare const ComposerPrimitiveTriggerPopoverRoot: FC<ComposerPrimitiveTriggerPopoverRoot.Props>;
+
+type ComposerRuntime = {
+  readonly path: ComposerRuntimePath;
+  readonly type: "edit" | "thread";
+  getState(): ComposerState$1;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  setText(text: string): void;
+  setRole(role: MessageRole): void;
+  setRunConfig(runConfig: RunConfig): void;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  subscribe(callback: () => void): Unsubscribe;
+  getAttachmentByIndex(idx: number): AttachmentRuntime;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+};
+
+type ComposerRuntimeCore = Readonly<{
+  isEditing: boolean;
+  canCancel: boolean;
+  canSend: boolean;
+  isEmpty: boolean;
+  attachments: readonly Attachment[];
+  attachmentAccept: string;
+  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
+  removeAttachment: (attachmentId: string) => Promise<void>;
+  text: string;
+  setText: (value: string) => void;
+  role: MessageRole;
+  setRole: (role: MessageRole) => void;
+  runConfig: RunConfig;
+  setRunConfig: (runConfig: RunConfig) => void;
+  quote: QuoteInfo | undefined;
+  setQuote: (quote: QuoteInfo | undefined) => void;
+  reset: () => Promise<void>;
+  clearAttachments: () => Promise<void>;
+  send: (options?: SendOptions) => void;
+  cancel: () => void;
+  queue: readonly QueueItemState[];
+  steerQueueItem: (queueItemId: string) => void;
+  removeQueueItem: (queueItemId: string) => void;
+  dictation: DictationState | undefined;
+  startDictation: () => void;
+  stopDictation: () => void;
+  subscribe: (callback: () => void) => Unsubscribe;
+  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe;
+}>;
+
+type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
+
+type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+
+type ComposerRuntimeEventPayload = {
+  send: Record<string, never>;
+  attachmentAdd: Record<string, never>;
+  attachmentAddError: AttachmentAddErrorEvent;
+};
+
+type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+
+declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
+  protected _core: ComposerRuntimeCoreBinding;
+  get path(): ComposerRuntimePath;
+  abstract get type(): "edit" | "thread";
+  constructor(_core: ComposerRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  abstract getState(): ComposerState$1;
+  setText(text: string): void;
+  setRunConfig(runConfig: RunConfig): void;
+  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
+  reset(): Promise<void>;
+  clearAttachments(): Promise<void>;
+  send(options?: SendOptions): void;
+  cancel(): void;
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  setRole(role: MessageRole): void;
+  startDictation(): void;
+  stopDictation(): void;
+  setQuote(quote: QuoteInfo | undefined): void;
+  subscribe(callback: () => void): Unsubscribe;
+  private _eventSubscriptionSubjects;
+  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
+  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
+}
+
+type ComposerRuntimePath = (ThreadRuntimePath & {
+  readonly composerSource: "thread";
+}) | (MessageRuntimePath & {
+  readonly composerSource: "edit";
+});
+
+type ComposerSendOptions = SendOptions & {
+  steer?: boolean;
+};
+
+type ComposerState = {
+  readonly text: string;
+  readonly role: MessageRole;
+  readonly attachments: readonly Attachment[];
+  readonly runConfig: RunConfig;
+  readonly isEditing: boolean;
+  readonly canCancel: boolean;
+  readonly canSend: boolean;
+  readonly attachmentAccept: string;
+  readonly isEmpty: boolean;
+  readonly type: "edit" | "thread";
+  readonly dictation: DictationState | undefined;
+  readonly quote: QuoteInfo | undefined;
+  readonly queue: readonly QueueItemState[];
+};
+
+type ComposerState$1 = ThreadComposerState | EditComposerState;
+
+declare class CompositeAttachmentAdapter implements AttachmentAdapter {
+  private _adapters;
+  accept: string;
+  constructor(adapters: AttachmentAdapter[]);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(attachment: Attachment): Promise<void>;
+}
+
+declare class CompositeContextProvider implements ModelContextProvider {
+  private _providers;
+  getModelContext(): ModelContext$1;
+  registerModelContextProvider(provider: ModelContextProvider): () => void;
+  private _subscribers;
+  notifySubscribers(): void;
+  subscribe(callback: () => void): () => void;
+}
+
+type CreateAppendMessage = string | {
+  parentId?: string | null | undefined;
+  sourceId?: string | null | undefined;
+  role?: AppendMessage["role"] | undefined;
+  content: AppendMessage["content"];
+  attachments?: AppendMessage["attachments"] | undefined;
+  metadata?: AppendMessage["metadata"] | undefined;
+  createdAt?: Date | undefined;
+  runConfig?: AppendMessage["runConfig"] | undefined;
+  startRun?: boolean | undefined;
+};
 
 type CreateAttachment = {
   id?: string;
@@ -228,30 +1735,562 @@ type CreateAttachment = {
   content: ThreadUserMessagePart[];
 };
 
-type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
-
-type ReadonlyJSONObject = {
-  readonly [key: string]: ReadonlyJSONValue;
+type CreateResumeRunConfig = CreateStartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
 };
 
-type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+type CreateStartRunConfig = {
+  parentId: string | null;
+  sourceId?: string | null | undefined;
+  runConfig?: RunConfig | undefined;
+};
 
-type AsyncIterableStream<T> = AsyncIterable<T> & ReadableStream<T>;
+type DataMessagePart<T = any> = {
+  readonly type: "data";
+  readonly name: string;
+  readonly data: T;
+};
 
-type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
 
-type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
+type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
 
-interface JSONSchema7Object {
-  [key: string]: JSONSchema7Type;
+type DataPrefixedPart = {
+  readonly type: `data-${string}`;
+  readonly data: any;
+};
+
+declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
+]>;
+
+type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
+  [key: string]: any;
+} ? {
+  readonly [K in keyof T]?: DeepPartial<T[K]>;
+} : T;
+
+declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
+  private runtime;
+  private _canCancel;
+  get canCancel(): boolean;
+  get canSend(): boolean;
+  get queue(): readonly QueueItemState[];
+  steerQueueItem(queueItemId: string): void;
+  removeQueueItem(queueItemId: string): void;
+  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
+  protected getDictationAdapter(): DictationAdapter | undefined;
+  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?: {
+      attachments?: AttachmentAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+    } | undefined;
+  });
+  connect(): Unsubscribe;
+  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
+  handleCancel(): Promise<void>;
 }
 
-interface JSONSchema7Array extends Array<JSONSchema7Type> {
+declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
+  _config: Derived.Props<K>
+]>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
 }
 
-type JSONSchema7Version = string;
+type DerivedElement<K extends ClientNames> = ResourceElement<null, [
+  Derived.Props<K>
+]>;
 
-type JSONSchema7Definition = JSONSchema7 | boolean;
+interface DevToolsApiEntry {
+  api: Partial<AssistantClient>;
+  logs: EventLog[];
+}
+
+interface DevToolsHook {
+  apis: Map<number, DevToolsApiEntry>;
+  nextId: number;
+  listeners: Set<(apiId: number) => void>;
+}
+
+declare class DevToolsHooks {
+  static subscribe(listener: () => void): Unsubscribe;
+  static clearEventLogs(apiId: number): void;
+  static getApis(): Map<number, DevToolsApiEntry>;
+  private static notifyListeners;
+}
+
+declare class DevToolsProviderApi {
+  private static readonly MAX_EVENT_LOGS_PER_API;
+  static register(aui: Partial<AssistantClient>): Unsubscribe;
+  private static notifyListeners;
+}
+
+declare namespace DictationAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "stopped";
+  };
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
+}
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+type DictationState = {
+  readonly status: DictationAdapter.Status;
+  readonly transcript?: string;
+  readonly inputDisabled?: boolean;
+};
+
+declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
+  get source(): "edit-composer";
+}
+
+type EditComposerAttachmentState = Attachment & {
+  readonly source: "edit-composer";
+};
+
+type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  readonly type: "edit";
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "edit-composer";
+  };
+};
+
+type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
+  parentId: string | null;
+  sourceId: string | null;
+}>;
+
+type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "edit";
+}>;
+
+declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
+  private _beginEdit;
+  get path(): ComposerRuntimePath & {
+    composerSource: "edit";
+  };
+  get type(): "edit";
+  private _getState;
+  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
+  __internal_bindMethods(): void;
+  getState(): EditComposerState;
+  beginEdit(): void;
+  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
+}
+
+type EditComposerState = BaseComposerState & {
+  readonly type: "edit";
+  readonly parentId: string | null;
+  readonly sourceId: string | null;
+};
+
+type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
+
+type EmptyMessagePartProps = {
+  status: MessagePartStatus;
+};
+
+type EnrichedPartState = (Extract<PartState, {
+  type: "tool-call";
+}> & {
+  readonly toolUI: ReactNode;
+  addResult: ToolCallMessagePartProps["addResult"];
+  resume: ToolCallMessagePartProps["resume"];
+  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
+}) | (Extract<PartState, {
+  type: "data";
+}> & {
+  readonly dataRendererUI: ReactNode;
+}) | Exclude<PartState, {
+  type: "tool-call";
+} | {
+  type: "data";
+}>;
+
+declare namespace ErrorPrimitiveMessage {
+  type Element = ComponentRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const ErrorPrimitiveMessage: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace ErrorPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
+
+declare const ErrorPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+interface EventLog {
+  time: Date;
+  event: string;
+  data: unknown;
+}
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type ExportedMessageRepository = {
+  headId?: string | null;
+  messages: Array<{
+    message: ThreadMessage;
+    parentId: string | null;
+    runConfig?: RunConfig;
+  }>;
+};
+
+declare const ExportedMessageRepository: {
+  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
+  fromBranchableArray: (items: readonly {
+    message: ThreadMessageLike;
+    parentId: string | null;
+  }[], options?: {
+    headId?: string | null;
+  }) => ExportedMessageRepository;
+};
+
+type ExportedMessageRepositoryItem = {
+  message: ThreadMessage;
+  parentId: string | null;
+  runConfig?: RunConfig;
+};
+
+type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
+
+type ExternalStoreAdapterBase<T> = {
+  isDisabled?: boolean | undefined;
+  isSendDisabled?: boolean | undefined;
+  isRunning?: boolean | undefined;
+  isLoading?: boolean | undefined;
+  messages?: readonly T[];
+  messageRepository?: ExportedMessageRepository;
+  suggestions?: readonly ThreadSuggestion[] | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
+  setMessages?: ((messages: readonly T[]) => void) | undefined;
+  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
+  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
+  onExportExternalState?: (() => any) | undefined;
+  onLoadExternalState?: ((state: any) => void) | undefined;
+  onNew: (message: AppendMessage) => Promise<void>;
+  queue?: ExternalThreadQueueAdapter | undefined;
+  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
+  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
+  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
+  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
+  onCancel?: (() => Promise<void>) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
+  onResumeToolCall?: ((options: {
+    toolCallId: string;
+    payload: unknown;
+  }) => void) | undefined;
+  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
+  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
+  adapters?: {
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    threadList?: ExternalStoreThreadListAdapter | undefined;
+  } | undefined;
+  unstable_capabilities?: {
+    copy?: boolean | undefined;
+  } | undefined;
+  unstable_enableToolInvocations?: boolean | undefined;
+  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
+};
+
+type ExternalStoreBranchChange = {
+  headId: string | null;
+  visibleMessageIds: readonly string[];
+};
+
+type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
+
+type ExternalStoreMessageConverterAdapter<T> = {
+  convertMessage: ExternalStoreMessageConverter<T>;
+};
+
+type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
+
+type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
+  status: TState;
+  id: string;
+  remoteId?: string | undefined;
+  externalId?: string | undefined;
+  title?: string | undefined;
+  custom?: Record<string, unknown> | undefined;
+};
+
+type ExternalStoreThreadListAdapter = {
+  threadId?: string | undefined;
+  isLoading?: boolean | undefined;
+  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
+  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
+  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
+  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
+  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
+  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
+  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
+  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
+};
+
+declare const ExternalThread: Resource<ClientOutput<"thread">, [
+  ExternalThreadProps
+]>;
+
+type ExternalThreadBranchAdapter = {
+  getBranches: (messageId: string) => readonly string[];
+  switchToBranch: (branchId: string) => void;
+};
+
+type ExternalThreadMessage = ThreadMessage & {
+  id: string;
+};
+
+type ExternalThreadProps = {
+  messages: readonly ExternalThreadMessage[];
+  isRunning?: boolean;
+  isSendDisabled?: boolean;
+  onNew?: (message: AppendMessage) => void;
+  onEdit?: (message: AppendMessage) => void;
+  onReload?: (parentId: string | null) => void;
+  onStartRun?: () => void;
+  onCancel?: () => void;
+  queue?: ExternalThreadQueueAdapter;
+  branches?: ExternalThreadBranchAdapter;
+  onRespondToToolApproval?: (options: RespondToToolApprovalOptions) => void;
+};
+
+type ExternalThreadQueueAdapter = {
+  items: readonly QueueItemState[];
+  enqueue: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  steer: (queueItemId: string) => void;
+  remove: (queueItemId: string) => void;
+  clear: (reason: "cancel-run" | "edit" | "reload") => void;
+};
+
+declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";
+
+type FeedbackAdapter = {
+  submit: (feedback: FeedbackAdapterFeedback) => void;
+};
+
+type FeedbackAdapterFeedback = {
+  message: ThreadMessage;
+  type: "negative" | "positive";
+};
+
+type FileMessagePart = {
+  readonly type: "file";
+  readonly filename?: string;
+  readonly data: string;
+  readonly mimeType: string;
+  readonly parentId?: string;
+};
+
+type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
+
+type FileMessagePartProps = MessagePartState & FileMessagePart;
+
+type FrameMessage = {
+  type: "model-context-request";
+} | {
+  type: "model-context-update";
+  context: SerializedModelContext;
+} | {
+  type: "tool-call";
+  id: string;
+  toolName: string;
+  args: unknown;
+} | {
+  type: "tool-result";
+  id: string;
+  result?: unknown;
+  error?: string;
+};
+
+type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
+
+type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "frontend";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  execute?: ToolExecuteFunction<TArgs, TResult>;
+  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
+  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
+  providerOptions?: ProviderOptions;
+};
+
+type GeneratePresignedUploadUrlRequestBody = {
+  filename: string;
+};
+
+type GeneratePresignedUploadUrlResponse = {
+  success: boolean;
+  signedUrl: string;
+  expiresAt: string;
+  publicUrl: string;
+};
+
+type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
+
+type GenerativeUIMessagePart = {
+  readonly type: "generative-ui";
+  readonly spec: GenerativeUISpec;
+  readonly id?: string;
+  readonly parentId?: string;
+};
+
+type GenerativeUIMessagePartComponent = ComponentType<GenerativeUIMessagePartProps>;
+
+type GenerativeUIMessagePartProps = MessagePartState & GenerativeUIMessagePart;
+
+type GenerativeUINode = string | {
+  readonly component: string;
+  readonly props?: Record<string, unknown>;
+  readonly children?: readonly GenerativeUINode[];
+  readonly key?: string;
+};
+
+declare const GenerativeUIRender: FC<GenerativeUIRenderProps>;
+
+declare class GenerativeUIRenderError extends Error {
+  readonly componentName: string;
+  constructor(componentName: string, message?: string);
+}
+
+type GenerativeUIRenderProps = {
+  spec: GenerativeUISpec;
+  components: GenerativeUIComponentRegistry;
+  Fallback?: ComponentType<{
+    component: string;
+    props?: unknown;
+  }> | undefined;
+};
+
+type GenerativeUISpec = {
+  readonly root: GenerativeUINode | readonly GenerativeUINode[];
+};
+
+type GenericThreadHistoryAdapter<TMessage> = {
+  load(): Promise<MessageFormatRepository<TMessage>>;
+  append(item: MessageFormatItem<TMessage>): Promise<void>;
+  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
+  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
+  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
+    durationMs?: number;
+    stepTimestamps?: {
+      start_ms: number;
+      end_ms: number;
+    }[];
+  }): void;
+};
+
+type GroupByContext = {
+  readonly toolUIs?: ToolsState["toolUIs"];
+};
+
+type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
+
+type GroupingFunction = (parts: readonly any[]) => MessagePartGroup[];
+
+type HeadersValue = Record<string, string> | Headers;
+
+type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "human";
+  description?: string | undefined;
+  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
+  disabled?: boolean;
+  display?: "standalone";
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ImageMessagePart = {
+  readonly type: "image";
+  readonly image: string;
+  readonly filename?: string;
+};
+
+type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
+
+type ImageMessagePartProps = MessagePartState & ImageMessagePart;
+
+type ImagePart = {
+  readonly type: "image";
+  readonly image: string;
+};
+
+declare const InMemoryThreadList: Resource<ClientOutput<"threads">, [
+  props: InMemoryThreadListProps
+]>;
+
+declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
+  list(): Promise<RemoteThreadListResponse>;
+  rename(): Promise<void>;
+  updateCustom(): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(): Promise<AssistantStream>;
+  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
+}
+
+type InMemoryThreadListProps = {
+  thread: (threadId: string) => ResourceElement<ClientOutput<"thread">>;
+  onSwitchToThread?: (threadId: string) => void;
+  onSwitchToNewThread?: () => void;
+};
+
+type InteractableScope = "app" | "thread";
+
+type InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+declare const Interactables: Resource<ClientOutput<"interactables">, [
+]>;
 
 interface JSONSchema7 {
   $id?: string | undefined;
@@ -313,175 +2352,159 @@ interface JSONSchema7 {
   examples?: JSONSchema7Type | undefined;
 }
 
-type AsNumber<K> = K extends `${infer N extends number}` ? N | K : never;
+interface JSONSchema7Array extends Array<JSONSchema7Type> {
+}
 
-type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+type JSONSchema7Definition = JSONSchema7 | boolean;
 
-type ObjectKey<T> = keyof T & (string | number);
+interface JSONSchema7Object {
+  [key: string]: JSONSchema7Type;
+}
 
-type TypePath<T> = [
-] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
-  [K in TupleIndex<T>]: [
-    AsNumber<K>,
-    ...TypePath<T[K]>
-  ];
-}[TupleIndex<T>] : [
-  number,
-  ...TypePath<T[number]>
-] : {
-  [K in ObjectKey<T>]: [
-    K,
-    ...TypePath<T[K]>
-  ];
-}[ObjectKey<T>] : [
-]);
+type JSONSchema7Type = string | number | boolean | JSONSchema7Object | JSONSchema7Array | null;
 
-type TypeAtPath<T, P extends readonly any[]> = P extends [
-  infer Head,
-  ...infer Rest
-] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+type JSONSchema7TypeName = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
 
-type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>[] : T extends {
-  [key: string]: any;
-} ? {
-  readonly [K in keyof T]?: DeepPartial<T[K]>;
-} : T;
+type JSONSchema7Version = string;
 
-declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+type JoinStrategy = "concat-content" | "none";
 
-type ToolResponseLike<TResult> = {
-  result: TResult;
-  artifact?: ReadonlyJSONValue | undefined;
-  isError?: boolean | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-  messages?: ReadonlyJSONValue | undefined;
+type LanguageModelConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  reasoningEffort?: string;
 };
 
-declare class ToolResponse<TResult> {
-  get [TOOL_RESPONSE_SYMBOL](): boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: TResult;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-  constructor(options: ToolResponseLike<TResult>);
-  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
-  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
-}
-
-type ToolModelContentPart = {
-  readonly type: "text";
-  readonly text: string;
-} | {
-  readonly type: "file";
-  readonly data: string;
-  readonly mediaType: string;
-  readonly filename?: string;
+type LanguageModelV1CallSettings = {
+  maxTokens?: number;
+  temperature?: number;
+  topP?: number;
+  presencePenalty?: number;
+  frequencyPenalty?: number;
+  seed?: number;
+  headers?: Record<string, string | undefined>;
 };
 
-type ToolModelOutputFunction<TArgs, TResult> = (options: {
-  toolCallId: string;
-  input: TArgs;
-  output: TResult;
-}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
+  cloud?: AssistantCloud | undefined;
+  initialMessages?: readonly ThreadMessageLike[] | undefined;
+  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
+};
 
-interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
-  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
-  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
-  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
-  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
-}
-
-interface ToolCallResponseReader<TResult> {
-  get: () => Promise<ToolResponse<TResult>>;
-}
-
-interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
-  args: ToolCallArgsReader<TArgs>;
-  response: ToolCallResponseReader<TResult>;
-  result: {
-    get: () => Promise<TResult>;
+type LocalRuntimeOptionsBase = {
+  maxSteps?: number | undefined;
+  adapters: {
+    chatModel: ChatModelAdapter;
+    history?: ThreadHistoryAdapter | undefined;
+    attachments?: AttachmentAdapter | undefined;
+    speech?: SpeechSynthesisAdapter | undefined;
+    dictation?: DictationAdapter | undefined;
+    voice?: RealtimeVoiceAdapter | undefined;
+    feedback?: FeedbackAdapter | undefined;
+    suggestion?: SuggestionAdapter | undefined;
   };
-}
-
-type ToolExecutionContext = {
-  toolCallId: string;
-  abortSignal: AbortSignal;
-  human: (payload: unknown) => Promise<unknown>;
+  unstable_humanToolNames?: string[] | undefined;
+  unstable_enableMessageQueue?: boolean | undefined;
 };
 
-type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+declare const MCP_APP_MIME_TYPE: "text/html;profile=mcp-app";
 
-type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
-
-type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
-
-type ProviderOptions = Record<string, Record<string, unknown>>;
-
-type ToolDisplay = "inline" | "standalone";
-
-type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
-  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
-  display?: ToolDisplay;
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
-type BackendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: undefined;
-  parameters?: undefined;
-  disabled?: undefined;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: undefined;
+type McpAppDisplayMode = "fullscreen" | "inline" | "pip";
+
+type McpAppHostContext = {
+  theme?: "dark" | "light";
+  displayMode?: McpAppDisplayMode;
+  availableDisplayModes?: McpAppDisplayMode[];
+  [k: string]: unknown;
 };
 
-type BackendToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "backend";
-  description?: string | undefined;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
+type McpAppHostInfo = {
+  name: string;
+  version: string;
 };
 
-type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "frontend";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  execute?: ToolExecuteFunction<TArgs, TResult>;
-  toModelOutput?: ToolModelOutputFunction<TArgs, TResult>;
-  experimental_onSchemaValidationError?: OnSchemaValidationErrorFunction<TResult>;
-  providerOptions?: ProviderOptions;
+type McpAppMetadata = {
+  readonly resourceUri: string;
+  readonly mimeType?: string;
+  readonly visibility?: readonly ("app" | "model")[];
 };
 
-type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "human";
-  description?: string | undefined;
-  parameters: StandardSchemaV1<TArgs> | JSONSchema7;
-  disabled?: boolean;
-  display?: "standalone";
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+declare const McpAppRenderer: Resource<{
+  readonly render: ToolCallMessagePartComponent;
+}, [
+  options: McpAppRendererOptions
+]>;
+
+type McpAppRendererOptions = {
+  host: ResourceElement<McpAppsHost>;
+  sandbox?: McpAppSandboxConfig;
+  maxHeight?: number;
+  hostInfo?: McpAppHostInfo;
+  hostContext?: McpAppHostContext;
+  fallback?: ReactNode;
+  loadingFallback?: ReactNode;
+  errorFallback?: ReactNode | ((error: Error) => ReactNode);
 };
 
-type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
-  type: "provider";
-  providerId: `${string}.${string}`;
-  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
-  args: Record<string, unknown>;
-  supportsDeferredResults?: boolean;
-  description?: undefined;
-  disabled?: boolean;
-  execute?: undefined;
-  toModelOutput?: undefined;
-  experimental_onSchemaValidationError?: undefined;
-  providerOptions?: ProviderOptions;
+type McpAppResource = {
+  uri: string;
+  mimeType: typeof MCP_APP_MIME_TYPE;
+  html: string;
+  meta?: McpAppResourceMeta;
+};
+
+type McpAppResourceCSP = {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  [k: string]: unknown;
+};
+
+type McpAppResourceMeta = {
+  prefersBorder?: boolean;
+  csp?: McpAppResourceCSP;
+  permissions?: Record<string, unknown>;
+  [k: string]: unknown;
+};
+
+type McpAppResourceOutput = {
+  readonly render: ToolCallMessagePartComponent;
+};
+
+type McpAppSandboxConfig = SandboxHostConfig;
+
+type McpAppToolCallParams = {
+  name: string;
+  arguments?: Record<string, unknown>;
+};
+
+type McpAppsHost = {
+  loadResource: (params: {
+    uri: string;
+  }) => Promise<McpAppResource>;
+  callTool: (params: McpAppToolCallParams) => Promise<unknown>;
+  readResource: (params: {
+    uri: string;
+  }) => Promise<unknown>;
+  listResources: (params?: unknown) => Promise<unknown>;
+};
+
+declare const McpAppsRemoteHost: Resource<McpAppsHost, [
+  options: McpAppsRemoteHostOptions
+]>;
+
+type McpAppsRemoteHostOptions = {
+  url: string;
+  fetch?: typeof fetch;
+  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>);
 };
 
 type McpServerConfig = {
@@ -511,13 +2534,604 @@ type McpTool = ToolBase<Record<string, unknown>, unknown> & {
   providerOptions?: undefined;
 };
 
-type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+type McpToolkitDefinition = Record<string, McpToolkitEntry>;
 
-type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
-
-type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
-  type?: undefined;
+type McpToolkitEntry = McpServerConfig | {
+  server: McpServerConfig;
+  disabled?: boolean | undefined;
+  tools?: Record<string, McpToolkitToolConfig> | undefined;
 };
+
+type McpToolkitToolConfig = {
+  disabled?: boolean | undefined;
+};
+
+declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
+  get source(): "message";
+  remove(): never;
+}
+
+type MessageAttachmentState = CompleteAttachment & {
+  readonly source: "message";
+};
+
+type MessageAttachmentsComponentConfig = {
+  Image?: ComponentType | undefined;
+  Document?: ComponentType | undefined;
+  File?: ComponentType | undefined;
+  Attachment?: ComponentType | undefined;
+};
+
+declare const MessageByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
+
+type MessageCommonProps = {
+  readonly id: string;
+  readonly createdAt: Date;
+};
+
+interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
+  format: string;
+  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
+  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
+  getId(message: TMessage): string;
+}
+
+interface MessageFormatItem<TMessage> {
+  parentId: string | null;
+  message: TMessage;
+}
+
+interface MessageFormatRepository<TMessage> {
+  headId?: string | null;
+  messages: MessageFormatItem<TMessage>[];
+}
+
+type MessageIfFilters = {
+  user: boolean | undefined;
+  assistant: boolean | undefined;
+  system: boolean | undefined;
+  hasBranches: boolean | undefined;
+  copied: boolean | undefined;
+  lastOrHover: boolean | undefined;
+  last: boolean | undefined;
+  speaking: boolean | undefined;
+  hasAttachments: boolean | undefined;
+  hasContent: boolean | undefined;
+  submittedFeedback: "positive" | "negative" | null | undefined;
+};
+
+type MessagePartGroup = {
+  groupKey: string | undefined;
+  indices: number[];
+};
+
+declare namespace MessagePartPrimitiveImage {
+  type Element = ComponentRef<typeof Primitive$1.img>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.img>;
+}
+
+declare const MessagePartPrimitiveImage: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLImageElement> & import("react").ImgHTMLAttributes<HTMLImageElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLImageElement>, "ref"> & import("react").RefAttributes<HTMLImageElement>>;
+
+declare namespace MessagePartPrimitiveInProgress {
+  type Props = PropsWithChildren;
+}
+
+declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
+
+declare namespace MessagePartPrimitiveText {
+  type Element = ComponentRef<typeof Primitive$1.span>;
+  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.span>, "asChild" | "children"> & {
+    smooth?: boolean | SmoothOptions;
+    component?: ElementType;
+  };
+}
+
+declare const MessagePartPrimitiveText: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref">, "asChild" | "children"> & {
+  smooth?: boolean | SmoothOptions;
+  component?: ElementType;
+} & import("react").RefAttributes<HTMLSpanElement>>;
+
+type MessagePartRuntime = {
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  readonly path: MessagePartRuntimePath;
+  getState(): MessagePartState;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+declare class MessagePartRuntimeImpl implements MessagePartRuntime {
+  private contentBinding;
+  private messageApi?;
+  private threadApi?;
+  get path(): MessagePartRuntimePath;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  protected __internal_bindMethods(): void;
+  getState(): MessagePartState;
+  addToolResult(result: any | ToolResponse<any>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  subscribe(callback: () => void): Unsubscribe;
+}
+
+type MessagePartRuntimePath = MessageRuntimePath & {
+  readonly messagePartSelector: {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "toolCallId";
+    readonly toolCallId: string;
+  };
+};
+
+type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
+
+type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type MessagePartStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "complete";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
+  readonly error?: unknown;
+};
+
+declare namespace MessagePrimitiveAttachmentByIndex {
+  type Props = {
+    index: number;
+    components?: MessageAttachmentsComponentConfig;
+  };
+}
+
+declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
+
+declare namespace MessagePrimitiveAttachments {
+  type Props = {
+    components: MessageAttachmentsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      attachment: CompleteAttachment;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
+
+declare const MessagePrimitiveError: FC<PropsWithChildren>;
+
+declare namespace MessagePrimitiveGenerativeUI {
+  type Props = {
+    components: GenerativeUIComponentRegistry;
+    spec?: GenerativeUISpec | undefined;
+    Fallback?: ComponentType<{
+      component: string;
+      props?: unknown;
+    }> | undefined;
+  };
+}
+
+declare const MessagePrimitiveGenerativeUI: FC<MessagePrimitiveGenerativeUI.Props>;
+
+declare namespace MessagePrimitiveGroupedParts {
+  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly type: TKey;
+    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+    readonly indices: readonly number[];
+  };
+  type IndicatorPart = {
+    readonly type: "indicator";
+  };
+  type IndicatorMode = "always" | "empty" | "never" | "no-text";
+  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
+    readonly children: ReactNode;
+  };
+  type Props<TKey extends `group-${string}` = `group-${string}`> = {
+    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
+    readonly indicator?: IndicatorMode;
+    readonly children: (info: RenderInfo<TKey>) => ReactNode;
+  };
+}
+
+declare const MessagePrimitiveGroupedParts: {
+  <TKey extends `group-${string}`>(_param2: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
+  displayName: string;
+};
+
+declare namespace MessagePrimitiveIf {
+  type Props = PropsWithChildren<UseMessageIfProps>;
+}
+
+declare const MessagePrimitiveIf: FC<MessagePrimitiveIf.Props>;
+
+declare namespace MessagePrimitivePartByIndex {
+  type Props = {
+    index: number;
+    components: MessagePrimitiveParts$1.Props["components"];
+  };
+}
+
+declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
+
+declare namespace MessagePrimitiveParts {
+  type Props = MessagePrimitiveParts$1.Props;
+}
+
+declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
+
+declare namespace MessagePrimitiveParts$1 {
+  type DataConfig = {
+    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
+    Fallback?: DataMessagePartComponent | undefined;
+  };
+  type BaseComponents = {
+    Empty?: EmptyMessagePartComponent | undefined;
+    Text?: TextMessagePartComponent | undefined;
+    Source?: SourceMessagePartComponent | undefined;
+    Image?: ImageMessagePartComponent | undefined;
+    File?: FileMessagePartComponent | undefined;
+    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+    data?: DataConfig | undefined;
+    Quote?: QuoteMessagePartComponent | undefined;
+    generativeUI?: {
+      components: GenerativeUIComponentRegistry;
+      Fallback?: ComponentType<{
+        component: string;
+        props?: unknown;
+      }> | undefined;
+    } | undefined;
+  };
+  type ToolsConfig = {
+    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
+    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+  } | {
+    Override: ComponentType<ToolCallMessagePartProps>;
+  };
+  type StandardComponents = BaseComponents & {
+    Reasoning?: ReasoningMessagePartComponent | undefined;
+    tools?: ToolsConfig | undefined;
+    ToolGroup?: ComponentType<PropsWithChildren<{
+      startIndex: number;
+      endIndex: number;
+    }>>;
+    ReasoningGroup?: ReasoningGroupComponent;
+    ChainOfThought?: never;
+  };
+  type ChainOfThoughtComponents = BaseComponents & {
+    ChainOfThought: ComponentType;
+    Reasoning?: never;
+    tools?: never;
+    ToolGroup?: never;
+    ReasoningGroup?: never;
+  };
+  export type Props = {
+    components?: StandardComponents | ChainOfThoughtComponents | undefined;
+    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
+    children?: never;
+  } | {
+    children: (value: {
+      part: EnrichedPartState;
+    }) => ReactNode;
+    components?: never;
+    unstable_showEmptyOnNonTextEnd?: never;
+  };
+  export {};
+}
+
+declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
+
+declare namespace MessagePrimitiveQuote {
+  type Props = {
+    children: (value: QuoteInfo) => ReactNode;
+  };
+}
+
+declare const MessagePrimitiveQuote: import("react").NamedExoticComponent<MessagePrimitiveQuote.Props>;
+
+declare namespace MessagePrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
+
+declare const MessagePrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace MessagePrimitiveUnstable_PartsGrouped {
+  type Props = {
+    groupingFunction: GroupingFunction;
+    components: {
+      Empty?: EmptyMessagePartComponent | undefined;
+      Text?: TextMessagePartComponent | undefined;
+      Reasoning?: ReasoningMessagePartComponent | undefined;
+      Source?: SourceMessagePartComponent | undefined;
+      Image?: ImageMessagePartComponent | undefined;
+      File?: FileMessagePartComponent | undefined;
+      Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
+      data?: {
+        by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
+        Fallback?: DataMessagePartComponent | undefined;
+      } | undefined;
+      tools?: {
+        by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
+        Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
+      } | {
+        Override: ComponentType<ToolCallMessagePartProps>;
+      } | undefined;
+      Group?: ComponentType<PropsWithChildren<{
+        groupKey: string | undefined;
+        indices: number[];
+      }>>;
+    } | undefined;
+  };
+}
+
+declare const MessagePrimitiveUnstable_PartsGrouped: FC<MessagePrimitiveUnstable_PartsGrouped.Props>;
+
+declare const MessagePrimitiveUnstable_PartsGroupedByParentId: FC<Omit<MessagePrimitiveUnstable_PartsGrouped.Props, "groupingFunction">>;
+
+declare const MessageProvider: FC<PropsWithChildren<ThreadMessageClientProps>>;
+
+type MessageQueueController = {
+  readonly adapter: ExternalThreadQueueAdapter;
+  notifyBusy: () => void;
+  notifyIdle: () => void;
+  subscribe: (callback: () => void) => () => void;
+};
+
+type MessageQueueDriver = {
+  run: (message: AppendMessage, options: {
+    steer: boolean;
+  }) => void;
+  cancel?: (() => void) | undefined;
+};
+
+declare class MessageRepository {
+  private messages;
+  private head;
+  private root;
+  private updateLevels;
+  private performOp;
+  private _messages;
+  get headId(): string | null;
+  get canonicalHeadId(): string | null;
+  getMessages(headId?: string): readonly ThreadMessage[];
+  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
+  getMessage(messageId: string): {
+    parentId: string | null;
+    message: ThreadMessage;
+    index: number;
+  };
+  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
+  getBranches(messageId: string): string[];
+  private evictOffBranchOptimisticMessages;
+  switchToBranch(messageId: string): void;
+  resetHead(messageId: string | null): void;
+  clear(): void;
+  export(): ExportedMessageRepository;
+  import(_param3: ExportedMessageRepository): void;
+}
+
+type MessageRole = ThreadMessage["role"];
+
+type MessageRuntime = {
+  readonly path: MessageRuntimePath;
+  readonly composer: EditComposerRuntime;
+  getState(): MessageState$1;
+  delete(): void | Promise<void>;
+  reload(config?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param4: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param5: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntime;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "message";
+  };
+};
+
+declare class MessageRuntimeImpl implements MessageRuntime {
+  private _core;
+  private _threadBinding;
+  get path(): MessageRuntimePath;
+  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  readonly composer: EditComposerRuntimeImpl;
+  private _getEditComposerRuntimeCore;
+  getState(): ThreadMessage & {
+    readonly parentId: string | null;
+    readonly index: number;
+    readonly isLast: boolean;
+    readonly branchNumber: number;
+    readonly branchCount: number;
+    readonly speech: SpeechState | undefined;
+  };
+  delete(): void | Promise<void>;
+  reload(reloadConfig?: ReloadConfig): void;
+  speak(): void;
+  stopSpeaking(): void;
+  submitFeedback(_param6: {
+    type: "positive" | "negative";
+  }): void;
+  switchToBranch(_param7: {
+    position?: "previous" | "next" | undefined;
+    branchId?: string | undefined;
+  }): void;
+  unstable_getCopyText(): string;
+  subscribe(callback: () => void): Unsubscribe;
+  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
+  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
+  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
+}
+
+type MessageRuntimePath = ThreadRuntimePath & {
+  readonly messageSelector: {
+    readonly type: "messageId";
+    readonly messageId: string;
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  };
+};
+
+type MessageState = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+  readonly composer: ComposerState;
+  readonly parts: readonly PartState[];
+  readonly isCopied: boolean;
+  readonly isHovering: boolean;
+  readonly index: number;
+};
+
+type MessageState$1 = ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+};
+
+type MessageStateBinding = SubscribableWithState<ThreadMessage & {
+  readonly parentId: string | null;
+  readonly index: number;
+  readonly isLast: boolean;
+  readonly branchNumber: number;
+  readonly branchCount: number;
+  readonly speech: SpeechState | undefined;
+}, MessageRuntimePath>;
+
+type MessageStatus = {
+  readonly type: "running";
+} | {
+  readonly type: "requires-action";
+  readonly reason: "interrupt" | "tool-calls";
+} | {
+  readonly type: "complete";
+  readonly reason: "stop" | "unknown";
+} | {
+  readonly type: "incomplete";
+  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
+  readonly error?: ReadonlyJSONValue;
+};
+
+interface MessageStorageEntry<TPayload> {
+  id: string;
+  parent_id: string | null;
+  format: string;
+  content: TPayload;
+}
+
+type MessageTiming = {
+  readonly streamStartTime: number;
+  readonly firstTokenTime?: number;
+  readonly totalStreamTime?: number;
+  readonly tokenCount?: number;
+  readonly tokensPerSecond?: number;
+  readonly totalChunks: number;
+  readonly toolCallCount: number;
+};
+
+type MessagesComponentConfig = {
+  Message: ComponentType;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage?: ComponentType | undefined;
+  AssistantMessage?: ComponentType | undefined;
+  SystemMessage?: ComponentType | undefined;
+} | {
+  Message?: ComponentType | undefined;
+  EditComposer?: ComponentType | undefined;
+  UserEditComposer?: ComponentType | undefined;
+  AssistantEditComposer?: ComponentType | undefined;
+  SystemEditComposer?: ComponentType | undefined;
+  UserMessage: ComponentType;
+  AssistantMessage: ComponentType;
+  SystemMessage?: ComponentType | undefined;
+};
+
+declare const ModelContext: Resource<ClientOutput<"modelContext">, [
+]>;
+
+type ModelContext$1 = {
+  priority?: number | undefined;
+  system?: string | undefined;
+  tools?: Record<string, Tool<any, any>> | undefined;
+  callSettings?: LanguageModelV1CallSettings | undefined;
+  config?: LanguageModelConfig | undefined;
+  unstable_composerMetadata?: Record<string, unknown> | undefined;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => ModelContext$1;
+  subscribe?: (callback: () => void) => Unsubscribe;
+};
+
+declare class ModelContextRegistry implements ModelContextProvider {
+  private _tools;
+  private _instructions;
+  private _providers;
+  private _subscribers;
+  private _providerUnsubscribes;
+  getModelContext(): ModelContext$1;
+  subscribe(callback: () => void): Unsubscribe;
+  private notifySubscribers;
+  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
+  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
+  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
+}
+
+interface ModelContextRegistryInstructionHandle {
+  update(config: string | AssistantInstructionsConfig): void;
+  remove(): void;
+}
+
+interface ModelContextRegistryProviderHandle {
+  remove(): void;
+}
+
+interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
+  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
+  remove(): void;
+}
+
+type ObjectKey<T> = keyof T & (string | number);
 
 type ObjectStreamOperation = {
   readonly type: "set";
@@ -528,6 +3142,30 @@ type ObjectStreamOperation = {
   readonly path: readonly string[];
   readonly value: string;
 };
+
+type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
+
+type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
+  [K in TKey]?: undefined;
+} : {
+  [K in TKey]?: TValue | undefined;
+} : {
+  [K in TKey]: TValue;
+};
+
+type OverrideToolDeclarationCallbacks<T extends {
+  streamCall?: unknown;
+}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
+  type?: never;
+} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+declare const PartByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+}>>;
 
 type PartInit = {
   readonly type: "reasoning" | "text";
@@ -556,520 +3194,258 @@ type PartInit = {
   readonly parentId?: string;
 };
 
-type AssistantStreamChunk = {
-  readonly path: readonly number[];
-} & ({
-  readonly type: "part-start";
-  readonly part: PartInit;
+type PartMethods = {
+  getState(): PartState;
+  addToolResult(result: unknown | ToolResponse<unknown>): void;
+  resumeToolCall(payload: unknown): void;
+  respondToToolApproval(response: ToolApprovalResponse): void;
+  __internal_getRuntime?(): MessagePartRuntime;
+};
+
+declare namespace PartPrimitiveMessages {
+  type Props = {
+    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
+    children?: never;
+  } | {
+    children: (value: {
+      message: ThreadMessage;
+    }) => ReactNode;
+    components?: never;
+  };
+}
+
+declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
+
+type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+type PdfToImagesRequestBody = {
+  file_blob?: string | undefined;
+  file_url?: string | undefined;
+};
+
+type PdfToImagesResponse = {
+  success: boolean;
+  urls: string[];
+  message: string;
+};
+
+type PendingAttachment = BaseAttachment & {
+  status: PendingAttachmentStatus;
+  file: File;
+};
+
+type PendingAttachmentStatus = {
+  type: "running";
+  reason: "uploading";
+  progress: number;
 } | {
-  readonly type: "part-finish";
+  type: "requires-action";
+  reason: "composer-send";
 } | {
-  readonly type: "tool-call-args-text-finish";
-} | {
-  readonly type: "text-delta";
-  readonly textDelta: string;
-} | {
-  readonly type: "annotations";
-  readonly annotations: ReadonlyJSONValue[];
-} | {
-  readonly type: "data";
-  readonly data: ReadonlyJSONValue[];
-} | {
-  readonly type: "step-start";
+  type: "incomplete";
+  reason: "error" | "upload-paused";
+};
+
+declare const Primitive$1: {
+  a: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLAnchorElement> & import("react").AnchorHTMLAttributes<HTMLAnchorElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLAnchorElement>>;
+  button: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLButtonElement>>;
+  div: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLDivElement>>;
+  form: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLFormElement>>;
+  h2: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLHeadingElement> & import("react").HTMLAttributes<HTMLHeadingElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLHeadingElement>>;
+  h3: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLHeadingElement> & import("react").HTMLAttributes<HTMLHeadingElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLHeadingElement>>;
+  img: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLImageElement> & import("react").ImgHTMLAttributes<HTMLImageElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLImageElement>>;
+  input: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLInputElement> & import("react").InputHTMLAttributes<HTMLInputElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLInputElement>>;
+  label: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLLabelElement> & import("react").LabelHTMLAttributes<HTMLLabelElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLLabelElement>>;
+  li: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLLIElement> & import("react").LiHTMLAttributes<HTMLLIElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLLIElement>>;
+  nav: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLElement> & import("react").HTMLAttributes<HTMLElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLElement>>;
+  ol: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLOListElement> & import("react").OlHTMLAttributes<HTMLOListElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLOListElement>>;
+  p: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLParagraphElement> & import("react").HTMLAttributes<HTMLParagraphElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLParagraphElement>>;
+  select: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSelectElement> & import("react").SelectHTMLAttributes<HTMLSelectElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLSelectElement>>;
+  span: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLSpanElement>>;
+  svg: ForwardRefExoticComponent<Omit<import("react").SVGProps<SVGSVGElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<SVGSVGElement>>;
+  ul: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLUListElement> & import("react").HTMLAttributes<HTMLUListElement> & {
+    asChild?: boolean;
+  }, "ref"> & {
+    render?: ReactElement | undefined;
+  } & RefAttributes<HTMLUListElement>>;
+};
+
+type PrimitiveButtonProps = ComponentPropsWithoutRef<typeof Primitive$1.button>;
+
+type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PrimitiveDivProps$1 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PrimitiveDivProps$2 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PrimitiveDivProps$3 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PrimitiveDivProps$4 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PrimitiveDivProps$5 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+
+type PropFieldStatus = "complete" | "streaming";
+
+type ProviderOptions = Record<string, Record<string, unknown>>;
+
+type ProviderTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
+  type: "provider";
+  providerId: `${string}.${string}`;
+  parameters?: StandardSchemaV1<TArgs> | JSONSchema7 | undefined;
+  args: Record<string, unknown>;
+  supportsDeferredResults?: boolean;
+  description?: undefined;
+  disabled?: boolean;
+  execute?: undefined;
+  toModelOutput?: undefined;
+  experimental_onSchemaValidationError?: undefined;
+  providerOptions?: ProviderOptions;
+};
+
+type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
+
+type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
+  type: "provider";
+}>;
+
+type QueueItemMethods = {
+  getState(): QueueItemState;
+  steer(): void;
+  remove(): void;
+};
+
+declare namespace QueueItemPrimitiveRemove {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useQueueItemRemove>;
+}
+
+declare const QueueItemPrimitiveRemove: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace QueueItemPrimitiveSteer {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useQueueItemSteer>;
+}
+
+declare const QueueItemPrimitiveSteer: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace QueueItemPrimitiveText {
+  type Element = ComponentRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const QueueItemPrimitiveText: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+type QueueItemState = {
+  readonly id: string;
+  readonly prompt: string;
+};
+
+type QueuedCommand = AssistantTransportCommand;
+
+type QuoteInfo = {
+  readonly text: string;
   readonly messageId: string;
-} | {
-  readonly type: "step-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-  readonly isContinued: boolean;
-} | {
-  readonly type: "message-finish";
-  readonly finishReason: "content-filter" | "error" | "length" | "other" | "stop" | "tool-calls" | "unknown";
-  readonly usage: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  };
-} | {
-  readonly type: "result";
-  readonly artifact?: ReadonlyJSONValue;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly modelContent?: readonly ToolModelContentPart[];
-  readonly messages?: ReadonlyJSONValue;
-} | {
-  readonly type: "error";
-  readonly error: string;
-} | {
-  readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
-});
-
-type AssistantStream = ReadableStream<AssistantStreamChunk>;
-
-type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
-  headers?: Headers;
 };
 
-declare const AssistantStream: {
-  toResponse(stream: AssistantStream, transformer: AssistantStreamEncoder): Response;
-  fromResponse(response: Response, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
-  toByteStream(stream: AssistantStream, transformer: ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk>): ReadableStream<Uint8Array<ArrayBuffer>>;
-  fromByteStream(readable: ReadableStream<Uint8Array<ArrayBuffer>>, transformer: ReadableWritablePair<AssistantStreamChunk, Uint8Array<ArrayBuffer>>): ReadableStream<AssistantStreamChunk>;
+type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
+
+type QuoteMessagePartProps = QuoteInfo;
+
+type ReadonlyJSONArray = readonly ReadonlyJSONValue[];
+
+type ReadonlyJSONObject = {
+  readonly [key: string]: ReadonlyJSONValue;
 };
 
-type ToolCallTiming = {
-  readonly startedAt: number;
-  readonly completedAt?: number;
-};
+type ReadonlyJSONValue = null | string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray;
 
-type TextMessagePart = {
-  readonly type: "text";
-  readonly text: string;
-  readonly parentId?: string;
-};
+type ReadonlyStore<T> = Omit<StoreApi<T>, "destroy" | "setState">;
 
-type ReasoningMessagePart = {
-  readonly type: "reasoning";
-  readonly text: string;
-  readonly parentId?: string;
-};
-
-type SourceProviderMetadata = {
-  readonly [providerName: string]: ReadonlyJSONObject;
-};
-
-type SourceMessagePart = {
-  readonly type: "source";
-  readonly sourceType: "url";
-  readonly id: string;
-  readonly url: string;
-  readonly title?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-} | {
-  readonly type: "source";
-  readonly sourceType: "document";
-  readonly id: string;
-  readonly url?: undefined;
-  readonly title: string;
-  readonly mediaType: string;
-  readonly filename?: string;
-  readonly providerMetadata?: SourceProviderMetadata;
-  readonly parentId?: string;
-};
-
-type ImageMessagePart = {
-  readonly type: "image";
-  readonly image: string;
-  readonly filename?: string;
-};
-
-type FileMessagePart = {
-  readonly type: "file";
-  readonly filename?: string;
-  readonly data: string;
-  readonly mimeType: string;
-  readonly parentId?: string;
-};
-
-type Unstable_AudioMessagePart = {
-  readonly type: "audio";
-  readonly audio: {
-    readonly data: string;
-    readonly format: "mp3" | "wav";
-  };
-};
-
-type DataMessagePart<T = any> = {
-  readonly type: "data";
-  readonly name: string;
-  readonly data: T;
-};
-
-type GenerativeUINode = string | {
-  readonly component: string;
-  readonly props?: Record<string, unknown>;
-  readonly children?: readonly GenerativeUINode[];
-  readonly key?: string;
-};
-
-type GenerativeUISpec = {
-  readonly root: GenerativeUINode | readonly GenerativeUINode[];
-};
-
-type GenerativeUIMessagePart = {
-  readonly type: "generative-ui";
-  readonly spec: GenerativeUISpec;
-  readonly id?: string;
-  readonly parentId?: string;
-};
-
-type McpAppMetadata = {
-  readonly resourceUri: string;
-  readonly mimeType?: string;
-  readonly visibility?: readonly ("app" | "model")[];
-};
-
-type ToolCallMessagePartMcpMetadata = {
-  readonly app?: McpAppMetadata;
-};
-
-type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
-
-type ToolApprovalOption = {
-  readonly id: string;
-  readonly kind: ToolApprovalOptionKind | (string & {});
-  readonly label?: string;
-  readonly description?: string;
-  readonly grants?: readonly string[];
-  readonly confirm?: boolean | {
-    title?: string;
-    description?: string;
-  };
-};
-
-type ToolApprovalResponse = {
-  readonly approved: boolean;
-  readonly reason?: string;
-} | {
-  readonly optionId: string;
-  readonly reason?: string;
-} | {
-  readonly approved: boolean;
-  readonly optionId: string;
-  readonly reason?: string;
-};
-
-type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
-  readonly type: "tool-call";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly args: TArgs;
-  readonly result?: TResult | undefined;
-  readonly isError?: boolean | undefined;
-  readonly argsText: string;
-  readonly artifact?: unknown;
-  readonly timing?: ToolCallTiming;
-  readonly mcp?: ToolCallMessagePartMcpMetadata;
-  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
-  readonly interrupt?: {
-    type: "human";
-    payload: unknown;
-  };
-  readonly approval?: {
-    readonly id: string;
-    readonly approved?: boolean;
-    readonly reason?: string;
-    readonly isAutomatic?: boolean;
-    readonly options?: readonly ToolApprovalOption[];
-    readonly optionId?: string;
-    readonly resolution?: "cancelled" | "expired";
-  };
-  readonly parentId?: string;
-  readonly messages?: readonly ThreadMessage[];
-};
-
-type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
-
-type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
-
-type MessagePartStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "complete";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other";
-  readonly error?: unknown;
-};
-
-type ToolCallMessagePartStatus = {
-  readonly type: "requires-action";
-  readonly reason: "interrupt";
-} | MessagePartStatus;
-
-type MessageStatus = {
-  readonly type: "running";
-} | {
-  readonly type: "requires-action";
-  readonly reason: "interrupt" | "tool-calls";
-} | {
-  readonly type: "complete";
-  readonly reason: "stop" | "unknown";
-} | {
-  readonly type: "incomplete";
-  readonly reason: "cancelled" | "content-filter" | "error" | "length" | "other" | "tool-calls";
-  readonly error?: ReadonlyJSONValue;
-};
-
-type MessageTiming = {
-  readonly streamStartTime: number;
-  readonly firstTokenTime?: number;
-  readonly totalStreamTime?: number;
-  readonly tokenCount?: number;
-  readonly tokensPerSecond?: number;
-  readonly totalChunks: number;
-  readonly toolCallCount: number;
-};
-
-type ThreadStep = {
-  readonly messageId?: string;
-  readonly usage?: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-  } | undefined;
-};
-
-type MessageCommonProps = {
-  readonly id: string;
-  readonly createdAt: Date;
-};
-
-type ThreadSystemMessage = MessageCommonProps & {
-  readonly role: "system";
-  readonly content: readonly [
-    TextMessagePart
-  ];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadUserMessage = MessageCommonProps & {
-  readonly role: "user";
-  readonly content: readonly ThreadUserMessagePart[];
-  readonly attachments: readonly CompleteAttachment[];
-  readonly metadata: {
-    readonly unstable_state?: undefined;
-    readonly unstable_annotations?: undefined;
-    readonly unstable_data?: undefined;
-    readonly steps?: undefined;
-    readonly submittedFeedback?: undefined;
-    readonly timing?: undefined;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type ThreadAssistantMessage = MessageCommonProps & {
-  readonly role: "assistant";
-  readonly content: readonly ThreadAssistantMessagePart[];
-  readonly status: MessageStatus;
-  readonly metadata: {
-    readonly unstable_state: ReadonlyJSONValue;
-    readonly unstable_annotations: readonly ReadonlyJSONValue[];
-    readonly unstable_data: readonly ReadonlyJSONValue[];
-    readonly steps: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-};
-
-type BaseThreadMessage = {
-  readonly status?: ThreadAssistantMessage["status"];
-  readonly metadata: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[];
-    readonly unstable_data?: readonly ReadonlyJSONValue[];
-    readonly steps?: readonly ThreadStep[];
-    readonly submittedFeedback?: {
-      readonly type: "negative" | "positive";
-    };
-    readonly timing?: MessageTiming;
-    readonly isOptimistic?: boolean;
-    readonly custom: Record<string, unknown>;
-  };
-  readonly attachments?: ThreadUserMessage["attachments"];
-};
-
-type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
-
-type MessageRole = ThreadMessage["role"];
-
-type RunConfig = {
-  readonly custom?: Record<string, unknown>;
-};
-
-type AppendMessage = Omit<ThreadMessage, "id"> & {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig | undefined;
-  startRun?: boolean | undefined;
-  steer?: boolean | undefined;
-};
-
-type AttachmentAdapter = {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-};
-
-declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
+declare namespace ReadonlyThreadProvider {
+  type Props = PropsWithChildren<{
+    messages: readonly ThreadMessage[];
+  }>;
 }
 
-declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
-  accept: string;
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(): Promise<void>;
-}
-
-declare class CompositeAttachmentAdapter implements AttachmentAdapter {
-  private _adapters;
-  accept: string;
-  constructor(adapters: AttachmentAdapter[]);
-  add(state: {
-    file: File;
-  }): Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void, any>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-  remove(attachment: Attachment): Promise<void>;
-}
-
-type Unstable_TriggerItem = {
-  readonly id: string;
-  readonly type: string;
-  readonly label: string;
-  readonly description?: string | undefined;
-  readonly metadata?: ReadonlyJSONObject | undefined;
-};
-
-type Unstable_TriggerCategory = {
-  readonly id: string;
-  readonly label: string;
-};
-
-type Unstable_DirectiveSegment = {
-  readonly kind: "text";
-  readonly text: string;
-} | {
-  readonly kind: "mention";
-  readonly type: string;
-  readonly label: string;
-  readonly id: string;
-};
-
-type Unstable_DirectiveFormatter = {
-  serialize(item: Unstable_TriggerItem): string;
-  parse(text: string): readonly Unstable_DirectiveSegment[];
-};
-
-declare const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
-
-type FeedbackAdapterFeedback = {
-  message: ThreadMessage;
-  type: "negative" | "positive";
-};
-
-type FeedbackAdapter = {
-  submit: (feedback: FeedbackAdapterFeedback) => void;
-};
-
-type Unsubscribe = () => void;
-
-declare namespace SpeechSynthesisAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "finished";
-    error?: unknown;
-  };
-  type Utterance = {
-    status: Status;
-    cancel: () => void;
-    subscribe: (callback: () => void) => Unsubscribe;
-  };
-}
-
-type SpeechSynthesisAdapter = {
-  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-declare namespace DictationAdapter {
-  type Status = {
-    type: "running" | "starting";
-  } | {
-    type: "ended";
-    reason: "cancelled" | "error" | "stopped";
-  };
-  type Result = {
-    transcript: string;
-    isFinal?: boolean;
-  };
-  type Session = {
-    status: Status;
-    stop: () => Promise<void>;
-    cancel: () => void;
-    onSpeechStart: (callback: () => void) => Unsubscribe;
-    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
-    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
-  };
-}
-
-type DictationAdapter = {
-  listen: () => DictationAdapter.Session;
-  disableInputDuringDictation?: boolean;
-};
-
-declare class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
-  speak(text: string): SpeechSynthesisAdapter.Utterance;
-}
-
-interface SpeechRecognitionInstance extends EventTarget {
-  lang: string;
-  continuous: boolean;
-  interimResults: boolean;
-  start(): void;
-  stop(): void;
-  abort(): void;
-}
-
-interface SpeechRecognitionConstructor {
-  new (): SpeechRecognitionInstance;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition?: SpeechRecognitionConstructor;
-    webkitSpeechRecognition?: SpeechRecognitionConstructor;
-  }
-}
-
-declare class WebSpeechDictationAdapter implements DictationAdapter {
-  private _language;
-  private _continuous;
-  private _interimResults;
-  constructor(options?: {
-    language?: string;
-    continuous?: boolean;
-    interimResults?: boolean;
-  });
-  static isSupported(): boolean;
-  listen(): DictationAdapter.Session;
-}
+declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
 
 declare namespace RealtimeVoiceAdapter {
   type Status = {
@@ -1104,109 +3480,936 @@ type RealtimeVoiceAdapter = {
   }) => RealtimeVoiceAdapter.Session;
 };
 
-type VoiceSessionControls = {
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
+type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
+
+type ReasoningGroupProps = PropsWithChildren<{
+  startIndex: number;
+  endIndex: number;
+}>;
+
+type ReasoningMessagePart = {
+  readonly type: "reasoning";
+  readonly text: string;
+  readonly parentId?: string;
 };
 
-type VoiceSessionHelpers = {
-  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
-  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
-  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
-  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
-  emitVolume: (volume: number) => void;
-  isDisposed: () => boolean;
+type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
+
+type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
+
+type RegisteredTrigger = {
+  readonly char: string;
+  readonly behavior?: TriggerBehavior;
+  readonly resource: TriggerPopoverResourceOutput;
 };
 
-declare function createVoiceSession(options: {
-  abortSignal?: AbortSignal;
-}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
-
-type LanguageModelV1CallSettings = {
-  maxTokens?: number;
-  temperature?: number;
-  topP?: number;
-  presencePenalty?: number;
-  frequencyPenalty?: number;
-  seed?: number;
-  headers?: Record<string, string | undefined>;
+type ReloadConfig = {
+  runConfig?: RunConfig;
 };
 
-type LanguageModelConfig = {
-  apiKey?: string;
-  baseUrl?: string;
-  modelName?: string;
-  reasoningEffort?: string;
+type RemoteThreadInitializeResponse = {
+  remoteId: string;
+  externalId: string | undefined;
 };
 
-type ModelContext$1 = {
-  priority?: number | undefined;
-  system?: string | undefined;
-  tools?: Record<string, Tool<any, any>> | undefined;
-  callSettings?: LanguageModelV1CallSettings | undefined;
-  config?: LanguageModelConfig | undefined;
-  unstable_composerMetadata?: Record<string, unknown> | undefined;
+type RemoteThreadListAdapter = {
+  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
+  rename(remoteId: string, newTitle: string): Promise<void>;
+  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(remoteId: string): Promise<void>;
+  unarchive(remoteId: string): Promise<void>;
+  delete(remoteId: string): Promise<void>;
+  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
+  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
+  fetch(threadId: string): Promise<RemoteThreadMetadata>;
+  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
 };
 
-type ModelContextProvider = {
-  getModelContext: () => ModelContext$1;
-  subscribe?: (callback: () => void) => Unsubscribe;
+type RemoteThreadListOptions = {
+  runtimeHook: () => AssistantRuntime;
+  adapter: RemoteThreadListAdapter;
+  initialThreadId?: string | undefined;
+  threadId?: string | undefined;
+  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
+  allowNesting?: boolean | undefined;
 };
 
-type AssistantToolProps$1<TArgs extends Record<string, unknown>, TResult> = Tool<TArgs, TResult> & {
-  toolName: string;
-  render?: unknown;
+type RemoteThreadListPageOptions = {
+  after?: string | undefined;
 };
 
-type AssistantInstructionsConfig = {
-  disabled?: boolean | undefined;
-  instruction: string;
+type RemoteThreadListResponse = {
+  threads: RemoteThreadMetadata[];
+  nextCursor?: string | undefined;
 };
 
-type AssistantContextConfig = {
-  getContext: () => string;
-  disabled?: boolean | undefined;
+type RemoteThreadMetadata = {
+  readonly status: "archived" | "regular";
+  readonly remoteId: string;
+  readonly externalId?: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
 };
 
-declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+type ReportToolCall = {
+  tool_name: string;
+  tool_call_id: string;
+  tool_args?: string;
+  tool_result?: string;
+  tool_source?: "backend" | "frontend" | "mcp";
+  start_ms?: number;
+  end_ms?: number;
+  sampling_calls?: SamplingCallData[];
+};
 
-type ChatModelRunUpdate = {
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
+  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+}[Keys];
+
+type RequireAtLeastOne$1<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
+  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
+}[Keys];
+
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+type RespondToToolApprovalOptions = {
+  approvalId: string;
+  approved: boolean;
+  optionId?: string;
+  reason?: string;
+};
+
+type ResumeRunConfig = StartRunConfig & {
+  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+};
+
+type ResumeToolCallOptions = {
+  toolCallId: string;
+  payload: unknown;
+};
+
+type RunConfig = {
+  readonly custom?: Record<string, unknown>;
+};
+
+declare namespace RuntimeAdapterProvider {
+  type Props = {
+    adapters: RuntimeAdapters;
+    children: ReactNode;
+  };
+}
+
+declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
+
+type RuntimeAdapters = {
+  modelContext?: ModelContextProvider | undefined;
+  history?: ThreadHistoryAdapter | undefined;
+  attachments?: AttachmentAdapter | undefined;
+};
+
+type RuntimeCapabilities = {
+  readonly switchToBranch: boolean;
+  readonly switchBranchDuringRun: boolean;
+  readonly edit: boolean;
+  readonly reload: boolean;
+  readonly delete: boolean;
+  readonly cancel: boolean;
+  readonly unstable_copy: boolean;
+  readonly speech: boolean;
+  readonly dictation: boolean;
+  readonly voice: boolean;
+  readonly attachments: boolean;
+  readonly feedback: boolean;
+  readonly queue: boolean;
+};
+
+type SamplingCallData = {
+  model_id?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cached_input_tokens?: number;
+  duration_ms?: number;
+};
+
+type SandboxHostConfig = {
+  sandbox?: SandboxOption[];
+  useShadowDom?: boolean;
+  enableBrowserCaching?: boolean;
+  salt?: string;
+  product?: string;
+  className?: string;
+  style?: CSSProperties;
+  unsafeDocumentWrite?: boolean;
+};
+
+type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
+
+type SelectItemOverride = (item: Unstable_TriggerItem) => boolean;
+
+declare namespace SelectionToolbarPrimitiveQuote {
+  type Element = ComponentRef<typeof Primitive$1.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
+}
+
+declare const SelectionToolbarPrimitiveQuote: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace SelectionToolbarPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
+
+declare const SelectionToolbarPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+type SendCommandsRequestBody = {
+  commands: QueuedCommand[];
+  state: unknown;
+  system: string | undefined;
+  tools: Record<string, unknown> | undefined;
+  callSettings: LanguageModelV1CallSettings | undefined;
+  config: LanguageModelConfig | undefined;
+  threadId: string | null;
+  parentId?: string | null;
+  [key: string]: unknown;
+};
+
+type SendOptions = {
+  startRun?: boolean;
+  steer?: boolean;
+};
+
+type SerializedModelContext = {
+  system?: string;
+  tools?: Record<string, SerializedTool>;
+};
+
+type SerializedTool = {
+  description?: string;
+  parameters: any;
+  disabled?: boolean;
+  type?: string;
+};
+
+declare class SimpleImageAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare class SimpleTextAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+declare const SingleThreadList: Resource<ClientOutput<"threads">, [
+  SingleThreadListProps
+]>;
+
+type SingleThreadListProps = {
+  thread: ClientElement<"thread">;
+};
+
+type SizeHandle = {
+  setHeight: (height: number) => void;
+  unregister: Unsubscribe;
+};
+
+type SmoothOptions = {
+  drainMs?: number | undefined;
+  maxCharIntervalMs?: number | undefined;
+  maxCharsPerFrame?: number | undefined;
+  minCommitMs?: number | undefined;
+};
+
+type SnapshotCarrierMessage = {
+  role: string;
+  metadata?: unknown;
+  content?: readonly unknown[] | undefined;
+};
+
+type SourceMessagePart = {
+  readonly type: "source";
+  readonly sourceType: "url";
+  readonly id: string;
+  readonly url: string;
+  readonly title?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+} | {
+  readonly type: "source";
+  readonly sourceType: "document";
+  readonly id: string;
+  readonly url?: undefined;
+  readonly title: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+  readonly providerMetadata?: SourceProviderMetadata;
+  readonly parentId?: string;
+};
+
+type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
+
+type SourceMessagePartProps = MessagePartState & SourceMessagePart;
+
+type SourceProviderMetadata = {
+  readonly [providerName: string]: ReadonlyJSONObject;
+};
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognitionInstance;
+}
+
+interface SpeechRecognitionInstance extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  start(): void;
+  stop(): void;
+  abort(): void;
+}
+
+type SpeechState = {
+  readonly messageId: string;
+  readonly status: SpeechSynthesisAdapter.Status;
+};
+
+declare namespace SpeechSynthesisAdapter {
+  type Status = {
+    type: "running" | "starting";
+  } | {
+    type: "ended";
+    reason: "cancelled" | "error" | "finished";
+    error?: unknown;
+  };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
+
+type SpeechSynthesisAdapter = {
+  speak: (text: string) => SpeechSynthesisAdapter.Utterance;
+};
+
+type StartRunConfig = {
+  parentId: string | null;
+  sourceId: string | null;
+  runConfig: RunConfig;
+};
+
+type StateUpdater<TState> = TState | ((prev: TState) => TState);
+
+type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
+
+type SubmitFeedbackOptions = {
+  messageId: string;
+  type: "negative" | "positive";
+};
+
+type Subscribable = {
+  subscribe: (callback: () => void) => Unsubscribe;
+};
+
+type SubscribableWithState<TState, TPath> = Subscribable & {
+  path: TPath;
+  getState: () => TState;
+};
+
+type SuggestionAdapter = {
+  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
+};
+
+type SuggestionAdapterGenerateOptions = {
+  messages: readonly ThreadMessage[];
+};
+
+declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
+
+type SuggestionByIndexProviderProps = PropsWithChildren<{
+  index: number;
+}>;
+
+type SuggestionConfig = string | {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare namespace SuggestionPrimitiveDescription {
+  type Element = ElementRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const SuggestionPrimitiveDescription: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace SuggestionPrimitiveTitle {
+  type Element = ElementRef<typeof Primitive$1.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
+}
+
+declare const SuggestionPrimitiveTitle: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace SuggestionPrimitiveTrigger {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useSuggestionTrigger>;
+}
+
+declare const SuggestionPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+type SuggestionState = {
+  title: string;
+  label: string;
+  prompt: string;
+};
+
+declare const Suggestions: Resource<ClientOutput<"suggestions">, [
+  suggestions?: SuggestionConfig[] | undefined
+]>;
+
+type SuggestionsComponentConfig = {
+  Suggestion: ComponentType;
+};
+
+declare const TOOL_RESPONSE_SYMBOL: unique symbol;
+
+type TextMessagePart = {
+  readonly type: "text";
+  readonly text: string;
+  readonly parentId?: string;
+};
+
+type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
+
+type TextMessagePartProps = MessagePartState & TextMessagePart;
+
+declare const TextMessagePartProvider: FC<PropsWithChildren<{
+  text: string;
+  isRunning?: boolean;
+}>>;
+
+type TextPart = {
+  readonly type: "text";
+  readonly text: string;
+};
+
+type ThreadAssistantMessage = MessageCommonProps & {
+  readonly role: "assistant";
   readonly content: readonly ThreadAssistantMessagePart[];
-  readonly metadata?: Record<string, unknown>;
-};
-
-type ChatModelRunResult = {
-  readonly content?: readonly ThreadAssistantMessagePart[] | undefined;
-  readonly status?: MessageStatus | undefined;
-  readonly metadata?: {
-    readonly unstable_state?: ReadonlyJSONValue;
-    readonly unstable_annotations?: readonly ReadonlyJSONValue[] | undefined;
-    readonly unstable_data?: readonly ReadonlyJSONValue[] | undefined;
-    readonly steps?: readonly ThreadStep[] | undefined;
-    readonly timing?: MessageTiming | undefined;
-    readonly custom?: Record<string, unknown> | undefined;
+  readonly status: MessageStatus;
+  readonly metadata: {
+    readonly unstable_state: ReadonlyJSONValue;
+    readonly unstable_annotations: readonly ReadonlyJSONValue[];
+    readonly unstable_data: readonly ReadonlyJSONValue[];
+    readonly steps: readonly ThreadStep[];
+    readonly submittedFeedback?: {
+      readonly type: "negative" | "positive";
+    };
+    readonly timing?: MessageTiming;
+    readonly isOptimistic?: boolean;
+    readonly custom: Record<string, unknown>;
   };
 };
 
-type ChatModelRunOptions = {
-  readonly messages: readonly ThreadMessage[];
-  readonly runConfig: RunConfig;
-  readonly abortSignal: AbortSignal;
-  readonly context: ModelContext$1;
-  readonly unstable_assistantMessageId?: string | undefined;
-  readonly unstable_threadId?: string | undefined;
-  readonly unstable_parentId?: string | null | undefined;
-  unstable_getMessage(): ThreadMessage;
+type ThreadAssistantMessagePart = TextMessagePart | ReasoningMessagePart | ToolCallMessagePart | SourceMessagePart | FileMessagePart | ImageMessagePart | DataMessagePart | GenerativeUIMessagePart;
+
+declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
+  get source(): "thread-composer";
+}
+
+type ThreadComposerAttachmentState = Attachment & {
+  readonly source: "thread-composer";
 };
 
-type ChatModelAdapter = {
-  run(options: ChatModelRunOptions): Promise<ChatModelRunResult> | AsyncGenerator<ChatModelRunResult, void>;
+type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
+  readonly path: ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  readonly type: "thread";
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): AttachmentRuntime & {
+    source: "thread-composer";
+  };
 };
 
-type DataPrefixedPart = {
-  readonly type: `data-${string}`;
-  readonly data: any;
+type ThreadComposerRuntimeCore = ComposerRuntimeCore;
+
+type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
+  composerSource: "thread";
+}>;
+
+declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
+  get path(): ComposerRuntimePath & {
+    composerSource: "thread";
+  };
+  get type(): "thread";
+  private _getState;
+  constructor(core: ThreadComposerRuntimeCoreBinding);
+  getState(): ThreadComposerState;
+  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
+}
+
+type ThreadComposerState = BaseComposerState & {
+  readonly type: "thread";
+};
+
+type ThreadData = {
+  externalId: string;
+};
+
+type ThreadData$1 = {
+  externalId: string | undefined;
+};
+
+type ThreadHistoryAdapter = {
+  load(): Promise<ExportedMessageRepository & {
+    state?: ReadonlyJSONValue;
+    unstable_resume?: boolean;
+  }>;
+  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
+  append(item: ExportedMessageRepositoryItem): Promise<void>;
+  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
+  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
+};
+
+type ThreadIfFilters = {
+  empty: boolean | undefined;
+  running: boolean | undefined;
+  disabled: boolean | undefined;
+};
+
+declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
+  index: number;
+  archived: boolean;
+}>>;
+
+type ThreadListItemCoreState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+  readonly runtime?: ThreadRuntimeCore | undefined;
+};
+
+type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
+
+type ThreadListItemEventPayload = {
+  switchedTo: Record<string, never>;
+  switchedAway: Record<string, never>;
+};
+
+type ThreadListItemEventType = keyof ThreadListItemEventPayload;
+
+declare namespace ThreadListItemMorePrimitiveContent {
+  type Element = ComponentRef<typeof DropdownMenu.Content>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Content> & {
+    portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
+  };
+}
+
+declare const ThreadListItemMorePrimitiveContent: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & {
+  portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ThreadListItemMorePrimitiveItem {
+  type Element = ComponentRef<typeof DropdownMenu.Item>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Item>;
+}
+
+declare const ThreadListItemMorePrimitiveItem: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuItemProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ThreadListItemMorePrimitiveRoot {
+  type Props = DropdownMenu.DropdownMenuProps & {
+    sharedFocusGroup?: boolean | undefined;
+  };
+}
+
+declare const ThreadListItemMorePrimitiveRoot: FC<ThreadListItemMorePrimitiveRoot.Props>;
+
+declare namespace ThreadListItemMorePrimitiveSeparator {
+  type Element = ComponentRef<typeof DropdownMenu.Separator>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Separator>;
+}
+
+declare const ThreadListItemMorePrimitiveSeparator: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuSeparatorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ThreadListItemMorePrimitiveTrigger {
+  type Element = ComponentRef<typeof DropdownMenu.Trigger>;
+  type Props = WithRenderPropProps<typeof DropdownMenu.Trigger>;
+}
+
+declare const ThreadListItemMorePrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListItemPrimitiveArchive {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadListItemArchive>;
+}
+
+declare const ThreadListItemPrimitiveArchive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListItemPrimitiveDelete {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadListItemDelete>;
+}
+
+declare const ThreadListItemPrimitiveDelete: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListItemPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps;
+}
+
+declare const ThreadListItemPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ThreadListItemPrimitiveTitle {
+  type Props = {
+    fallback?: ReactNode;
+  };
+}
+
+declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
+
+declare namespace ThreadListItemPrimitiveTrigger {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadListItemTrigger>;
+}
+
+declare const ThreadListItemPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListItemPrimitiveUnarchive {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadListItemUnarchive>;
+}
+
+declare const ThreadListItemPrimitiveUnarchive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+type ThreadListItemRuntime = {
+  readonly path: ThreadListItemRuntimePath;
+  getState(): ThreadListItemState$1;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  detach(): void;
+  subscribe(callback: () => void): Unsubscribe;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  __internal_getRuntime(): ThreadListItemRuntime;
+};
+
+type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  private _core;
+  private _threadListBinding;
+  get path(): ThreadListItemRuntimePath;
+  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
+  protected __internal_bindMethods(): void;
+  getState(): ThreadListItemState$1;
+  switchTo(options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  rename(newTitle: string): Promise<void>;
+  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(): Promise<void>;
+  unarchive(): Promise<void>;
+  delete(): Promise<void>;
+  initialize(): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(): Promise<void>;
+  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
+  subscribe(callback: () => void): Unsubscribe;
+  detach(): void;
+  __internal_getRuntime(): ThreadListItemRuntime;
+}
+
+type ThreadListItemRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "index";
+    readonly index: number;
+  } | {
+    readonly type: "archiveIndex";
+    readonly index: number;
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
+  runtime: ThreadListItemRuntime;
+}>>;
+
+type ThreadListItemState = {
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemState$1 = {
+  readonly isMain: boolean;
+  readonly id: string;
+  readonly remoteId: string | undefined;
+  readonly externalId: string | undefined;
+  readonly status: ThreadListItemStatus;
+  readonly title?: string | undefined;
+  readonly lastMessageAt?: Date | undefined;
+  readonly custom?: Record<string, unknown> | undefined;
+};
+
+type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+
+type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
+
+type ThreadListItemsComponentConfig = {
+  ThreadListItem: ComponentType;
+};
+
+declare namespace ThreadListPrimitiveItemByIndex {
+  type Props = {
+    index: number;
+    archived?: boolean | undefined;
+    components: ThreadListItemsComponentConfig;
+  };
+}
+
+declare const ThreadListPrimitiveItemByIndex: FC<ThreadListPrimitiveItemByIndex.Props>;
+
+declare namespace ThreadListPrimitiveItems {
+  type Props = {
+    archived?: boolean | undefined;
+  } & ({
+    components: ThreadListItemsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      threadListItem: ThreadListItemState;
+    }) => ReactNode;
+    components?: never;
+  });
+}
+
+declare const ThreadListPrimitiveItems: FC<ThreadListPrimitiveItems.Props>;
+
+declare namespace ThreadListPrimitiveLoadMore {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadListLoadMore>;
+}
+
+declare const ThreadListPrimitiveLoadMore: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListPrimitiveNew {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<() => void>;
+}
+
+declare const ThreadListPrimitiveNew: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace ThreadListPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = PrimitiveDivProps$1;
+}
+
+declare const ThreadListPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+type ThreadListRuntime = {
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  readonly main: ThreadRuntime;
+  getById(threadId: string): ThreadRuntime;
+  readonly mainItem: ThreadListItemRuntime;
+  getItemById(threadId: string): ThreadListItemRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntime;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+};
+
+type ThreadListRuntimeCore = {
+  readonly isLoading: boolean;
+  readonly isLoadingMore?: boolean;
+  readonly hasMore?: boolean;
+  mainThreadId: string;
+  newThreadId: string | undefined;
+  threadIds: readonly string[];
+  archivedThreadIds: readonly string[];
+  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
+  getMainThreadRuntimeCore(): ThreadRuntimeCore;
+  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  getItemById(threadId: string): ThreadListItemCoreState | undefined;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload?(): Promise<void>;
+  loadMore?(): Promise<void>;
+  detach(threadId: string): Promise<void>;
+  rename(threadId: string, newTitle: string): Promise<void>;
+  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
+  archive(threadId: string): Promise<void>;
+  unarchive(threadId: string): Promise<void>;
+  delete(threadId: string): Promise<void>;
+  initialize(threadId: string): Promise<{
+    remoteId: string;
+    externalId: string | undefined;
+  }>;
+  generateTitle(threadId: string): Promise<void>;
+  subscribe(callback: () => void): Unsubscribe;
+};
+
+type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
+
+declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _core;
+  private _runtimeFactory;
+  private _getState;
+  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
+  protected __internal_bindMethods(): void;
+  switchToThread(threadId: string, options?: {
+    unarchive?: boolean;
+  }): Promise<void>;
+  switchToNewThread(): Promise<void>;
+  getLoadThreadsPromise(): Promise<void>;
+  reload(): Promise<void>;
+  loadMore(): Promise<void>;
+  getState(): ThreadListState;
+  subscribe(callback: () => void): Unsubscribe;
+  private _mainThreadListItemRuntime;
+  readonly main: ThreadRuntime;
+  get mainItem(): ThreadListItemRuntimeImpl;
+  getById(threadId: string): ThreadRuntime;
+  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
+  getItemById(threadId: string): ThreadListItemRuntimeImpl;
+}
+
+type ThreadListState = {
+  readonly mainThreadId: string;
+  readonly newThreadId: string | undefined;
+  readonly threadIds: readonly string[];
+  readonly archivedThreadIds: readonly string[];
+  readonly isLoading: boolean;
+  readonly isLoadingMore: boolean;
+  readonly hasMore: boolean;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+};
+
+type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);
+
+type ThreadMessageClientProps = {
+  message: ThreadMessage;
+  index: number;
+  isLast?: boolean;
+  branchNumber?: number;
+  branchCount?: number;
 };
 
 type ThreadMessageLike = {
@@ -1257,220 +4460,182 @@ type ThreadMessageLike = {
   } | undefined;
 };
 
-declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
-
-type ExportedMessageRepositoryItem = {
-  message: ThreadMessage;
-  parentId: string | null;
-  runConfig?: RunConfig;
-};
-
-type ExportedMessageRepository = {
-  headId?: string | null;
-  messages: Array<{
-    message: ThreadMessage;
-    parentId: string | null;
-    runConfig?: RunConfig;
-  }>;
-};
-
-declare const ExportedMessageRepository: {
-  fromArray: (messages: readonly ThreadMessageLike[]) => ExportedMessageRepository;
-  fromBranchableArray: (items: readonly {
-    message: ThreadMessageLike;
-    parentId: string | null;
-  }[], options?: {
-    headId?: string | null;
-  }) => ExportedMessageRepository;
-};
-
-declare class MessageRepository {
-  private messages;
-  private head;
-  private root;
-  private updateLevels;
-  private performOp;
-  private _messages;
-  get headId(): string | null;
-  get canonicalHeadId(): string | null;
-  getMessages(headId?: string): readonly ThreadMessage[];
-  addOrUpdateMessage(parentId: string | null, message: ThreadMessage): void;
-  getMessage(messageId: string): {
-    parentId: string | null;
-    message: ThreadMessage;
-    index: number;
-  };
-  deleteMessage(messageId: string, replacementId?: string | null | undefined): void;
-  getBranches(messageId: string): string[];
-  private evictOffBranchOptimisticMessages;
-  switchToBranch(messageId: string): void;
-  resetHead(messageId: string | null): void;
-  clear(): void;
-  export(): ExportedMessageRepository;
-  import(_param1: ExportedMessageRepository): void;
+declare namespace ThreadPrimitiveEmpty {
+  type Props = PropsWithChildren;
 }
 
-type QuoteInfo = {
-  readonly text: string;
-  readonly messageId: string;
-};
+declare const ThreadPrimitiveEmpty: FC<ThreadPrimitiveEmpty.Props>;
 
-type QueueItemState = {
-  readonly id: string;
-  readonly prompt: string;
-};
+declare namespace ThreadPrimitiveIf {
+  type Props = PropsWithChildren<UseThreadIfProps>;
+}
 
-type QueueItemMethods = {
-  getState(): QueueItemState;
-  steer(): void;
-  remove(): void;
-};
+declare const ThreadPrimitiveIf: FC<ThreadPrimitiveIf.Props>;
 
-type AttachmentAddErrorReason = "adapter-error" | "no-adapter" | "not-accepted";
+declare namespace ThreadPrimitiveMessageByIndex {
+  type Props = {
+    index: number;
+    components: MessagesComponentConfig;
+  };
+}
 
-type AttachmentAddErrorEvent = {
-  readonly reason: AttachmentAddErrorReason;
-  readonly message: string;
-  readonly attachmentId?: string;
-  readonly error?: Error;
-};
+declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
 
-type ComposerRuntimeEventPayload = {
-  send: Record<string, never>;
-  attachmentAdd: Record<string, never>;
-  attachmentAddError: AttachmentAddErrorEvent;
-};
+declare namespace ThreadPrimitiveMessages {
+  type Props = {
+    components: MessagesComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      message: MessageState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
 
-type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
+declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
 
-type ComposerRuntimeEventCallback<E extends ComposerRuntimeEventType> = (payload: ComposerRuntimeEventPayload[E]) => void;
+declare namespace ThreadPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
 
-type DictationState = {
-  readonly status: DictationAdapter.Status;
-  readonly transcript?: string;
-  readonly inputDisabled?: boolean;
-};
+declare const ThreadPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
 
-type SendOptions = {
-  startRun?: boolean;
-  steer?: boolean;
-};
+declare namespace ThreadPrimitiveScrollToBottom {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadScrollToBottom>;
+}
 
-type ComposerRuntimeCore = Readonly<{
-  isEditing: boolean;
-  canCancel: boolean;
-  canSend: boolean;
-  isEmpty: boolean;
-  attachments: readonly Attachment[];
-  attachmentAccept: string;
-  addAttachment: (fileOrAttachment: File | CreateAttachment) => Promise<void>;
-  removeAttachment: (attachmentId: string) => Promise<void>;
-  text: string;
-  setText: (value: string) => void;
-  role: MessageRole;
-  setRole: (role: MessageRole) => void;
-  runConfig: RunConfig;
-  setRunConfig: (runConfig: RunConfig) => void;
-  quote: QuoteInfo | undefined;
-  setQuote: (quote: QuoteInfo | undefined) => void;
-  reset: () => Promise<void>;
-  clearAttachments: () => Promise<void>;
-  send: (options?: SendOptions) => void;
-  cancel: () => void;
-  queue: readonly QueueItemState[];
-  steerQueueItem: (queueItemId: string) => void;
-  removeQueueItem: (queueItemId: string) => void;
-  dictation: DictationState | undefined;
-  startDictation: () => void;
-  stopDictation: () => void;
-  subscribe: (callback: () => void) => Unsubscribe;
-  unstable_on: <E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>) => Unsubscribe;
-}>;
+declare const ThreadPrimitiveScrollToBottom: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & useThreadScrollToBottom.Options & import("react").RefAttributes<HTMLButtonElement>>;
 
-type ThreadComposerRuntimeCore = ComposerRuntimeCore;
+declare namespace ThreadPrimitiveSuggestion {
+  type Element = ActionButtonElement;
+  type Props = ActionButtonProps<typeof useThreadSuggestion>;
+}
 
-type EditComposerRuntimeCore = ComposerRuntimeCore & Readonly<{
-  parentId: string | null;
-  sourceId: string | null;
-}>;
-
-type RuntimeCapabilities = {
-  readonly switchToBranch: boolean;
-  readonly switchBranchDuringRun: boolean;
-  readonly edit: boolean;
-  readonly reload: boolean;
-  readonly delete: boolean;
-  readonly cancel: boolean;
-  readonly unstable_copy: boolean;
-  readonly speech: boolean;
-  readonly dictation: boolean;
-  readonly voice: boolean;
-  readonly attachments: boolean;
-  readonly feedback: boolean;
-  readonly queue: boolean;
-};
-
-type AddToolResultOptions = {
-  messageId: string;
-  toolName: string;
-  toolCallId: string;
-  result: ReadonlyJSONValue;
-  isError: boolean;
-  artifact?: ReadonlyJSONValue | undefined;
-  modelContent?: readonly ToolModelContentPart[] | undefined;
-};
-
-type ResumeToolCallOptions = {
-  toolCallId: string;
-  payload: unknown;
-};
-
-type RespondToToolApprovalOptions = {
-  approvalId: string;
-  approved: boolean;
-  optionId?: string;
-  reason?: string;
-};
-
-type SubmitFeedbackOptions = {
-  messageId: string;
-  type: "negative" | "positive";
-};
-
-type ThreadSuggestion = {
+declare const ThreadPrimitiveSuggestion: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
   prompt: string;
-};
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+  autoSend?: boolean | undefined;
+  method?: "replace";
+} & import("react").RefAttributes<HTMLButtonElement>>;
 
-type SpeechState = {
-  readonly messageId: string;
-  readonly status: SpeechSynthesisAdapter.Status;
-};
+declare namespace ThreadPrimitiveSuggestionByIndex {
+  type Props = {
+    index: number;
+    components: SuggestionsComponentConfig;
+  };
+}
 
-type VoiceSessionState = {
-  readonly status: RealtimeVoiceAdapter.Status;
-  readonly isMuted: boolean;
-  readonly mode: RealtimeVoiceAdapter.Mode;
-};
+declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
 
-type ThreadRuntimeEventPayload = {
-  runStart: Record<string, never>;
-  runEnd: Record<string, never>;
-  initialize: Record<string, never>;
-  modelContextUpdate: Record<string, never>;
-};
+declare namespace ThreadPrimitiveSuggestions {
+  type Props = {
+    components: SuggestionsComponentConfig;
+    children?: never;
+  } | {
+    children: (value: {
+      suggestion: SuggestionState;
+    }) => ReactNode;
+    components?: never;
+  };
+}
 
-type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
+declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
 
-type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
+declare namespace ThreadPrimitiveUnstable_MessageById {
+  type Props = {
+    messageId: string;
+    components: MessagesComponentConfig;
+  };
+}
 
-type StartRunConfig = {
-  parentId: string | null;
-  sourceId: string | null;
-  runConfig: RunConfig;
-};
+declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
 
-type ResumeRunConfig = StartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
+declare namespace ThreadPrimitiveViewport {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div> & {
+    autoScroll?: boolean | undefined;
+    turnAnchor?: "top" | "bottom" | undefined;
+    topAnchorMessageClamp?: {
+      tallerThan?: string;
+      visibleHeight?: string;
+    };
+    scrollToBottomOnRunStart?: boolean | undefined;
+    scrollToBottomOnInitialize?: boolean | undefined;
+    scrollToBottomOnThreadSwitch?: boolean | undefined;
+  };
+}
+
+declare const ThreadPrimitiveViewport: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  autoScroll?: boolean | undefined;
+  turnAnchor?: "top" | "bottom" | undefined;
+  topAnchorMessageClamp?: {
+    tallerThan?: string;
+    visibleHeight?: string;
+  };
+  scrollToBottomOnRunStart?: boolean | undefined;
+  scrollToBottomOnInitialize?: boolean | undefined;
+  scrollToBottomOnThreadSwitch?: boolean | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+declare namespace ThreadPrimitiveViewportFooter {
+  type Element = ComponentRef<typeof Primitive$1.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
+}
+
+declare const ThreadPrimitiveViewportFooter: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+declare const ThreadPrimitiveViewportProvider: FC<ThreadViewportProviderProps>;
+
+type ThreadRuntime = {
+  readonly path: ThreadRuntimePath;
+  readonly composer: ThreadComposerRuntime;
+  getState(): ThreadState;
+  append(message: CreateAppendMessage): void;
+  deleteMessage(messageId: string): void | Promise<void>;
+  startRun(config: CreateStartRunConfig): void;
+  resumeRun(config: CreateResumeRunConfig): void;
+  exportExternalState(): any;
+  importExternalState(state: any): void;
+  subscribe(callback: () => void): Unsubscribe;
+  cancelRun(): void;
+  getModelContext(): ModelContext$1;
+  export(): ExportedMessageRepository;
+  import(repository: ExportedMessageRepository): void;
+  reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  getMessageByIndex(idx: number): MessageRuntime;
+  getMessageById(messageId: string): MessageRuntime;
+  stopSpeaking(): void;
+  connectVoice(): void;
+  disconnectVoice(): void;
+  getVoiceVolume(): number;
+  subscribeVoiceVolume(callback: () => void): Unsubscribe;
+  muteVoice(): void;
+  unmuteVoice(): void;
+  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 };
 
 type ThreadRuntimeCore = Readonly<{
@@ -1525,735 +4690,20 @@ type ThreadRuntimeCore = Readonly<{
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 }>;
 
-type SuggestionAdapterGenerateOptions = {
-  messages: readonly ThreadMessage[];
-};
-
-type SuggestionAdapter = {
-  generate: (options: SuggestionAdapterGenerateOptions) => Promise<readonly ThreadSuggestion[]> | AsyncGenerator<readonly ThreadSuggestion[], void>;
-};
-
-type Unstable_TriggerAdapter = {
-  categories(): readonly Unstable_TriggerCategory[];
-  categoryItems(categoryId: string): readonly Unstable_TriggerItem[];
-  search?(query: string): readonly Unstable_TriggerItem[];
-};
-
-interface MessageStorageEntry<TPayload> {
-  id: string;
-  parent_id: string | null;
-  format: string;
-  content: TPayload;
-}
-
-interface MessageFormatItem<TMessage> {
-  parentId: string | null;
-  message: TMessage;
-}
-
-interface MessageFormatRepository<TMessage> {
-  headId?: string | null;
-  messages: MessageFormatItem<TMessage>[];
-}
-
-interface MessageFormatAdapter<TMessage, TStorageFormat extends Record<string, unknown>> {
-  format: string;
-  encode(item: MessageFormatItem<TMessage>): TStorageFormat;
-  decode(stored: MessageStorageEntry<TStorageFormat>): MessageFormatItem<TMessage>;
-  getId(message: TMessage): string;
-}
-
-type GenericThreadHistoryAdapter<TMessage> = {
-  load(): Promise<MessageFormatRepository<TMessage>>;
-  append(item: MessageFormatItem<TMessage>): Promise<void>;
-  update?(item: MessageFormatItem<TMessage>, localMessageId: string): Promise<void>;
-  delete?(items: MessageFormatItem<TMessage>[]): Promise<void>;
-  reportTelemetry?(items: MessageFormatItem<TMessage>[], options?: {
-    durationMs?: number;
-    stepTimestamps?: {
-      start_ms: number;
-      end_ms: number;
-    }[];
-  }): void;
-};
-
-type ThreadHistoryAdapter = {
-  load(): Promise<ExportedMessageRepository & {
-    state?: ReadonlyJSONValue;
-    unstable_resume?: boolean;
-  }>;
-  resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
-  append(item: ExportedMessageRepositoryItem): Promise<void>;
-  delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
-  withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
-};
-
-declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
-
-type Unstable_InteractableSnapshotEntry = {
-  id: string;
-  name: string;
-  state: unknown;
-  partial?: boolean | undefined;
-};
-
-type SnapshotCarrierMessage = {
-  role: string;
-  metadata?: unknown;
-  content?: readonly unknown[] | undefined;
-};
-
-declare function unstable_getInteractableSnapshots(message: {
-  metadata?: unknown;
-}): Unstable_InteractableSnapshotEntry[] | undefined;
-
-declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
-
-type Unstable_InteractableVersion = {
-  state: unknown;
-  origin: "create" | "update" | "user-edit";
-  toolCallId?: string | undefined;
-};
-
-declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
-
-type ToolExecutionStatus = {
-  type: "executing";
-} | {
-  type: "interrupt";
-  payload: {
-    type: "human";
-    payload: unknown;
-  };
-};
-
-interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> = any, TResult = any> {
-  update(tool: AssistantToolProps$1<TArgs, TResult>): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryInstructionHandle {
-  update(config: string | AssistantInstructionsConfig): void;
-  remove(): void;
-}
-
-interface ModelContextRegistryProviderHandle {
-  remove(): void;
-}
-
-declare class ModelContextRegistry implements ModelContextProvider {
-  private _tools;
-  private _instructions;
-  private _providers;
-  private _subscribers;
-  private _providerUnsubscribes;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe;
-  private notifySubscribers;
-  addTool<TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps$1<TArgs, TResult>): ModelContextRegistryToolHandle<TArgs, TResult>;
-  addInstruction(config: string | AssistantInstructionsConfig): ModelContextRegistryInstructionHandle;
-  addProvider(provider: ModelContextProvider): ModelContextRegistryProviderHandle;
-}
-
-declare class AssistantFrameHost implements ModelContextProvider {
-  private _context;
-  private _subscribers;
-  private _pendingRequests;
-  private _requestCounter;
-  private _iframeWindow;
-  private _targetOrigin;
-  constructor(iframeWindow: Window, targetOrigin?: string);
-  private handleMessage;
-  private updateContext;
-  private callTool;
-  private sendRequest;
-  private requestContext;
-  private notifySubscribers;
-  getModelContext(): ModelContext$1;
-  subscribe(callback: () => void): Unsubscribe;
-  dispose(): void;
-}
-
-declare class AssistantFrameProvider {
-  private static _instance;
-  private _providers;
-  private _providerUnsubscribes;
-  private _targetOrigin;
-  private constructor();
-  private static getInstance;
-  private handleMessage;
-  private handleToolCall;
-  private sendMessage;
-  private getModelContext;
-  private broadcastUpdate;
-  static addModelContextProvider(provider: ModelContextProvider, targetOrigin?: string): Unsubscribe;
-  static dispose(): void;
-}
-
-type SerializedTool = {
-  description?: string;
-  parameters: any;
-  disabled?: boolean;
-  type?: string;
-};
-
-type SerializedModelContext = {
-  system?: string;
-  tools?: Record<string, SerializedTool>;
-};
-
-type FrameMessageType = "model-context-request" | "model-context-update" | "tool-call" | "tool-result";
-
-type FrameMessage = {
-  type: "model-context-request";
-} | {
-  type: "model-context-update";
-  context: SerializedModelContext;
-} | {
-  type: "tool-call";
-  id: string;
-  toolName: string;
-  args: unknown;
-} | {
-  type: "tool-result";
-  id: string;
-  result?: unknown;
-  error?: string;
-};
-
-declare const FRAME_MESSAGE_CHANNEL = "assistant-ui-frame";
-
-type ThreadListItemRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "archiveIndex";
-    readonly index: number;
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type ThreadRuntimePath = {
-  readonly ref: string;
-  readonly threadSelector: {
-    readonly type: "main";
-  } | {
-    readonly type: "threadId";
-    readonly threadId: string;
-  };
-};
-
-type MessageRuntimePath = ThreadRuntimePath & {
-  readonly messageSelector: {
-    readonly type: "messageId";
-    readonly messageId: string;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type MessagePartRuntimePath = MessageRuntimePath & {
-  readonly messagePartSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "toolCallId";
-    readonly toolCallId: string;
-  };
-};
-
-type AttachmentRuntimePath = ((MessageRuntimePath & {
-  readonly attachmentSource: "edit-composer" | "message";
-}) | (ThreadRuntimePath & {
-  readonly attachmentSource: "thread-composer";
-})) & {
-  readonly attachmentSelector: {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  } | {
-    readonly type: "index";
-    readonly index: number;
-  };
-};
-
-type ComposerRuntimePath = (ThreadRuntimePath & {
-  readonly composerSource: "thread";
-}) | (MessageRuntimePath & {
-  readonly composerSource: "edit";
-});
-
-type ThreadListItemStatus = "archived" | "deleted" | "new" | "regular";
-
-type ThreadListItemCoreState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-  readonly runtime?: ThreadRuntimeCore | undefined;
-};
-
-type ThreadListRuntimeCore = {
-  readonly isLoading: boolean;
-  readonly isLoadingMore?: boolean;
-  readonly hasMore?: boolean;
-  mainThreadId: string;
-  newThreadId: string | undefined;
-  threadIds: readonly string[];
-  archivedThreadIds: readonly string[];
-  readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
-  getMainThreadRuntimeCore(): ThreadRuntimeCore;
-  getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
-  getItemById(threadId: string): ThreadListItemCoreState | undefined;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload?(): Promise<void>;
-  loadMore?(): Promise<void>;
-  detach(threadId: string): Promise<void>;
-  rename(threadId: string, newTitle: string): Promise<void>;
-  updateCustom?(threadId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(threadId: string): Promise<void>;
-  unarchive(threadId: string): Promise<void>;
-  delete(threadId: string): Promise<void>;
-  initialize(threadId: string): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(threadId: string): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-type AssistantRuntimeCore = {
-  readonly threads: ThreadListRuntimeCore;
-  registerModelContextProvider: (provider: ModelContextProvider) => Unsubscribe;
-  getModelContextProvider: () => ModelContextProvider;
-  readonly RenderComponent?: ((...args: any[]) => unknown) | undefined;
-};
-
-declare const generateId: (size?: number) => string;
-
-type Subscribable = {
-  subscribe: (callback: () => void) => Unsubscribe;
-};
-
-type SubscribableWithState<TState, TPath> = Subscribable & {
-  path: TPath;
-  getState: () => TState;
-};
-
-declare class BaseSubscribable {
-  private _subscribers;
-  subscribe(callback: () => void): Unsubscribe;
-  waitForUpdate(): Promise<void>;
-  protected _notifySubscribers(): void;
-}
-
-type ComposerRuntimeCoreBinding = SubscribableWithState<ComposerRuntimeCore | undefined, ComposerRuntimePath>;
-
-type ThreadComposerRuntimeCoreBinding = SubscribableWithState<ThreadComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "thread";
-}>;
-
-type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeCore | undefined, ComposerRuntimePath & {
-  composerSource: "edit";
-}>;
-
-type MessageStateBinding = SubscribableWithState<ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-}, MessageRuntimePath>;
-
-type ThreadListItemState$1 = {
-  readonly isMain: boolean;
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type MessageAttachmentState = CompleteAttachment & {
-  readonly source: "message";
-};
-
-type ThreadComposerAttachmentState = Attachment & {
-  readonly source: "thread-composer";
-};
-
-type EditComposerAttachmentState = Attachment & {
-  readonly source: "edit-composer";
-};
-
-type AttachmentState = ThreadComposerAttachmentState | EditComposerAttachmentState | MessageAttachmentState;
-
-type AttachmentSnapshotBinding<Source extends AttachmentRuntimeSource> = SubscribableWithState<AttachmentState & {
-  source: Source;
-}, AttachmentRuntimePath & {
-  attachmentSource: Source;
-}>;
-
-type AttachmentRuntimeSource = AttachmentState["source"];
-
-type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRuntimeSource> = {
-  readonly path: AttachmentRuntimePath & {
-    attachmentSource: TSource;
-  };
-  readonly source: TSource;
-  getState(): AttachmentState & {
-    source: TSource;
-  };
-  remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
-  get path(): AttachmentRuntimePath & {
-    attachmentSource: Source;
-  };
-  abstract get source(): Source;
-  constructor(_core: AttachmentSnapshotBinding<Source>);
-  protected __internal_bindMethods(): void;
-  getState(): AttachmentState & {
-    source: Source;
-  };
-  abstract remove(): Promise<void>;
-  subscribe(callback: () => void): Unsubscribe;
-}
-
-declare abstract class ComposerAttachmentRuntime<Source extends "edit-composer" | "thread-composer"> extends AttachmentRuntimeImpl<Source> {
-  private _composerApi;
-  constructor(core: AttachmentSnapshotBinding<Source>, _composerApi: ComposerRuntimeCoreBinding);
-  remove(): Promise<void>;
-}
-
-declare class ThreadComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"thread-composer"> {
-  get source(): "thread-composer";
-}
-
-declare class EditComposerAttachmentRuntimeImpl extends ComposerAttachmentRuntime<"edit-composer"> {
-  get source(): "edit-composer";
-}
-
-declare class MessageAttachmentRuntimeImpl extends AttachmentRuntimeImpl<"message"> {
-  get source(): "message";
-  remove(): never;
-}
-
-type BaseComposerState = {
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly isEditing: boolean;
-  readonly isEmpty: boolean;
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly attachmentAccept: string;
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type ThreadComposerState = BaseComposerState & {
-  readonly type: "thread";
-};
-
-type EditComposerState = BaseComposerState & {
-  readonly type: "edit";
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type ComposerState$1 = ThreadComposerState | EditComposerState;
-
-type ComposerRuntime = {
-  readonly path: ComposerRuntimePath;
-  readonly type: "edit" | "thread";
-  getState(): ComposerState$1;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  setText(text: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  subscribe(callback: () => void): Unsubscribe;
-  getAttachmentByIndex(idx: number): AttachmentRuntime;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-};
-
-declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
-  get path(): ComposerRuntimePath;
-  abstract get type(): "edit" | "thread";
-  constructor(_core: ComposerRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  abstract getState(): ComposerState$1;
-  setText(text: string): void;
-  setRunConfig(runConfig: RunConfig): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): void;
-  cancel(): void;
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  setRole(role: MessageRole): void;
-  startDictation(): void;
-  stopDictation(): void;
-  setQuote(quote: QuoteInfo | undefined): void;
-  subscribe(callback: () => void): Unsubscribe;
-  private _eventSubscriptionSubjects;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): Unsubscribe;
-  abstract getAttachmentByIndex(idx: number): AttachmentRuntime;
-}
-
-type ThreadComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  readonly type: "thread";
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "thread-composer";
-  };
-};
-
-declare class ThreadComposerRuntimeImpl extends ComposerRuntimeImpl implements ThreadComposerRuntime {
-  get path(): ComposerRuntimePath & {
-    composerSource: "thread";
-  };
-  get type(): "thread";
-  private _getState;
-  constructor(core: ThreadComposerRuntimeCoreBinding);
-  getState(): ThreadComposerState;
-  getAttachmentByIndex(idx: number): ThreadComposerAttachmentRuntimeImpl;
-}
-
-type EditComposerRuntime = Omit<ComposerRuntime, "getAttachmentByIndex" | "getState"> & {
-  readonly path: ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  readonly type: "edit";
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "edit-composer";
-  };
-};
-
-declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
-  get path(): ComposerRuntimePath & {
-    composerSource: "edit";
-  };
-  get type(): "edit";
-  private _getState;
-  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
-  __internal_bindMethods(): void;
-  getState(): EditComposerState;
-  beginEdit(): void;
-  getAttachmentByIndex(idx: number): EditComposerAttachmentRuntimeImpl;
-}
-
-type MessagePartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type MessagePartSnapshotBinding = SubscribableWithState<MessagePartState, MessagePartRuntimePath>;
-
-type MessagePartRuntime = {
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  readonly path: MessagePartRuntimePath;
-  getState(): MessagePartState;
-  subscribe(callback: () => void): Unsubscribe;
-};
-
-declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
-  get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
-  protected __internal_bindMethods(): void;
-  getState(): MessagePartState;
-  addToolResult(result: any | ToolResponse<any>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  subscribe(callback: () => void): Unsubscribe;
-}
-
-type MessageState$1 = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly index: number;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
-  readonly speech: SpeechState | undefined;
-};
-
-type ReloadConfig = {
-  runConfig?: RunConfig;
-};
-
-type MessageRuntime = {
-  readonly path: MessageRuntimePath;
-  readonly composer: EditComposerRuntime;
-  getState(): MessageState$1;
-  delete(): void | Promise<void>;
-  reload(config?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param2: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param3: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntime;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntime;
-  getAttachmentByIndex(idx: number): AttachmentRuntime & {
-    source: "message";
-  };
-};
-
-declare class MessageRuntimeImpl implements MessageRuntime {
-  private _core;
-  private _threadBinding;
-  get path(): MessageRuntimePath;
-  constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  readonly composer: EditComposerRuntimeImpl;
-  private _getEditComposerRuntimeCore;
-  getState(): ThreadMessage & {
-    readonly parentId: string | null;
-    readonly index: number;
-    readonly isLast: boolean;
-    readonly branchNumber: number;
-    readonly branchCount: number;
-    readonly speech: SpeechState | undefined;
-  };
-  delete(): void | Promise<void>;
-  reload(reloadConfig?: ReloadConfig): void;
-  speak(): void;
-  stopSpeaking(): void;
-  submitFeedback(_param4: {
-    type: "positive" | "negative";
-  }): void;
-  switchToBranch(_param5: {
-    position?: "previous" | "next" | undefined;
-    branchId?: string | undefined;
-  }): void;
-  unstable_getCopyText(): string;
-  subscribe(callback: () => void): Unsubscribe;
-  getMessagePartByIndex(idx: number): MessagePartRuntimeImpl;
-  getMessagePartByToolCallId(toolCallId: string): MessagePartRuntimeImpl;
-  getAttachmentByIndex(idx: number): MessageAttachmentRuntimeImpl;
-}
-
-type CreateStartRunConfig = {
-  parentId: string | null;
-  sourceId?: string | null | undefined;
-  runConfig?: RunConfig | undefined;
-};
-
-type CreateResumeRunConfig = CreateStartRunConfig & {
-  stream?: (options: ChatModelRunOptions) => AsyncGenerator<ChatModelRunResult, void, unknown>;
-};
-
-type CreateAppendMessage = string | {
-  parentId?: string | null | undefined;
-  sourceId?: string | null | undefined;
-  role?: AppendMessage["role"] | undefined;
-  content: AppendMessage["content"];
-  attachments?: AppendMessage["attachments"] | undefined;
-  metadata?: AppendMessage["metadata"] | undefined;
-  createdAt?: Date | undefined;
-  runConfig?: AppendMessage["runConfig"] | undefined;
-  startRun?: boolean | undefined;
-};
-
 type ThreadRuntimeCoreBinding = SubscribableWithState<ThreadRuntimeCore, ThreadRuntimePath> & {
   outerSubscribe(callback: () => void): Unsubscribe;
 };
 
-type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
+type ThreadRuntimeEventCallback<E extends ThreadRuntimeEventType> = (payload: ThreadRuntimeEventPayload[E]) => void;
 
-type ThreadState = {
-  readonly threadId: string;
-  readonly metadata: ThreadListItemState$1;
-  readonly isDisabled: boolean;
-  readonly isLoading: boolean;
-  readonly isRunning: boolean;
-  readonly capabilities: RuntimeCapabilities;
-  readonly messages: readonly ThreadMessage[];
-  readonly state: ReadonlyJSONValue;
-  readonly suggestions: readonly ThreadSuggestion[];
-  readonly extras: unknown;
-  readonly speech: SpeechState | undefined;
-  readonly voice: VoiceSessionState | undefined;
+type ThreadRuntimeEventPayload = {
+  runStart: Record<string, never>;
+  runEnd: Record<string, never>;
+  initialize: Record<string, never>;
+  modelContextUpdate: Record<string, never>;
 };
 
-type ThreadRuntime = {
-  readonly path: ThreadRuntimePath;
-  readonly composer: ThreadComposerRuntime;
-  getState(): ThreadState;
-  append(message: CreateAppendMessage): void;
-  deleteMessage(messageId: string): void | Promise<void>;
-  startRun(config: CreateStartRunConfig): void;
-  resumeRun(config: CreateResumeRunConfig): void;
-  exportExternalState(): any;
-  importExternalState(state: any): void;
-  subscribe(callback: () => void): Unsubscribe;
-  cancelRun(): void;
-  getModelContext(): ModelContext$1;
-  export(): ExportedMessageRepository;
-  import(repository: ExportedMessageRepository): void;
-  reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  getMessageByIndex(idx: number): MessageRuntime;
-  getMessageById(messageId: string): MessageRuntime;
-  stopSpeaking(): void;
-  connectVoice(): void;
-  disconnectVoice(): void;
-  getVoiceVolume(): number;
-  subscribeVoiceVolume(callback: () => void): Unsubscribe;
-  muteVoice(): void;
-  unmuteVoice(): void;
-  unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
-};
+type ThreadRuntimeEventType = keyof ThreadRuntimeEventPayload;
 
 declare class ThreadRuntimeImpl implements ThreadRuntime {
   get path(): ThreadRuntimePath;
@@ -2375,1873 +4825,86 @@ declare class ThreadRuntimeImpl implements ThreadRuntime {
   unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe;
 }
 
-type ThreadListState = {
-  readonly mainThreadId: string;
-  readonly newThreadId: string | undefined;
-  readonly threadIds: readonly string[];
-  readonly archivedThreadIds: readonly string[];
+type ThreadRuntimePath = {
+  readonly ref: string;
+  readonly threadSelector: {
+    readonly type: "main";
+  } | {
+    readonly type: "threadId";
+    readonly threadId: string;
+  };
+};
+
+type ThreadState = {
+  readonly threadId: string;
+  readonly metadata: ThreadListItemState$1;
+  readonly isDisabled: boolean;
   readonly isLoading: boolean;
-  readonly isLoadingMore: boolean;
-  readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
-};
-
-type ThreadListRuntime = {
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  readonly main: ThreadRuntime;
-  getById(threadId: string): ThreadRuntime;
-  readonly mainItem: ThreadListItemRuntime;
-  getItemById(threadId: string): ThreadListItemRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntime;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntime;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-};
-
-type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
-
-declare class ThreadListRuntimeImpl implements ThreadListRuntime {
-  private _core;
-  private _runtimeFactory;
-  private _getState;
-  constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
-  protected __internal_bindMethods(): void;
-  switchToThread(threadId: string, options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  switchToNewThread(): Promise<void>;
-  getLoadThreadsPromise(): Promise<void>;
-  reload(): Promise<void>;
-  loadMore(): Promise<void>;
-  getState(): ThreadListState;
-  subscribe(callback: () => void): Unsubscribe;
-  private _mainThreadListItemRuntime;
-  readonly main: ThreadRuntime;
-  get mainItem(): ThreadListItemRuntimeImpl;
-  getById(threadId: string): ThreadRuntime;
-  getItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getArchivedItemByIndex(idx: number): ThreadListItemRuntimeImpl;
-  getItemById(threadId: string): ThreadListItemRuntimeImpl;
-}
-
-type ThreadListItemEventPayload = {
-  switchedTo: Record<string, never>;
-  switchedAway: Record<string, never>;
-};
-
-type ThreadListItemEventType = keyof ThreadListItemEventPayload;
-
-type ThreadListItemEventCallback<E extends ThreadListItemEventType> = (payload: ThreadListItemEventPayload[E]) => void;
-
-type ThreadListItemRuntime = {
-  readonly path: ThreadListItemRuntimePath;
-  getState(): ThreadListItemState$1;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  detach(): void;
-  subscribe(callback: () => void): Unsubscribe;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  __internal_getRuntime(): ThreadListItemRuntime;
-};
-
-type ThreadListItemStateBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
-
-declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
-  private _core;
-  private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
-  constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
-  protected __internal_bindMethods(): void;
-  getState(): ThreadListItemState$1;
-  switchTo(options?: {
-    unarchive?: boolean;
-  }): Promise<void>;
-  rename(newTitle: string): Promise<void>;
-  updateCustom(custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(): Promise<{
-    remoteId: string;
-    externalId: string | undefined;
-  }>;
-  generateTitle(): Promise<void>;
-  unstable_on<E extends ThreadListItemEventType>(event: E, callback: ThreadListItemEventCallback<E>): Unsubscribe;
-  subscribe(callback: () => void): Unsubscribe;
-  detach(): void;
-  __internal_getRuntime(): ThreadListItemRuntime;
-}
-
-declare const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
-
-declare const getExternalStoreMessages: <T>(input: {
-  messages: readonly ThreadMessage[];
-} | ThreadMessage | ThreadMessage["content"][number]) => T[];
-
-type LocalRuntimeOptionsBase = {
-  maxSteps?: number | undefined;
-  adapters: {
-    chatModel: ChatModelAdapter;
-    history?: ThreadHistoryAdapter | undefined;
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    suggestion?: SuggestionAdapter | undefined;
-  };
-  unstable_humanToolNames?: string[] | undefined;
-  unstable_enableMessageQueue?: boolean | undefined;
-};
-
-type ExternalThreadQueueAdapter = {
-  items: readonly QueueItemState[];
-  enqueue: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  steer: (queueItemId: string) => void;
-  remove: (queueItemId: string) => void;
-  clear: (reason: "cancel-run" | "edit" | "reload") => void;
-};
-
-type ExternalStoreThreadData<TState extends "archived" | "regular"> = {
-  status: TState;
-  id: string;
-  remoteId?: string | undefined;
-  externalId?: string | undefined;
-  title?: string | undefined;
-  custom?: Record<string, unknown> | undefined;
-};
-
-type ExternalStoreThreadListAdapter = {
-  threadId?: string | undefined;
-  isLoading?: boolean | undefined;
-  threads?: readonly ExternalStoreThreadData<"regular">[] | undefined;
-  archivedThreads?: readonly ExternalStoreThreadData<"archived">[] | undefined;
-  onSwitchToNewThread?: (() => Promise<void> | void) | undefined;
-  onSwitchToThread?: ((threadId: string) => Promise<void> | void) | undefined;
-  onRename?: (threadId: string, newTitle: string) => (Promise<void> | void) | undefined;
-  onUpdateCustom?: ((threadId: string, custom: Record<string, unknown> | undefined) => Promise<void> | void) | undefined;
-  onArchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onUnarchive?: ((threadId: string) => Promise<void> | void) | undefined;
-  onDelete?: ((threadId: string) => Promise<void> | void) | undefined;
-};
-
-type ExternalStoreMessageConverter<T> = (message: T, idx: number) => ThreadMessageLike;
-
-type ExternalStoreBranchChange = {
-  headId: string | null;
-  visibleMessageIds: readonly string[];
-};
-
-type ExternalStoreMessageConverterAdapter<T> = {
-  convertMessage: ExternalStoreMessageConverter<T>;
-};
-
-type ExternalStoreAdapterBase<T> = {
-  isDisabled?: boolean | undefined;
-  isSendDisabled?: boolean | undefined;
-  isRunning?: boolean | undefined;
-  isLoading?: boolean | undefined;
-  messages?: readonly T[];
-  messageRepository?: ExportedMessageRepository;
-  suggestions?: readonly ThreadSuggestion[] | undefined;
-  state?: ReadonlyJSONValue | undefined;
-  extras?: unknown;
-  setMessages?: ((messages: readonly T[]) => void) | undefined;
-  unstable_onBranchChange?: ((event: ExternalStoreBranchChange) => void) | undefined;
-  onImport?: ((messages: readonly ThreadMessage[]) => void) | undefined;
-  onExportExternalState?: (() => any) | undefined;
-  onLoadExternalState?: ((state: any) => void) | undefined;
-  onNew: (message: AppendMessage) => Promise<void>;
-  queue?: ExternalThreadQueueAdapter | undefined;
-  onEdit?: ((message: AppendMessage) => Promise<void>) | undefined;
-  onDelete?: ((messageId: string) => Promise<void> | void) | undefined;
-  onReload?: ((parentId: string | null, config: StartRunConfig) => Promise<void>) | undefined;
-  onResume?: ((config: ResumeRunConfig) => Promise<void>) | undefined;
-  onCancel?: (() => Promise<void>) | undefined;
-  onAddToolResult?: ((options: AddToolResultOptions) => Promise<void> | void) | undefined;
-  onResumeToolCall?: ((options: {
-    toolCallId: string;
-    payload: unknown;
-  }) => void) | undefined;
-  onRespondToToolApproval?: ((options: RespondToToolApprovalOptions) => Promise<void> | void) | undefined;
-  convertMessage?: ExternalStoreMessageConverter<T> | undefined;
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    speech?: SpeechSynthesisAdapter | undefined;
-    dictation?: DictationAdapter | undefined;
-    voice?: RealtimeVoiceAdapter | undefined;
-    feedback?: FeedbackAdapter | undefined;
-    threadList?: ExternalStoreThreadListAdapter | undefined;
-  } | undefined;
-  unstable_capabilities?: {
-    copy?: boolean | undefined;
-  } | undefined;
-  unstable_enableToolInvocations?: boolean | undefined;
-  setToolStatuses?: ((statuses: Record<string, ToolExecutionStatus>) => void) | undefined;
-};
-
-type ExternalStoreAdapter<T = ThreadMessage> = ExternalStoreAdapterBase<T> & (T extends ThreadMessage ? object : ExternalStoreMessageConverterAdapter<T>);
-
-type AssistantRuntime = {
-  readonly threads: ThreadListRuntime;
-  readonly thread: ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-};
-
-declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
-  readonly threads: ThreadListRuntimeImpl;
-  readonly _thread: ThreadRuntime;
-  constructor(_core: AssistantRuntimeCore);
-  protected __internal_bindMethods(): void;
-  get thread(): ThreadRuntime;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-}
-
-type RemoteThreadInitializeResponse = {
-  remoteId: string;
-  externalId: string | undefined;
-};
-
-type RemoteThreadMetadata = {
-  readonly status: "archived" | "regular";
-  readonly remoteId: string;
-  readonly externalId?: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type RemoteThreadListResponse = {
-  threads: RemoteThreadMetadata[];
-  nextCursor?: string | undefined;
-};
-
-type RemoteThreadListPageOptions = {
-  after?: string | undefined;
-};
-
-type RemoteThreadListAdapter = {
-  list(params?: RemoteThreadListPageOptions): Promise<RemoteThreadListResponse>;
-  rename(remoteId: string, newTitle: string): Promise<void>;
-  updateCustom?(remoteId: string, custom: Record<string, unknown> | undefined): Promise<void>;
-  archive(remoteId: string): Promise<void>;
-  unarchive(remoteId: string): Promise<void>;
-  delete(remoteId: string): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(remoteId: string, unstable_messages: readonly ThreadMessage[]): Promise<AssistantStream>;
-  fetch(threadId: string): Promise<RemoteThreadMetadata>;
-  unstable_Provider?: ComponentType<PropsWithChildren> | undefined;
-};
-
-type RemoteThreadListOptions = {
-  runtimeHook: () => AssistantRuntime;
-  adapter: RemoteThreadListAdapter;
-  initialThreadId?: string | undefined;
-  threadId?: string | undefined;
-  onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
-  allowNesting?: boolean | undefined;
-};
-
-type ExternalStoreSharedOptions = Pick<ExternalStoreAdapter, "isDisabled" | "isSendDisabled" | "suggestions" | "unstable_capabilities">;
-
-declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
-
-type ExternalThreadBranchAdapter = {
-  getBranches: (messageId: string) => readonly string[];
-  switchToBranch: (branchId: string) => void;
-};
-
-type MessageQueueDriver = {
-  run: (message: AppendMessage, options: {
-    steer: boolean;
-  }) => void;
-  cancel?: (() => void) | undefined;
-};
-
-type MessageQueueController = {
-  readonly adapter: ExternalThreadQueueAdapter;
-  notifyBusy: () => void;
-  notifyIdle: () => void;
-  subscribe: (callback: () => void) => () => void;
-};
-
-declare const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController;
-
-declare class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
-  list(): Promise<RemoteThreadListResponse>;
-  rename(): Promise<void>;
-  updateCustom(): Promise<void>;
-  archive(): Promise<void>;
-  unarchive(): Promise<void>;
-  delete(): Promise<void>;
-  initialize(threadId: string): Promise<RemoteThreadInitializeResponse>;
-  generateTitle(): Promise<AssistantStream>;
-  fetch(_threadId: string): Promise<RemoteThreadMetadata>;
-}
-
-type ExternalThreadMessage = ThreadMessage & {
-  id: string;
-};
-
-type ExternalThreadProps = {
-  messages: readonly ExternalThreadMessage[];
-  isRunning?: boolean;
-  isSendDisabled?: boolean;
-  onNew?: (message: AppendMessage) => void;
-  onEdit?: (message: AppendMessage) => void;
-  onReload?: (parentId: string | null) => void;
-  onStartRun?: () => void;
-  onCancel?: () => void;
-  queue?: ExternalThreadQueueAdapter;
-  branches?: ExternalThreadBranchAdapter;
-  onRespondToToolApproval?: (options: RespondToToolApprovalOptions) => void;
-};
-
-declare const ExternalThread: Resource<ClientOutput<"thread">, [
-  ExternalThreadProps
-]>;
-
-type InMemoryThreadListProps = {
-  thread: (threadId: string) => ResourceElement<ClientOutput<"thread">>;
-  onSwitchToThread?: (threadId: string) => void;
-  onSwitchToNewThread?: () => void;
-};
-
-declare const InMemoryThreadList: Resource<ClientOutput<"threads">, [
-  props: InMemoryThreadListProps
-]>;
-
-type SingleThreadListProps = {
-  thread: ClientElement<"thread">;
-};
-
-declare const SingleThreadList: Resource<ClientOutput<"threads">, [
-  SingleThreadListProps
-]>;
-
-declare class CompositeContextProvider implements ModelContextProvider {
-  private _providers;
-  getModelContext(): ModelContext$1;
-  registerModelContextProvider(provider: ModelContextProvider): () => void;
-  private _subscribers;
-  notifySubscribers(): void;
-  subscribe(callback: () => void): () => void;
-}
-
-declare abstract class BaseAssistantRuntimeCore implements AssistantRuntimeCore {
-  protected readonly _contextProvider: CompositeContextProvider;
-  abstract get threads(): ThreadListRuntimeCore;
-  registerModelContextProvider(provider: ModelContextProvider): Unsubscribe;
-  getModelContextProvider(): ModelContextProvider;
-}
-
-declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implements ComposerRuntimeCore {
-  readonly isEditing = true;
-  protected abstract getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected abstract getDictationAdapter(): DictationAdapter | undefined;
-  protected enrichWithComposerMetadata<T extends {
-    metadata?: {
-      custom?: Record<string, unknown>;
-    };
-  }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
-  get attachmentAccept(): string;
-  private _attachments;
-  get attachments(): readonly Attachment[];
-  protected setAttachments(value: readonly Attachment[]): void;
-  abstract get canCancel(): boolean;
-  abstract get canSend(): boolean;
-  get isEmpty(): boolean;
-  private _text;
-  get text(): string;
-  private _role;
-  get role(): "assistant" | "system" | "user";
-  private _runConfig;
-  get runConfig(): RunConfig;
-  private _quote;
-  get quote(): QuoteInfo | undefined;
-  setQuote(quote: QuoteInfo | undefined): void;
-  setText(value: string): void;
-  setRole(role: MessageRole): void;
-  setRunConfig(runConfig: RunConfig): void;
-  private _emptyTextAndAttachments;
-  private _onClearAttachments;
-  reset(): Promise<void>;
-  clearAttachments(): Promise<void>;
-  send(options?: SendOptions): Promise<void>;
-  cancel(): void;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(_queueItemId: string): void;
-  removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
-  protected abstract handleCancel(): void;
-  addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
-  private _safeEmitAttachmentAddError;
-  removeAttachment(attachmentId: string): Promise<void>;
-  private _dictation;
-  private _dictationSession;
-  private _dictationUnsubscribes;
-  private _dictationBaseText;
-  private _currentInterimText;
-  private _dictationSessionIdCounter;
-  private _activeDictationSessionId;
-  private _isCleaningDictation;
-  get dictation(): DictationState | undefined;
-  private _isActiveSession;
-  startDictation(): void;
-  stopDictation(): void;
-  private _cleanupDictation;
-  private _eventSubscribers;
-  protected _notifyEventSubscribers<E extends ComposerRuntimeEventType>(event: E, payload: ComposerRuntimeEventPayload[E]): void;
-  unstable_on<E extends ComposerRuntimeEventType>(event: E, callback: ComposerRuntimeEventCallback<E>): () => void;
-}
-
-declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
-  private _canCancel;
-  get canCancel(): boolean;
-  get canSend(): boolean;
-  get queue(): readonly QueueItemState[];
-  steerQueueItem(queueItemId: string): void;
-  removeQueueItem(queueItemId: string): void;
-  protected getAttachmentAdapter(): AttachmentAdapter | undefined;
-  protected getDictationAdapter(): DictationAdapter | undefined;
-  constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
-    adapters?: {
-      attachments?: AttachmentAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-    } | undefined;
-  });
-  connect(): Unsubscribe;
-  handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): Promise<void>;
-  handleCancel(): Promise<void>;
-}
-
-declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
-
-declare namespace AssistantRuntimeProvider {
-  type Props = PropsWithChildren<{
-    runtime: AssistantRuntime;
-    aui?: AssistantClient;
-  }>;
-}
-
-declare const AssistantRuntimeProvider: import("react").NamedExoticComponent<AssistantRuntimeProvider.Props>;
-
-type PartState = (ThreadUserMessagePart | ThreadAssistantMessagePart) & {
-  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-type PartMethods = {
-  getState(): PartState;
-  addToolResult(result: unknown | ToolResponse<unknown>): void;
-  resumeToolCall(payload: unknown): void;
-  respondToToolApproval(response: ToolApprovalResponse): void;
-  __internal_getRuntime?(): MessagePartRuntime;
-};
-
-declare const DataRenderers: Resource<ClientOutput<"dataRenderers">, [
-]>;
-
-type EmptyMessagePartProps = {
-  status: MessagePartStatus;
-};
-
-type EmptyMessagePartComponent = ComponentType<EmptyMessagePartProps>;
-
-type TextMessagePartProps = MessagePartState & TextMessagePart;
-
-type TextMessagePartComponent = ComponentType<TextMessagePartProps>;
-
-type ReasoningMessagePartProps = MessagePartState & ReasoningMessagePart;
-
-type ReasoningMessagePartComponent = ComponentType<ReasoningMessagePartProps>;
-
-type ReasoningGroupProps = PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>;
-
-type ReasoningGroupComponent = ComponentType<ReasoningGroupProps>;
-
-type SourceMessagePartProps = MessagePartState & SourceMessagePart;
-
-type SourceMessagePartComponent = ComponentType<SourceMessagePartProps>;
-
-type ImageMessagePartProps = MessagePartState & ImageMessagePart;
-
-type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
-
-type FileMessagePartProps = MessagePartState & FileMessagePart;
-
-type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
-
-type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
-
-type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
-
-type DataMessagePartProps<T = any> = MessagePartState & DataMessagePart<T>;
-
-type DataMessagePartComponent<T = any> = ComponentType<DataMessagePartProps<T>>;
-
-type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
-  addResult: (result: TResult | ToolResponse<TResult>) => void;
-  resume: (payload: unknown) => void;
-  respondToApproval: (response: ToolApprovalResponse) => void;
-};
-
-type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
-
-type QuoteMessagePartProps = QuoteInfo;
-
-type QuoteMessagePartComponent = ComponentType<QuoteMessagePartProps>;
-
-type GenerativeUIComponentRegistry = Record<string, ComponentType<any>>;
-
-type GenerativeUIMessagePartProps = MessagePartState & GenerativeUIMessagePart;
-
-type GenerativeUIMessagePartComponent = ComponentType<GenerativeUIMessagePartProps>;
-
-type GenerativeUIRenderProps = {
-  spec: GenerativeUISpec;
-  components: GenerativeUIComponentRegistry;
-  Fallback?: ComponentType<{
-    component: string;
-    props?: unknown;
-  }> | undefined;
-};
-
-type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type InteractableScope = "app" | "thread";
-
-type Unstable_InteractableDefinition = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  state: unknown;
-  initialState: unknown;
-  scope?: InteractableScope | undefined;
-};
-
-type Unstable_InteractableRegistration = {
-  id: string;
-  name: string;
-  description: string;
-  stateSchema: Unstable_InteractableStateSchema;
-  initialState: unknown;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-type Unstable_InteractablePersistenceStatus = {
-  isPending: boolean;
-  error: unknown;
-};
-
-type Unstable_InteractablesState = {
-  definitions: Record<string, Unstable_InteractableDefinition>;
-  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
-};
-
-type Unstable_InteractablePersistedState = Record<string, {
-  name: string;
-  state: unknown;
-}>;
-
-type Unstable_InteractablePersistenceAdapter = {
-  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
-  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
-};
-
-type Unstable_InteractablesConfig = {
-  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
-};
-
-type Unstable_InteractablesMethods = {
-  getState(): Unstable_InteractablesState;
-  register(def: Unstable_InteractableRegistration): Unsubscribe;
-  setState(id: string, updater: (prev: unknown) => unknown): void;
-  exportState(): Unstable_InteractablePersistedState;
-  importState(saved: Unstable_InteractablePersistedState): void;
-  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
-  flush(): Promise<void>;
-};
-
-type Unstable_InteractablesClientSchema = {
-  methods: Unstable_InteractablesMethods;
-};
-
-declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
-  (Unstable_InteractablesConfig | undefined)?
-]>;
-
-type McpAppResourceOutput = {
-  readonly render: ToolCallMessagePartComponent;
-};
-
-type ToolRegistration = {
-  readonly render: ToolCallMessagePartComponent;
-  readonly standalone: boolean;
-};
-
-type ToolsState = {
-  toolUIs: Record<string, readonly ToolRegistration[]>;
-  mcpApp?: McpAppResourceOutput | undefined;
-  tools: Record<string, ToolCallMessagePartComponent[]>;
-};
-
-type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
-  type: "frontend" | "human";
-} ? T & (T extends {
-  type: "frontend";
-} ? {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-} | {
-  render?: ToolCallMessagePartComponent<TArgs, TResult>;
-  renderText: ToolCallText<TArgs, TResult>;
-} : {
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-}) : T & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
-
-type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
-
-type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
-
-type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
-
-type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
-  args: TArgs;
-}) => ReactNode);
-
-type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
-  args: TArgs;
-  result: TResult | undefined;
-}) => ReactNode);
-
-type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
-  running: ToolCallRunningText<TArgs>;
-  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
-} | {
-  running?: ToolCallRunningText<TArgs> | undefined;
-  complete: ToolCallCompleteText<TArgs, TResult>;
-};
-
-type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
-
-type Toolkit = Record<string, ToolDefinition<any, any>>;
-
-type OverrideOptionalField<T, TKey extends keyof T, TValue> = undefined extends T[TKey] ? Exclude<T[TKey], undefined> extends never ? {
-  [K in TKey]?: undefined;
-} : {
-  [K in TKey]?: TValue | undefined;
-} : {
-  [K in TKey]: TValue;
-};
-
-type OverrideToolDeclarationCallbacks<T extends {
-  streamCall?: unknown;
-}, TArgs extends Record<string, unknown>, TResult> = Omit<T, "execute" | "experimental_onSchemaValidationError" | "streamCall" | "toModelOutput" | "type"> & {
-  type?: never;
-} & ("execute" extends keyof T ? OverrideOptionalField<T, "execute", ToolExecute<NoInfer<TArgs>, TResult>> : {}) & ("toModelOutput" extends keyof T ? OverrideOptionalField<T, "toModelOutput", ToolModelOutputFunction<NoInfer<TArgs>, NoInfer<TResult>>> : {}) & ("experimental_onSchemaValidationError" extends keyof T ? OverrideOptionalField<T, "experimental_onSchemaValidationError", (args: unknown, context: ToolExecuteContext) => NoInfer<TResult> | Promise<NoInfer<TResult>>> : {}) & OverrideOptionalField<T, "streamCall", ToolStreamCall<TArgs, unknown>>;
-
-type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
-  streamCall?: unknown;
-} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
-
-type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
-
-type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
-  parameters: NonNullable<ToolParameters<TArgs>>;
-};
-
-type ToolkitDefinition<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-} = Record<string, any>, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}> = {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
-};
-
-declare const Tools: Resource<ClientOutput<"tools">, [
-  {
-    toolkit?: Toolkit;
-    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
-  }
-]>;
-
-type AssistantToolProps<TArgs extends Record<string, unknown>, TResult> = AssistantToolProps$1<TArgs, TResult> & {
-  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
-  renderText?: ToolCallText<TArgs, TResult> | undefined;
-};
-
-declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
-
-type AssistantTool = FC & {
-  unstable_tool: AssistantToolProps<any, any>;
-};
-
-declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
-
-type AssistantToolUIProps<TArgs, TResult> = {
-  toolName: string;
-  render: ToolCallMessagePartComponent<TArgs, TResult>;
-  display?: "inline" | "standalone";
-};
-
-declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
-
-type AssistantToolUI = FC & {
-  unstable_tool: AssistantToolUIProps<any, any>;
-};
-
-declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
-
-type AssistantDataUIProps<T = any> = {
-  name: string;
-  render: DataMessagePartComponent<T>;
-};
-
-declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
-
-type AssistantDataUI = FC & {
-  unstable_data: AssistantDataUIProps;
-};
-
-declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
-
-declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
-
-declare const useAssistantContext: (config: AssistantContextConfig) => void;
-
-declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
-
-declare function defineToolkit<TArgsByName extends {
-  [K in keyof TArgsByName]: Record<string, unknown>;
-}, TResultByName extends {
-  [K in keyof TArgsByName]: unknown;
-} = {
-  [K in keyof TArgsByName]: any;
-}>(_definition: {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-}): Toolkit & {
-  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
-};
-
-declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
-
-declare function stubTool(): never;
-
-declare function externalTool(): never;
-
-type AuiToolOverride<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = Partial<Tool<TArgs, TResult>>;
-
-type AuiToolOverrides = Record<string, AuiToolOverride<any, any>>;
-
-declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
-
-declare function humanTool(): never;
-
-declare const hitlTool: typeof humanTool;
-
-declare const hitl: typeof humanTool;
-
-type ProviderToolDefinition<TArgs extends Record<string, unknown>> = Extract<Tool<TArgs, unknown>, {
-  type: "provider";
-}>;
-
-type ProviderToolConfig<TArgs extends Record<string, unknown> = Record<string, unknown>> = Pick<ProviderToolDefinition<TArgs>, "args" | "parameters" | "providerId" | "providerOptions" | "supportsDeferredResults">;
-
-declare function providerTool(_config: ProviderToolConfig): never;
-
-type McpToolkitEntry = McpServerConfig | {
-  server: McpServerConfig;
-  disabled?: boolean | undefined;
-  tools?: Record<string, McpToolkitToolConfig> | undefined;
-};
-
-type McpToolkitToolConfig = {
-  disabled?: boolean | undefined;
-};
-
-type McpToolkitDefinition = Record<string, McpToolkitEntry>;
-
-declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
-
-type InteractableStateSchema = NonNullable<Extract<Tool, {
-  parameters: unknown;
-}>["parameters"]>;
-
-type AssistantInteractableProps = {
-  description: string;
-  stateSchema: InteractableStateSchema;
-  initialState: unknown;
-  id?: string;
-  selected?: boolean;
-};
-
-declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
-
-type StateUpdater$1<TState> = TState | ((prev: TState) => TState);
-
-declare const useInteractableState: <TState>(id: string, fallback: TState) => [
-  TState,
-  {
-    setState: (updater: StateUpdater$1<TState>) => void;
-    setSelected: (selected: boolean) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type Unstable_InferInteractableState<TSchema> = TSchema extends {
-  "~standard": {
-    types?: {
-      output: infer TOutput;
-    } | undefined;
-  };
-} ? TOutput : unknown;
-
-type Unstable_InteractableVersionInfo<TState> = {
-  state: TState;
-  isLatest: boolean;
-  restore: () => void;
-};
-
-type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  initialState: Unstable_InferInteractableState<TSchema>;
-  id?: string | undefined;
-  updateRender?: ToolCallMessagePartComponent | undefined;
-};
-
-declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
-  Unstable_InferInteractableState<TSchema>,
-  {
-    id: string;
-    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
-    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-type StateUpdater<TState> = TState | ((prev: TState) => TState);
-
-declare const unstable_useInteractableState: <TState>(id: string) => [
-  TState | undefined,
-  {
-    setState: (updater: StateUpdater<TState>) => void;
-    isPending: boolean;
-    error: unknown;
-    flush: () => Promise<void>;
-  }
-];
-
-declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
-  state: TState;
-  restore: () => void;
-})[];
-
-type Unstable_InteractableToolRenderProps<TState> = {
-  state: TState;
-  setState: (updater: TState | ((prev: TState) => TState)) => void;
-  version: Unstable_InteractableVersionInfo<TState> | undefined;
-  id: string;
-  streaming: boolean;
-};
-
-type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
-  description: string;
-  stateSchema: TSchema;
-  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
-};
-
-declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
-  success: true;
-}>;
-
-type PropFieldStatus = "complete" | "streaming";
-
-type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
-  status: "complete" | "incomplete" | "requires-action" | "running";
-  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
-};
-
-declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
-
-declare const Interactables: Resource<ClientOutput<"interactables">, [
-]>;
-
-declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const ThreadListItemRuntimeProvider: FC<PropsWithChildren<{
-  runtime: ThreadListItemRuntime;
-}>>;
-
-declare const MessageByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const PartByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-}>>;
-
-declare const TextMessagePartProvider: FC<PropsWithChildren<{
-  text: string;
-  isRunning?: boolean;
-}>>;
-
-declare const ChainOfThoughtByIndicesProvider: FC<PropsWithChildren<{
-  startIndex: number;
-  endIndex: number;
-}>>;
-
-declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
-  index: number;
-  archived: boolean;
-}>>;
-
-type SuggestionByIndexProviderProps = PropsWithChildren<{
-  index: number;
-}>;
-
-declare const SuggestionByIndexProvider: FC<SuggestionByIndexProviderProps>;
-
-declare namespace ReadonlyThreadProvider {
-  type Props = PropsWithChildren<{
-    messages: readonly ThreadMessage[];
-  }>;
-}
-
-declare const ReadonlyThreadProvider: FC<ReadonlyThreadProvider.Props>;
-
-type RuntimeAdapters = {
-  modelContext?: ModelContextProvider | undefined;
-  history?: ThreadHistoryAdapter | undefined;
-  attachments?: AttachmentAdapter | undefined;
-};
-
-declare namespace RuntimeAdapterProvider {
-  type Props = {
-    adapters: RuntimeAdapters;
-    children: ReactNode;
-  };
-}
-
-declare const RuntimeAdapterProvider: FC<RuntimeAdapterProvider.Props>;
-
-declare const useRuntimeAdapters: () => RuntimeAdapters | null;
-
-declare const useExternalStoreRuntime: <T>(store: ExternalStoreAdapter<T>) => AssistantRuntime;
-
-declare const useExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
-
-type JoinStrategy = "concat-content" | "none";
-
-declare namespace useExternalMessageConverter {
-  type Message = (ThreadMessageLike & {
-    readonly convertConfig?: {
-      readonly joinStrategy?: JoinStrategy;
-    };
-  }) | {
-    role: "tool";
-    toolCallId: string;
-    toolName?: string | undefined;
-    result: any;
-    artifact?: any;
-    isError?: boolean;
-    messages?: readonly ThreadMessage[];
-  };
-  type Metadata = {
-    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
-    readonly error?: ReadonlyJSONValue;
-    readonly messageTiming?: Record<string, MessageTiming>;
-  };
-  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
-}
-
-declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
-
-declare const useExternalMessageConverter: <T extends WeakKey>(_param6: {
-  callback: useExternalMessageConverter.Callback<T>;
-  messages: T[];
-  isRunning: boolean;
-  joinStrategy?: JoinStrategy | undefined;
-  metadata?: useExternalMessageConverter.Metadata | undefined;
-}) => ThreadMessage[];
-
-declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
-  useThreadMessages: (_param7: {
-    messages: T[];
-    isRunning: boolean;
-    joinStrategy?: JoinStrategy | undefined;
-    metadata?: useExternalMessageConverter.Metadata;
-  }) => ThreadMessage[];
-  toThreadMessages: (messages: T[], isRunning?: boolean, metadata?: useExternalMessageConverter.Metadata) => ThreadMessage[];
-  toOriginalMessages: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => unknown[];
-  toOriginalMessage: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => {};
-  useOriginalMessage: () => {};
-  useOriginalMessages: () => unknown[];
-};
-
-declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
-
-type SamplingCallData = {
-  model_id?: string;
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  duration_ms?: number;
-};
-
-type AssistantCloudAuthStrategy = {
-  readonly strategy: "anon" | "api-key" | "jwt";
-  getAuthHeaders(): Promise<Record<string, string> | false>;
-  readAuthHeaders(headers: Headers): void;
-};
-
-type AssistantCloudTelemetryConfig = {
-  enabled?: boolean;
-  beforeReport?: (report: AssistantCloudRunReport) => AssistantCloudRunReport | null;
-};
-
-type AssistantCloudConfig = ({
-  baseUrl: string;
-  authToken: () => Promise<string | null>;
-} | {
-  baseUrl?: string;
-  apiKey: string;
-  userId: string;
-  workspaceId: string;
-} | {
-  baseUrl: string;
-  anonymous: true;
-}) & {
-  telemetry?: boolean | AssistantCloudTelemetryConfig;
-};
-
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-declare class AssistantCloudAPI {
-  _auth: AssistantCloudAuthStrategy;
-  _baseUrl: string;
-  constructor(config: AssistantCloudConfig);
-  initializeAuth(): Promise<boolean>;
-  makeRawRequest(endpoint: string, options?: MakeRequestOptions): Promise<Response>;
-  makeRequest(endpoint: string, options?: MakeRequestOptions): Promise<any>;
-}
-
-type AssistantCloudRunsStreamBody = {
-  thread_id: string;
-  assistant_id: "system/thread_title";
-  messages: readonly unknown[];
-};
-
-type ReportToolCall = {
-  tool_name: string;
-  tool_call_id: string;
-  tool_args?: string;
-  tool_result?: string;
-  tool_source?: "backend" | "frontend" | "mcp";
-  start_ms?: number;
-  end_ms?: number;
-  sampling_calls?: SamplingCallData[];
-};
-
-type AssistantCloudRunReport = {
-  thread_id: string;
-  status: "completed" | "error" | "incomplete";
-  total_steps?: number;
-  tool_calls?: ReportToolCall[];
-  steps?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    reasoning_tokens?: number;
-    cached_input_tokens?: number;
-    tool_calls?: ReportToolCall[];
-    start_ms?: number;
-    end_ms?: number;
-  }[];
-  input_tokens?: number;
-  output_tokens?: number;
-  reasoning_tokens?: number;
-  cached_input_tokens?: number;
-  model_id?: string;
-  provider_type?: string;
-  duration_ms?: number;
-  output_text?: string;
-  metadata?: Record<string, unknown>;
-};
-
-declare class AssistantCloudRuns {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  __internal_getAssistantOptions(assistantId: string): {
-    api: string;
-    headers: () => Promise<{
-      Accept: string;
-    }>;
-    body: {
-      assistant_id: string;
-      response_format: string;
-      thread_id: string;
-    };
-  };
-  stream(body: AssistantCloudRunsStreamBody): Promise<AssistantStream>;
-  report(body: AssistantCloudRunReport): Promise<{
-    run_id: string;
-  }>;
-}
-
-type CloudMessage = {
-  id: string;
-  parent_id: string | null;
-  height: number;
-  created_at: Date;
-  updated_at: Date;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudThreadMessageListQuery = {
-  format?: string;
-};
-
-type AssistantCloudThreadMessageListResponse = {
-  messages: CloudMessage[];
-};
-
-type AssistantCloudThreadMessageCreateBody = {
-  parent_id: string | null;
-  format: "aui/v0" | string;
-  content: ReadonlyJSONObject;
-};
-
-type AssistantCloudMessageCreateResponse = {
-  message_id: string;
-};
-
-type AssistantCloudThreadMessageUpdateBody = {
-  content: ReadonlyJSONObject;
-};
-
-declare class AssistantCloudThreadMessages {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  list(threadId: string, query?: AssistantCloudThreadMessageListQuery): Promise<AssistantCloudThreadMessageListResponse>;
-  create(threadId: string, body: AssistantCloudThreadMessageCreateBody): Promise<AssistantCloudMessageCreateResponse>;
-  update(threadId: string, messageId: string, body: AssistantCloudThreadMessageUpdateBody): Promise<void>;
-}
-
-type AssistantCloudAuthTokensCreateResponse = {
-  token: string;
-};
-
-declare class AssistantCloudAuthTokens {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  create(): Promise<AssistantCloudAuthTokensCreateResponse>;
-}
-
-type AssistantCloudThreadsListQuery = {
-  is_archived?: boolean;
-  limit?: number;
-  after?: string;
-};
-
-type CloudThread = {
-  title: string;
-  last_message_at: Date;
-  metadata: unknown;
-  external_id: string | null;
-  id: string;
-  project_id: string;
-  created_at: Date;
-  updated_at: Date;
-  workspace_id: string;
-  is_archived: boolean;
-};
-
-type AssistantCloudThreadsListResponse = {
-  threads: CloudThread[];
-};
-
-type AssistantCloudThreadsCreateBody = {
-  title?: string | undefined;
-  last_message_at: Date;
-  metadata?: unknown | undefined;
-  external_id?: string | undefined;
-};
-
-type AssistantCloudThreadsCreateResponse = {
-  thread_id: string;
-};
-
-type AssistantCloudThreadsUpdateBody = {
-  title?: string | undefined;
-  last_message_at?: Date | undefined;
-  metadata?: unknown | undefined;
-  is_archived?: boolean | undefined;
-};
-
-declare class AssistantCloudThreads {
-  private cloud;
-  readonly messages: AssistantCloudThreadMessages;
-  constructor(cloud: AssistantCloudAPI);
-  list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
-  get(threadId: string): Promise<CloudThread>;
-  create(body: AssistantCloudThreadsCreateBody): Promise<AssistantCloudThreadsCreateResponse>;
-  update(threadId: string, body: AssistantCloudThreadsUpdateBody): Promise<void>;
-  delete(threadId: string): Promise<void>;
-}
-
-type PdfToImagesRequestBody = {
-  file_blob?: string | undefined;
-  file_url?: string | undefined;
-};
-
-type PdfToImagesResponse = {
-  success: boolean;
-  urls: string[];
-  message: string;
-};
-
-type GeneratePresignedUploadUrlRequestBody = {
-  filename: string;
-};
-
-type GeneratePresignedUploadUrlResponse = {
-  success: boolean;
-  signedUrl: string;
-  expiresAt: string;
-  publicUrl: string;
-};
-
-declare class AssistantCloudFiles {
-  private cloud;
-  constructor(cloud: AssistantCloudAPI);
-  pdfToImages(body: PdfToImagesRequestBody): Promise<PdfToImagesResponse>;
-  generatePresignedUploadUrl(body: GeneratePresignedUploadUrlRequestBody): Promise<GeneratePresignedUploadUrlResponse>;
-}
-
-declare class AssistantCloud {
-  readonly threads: AssistantCloudThreads;
-  readonly auth: {
-    tokens: AssistantCloudAuthTokens;
-  };
-  readonly runs: AssistantCloudRuns;
-  readonly files: AssistantCloudFiles;
-  readonly telemetry: AssistantCloudTelemetryConfig;
-  constructor(config: AssistantCloudConfig);
-}
-
-type ThreadData$1 = {
-  externalId: string | undefined;
-};
-
-type CloudThreadListAdapterOptions = {
-  cloud?: AssistantCloud | undefined;
-  create?: (() => Promise<ThreadData$1>) | undefined;
-  delete?: ((threadId: string) => Promise<void>) | undefined;
-};
-
-declare const useCloudThreadListAdapter: (adapter: CloudThreadListAdapterOptions) => RemoteThreadListAdapter;
-
-declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
-  private cloud;
-  accept: string;
-  constructor(cloud: AssistantCloud);
-  private uploadedUrls;
-  add(_param8: {
-    file: File;
-  }): AsyncGenerator<PendingAttachment, void>;
-  remove(attachment: Attachment): Promise<void>;
-  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
-}
-
-type ComposerSendOptions = SendOptions & {
-  steer?: boolean;
-};
-
-type ComposerState = {
-  readonly text: string;
-  readonly role: MessageRole;
-  readonly attachments: readonly Attachment[];
-  readonly runConfig: RunConfig;
-  readonly isEditing: boolean;
-  readonly canCancel: boolean;
-  readonly canSend: boolean;
-  readonly attachmentAccept: string;
-  readonly isEmpty: boolean;
-  readonly type: "edit" | "thread";
-  readonly dictation: DictationState | undefined;
-  readonly quote: QuoteInfo | undefined;
-  readonly queue: readonly QueueItemState[];
-};
-
-type MessageState = ThreadMessage & {
-  readonly parentId: string | null;
-  readonly isLast: boolean;
-  readonly branchNumber: number;
-  readonly branchCount: number;
+  readonly isRunning: boolean;
+  readonly capabilities: RuntimeCapabilities;
+  readonly messages: readonly ThreadMessage[];
+  readonly state: ReadonlyJSONValue;
+  readonly suggestions: readonly ThreadSuggestion[];
+  readonly extras: unknown;
   readonly speech: SpeechState | undefined;
-  readonly composer: ComposerState;
-  readonly parts: readonly PartState[];
-  readonly isCopied: boolean;
-  readonly isHovering: boolean;
-  readonly index: number;
+  readonly voice: VoiceSessionState | undefined;
 };
 
-type MessagesComponentConfig = {
-  Message: ComponentType;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage?: ComponentType | undefined;
-  AssistantMessage?: ComponentType | undefined;
-  SystemMessage?: ComponentType | undefined;
-} | {
-  Message?: ComponentType | undefined;
-  EditComposer?: ComponentType | undefined;
-  UserEditComposer?: ComponentType | undefined;
-  AssistantEditComposer?: ComponentType | undefined;
-  SystemEditComposer?: ComponentType | undefined;
-  UserMessage: ComponentType;
-  AssistantMessage: ComponentType;
-  SystemMessage?: ComponentType | undefined;
+type ThreadStep = {
+  readonly messageId?: string;
+  readonly usage?: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+  } | undefined;
 };
 
-declare namespace ThreadPrimitiveMessages {
-  type Props = {
-    components: MessagesComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      message: MessageState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ThreadPrimitiveMessageByIndex {
-  type Props = {
-    index: number;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveMessageByIndex: FC<ThreadPrimitiveMessageByIndex.Props>;
-
-declare namespace ThreadPrimitiveUnstable_MessageById {
-  type Props = {
-    messageId: string;
-    components: MessagesComponentConfig;
-  };
-}
-
-declare const ThreadPrimitiveUnstable_MessageById: FC<ThreadPrimitiveUnstable_MessageById.Props>;
-
-declare const ThreadPrimitiveMessages: import("react").NamedExoticComponent<ThreadPrimitiveMessages.Props>;
-
-declare namespace MessagePrimitiveParts$1 {
-  type DataConfig = {
-    by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
-    Fallback?: DataMessagePartComponent | undefined;
-  };
-  type BaseComponents = {
-    Empty?: EmptyMessagePartComponent | undefined;
-    Text?: TextMessagePartComponent | undefined;
-    Source?: SourceMessagePartComponent | undefined;
-    Image?: ImageMessagePartComponent | undefined;
-    File?: FileMessagePartComponent | undefined;
-    Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
-    data?: DataConfig | undefined;
-    Quote?: QuoteMessagePartComponent | undefined;
-    generativeUI?: {
-      components: GenerativeUIComponentRegistry;
-      Fallback?: ComponentType<{
-        component: string;
-        props?: unknown;
-      }> | undefined;
-    } | undefined;
-  };
-  type ToolsConfig = {
-    by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
-    Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
-  } | {
-    Override: ComponentType<ToolCallMessagePartProps>;
-  };
-  type StandardComponents = BaseComponents & {
-    Reasoning?: ReasoningMessagePartComponent | undefined;
-    tools?: ToolsConfig | undefined;
-    ToolGroup?: ComponentType<PropsWithChildren<{
-      startIndex: number;
-      endIndex: number;
-    }>>;
-    ReasoningGroup?: ReasoningGroupComponent;
-    ChainOfThought?: never;
-  };
-  type ChainOfThoughtComponents = BaseComponents & {
-    ChainOfThought: ComponentType;
-    Reasoning?: never;
-    tools?: never;
-    ToolGroup?: never;
-    ReasoningGroup?: never;
-  };
-  export type Props = {
-    components?: StandardComponents | ChainOfThoughtComponents | undefined;
-    unstable_showEmptyOnNonTextEnd?: boolean | undefined;
-    children?: never;
-  } | {
-    children: (value: {
-      part: EnrichedPartState;
-    }) => ReactNode;
-    components?: never;
-    unstable_showEmptyOnNonTextEnd?: never;
-  };
-  export {};
-}
-
-declare namespace MessagePrimitivePartByIndex {
-  type Props = {
-    index: number;
-    components: MessagePrimitiveParts$1.Props["components"];
-  };
-}
-
-declare const MessagePrimitivePartByIndex: FC<MessagePrimitivePartByIndex.Props>;
-
-type EnrichedPartState = (Extract<PartState, {
-  type: "tool-call";
-}> & {
-  readonly toolUI: ReactNode;
-  addResult: ToolCallMessagePartProps["addResult"];
-  resume: ToolCallMessagePartProps["resume"];
-  respondToApproval: ToolCallMessagePartProps["respondToApproval"];
-}) | (Extract<PartState, {
-  type: "data";
-}> & {
-  readonly dataRendererUI: ReactNode;
-}) | Exclude<PartState, {
-  type: "tool-call";
-} | {
-  type: "data";
-}>;
-
-declare const MessagePrimitiveParts$1: FC<MessagePrimitiveParts$1.Props>;
-
-type GroupByContext = {
-  readonly toolUIs?: ToolsState["toolUIs"];
-};
-
-type GroupPartType = PartState["type"] | "standalone-tool-call" | "mcp-app";
-
-declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
-
-declare namespace MessagePrimitiveGroupedParts {
-  type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly type: TKey;
-    readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-    readonly indices: readonly number[];
-  };
-  type IndicatorPart = {
-    readonly type: "indicator";
-  };
-  type IndicatorMode = "always" | "empty" | "never" | "no-text";
-  type RenderInfo<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly part: GroupPart<TKey> | EnrichedPartState | IndicatorPart;
-    readonly children: ReactNode;
-  };
-  type Props<TKey extends `group-${string}` = `group-${string}`> = {
-    readonly groupBy: (part: PartState, context: GroupByContext) => readonly TKey[] | null;
-    readonly indicator?: IndicatorMode;
-    readonly children: (info: RenderInfo<TKey>) => ReactNode;
-  };
-}
-
-declare const MessagePrimitiveGroupedParts: {
-  <TKey extends `group-${string}`>(_param9: MessagePrimitiveGroupedParts.Props<TKey>): ReactNode;
-  displayName: string;
-};
-
-declare class GenerativeUIRenderError extends Error {
-  readonly componentName: string;
-  constructor(componentName: string, message?: string);
-}
-
-declare const GenerativeUIRender: FC<GenerativeUIRenderProps>;
-
-declare namespace MessagePrimitiveGenerativeUI {
-  type Props = {
-    components: GenerativeUIComponentRegistry;
-    spec?: GenerativeUISpec | undefined;
-    Fallback?: ComponentType<{
-      component: string;
-      props?: unknown;
-    }> | undefined;
-  };
-}
-
-declare const MessagePrimitiveGenerativeUI: FC<MessagePrimitiveGenerativeUI.Props>;
-
-declare namespace MessagePrimitiveQuote {
-  type Props = {
-    children: (value: QuoteInfo) => ReactNode;
-  };
-}
-
-declare const MessagePrimitiveQuote: import("react").NamedExoticComponent<MessagePrimitiveQuote.Props>;
-
-type MessageAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace MessagePrimitiveAttachments {
-  type Props = {
-    components: MessageAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: CompleteAttachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace MessagePrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: MessageAttachmentsComponentConfig;
-  };
-}
-
-declare const MessagePrimitiveAttachmentByIndex: FC<MessagePrimitiveAttachmentByIndex.Props>;
-
-declare const MessagePrimitiveAttachments: FC<MessagePrimitiveAttachments.Props>;
-
-type ComposerAttachmentsComponentConfig = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
-
-declare namespace ComposerPrimitiveAttachments {
-  type Props = {
-    components: ComposerAttachmentsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      attachment: Attachment;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare namespace ComposerPrimitiveAttachmentByIndex {
-  type Props = {
-    index: number;
-    components?: ComposerAttachmentsComponentConfig;
-  };
-}
-
-declare const ComposerPrimitiveAttachmentByIndex: FC<ComposerPrimitiveAttachmentByIndex.Props>;
-
-declare const ComposerPrimitiveAttachments: FC<ComposerPrimitiveAttachments.Props>;
-
-declare namespace ComposerPrimitiveQueue {
-  type Props = {
-    children: (value: {
-      queueItem: QueueItemState;
-    }) => ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveQueue: import("react").NamedExoticComponent<{
-  children: (value: {
-    queueItem: QueueItemState;
-  }) => ReactNode;
-}>;
-
-type ThreadListItemState = {
-  readonly id: string;
-  readonly remoteId: string | undefined;
-  readonly externalId: string | undefined;
-  readonly title?: string | undefined;
-  readonly lastMessageAt?: Date | undefined;
-  readonly status: ThreadListItemStatus;
-  readonly custom?: Record<string, unknown> | undefined;
-};
-
-type ThreadListItemsComponentConfig = {
-  ThreadListItem: ComponentType;
-};
-
-declare namespace ThreadListPrimitiveItems {
-  type Props = {
-    archived?: boolean | undefined;
-  } & ({
-    components: ThreadListItemsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      threadListItem: ThreadListItemState;
-    }) => ReactNode;
-    components?: never;
-  });
-}
-
-declare namespace ThreadListPrimitiveItemByIndex {
-  type Props = {
-    index: number;
-    archived?: boolean | undefined;
-    components: ThreadListItemsComponentConfig;
-  };
-}
-
-declare const ThreadListPrimitiveItemByIndex: FC<ThreadListPrimitiveItemByIndex.Props>;
-
-declare const ThreadListPrimitiveItems: FC<ThreadListPrimitiveItems.Props>;
-
-type ChainOfThoughtPartsComponentConfig = {
-  Reasoning?: ReasoningMessagePartComponent | undefined;
-  tools?: {
-    Fallback?: ToolCallMessagePartComponent | undefined;
-  };
-  Layout?: ComponentType<PropsWithChildren> | undefined;
-};
-
-declare namespace ChainOfThoughtPrimitiveParts {
-  type Props = {
-    components?: ChainOfThoughtPartsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      part: PartState;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare const ChainOfThoughtPrimitiveParts: FC<ChainOfThoughtPrimitiveParts.Props>;
-
-declare namespace PartPrimitiveMessages {
-  type Props = {
-    components: NonNullable<ThreadPrimitiveMessages.Props["components"]>;
-    children?: never;
-  } | {
-    children: (value: {
-      message: ThreadMessage;
-    }) => ReactNode;
-    components?: never;
-  };
-}
-
-declare const PartPrimitiveMessages: import("react").NamedExoticComponent<PartPrimitiveMessages.Props>;
-
-declare namespace MessagePartPrimitiveInProgress {
-  type Props = PropsWithChildren;
-}
-
-declare const MessagePartPrimitiveInProgress: FC<MessagePartPrimitiveInProgress.Props>;
-
-declare namespace ThreadListItemPrimitiveTitle {
-  type Props = {
-    fallback?: ReactNode;
-  };
-}
-
-declare const ThreadListItemPrimitiveTitle: FC<ThreadListItemPrimitiveTitle.Props>;
-
-type SuggestionState = {
-  title: string;
-  label: string;
+type ThreadSuggestion = {
   prompt: string;
 };
 
-type SuggestionsComponentConfig = {
-  Suggestion: ComponentType;
-};
-
-declare namespace ThreadPrimitiveSuggestions {
-  type Props = {
-    components: SuggestionsComponentConfig;
-    children?: never;
-  } | {
-    children: (value: {
-      suggestion: SuggestionState;
-    }) => ReactNode;
-    components?: never;
+type ThreadSystemMessage = MessageCommonProps & {
+  readonly role: "system";
+  readonly content: readonly [
+    TextMessagePart
+  ];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
   };
-}
+};
 
-declare namespace ThreadPrimitiveSuggestionByIndex {
-  type Props = {
-    index: number;
-    components: SuggestionsComponentConfig;
+type ThreadUserMessage = MessageCommonProps & {
+  readonly role: "user";
+  readonly content: readonly ThreadUserMessagePart[];
+  readonly attachments: readonly CompleteAttachment[];
+  readonly metadata: {
+    readonly unstable_state?: undefined;
+    readonly unstable_annotations?: undefined;
+    readonly unstable_data?: undefined;
+    readonly steps?: undefined;
+    readonly submittedFeedback?: undefined;
+    readonly timing?: undefined;
+    readonly custom: Record<string, unknown>;
   };
-}
-
-declare const ThreadPrimitiveSuggestionByIndex: FC<ThreadPrimitiveSuggestionByIndex.Props>;
-
-declare const ThreadPrimitiveSuggestions: import("react").NamedExoticComponent<ThreadPrimitiveSuggestions.Props>;
-
-type ComposerIfFilters = {
-  editing: boolean | undefined;
-  dictation: boolean | undefined;
 };
 
-type RequireAtLeastOne$1<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
-  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-}[Keys];
+type ThreadUserMessagePart = TextMessagePart | ImageMessagePart | FileMessagePart | DataMessagePart | Unstable_AudioMessagePart;
 
-type UseComposerIfProps = RequireAtLeastOne$1<ComposerIfFilters>;
-
-declare namespace ComposerPrimitiveIf {
-  type Props = PropsWithChildren<UseComposerIfProps>;
-}
-
-declare const ComposerPrimitiveIf: FC<ComposerPrimitiveIf.Props>;
-
-declare const unstable_useThreadMessageIds: () => readonly string[];
-
-declare const useVoiceState: () => VoiceSessionState | undefined;
-
-declare const useVoiceVolume: () => number;
-
-declare const useVoiceControls: () => {
-  connect: () => void;
-  disconnect: () => void;
-  mute: () => void;
-  unmute: () => void;
-};
-
-type LocalRuntimeOptions = Omit<LocalRuntimeOptionsBase, "adapters"> & {
-  cloud?: AssistantCloud | undefined;
-  initialMessages?: readonly ThreadMessageLike[] | undefined;
-  adapters?: Omit<LocalRuntimeOptionsBase["adapters"], "chatModel"> | undefined;
-};
-
-declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options: T) => {
-  localRuntimeOptions: {
-    cloud: AssistantCloud | undefined;
-    initialMessages: readonly ThreadMessageLike[] | undefined;
-    maxSteps: number | undefined;
-    adapters: Omit<{
-      chatModel: ChatModelAdapter;
-      history?: ThreadHistoryAdapter | undefined;
-      attachments?: AttachmentAdapter | undefined;
-      speech?: SpeechSynthesisAdapter | undefined;
-      dictation?: DictationAdapter | undefined;
-      voice?: RealtimeVoiceAdapter | undefined;
-      feedback?: FeedbackAdapter | undefined;
-      suggestion?: SuggestionAdapter | undefined;
-    }, "chatModel"> | undefined;
-    unstable_humanToolNames: string[] | undefined;
-    unstable_enableMessageQueue: boolean | undefined;
-  };
-  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
-};
-
-declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param10?: LocalRuntimeOptions) => AssistantRuntime;
-
-type ChainOfThoughtPart = Extract<PartState, {
-  type: "tool-call";
-} | {
-  type: "reasoning";
+type ThreadViewportProviderProps = PropsWithChildren<{
+  options?: ThreadViewportStoreOptions;
 }>;
-
-type SuggestionConfig = string | {
-  title: string;
-  label: string;
-  prompt: string;
-};
-
-declare const Suggestions: Resource<ClientOutput<"suggestions">, [
-  suggestions?: SuggestionConfig[] | undefined
-]>;
-
-declare const ChainOfThoughtClient: Resource<ClientOutput<"chainOfThought">, [
-  {
-    parts: readonly ChainOfThoughtPart[];
-    getMessagePart: (selector: {
-      index: number;
-    }) => PartMethods;
-  }
-]>;
-
-type ThreadMessageClientProps = {
-  message: ThreadMessage;
-  index: number;
-  isLast?: boolean;
-  branchNumber?: number;
-  branchCount?: number;
-};
-
-declare const ModelContext: Resource<ClientOutput<"modelContext">, [
-]>;
-
-declare const MessageProvider: FC<PropsWithChildren<ThreadMessageClientProps>>;
-
-type SizeHandle = {
-  setHeight: (height: number) => void;
-  unregister: Unsubscribe;
-};
 
 type ThreadViewportState = {
   readonly isAtBottom: boolean;
   readonly scrollToBottom: (config?: {
     behavior?: ScrollBehavior | undefined;
   }) => void;
-  readonly onScrollToBottom: (callback: (_param11: {
+  readonly onScrollToBottom: (callback: (_param8: {
     behavior: ScrollBehavior;
   }) => void) => Unsubscribe;
   readonly turnAnchor: "bottom" | "top";
@@ -4288,24 +4951,980 @@ type ThreadViewportStoreOptions = {
   } | undefined;
 };
 
-type ReadonlyStore<T> = Omit<StoreApi<T>, "destroy" | "setState">;
+type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
 
-declare const useThreadViewport: {
-  (): ThreadViewportState;
-  <TSelected>(selector: (state: ThreadViewportState) => TSelected): TSelected;
-  (options: {
-    optional: true;
-  }): ThreadViewportState | null;
-  <TSelected>(options: {
-    optional: true;
-    selector?: (state: ThreadViewportState) => TSelected;
-  }): TSelected | null;
-}, useThreadViewportStore: {
-  (): ReadonlyStore<ThreadViewportState>;
-  (options: {
-    optional: true;
-  }): ReadonlyStore<ThreadViewportState> | null;
+type ToolApprovalOption = {
+  readonly id: string;
+  readonly kind: ToolApprovalOptionKind | (string & {});
+  readonly label?: string;
+  readonly description?: string;
+  readonly grants?: readonly string[];
+  readonly confirm?: boolean | {
+    title?: string;
+    description?: string;
+  };
 };
+
+type ToolApprovalOptionKind = "allow-always" | "allow-once" | "reject-always" | "reject-once";
+
+type ToolApprovalResponse = {
+  readonly approved: boolean;
+  readonly reason?: string;
+} | {
+  readonly optionId: string;
+  readonly reason?: string;
+} | {
+  readonly approved: boolean;
+  readonly optionId: string;
+  readonly reason?: string;
+};
+
+type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unknown>> = {
+  status: "complete" | "incomplete" | "requires-action" | "running";
+  propStatus: Partial<Record<keyof TArgs, PropFieldStatus>>;
+};
+
+type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
+  streamCall?: ToolStreamCallFunction<TArgs, TResult>;
+  display?: ToolDisplay;
+};
+
+interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {
+  get<PathT extends TypePath<TArgs>>(...fieldPath: PathT): Promise<TypeAtPath<TArgs, PathT>>;
+  streamValues<PathT extends TypePath<TArgs>>(...fieldPath: PathT): AsyncIterableStream<DeepPartial<TypeAtPath<TArgs, PathT>>>;
+  streamText<PathT extends TypePath<TArgs>>(...fieldPath: PathT): TypeAtPath<TArgs, PathT> extends string & (infer U) ? AsyncIterableStream<U> : never;
+  forEach<PathT extends TypePath<TArgs>>(...fieldPath: PathT): NonNullable<TypeAtPath<TArgs, PathT>> extends Array<infer U> ? AsyncIterableStream<U> : never;
+}
+
+type ToolCallCompleteText<TArgs extends Record<string, unknown>, TResult> = ReactNode | ((options: {
+  args: TArgs;
+  result: TResult | undefined;
+}) => ReactNode);
+
+type ToolCallMessagePart<TArgs = ReadonlyJSONObject, TResult = unknown> = {
+  readonly type: "tool-call";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly args: TArgs;
+  readonly result?: TResult | undefined;
+  readonly isError?: boolean | undefined;
+  readonly argsText: string;
+  readonly artifact?: unknown;
+  readonly timing?: ToolCallTiming;
+  readonly mcp?: ToolCallMessagePartMcpMetadata;
+  readonly modelContent?: readonly ToolModelContentPart[] | undefined;
+  readonly interrupt?: {
+    type: "human";
+    payload: unknown;
+  };
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+    readonly isAutomatic?: boolean;
+    readonly options?: readonly ToolApprovalOption[];
+    readonly optionId?: string;
+    readonly resolution?: "cancelled" | "expired";
+  };
+  readonly parentId?: string;
+  readonly messages?: readonly ThreadMessage[];
+};
+
+type ToolCallMessagePartComponent<TArgs = any, TResult = any> = ComponentType<ToolCallMessagePartProps<TArgs, TResult>>;
+
+type ToolCallMessagePartMcpMetadata = {
+  readonly app?: McpAppMetadata;
+};
+
+type ToolCallMessagePartProps<TArgs = any, TResult = unknown> = MessagePartState & ToolCallMessagePart<TArgs, TResult> & {
+  addResult: (result: TResult | ToolResponse<TResult>) => void;
+  resume: (payload: unknown) => void;
+  respondToApproval: (response: ToolApprovalResponse) => void;
+};
+
+type ToolCallMessagePartStatus = {
+  readonly type: "requires-action";
+  readonly reason: "interrupt";
+} | MessagePartStatus;
+
+interface ToolCallReader<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> {
+  args: ToolCallArgsReader<TArgs>;
+  response: ToolCallResponseReader<TResult>;
+  result: {
+    get: () => Promise<TResult>;
+  };
+}
+
+interface ToolCallResponseReader<TResult> {
+  get: () => Promise<ToolResponse<TResult>>;
+}
+
+type ToolCallRunningText<TArgs extends Record<string, unknown>> = ReactNode | ((options: {
+  args: TArgs;
+}) => ReactNode);
+
+type ToolCallText<TArgs extends Record<string, unknown>, TResult> = {
+  running: ToolCallRunningText<TArgs>;
+  complete?: ToolCallCompleteText<TArgs, TResult> | undefined;
+} | {
+  running?: ToolCallRunningText<TArgs> | undefined;
+  complete: ToolCallCompleteText<TArgs, TResult>;
+};
+
+type ToolCallTiming = {
+  readonly startedAt: number;
+  readonly completedAt?: number;
+};
+
+type ToolDeclaration<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendToolDeclaration<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
+
+type ToolDefinition<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = WithRender<Tool<TArgs, TResult>, TArgs, TResult>;
+
+type ToolDisplay = "inline" | "standalone";
+
+type ToolExecute<TArgs extends Record<string, unknown>, TResult> = (args: TArgs, context: ToolExecuteContext) => TResult | Promise<TResult>;
+
+type ToolExecuteContext = Parameters<NonNullable<ToolDeclaration["execute"]>>[1];
+
+type ToolExecuteFunction<TArgs, TResult> = (args: TArgs, context: ToolExecutionContext) => TResult | Promise<TResult>;
+
+type ToolExecutionContext = {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+  human: (payload: unknown) => Promise<unknown>;
+};
+
+type ToolExecutionStatus = {
+  type: "executing";
+} | {
+  type: "interrupt";
+  payload: {
+    type: "human";
+    payload: unknown;
+  };
+};
+
+type ToolModelContentPart = {
+  readonly type: "text";
+  readonly text: string;
+} | {
+  readonly type: "file";
+  readonly data: string;
+  readonly mediaType: string;
+  readonly filename?: string;
+};
+
+type ToolModelOutputFunction<TArgs, TResult> = (options: {
+  toolCallId: string;
+  input: TArgs;
+  output: TResult;
+}) => readonly ToolModelContentPart[] | Promise<readonly ToolModelContentPart[]>;
+
+type ToolParameters<TArgs extends Record<string, unknown>> = ToolDeclaration<TArgs>["parameters"];
+
+type ToolPartLike = Pick<ToolCallMessagePart, "mcp">;
+
+type ToolRegistration = {
+  readonly render: ToolCallMessagePartComponent;
+  readonly standalone: boolean;
+};
+
+declare class ToolResponse<TResult> {
+  get [TOOL_RESPONSE_SYMBOL](): boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly result: TResult;
+  readonly isError: boolean;
+  readonly modelContent?: readonly ToolModelContentPart[];
+  readonly messages?: ReadonlyJSONValue;
+  constructor(options: ToolResponseLike<TResult>);
+  static [Symbol.hasInstance](obj: unknown): obj is ToolResponse<ReadonlyJSONValue>;
+  static toResponse(result: any | ToolResponse<any>): ToolResponse<any>;
+}
+
+type ToolResponseLike<TResult> = {
+  result: TResult;
+  artifact?: ReadonlyJSONValue | undefined;
+  isError?: boolean | undefined;
+  modelContent?: readonly ToolModelContentPart[] | undefined;
+  messages?: ReadonlyJSONValue | undefined;
+};
+
+type ToolStreamCall<TArgs extends Record<string, unknown>, TResult> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecuteContext) => void;
+
+type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
+
+type ToolWithoutType<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (Omit<FrontendTool<TArgs, TResult>, "type"> | Omit<BackendTool<TArgs, TResult>, "type"> | Omit<HumanTool<TArgs, TResult>, "type"> | Omit<ProviderTool<TArgs, TResult>, "type">) & {
+  type?: undefined;
+};
+
+type Toolkit = Record<string, ToolDefinition<any, any>>;
+
+type ToolkitDefinition<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+} = Record<string, any>, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}> = {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntry<TArgsByName[K], TResultByName[K]>;
+};
+
+type ToolkitDefinitionEntry<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> | ToolDefinition<any, any>;
+
+type ToolkitDefinitionEntryWithParameters<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolkitDefinitionInput<TArgs, TResult> & {
+  parameters: NonNullable<ToolParameters<TArgs>>;
+};
+
+type ToolkitDefinitionInput<TArgs extends Record<string, unknown>, TResult> = WithRender<ToolDeclaration<TArgs, TResult> extends infer T ? T extends {
+  streamCall?: unknown;
+} ? OverrideToolDeclarationCallbacks<T, TArgs, TResult> : never : never, TArgs, TResult>;
+
+declare const Tools: Resource<ClientOutput<"tools">, [
+  {
+    toolkit?: Toolkit;
+    mcpApp?: ResourceElement<McpAppResourceOutput> | undefined;
+  }
+]>;
+
+type ToolsState = {
+  toolUIs: Record<string, readonly ToolRegistration[]>;
+  mcpApp?: McpAppResourceOutput | undefined;
+  tools: Record<string, ToolCallMessagePartComponent[]>;
+};
+
+type TriggerBehavior = {
+  readonly kind: "directive";
+  readonly formatter: Unstable_DirectiveFormatter;
+  readonly onInserted?: (item: Unstable_TriggerItem) => void;
+} | {
+  readonly kind: "action";
+  readonly formatter: Unstable_DirectiveFormatter;
+  readonly onExecute: (item: Unstable_TriggerItem) => void;
+  readonly removeOnExecute?: boolean;
+};
+
+type TriggerPopoverActiveAria = {
+  popoverId: string;
+  highlightedItemId: string | undefined;
+};
+
+type TriggerPopoverAriaProps = {
+  "aria-controls"?: string;
+  "aria-expanded"?: true;
+  "aria-haspopup"?: "listbox";
+  "aria-activedescendant"?: string | undefined;
+};
+
+type TriggerPopoverLifecycleListener = {
+  added(trigger: RegisteredTrigger): void;
+  removed(char: string): void;
+};
+
+type TriggerPopoverResourceOutput = {
+  readonly open: boolean;
+  readonly query: string;
+  readonly activeCategoryId: string | null;
+  readonly categories: readonly Unstable_TriggerCategory[];
+  readonly items: readonly Unstable_TriggerItem[];
+  readonly highlightedIndex: number;
+  readonly isSearchMode: boolean;
+  readonly isLoading: boolean;
+  readonly popoverId: string;
+  readonly highlightedItemId: string | undefined;
+  selectCategory(categoryId: string): void;
+  goBack(): void;
+  selectItem(item: Unstable_TriggerItem): void;
+  close(): void;
+  highlightIndex(index: number): void;
+  handleKeyDown(e: {
+    readonly key: string;
+    readonly shiftKey: boolean;
+    preventDefault(): void;
+  }): boolean;
+  setCursorPosition(pos: number): void;
+  registerSelectItemOverride(fn: SelectItemOverride): () => void;
+};
+
+type TriggerPopoverRootContextValue = {
+  register(trigger: RegisteredTrigger): () => void;
+  getTriggers(): ReadonlyMap<string, RegisteredTrigger>;
+  subscribe(listener: () => void): () => void;
+  subscribeLifecycle(listener: TriggerPopoverLifecycleListener): () => void;
+  getActiveAria(): TriggerPopoverActiveAria | null;
+  subscribeAria(listener: () => void): () => void;
+};
+
+type TupleIndex<T extends readonly any[]> = Exclude<keyof T, keyof any[]>;
+
+type TypeAtPath<T, P extends readonly any[]> = P extends [
+  infer Head,
+  ...infer Rest
+] ? Head extends keyof T ? TypeAtPath<T[Head], Rest> : never : T;
+
+type TypePath<T> = [
+] | (0 extends 1 & T ? any[] : T extends object ? T extends readonly any[] ? number extends T["length"] ? {
+  [K in TupleIndex<T>]: [
+    AsNumber<K>,
+    ...TypePath<T[K]>
+  ];
+}[TupleIndex<T>] : [
+  number,
+  ...TypePath<T[number]>
+] : {
+  [K in ObjectKey<T>]: [
+    K,
+    ...TypePath<T[K]>
+  ];
+}[ObjectKey<T>] : [
+]);
+
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unstable_AudioMessagePart = {
+  readonly type: "audio";
+  readonly audio: {
+    readonly data: string;
+    readonly format: "mp3" | "wav";
+  };
+};
+
+type Unstable_AudioMessagePartComponent = ComponentType<Unstable_AudioMessagePartProps>;
+
+type Unstable_AudioMessagePartProps = MessagePartState & Unstable_AudioMessagePart;
+
+type Unstable_ComposerInput = {
+  value: string;
+  setText(text: string): void;
+  send(options?: ComposerSendOptions): void;
+  isDisabled: boolean;
+  canSend: boolean;
+};
+
+type Unstable_ComposerInputHistory = {
+  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+};
+
+type Unstable_DirectiveFormatter = {
+  serialize(item: Unstable_TriggerItem): string;
+  parse(text: string): readonly Unstable_DirectiveSegment[];
+};
+
+type Unstable_DirectiveSegment = {
+  readonly kind: "text";
+  readonly text: string;
+} | {
+  readonly kind: "mention";
+  readonly type: string;
+  readonly label: string;
+  readonly id: string;
+};
+
+type Unstable_IconComponent = FC<{
+  className?: string;
+}>;
+
+type Unstable_InferInteractableState<TSchema> = TSchema extends {
+  "~standard": {
+    types?: {
+      output: infer TOutput;
+    } | undefined;
+  };
+} ? TOutput : unknown;
+
+type Unstable_InteractableConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  initialState: Unstable_InferInteractableState<TSchema>;
+  id?: string | undefined;
+  updateRender?: ToolCallMessagePartComponent | undefined;
+};
+
+type Unstable_InteractableDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  state: unknown;
+  initialState: unknown;
+  scope?: InteractableScope | undefined;
+};
+
+type Unstable_InteractablePersistedState = Record<string, {
+  name: string;
+  state: unknown;
+}>;
+
+type Unstable_InteractablePersistenceAdapter = {
+  save(state: Unstable_InteractablePersistedState): void | Promise<void>;
+  load?(): Unstable_InteractablePersistedState | null | undefined | Promise<Unstable_InteractablePersistedState | null | undefined>;
+};
+
+type Unstable_InteractablePersistenceStatus = {
+  isPending: boolean;
+  error: unknown;
+};
+
+type Unstable_InteractableRegistration = {
+  id: string;
+  name: string;
+  description: string;
+  stateSchema: Unstable_InteractableStateSchema;
+  initialState: unknown;
+  updateRender?: ToolCallMessagePartComponent | undefined;
+};
+
+type Unstable_InteractableSnapshotEntry = {
+  id: string;
+  name: string;
+  state: unknown;
+  partial?: boolean | undefined;
+};
+
+type Unstable_InteractableStateSchema = NonNullable<Extract<Tool, {
+  parameters: unknown;
+}>["parameters"]>;
+
+type Unstable_InteractableToolConfig<TSchema extends Unstable_InteractableStateSchema> = {
+  description: string;
+  stateSchema: TSchema;
+  render: (props: Unstable_InteractableToolRenderProps<Unstable_InferInteractableState<TSchema>>) => ReactNode;
+};
+
+type Unstable_InteractableToolRenderProps<TState> = {
+  state: TState;
+  setState: (updater: TState | ((prev: TState) => TState)) => void;
+  version: Unstable_InteractableVersionInfo<TState> | undefined;
+  id: string;
+  streaming: boolean;
+};
+
+type Unstable_InteractableVersion = {
+  state: unknown;
+  origin: "create" | "update" | "user-edit";
+  toolCallId?: string | undefined;
+};
+
+type Unstable_InteractableVersionInfo<TState> = {
+  state: TState;
+  isLatest: boolean;
+  restore: () => void;
+};
+
+type Unstable_InteractablesClientSchema = {
+  methods: Unstable_InteractablesMethods;
+};
+
+type Unstable_InteractablesConfig = {
+  persistence?: Unstable_InteractablePersistenceAdapter | undefined;
+};
+
+type Unstable_InteractablesMethods = {
+  getState(): Unstable_InteractablesState;
+  register(def: Unstable_InteractableRegistration): Unsubscribe;
+  setState(id: string, updater: (prev: unknown) => unknown): void;
+  exportState(): Unstable_InteractablePersistedState;
+  importState(saved: Unstable_InteractablePersistedState): void;
+  setPersistenceAdapter(adapter: Unstable_InteractablePersistenceAdapter | undefined): void;
+  flush(): Promise<void>;
+};
+
+type Unstable_InteractablesState = {
+  definitions: Record<string, Unstable_InteractableDefinition>;
+  persistence: Record<string, Unstable_InteractablePersistenceStatus>;
+};
+
+type Unstable_Mention = {
+  readonly id: string;
+  readonly type: string;
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly icon?: string | undefined;
+  readonly metadata?: ReadonlyJSONObject | undefined;
+};
+
+type Unstable_MentionCategory = {
+  readonly id: string;
+  readonly label: string;
+  readonly items: readonly Unstable_Mention[];
+};
+
+type Unstable_MentionDirective = {
+  readonly formatter: Unstable_DirectiveFormatter;
+  readonly onInserted?: ((item: Unstable_TriggerItem) => void) | undefined;
+};
+
+type Unstable_MessageStallDetection = {
+  stalled: boolean;
+  stalledForMs: number;
+};
+
+type Unstable_MessageStallDetectionOptions = {
+  thresholdMs?: number | undefined;
+};
+
+type Unstable_ModelContextToolsOptions = {
+  readonly category?: {
+    readonly id: string;
+    readonly label: string;
+  };
+  readonly formatLabel?: (toolName: string) => string;
+  readonly icon?: string;
+};
+
+type Unstable_SlashCommand = {
+  readonly id: string;
+  readonly label?: string | undefined;
+  readonly description?: string | undefined;
+  readonly icon?: string | undefined;
+  readonly execute: () => void;
+};
+
+type Unstable_SlashCommandAction = {
+  readonly onExecute: (item: Unstable_TriggerItem) => void;
+  readonly removeOnExecute?: boolean | undefined;
+};
+
+type Unstable_TriggerAdapter = {
+  categories(): readonly Unstable_TriggerCategory[];
+  categoryItems(categoryId: string): readonly Unstable_TriggerItem[];
+  search?(query: string): readonly Unstable_TriggerItem[];
+};
+
+type Unstable_TriggerCategory = {
+  readonly id: string;
+  readonly label: string;
+};
+
+type Unstable_TriggerItem = {
+  readonly id: string;
+  readonly type: string;
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly metadata?: ReadonlyJSONObject | undefined;
+};
+
+type Unstable_TriggerPopoverAriaProps = TriggerPopoverAriaProps;
+
+type Unstable_UseComposerInputOptions = {
+  disabled?: boolean | undefined;
+};
+
+type Unstable_UseLiveCompletionAdapterOptions = {
+  readonly fetcher: (query: string) => Promise<readonly Unstable_TriggerItem[]>;
+  readonly debounceMs?: number | undefined;
+  readonly enabled?: boolean | undefined;
+};
+
+type Unstable_UseMentionAdapterOptions = {
+  readonly items?: readonly Unstable_Mention[];
+  readonly categories?: readonly Unstable_MentionCategory[];
+  readonly includeModelContextTools?: boolean | Unstable_ModelContextToolsOptions;
+  readonly formatter?: Unstable_DirectiveFormatter;
+  readonly onInserted?: (item: Unstable_TriggerItem) => void;
+  readonly iconMap?: Record<string, Unstable_IconComponent>;
+  readonly fallbackIcon?: Unstable_IconComponent;
+};
+
+type Unstable_UseSlashCommandAdapterOptions = {
+  readonly commands: readonly Unstable_SlashCommand[];
+  readonly removeOnExecute?: boolean | undefined;
+  readonly iconMap?: Record<string, Unstable_IconComponent>;
+  readonly fallbackIcon?: Unstable_IconComponent;
+};
+
+type Unsubscribe = () => void;
+
+type Unsubscribe$1 = () => void;
+
+type UseAssistantFrameHostOptions = {
+  iframeRef: Readonly<RefObject<HTMLIFrameElement | null | undefined>>;
+  targetOrigin?: string;
+  register: (frameHost: AssistantFrameHost) => Unsubscribe;
+};
+
+type UseComposerIfProps = RequireAtLeastOne$1<ComposerIfFilters>;
+
+type UseMessageIfProps = RequireAtLeastOne<MessageIfFilters>;
+
+type UseThreadIfProps = RequireAtLeastOne<ThreadIfFilters>;
+
+type UserCommands = Assistant.Commands[keyof Assistant.Commands];
+
+type UserExternalState = keyof Assistant.ExternalState extends never ? Record<string, unknown> : Assistant.ExternalState[keyof Assistant.ExternalState];
+
+type UserMessage = {
+  readonly role: "user";
+  readonly parts: readonly UserMessagePart[];
+};
+
+type UserMessagePart = TextPart | ImagePart;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type VoiceSessionControls = {
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
+};
+
+type VoiceSessionHelpers = {
+  setStatus: (status: RealtimeVoiceAdapter.Status) => void;
+  end: (reason: "cancelled" | "error" | "finished", error?: unknown) => void;
+  emitTranscript: (item: RealtimeVoiceAdapter.TranscriptItem) => void;
+  emitMode: (mode: RealtimeVoiceAdapter.Mode) => void;
+  emitVolume: (volume: number) => void;
+  isDisposed: () => boolean;
+};
+
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+
+declare class WebSpeechDictationAdapter implements DictationAdapter {
+  private _language;
+  private _continuous;
+  private _interimResults;
+  constructor(options?: {
+    language?: string;
+    continuous?: boolean;
+    interimResults?: boolean;
+  });
+  static isSupported(): boolean;
+  listen(): DictationAdapter.Session;
+}
+
+declare class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
+  speak(text: string): SpeechSynthesisAdapter.Utterance;
+}
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
+
+type WithRender<T, TArgs extends Record<string, unknown>, TResult> = T extends {
+  type: "frontend" | "human";
+} ? T & (T extends {
+  type: "frontend";
+} ? {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+} | {
+  render?: ToolCallMessagePartComponent<TArgs, TResult>;
+  renderText: ToolCallText<TArgs, TResult>;
+} : {
+  render: ToolCallMessagePartComponent<TArgs, TResult>;
+}) : T & {
+  render?: ToolCallMessagePartComponent<TArgs, TResult> | undefined;
+  renderText?: ToolCallText<TArgs, TResult> | undefined;
+};
+
+type WithRenderPropProps<T extends ElementType> = ComponentPropsWithoutRef<T> & {
+  render?: ReactElement | undefined;
+};
+
+declare namespace actionBarMore_d_exports {
+  export { ActionBarMorePrimitiveContent as Content, ActionBarMorePrimitiveItem as Item, ActionBarMorePrimitiveRoot as Root, ActionBarMorePrimitiveSeparator as Separator, ActionBarMorePrimitiveTrigger as Trigger };
+}
+
+declare namespace actionBar_d_exports {
+  export { ActionBarPrimitiveCopy as Copy, ActionBarPrimitiveEdit as Edit, ActionBarPrimitiveExportMarkdown as ExportMarkdown, ActionBarPrimitiveFeedbackNegative as FeedbackNegative, ActionBarPrimitiveFeedbackPositive as FeedbackPositive, ActionBarPrimitiveReload as Reload, ActionBarPrimitiveRoot as Root, ActionBarPrimitiveSpeak as Speak, ActionBarPrimitiveStopSpeaking as StopSpeaking };
+}
+
+declare namespace assistantModal_d_exports {
+  export { AssistantModalPrimitiveAnchor as Anchor, AssistantModalPrimitiveContent as Content, AssistantModalPrimitiveRoot as Root, AssistantModalPrimitiveTrigger as Trigger };
+}
+
+declare namespace attachment_d_exports {
+  export { AttachmentPrimitiveName as Name, AttachmentPrimitiveRemove as Remove, AttachmentPrimitiveRoot as Root, AttachmentPrimitiveThumb as unstable_Thumb };
+}
+
+declare const bindExternalStoreMessage: <T>(target: object, message: T | T[]) => void;
+
+declare namespace branchPicker_d_exports {
+  export { BranchPickerPrimitiveCount as Count, BranchPickerPrimitiveNext as Next, BranchPickerPrimitiveNumber as Number, BranchPickerPrimitivePrevious as Previous, BranchPickerPrimitiveRoot as Root };
+}
+
+declare namespace chainOfThought_d_exports {
+  export { ChainOfThoughtPrimitiveAccordionTrigger as AccordionTrigger, ChainOfThoughtPrimitiveAccordionTrigger as AccordionTriggerPrimitive, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtPrimitiveParts as PartsPrimitive, ChainOfThoughtPrimitiveRoot as Root, ChainOfThoughtPrimitiveRoot as RootPrimitive };
+}
+
+declare namespace composer_d_exports {
+  export { ComposerPrimitiveAddAttachment as AddAttachment, ComposerPrimitiveAttachmentByIndex as AttachmentByIndex, ComposerPrimitiveAttachmentDropzone as AttachmentDropzone, ComposerPrimitiveAttachments as Attachments, ComposerPrimitiveCancel as Cancel, ComposerPrimitiveDictate as Dictate, ComposerPrimitiveDictationTranscript as DictationTranscript, ComposerPrimitiveIf as If, ComposerPrimitiveInput as Input, ComposerPrimitiveQueue as Queue, ComposerPrimitiveQuote as Quote, ComposerPrimitiveQuoteDismiss as QuoteDismiss, ComposerPrimitiveQuoteText as QuoteText, ComposerPrimitiveRoot as Root, ComposerPrimitiveSend as Send, ComposerPrimitiveStopDictation as StopDictation, RegisteredTrigger as Unstable_RegisteredTrigger, ComposerPrimitiveTriggerPopover as Unstable_TriggerPopover, ComposerPrimitiveTriggerPopoverBack as Unstable_TriggerPopoverBack, ComposerPrimitiveTriggerPopoverCategories as Unstable_TriggerPopoverCategories, ComposerPrimitiveTriggerPopoverCategoryItem as Unstable_TriggerPopoverCategoryItem, ComposerPrimitiveTriggerPopoverItem as Unstable_TriggerPopoverItem, ComposerPrimitiveTriggerPopoverItems as Unstable_TriggerPopoverItems, ComposerPrimitiveTriggerPopoverRoot as Unstable_TriggerPopoverRoot, useTriggerPopoverRootContext as unstable_useTriggerPopoverRootContext, useTriggerPopoverRootContextOptional as unstable_useTriggerPopoverRootContextOptional, useTriggerPopoverScopeContext as unstable_useTriggerPopoverScopeContext, useTriggerPopoverScopeContextOptional as unstable_useTriggerPopoverScopeContextOptional, useTriggerPopoverTriggers as unstable_useTriggerPopoverTriggers, useTriggerPopoverTriggersOptional as unstable_useTriggerPopoverTriggersOptional };
+}
+
+declare const convertExternalMessages: <T extends WeakKey>(messages: T[], callback: useExternalMessageConverter.Callback<T>, isRunning: boolean, metadata: useExternalMessageConverter.Metadata) => ThreadMessage[];
+
+declare const createMessageConverter: <T extends object>(callback: useExternalMessageConverter.Callback<T>) => {
+  useThreadMessages: (_param9: {
+    messages: T[];
+    isRunning: boolean;
+    joinStrategy?: JoinStrategy | undefined;
+    metadata?: useExternalMessageConverter.Metadata;
+  }) => ThreadMessage[];
+  toThreadMessages: (messages: T[], isRunning?: boolean, metadata?: useExternalMessageConverter.Metadata) => ThreadMessage[];
+  toOriginalMessages: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => unknown[];
+  toOriginalMessage: (input: ThreadState | ThreadMessage | ThreadMessage["content"][number]) => {};
+  useOriginalMessage: () => {};
+  useOriginalMessages: () => unknown[];
+};
+
+declare const createMessageQueue: (driver: MessageQueueDriver) => MessageQueueController;
+
+declare function createVoiceSession(options: {
+  abortSignal?: AbortSignal;
+}, setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>): RealtimeVoiceAdapter.Session;
+
+declare function defineMcpToolkit(definition: McpToolkitDefinition): Toolkit;
+
+declare function defineToolkit<TArgsByName extends {
+  [K in keyof TArgsByName]: Record<string, unknown>;
+}, TResultByName extends {
+  [K in keyof TArgsByName]: unknown;
+} = {
+  [K in keyof TArgsByName]: any;
+}>(_definition: {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
+}): Toolkit & {
+  [K in keyof TArgsByName]: ToolkitDefinitionEntryWithParameters<TArgsByName[K], TResultByName[K]>;
+};
+
+declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
+
+declare namespace error_d_exports {
+  export { ErrorPrimitiveMessage as Message, ErrorPrimitiveRoot as Root };
+}
+
+declare function externalTool(): never;
+
+declare const fromThreadMessageLike: (like: ThreadMessageLike, fallbackId: string, fallbackStatus: MessageStatus) => ThreadMessage;
+
+declare const generateId: (size?: number) => string;
+
+declare const getAutoStatus: (isLast: boolean, isRunning: boolean, hasInterruptedToolCalls: boolean, hasPendingToolCalls: boolean, error?: ReadonlyJSONValue) => MessageStatus;
+
+declare const getExternalStoreMessages: <T>(input: {
+  messages: readonly ThreadMessage[];
+} | ThreadMessage | ThreadMessage["content"][number]) => T[];
+
+declare function getMcpAppFromToolPart(part: ToolPartLike): McpAppMetadata | undefined;
+
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+declare global {
+  interface Window {
+    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
+  }
+}
+
+declare const groupPartByType: <TKey extends `group-${string}`>(map: Partial<Readonly<Record<GroupPartType, readonly TKey[]>>>) => ((part: PartState, context?: GroupByContext) => readonly TKey[]);
+
+declare const hitl: typeof humanTool;
+
+declare const hitlTool: typeof humanTool;
+
+declare function humanTool(): never;
+
+declare namespace entry_root_exports {
+  export { actionBarMore_d_exports as ActionBarMorePrimitive, actionBar_d_exports as ActionBarPrimitive, AddToolResultOptions, AppendMessage, Assistant, AssistantClient, AssistantCloud, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantFrameHost, AssistantFrameProvider, AssistantInteractableProps, assistantModal_d_exports as AssistantModalPrimitive, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, AssistantTransportCommand, AssistantTransportConnectionMetadata, AssistantTransportProtocol, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AttachmentStatus, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChatModelRunUpdate, CloudFileAttachmentAdapter, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerSendOptions, ComposerState$1 as ComposerState, CompositeAttachmentAdapter, CreateAppendMessage, CreateAttachment, CreateResumeRunConfig, CreateStartRunConfig, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, DevToolsHooks, DevToolsProviderApi, DictationAdapter, DictationState, EditComposerRuntime, EditComposerState, EmptyMessagePartComponent, EmptyMessagePartProps, EnrichedPartState, error_d_exports as ErrorPrimitive, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreAdapter, ExternalStoreBranchChange, ExternalStoreMessageConverter, ExternalStoreSharedOptions, ExternalStoreThreadData, ExternalStoreThreadListAdapter, ExternalThread, ExternalThreadBranchAdapter, ExternalThreadMessage, ExternalThreadProps, ExternalThreadQueueAdapter, FRAME_MESSAGE_CHANNEL, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, FrameMessage, FrameMessageType, GenerativeUIComponentRegistry, GenerativeUIMessagePart, GenerativeUIMessagePartComponent, GenerativeUIMessagePartProps, GenerativeUINode, GenerativeUIRender, GenerativeUIRenderError, GenerativeUIRenderProps, GenerativeUISpec, GenericThreadHistoryAdapter, GroupByContext, internal_d_exports as INTERNAL, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadList, InMemoryThreadListAdapter, InMemoryThreadListProps, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptions, LocalRuntimeOptionsBase, McpAppDisplayMode, McpAppHostContext, McpAppHostInfo, McpAppMetadata, McpAppRenderer, McpAppRendererOptions, McpAppResource, McpAppResourceCSP, McpAppResourceMeta, McpAppResourceOutput, McpAppSandboxConfig, McpAppToolCallParams, McpAppsHost, McpAppsRemoteHost, McpAppsRemoteHostOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, MessageFormatAdapter, MessageFormatItem, MessageFormatRepository, messagePart_d_exports as MessagePartPrimitive, MessagePartRuntime, MessagePartState, MessagePartStatus, message_d_exports as MessagePrimitive, MessageProvider, MessageQueueController, MessageQueueDriver, MessageRuntime, MessageState$1 as MessageState, MessageStatus, MessageStorageEntry, MessageTiming, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PartByIndexProvider, PartState, PendingAttachment, ProviderToolConfig, QueueItemMethods, queueItem_d_exports as QueueItemPrimitive, QueueItemState, QuoteInfo, QuoteMessagePartComponent, QuoteMessagePartProps, ReadonlyThreadProvider, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RespondToToolApprovalOptions, RuntimeAdapterProvider, RuntimeAdapters, selectionToolbar_d_exports as SelectionToolbarPrimitive, SendCommandsRequestBody, SerializedModelContext, SerializedTool, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SingleThreadList, SmoothOptions, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, SourceProviderMetadata, SpeechSynthesisAdapter, SubmitFeedbackOptions, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadComposerState, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItemMore_d_exports as ThreadListItemMorePrimitive, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState$1 as ThreadListItemState, ThreadListItemStatus, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadListState, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState, ThreadSuggestion, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadViewportState, Tool, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartMcpMetadata, ToolCallMessagePartProps, ToolCallMessagePartStatus, ToolCallText, ToolCallTiming, ToolDefinition, ToolExecutionStatus, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_ComposerInput, Unstable_ComposerInputHistory, Unstable_DirectiveFormatter, Unstable_DirectiveSegment, Unstable_IconComponent, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unstable_Mention, Unstable_MentionCategory, Unstable_MentionDirective, Unstable_MessageStallDetection, Unstable_MessageStallDetectionOptions, Unstable_ModelContextToolsOptions, RegisteredTrigger as Unstable_RegisteredTrigger, Unstable_SlashCommand, Unstable_SlashCommandAction, TriggerBehavior as Unstable_TriggerBehavior, Unstable_TriggerItem, Unstable_TriggerPopoverAriaProps, Unstable_UseComposerInputOptions, Unstable_UseLiveCompletionAdapterOptions, Unstable_UseMentionAdapterOptions, Unstable_UseSlashCommandAdapterOptions, Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, VoiceSessionState, WebSpeechDictationAdapter, WebSpeechSynthesisAdapter, bindExternalStoreMessage, createMessageQueue, createVoiceSession, defineMcpToolkit, defineToolkit, externalTool, fromThreadMessageLike, generateId, getExternalStoreMessages, getMcpAppFromToolPart, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, makeAssistantVisible, mergeModelContexts, pickExternalStoreSharedOptions, providerTool, stubTool, tool, unstable_Interactables, convertExternalMessages as unstable_convertExternalMessages, createMessageConverter as unstable_createMessageConverter, unstable_defaultDirectiveFormatter, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useComposerInput, unstable_useComposerInputHistory, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useLiveCompletionAdapter, unstable_useMentionAdapter, unstable_useMessageStallDetection, unstable_useSlashCommandAdapter, unstable_useThreadMessageIds, unstable_useTriggerPopoverAriaProps, useTriggerPopoverRootContext as unstable_useTriggerPopoverRootContext, useTriggerPopoverRootContextOptional as unstable_useTriggerPopoverRootContextOptional, useTriggerPopoverScopeContext as unstable_useTriggerPopoverScopeContext, useTriggerPopoverScopeContextOptional as unstable_useTriggerPopoverScopeContextOptional, useTriggerPopoverTriggers as unstable_useTriggerPopoverTriggers, useTriggerPopoverTriggersOptional as unstable_useTriggerPopoverTriggersOptional, useAssistantContext, useAssistantDataUI, useAssistantFrameHost, useAssistantInstructions, useAssistantInteractable, useAssistantRuntime, useAssistantTool, useAssistantToolUI, useAssistantTransportRuntime, useAssistantTransportSendCommand, useAssistantTransportState, useAttachment, useAttachmentRuntime, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useCloudThreadListAdapter, useCloudThreadListRuntime, useComposer, useComposerRuntime, useEditComposer, useEditComposerAttachment, useEditComposerAttachmentRuntime, useExternalMessageConverter, useExternalStoreRuntime, useExternalStoreSharedOptions, useInlineRender, useInteractableState, useLocalRuntime, useMessage, useMessageAttachment, useMessageAttachmentRuntime, useMessagePart, useMessagePartData, useMessagePartFile, useMessagePartImage, useMessagePartReasoning, useMessagePartRuntime, useMessagePartSource, useMessagePartText, useMessageQuote, useMessageRuntime, useMessageTiming, useRemoteThreadListRuntime, useRuntimeAdapters, useScrollLock, useSmooth, useThread, useThreadComposer, useThreadComposerAttachment, useThreadComposerAttachmentRuntime, useThreadList, useThreadListItem, useThreadListItemRuntime, useThreadModelContext, useThreadRuntime, useThreadViewport, useThreadViewportAutoScroll, useThreadViewportStore, useToolArgsStatus, useToolCallElapsed, useVoiceControls, useVoiceState, useVoiceVolume };
+}
+
+declare namespace internal_d_exports {
+  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolExecutionStatus, getAutoStatus, splitLocalRuntimeOptions, useComposerInputPluginRegistryOptional, useSmooth, useSmoothStatus, withSmoothContextProvider };
+}
+
+declare const makeAssistantDataUI: <T = any>(dataUI: AssistantDataUIProps<T>) => AssistantDataUI;
+
+declare const makeAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => AssistantTool;
+
+declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<TArgs, TResult>) => AssistantToolUI;
+
+declare const makeAssistantVisible: <T extends ComponentType<any>>(Component: T, config?: {
+  clickable?: boolean | undefined;
+  editable?: boolean | undefined;
+}) => T;
+
+declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
+
+declare namespace messagePart_d_exports {
+  export { MessagePartPrimitiveImage as Image, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveText as Text };
+}
+
+declare namespace message_d_exports {
+  export { MessagePrimitiveAttachmentByIndex as AttachmentByIndex, MessagePrimitiveAttachments as Attachments, MessagePrimitiveParts as Content, MessagePrimitiveError as Error, MessagePrimitiveGenerativeUI as GenerativeUI, MessagePrimitiveGroupedParts as GroupedParts, MessagePrimitiveIf as If, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessagePrimitiveQuote as Quote, MessagePrimitiveRoot as Root, MessagePrimitiveUnstable_PartsGrouped as Unstable_PartsGrouped, MessagePrimitiveUnstable_PartsGroupedByParentId as Unstable_PartsGroupedByParentId };
+}
+
+declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
+
+declare function providerTool(_config: ProviderToolConfig): never;
+
+declare namespace queueItem_d_exports {
+  export { QueueItemPrimitiveRemove as Remove, QueueItemPrimitiveSteer as Steer, QueueItemPrimitiveText as Text };
+}
+
+declare namespace selectionToolbar_d_exports {
+  export { SelectionToolbarPrimitiveQuote as Quote, SelectionToolbarPrimitiveRoot as Root, SelectionToolbarPrimitiveQuote, SelectionToolbarPrimitiveRoot };
+}
+
+declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options: T) => {
+  localRuntimeOptions: {
+    cloud: AssistantCloud | undefined;
+    initialMessages: readonly ThreadMessageLike[] | undefined;
+    maxSteps: number | undefined;
+    adapters: Omit<{
+      chatModel: ChatModelAdapter;
+      history?: ThreadHistoryAdapter | undefined;
+      attachments?: AttachmentAdapter | undefined;
+      speech?: SpeechSynthesisAdapter | undefined;
+      dictation?: DictationAdapter | undefined;
+      voice?: RealtimeVoiceAdapter | undefined;
+      feedback?: FeedbackAdapter | undefined;
+      suggestion?: SuggestionAdapter | undefined;
+    }, "chatModel"> | undefined;
+    unstable_humanToolNames: string[] | undefined;
+    unstable_enableMessageQueue: boolean | undefined;
+  };
+  otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
+};
+
+declare function stubTool(): never;
+
+declare namespace suggestion_d_exports {
+  export { SuggestionPrimitiveDescription as Description, SuggestionPrimitiveTitle as Title, SuggestionPrimitiveTrigger as Trigger };
+}
+
+declare namespace threadListItemMore_d_exports {
+  export { ThreadListItemMorePrimitiveContent as Content, ThreadListItemMorePrimitiveItem as Item, ThreadListItemMorePrimitiveRoot as Root, ThreadListItemMorePrimitiveSeparator as Separator, ThreadListItemMorePrimitiveTrigger as Trigger };
+}
+
+declare namespace threadListItem_d_exports {
+  export { ThreadListItemPrimitiveArchive as Archive, ThreadListItemPrimitiveDelete as Delete, ThreadListItemPrimitiveRoot as Root, ThreadListItemPrimitiveTitle as Title, ThreadListItemPrimitiveTrigger as Trigger, ThreadListItemPrimitiveUnarchive as Unarchive };
+}
+
+declare namespace threadList_d_exports {
+  export { ThreadListPrimitiveItemByIndex as ItemByIndex, ThreadListPrimitiveItems as Items, ThreadListPrimitiveLoadMore as LoadMore, ThreadListPrimitiveNew as New, ThreadListPrimitiveRoot as Root };
+}
+
+declare namespace thread_d_exports {
+  export { ThreadPrimitiveEmpty as Empty, ThreadPrimitiveIf as If, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadPrimitiveMessages as Messages, ThreadPrimitiveRoot as Root, ThreadPrimitiveScrollToBottom as ScrollToBottom, ThreadPrimitiveSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById, ThreadPrimitiveViewport as Viewport, ThreadPrimitiveViewportFooter as ViewportFooter, ThreadPrimitiveViewportProvider as ViewportProvider };
+}
+
+declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
+
+declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
+  (Unstable_InteractablesConfig | undefined)?
+]>;
+
+declare const unstable_defaultDirectiveFormatter: Unstable_DirectiveFormatter;
+
+declare function unstable_formatInteractableSnapshot(entry: Unstable_InteractableSnapshotEntry): string;
+
+declare function unstable_getInteractableSnapshots(message: {
+  metadata?: unknown;
+}): Unstable_InteractableSnapshotEntry[] | undefined;
+
+declare function unstable_getInteractableVersions(messages: readonly SnapshotCarrierMessage[], id: string, name: string): Unstable_InteractableVersion[];
+
+declare const unstable_interactableTool: <TSchema extends Unstable_InteractableStateSchema>(config: Unstable_InteractableToolConfig<TSchema>) => ToolDefinition<Record<string, unknown>, {
+  success: true;
+}>;
+
+declare function unstable_useComposerInput(options?: Unstable_UseComposerInputOptions): Unstable_ComposerInput;
+
+declare function unstable_useComposerInputHistory(): Unstable_ComposerInputHistory;
+
+declare const unstable_useInteractable: <TSchema extends Unstable_InteractableStateSchema>(name: string, config: Unstable_InteractableConfig<TSchema>) => readonly [
+  Unstable_InferInteractableState<TSchema>,
+  {
+    id: string;
+    version: Unstable_InteractableVersionInfo<Unstable_InferInteractableState<TSchema>> | undefined;
+    setState: (updater: Unstable_InferInteractableState<TSchema> | ((prev: Unstable_InferInteractableState<TSchema>) => Unstable_InferInteractableState<TSchema>)) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableState: <TState>(id: string) => [
+  TState | undefined,
+  {
+    setState: (updater: StateUpdater<TState>) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const unstable_useInteractableVersions: <TState = unknown>(id: string, name: string) => (Omit<Unstable_InteractableVersion, "state"> & {
+  state: TState;
+  restore: () => void;
+})[];
+
+declare function unstable_useLiveCompletionAdapter(options: Unstable_UseLiveCompletionAdapterOptions): {
+  adapter: Unstable_TriggerAdapter;
+  isLoading: boolean;
+};
+
+declare function unstable_useMentionAdapter(options?: Unstable_UseMentionAdapterOptions): {
+  adapter: Unstable_TriggerAdapter;
+  directive: Unstable_MentionDirective;
+  iconMap?: Record<string, Unstable_IconComponent>;
+  fallbackIcon?: Unstable_IconComponent;
+};
+
+declare function unstable_useMessageStallDetection(options?: Unstable_MessageStallDetectionOptions): Unstable_MessageStallDetection;
+
+declare function unstable_useSlashCommandAdapter(options: Unstable_UseSlashCommandAdapterOptions): {
+  adapter: Unstable_TriggerAdapter;
+  action: Unstable_SlashCommandAction;
+  iconMap?: Record<string, Unstable_IconComponent>;
+  fallbackIcon?: Unstable_IconComponent;
+};
+
+declare const unstable_useThreadMessageIds: () => readonly string[];
+
+declare function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps;
+
+declare const useActionBarEdit: () => (() => void) | null;
+
+declare const useActionBarExportMarkdown: (_param10?: {
+  filename?: string | undefined;
+  onExport?: ((content: string) => void | Promise<void>) | undefined;
+}) => (() => Promise<void>) | null;
+
+declare const useActionBarFeedbackNegative: () => () => void;
+
+declare const useActionBarFeedbackPositive: () => () => void;
+
+declare const useActionBarPrimitiveCopy: (_param11?: {
+  copiedDuration?: number | undefined;
+}) => (() => void) | null;
+
+declare const useActionBarReload: () => (() => void) | null;
+
+declare const useActionBarSpeak: () => (() => Promise<void>) | null;
+
+declare const useActionBarStopSpeaking: () => (() => void) | null;
+
+declare const useAssistantContext: (config: AssistantContextConfig) => void;
+
+declare const useAssistantDataUI: (dataUI: AssistantDataUIProps | null) => void;
+
+declare const useAssistantFrameHost: (_param12: UseAssistantFrameHostOptions) => void;
+
+declare const useAssistantInstructions: (config: string | AssistantInstructionsConfig) => void;
+
+declare const useAssistantInteractable: (name: string, config: AssistantInteractableProps) => string;
 
 declare function useAssistantRuntime(options?: {
   optional?: false | undefined;
@@ -4315,65 +5934,17 @@ declare function useAssistantRuntime(options?: {
   optional?: boolean | undefined;
 }): AssistantRuntime | null;
 
-declare const useThreadList: {
-  (): ThreadListState;
-  <TSelected>(selector: (state: ThreadListState) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ThreadListState) => TSelected) | undefined): ThreadListState | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): ThreadListState;
-  (options: {
-    optional?: boolean | undefined;
-  }): ThreadListState | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: ThreadListState) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: ThreadListState) => TSelected) | undefined;
-  }): ThreadListState | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: ThreadListState) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: ThreadListState) => TSelected) | undefined;
-  }): ThreadListState | TSelected | null;
-};
+declare const useAssistantTool: <TArgs extends Record<string, unknown>, TResult>(tool: AssistantToolProps<TArgs, TResult>) => void;
 
-declare function useAttachmentRuntime(options?: {
-  optional?: false | undefined;
-}): AttachmentRuntime;
+declare const useAssistantToolUI: (tool: AssistantToolUIProps<any, any> | null) => void;
 
-declare function useAttachmentRuntime(options?: {
-  optional?: boolean | undefined;
-}): AttachmentRuntime | null;
+declare const useAssistantTransportRuntime: <T>(options: AssistantTransportOptions<T>) => AssistantRuntime;
 
-declare function useThreadComposerAttachmentRuntime(options?: {
-  optional?: false | undefined;
-}): AttachmentRuntime<"thread-composer">;
+declare const useAssistantTransportSendCommand: () => (command: AssistantTransportCommand) => void;
 
-declare function useThreadComposerAttachmentRuntime(options?: {
-  optional?: boolean | undefined;
-}): AttachmentRuntime<"thread-composer"> | null;
+declare function useAssistantTransportState(): UserExternalState;
 
-declare function useEditComposerAttachmentRuntime(options?: {
-  optional?: false | undefined;
-}): AttachmentRuntime<"edit-composer">;
-
-declare function useEditComposerAttachmentRuntime(options?: {
-  optional?: boolean | undefined;
-}): AttachmentRuntime<"edit-composer"> | null;
-
-declare function useMessageAttachmentRuntime(options?: {
-  optional?: false | undefined;
-}): AttachmentRuntime<"message">;
-
-declare function useMessageAttachmentRuntime(options?: {
-  optional?: boolean | undefined;
-}): AttachmentRuntime<"message"> | null;
+declare function useAssistantTransportState<T>(selector: (state: UserExternalState) => T): T;
 
 declare const useAttachment: {
   (): AttachmentState & {
@@ -4427,368 +5998,122 @@ declare const useAttachment: {
   }) | TSelected | null;
 };
 
-declare const useThreadComposerAttachment: {
-  (): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  });
-  <TSelected>(selector: (state: ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  })) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  })) => TSelected) | undefined): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | TSelected;
+declare const useAttachmentRemove: () => () => void;
+
+declare function useAttachmentRuntime(options?: {
+  optional?: false | undefined;
+}): AttachmentRuntime;
+
+declare function useAttachmentRuntime(options?: {
+  optional?: boolean | undefined;
+}): AttachmentRuntime | null;
+
+declare namespace useAui {
+  type Props = {
+    [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
+  };
+}
+
+declare function useAui(): AssistantClient;
+
+declare function useAui(clients: useAui.Props): AssistantClient;
+
+declare function useAui(clients: useAui.Props, config: {
+  parent: null | AssistantClient;
+}): AssistantClient;
+
+declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
+
+declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
+
+declare function useAuiToolOverrides(overrides: AuiToolOverrides): void;
+
+declare const useBranchPickerNext: () => (() => void) | null;
+
+declare const useBranchPickerPrevious: () => (() => void) | null;
+
+declare const useChainOfThoughtAccordionTrigger: () => () => void;
+
+declare const useCloudThreadListAdapter: (adapter: CloudThreadListAdapterOptions) => RemoteThreadListAdapter;
+
+declare function useCloudThreadListRuntime(_param13: CloudThreadListAdapter): AssistantRuntime;
+
+declare const useComposer: {
+  (): ComposerState$1;
+  <TSelected>(selector: (state: ComposerState$1) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ComposerState$1) => TSelected) | undefined): ComposerState$1 | TSelected;
   (options: {
     optional?: false | undefined;
-  }): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  });
+  }): ComposerState$1;
   (options: {
     optional?: boolean | undefined;
-  }): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | null;
+  }): ComposerState$1 | null;
   <TSelected>(options: {
     optional?: false | undefined;
-    selector: (state: ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    }) | ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: PendingAttachmentStatus;
-      file: File;
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    })) => TSelected;
+    selector: (state: ComposerState$1) => TSelected;
   }): TSelected;
   <TSelected>(options: {
     optional?: false | undefined;
-    selector: ((state: ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    }) | ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: PendingAttachmentStatus;
-      file: File;
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    })) => TSelected) | undefined;
-  }): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | TSelected;
+    selector: ((state: ComposerState$1) => TSelected) | undefined;
+  }): ComposerState$1 | TSelected;
   <TSelected>(options: {
     optional?: boolean | undefined;
-    selector: (state: ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    }) | ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: PendingAttachmentStatus;
-      file: File;
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    })) => TSelected;
+    selector: (state: ComposerState$1) => TSelected;
   }): TSelected | null;
   <TSelected>(options: {
     optional?: boolean | undefined;
-    selector: ((state: ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: CompleteAttachmentStatus;
-      content: ThreadUserMessagePart[];
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    }) | ({
-      id: string;
-      type: "image" | "document" | "file" | (string & {});
-      name: string;
-      contentType?: string | undefined;
-      file?: File;
-      content?: ThreadUserMessagePart[];
-    } & {
-      status: PendingAttachmentStatus;
-      file: File;
-    } & {
-      readonly source: "thread-composer";
-    } & {
-      source: "thread-composer";
-    })) => TSelected) | undefined;
-  }): ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: CompleteAttachmentStatus;
-    content: ThreadUserMessagePart[];
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | ({
-    id: string;
-    type: "image" | "document" | "file" | (string & {});
-    name: string;
-    contentType?: string | undefined;
-    file?: File;
-    content?: ThreadUserMessagePart[];
-  } & {
-    status: PendingAttachmentStatus;
-    file: File;
-  } & {
-    readonly source: "thread-composer";
-  } & {
-    source: "thread-composer";
-  }) | TSelected | null;
+    selector: ((state: ComposerState$1) => TSelected) | undefined;
+  }): ComposerState$1 | TSelected | null;
+};
+
+declare const useComposerAddAttachment: (_param14?: {
+  multiple?: boolean | undefined;
+}) => (() => void) | null;
+
+declare const useComposerCancel: () => (() => void) | null;
+
+declare const useComposerDictate: () => (() => void) | null;
+
+declare const useComposerInputPluginRegistryOptional: () => ComposerInputPluginRegistry | null;
+
+declare function useComposerRuntime(options?: {
+  optional?: false | undefined;
+}): ComposerRuntime;
+
+declare function useComposerRuntime(options?: {
+  optional?: boolean | undefined;
+}): ComposerRuntime | null;
+
+declare const useComposerSend: () => (() => void) | null;
+
+declare const useComposerStopDictation: () => (() => void) | null;
+
+declare const useEditComposer: {
+  (): EditComposerState;
+  <TSelected>(selector: (state: EditComposerState) => TSelected): TSelected;
+  <TSelected>(selector: ((state: EditComposerState) => TSelected) | undefined): EditComposerState | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): EditComposerState;
+  (options: {
+    optional?: boolean | undefined;
+  }): EditComposerState | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: EditComposerState) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: EditComposerState) => TSelected) | undefined;
+  }): EditComposerState | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: EditComposerState) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: EditComposerState) => TSelected) | undefined;
+  }): EditComposerState | TSelected | null;
 };
 
 declare const useEditComposerAttachment: {
@@ -5155,6 +6480,91 @@ declare const useEditComposerAttachment: {
   }) | TSelected | null;
 };
 
+declare function useEditComposerAttachmentRuntime(options?: {
+  optional?: false | undefined;
+}): AttachmentRuntime<"edit-composer">;
+
+declare function useEditComposerAttachmentRuntime(options?: {
+  optional?: boolean | undefined;
+}): AttachmentRuntime<"edit-composer"> | null;
+
+declare namespace useExternalMessageConverter {
+  type Message = (ThreadMessageLike & {
+    readonly convertConfig?: {
+      readonly joinStrategy?: JoinStrategy;
+    };
+  }) | {
+    role: "tool";
+    toolCallId: string;
+    toolName?: string | undefined;
+    result: any;
+    artifact?: any;
+    isError?: boolean;
+    messages?: readonly ThreadMessage[];
+  };
+  type Metadata = {
+    readonly toolStatuses?: Record<string, ToolExecutionStatus>;
+    readonly error?: ReadonlyJSONValue;
+    readonly messageTiming?: Record<string, MessageTiming>;
+  };
+  type Callback<T> = (message: T, metadata: Metadata) => Message | Message[];
+}
+
+declare const useExternalMessageConverter: <T extends WeakKey>(_param15: {
+  callback: useExternalMessageConverter.Callback<T>;
+  messages: T[];
+  isRunning: boolean;
+  joinStrategy?: JoinStrategy | undefined;
+  metadata?: useExternalMessageConverter.Metadata | undefined;
+}) => ThreadMessage[];
+
+declare const useExternalStoreRuntime: <T>(store: ExternalStoreAdapter<T>) => AssistantRuntime;
+
+declare const useExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
+
+declare const useInlineRender: <TArgs, TResult>(toolUI: FC<ToolCallMessagePartProps<TArgs, TResult>>) => FC<ToolCallMessagePartProps<TArgs, TResult>>;
+
+declare const useInteractableState: <TState>(id: string, fallback: TState) => [
+  TState,
+  {
+    setState: (updater: StateUpdater$1<TState>) => void;
+    setSelected: (selected: boolean) => void;
+    isPending: boolean;
+    error: unknown;
+    flush: () => Promise<void>;
+  }
+];
+
+declare const useLocalRuntime: (chatModel: ChatModelAdapter, _param16?: LocalRuntimeOptions) => AssistantRuntime;
+
+declare const useMessage: {
+  (): MessageState$1;
+  <TSelected>(selector: (state: MessageState$1) => TSelected): TSelected;
+  <TSelected>(selector: ((state: MessageState$1) => TSelected) | undefined): MessageState$1 | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): MessageState$1;
+  (options: {
+    optional?: boolean | undefined;
+  }): MessageState$1 | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: MessageState$1) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: MessageState$1) => TSelected) | undefined;
+  }): MessageState$1 | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: MessageState$1) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: MessageState$1) => TSelected) | undefined;
+  }): MessageState$1 | TSelected | null;
+};
+
 declare const useMessageAttachment: {
   (): {
     id: string;
@@ -5351,113 +6761,13 @@ declare const useMessageAttachment: {
   }) | TSelected | null;
 };
 
-declare function useComposerRuntime(options?: {
+declare function useMessageAttachmentRuntime(options?: {
   optional?: false | undefined;
-}): ComposerRuntime;
+}): AttachmentRuntime<"message">;
 
-declare function useComposerRuntime(options?: {
+declare function useMessageAttachmentRuntime(options?: {
   optional?: boolean | undefined;
-}): ComposerRuntime | null;
-
-declare const useComposer: {
-  (): ComposerState$1;
-  <TSelected>(selector: (state: ComposerState$1) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ComposerState$1) => TSelected) | undefined): ComposerState$1 | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): ComposerState$1;
-  (options: {
-    optional?: boolean | undefined;
-  }): ComposerState$1 | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: ComposerState$1) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: ComposerState$1) => TSelected) | undefined;
-  }): ComposerState$1 | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: ComposerState$1) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: ComposerState$1) => TSelected) | undefined;
-  }): ComposerState$1 | TSelected | null;
-};
-
-declare function useMessageRuntime(options?: {
-  optional?: false | undefined;
-}): MessageRuntime;
-
-declare function useMessageRuntime(options?: {
-  optional?: boolean | undefined;
-}): MessageRuntime | null;
-
-declare const useMessage: {
-  (): MessageState$1;
-  <TSelected>(selector: (state: MessageState$1) => TSelected): TSelected;
-  <TSelected>(selector: ((state: MessageState$1) => TSelected) | undefined): MessageState$1 | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): MessageState$1;
-  (options: {
-    optional?: boolean | undefined;
-  }): MessageState$1 | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: MessageState$1) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: MessageState$1) => TSelected) | undefined;
-  }): MessageState$1 | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: MessageState$1) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: MessageState$1) => TSelected) | undefined;
-  }): MessageState$1 | TSelected | null;
-};
-
-declare const useEditComposer: {
-  (): EditComposerState;
-  <TSelected>(selector: (state: EditComposerState) => TSelected): TSelected;
-  <TSelected>(selector: ((state: EditComposerState) => TSelected) | undefined): EditComposerState | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): EditComposerState;
-  (options: {
-    optional?: boolean | undefined;
-  }): EditComposerState | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: EditComposerState) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: EditComposerState) => TSelected) | undefined;
-  }): EditComposerState | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: EditComposerState) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: EditComposerState) => TSelected) | undefined;
-  }): EditComposerState | TSelected | null;
-};
-
-declare function useMessagePartRuntime(options?: {
-  optional?: false | undefined;
-}): MessagePartRuntime;
-
-declare function useMessagePartRuntime(options?: {
-  optional?: boolean | undefined;
-}): MessagePartRuntime | null;
+}): AttachmentRuntime<"message"> | null;
 
 declare const useMessagePart: {
   (): MessagePartState;
@@ -5487,1676 +6797,27 @@ declare const useMessagePart: {
   }): MessagePartState | TSelected | null;
 };
 
-declare function useThreadRuntime(options?: {
-  optional?: false | undefined;
-}): ThreadRuntime;
+declare const useMessagePartData: <T = any>(name?: string) => DataMessagePart<T> | null;
 
-declare function useThreadRuntime(options?: {
-  optional?: boolean | undefined;
-}): ThreadRuntime | null;
-
-declare const useThread: {
-  (): ThreadState;
-  <TSelected>(selector: (state: ThreadState) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ThreadState) => TSelected) | undefined): ThreadState | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): ThreadState;
-  (options: {
-    optional?: boolean | undefined;
-  }): ThreadState | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: ThreadState) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: ThreadState) => TSelected) | undefined;
-  }): ThreadState | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: ThreadState) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: ThreadState) => TSelected) | undefined;
-  }): ThreadState | TSelected | null;
-};
-
-declare const useThreadComposer: {
-  (): ThreadComposerState;
-  <TSelected>(selector: (state: ThreadComposerState) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ThreadComposerState) => TSelected) | undefined): ThreadComposerState | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): ThreadComposerState;
-  (options: {
-    optional?: boolean | undefined;
-  }): ThreadComposerState | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: ThreadComposerState) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: ThreadComposerState) => TSelected) | undefined;
-  }): ThreadComposerState | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: ThreadComposerState) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: ThreadComposerState) => TSelected) | undefined;
-  }): ThreadComposerState | TSelected | null;
-};
-
-declare function useThreadModelContext(options?: {
-  optional?: false | undefined;
-}): ModelContext$1;
-
-declare function useThreadModelContext(options?: {
-  optional?: boolean | undefined;
-}): ModelContext$1 | null;
-
-declare function useThreadListItemRuntime(options?: {
-  optional?: false | undefined;
-}): ThreadListItemRuntime;
-
-declare function useThreadListItemRuntime(options?: {
-  optional?: boolean | undefined;
-}): ThreadListItemRuntime | null;
-
-declare const useThreadListItem: {
-  (): ThreadListItemState$1;
-  <TSelected>(selector: (state: ThreadListItemState$1) => TSelected): TSelected;
-  <TSelected>(selector: ((state: ThreadListItemState$1) => TSelected) | undefined): ThreadListItemState$1 | TSelected;
-  (options: {
-    optional?: false | undefined;
-  }): ThreadListItemState$1;
-  (options: {
-    optional?: boolean | undefined;
-  }): ThreadListItemState$1 | null;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: (state: ThreadListItemState$1) => TSelected;
-  }): TSelected;
-  <TSelected>(options: {
-    optional?: false | undefined;
-    selector: ((state: ThreadListItemState$1) => TSelected) | undefined;
-  }): ThreadListItemState$1 | TSelected;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: (state: ThreadListItemState$1) => TSelected;
-  }): TSelected | null;
-  <TSelected>(options: {
-    optional?: boolean | undefined;
-    selector: ((state: ThreadListItemState$1) => TSelected) | undefined;
-  }): ThreadListItemState$1 | TSelected | null;
-};
-
-interface EventLog {
-  time: Date;
-  event: string;
-  data: unknown;
-}
-
-interface DevToolsApiEntry {
-  api: Partial<AssistantClient>;
-  logs: EventLog[];
-}
-
-interface DevToolsHook {
-  apis: Map<number, DevToolsApiEntry>;
-  nextId: number;
-  listeners: Set<(apiId: number) => void>;
-}
-
-declare global {
-  interface Window {
-    __ASSISTANT_UI_DEVTOOLS_HOOK__?: any;
-  }
-}
-
-declare class DevToolsHooks {
-  static subscribe(listener: () => void): Unsubscribe;
-  static clearEventLogs(apiId: number): void;
-  static getApis(): Map<number, DevToolsApiEntry>;
-  private static notifyListeners;
-}
-
-declare class DevToolsProviderApi {
-  private static readonly MAX_EVENT_LOGS_PER_API;
-  static register(aui: Partial<AssistantClient>): Unsubscribe;
-  private static notifyListeners;
-}
-
-declare const useMessageQuote: () => QuoteInfo | undefined;
-
-declare const useMessageTiming: () => MessageTiming | undefined;
-
-declare const useToolCallElapsed: () => number | undefined;
-
-type ThreadData = {
-  externalId: string;
-};
-
-type CloudThreadListAdapter = {
-  cloud: AssistantCloud;
-  runtimeHook: () => AssistantRuntime;
-  create?(): Promise<ThreadData>;
-  delete?(threadId: string): Promise<void>;
-};
-
-declare function useCloudThreadListRuntime(_param12: CloudThreadListAdapter): AssistantRuntime;
-
-type TextPart = {
-  readonly type: "text";
-  readonly text: string;
-};
-
-type ImagePart = {
-  readonly type: "image";
-  readonly image: string;
-};
-
-type UserMessagePart = TextPart | ImagePart;
-
-type UserMessage = {
-  readonly role: "user";
-  readonly parts: readonly UserMessagePart[];
-};
-
-type AssistantMessage = {
-  readonly role: "assistant";
-  readonly parts: readonly TextPart[];
-};
-
-type AddMessageCommand = {
-  readonly type: "add-message";
-  readonly message: UserMessage | AssistantMessage;
-  readonly parentId: string | null;
-  readonly sourceId: string | null;
-};
-
-type AddToolResultCommand = {
-  readonly type: "add-tool-result";
-  readonly toolCallId: string;
-  readonly toolName: string;
-  readonly result: ReadonlyJSONValue;
-  readonly isError: boolean;
-  readonly artifact?: ReadonlyJSONValue;
-  readonly modelContent?: readonly ToolModelContentPart[];
-};
-
-type AssistantTransportCommand = AddMessageCommand | AddToolResultCommand | UserCommands;
-
-type AssistantTransportState = {
-  readonly messages: readonly ThreadMessage[];
-  readonly state?: ReadonlyJSONValue;
-  readonly isRunning: boolean;
-};
-
-type AssistantTransportConnectionMetadata = {
-  pendingCommands: AssistantTransportCommand[];
-  isSending: boolean;
-  toolStatuses: Record<string, ToolExecutionStatus>;
-};
-
-type AssistantTransportStateConverter<T> = (state: T, connectionMetadata: AssistantTransportConnectionMetadata) => AssistantTransportState;
-
-type QueuedCommand = AssistantTransportCommand;
-
-type HeadersValue = Record<string, string> | Headers;
-
-type AssistantTransportProtocol = "assistant-transport" | "data-stream";
-
-type SendCommandsRequestBody = {
-  commands: QueuedCommand[];
-  state: unknown;
-  system: string | undefined;
-  tools: Record<string, unknown> | undefined;
-  callSettings: LanguageModelV1CallSettings | undefined;
-  config: LanguageModelConfig | undefined;
-  threadId: string | null;
-  parentId?: string | null;
-  [key: string]: unknown;
-};
-
-type AssistantTransportOptions<T> = {
-  initialState: T;
-  api: string;
-  resumeApi?: string;
-  protocol?: AssistantTransportProtocol;
-  converter: AssistantTransportStateConverter<T>;
-  headers: HeadersValue | (() => Promise<HeadersValue>);
-  body?: object | (() => Promise<object | undefined>);
-  prepareSendCommandsRequest?: (body: SendCommandsRequestBody) => Record<string, unknown> | Promise<Record<string, unknown>>;
-  onResponse?: (response: Response) => void;
-  onFinish?: () => void;
-  onError?: (error: Error, params: {
-    commands: AssistantTransportCommand[];
-    updateState: (updater: (state: T) => T) => void;
-  }) => void | Promise<void>;
-  onCancel?: (params: {
-    commands: AssistantTransportCommand[];
-    updateState: (updater: (state: T) => T) => void;
-    error?: Error;
-  }) => void;
-  capabilities?: {
-    edit?: boolean;
-  };
-  adapters?: {
-    attachments?: AttachmentAdapter | undefined;
-    history?: ThreadHistoryAdapter | undefined;
-  };
-};
-
-declare const useAssistantTransportSendCommand: () => (command: AssistantTransportCommand) => void;
-
-declare function useAssistantTransportState(): UserExternalState;
-
-declare function useAssistantTransportState<T>(selector: (state: UserExternalState) => T): T;
-
-declare const useAssistantTransportRuntime: <T>(options: AssistantTransportOptions<T>) => AssistantRuntime;
-
-declare const makeAssistantVisible: <T extends ComponentType<any>>(Component: T, config?: {
-  clickable?: boolean | undefined;
-  editable?: boolean | undefined;
-}) => T;
-
-type UseAssistantFrameHostOptions = {
-  iframeRef: Readonly<RefObject<HTMLIFrameElement | null | undefined>>;
-  targetOrigin?: string;
-  register: (frameHost: AssistantFrameHost) => Unsubscribe;
-};
-
-declare const useAssistantFrameHost: (_param13: UseAssistantFrameHostOptions) => void;
-
-type WithRenderPropProps<T extends ElementType> = ComponentPropsWithoutRef<T> & {
-  render?: ReactElement | undefined;
-};
-
-declare const Primitive$1: {
-  a: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLAnchorElement> & import("react").AnchorHTMLAttributes<HTMLAnchorElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLAnchorElement>>;
-  button: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLButtonElement>>;
-  div: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLDivElement>>;
-  form: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLFormElement>>;
-  h2: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLHeadingElement> & import("react").HTMLAttributes<HTMLHeadingElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLHeadingElement>>;
-  h3: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLHeadingElement> & import("react").HTMLAttributes<HTMLHeadingElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLHeadingElement>>;
-  img: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLImageElement> & import("react").ImgHTMLAttributes<HTMLImageElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLImageElement>>;
-  input: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLInputElement> & import("react").InputHTMLAttributes<HTMLInputElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLInputElement>>;
-  label: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLLabelElement> & import("react").LabelHTMLAttributes<HTMLLabelElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLLabelElement>>;
-  li: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLLIElement> & import("react").LiHTMLAttributes<HTMLLIElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLLIElement>>;
-  nav: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLElement> & import("react").HTMLAttributes<HTMLElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLElement>>;
-  ol: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLOListElement> & import("react").OlHTMLAttributes<HTMLOListElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLOListElement>>;
-  p: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLParagraphElement> & import("react").HTMLAttributes<HTMLParagraphElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLParagraphElement>>;
-  select: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSelectElement> & import("react").SelectHTMLAttributes<HTMLSelectElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLSelectElement>>;
-  span: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLSpanElement>>;
-  svg: ForwardRefExoticComponent<Omit<import("react").SVGProps<SVGSVGElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<SVGSVGElement>>;
-  ul: ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLUListElement> & import("react").HTMLAttributes<HTMLUListElement> & {
-    asChild?: boolean;
-  }, "ref"> & {
-    render?: ReactElement | undefined;
-  } & RefAttributes<HTMLUListElement>>;
-};
-
-type PrimitiveDivProps$5 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace ActionBarPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps$5 & {
-    hideWhenRunning?: boolean | undefined;
-    autohide?: "always" | "not-last" | "never" | undefined;
-    autohideFloat?: "always" | "single-branch" | "never" | undefined;
-  };
-}
-
-declare const ActionBarPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  hideWhenRunning?: boolean | undefined;
-  autohide?: "always" | "not-last" | "never" | undefined;
-  autohideFloat?: "always" | "single-branch" | "never" | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-type PrimitiveButtonProps = ComponentPropsWithoutRef<typeof Primitive$1.button>;
-
-type ActionButtonProps<THook> = PrimitiveButtonProps & (THook extends ((props: infer TProps) => unknown) ? TProps : never);
-
-type ActionButtonElement = ComponentRef<typeof Primitive$1.button>;
-
-declare const useActionBarPrimitiveCopy: (_param14?: {
-  copiedDuration?: number | undefined;
-}) => (() => void) | null;
-
-declare namespace ActionBarPrimitiveCopy {
-  type Element = HTMLButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarPrimitiveCopy>;
-}
-
-declare const ActionBarPrimitiveCopy: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  copiedDuration?: number | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarReload: () => (() => void) | null;
-
-declare namespace ActionBarPrimitiveReload {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarReload>;
-}
-
-declare const ActionBarPrimitiveReload: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarEdit: () => (() => void) | null;
-
-declare namespace ActionBarPrimitiveEdit {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarEdit>;
-}
-
-declare const ActionBarPrimitiveEdit: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarSpeak: () => (() => Promise<void>) | null;
-
-declare namespace ActionBarPrimitiveSpeak {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarSpeak>;
-}
-
-declare const ActionBarPrimitiveSpeak: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarStopSpeaking: () => (() => void) | null;
-
-declare namespace ActionBarPrimitiveStopSpeaking {
-  type Element = HTMLButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarStopSpeaking>;
-}
-
-declare const ActionBarPrimitiveStopSpeaking: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarFeedbackPositive: () => () => void;
-
-declare namespace ActionBarPrimitiveFeedbackPositive {
-  type Element = HTMLButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarFeedbackPositive>;
-}
-
-declare const ActionBarPrimitiveFeedbackPositive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarFeedbackNegative: () => () => void;
-
-declare namespace ActionBarPrimitiveFeedbackNegative {
-  type Element = HTMLButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarFeedbackNegative>;
-}
-
-declare const ActionBarPrimitiveFeedbackNegative: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useActionBarExportMarkdown: (_param15?: {
-  filename?: string | undefined;
-  onExport?: ((content: string) => void | Promise<void>) | undefined;
-}) => (() => Promise<void>) | null;
-
-declare namespace ActionBarPrimitiveExportMarkdown {
-  type Element = HTMLButtonElement;
-  type Props = ActionButtonProps<typeof useActionBarExportMarkdown>;
-}
-
-declare const ActionBarPrimitiveExportMarkdown: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  filename?: string | undefined;
-  onExport?: ((content: string) => void | Promise<void>) | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace actionBar_d_exports {
-  export { ActionBarPrimitiveCopy as Copy, ActionBarPrimitiveEdit as Edit, ActionBarPrimitiveExportMarkdown as ExportMarkdown, ActionBarPrimitiveFeedbackNegative as FeedbackNegative, ActionBarPrimitiveFeedbackPositive as FeedbackPositive, ActionBarPrimitiveReload as Reload, ActionBarPrimitiveRoot as Root, ActionBarPrimitiveSpeak as Speak, ActionBarPrimitiveStopSpeaking as StopSpeaking };
-}
-
-declare namespace ActionBarMorePrimitiveRoot {
-  type Props = DropdownMenu.DropdownMenuProps;
-}
-
-declare const ActionBarMorePrimitiveRoot: FC<ActionBarMorePrimitiveRoot.Props>;
-
-declare namespace ActionBarMorePrimitiveTrigger {
-  type Element = ComponentRef<typeof DropdownMenu.Trigger>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Trigger>;
-}
-
-declare const ActionBarMorePrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ActionBarMorePrimitiveContent {
-  type Element = ComponentRef<typeof DropdownMenu.Content>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Content> & {
-    portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
-  };
-}
-
-declare const ActionBarMorePrimitiveContent: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & {
-  portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ActionBarMorePrimitiveItem {
-  type Element = ComponentRef<typeof DropdownMenu.Item>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Item>;
-}
-
-declare const ActionBarMorePrimitiveItem: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuItemProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ActionBarMorePrimitiveSeparator {
-  type Element = ComponentRef<typeof DropdownMenu.Separator>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Separator>;
-}
-
-declare const ActionBarMorePrimitiveSeparator: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuSeparatorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace actionBarMore_d_exports {
-  export { ActionBarMorePrimitiveContent as Content, ActionBarMorePrimitiveItem as Item, ActionBarMorePrimitiveRoot as Root, ActionBarMorePrimitiveSeparator as Separator, ActionBarMorePrimitiveTrigger as Trigger };
-}
-
-declare namespace AssistantModalPrimitiveRoot {
-  type Props = Popover.PopoverProps & {
-    unstable_openOnRunStart?: boolean | undefined;
-  };
-}
-
-declare const AssistantModalPrimitiveRoot: FC<AssistantModalPrimitiveRoot.Props>;
-
-declare namespace AssistantModalPrimitiveTrigger {
-  type Element = ComponentRef<typeof Popover.Trigger>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Trigger>;
-}
-
-declare const AssistantModalPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace AssistantModalPrimitiveContent {
-  type Element = ComponentRef<typeof Popover.Content>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Content> & {
-    portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
-    dissmissOnInteractOutside?: boolean | undefined;
-  };
-}
-
-declare const AssistantModalPrimitiveContent: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
-  dissmissOnInteractOutside?: boolean | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace AssistantModalPrimitiveAnchor {
-  type Element = ComponentRef<typeof Popover.Anchor>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Anchor>;
-}
-
-declare const AssistantModalPrimitiveAnchor: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverAnchorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace assistantModal_d_exports {
-  export { AssistantModalPrimitiveAnchor as Anchor, AssistantModalPrimitiveContent as Content, AssistantModalPrimitiveRoot as Root, AssistantModalPrimitiveTrigger as Trigger };
-}
-
-type PrimitiveDivProps$4 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace AttachmentPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps$4;
-}
-
-declare const AttachmentPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-type PrimitiveDivProps$3 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace AttachmentPrimitiveThumb {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps$3;
-}
-
-declare const AttachmentPrimitiveThumb: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace AttachmentPrimitiveName {
-  type Props = Record<string, never>;
-}
-
-declare const AttachmentPrimitiveName: FC<AttachmentPrimitiveName.Props>;
-
-declare const useAttachmentRemove: () => () => void;
-
-declare namespace AttachmentPrimitiveRemove {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useAttachmentRemove>;
-}
-
-declare const AttachmentPrimitiveRemove: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace attachment_d_exports {
-  export { AttachmentPrimitiveName as Name, AttachmentPrimitiveRemove as Remove, AttachmentPrimitiveRoot as Root, AttachmentPrimitiveThumb as unstable_Thumb };
-}
-
-declare const useBranchPickerNext: () => (() => void) | null;
-
-declare namespace BranchPickerPrimitiveNext {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useBranchPickerNext>;
-}
-
-declare const BranchPickerPrimitiveNext: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useBranchPickerPrevious: () => (() => void) | null;
-
-declare namespace BranchPickerPrimitivePrevious {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useBranchPickerPrevious>;
-}
-
-declare const BranchPickerPrimitivePrevious: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace BranchPickerPrimitiveCount {
-  type Props = Record<string, never>;
-}
-
-declare const BranchPickerPrimitiveCount: FC<BranchPickerPrimitiveCount.Props>;
-
-declare namespace BranchPickerPrimitiveNumber {
-  type Props = Record<string, never>;
-}
-
-declare const BranchPickerPrimitiveNumber: FC<BranchPickerPrimitiveNumber.Props>;
-
-declare namespace BranchPickerPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div> & {
-    hideWhenSingleBranch?: boolean | undefined;
-  };
-}
-
-declare const BranchPickerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  hideWhenSingleBranch?: boolean | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace branchPicker_d_exports {
-  export { BranchPickerPrimitiveCount as Count, BranchPickerPrimitiveNext as Next, BranchPickerPrimitiveNumber as Number, BranchPickerPrimitivePrevious as Previous, BranchPickerPrimitiveRoot as Root };
-}
-
-type PrimitiveDivProps$2 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace ChainOfThoughtPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps$2;
-}
-
-declare const ChainOfThoughtPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare const useChainOfThoughtAccordionTrigger: () => () => void;
-
-declare namespace ChainOfThoughtPrimitiveAccordionTrigger {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useChainOfThoughtAccordionTrigger>;
-}
-
-declare const ChainOfThoughtPrimitiveAccordionTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace chainOfThought_d_exports {
-  export { ChainOfThoughtPrimitiveAccordionTrigger as AccordionTrigger, ChainOfThoughtPrimitiveAccordionTrigger as AccordionTriggerPrimitive, ChainOfThoughtPrimitiveParts as Parts, ChainOfThoughtPrimitiveParts as PartsPrimitive, ChainOfThoughtPrimitiveRoot as Root, ChainOfThoughtPrimitiveRoot as RootPrimitive };
-}
-
-type SelectItemOverride = (item: Unstable_TriggerItem) => boolean;
-
-type TriggerBehavior = {
-  readonly kind: "directive";
-  readonly formatter: Unstable_DirectiveFormatter;
-  readonly onInserted?: (item: Unstable_TriggerItem) => void;
-} | {
-  readonly kind: "action";
-  readonly formatter: Unstable_DirectiveFormatter;
-  readonly onExecute: (item: Unstable_TriggerItem) => void;
-  readonly removeOnExecute?: boolean;
-};
-
-type TriggerPopoverResourceOutput = {
-  readonly open: boolean;
-  readonly query: string;
-  readonly activeCategoryId: string | null;
-  readonly categories: readonly Unstable_TriggerCategory[];
-  readonly items: readonly Unstable_TriggerItem[];
-  readonly highlightedIndex: number;
-  readonly isSearchMode: boolean;
-  readonly isLoading: boolean;
-  readonly popoverId: string;
-  readonly highlightedItemId: string | undefined;
-  selectCategory(categoryId: string): void;
-  goBack(): void;
-  selectItem(item: Unstable_TriggerItem): void;
-  close(): void;
-  highlightIndex(index: number): void;
-  handleKeyDown(e: {
-    readonly key: string;
-    readonly shiftKey: boolean;
-    preventDefault(): void;
-  }): boolean;
-  setCursorPosition(pos: number): void;
-  registerSelectItemOverride(fn: SelectItemOverride): () => void;
-};
-
-type RegisteredTrigger = {
-  readonly char: string;
-  readonly behavior?: TriggerBehavior;
-  readonly resource: TriggerPopoverResourceOutput;
-};
-
-type TriggerPopoverLifecycleListener = {
-  added(trigger: RegisteredTrigger): void;
-  removed(char: string): void;
-};
-
-type TriggerPopoverActiveAria = {
-  popoverId: string;
-  highlightedItemId: string | undefined;
-};
-
-type TriggerPopoverRootContextValue = {
-  register(trigger: RegisteredTrigger): () => void;
-  getTriggers(): ReadonlyMap<string, RegisteredTrigger>;
-  subscribe(listener: () => void): () => void;
-  subscribeLifecycle(listener: TriggerPopoverLifecycleListener): () => void;
-  getActiveAria(): TriggerPopoverActiveAria | null;
-  subscribeAria(listener: () => void): () => void;
-};
-
-declare const useTriggerPopoverRootContext: () => TriggerPopoverRootContextValue;
-
-declare const useTriggerPopoverRootContextOptional: () => TriggerPopoverRootContextValue | null;
-
-declare const useTriggerPopoverTriggers: () => ReadonlyMap<string, RegisteredTrigger>;
-
-declare const useTriggerPopoverTriggersOptional: () => ReadonlyMap<string, RegisteredTrigger>;
-
-declare namespace ComposerPrimitiveTriggerPopoverRoot {
-  type Props = {
-    children: ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverRoot: FC<ComposerPrimitiveTriggerPopoverRoot.Props>;
-
-declare const useTriggerPopoverScopeContext: () => TriggerPopoverResourceOutput;
-
-declare const useTriggerPopoverScopeContextOptional: () => TriggerPopoverResourceOutput | null;
-
-declare namespace ComposerPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.form>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.form>;
-}
-
-declare const ComposerPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLFormElement> & import("react").FormHTMLAttributes<HTMLFormElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLFormElement>, "ref"> & import("react").RefAttributes<HTMLFormElement>>;
-
-declare namespace ComposerPrimitiveInput {
-  export type Element = HTMLTextAreaElement;
-  type BaseProps = {
-    asChild?: boolean | undefined;
-    render?: ReactElement | undefined;
-    cancelOnEscape?: boolean | undefined;
-    unstable_focusOnRunStart?: boolean | undefined;
-    unstable_focusOnScrollToBottom?: boolean | undefined;
-    unstable_focusOnThreadSwitched?: boolean | undefined;
-    unstable_insertNewlineOnTouchEnter?: boolean | undefined;
-    addAttachmentOnPaste?: boolean | undefined;
-  };
-  type SubmitModeProps = {
-    submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
-    submitOnEnter?: never;
-  } | {
-    submitMode?: never;
-    submitOnEnter?: boolean | undefined;
-  };
-  export type Props = TextareaAutosizeProps & BaseProps & SubmitModeProps;
-  export {};
-}
-
-declare const ComposerPrimitiveInput: import("react").ForwardRefExoticComponent<ComposerPrimitiveInput.Props & import("react").RefAttributes<HTMLTextAreaElement>>;
-
-declare const useComposerSend: () => (() => void) | null;
-
-declare namespace ComposerPrimitiveSend {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useComposerSend>;
-}
-
-declare const ComposerPrimitiveSend: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useComposerCancel: () => (() => void) | null;
-
-declare namespace ComposerPrimitiveCancel {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useComposerCancel>;
-}
-
-declare const ComposerPrimitiveCancel: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useComposerAddAttachment: (_param16?: {
-  multiple?: boolean | undefined;
-}) => (() => void) | null;
-
-declare namespace ComposerPrimitiveAddAttachment {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useComposerAddAttachment>;
-}
-
-declare const ComposerPrimitiveAddAttachment: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  multiple?: boolean | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveAttachmentDropzone {
-  type Element = HTMLDivElement;
-  type Props = React.HTMLAttributes<HTMLDivElement> & {
-    asChild?: boolean | undefined;
-    render?: ReactElement | undefined;
-    disabled?: boolean | undefined;
-  };
-}
-
-declare const ComposerPrimitiveAttachmentDropzone: React.ForwardRefExoticComponent<React.HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean | undefined;
-  render?: ReactElement | undefined;
-  disabled?: boolean | undefined;
-} & React.RefAttributes<HTMLDivElement>>;
-
-declare const useComposerDictate: () => (() => void) | null;
-
-declare namespace ComposerPrimitiveDictate {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useComposerDictate>;
-}
-
-declare const ComposerPrimitiveDictate: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useComposerStopDictation: () => (() => void) | null;
-
-declare namespace ComposerPrimitiveStopDictation {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useComposerStopDictation>;
-}
-
-declare const ComposerPrimitiveStopDictation: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveDictationTranscript {
-  type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const ComposerPrimitiveDictationTranscript: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace ComposerPrimitiveQuote {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const ComposerPrimitiveQuote: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ComposerPrimitiveQuoteText {
-  type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const ComposerPrimitiveQuoteText: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace ComposerPrimitiveQuoteDismiss {
-  type Element = ComponentRef<typeof Primitive$1.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
-}
-
-declare const ComposerPrimitiveQuoteDismiss: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverCategories {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.div>, "children"> & {
-    children: (categories: readonly Unstable_TriggerCategory[]) => ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverCategories: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
-  children: (categories: readonly Unstable_TriggerCategory[]) => ReactNode;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverCategoryItem {
-  type Element = ComponentRef<typeof Primitive$1.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button> & {
-    categoryId: string;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverCategoryItem: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  categoryId: string;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverItems {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.div>, "children"> & {
-    children: (items: readonly Unstable_TriggerItem[]) => ReactNode;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverItems: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
-  children: (items: readonly Unstable_TriggerItem[]) => ReactNode;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverItem {
-  type Element = ComponentRef<typeof Primitive$1.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button> & {
-    item: Unstable_TriggerItem;
-    index?: number | undefined;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverItem: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  item: Unstable_TriggerItem;
-  index?: number | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverBack {
-  type Element = ComponentRef<typeof Primitive$1.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
-}
-
-declare const ComposerPrimitiveTriggerPopoverBack: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ComposerPrimitiveTriggerPopoverAction {
-  type Props = {
-    readonly formatter?: Unstable_DirectiveFormatter | undefined;
-    readonly onExecute: (item: Unstable_TriggerItem) => void;
-    readonly removeOnExecute?: boolean | undefined;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverAction: FC<ComposerPrimitiveTriggerPopoverAction.Props>;
-
-declare namespace ComposerPrimitiveTriggerPopoverDirective {
-  type Props = {
-    readonly formatter?: Unstable_DirectiveFormatter | undefined;
-    readonly onInserted?: ((item: Unstable_TriggerItem) => void) | undefined;
-  };
-}
-
-declare const ComposerPrimitiveTriggerPopoverDirective: FC<ComposerPrimitiveTriggerPopoverDirective.Props>;
-
-declare const ComposerPrimitiveTriggerPopover: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref">, "onSelect"> & {
-  readonly char: string;
-  readonly adapter?: Unstable_TriggerAdapter | undefined;
-  readonly isLoading?: boolean | undefined;
-} & import("react").RefAttributes<HTMLDivElement>> & {
-  Directive: import("react").FC<ComposerPrimitiveTriggerPopoverDirective.Props>;
-  Action: import("react").FC<ComposerPrimitiveTriggerPopoverAction.Props>;
-};
-
-declare namespace composer_d_exports {
-  export { ComposerPrimitiveAddAttachment as AddAttachment, ComposerPrimitiveAttachmentByIndex as AttachmentByIndex, ComposerPrimitiveAttachmentDropzone as AttachmentDropzone, ComposerPrimitiveAttachments as Attachments, ComposerPrimitiveCancel as Cancel, ComposerPrimitiveDictate as Dictate, ComposerPrimitiveDictationTranscript as DictationTranscript, ComposerPrimitiveIf as If, ComposerPrimitiveInput as Input, ComposerPrimitiveQueue as Queue, ComposerPrimitiveQuote as Quote, ComposerPrimitiveQuoteDismiss as QuoteDismiss, ComposerPrimitiveQuoteText as QuoteText, ComposerPrimitiveRoot as Root, ComposerPrimitiveSend as Send, ComposerPrimitiveStopDictation as StopDictation, RegisteredTrigger as Unstable_RegisteredTrigger, ComposerPrimitiveTriggerPopover as Unstable_TriggerPopover, ComposerPrimitiveTriggerPopoverBack as Unstable_TriggerPopoverBack, ComposerPrimitiveTriggerPopoverCategories as Unstable_TriggerPopoverCategories, ComposerPrimitiveTriggerPopoverCategoryItem as Unstable_TriggerPopoverCategoryItem, ComposerPrimitiveTriggerPopoverItem as Unstable_TriggerPopoverItem, ComposerPrimitiveTriggerPopoverItems as Unstable_TriggerPopoverItems, ComposerPrimitiveTriggerPopoverRoot as Unstable_TriggerPopoverRoot, useTriggerPopoverRootContext as unstable_useTriggerPopoverRootContext, useTriggerPopoverRootContextOptional as unstable_useTriggerPopoverRootContextOptional, useTriggerPopoverScopeContext as unstable_useTriggerPopoverScopeContext, useTriggerPopoverScopeContextOptional as unstable_useTriggerPopoverScopeContextOptional, useTriggerPopoverTriggers as unstable_useTriggerPopoverTriggers, useTriggerPopoverTriggersOptional as unstable_useTriggerPopoverTriggersOptional };
-}
-
-declare namespace QueueItemPrimitiveText {
-  type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const QueueItemPrimitiveText: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare const useQueueItemSteer: () => () => void;
-
-declare namespace QueueItemPrimitiveSteer {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useQueueItemSteer>;
-}
-
-declare const QueueItemPrimitiveSteer: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useQueueItemRemove: () => () => void;
-
-declare namespace QueueItemPrimitiveRemove {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useQueueItemRemove>;
-}
-
-declare const QueueItemPrimitiveRemove: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace queueItem_d_exports {
-  export { QueueItemPrimitiveRemove as Remove, QueueItemPrimitiveSteer as Steer, QueueItemPrimitiveText as Text };
-}
-
-type SmoothOptions = {
-  drainMs?: number | undefined;
-  maxCharIntervalMs?: number | undefined;
-  maxCharsPerFrame?: number | undefined;
-  minCommitMs?: number | undefined;
-};
-
-declare const useSmooth: (state: MessagePartState & (TextMessagePart | ReasoningMessagePart), smooth?: boolean | SmoothOptions) => MessagePartState & (TextMessagePart | ReasoningMessagePart);
-
-declare namespace MessagePartPrimitiveText {
-  type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = Omit<ComponentPropsWithoutRef<typeof Primitive$1.span>, "asChild" | "children"> & {
-    smooth?: boolean | SmoothOptions;
-    component?: ElementType;
-  };
-}
-
-declare const MessagePartPrimitiveText: import("react").ForwardRefExoticComponent<Omit<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref">, "asChild" | "children"> & {
-  smooth?: boolean | SmoothOptions;
-  component?: ElementType;
-} & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace MessagePartPrimitiveImage {
-  type Element = ComponentRef<typeof Primitive$1.img>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.img>;
-}
-
-declare const MessagePartPrimitiveImage: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLImageElement> & import("react").ImgHTMLAttributes<HTMLImageElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLImageElement>, "ref"> & import("react").RefAttributes<HTMLImageElement>>;
-
-declare namespace messagePart_d_exports {
-  export { MessagePartPrimitiveImage as Image, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveText as Text };
-}
-
-declare namespace ErrorPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const ErrorPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ErrorPrimitiveMessage {
-  type Element = ComponentRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const ErrorPrimitiveMessage: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace error_d_exports {
-  export { ErrorPrimitiveMessage as Message, ErrorPrimitiveRoot as Root };
-}
-
-declare namespace MessagePrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const MessagePrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace MessagePrimitiveParts {
-  type Props = MessagePrimitiveParts$1.Props;
-}
-
-declare const MessagePrimitiveParts: FC<MessagePrimitiveParts.Props>;
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> & {
-  [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
-}[Keys];
-
-type MessageIfFilters = {
-  user: boolean | undefined;
-  assistant: boolean | undefined;
-  system: boolean | undefined;
-  hasBranches: boolean | undefined;
-  copied: boolean | undefined;
-  lastOrHover: boolean | undefined;
-  last: boolean | undefined;
-  speaking: boolean | undefined;
-  hasAttachments: boolean | undefined;
-  hasContent: boolean | undefined;
-  submittedFeedback: "positive" | "negative" | null | undefined;
-};
-
-type UseMessageIfProps = RequireAtLeastOne<MessageIfFilters>;
-
-declare namespace MessagePrimitiveIf {
-  type Props = PropsWithChildren<UseMessageIfProps>;
-}
-
-declare const MessagePrimitiveIf: FC<MessagePrimitiveIf.Props>;
-
-declare const MessagePrimitiveError: FC<PropsWithChildren>;
-
-type MessagePartGroup = {
-  groupKey: string | undefined;
-  indices: number[];
-};
-
-type GroupingFunction = (parts: readonly any[]) => MessagePartGroup[];
-
-declare namespace MessagePrimitiveUnstable_PartsGrouped {
-  type Props = {
-    groupingFunction: GroupingFunction;
-    components: {
-      Empty?: EmptyMessagePartComponent | undefined;
-      Text?: TextMessagePartComponent | undefined;
-      Reasoning?: ReasoningMessagePartComponent | undefined;
-      Source?: SourceMessagePartComponent | undefined;
-      Image?: ImageMessagePartComponent | undefined;
-      File?: FileMessagePartComponent | undefined;
-      Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
-      data?: {
-        by_name?: Record<string, DataMessagePartComponent | undefined> | undefined;
-        Fallback?: DataMessagePartComponent | undefined;
-      } | undefined;
-      tools?: {
-        by_name?: Record<string, ToolCallMessagePartComponent | undefined> | undefined;
-        Fallback?: ComponentType<ToolCallMessagePartProps> | undefined;
-      } | {
-        Override: ComponentType<ToolCallMessagePartProps>;
-      } | undefined;
-      Group?: ComponentType<PropsWithChildren<{
-        groupKey: string | undefined;
-        indices: number[];
-      }>>;
-    } | undefined;
-  };
-}
-
-declare const MessagePrimitiveUnstable_PartsGrouped: FC<MessagePrimitiveUnstable_PartsGrouped.Props>;
-
-declare const MessagePrimitiveUnstable_PartsGroupedByParentId: FC<Omit<MessagePrimitiveUnstable_PartsGrouped.Props, "groupingFunction">>;
-
-declare namespace message_d_exports {
-  export { MessagePrimitiveAttachmentByIndex as AttachmentByIndex, MessagePrimitiveAttachments as Attachments, MessagePrimitiveParts as Content, MessagePrimitiveError as Error, MessagePrimitiveGenerativeUI as GenerativeUI, MessagePrimitiveGroupedParts as GroupedParts, MessagePrimitiveIf as If, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessagePrimitiveQuote as Quote, MessagePrimitiveRoot as Root, MessagePrimitiveUnstable_PartsGrouped as Unstable_PartsGrouped, MessagePrimitiveUnstable_PartsGroupedByParentId as Unstable_PartsGroupedByParentId };
-}
-
-type ThreadViewportProviderProps = PropsWithChildren<{
-  options?: ThreadViewportStoreOptions;
-}>;
-
-declare const ThreadPrimitiveViewportProvider: FC<ThreadViewportProviderProps>;
-
-declare namespace ThreadPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const ThreadPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ThreadPrimitiveEmpty {
-  type Props = PropsWithChildren;
-}
-
-declare const ThreadPrimitiveEmpty: FC<ThreadPrimitiveEmpty.Props>;
-
-type ThreadIfFilters = {
-  empty: boolean | undefined;
-  running: boolean | undefined;
-  disabled: boolean | undefined;
-};
-
-type UseThreadIfProps = RequireAtLeastOne<ThreadIfFilters>;
-
-declare namespace ThreadPrimitiveIf {
-  type Props = PropsWithChildren<UseThreadIfProps>;
-}
-
-declare const ThreadPrimitiveIf: FC<ThreadPrimitiveIf.Props>;
-
-declare namespace ThreadPrimitiveViewport {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div> & {
-    autoScroll?: boolean | undefined;
-    turnAnchor?: "top" | "bottom" | undefined;
-    topAnchorMessageClamp?: {
-      tallerThan?: string;
-      visibleHeight?: string;
-    };
-    scrollToBottomOnRunStart?: boolean | undefined;
-    scrollToBottomOnInitialize?: boolean | undefined;
-    scrollToBottomOnThreadSwitch?: boolean | undefined;
-  };
-}
-
-declare const ThreadPrimitiveViewport: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  autoScroll?: boolean | undefined;
-  turnAnchor?: "top" | "bottom" | undefined;
-  topAnchorMessageClamp?: {
-    tallerThan?: string;
-    visibleHeight?: string;
-  };
-  scrollToBottomOnRunStart?: boolean | undefined;
-  scrollToBottomOnInitialize?: boolean | undefined;
-  scrollToBottomOnThreadSwitch?: boolean | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ThreadPrimitiveViewportFooter {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const ThreadPrimitiveViewportFooter: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace useThreadScrollToBottom {
-  type Options = {
-    behavior?: ScrollBehavior | undefined;
-  };
-}
-
-declare const useThreadScrollToBottom: (_param17?: useThreadScrollToBottom.Options) => (() => void) | null;
-
-declare namespace ThreadPrimitiveScrollToBottom {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadScrollToBottom>;
-}
-
-declare const ThreadPrimitiveScrollToBottom: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & useThreadScrollToBottom.Options & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useThreadSuggestion: (_param18: {
-  prompt: string;
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-  autoSend?: boolean | undefined;
-  method?: "replace";
-}) => (() => void) | null;
-
-declare namespace ThreadPrimitiveSuggestion {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadSuggestion>;
-}
-
-declare const ThreadPrimitiveSuggestion: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  prompt: string;
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-  autoSend?: boolean | undefined;
-  method?: "replace";
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace thread_d_exports {
-  export { ThreadPrimitiveEmpty as Empty, ThreadPrimitiveIf as If, ThreadPrimitiveMessageByIndex as MessageByIndex, ThreadPrimitiveMessages as Messages, ThreadPrimitiveRoot as Root, ThreadPrimitiveScrollToBottom as ScrollToBottom, ThreadPrimitiveSuggestion as Suggestion, ThreadPrimitiveSuggestionByIndex as SuggestionByIndex, ThreadPrimitiveSuggestions as Suggestions, ThreadPrimitiveUnstable_MessageById as Unstable_MessageById, ThreadPrimitiveViewport as Viewport, ThreadPrimitiveViewportFooter as ViewportFooter, ThreadPrimitiveViewportProvider as ViewportProvider };
-}
-
-declare namespace SuggestionPrimitiveTitle {
-  type Element = ElementRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const SuggestionPrimitiveTitle: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare namespace SuggestionPrimitiveDescription {
-  type Element = ElementRef<typeof Primitive$1.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.span>;
-}
-
-declare const SuggestionPrimitiveDescription: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLSpanElement>, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
-
-declare const useSuggestionTrigger: (_param19: {
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-}) => (() => void) | null;
-
-declare namespace SuggestionPrimitiveTrigger {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useSuggestionTrigger>;
-}
-
-declare const SuggestionPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  send?: boolean | undefined;
-  clearComposer?: boolean | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace suggestion_d_exports {
-  export { SuggestionPrimitiveDescription as Description, SuggestionPrimitiveTitle as Title, SuggestionPrimitiveTrigger as Trigger };
-}
-
-declare namespace ThreadListPrimitiveNew {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<() => void>;
-}
-
-declare const ThreadListPrimitiveNew: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useThreadListLoadMore: () => (() => void) | null;
-
-declare namespace ThreadListPrimitiveLoadMore {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadListLoadMore>;
-}
-
-declare const ThreadListPrimitiveLoadMore: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-type PrimitiveDivProps$1 = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace ThreadListPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps$1;
-}
-
-declare const ThreadListPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace threadList_d_exports {
-  export { ThreadListPrimitiveItemByIndex as ItemByIndex, ThreadListPrimitiveItems as Items, ThreadListPrimitiveLoadMore as LoadMore, ThreadListPrimitiveNew as New, ThreadListPrimitiveRoot as Root };
-}
-
-type PrimitiveDivProps = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-
-declare namespace ThreadListItemPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = PrimitiveDivProps;
-}
-
-declare const ThreadListItemPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare const useThreadListItemArchive: () => () => void;
-
-declare namespace ThreadListItemPrimitiveArchive {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadListItemArchive>;
-}
-
-declare const ThreadListItemPrimitiveArchive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useThreadListItemUnarchive: () => () => void;
-
-declare namespace ThreadListItemPrimitiveUnarchive {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadListItemUnarchive>;
-}
-
-declare const ThreadListItemPrimitiveUnarchive: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useThreadListItemDelete: () => () => void;
-
-declare namespace ThreadListItemPrimitiveDelete {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadListItemDelete>;
-}
-
-declare const ThreadListItemPrimitiveDelete: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare const useThreadListItemTrigger: () => () => void;
-
-declare namespace ThreadListItemPrimitiveTrigger {
-  type Element = ActionButtonElement;
-  type Props = ActionButtonProps<typeof useThreadListItemTrigger>;
-}
-
-declare const ThreadListItemPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace threadListItem_d_exports {
-  export { ThreadListItemPrimitiveArchive as Archive, ThreadListItemPrimitiveDelete as Delete, ThreadListItemPrimitiveRoot as Root, ThreadListItemPrimitiveTitle as Title, ThreadListItemPrimitiveTrigger as Trigger, ThreadListItemPrimitiveUnarchive as Unarchive };
-}
-
-declare namespace ThreadListItemMorePrimitiveRoot {
-  type Props = DropdownMenu.DropdownMenuProps & {
-    sharedFocusGroup?: boolean | undefined;
-  };
-}
-
-declare const ThreadListItemMorePrimitiveRoot: FC<ThreadListItemMorePrimitiveRoot.Props>;
-
-declare namespace ThreadListItemMorePrimitiveTrigger {
-  type Element = ComponentRef<typeof DropdownMenu.Trigger>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Trigger>;
-}
-
-declare const ThreadListItemMorePrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace ThreadListItemMorePrimitiveContent {
-  type Element = ComponentRef<typeof DropdownMenu.Content>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Content> & {
-    portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
-  };
-}
-
-declare const ThreadListItemMorePrimitiveContent: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & {
-  portalProps?: ComponentPropsWithoutRef<typeof DropdownMenu.Portal> | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ThreadListItemMorePrimitiveItem {
-  type Element = ComponentRef<typeof DropdownMenu.Item>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Item>;
-}
-
-declare const ThreadListItemMorePrimitiveItem: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuItemProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace ThreadListItemMorePrimitiveSeparator {
-  type Element = ComponentRef<typeof DropdownMenu.Separator>;
-  type Props = WithRenderPropProps<typeof DropdownMenu.Separator>;
-}
-
-declare const ThreadListItemMorePrimitiveSeparator: import("react").ForwardRefExoticComponent<Omit<DropdownMenu.DropdownMenuSeparatorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace threadListItemMore_d_exports {
-  export { ThreadListItemMorePrimitiveContent as Content, ThreadListItemMorePrimitiveItem as Item, ThreadListItemMorePrimitiveRoot as Root, ThreadListItemMorePrimitiveSeparator as Separator, ThreadListItemMorePrimitiveTrigger as Trigger };
-}
-
-declare namespace SelectionToolbarPrimitiveRoot {
-  type Element = ComponentRef<typeof Primitive$1.div>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.div>;
-}
-
-declare const SelectionToolbarPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-declare namespace SelectionToolbarPrimitiveQuote {
-  type Element = ComponentRef<typeof Primitive$1.button>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive$1.button>;
-}
-
-declare const SelectionToolbarPrimitiveQuote: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
-  asChild?: boolean;
-}, "ref"> & {
-  render?: import("react").ReactElement | undefined;
-} & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
-
-declare namespace selectionToolbar_d_exports {
-  export { SelectionToolbarPrimitiveQuote as Quote, SelectionToolbarPrimitiveRoot as Root, SelectionToolbarPrimitiveQuote, SelectionToolbarPrimitiveRoot };
-}
-
-declare const useMessagePartText: () => (TextMessagePart & {
+declare const useMessagePartFile: () => FileMessagePart & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-}) | (ReasoningMessagePart & {
+};
+
+declare const useMessagePartImage: () => ImageMessagePart & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-});
+};
 
 declare const useMessagePartReasoning: () => ReasoningMessagePart & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
+
+declare function useMessagePartRuntime(options?: {
+  optional?: false | undefined;
+}): MessagePartRuntime;
+
+declare function useMessagePartRuntime(options?: {
+  optional?: boolean | undefined;
+}): MessagePartRuntime | null;
 
 declare const useMessagePartSource: () => ({
   readonly type: "source";
@@ -7182,41 +6843,35 @@ declare const useMessagePartSource: () => ({
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 });
 
-declare const useMessagePartFile: () => FileMessagePart & {
+declare const useMessagePartText: () => (TextMessagePart & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
-
-declare const useMessagePartImage: () => ImageMessagePart & {
+}) | (ReasoningMessagePart & {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
-};
+});
 
-declare const useMessagePartData: <T = any>(name?: string) => DataMessagePart<T> | null;
+declare const useMessageQuote: () => QuoteInfo | undefined;
 
-declare namespace useThreadViewportAutoScroll {
-  type Options = {
-    autoScroll?: boolean | undefined;
-    scrollToBottomOnRunStart?: boolean | undefined;
-    scrollToBottomOnInitialize?: boolean | undefined;
-    scrollToBottomOnThreadSwitch?: boolean | undefined;
-  };
-}
+declare function useMessageRuntime(options?: {
+  optional?: false | undefined;
+}): MessageRuntime;
 
-declare const useThreadViewportAutoScroll: <TElement extends HTMLElement>(_param20: useThreadViewportAutoScroll.Options) => RefCallback<TElement>;
+declare function useMessageRuntime(options?: {
+  optional?: boolean | undefined;
+}): MessageRuntime | null;
+
+declare const useMessageTiming: () => MessageTiming | undefined;
+
+declare const useQueueItemRemove: () => () => void;
+
+declare const useQueueItemSteer: () => () => void;
+
+declare const useRemoteThreadListRuntime: (options: RemoteThreadListOptions) => AssistantRuntime;
+
+declare const useRuntimeAdapters: () => RuntimeAdapters | null;
 
 declare const useScrollLock: <T extends HTMLElement = HTMLElement>(animatedElementRef: RefObject<T | null>, animationDuration: number) => () => void;
 
-type Unstable_MessageStallDetectionOptions = {
-  thresholdMs?: number | undefined;
-};
-
-type Unstable_MessageStallDetection = {
-  stalled: boolean;
-  stalledForMs: number;
-};
-
-declare function unstable_useMessageStallDetection(options?: Unstable_MessageStallDetectionOptions): Unstable_MessageStallDetection;
-
-declare const withSmoothContextProvider: <C extends ComponentType<any>>(Component: C) => C;
+declare const useSmooth: (state: MessagePartState & (TextMessagePart | ReasoningMessagePart), smooth?: boolean | SmoothOptions) => MessagePartState & (TextMessagePart | ReasoningMessagePart);
 
 declare const useSmoothStatus: {
   (): {
@@ -7301,255 +6956,600 @@ declare const useSmoothStatus: {
   }> | null;
 };
 
-type ComposerInputPlugin = {
-  handleKeyDown(e: {
-    readonly key: string;
-    readonly shiftKey: boolean;
-    readonly ctrlKey?: boolean;
-    readonly metaKey?: boolean;
-    readonly nativeEvent?: {
-      isComposing?: boolean;
-    };
-    preventDefault(): void;
-  }): boolean;
-  setCursorPosition(pos: number): void;
+declare const useSuggestionTrigger: (_param17: {
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+}) => (() => void) | null;
+
+declare const useThread: {
+  (): ThreadState;
+  <TSelected>(selector: (state: ThreadState) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ThreadState) => TSelected) | undefined): ThreadState | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): ThreadState;
+  (options: {
+    optional?: boolean | undefined;
+  }): ThreadState | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: ThreadState) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: ThreadState) => TSelected) | undefined;
+  }): ThreadState | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: ThreadState) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: ThreadState) => TSelected) | undefined;
+  }): ThreadState | TSelected | null;
 };
 
-type ComposerInputPluginRegisterOptions = {
-  priority?: number;
+declare const useThreadComposer: {
+  (): ThreadComposerState;
+  <TSelected>(selector: (state: ThreadComposerState) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ThreadComposerState) => TSelected) | undefined): ThreadComposerState | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): ThreadComposerState;
+  (options: {
+    optional?: boolean | undefined;
+  }): ThreadComposerState | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: ThreadComposerState) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: ThreadComposerState) => TSelected) | undefined;
+  }): ThreadComposerState | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: ThreadComposerState) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: ThreadComposerState) => TSelected) | undefined;
+  }): ThreadComposerState | TSelected | null;
 };
 
-type ComposerInputPluginRegistry = {
-  register(plugin: ComposerInputPlugin, opts?: ComposerInputPluginRegisterOptions): () => void;
-  getPlugins(): readonly ComposerInputPlugin[];
+declare const useThreadComposerAttachment: {
+  (): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  });
+  <TSelected>(selector: (state: ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  })) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  })) => TSelected) | undefined): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  });
+  (options: {
+    optional?: boolean | undefined;
+  }): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    }) | ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: PendingAttachmentStatus;
+      file: File;
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    })) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    }) | ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: PendingAttachmentStatus;
+      file: File;
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    })) => TSelected) | undefined;
+  }): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    }) | ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: PendingAttachmentStatus;
+      file: File;
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    })) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: CompleteAttachmentStatus;
+      content: ThreadUserMessagePart[];
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    }) | ({
+      id: string;
+      type: "image" | "document" | "file" | (string & {});
+      name: string;
+      contentType?: string | undefined;
+      file?: File;
+      content?: ThreadUserMessagePart[];
+    } & {
+      status: PendingAttachmentStatus;
+      file: File;
+    } & {
+      readonly source: "thread-composer";
+    } & {
+      source: "thread-composer";
+    })) => TSelected) | undefined;
+  }): ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: CompleteAttachmentStatus;
+    content: ThreadUserMessagePart[];
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | ({
+    id: string;
+    type: "image" | "document" | "file" | (string & {});
+    name: string;
+    contentType?: string | undefined;
+    file?: File;
+    content?: ThreadUserMessagePart[];
+  } & {
+    status: PendingAttachmentStatus;
+    file: File;
+  } & {
+    readonly source: "thread-composer";
+  } & {
+    source: "thread-composer";
+  }) | TSelected | null;
 };
 
-declare const useComposerInputPluginRegistryOptional: () => ComposerInputPluginRegistry | null;
+declare function useThreadComposerAttachmentRuntime(options?: {
+  optional?: false | undefined;
+}): AttachmentRuntime<"thread-composer">;
 
-declare namespace internal_d_exports {
-  export { AssistantRuntimeImpl, BaseAssistantRuntimeCore, CompositeContextProvider, DefaultThreadComposerRuntimeCore, MessageRepository, ThreadListItemRuntimeBinding, ThreadListRuntimeCore, ThreadRuntimeCore, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolExecutionStatus, getAutoStatus, splitLocalRuntimeOptions, useComposerInputPluginRegistryOptional, useSmooth, useSmoothStatus, withSmoothContextProvider };
-}
+declare function useThreadComposerAttachmentRuntime(options?: {
+  optional?: boolean | undefined;
+}): AttachmentRuntime<"thread-composer"> | null;
 
-type Unstable_IconComponent = FC<{
-  className?: string;
-}>;
-
-type Unstable_Mention = {
-  readonly id: string;
-  readonly type: string;
-  readonly label: string;
-  readonly description?: string | undefined;
-  readonly icon?: string | undefined;
-  readonly metadata?: ReadonlyJSONObject | undefined;
+declare const useThreadList: {
+  (): ThreadListState;
+  <TSelected>(selector: (state: ThreadListState) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ThreadListState) => TSelected) | undefined): ThreadListState | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): ThreadListState;
+  (options: {
+    optional?: boolean | undefined;
+  }): ThreadListState | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: ThreadListState) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: ThreadListState) => TSelected) | undefined;
+  }): ThreadListState | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: ThreadListState) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: ThreadListState) => TSelected) | undefined;
+  }): ThreadListState | TSelected | null;
 };
 
-type Unstable_MentionCategory = {
-  readonly id: string;
-  readonly label: string;
-  readonly items: readonly Unstable_Mention[];
+declare const useThreadListItem: {
+  (): ThreadListItemState$1;
+  <TSelected>(selector: (state: ThreadListItemState$1) => TSelected): TSelected;
+  <TSelected>(selector: ((state: ThreadListItemState$1) => TSelected) | undefined): ThreadListItemState$1 | TSelected;
+  (options: {
+    optional?: false | undefined;
+  }): ThreadListItemState$1;
+  (options: {
+    optional?: boolean | undefined;
+  }): ThreadListItemState$1 | null;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: (state: ThreadListItemState$1) => TSelected;
+  }): TSelected;
+  <TSelected>(options: {
+    optional?: false | undefined;
+    selector: ((state: ThreadListItemState$1) => TSelected) | undefined;
+  }): ThreadListItemState$1 | TSelected;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: (state: ThreadListItemState$1) => TSelected;
+  }): TSelected | null;
+  <TSelected>(options: {
+    optional?: boolean | undefined;
+    selector: ((state: ThreadListItemState$1) => TSelected) | undefined;
+  }): ThreadListItemState$1 | TSelected | null;
 };
 
-type Unstable_ModelContextToolsOptions = {
-  readonly category?: {
-    readonly id: string;
-    readonly label: string;
+declare const useThreadListItemArchive: () => () => void;
+
+declare const useThreadListItemDelete: () => () => void;
+
+declare function useThreadListItemRuntime(options?: {
+  optional?: false | undefined;
+}): ThreadListItemRuntime;
+
+declare function useThreadListItemRuntime(options?: {
+  optional?: boolean | undefined;
+}): ThreadListItemRuntime | null;
+
+declare const useThreadListItemTrigger: () => () => void;
+
+declare const useThreadListItemUnarchive: () => () => void;
+
+declare const useThreadListLoadMore: () => (() => void) | null;
+
+declare function useThreadModelContext(options?: {
+  optional?: false | undefined;
+}): ModelContext$1;
+
+declare function useThreadModelContext(options?: {
+  optional?: boolean | undefined;
+}): ModelContext$1 | null;
+
+declare function useThreadRuntime(options?: {
+  optional?: false | undefined;
+}): ThreadRuntime;
+
+declare function useThreadRuntime(options?: {
+  optional?: boolean | undefined;
+}): ThreadRuntime | null;
+
+declare namespace useThreadScrollToBottom {
+  type Options = {
+    behavior?: ScrollBehavior | undefined;
   };
-  readonly formatLabel?: (toolName: string) => string;
-  readonly icon?: string;
-};
-
-type Unstable_UseMentionAdapterOptions = {
-  readonly items?: readonly Unstable_Mention[];
-  readonly categories?: readonly Unstable_MentionCategory[];
-  readonly includeModelContextTools?: boolean | Unstable_ModelContextToolsOptions;
-  readonly formatter?: Unstable_DirectiveFormatter;
-  readonly onInserted?: (item: Unstable_TriggerItem) => void;
-  readonly iconMap?: Record<string, Unstable_IconComponent>;
-  readonly fallbackIcon?: Unstable_IconComponent;
-};
-
-type Unstable_MentionDirective = {
-  readonly formatter: Unstable_DirectiveFormatter;
-  readonly onInserted?: ((item: Unstable_TriggerItem) => void) | undefined;
-};
-
-declare function unstable_useMentionAdapter(options?: Unstable_UseMentionAdapterOptions): {
-  adapter: Unstable_TriggerAdapter;
-  directive: Unstable_MentionDirective;
-  iconMap?: Record<string, Unstable_IconComponent>;
-  fallbackIcon?: Unstable_IconComponent;
-};
-
-type Unstable_SlashCommand = {
-  readonly id: string;
-  readonly label?: string | undefined;
-  readonly description?: string | undefined;
-  readonly icon?: string | undefined;
-  readonly execute: () => void;
-};
-
-type Unstable_UseSlashCommandAdapterOptions = {
-  readonly commands: readonly Unstable_SlashCommand[];
-  readonly removeOnExecute?: boolean | undefined;
-  readonly iconMap?: Record<string, Unstable_IconComponent>;
-  readonly fallbackIcon?: Unstable_IconComponent;
-};
-
-type Unstable_SlashCommandAction = {
-  readonly onExecute: (item: Unstable_TriggerItem) => void;
-  readonly removeOnExecute?: boolean | undefined;
-};
-
-declare function unstable_useSlashCommandAdapter(options: Unstable_UseSlashCommandAdapterOptions): {
-  adapter: Unstable_TriggerAdapter;
-  action: Unstable_SlashCommandAction;
-  iconMap?: Record<string, Unstable_IconComponent>;
-  fallbackIcon?: Unstable_IconComponent;
-};
-
-type Unstable_UseLiveCompletionAdapterOptions = {
-  readonly fetcher: (query: string) => Promise<readonly Unstable_TriggerItem[]>;
-  readonly debounceMs?: number | undefined;
-  readonly enabled?: boolean | undefined;
-};
-
-declare function unstable_useLiveCompletionAdapter(options: Unstable_UseLiveCompletionAdapterOptions): {
-  adapter: Unstable_TriggerAdapter;
-  isLoading: boolean;
-};
-
-type Unstable_ComposerInputHistory = {
-  onKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
-};
-
-declare function unstable_useComposerInputHistory(): Unstable_ComposerInputHistory;
-
-type TriggerPopoverAriaProps = {
-  "aria-controls"?: string;
-  "aria-expanded"?: true;
-  "aria-haspopup"?: "listbox";
-  "aria-activedescendant"?: string | undefined;
-};
-
-type Unstable_UseComposerInputOptions = {
-  disabled?: boolean | undefined;
-};
-
-type Unstable_ComposerInput = {
-  value: string;
-  setText(text: string): void;
-  send(options?: ComposerSendOptions): void;
-  isDisabled: boolean;
-  canSend: boolean;
-};
-
-declare function unstable_useComposerInput(options?: Unstable_UseComposerInputOptions): Unstable_ComposerInput;
-
-type Unstable_TriggerPopoverAriaProps = TriggerPopoverAriaProps;
-
-declare function unstable_useTriggerPopoverAriaProps(): Unstable_TriggerPopoverAriaProps;
-
-type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
-
-type SandboxHostConfig = {
-  sandbox?: SandboxOption[];
-  useShadowDom?: boolean;
-  enableBrowserCaching?: boolean;
-  salt?: string;
-  product?: string;
-  className?: string;
-  style?: CSSProperties;
-  unsafeDocumentWrite?: boolean;
-};
-
-declare const MCP_APP_MIME_TYPE: "text/html;profile=mcp-app";
-
-type McpAppResourceCSP = {
-  connectDomains?: string[];
-  resourceDomains?: string[];
-  frameDomains?: string[];
-  [k: string]: unknown;
-};
-
-type McpAppResourceMeta = {
-  prefersBorder?: boolean;
-  csp?: McpAppResourceCSP;
-  permissions?: Record<string, unknown>;
-  [k: string]: unknown;
-};
-
-type McpAppResource = {
-  uri: string;
-  mimeType: typeof MCP_APP_MIME_TYPE;
-  html: string;
-  meta?: McpAppResourceMeta;
-};
-
-type McpAppDisplayMode = "fullscreen" | "inline" | "pip";
-
-type McpAppHostContext = {
-  theme?: "dark" | "light";
-  displayMode?: McpAppDisplayMode;
-  availableDisplayModes?: McpAppDisplayMode[];
-  [k: string]: unknown;
-};
-
-type McpAppHostInfo = {
-  name: string;
-  version: string;
-};
-
-type McpAppsHost = {
-  loadResource: (params: {
-    uri: string;
-  }) => Promise<McpAppResource>;
-  callTool: (params: McpAppToolCallParams) => Promise<unknown>;
-  readResource: (params: {
-    uri: string;
-  }) => Promise<unknown>;
-  listResources: (params?: unknown) => Promise<unknown>;
-};
-
-type McpAppsRemoteHostOptions = {
-  url: string;
-  fetch?: typeof fetch;
-  headers?: Record<string, string> | (() => Record<string, string> | Promise<Record<string, string>>);
-};
-
-type McpAppToolCallParams = {
-  name: string;
-  arguments?: Record<string, unknown>;
-};
-
-type McpAppSandboxConfig = SandboxHostConfig;
-
-type McpAppRendererOptions = {
-  host: ResourceElement<McpAppsHost>;
-  sandbox?: McpAppSandboxConfig;
-  maxHeight?: number;
-  hostInfo?: McpAppHostInfo;
-  hostContext?: McpAppHostContext;
-  fallback?: ReactNode;
-  loadingFallback?: ReactNode;
-  errorFallback?: ReactNode | ((error: Error) => ReactNode);
-};
-
-declare const McpAppRenderer: Resource<{
-  readonly render: ToolCallMessagePartComponent;
-}, [
-  options: McpAppRendererOptions
-]>;
-
-declare const McpAppsRemoteHost: Resource<McpAppsHost, [
-  options: McpAppsRemoteHostOptions
-]>;
-
-type ToolPartLike = Pick<ToolCallMessagePart, "mcp">;
-
-declare function getMcpAppFromToolPart(part: ToolPartLike): McpAppMetadata | undefined;
-
-declare namespace entry_root_exports {
-  export { actionBarMore_d_exports as ActionBarMorePrimitive, actionBar_d_exports as ActionBarPrimitive, AddToolResultOptions, AppendMessage, Assistant, AssistantClient, AssistantCloud, AssistantContextConfig, AssistantDataUI, AssistantDataUIProps, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantFrameHost, AssistantFrameProvider, AssistantInteractableProps, assistantModal_d_exports as AssistantModalPrimitive, AssistantRuntime, AssistantRuntimeProvider, AssistantState, AssistantTool, AssistantToolProps, AssistantToolUI, AssistantToolUIProps, AssistantTransportCommand, AssistantTransportConnectionMetadata, AssistantTransportProtocol, Attachment, AttachmentAdapter, attachment_d_exports as AttachmentPrimitive, AttachmentRuntime, AttachmentState, AttachmentStatus, AuiIf, AuiProvider, branchPicker_d_exports as BranchPickerPrimitive, ChainOfThoughtByIndicesProvider, ChainOfThoughtClient, chainOfThought_d_exports as ChainOfThoughtPrimitive, ChatModelAdapter, ChatModelRunOptions, ChatModelRunResult, ChatModelRunUpdate, CloudFileAttachmentAdapter, CompleteAttachment, ComposerAttachmentByIndexProvider, composer_d_exports as ComposerPrimitive, ComposerRuntime, ComposerSendOptions, ComposerState$1 as ComposerState, CompositeAttachmentAdapter, CreateAppendMessage, CreateAttachment, CreateResumeRunConfig, CreateStartRunConfig, DataMessagePart, DataMessagePartComponent, DataMessagePartProps, DataRenderers, DevToolsHooks, DevToolsProviderApi, DictationAdapter, DictationState, EditComposerRuntime, EditComposerState, EmptyMessagePartComponent, EmptyMessagePartProps, EnrichedPartState, error_d_exports as ErrorPrimitive, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreAdapter, ExternalStoreBranchChange, ExternalStoreMessageConverter, ExternalStoreSharedOptions, ExternalStoreThreadData, ExternalStoreThreadListAdapter, ExternalThread, ExternalThreadBranchAdapter, ExternalThreadMessage, ExternalThreadProps, ExternalThreadQueueAdapter, FRAME_MESSAGE_CHANNEL, FeedbackAdapter, FileMessagePart, FileMessagePartComponent, FileMessagePartProps, FrameMessage, FrameMessageType, GenerativeUIComponentRegistry, GenerativeUIMessagePart, GenerativeUIMessagePartComponent, GenerativeUIMessagePartProps, GenerativeUINode, GenerativeUIRender, GenerativeUIRenderError, GenerativeUIRenderProps, GenerativeUISpec, GenericThreadHistoryAdapter, GroupByContext, internal_d_exports as INTERNAL, ImageMessagePart, ImageMessagePartComponent, ImageMessagePartProps, InMemoryThreadList, InMemoryThreadListAdapter, InMemoryThreadListProps, Interactables, LanguageModelConfig, LanguageModelV1CallSettings, LocalRuntimeOptions, LocalRuntimeOptionsBase, McpAppDisplayMode, McpAppHostContext, McpAppHostInfo, McpAppMetadata, McpAppRenderer, McpAppRendererOptions, McpAppResource, McpAppResourceCSP, McpAppResourceMeta, McpAppResourceOutput, McpAppSandboxConfig, McpAppToolCallParams, McpAppsHost, McpAppsRemoteHost, McpAppsRemoteHostOptions, McpToolkitDefinition, McpToolkitEntry, McpToolkitToolConfig, MessageAttachmentByIndexProvider, MessageByIndexProvider, MessageFormatAdapter, MessageFormatItem, MessageFormatRepository, messagePart_d_exports as MessagePartPrimitive, MessagePartRuntime, MessagePartState, MessagePartStatus, message_d_exports as MessagePrimitive, MessageProvider, MessageQueueController, MessageQueueDriver, MessageRuntime, MessageState$1 as MessageState, MessageStatus, MessageStorageEntry, MessageTiming, ModelContext$1 as ModelContext, ModelContext as ModelContextClient, ModelContextProvider, ModelContextRegistry, ModelContextRegistryInstructionHandle, ModelContextRegistryProviderHandle, ModelContextRegistryToolHandle, PartByIndexProvider, PartState, PendingAttachment, ProviderToolConfig, QueueItemMethods, queueItem_d_exports as QueueItemPrimitive, QueueItemState, QuoteInfo, QuoteMessagePartComponent, QuoteMessagePartProps, ReadonlyThreadProvider, RealtimeVoiceAdapter, ReasoningGroupComponent, ReasoningGroupProps, ReasoningMessagePart, ReasoningMessagePartComponent, ReasoningMessagePartProps, RemoteThreadListAdapter, RespondToToolApprovalOptions, RuntimeAdapterProvider, RuntimeAdapters, selectionToolbar_d_exports as SelectionToolbarPrimitive, SendCommandsRequestBody, SerializedModelContext, SerializedTool, SimpleImageAttachmentAdapter, SimpleTextAttachmentAdapter, SingleThreadList, SmoothOptions, SourceMessagePart, SourceMessagePartComponent, SourceMessagePartProps, SourceProviderMetadata, SpeechSynthesisAdapter, SubmitFeedbackOptions, SuggestionAdapter, SuggestionByIndexProvider, SuggestionConfig, suggestion_d_exports as SuggestionPrimitive, Suggestions, TextMessagePart, TextMessagePartComponent, TextMessagePartProps, TextMessagePartProvider, ThreadAssistantMessage, ThreadAssistantMessagePart, ThreadComposerRuntime, ThreadComposerState, ThreadHistoryAdapter, ThreadListItemByIndexProvider, threadListItemMore_d_exports as ThreadListItemMorePrimitive, threadListItem_d_exports as ThreadListItemPrimitive, ThreadListItemRuntime, ThreadListItemRuntimeProvider, ThreadListItemState$1 as ThreadListItemState, ThreadListItemStatus, threadList_d_exports as ThreadListPrimitive, ThreadListRuntime, ThreadListState, ThreadMessage, ThreadMessageLike, thread_d_exports as ThreadPrimitive, ThreadRuntime, ThreadState, ThreadSuggestion, ThreadSystemMessage, ThreadUserMessage, ThreadUserMessagePart, ThreadViewportState, Tool, ToolApprovalOption, ToolApprovalOptionKind, ToolApprovalResponse, ToolArgsStatus, ToolCallMessagePart, ToolCallMessagePartComponent, ToolCallMessagePartMcpMetadata, ToolCallMessagePartProps, ToolCallMessagePartStatus, ToolCallText, ToolCallTiming, ToolDefinition, ToolExecutionStatus, ToolModelContentPart, Toolkit, ToolkitDefinition, ToolkitDefinitionEntry, Tools, Unstable_AudioMessagePart, Unstable_AudioMessagePartComponent, Unstable_AudioMessagePartProps, Unstable_ComposerInput, Unstable_ComposerInputHistory, Unstable_DirectiveFormatter, Unstable_DirectiveSegment, Unstable_IconComponent, Unstable_InferInteractableState, Unstable_InteractableConfig, Unstable_InteractableDefinition, Unstable_InteractablePersistedState, Unstable_InteractablePersistenceAdapter, Unstable_InteractablePersistenceStatus, Unstable_InteractableRegistration, Unstable_InteractableSnapshotEntry, Unstable_InteractableStateSchema, Unstable_InteractableToolConfig, Unstable_InteractableToolRenderProps, Unstable_InteractableVersion, Unstable_InteractableVersionInfo, Unstable_InteractablesClientSchema, Unstable_InteractablesConfig, Unstable_InteractablesMethods, Unstable_InteractablesState, Unstable_Mention, Unstable_MentionCategory, Unstable_MentionDirective, Unstable_MessageStallDetection, Unstable_MessageStallDetectionOptions, Unstable_ModelContextToolsOptions, RegisteredTrigger as Unstable_RegisteredTrigger, Unstable_SlashCommand, Unstable_SlashCommandAction, TriggerBehavior as Unstable_TriggerBehavior, Unstable_TriggerItem, Unstable_TriggerPopoverAriaProps, Unstable_UseComposerInputOptions, Unstable_UseLiveCompletionAdapterOptions, Unstable_UseMentionAdapterOptions, Unstable_UseSlashCommandAdapterOptions, Unsubscribe, VoiceSessionControls, VoiceSessionHelpers, VoiceSessionState, WebSpeechDictationAdapter, WebSpeechSynthesisAdapter, bindExternalStoreMessage, createMessageQueue, createVoiceSession, defineMcpToolkit, defineToolkit, externalTool, fromThreadMessageLike, generateId, getExternalStoreMessages, getMcpAppFromToolPart, groupPartByType, hitl, hitlTool, humanTool, makeAssistantDataUI, makeAssistantTool, makeAssistantToolUI, makeAssistantVisible, mergeModelContexts, pickExternalStoreSharedOptions, providerTool, stubTool, tool, unstable_Interactables, convertExternalMessages as unstable_convertExternalMessages, createMessageConverter as unstable_createMessageConverter, unstable_defaultDirectiveFormatter, unstable_formatInteractableSnapshot, unstable_getInteractableSnapshots, unstable_getInteractableVersions, unstable_interactableTool, unstable_useComposerInput, unstable_useComposerInputHistory, unstable_useInteractable, unstable_useInteractableState, unstable_useInteractableVersions, unstable_useLiveCompletionAdapter, unstable_useMentionAdapter, unstable_useMessageStallDetection, unstable_useSlashCommandAdapter, unstable_useThreadMessageIds, unstable_useTriggerPopoverAriaProps, useTriggerPopoverRootContext as unstable_useTriggerPopoverRootContext, useTriggerPopoverRootContextOptional as unstable_useTriggerPopoverRootContextOptional, useTriggerPopoverScopeContext as unstable_useTriggerPopoverScopeContext, useTriggerPopoverScopeContextOptional as unstable_useTriggerPopoverScopeContextOptional, useTriggerPopoverTriggers as unstable_useTriggerPopoverTriggers, useTriggerPopoverTriggersOptional as unstable_useTriggerPopoverTriggersOptional, useAssistantContext, useAssistantDataUI, useAssistantFrameHost, useAssistantInstructions, useAssistantInteractable, useAssistantRuntime, useAssistantTool, useAssistantToolUI, useAssistantTransportRuntime, useAssistantTransportSendCommand, useAssistantTransportState, useAttachment, useAttachmentRuntime, useAui, useAuiEvent, useAuiState, useAuiToolOverrides, useCloudThreadListAdapter, useCloudThreadListRuntime, useComposer, useComposerRuntime, useEditComposer, useEditComposerAttachment, useEditComposerAttachmentRuntime, useExternalMessageConverter, useExternalStoreRuntime, useExternalStoreSharedOptions, useInlineRender, useInteractableState, useLocalRuntime, useMessage, useMessageAttachment, useMessageAttachmentRuntime, useMessagePart, useMessagePartData, useMessagePartFile, useMessagePartImage, useMessagePartReasoning, useMessagePartRuntime, useMessagePartSource, useMessagePartText, useMessageQuote, useMessageRuntime, useMessageTiming, useRemoteThreadListRuntime, useRuntimeAdapters, useScrollLock, useSmooth, useThread, useThreadComposer, useThreadComposerAttachment, useThreadComposerAttachmentRuntime, useThreadList, useThreadListItem, useThreadListItemRuntime, useThreadModelContext, useThreadRuntime, useThreadViewport, useThreadViewportAutoScroll, useThreadViewportStore, useToolArgsStatus, useToolCallElapsed, useVoiceControls, useVoiceState, useVoiceVolume };
 }
+
+declare const useThreadScrollToBottom: (_param18?: useThreadScrollToBottom.Options) => (() => void) | null;
+
+declare const useThreadSuggestion: (_param19: {
+  prompt: string;
+  send?: boolean | undefined;
+  clearComposer?: boolean | undefined;
+  autoSend?: boolean | undefined;
+  method?: "replace";
+}) => (() => void) | null;
+
+declare const useThreadViewport: {
+  (): ThreadViewportState;
+  <TSelected>(selector: (state: ThreadViewportState) => TSelected): TSelected;
+  (options: {
+    optional: true;
+  }): ThreadViewportState | null;
+  <TSelected>(options: {
+    optional: true;
+    selector?: (state: ThreadViewportState) => TSelected;
+  }): TSelected | null;
+}, useThreadViewportStore: {
+  (): ReadonlyStore<ThreadViewportState>;
+  (options: {
+    optional: true;
+  }): ReadonlyStore<ThreadViewportState> | null;
+};
+
+declare namespace useThreadViewportAutoScroll {
+  type Options = {
+    autoScroll?: boolean | undefined;
+    scrollToBottomOnRunStart?: boolean | undefined;
+    scrollToBottomOnInitialize?: boolean | undefined;
+    scrollToBottomOnThreadSwitch?: boolean | undefined;
+  };
+}
+
+declare const useThreadViewportAutoScroll: <TElement extends HTMLElement>(_param20: useThreadViewportAutoScroll.Options) => RefCallback<TElement>;
+
+declare const useToolArgsStatus: <TArgs extends Record<string, unknown> = Record<string, unknown>>() => ToolArgsStatus<TArgs>;
+
+declare const useToolCallElapsed: () => number | undefined;
+
+declare const useTriggerPopoverRootContext: () => TriggerPopoverRootContextValue;
+
+declare const useTriggerPopoverRootContextOptional: () => TriggerPopoverRootContextValue | null;
+
+declare const useTriggerPopoverScopeContext: () => TriggerPopoverResourceOutput;
+
+declare const useTriggerPopoverScopeContextOptional: () => TriggerPopoverResourceOutput | null;
+
+declare const useTriggerPopoverTriggers: () => ReadonlyMap<string, RegisteredTrigger>;
+
+declare const useTriggerPopoverTriggersOptional: () => ReadonlyMap<string, RegisteredTrigger>;
+
+declare const useVoiceControls: () => {
+  connect: () => void;
+  disconnect: () => void;
+  mute: () => void;
+  unmute: () => void;
+};
+
+declare const useVoiceState: () => VoiceSessionState | undefined;
+
+declare const useVoiceVolume: () => number;
+
+declare const withSmoothContextProvider: <C extends ComponentType<any>>(Component: C) => C;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -1,70 +1,12 @@
 import React, { FC, PropsWithChildren, ReactNode } from "react";
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
-  readonly key?: string | number;
-  readonly deps?: readonly unknown[];
-};
+type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
-type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
-
-interface ClientMethods {
-  [key: string | symbol]: (...args: any[]) => any;
-}
-
-type ClientMetaType = {
-  source: ClientNames;
-  query: Record<string, unknown>;
-};
-
-type ClientSchema<TMethods extends ClientMethods = ClientMethods, TMeta extends ClientMetaType = never, TEvents extends Record<string, unknown> = never> = {
-  methods: TMethods;
-  meta?: TMeta;
-  events?: TEvents;
-};
-
-interface ScopeRegistry {
-  [key: string]: { methods: any; meta?: any; events?: any };
-}
-
-type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
-
-type ClientError<E extends string> = {
-  methods: Record<E, () => E>;
-  meta: {
-    source: ClientNames;
-    query: Record<E, E>;
-  };
-  events: Record<`${E}.`, E>;
-};
-
-type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
-  methods: ClientMethods;
-} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
-
-type ClientSchemas = keyof ScopeRegistry extends never ? {
-  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
-} : {
-  [K in keyof ScopeRegistry]: ValidateClient<K>;
-};
-
-type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
-
-type ClientNames = keyof ClientSchemas extends infer U ? U : never;
-
-type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
-
-type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
-
-type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
-
-type Unsubscribe = () => void;
-
-type AssistantState = {
-  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
-    getState: () => infer S;
-  } ? S : never;
+type AssistantClient = {
+  [K in ClientNames]: AssistantClientAccessor<K>;
+} & {
+  subscribe(listener: () => void): Unsubscribe;
+  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
 };
 
 type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["methods"]) & (ClientMeta<K> | {
@@ -77,39 +19,13 @@ type AssistantClientAccessor<K extends ClientNames> = (() => ClientSchemas[K]["m
   name: K;
 };
 
-type AssistantClient = {
-  [K in ClientNames]: AssistantClientAccessor<K>;
-} & {
-  subscribe(listener: () => void): Unsubscribe;
-  on<TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>): Unsubscribe;
-};
+type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
 
-type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
-
-type ClientEventMap = UnionToIntersection<{
-  [K in ClientNames]: ClientEvents<K>;
-}[ClientNames]>;
-
-type WildcardPayload = {
-  [K in keyof ClientEventMap]: {
-    event: K;
-    payload: ClientEventMap[K];
-  };
-}[Extract<keyof ClientEventMap, string>];
+type AssistantEventName = keyof AssistantEventPayload;
 
 type AssistantEventPayload = ClientEventMap & {
   "*": WildcardPayload;
 };
-
-type AssistantEventName = keyof AssistantEventPayload;
-
-type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
-
-type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
-  source: infer S;
-} ? S extends ClientNames ? S : never : never;
-
-type AncestorsOf<K extends ClientNames, Seen extends ClientNames = never> = K extends Seen ? never : ParentOf<K> extends never ? never : ParentOf<K> | AncestorsOf<ParentOf<K>, Seen | K>;
 
 type AssistantEventScope<TEvent extends AssistantEventName> = "*" | EventSource<TEvent> | (EventSource<TEvent> extends ClientNames ? AncestorsOf<EventSource<TEvent>> : never);
 
@@ -118,12 +34,11 @@ type AssistantEventSelector<TEvent extends AssistantEventName> = TEvent | {
   event: TEvent;
 };
 
-declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {
-  scope: AssistantEventScope<TEvent>;
-  event: TEvent;
+type AssistantState = {
+  [K in ClientNames]: ClientSchemas[K]["methods"] extends {
+    getState: () => infer S;
+  } ? S : never;
 };
-
-type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
 
 declare namespace AuiIf {
   type Props = PropsWithChildren<{
@@ -134,12 +49,61 @@ declare namespace AuiIf {
 
 declare const AuiIf: FC<AuiIf.Props>;
 
+declare const AuiProvider: (_param0: {
+  value: AssistantClient;
+  children: React.ReactNode;
+}) => React.ReactElement;
+
+type ClientElement<K extends ClientNames> = ResourceElement<ClientOutput<K>>;
+
+type ClientError<E extends string> = {
+  methods: Record<E, () => E>;
+  meta: {
+    source: ClientNames;
+    query: Record<E, E>;
+  };
+  events: Record<`${E}.`, E>;
+};
+
+type ClientEventMap = UnionToIntersection<{
+  [K in ClientNames]: ClientEvents<K>;
+}[ClientNames]>;
+
+type ClientEvents<K extends ClientNames> = "events" extends keyof ClientSchemas[K] ? ClientSchemas[K]["events"] extends ClientEventsType<K> ? ClientSchemas[K]["events"] : never : never;
+
+type ClientEventsType<K extends ClientNames> = Record<`${K}.${string}`, unknown>;
+
+type ClientMeta<K extends ClientNames> = "meta" extends keyof ClientSchemas[K] ? Pick<ClientSchemas[K]["meta"] extends ClientMetaType ? ClientSchemas[K]["meta"] : never, "query" | "source"> : never;
+
+type ClientMetaType = {
+  source: ClientNames;
+  query: Record<string, unknown>;
+};
+
+interface ClientMethods {
+  [key: string | symbol]: (...args: any[]) => any;
+}
+
+type ClientNames = keyof ClientSchemas extends infer U ? U : never;
+
+type ClientOutput<K extends ClientNames> = ClientSchemas[K]["methods"] & ClientMethods;
+
+type ClientSchema<TMethods extends ClientMethods = ClientMethods, TMeta extends ClientMetaType = never, TEvents extends Record<string, unknown> = never> = {
+  methods: TMethods;
+  meta?: TMeta;
+  events?: TEvents;
+};
+
+type ClientSchemas = keyof ScopeRegistry extends never ? {
+  "ERROR: No clients were defined": ClientError<"ERROR: No clients were defined">;
+} : {
+  [K in keyof ScopeRegistry]: ValidateClient<K>;
+};
+
+type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
+
 declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
   _config: Derived.Props<K>
-]>;
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
 ]>;
 
 declare namespace Derived {
@@ -148,10 +112,45 @@ declare namespace Derived {
   } & ClientMeta<K>;
 }
 
-declare function RenderChildrenWithAccessor<T>(_param0: {
+type DerivedElement<K extends ClientNames> = ResourceElement<null, [
+  Derived.Props<K>
+]>;
+
+type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
+
+type Hook = (...args: any[]) => any;
+
+type InferClientState<TMethods> = TMethods extends {
+  getState: () => infer S;
+} ? S : unknown;
+
+type InferClientState$1<TMethods> = TMethods extends {
+  getState: () => infer S;
+} ? S : unknown;
+
+type InferClientState$2<TMethods> = TMethods extends {
+  getState: () => infer S;
+} ? S : undefined;
+
+type ParentOf<K extends ClientNames> = AssistantClientAccessor<K> extends {
+  source: infer S;
+} ? S extends ClientNames ? S : never : never;
+
+declare function RenderChildrenWithAccessor<T>(_param1: {
   getItemState: (aui: AssistantClient) => T;
   children: (getItem: () => T) => ReactNode;
 }): ReactNode;
+
+type ResourceElement<R, A extends readonly unknown[] = any[]> = {
+  readonly hook: (...args: A) => R;
+  readonly args: Readonly<A>;
+  readonly key?: string | number;
+  readonly deps?: readonly unknown[];
+};
+
+interface ScopeRegistry {
+  [key: string]: { methods: any; meta?: any; events?: any };
+}
 
 type ScopesConfig = {
   [K in ClientNames]?: ClientElement<K> | DerivedElement<K>;
@@ -159,11 +158,40 @@ type ScopesConfig = {
 
 type TransformScopesFn = (scopes: ScopesConfig, parent: AssistantClient) => void;
 
-type Hook = (...args: any[]) => any;
+type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never;
+
+type Unsubscribe = () => void;
+
+type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
+  methods: ClientMethods;
+} ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
+
+type WildcardPayload = {
+  [K in keyof ClientEventMap]: {
+    event: K;
+    payload: ClientEventMap[K];
+  };
+}[Extract<keyof ClientEventMap, string>];
 
 declare function attachTransformScopes(hook: Hook, transform: TransformScopesFn): void;
 
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
+
+declare namespace entry_root_exports {
+  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
+}
+
+declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {
+  scope: AssistantEventScope<TEvent>;
+  event: TEvent;
+};
+
+declare const useAssistantClientRef: () => {
+  parent: AssistantClient;
+  current: AssistantClient | null;
+};
+
+declare const useAssistantEmit: () => <TEvent extends Exclude<AssistantEventName, "*">>(event: TEvent, payload: AssistantEventPayload[TEvent]) => void;
 
 declare namespace useAui {
   type Props = {
@@ -179,48 +207,9 @@ declare function useAui(clients: useAui.Props, config: {
   parent: null | AssistantClient;
 }): AssistantClient;
 
-declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
-
 declare const useAuiEvent: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>, callback: AssistantEventCallback<TEvent>) => void;
 
-declare const AuiProvider: (_param1: {
-  value: AssistantClient;
-  children: React.ReactNode;
-}) => React.ReactElement;
-
-declare const useAssistantClientRef: () => {
-  parent: AssistantClient;
-  current: AssistantClient | null;
-};
-
-declare const useAssistantEmit: () => <TEvent extends Exclude<AssistantEventName, "*">>(event: TEvent, payload: AssistantEventPayload[TEvent]) => void;
-
-type InferClientState$2<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : undefined;
-
-declare const useClientResource: <TMethods extends ClientMethods>(element: ResourceElement<TMethods>) => {
-  state: InferClientState$2<TMethods>;
-  methods: TMethods;
-  key: string | number | undefined;
-};
-
-type InferClientState$1<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
-
-declare function useClientLookup<TMethods extends ClientMethods>(elements: readonly ResourceElement<TMethods>[]): {
-  state: InferClientState$1<TMethods>[];
-  get: (lookup: {
-    index: number;
-  } | {
-    key: string;
-  }) => TMethods;
-};
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
+declare const useAuiState: <T>(selector: (state: AssistantState) => T) => T;
 
 declare const useClientList: <TData, TMethods extends ClientMethods>(props: useClientList.Props<TData, TMethods>) => {
   state: InferClientState<TMethods>[];
@@ -247,8 +236,19 @@ declare namespace useClientList {
   };
 }
 
-declare namespace entry_root_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
-}
+declare function useClientLookup<TMethods extends ClientMethods>(elements: readonly ResourceElement<TMethods>[]): {
+  state: InferClientState$1<TMethods>[];
+  get: (lookup: {
+    index: number;
+  } | {
+    key: string;
+  }) => TMethods;
+};
+
+declare const useClientResource: <TMethods extends ClientMethods>(element: ResourceElement<TMethods>) => {
+  state: InferClientState$2<TMethods>;
+  methods: TMethods;
+  key: string | number | undefined;
+};
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -1,5 +1,11 @@
 import { Context } from "react";
 
+type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
+
+type ExtractResourceReturnType<T> = T extends ResourceElement<infer R, any> ? R : T extends Resource<infer R, any> ? R : never;
+
+type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+
 type ResourceElement<R, A extends readonly unknown[] = any[]> = {
   readonly hook: (...args: A) => R;
   readonly args: Readonly<A>;
@@ -7,33 +13,19 @@ type ResourceElement<R, A extends readonly unknown[] = any[]> = {
   readonly deps?: readonly unknown[];
 };
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
-
-type ExtractResourceReturnType<T> = T extends ResourceElement<infer R, any> ? R : T extends Resource<infer R, any> ? R : never;
-
-declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn: () => TResult) => TResult;
-
-declare namespace useTapRoot {
-  type Unsubscribe = () => void;
-  interface Root<R> {
-    getValue(): R;
-    subscribe(listener: () => void): Unsubscribe;
-  }
-}
-
-declare const useTapRoot: <R>(render: () => R) => useTapRoot.Root<R>;
-
 declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
   unmount: () => void;
 };
 
-declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
-
 declare const flushTapSync: <T>(callback: () => T) => T;
 
-declare function withKey<E extends ResourceElement<any, any>>(key: string | number, element: E, deps?: readonly unknown[]): E;
+declare namespace entry_root_exports {
+  export { ContravariantResource, Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
+}
+
+declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
+
+declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn: () => TResult) => TResult;
 
 declare function useResource<E extends ResourceElement<any, any[]>>(element: E): ExtractResourceReturnType<E>;
 
@@ -48,8 +40,16 @@ declare namespace useTapHost {
 
 declare const useTapHost: <R>(callback: () => R) => useTapHost.Result<R>;
 
-declare namespace entry_root_exports {
-  export { ContravariantResource, Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
+declare namespace useTapRoot {
+  type Unsubscribe = () => void;
+  interface Root<R> {
+    getValue(): R;
+    subscribe(listener: () => void): Unsubscribe;
+  }
 }
+
+declare const useTapRoot: <R>(render: () => R) => useTapRoot.Root<R>;
+
+declare function withKey<E extends ResourceElement<any, any>>(key: string | number, element: E, deps?: readonly unknown[]): E;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__vite.ts
+++ b/api-surface/assistant-ui__vite.ts
@@ -1,9 +1,9 @@
 import { Plugin } from "vite";
 
+declare function aui(): Plugin[];
+
 declare namespace entry_root_exports {
   export { aui };
 }
-
-declare function aui(): Plugin[];
 
 export { entry_root_exports as entry_root };

--- a/api-surface/assistant-ui__x-generative-compiler.ts
+++ b/api-surface/assistant-ui__x-generative-compiler.ts
@@ -1,9 +1,3 @@
-declare const DIRECTIVE = "use generative";
-
-type Target = "client" | "server";
-
-type ToolType = "backend" | "frontend" | "human" | "provider";
-
 interface CompileOptions {
   target: Target;
   filename?: string;
@@ -16,16 +10,22 @@ interface CompileResult {
   map?: object | null;
 }
 
+declare const DIRECTIVE = "use generative";
+
 declare class GenerativeCompileError extends Error {
   constructor(message: string, filename?: string);
 }
 
-declare function isGenerativeModule(code: string): boolean;
+type Target = "client" | "server";
+
+type ToolType = "backend" | "frontend" | "human" | "provider";
 
 declare function compileGenerative(code: string, options: CompileOptions): CompileResult;
 
 declare namespace entry_root_exports {
   export { CompileOptions, CompileResult, DIRECTIVE, GenerativeCompileError, Target, ToolType, compileGenerative, isGenerativeModule };
 }
+
+declare function isGenerativeModule(code: string): boolean;
 
 export { entry_root_exports as entry_root };

--- a/api-surface/heat-graph.ts
+++ b/api-surface/heat-graph.ts
@@ -1,21 +1,10 @@
-import { ComponentPropsWithoutRef, ReactNode } from "react";
-
 import * as Popper from "@radix-ui/react-popper";
 
-type CellProps = ComponentPropsWithoutRef<"div"> & {
-  colorScale?: string[];
-};
+import { ComponentPropsWithoutRef, ReactNode } from "react";
 
 declare const Cell: import("react").ForwardRefExoticComponent<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & {
   colorScale?: string[];
 } & import("react").RefAttributes<HTMLDivElement>>;
-
-type DataPoint = {
-  date: string | Date;
-  count: number;
-};
-
-type ClassifyFn = (counts: number[]) => (count: number) => number;
 
 type CellData = {
   date: Date;
@@ -25,9 +14,33 @@ type CellData = {
   row: number;
 };
 
-type MonthLabel = {
-  month: number;
-  column: number;
+type CellProps = ComponentPropsWithoutRef<"div"> & {
+  colorScale?: string[];
+};
+
+type ClassifyFn = (counts: number[]) => (count: number) => number;
+
+type ComputeGridOptions = {
+  data: DataPoint[];
+  start?: string | Date | undefined;
+  end?: string | Date | undefined;
+  weekStart?: WeekStart | undefined;
+  classify?: ClassifyFn | undefined;
+};
+
+declare const DAY_SHORT: readonly [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat"
+];
+
+type DataPoint = {
+  date: string | Date;
+  count: number;
 };
 
 type DayLabel = {
@@ -35,7 +48,25 @@ type DayLabel = {
   row: number;
 };
 
-type WeekStart = "monday" | "sunday";
+declare const DayLabels: (_param0: DayLabelsProps) => import("react").JSX.Element[];
+
+type DayLabelsProps = {
+  children: (props: {
+    label: DayLabel;
+  }) => ReactNode;
+};
+
+declare const Grid: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref">, "children"> & {
+  children: (props: {
+    cell: CellData;
+  }) => ReactNode;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+type GridProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
+  children: (props: {
+    cell: CellData;
+  }) => ReactNode;
+};
 
 type HeatGraphState = {
   cells: CellData[];
@@ -46,83 +77,22 @@ type HeatGraphState = {
   colorScale?: string[] | undefined;
 };
 
-type DayLabelsProps = {
-  children: (props: {
-    label: DayLabel;
-  }) => ReactNode;
-};
-
-declare const DayLabels: (_param0: DayLabelsProps) => import("react").JSX.Element[];
-
-type GridProps = Omit<ComponentPropsWithoutRef<"div">, "children"> & {
-  children: (props: {
-    cell: CellData;
-  }) => ReactNode;
-};
-
-declare const Grid: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref">, "children"> & {
-  children: (props: {
-    cell: CellData;
-  }) => ReactNode;
-} & import("react").RefAttributes<HTMLDivElement>>;
+declare const Legend: (_param1: LegendProps) => import("react").JSX.Element[];
 
 type LegendItemData = {
   level: number;
   color: string | undefined;
 };
 
+declare const LegendLevel: import("react").ForwardRefExoticComponent<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+
+type LegendLevelProps = ComponentPropsWithoutRef<"div">;
+
 type LegendProps = {
   children: (props: {
     item: LegendItemData;
   }) => ReactNode;
 };
-
-declare const Legend: (_param1: LegendProps) => import("react").JSX.Element[];
-
-type LegendLevelProps = ComponentPropsWithoutRef<"div">;
-
-declare const LegendLevel: import("react").ForwardRefExoticComponent<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
-
-type MonthLabelsProps = {
-  children: (props: {
-    label: MonthLabel;
-    totalWeeks: number;
-  }) => ReactNode;
-};
-
-declare const MonthLabels: (_param2: MonthLabelsProps) => import("react").JSX.Element[];
-
-type ComputeGridOptions = {
-  data: DataPoint[];
-  start?: string | Date | undefined;
-  end?: string | Date | undefined;
-  weekStart?: WeekStart | undefined;
-  classify?: ClassifyFn | undefined;
-};
-
-type RootProps = ComponentPropsWithoutRef<"div"> & ComputeGridOptions & {
-  colorScale?: string[];
-};
-
-declare const Root: import("react").ForwardRefExoticComponent<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & ComputeGridOptions & {
-  colorScale?: string[];
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-type PopperContentProps = ComponentPropsWithoutRef<typeof Popper.Content>;
-
-type TooltipProps = Omit<PopperContentProps, "children"> & {
-  children: (props: {
-    cell: CellData;
-  }) => ReactNode;
-};
-
-declare const Tooltip: import("react").ForwardRefExoticComponent<Omit<Omit<Popper.PopperContentProps & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
-  children: (props: {
-    cell: CellData;
-  }) => ReactNode;
-} & import("react").RefAttributes<HTMLDivElement>>;
-
-declare const autoLevels: (n: number) => ClassifyFn;
 
 declare const MONTH_SHORT: readonly [
   "Jan",
@@ -139,15 +109,45 @@ declare const MONTH_SHORT: readonly [
   "Dec"
 ];
 
-declare const DAY_SHORT: readonly [
-  "Sun",
-  "Mon",
-  "Tue",
-  "Wed",
-  "Thu",
-  "Fri",
-  "Sat"
-];
+type MonthLabel = {
+  month: number;
+  column: number;
+};
+
+declare const MonthLabels: (_param2: MonthLabelsProps) => import("react").JSX.Element[];
+
+type MonthLabelsProps = {
+  children: (props: {
+    label: MonthLabel;
+    totalWeeks: number;
+  }) => ReactNode;
+};
+
+type PopperContentProps = ComponentPropsWithoutRef<typeof Popper.Content>;
+
+declare const Root: import("react").ForwardRefExoticComponent<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref"> & ComputeGridOptions & {
+  colorScale?: string[];
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+type RootProps = ComponentPropsWithoutRef<"div"> & ComputeGridOptions & {
+  colorScale?: string[];
+};
+
+declare const Tooltip: import("react").ForwardRefExoticComponent<Omit<Omit<Popper.PopperContentProps & import("react").RefAttributes<HTMLDivElement>, "ref">, "children"> & {
+  children: (props: {
+    cell: CellData;
+  }) => ReactNode;
+} & import("react").RefAttributes<HTMLDivElement>>;
+
+type TooltipProps = Omit<PopperContentProps, "children"> & {
+  children: (props: {
+    cell: CellData;
+  }) => ReactNode;
+};
+
+type WeekStart = "monday" | "sunday";
+
+declare const autoLevels: (n: number) => ClassifyFn;
 
 declare namespace entry_root_exports {
   export { Cell, CellData, CellProps, ClassifyFn, DAY_SHORT, DataPoint, DayLabel, DayLabels, DayLabelsProps, Grid, GridProps, HeatGraphState, Legend, LegendLevel, LegendLevelProps, LegendProps, MONTH_SHORT, MonthLabel, MonthLabels, MonthLabelsProps, Root, RootProps, Tooltip, TooltipProps, WeekStart, autoLevels };

--- a/api-surface/safe-content-frame.ts
+++ b/api-surface/safe-content-frame.ts
@@ -1,24 +1,3 @@
-declare namespace entry_shadow_dom_exports {
-  export { enableShadowDom, unsafeDisableShadowDom };
-}
-
-declare const enableShadowDom: () => boolean;
-
-declare const unsafeDisableShadowDom: () => boolean;
-
-declare namespace entry_root_exports {
-  export { RenderedFrame, SafeContentFrame, SafeContentFrameOptions, SandboxOption };
-}
-
-type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
-
-interface SafeContentFrameOptions {
-  useShadowDom?: boolean;
-  enableBrowserCaching?: boolean;
-  sandbox?: SandboxOption[];
-  salt?: string;
-}
-
 interface RenderedFrame {
   iframe: HTMLIFrameElement;
   origin: string;
@@ -39,5 +18,26 @@ declare class SafeContentFrame {
   private render;
   private getSandbox;
 }
+
+interface SafeContentFrameOptions {
+  useShadowDom?: boolean;
+  enableBrowserCaching?: boolean;
+  sandbox?: SandboxOption[];
+  salt?: string;
+}
+
+type SandboxOption = "allow-downloads" | "allow-forms" | "allow-modals" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts";
+
+declare const enableShadowDom: () => boolean;
+
+declare namespace entry_root_exports {
+  export { RenderedFrame, SafeContentFrame, SafeContentFrameOptions, SandboxOption };
+}
+
+declare namespace entry_shadow_dom_exports {
+  export { enableShadowDom, unsafeDisableShadowDom };
+}
+
+declare const unsafeDisableShadowDom: () => boolean;
 
 export { entry_root_exports as entry_root, entry_shadow_dom_exports as entry_shadow_dom };

--- a/scripts/generate-api-surface.mjs
+++ b/scripts/generate-api-surface.mjs
@@ -234,6 +234,55 @@ function entryNamespace(entry) {
   return sanitizeIdentifier(`entry_${exportPath}${conditions}`);
 }
 
+function statementCategory(statement) {
+  if (
+    ts.isImportDeclaration(statement) ||
+    ts.isImportEqualsDeclaration(statement)
+  ) {
+    return 0;
+  }
+  if (ts.isExportDeclaration(statement) || ts.isExportAssignment(statement)) {
+    return 2;
+  }
+  return 1;
+}
+
+function statementSortName(statement) {
+  if (ts.isImportDeclaration(statement)) {
+    return ts.isStringLiteral(statement.moduleSpecifier)
+      ? statement.moduleSpecifier.text
+      : "";
+  }
+  if (ts.isVariableStatement(statement)) {
+    const [declaration] = statement.declarationList.declarations;
+    return declaration && ts.isIdentifier(declaration.name)
+      ? declaration.name.text
+      : "";
+  }
+  if (ts.isModuleDeclaration(statement)) return statement.name.text;
+  if (statement.name && ts.isIdentifier(statement.name)) {
+    return statement.name.text;
+  }
+  return "";
+}
+
+function sortTopLevelStatements(statements) {
+  return statements
+    .map((statement, index) => ({
+      statement,
+      index,
+      category: statementCategory(statement),
+      name: statementSortName(statement),
+    }))
+    .toSorted(
+      (a, b) =>
+        a.category - b.category ||
+        compareStrings(a.name, b.name) ||
+        a.index - b.index,
+    )
+    .map(({ statement }) => statement);
+}
+
 function printSurfaceFile(sourceFile) {
   const printer = ts.createPrinter({
     newLine: ts.NewLineKind.LineFeed,
@@ -258,7 +307,7 @@ function normalizeReactImports(content) {
       /^import React, \{([^}]+)\} from "react";$/m,
       (_, specifiers) => `import {${specifiers}} from "react";`,
     )
-    .replace(/^import React from "react";\n?/m, "");
+    .replace(/^import React from "react";\n{0,2}/m, "");
 }
 
 function normalizeBundlerNamespaceNames(content) {
@@ -518,7 +567,11 @@ export function normalizeBundledDeclaration(content) {
     true,
     ts.ScriptKind.TS,
   );
-  const result = ts.transform(sourceFile, [
+  const sortedSourceFile = ts.factory.updateSourceFile(
+    sourceFile,
+    sortTopLevelStatements(sourceFile.statements),
+  );
+  const result = ts.transform(sortedSourceFile, [
     (context) => {
       let bindingParameterIndex = 0;
       const visit = (node) => {

--- a/scripts/generate-api-surface.test.mjs
+++ b/scripts/generate-api-surface.test.mjs
@@ -66,6 +66,51 @@ test("normalization is idempotent", () => {
   assert.equal(normalizeBundledDeclaration(once), once);
 });
 
+test("top-level statements are grouped and sorted by name", () => {
+  const output = normalizeBundledDeclaration(
+    [
+      `type Zebra = string;`,
+      `import { Second } from "second";`,
+      `declare function alpha(a: string): void;`,
+      `import { First } from "first";`,
+      `interface Middle { a: 1; }`,
+      `export { Middle, Zebra, alpha };`,
+      `declare function alpha(a: number): void;`,
+    ].join("\n"),
+  );
+
+  const order = [
+    `import { First } from "first";`,
+    `import { Second } from "second";`,
+    "interface Middle",
+    "type Zebra",
+    "alpha(a: string)",
+    "alpha(a: number)",
+    "export { Middle, Zebra, alpha };",
+  ].map((snippet) => output.indexOf(snippet));
+
+  assert.ok(order.every((index) => index >= 0));
+  assert.deepEqual(
+    order,
+    [...order].sort((a, b) => a - b),
+  );
+});
+
+test("removing an unused React default import leaves no blank gap", () => {
+  const output = normalizeBundledDeclaration(
+    `import { A } from "a";\nimport React from "react";\ntype B = string;\nexport { B };\n`,
+  );
+  assert.ok(!output.includes(`import React`));
+  assert.ok(!output.includes("\n\n\n"));
+});
+
+test("statement sorting is idempotent", () => {
+  const once = normalizeBundledDeclaration(
+    `type Beta = 1;\n\ntype Alpha = 2;\n\nexport { Alpha, Beta };\n`,
+  );
+  assert.equal(normalizeBundledDeclaration(once), once);
+});
+
 test("an unrecognized composer attachment union shape throws", () => {
   const bad = attachmentUnion(
     `{ status: CompleteAttachmentStatus } & { source: "thread-composer" }`,


### PR DESCRIPTION
## summary

- the api-surface generator emitted top-level declarations in the bundler's module-graph order, so a refactor that moves a declaration between source modules (or changes import order) reshuffled the snapshot without any API change; #4755 hit this when moving `DataStreamProtocol` into a new `protocol.ts` module
- `normalizeBundledDeclaration` now sorts top-level statements: imports first (by module specifier), then declarations by name, with the trailing `export { ... }` list kept last; the sort is stable, so function overloads and merged declarations keep their relative order
- the sort runs before the transform pass, so `_paramN` destructuring placeholders are numbered in sorted order and no longer shift when the module graph changes
- `normalizeReactImports` now consumes the blank line left behind when it strips an unused `import React` default import; previously the strip was only clean when the import happened to sit at the very top of the file

the snapshots exist so a reviewer can trust that any diff is a real surface change. declaration position is a bundler artifact, not part of the surface, and with the ongoing legacy-runtime migration moving declarations between modules the reorder noise would keep growing. same lineage as #4601 and #4623, which normalized other incidental bundler output.

## test plan

### already verified

- [x] `pnpm api-surface:test` -> 8/8 pass (new tests cover the grouped name sort, sort idempotency, and the React import blank gap)
- [x] `pnpm api-surface` regenerated all 40 snapshots; a per-file line-multiset diff against the previous snapshots confirms the churn is pure reordering plus `_paramN` renumbering, and one pre-existing double blank line removed in `assistant-ui__react-pi.ts`
- [x] `node scripts/check-api-surface.mjs --skip-build` -> clean, so a second generation produces zero diff and `tsc --noEmit` passes on the regenerated snapshots

### reviewer should verify

- [ ] CI `Check API surface` is green

## notes

- this is a one-time full reorder of every snapshot (~48k lines); after it lands, snapshot diffs only reflect real surface changes
- the bundler's `$N` duplicate-name suffixes are still assigned in graph order, so a refactor that changes which duplicate gets the bare name can still produce a content diff; left for a follow-up if it ever bites

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

