### PR TITLE
docs: use transport instead of removed useChatRuntime({ api }) in guides

### DIFF
--- a/apps/docs/content/docs/migrations/toolkit-tools.mdx
+++ b/apps/docs/content/docs/migrations/toolkit-tools.mdx
@@ -16,7 +16,10 @@ Use a toolkit registered with `Tools({ toolkit })` instead. Toolkits keep the mo
 
 ```tsx
 import { AssistantRuntimeProvider, makeAssistantTool } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import { z } from "zod";
 
 const WeatherTool = makeAssistantTool({
@@ -32,7 +35,9 @@ const WeatherTool = makeAssistantTool({
 });
 
 export function App() {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
+  });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -76,11 +81,16 @@ import {
   Tools,
   useAui,
 } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 export function App() {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
+  });
   const aui = useAui({
     tools: Tools({ toolkit }),
   });

--- a/apps/docs/content/docs/migrations/toolkit-tools.mdx
+++ b/apps/docs/content/docs/migrations/toolkit-tools.mdx
@@ -16,10 +16,7 @@ Use a toolkit registered with `Tools({ toolkit })` instead. Toolkits keep the mo
 
 ```tsx
 import { AssistantRuntimeProvider, makeAssistantTool } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import { z } from "zod";
 
 const WeatherTool = makeAssistantTool({
@@ -35,9 +32,7 @@ const WeatherTool = makeAssistantTool({
 });
 
 export function App() {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
+  const runtime = useChatRuntime();
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -81,16 +76,11 @@ import {
   Tools,
   useAui,
 } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 export function App() {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
+  const runtime = useChatRuntime();
   const aui = useAui({
     tools: Tools({ toolkit }),
   });
@@ -102,6 +92,8 @@ export function App() {
   );
 }
 ```
+
+`useChatRuntime()` targets `/api/chat` by default. To point at a different endpoint or customize requests, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 ## Mechanical Steps
 

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -317,7 +317,7 @@ export async function POST(req: Request) {
 }
 ```
 
-On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the response is sent back to the server when the user decides:
+On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the response is sent back to the server when the user decides. These blocks use a plain `DefaultChatTransport` because the `AssistantChatTransport` system-message and frontend-tool forwarding only activates through `useChatRuntime`, not raw `useAISDKRuntime`:
 
 ```tsx title="@/app/page.tsx"
 "use client";
@@ -327,12 +327,15 @@ import {
   AssistantRuntimeProvider,
   useAISDKRuntime,
 } from "@assistant-ui/react-ai-sdk";
-import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from "ai";
 import { Thread } from "@/components/assistant-ui/thread";
 
 export default function Page() {
   const chat = useChat({
-    api: "/api/chat",
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
   const runtime = useAISDKRuntime(chat);
@@ -358,7 +361,10 @@ import {
   useAui,
 } from "@assistant-ui/react";
 import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
-import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from "ai";
 import { Thread } from "@/components/assistant-ui/thread";
 
 const toolkit = defineToolkit({
@@ -391,7 +397,7 @@ const toolkit = defineToolkit({
 
 export default function Page() {
   const chat = useChat({
-    api: "/api/chat",
+    transport: new DefaultChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
   const runtime = useAISDKRuntime(chat);

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6.mdx
@@ -317,7 +317,7 @@ export async function POST(req: Request) {
 }
 ```
 
-On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the response is sent back to the server when the user decides. These blocks use a plain `DefaultChatTransport` because the `AssistantChatTransport` system-message and frontend-tool forwarding only activates through `useChatRuntime`, not raw `useAISDKRuntime`:
+On the client, configure `useChat` with `sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses` so the response is sent back to the server when the user decides:
 
 ```tsx title="@/app/page.tsx"
 "use client";
@@ -327,15 +327,11 @@ import {
   AssistantRuntimeProvider,
   useAISDKRuntime,
 } from "@assistant-ui/react-ai-sdk";
-import {
-  DefaultChatTransport,
-  lastAssistantMessageIsCompleteWithApprovalResponses,
-} from "ai";
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { Thread } from "@/components/assistant-ui/thread";
 
 export default function Page() {
   const chat = useChat({
-    transport: new DefaultChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
   const runtime = useAISDKRuntime(chat);
@@ -361,10 +357,7 @@ import {
   useAui,
 } from "@assistant-ui/react";
 import { useAISDKRuntime } from "@assistant-ui/react-ai-sdk";
-import {
-  DefaultChatTransport,
-  lastAssistantMessageIsCompleteWithApprovalResponses,
-} from "ai";
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from "ai";
 import { Thread } from "@/components/assistant-ui/thread";
 
 const toolkit = defineToolkit({
@@ -397,7 +390,6 @@ const toolkit = defineToolkit({
 
 export default function Page() {
   const chat = useChat({
-    transport: new DefaultChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   });
   const runtime = useAISDKRuntime(chat);

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -134,9 +134,13 @@ To let the model see a frontend tool's result and continue, configure the runtim
 
 ```tsx
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 
 const runtime = useChatRuntime({
-  api: "/api/chat",
+  transport: new AssistantChatTransport({ api: "/api/chat" }),
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 });
 ```

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -134,15 +134,12 @@ To let the model see a frontend tool's result and continue, configure the runtim
 
 ```tsx
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
 
 const runtime = useChatRuntime({
-  transport: new AssistantChatTransport({ api: "/api/chat" }),
   sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 });
 ```
+
+`useChatRuntime()` targets `/api/chat` by default. To point at a different endpoint or customize requests, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 For the full AI SDK v6 backend setup — history persistence, reasoning, server-side approvals — see the [AI SDK v6 guide](/docs/runtimes/ai-sdk/v6).

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -121,16 +121,11 @@ Import the toolkit in your runtime provider and pass it to `useAui` via `Tools`:
 "use client";
 
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
+  const runtime = useChatRuntime();
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (
@@ -140,6 +135,8 @@ export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   );
 }
 ```
+
+`useChatRuntime()` targets `/api/chat` by default. To point at a different endpoint or customize requests, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -121,11 +121,16 @@ Import the toolkit in your runtime provider and pass it to `useAui` via `Tools`:
 "use client";
 
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 export function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
+  });
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -348,13 +348,18 @@ Register the toolkit once with `Tools({ toolkit })`. Renderer keys such as
 "use client";
 
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import type { ReactNode } from "react";
 
 import { toolkit } from "./GitHubIssueToolUI";
 
 export function MyRuntimeProvider({ children }: { children: ReactNode }) {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
+  });
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -348,18 +348,13 @@ Register the toolkit once with `Tools({ toolkit })`. Renderer keys such as
 "use client";
 
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import type { ReactNode } from "react";
 
 import { toolkit } from "./GitHubIssueToolUI";
 
 export function MyRuntimeProvider({ children }: { children: ReactNode }) {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
+  const runtime = useChatRuntime();
   const aui = useAui({ tools: Tools({ toolkit }) });
 
   return (
@@ -369,6 +364,8 @@ export function MyRuntimeProvider({ children }: { children: ReactNode }) {
   );
 }
 ```
+
+`useChatRuntime()` targets `/api/chat` by default. To point at a different endpoint or customize requests, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/tools/tool-ui.mdx
+++ b/apps/docs/content/docs/tools/tool-ui.mdx
@@ -70,16 +70,11 @@ export default defineToolkit({
 
 ```tsx title="app/MyRuntimeProvider.tsx"
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
-  const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
-  });
+  const runtime = useChatRuntime();
   const aui = useAui({ tools: Tools({ toolkit }) });
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>
@@ -88,6 +83,8 @@ function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
   );
 }
 ```
+
+`useChatRuntime()` targets `/api/chat` by default. To point at a different endpoint or customize requests, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 <Callout type="tip">
   Frontend toolkit entries can be passed to your backend using the

--- a/apps/docs/content/docs/tools/tool-ui.mdx
+++ b/apps/docs/content/docs/tools/tool-ui.mdx
@@ -70,11 +70,16 @@ export default defineToolkit({
 
 ```tsx title="app/MyRuntimeProvider.tsx"
 import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 import toolkit from "./toolkit";
 
 function MyRuntimeProvider({ children }: { children: React.ReactNode }) {
-  const runtime = useChatRuntime({ api: "/api/chat" });
+  const runtime = useChatRuntime({
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
+  });
   const aui = useAui({ tools: Tools({ toolkit }) });
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -217,11 +217,14 @@ The callback reads `?state=...&code=...` from the URL, derives the target server
 ```tsx
 "use client";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import {
+  useChatRuntime,
+  AssistantChatTransport,
+} from "@assistant-ui/react-ai-sdk";
 
 export function Chat() {
   const runtime = useChatRuntime({
-    api: "/api/chat",
+    transport: new AssistantChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
   /* … */

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -217,21 +217,17 @@ The callback reads `?state=...&code=...` from the URL, derives the target server
 ```tsx
 "use client";
 import { lastAssistantMessageIsCompleteWithToolCalls } from "ai";
-import {
-  useChatRuntime,
-  AssistantChatTransport,
-} from "@assistant-ui/react-ai-sdk";
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 export function Chat() {
   const runtime = useChatRuntime({
-    transport: new AssistantChatTransport({ api: "/api/chat" }),
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
   });
   /* … */
 }
 ```
 
-`sendAutomaticallyWhen` sends completed frontend tool results back to the server so the model can continue after a tool call.
+`sendAutomaticallyWhen` sends completed frontend tool results back to the server so the model can continue after a tool call. `useChatRuntime()` targets `/api/chat` by default; to point at a different endpoint, see [Custom transport](/docs/runtimes/ai-sdk/v6#custom-transport).
 
 Tool names are prefixed `serverId__toolName` to avoid collisions across connected servers. The toolkit re-registers whenever a server connects / disconnects or its tool list changes.
 


### PR DESCRIPTION
## What

Nine v6 chat-runtime snippets across seven guide pages used the removed `{ api }` option. Swaps each to the canonical transport form so they type-check.

- `useChatRuntime({ api })` -> `useChatRuntime({ transport: new AssistantChatTransport({ api }) })`: defining-tools, tool-ui, mcp, user-managed-mcp, backend, and both blocks of migrations/toolkit-tools.
- `useChat({ api })` -> `useChat({ transport: new DefaultChatTransport({ api }) })`: the two HITL blocks in runtimes/ai-sdk/v6.
- Each block gains the import for the transport it instantiates.

## Why

In AI SDK v6 the endpoint moved onto the transport. `ChatInit` and `UseChatRuntimeOptions` no longer have `api`, so `{ api }` is a TS excess-property error when pasted into a strict project. Type/teaching fix only, behavior-neutral: the default transport already targets `/api/chat`.

## Notes

- HITL blocks use `DefaultChatTransport` (not `AssistantChatTransport`) because the latter's forwarding is only wired by `useChatRuntime`, not raw `useAISDKRuntime`.
- Docs-only, no changeset (private app), no generated-output change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

