### PR TITLE
chore: add okisdev as code owner for CODEOWNERS and api-surface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CI and repository policy changes require maintainer review.
-/.github/CODEOWNERS @Yonom
+/.github/CODEOWNERS @Yonom @okisdev
 /.github/actions/ @assistant-ui/maintainers
 /.github/workflows/ @assistant-ui/maintainers
 
-# Public API surface snapshots require Yonom review.
-/api-surface/ @Yonom
+# Public API surface snapshots require maintainer review.
+/api-surface/ @Yonom @okisdev


### PR DESCRIPTION
## summary

- adds @okisdev as a code owner for `/.github/CODEOWNERS` and `/api-surface/`, alongside @Yonom
- updates the api-surface comment to say maintainer review instead of naming a single reviewer

no test plan, CODEOWNERS only change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

