### PR TITLE
fix(templates): surface the real error on failed chat requests

### DIFF
--- a/templates/cloud-clerk/app/api/chat/route.ts
+++ b/templates/cloud-clerk/app/api/chat/route.ts
@@ -35,6 +35,8 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     sendReasoning: true,
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
     messageMetadata: ({ part }) => {
       if (part.type === "finish") {
         return {

--- a/templates/cloud/app/api/chat/route.ts
+++ b/templates/cloud/app/api/chat/route.ts
@@ -35,6 +35,8 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     sendReasoning: true,
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
     messageMetadata: ({ part }) => {
       if (part.type === "finish") {
         return {

--- a/templates/default/app/api/chat/route.ts
+++ b/templates/default/app/api/chat/route.ts
@@ -35,5 +35,7 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     sendReasoning: true,
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
   });
 }

--- a/templates/mcp/app/api/chat/route.ts
+++ b/templates/mcp/app/api/chat/route.ts
@@ -52,5 +52,7 @@ export async function POST(req: Request) {
 
   return result.toUIMessageStreamResponse({
     sendReasoning: true,
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
   });
 }

--- a/templates/minimal/app/api/chat/route.ts
+++ b/templates/minimal/app/api/chat/route.ts
@@ -27,5 +27,8 @@ export async function POST(req: Request) {
     },
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({
+    onError: (error) =>
+      error instanceof Error ? error.message : String(error),
+  });
 }


### PR DESCRIPTION
## What

Adds an `onError` to `toUIMessageStreamResponse` in every AI-SDK template (default, minimal, cloud, cloud-clerk, mcp) so failed requests return the real error text.

```ts
onError: (error) => (error instanceof Error ? error.message : String(error)),
```

## Why

The AI SDK v6 defaults `onError = () => "An error occurred."`, masking server errors from the client. So a user who forgets `OPENAI_API_KEY` gets a generic red bubble while the real `AI_LoadAPIKeyError` shows only in the terminal. Missing/invalid key is the most likely first-run failure; forwarding the message makes it self-diagnosing.

## Impact

- First-run failures now render their real message in the error surface (which already shows `errorText`).
- Happy path unchanged; `onError` only fires on error.
- Terminal logging unchanged (it comes from `streamText`'s separate `onError`).

## Mechanics

- 5 files, one line each. Not touched: `langchain` (already forwards its error) and `eve` (no AI-SDK route).
- No changeset (templates are `private: true`), no new dependency.
- Lint and `tsc --noEmit` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

