### PR TITLE
chore: add build:packages and build:affected root scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ pnpm turbo build
 
 (some packages rely on build outputs from other packages, even if you want to start the project in development mode)
 
+### Building for a pull request
+
+- `pnpm build:packages` builds every package under `packages/` (no example or template apps). Use it before pushing a change to `packages/*` to catch cross-package export breakage.
+- `pnpm build:affected` builds only the packages you changed plus their dependents, approximating what CI runs on your PR. Fastest check on a feature branch. It compares against your local `main`, so run `git fetch origin main:main` first if yours is stale or missing.
+- `pnpm build` builds everything including the example and template apps. Use it only when you touch `examples/`, `templates/`, or `turbo.json`.
+
 ### Running the project
 
 To run the docs project in development mode:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",
     "ci:publish": "turbo build --filter=\"./packages/*\" && changeset publish",
     "build": "turbo build --concurrency=4",
+    "build:packages": "turbo build --filter='./packages/*'",
+    "build:affected": "turbo build --affected",
     "api-surface": "pnpm api-surface:build && node scripts/generate-api-surface.mjs",
     "api-surface:build": "pnpm exec turbo build --filter='./packages/*' --force",
     "api-surface:check": "node scripts/check-api-surface.mjs",


### PR DESCRIPTION
## What

Two additive root scripts plus a short CONTRIBUTING section. No existing script or build behavior changes.

- `build:packages` = `turbo build --filter='./packages/*'`:  builds every publishable package, no example or template apps.
- `build:affected` = `turbo build --affected`:  builds only changed packages plus their dependents.

## Why

The only build entrypoint today is `build`, which builds the full 93-task graph (45 packages plus 40 Next.js apps). Neither everyday package check has a memorable script: `build:packages` is the pre-push cross-package export check (cache-friendly, unlike `api-surface:build`'s `--force`), and `build:affected` is the local mirror of CI's `--filter="...[origin/base]"`.

## Impact

- CI: none. No workflow reads these scripts; CI invokes turbo with its own filters.
- Build outputs: none. Additive keys, strict subsets of the existing graph.
- No changeset: root `package.json` is private and CONTRIBUTING.md is unpublished.
- `build:affected` diffs against local `main`; the CONTRIBUTING note says to fetch first if stale.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

