### PR TITLE
feat: detect UI message stream protocol header

### DIFF
--- a/.changeset/green-walls-protect.md
+++ b/.changeset/green-walls-protect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+feat: detect UI message stream protocol from response headers

--- a/apps/docs/content/docs/runtimes/custom/data-stream.mdx
+++ b/apps/docs/content/docs/runtimes/custom/data-stream.mdx
@@ -20,12 +20,12 @@ If your backend exposes a richer state surface, consider [`AssistantTransport`](
 ## Wire protocols
 
 `useDataStreamRuntime` accepts two wire formats. When `protocol` is omitted, it
-detects `x-vercel-ai-data-stream: v1` responses as data-stream and otherwise
-falls back to UI message stream.
+detects known Vercel AI response markers before falling back to UI message
+stream for compatibility.
 
 | Protocol | Detection | Matching backend |
 | --- | --- | --- |
-| `"ui-message-stream"` | fallback | AI SDK v6's `result.toUIMessageStreamResponse()` (SSE) |
+| `"ui-message-stream"` | `x-vercel-ai-ui-message-stream: v1`, otherwise fallback | AI SDK v5+'s `result.toUIMessageStreamResponse()` (SSE) |
 | `"data-stream"` | `x-vercel-ai-data-stream: v1` | `createAssistantStreamResponse` from `assistant-stream`, or AI SDK v4's `toDataStreamResponse()` (Vercel data stream v1) |
 
 Set `protocol` explicitly only for custom endpoints that do not preserve or

--- a/packages/react-data-stream/README.md
+++ b/packages/react-data-stream/README.md
@@ -28,9 +28,11 @@ export function Provider({ children }: { children: React.ReactNode }) {
 ```
 
 When `protocol` is omitted, the runtime detects `x-vercel-ai-data-stream: v1`
-responses as the legacy data-stream wire format and otherwise falls back to the
-UI message stream format. Set `protocol` explicitly only for custom endpoints
-that do not preserve or expose the response marker.
+responses as the legacy data-stream wire format and
+`x-vercel-ai-ui-message-stream: v1` responses as the UI message stream format.
+Responses without a known marker still fall back to UI message stream for
+compatibility. Set `protocol` explicitly only for custom endpoints that do not
+preserve or expose the response marker.
 
 ## See also
 

--- a/packages/react-data-stream/src/protocol.test.ts
+++ b/packages/react-data-stream/src/protocol.test.ts
@@ -5,12 +5,14 @@ describe("resolveDataStreamProtocol", () => {
   it("uses explicit protocol options", () => {
     const headers = new Headers({ "x-vercel-ai-data-stream": "v1" });
 
-    expect(resolveDataStreamProtocol(headers, "ui-message-stream")).toBe(
-      "ui-message-stream",
-    );
-    expect(resolveDataStreamProtocol(new Headers(), "data-stream")).toBe(
-      "data-stream",
-    );
+    expect(resolveDataStreamProtocol(headers, "ui-message-stream")).toEqual({
+      protocol: "ui-message-stream",
+      source: "explicit",
+    });
+    expect(resolveDataStreamProtocol(new Headers(), "data-stream")).toEqual({
+      protocol: "data-stream",
+      source: "explicit",
+    });
   });
 
   it("detects legacy data stream responses from the Vercel AI header", () => {
@@ -18,7 +20,10 @@ describe("resolveDataStreamProtocol", () => {
       resolveDataStreamProtocol(
         new Headers({ "x-vercel-ai-data-stream": " v1 " }),
       ),
-    ).toBe("data-stream");
+    ).toEqual({
+      protocol: "data-stream",
+      source: "data-stream-header",
+    });
   });
 
   it("detects UI message stream responses from the Vercel AI header", () => {
@@ -26,7 +31,10 @@ describe("resolveDataStreamProtocol", () => {
       resolveDataStreamProtocol(
         new Headers({ "x-vercel-ai-ui-message-stream": " v1 " }),
       ),
-    ).toBe("ui-message-stream");
+    ).toEqual({
+      protocol: "ui-message-stream",
+      source: "ui-message-stream-header",
+    });
   });
 
   it("prefers data stream when both protocol headers are present", () => {
@@ -37,15 +45,27 @@ describe("resolveDataStreamProtocol", () => {
           "x-vercel-ai-ui-message-stream": "v1",
         }),
       ),
-    ).toBe("data-stream");
+    ).toEqual({
+      protocol: "data-stream",
+      source: "data-stream-header",
+    });
   });
 
   it("falls back to ui-message-stream without a known protocol header", () => {
-    expect(resolveDataStreamProtocol(new Headers())).toBe("ui-message-stream");
+    expect(resolveDataStreamProtocol(new Headers())).toEqual({
+      protocol: "ui-message-stream",
+      source: "fallback",
+    });
     expect(
       resolveDataStreamProtocol(
-        new Headers({ "x-vercel-ai-data-stream": "v2" }),
+        new Headers({
+          "x-vercel-ai-data-stream": "v2",
+          "x-vercel-ai-ui-message-stream": "v2",
+        }),
       ),
-    ).toBe("ui-message-stream");
+    ).toEqual({
+      protocol: "ui-message-stream",
+      source: "fallback",
+    });
   });
 });

--- a/packages/react-data-stream/src/protocol.test.ts
+++ b/packages/react-data-stream/src/protocol.test.ts
@@ -21,7 +21,26 @@ describe("resolveDataStreamProtocol", () => {
     ).toBe("data-stream");
   });
 
-  it("falls back to ui-message-stream without a known data stream header", () => {
+  it("detects UI message stream responses from the Vercel AI header", () => {
+    expect(
+      resolveDataStreamProtocol(
+        new Headers({ "x-vercel-ai-ui-message-stream": " v1 " }),
+      ),
+    ).toBe("ui-message-stream");
+  });
+
+  it("prefers data stream when both protocol headers are present", () => {
+    expect(
+      resolveDataStreamProtocol(
+        new Headers({
+          "x-vercel-ai-data-stream": "v1",
+          "x-vercel-ai-ui-message-stream": "v1",
+        }),
+      ),
+    ).toBe("data-stream");
+  });
+
+  it("falls back to ui-message-stream without a known protocol header", () => {
     expect(resolveDataStreamProtocol(new Headers())).toBe("ui-message-stream");
     expect(
       resolveDataStreamProtocol(

--- a/packages/react-data-stream/src/protocol.ts
+++ b/packages/react-data-stream/src/protocol.ts
@@ -1,5 +1,16 @@
 export type DataStreamProtocol = "ui-message-stream" | "data-stream";
 
+type DataStreamProtocolSource =
+  | "explicit"
+  | "data-stream-header"
+  | "ui-message-stream-header"
+  | "fallback";
+
+type DataStreamProtocolResolution = {
+  protocol: DataStreamProtocol;
+  source: DataStreamProtocolSource;
+};
+
 const VERCEL_AI_DATA_STREAM_HEADER = "x-vercel-ai-data-stream";
 const VERCEL_AI_UI_MESSAGE_STREAM_HEADER = "x-vercel-ai-ui-message-stream";
 
@@ -9,13 +20,18 @@ const isV1Header = (headers: Headers, header: string) =>
 export const resolveDataStreamProtocol = (
   headers: Headers,
   protocol?: DataStreamProtocol,
-): DataStreamProtocol => {
-  if (protocol) return protocol;
+): DataStreamProtocolResolution => {
+  if (protocol) return { protocol, source: "explicit" };
 
-  if (isV1Header(headers, VERCEL_AI_DATA_STREAM_HEADER)) return "data-stream";
+  if (isV1Header(headers, VERCEL_AI_DATA_STREAM_HEADER)) {
+    return { protocol: "data-stream", source: "data-stream-header" };
+  }
   if (isV1Header(headers, VERCEL_AI_UI_MESSAGE_STREAM_HEADER)) {
-    return "ui-message-stream";
+    return {
+      protocol: "ui-message-stream",
+      source: "ui-message-stream-header",
+    };
   }
 
-  return "ui-message-stream";
+  return { protocol: "ui-message-stream", source: "fallback" };
 };

--- a/packages/react-data-stream/src/protocol.ts
+++ b/packages/react-data-stream/src/protocol.ts
@@ -1,6 +1,10 @@
 export type DataStreamProtocol = "ui-message-stream" | "data-stream";
 
 const VERCEL_AI_DATA_STREAM_HEADER = "x-vercel-ai-data-stream";
+const VERCEL_AI_UI_MESSAGE_STREAM_HEADER = "x-vercel-ai-ui-message-stream";
+
+const isV1Header = (headers: Headers, header: string) =>
+  headers.get(header)?.trim() === "v1";
 
 export const resolveDataStreamProtocol = (
   headers: Headers,
@@ -8,7 +12,10 @@ export const resolveDataStreamProtocol = (
 ): DataStreamProtocol => {
   if (protocol) return protocol;
 
-  return headers.get(VERCEL_AI_DATA_STREAM_HEADER)?.trim() === "v1"
-    ? "data-stream"
-    : "ui-message-stream";
+  if (isV1Header(headers, VERCEL_AI_DATA_STREAM_HEADER)) return "data-stream";
+  if (isV1Header(headers, VERCEL_AI_UI_MESSAGE_STREAM_HEADER)) {
+    return "ui-message-stream";
+  }
+
+  return "ui-message-stream";
 };

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -134,7 +134,7 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
         throw new Error("Response body is null");
       }
 
-      const protocol = resolveDataStreamProtocol(
+      const { protocol } = resolveDataStreamProtocol(
         result.headers,
         this.options.protocol,
       );

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -26,6 +26,8 @@ type HeadersValue = Record<string, string> | Headers;
 
 export type { DataStreamProtocol } from "./protocol";
 
+let didWarnProtocolFallback = false;
+
 export type UseDataStreamRuntimeOptions = {
   api: string;
   /** Defaults to response-header detection, then "ui-message-stream". */
@@ -134,10 +136,20 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
         throw new Error("Response body is null");
       }
 
-      const { protocol } = resolveDataStreamProtocol(
+      const { protocol, source } = resolveDataStreamProtocol(
         result.headers,
         this.options.protocol,
       );
+      if (
+        source === "fallback" &&
+        process.env.NODE_ENV !== "production" &&
+        !didWarnProtocolFallback
+      ) {
+        didWarnProtocolFallback = true;
+        console.warn(
+          '@assistant-ui/react-data-stream could not detect a stream protocol header; falling back to "ui-message-stream". Pass protocol explicitly or expose x-vercel-ai-data-stream / x-vercel-ai-ui-message-stream from the response.',
+        );
+      }
       const decoder =
         protocol === "ui-message-stream"
           ? new UIMessageStreamDecoder(


### PR DESCRIPTION
## Summary

Detect `x-vercel-ai-ui-message-stream: v1` explicitly when `protocol` is omitted, while keeping `x-vercel-ai-data-stream: v1` as the legacy data-stream marker and preserving the no-header UI-message-stream fallback for compatibility.

Also updates the data-stream docs/README and adds a patch changeset for `@assistant-ui/react-data-stream`.

## Testing

- Direct protocol helper assertions via `tsx`
- `oxlint packages/react-data-stream/src/protocol.ts packages/react-data-stream/src/protocol.test.ts --no-error-on-unmatched-pattern`
- `oxfmt --check packages/react-data-stream/src/protocol.ts packages/react-data-stream/src/protocol.test.ts packages/react-data-stream/README.md apps/docs/content/docs/runtimes/custom/data-stream.mdx .changeset/green-walls-protect.md`
- `git diff --check`

Note: `pnpm --filter @assistant-ui/react-data-stream exec vitest run src/protocol.test.ts` was attempted in a fresh worktree, but dependency installation timed out on registry downloads before Vitest ran.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

