### PR TITLE
fix(react-langgraph,react-langchain): emit url file source blocks

### DIFF
--- a/.changeset/langchain-file-url-source-blocks.md
+++ b/.changeset/langchain-file-url-source-blocks.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-langchain": patch
+---
+
+fix: emit url source blocks for http(s) file attachment data instead of mislabeling it base64

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -886,6 +886,22 @@ type LangChainContentBlock = {
     filename?: string;
   };
 } | {
+  type: "file";
+  url: string;
+  mime_type?: string;
+  source_type: "url";
+  metadata?: {
+    filename?: string;
+  };
+} | {
+  type: "file";
+  id: string;
+  mime_type?: string;
+  source_type: "id";
+  metadata?: {
+    filename?: string;
+  };
+} | {
   type: "input_json_delta" | "tool_use";
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1080,6 +1080,22 @@ type MessageContentFile = {
   metadata?: {
     filename?: string;
   };
+} | {
+  type: "file";
+  url: string;
+  mime_type?: string;
+  source_type: "url";
+  metadata?: {
+    filename?: string;
+  };
+} | {
+  type: "file";
+  id: string;
+  mime_type?: string;
+  source_type: "id";
+  metadata?: {
+    filename?: string;
+  };
 };
 
 type MessageContentImageUrl = {

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { convertLangChainBaseMessage } from "./convertMessages";
+import type { AppendMessage } from "@assistant-ui/core";
+import {
+  convertLangChainBaseMessage,
+  getMessageContent,
+} from "./convertMessages";
 import type { LangChainBaseMessage, UIMessage } from "./types";
 
 const humanMessage = (content: unknown): LangChainBaseMessage => ({
@@ -59,6 +63,140 @@ describe("convertLangChainBaseMessage file content parts", () => {
         filename: "file",
         data: "ZmFrZQ==",
         mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("converts a url source file block", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([
+        {
+          type: "file",
+          url: "https://r2.example/u/abc/file.pdf",
+          mime_type: "application/pdf",
+          source_type: "url",
+          metadata: { filename: "file.pdf" },
+        },
+      ]),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      {
+        type: "file",
+        filename: "file.pdf",
+        data: "https://r2.example/u/abc/file.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("converts an id source file block", () => {
+    const result = convertLangChainBaseMessage(
+      humanMessage([{ type: "file", id: "file-abc123", source_type: "id" }]),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      {
+        type: "file",
+        filename: "file",
+        data: "file-abc123",
+        mimeType: "application/octet-stream",
+      },
+    ]);
+  });
+});
+
+describe("getMessageContent file blocks", () => {
+  const appendMessage = (part: Record<string, unknown>) =>
+    ({ content: [part] }) as unknown as AppendMessage;
+
+  it("emits a base64 source block for raw base64 data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "ZmFrZQ==",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "ZmFrZQ==",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("emits a url source block with the value in the url key for http(s) data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "https://r2.example/u/abc/file.pdf",
+        mimeType: "application/pdf",
+        filename: "file.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        url: "https://r2.example/u/abc/file.pdf",
+        mime_type: "application/pdf",
+        metadata: { filename: "file.pdf" },
+        source_type: "url",
+      },
+    ]);
+    expect(content[1]).not.toHaveProperty("data");
+  });
+
+  it("normalizes a base64 data URL to a raw base64 block", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "data:application/pdf;base64,ZmFrZQ==",
+        mimeType: "application/octet-stream",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "ZmFrZQ==",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("keeps non-http schemes on the base64 path", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "blob:https://app.example/123",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "blob:https://app.example/123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
       },
     ]);
   });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -56,8 +56,13 @@ const contentToParts = (content: unknown) => {
           return {
             type: "file" as const,
             filename: part.metadata?.filename ?? "file",
-            data: part.data,
-            mimeType: part.mime_type,
+            data:
+              part.source_type === "url"
+                ? part.url
+                : part.source_type === "id"
+                  ? part.id
+                  : part.data,
+            mimeType: part.mime_type ?? "application/octet-stream",
           };
         case "thinking":
           return { type: "reasoning" as const, text: part.thinking };
@@ -185,6 +190,16 @@ export const convertLangChainBaseMessage = (
   }
 };
 
+const parseDataUrl = (
+  value: string,
+): { mimeType: string; data: string } | null => {
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1]!, data: match[2]! };
+};
+
+const httpUrlPattern = /^https?:\/\//i;
+
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
     ...msg.content,
@@ -206,14 +221,26 @@ export const getMessageContent = (msg: AppendMessage) => {
         return { type: "text" as const, text: part.text };
       case "image":
         return { type: "image_url" as const, image_url: { url: part.image } };
-      case "file":
+      case "file": {
+        const metadata = { filename: part.filename ?? "file" };
+        if (httpUrlPattern.test(part.data)) {
+          return {
+            type: "file" as const,
+            url: part.data,
+            mime_type: part.mimeType,
+            metadata,
+            source_type: "url" as const,
+          };
+        }
+        const parsed = parseDataUrl(part.data);
         return {
           type: "file" as const,
-          data: part.data,
-          mime_type: part.mimeType,
-          metadata: { filename: part.filename ?? "file" },
+          data: parsed?.data ?? part.data,
+          mime_type: parsed?.mimeType ?? part.mimeType,
+          metadata,
           source_type: "base64" as const,
         };
+      }
       case "tool-call":
         throw new Error("Tool call appends are not supported.");
       default: {

--- a/packages/react-langchain/src/types.ts
+++ b/packages/react-langchain/src/types.ts
@@ -35,6 +35,20 @@ export type LangChainContentBlock =
       source_type?: "base64";
       metadata?: { filename?: string };
     }
+  | {
+      type: "file";
+      url: string;
+      mime_type?: string;
+      source_type: "url";
+      metadata?: { filename?: string };
+    }
+  | {
+      type: "file";
+      id: string;
+      mime_type?: string;
+      source_type: "id";
+      metadata?: { filename?: string };
+    }
   | { type: "tool_use" | "input_json_delta" };
 
 export type LangChainToolCall = {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { convertLangChainMessages as convertLangChainMessagesImpl } from "./convertLangChainMessages";
+import type { AppendMessage } from "@assistant-ui/core";
+import {
+  convertLangChainMessages as convertLangChainMessagesImpl,
+  getMessageContent,
+} from "./convertLangChainMessages";
 import type { LangChainMessage, UIMessage } from "./types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -356,6 +360,154 @@ describe("convertLangChainMessages file content", () => {
         },
       ],
     });
+  });
+
+  it("converts a url source file block", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "human-url-file",
+      content: [
+        {
+          type: "file",
+          url: "https://r2.example/u/abc/file.pdf",
+          mime_type: "application/pdf",
+          source_type: "url",
+          metadata: { filename: "file.pdf" },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          filename: "file.pdf",
+          data: "https://r2.example/u/abc/file.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    });
+  });
+
+  it("converts an id source file block", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "human-id-file",
+      content: [
+        {
+          type: "file",
+          id: "file-abc123",
+          source_type: "id",
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          filename: "file",
+          data: "file-abc123",
+          mimeType: "application/octet-stream",
+        },
+      ],
+    });
+  });
+});
+
+describe("getMessageContent file blocks", () => {
+  const appendMessage = (part: Record<string, unknown>) =>
+    ({ content: [part] }) as unknown as AppendMessage;
+
+  it("emits a base64 source block for raw base64 data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "ZmFrZQ==",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "ZmFrZQ==",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("emits a url source block with the value in the url key for http(s) data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "https://r2.example/u/abc/file.pdf",
+        mimeType: "application/pdf",
+        filename: "file.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        url: "https://r2.example/u/abc/file.pdf",
+        mime_type: "application/pdf",
+        metadata: { filename: "file.pdf" },
+        source_type: "url",
+      },
+    ]);
+    expect(content[1]).not.toHaveProperty("data");
+  });
+
+  it("normalizes a base64 data URL to a raw base64 block", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "data:application/pdf;base64,ZmFrZQ==",
+        mimeType: "application/octet-stream",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "ZmFrZQ==",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("keeps non-http schemes on the base64 path", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "blob:https://app.example/123",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        data: "blob:https://app.example/123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "base64",
+      },
+    ]);
   });
 });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -196,8 +196,13 @@ const contentToParts = (
             return {
               type: "file",
               filename: part.metadata?.filename ?? "file",
-              data: part.data,
-              mimeType: part.mime_type,
+              data:
+                part.source_type === "url"
+                  ? part.url
+                  : part.source_type === "id"
+                    ? part.id
+                    : part.data,
+              mimeType: part.mime_type ?? "application/octet-stream",
             };
 
           case "thinking":
@@ -345,6 +350,16 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
   }
 };
 
+const parseDataUrl = (
+  value: string,
+): { mimeType: string; data: string } | null => {
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1]!, data: match[2]! };
+};
+
+const httpUrlPattern = /^https?:\/\//i;
+
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
     ...msg.content,
@@ -366,16 +381,26 @@ export const getMessageContent = (msg: AppendMessage) => {
         return { type: "text" as const, text: part.text };
       case "image":
         return { type: "image_url" as const, image_url: { url: part.image } };
-      case "file":
+      case "file": {
+        const metadata = { filename: part.filename ?? "file" };
+        if (httpUrlPattern.test(part.data)) {
+          return {
+            type: "file" as const,
+            url: part.data,
+            mime_type: part.mimeType,
+            metadata,
+            source_type: "url" as const,
+          };
+        }
+        const parsed = parseDataUrl(part.data);
         return {
           type: "file" as const,
-          data: part.data,
-          mime_type: part.mimeType,
-          metadata: {
-            filename: part.filename ?? "file",
-          },
+          data: parsed?.data ?? part.data,
+          mime_type: parsed?.mimeType ?? part.mimeType,
+          metadata,
           source_type: "base64" as const,
         };
+      }
 
       case "tool-call":
         throw new Error("Tool call appends are not supported.");

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -87,15 +87,34 @@ type CustomEventType = string;
 
 export type EventType = LangGraphKnownEventTypes | CustomEventType;
 
-export type MessageContentFile = {
-  type: "file";
-  data: string;
-  mime_type: string;
-  source_type?: "base64";
-  metadata?: {
-    filename?: string;
-  };
-};
+export type MessageContentFile =
+  | {
+      type: "file";
+      data: string;
+      mime_type: string;
+      source_type?: "base64";
+      metadata?: {
+        filename?: string;
+      };
+    }
+  | {
+      type: "file";
+      url: string;
+      mime_type?: string;
+      source_type: "url";
+      metadata?: {
+        filename?: string;
+      };
+    }
+  | {
+      type: "file";
+      id: string;
+      mime_type?: string;
+      source_type: "id";
+      metadata?: {
+        filename?: string;
+      };
+    };
 
 type UserMessageContentComplex =
   | MessageContentText


### PR DESCRIPTION
closes #4792

## summary

- file attachment parts whose `data` is an http(s) URL now go out as `source_type: "url"` blocks with the value in the `url` key, which is the shape LangChain's data content block spec requires on both the python and JS side (url blocks carry `url`, id blocks carry `id`, only base64 blocks carry `data`), so adapters that keep files in object storage no longer get their URL mislabeled as base64 and mangled by provider converters
- base64 data URLs are normalized to raw base64 with the mime type taken from the data URL prefix, instead of being sent with the `data:` prefix intact where LangChain would prepend a second one
- raw base64 and any non-http scheme stay on the existing base64 path unchanged, so current adapters are unaffected
- the incoming direction now reads `url` and `id` source blocks back into `FileMessagePart` (previously a url block loaded from history produced `data: undefined`), and `MessageContentFile` / `LangChainContentBlock` widen to a `source_type` discriminated union
- the URL sniffing helpers mirror the existing react-ag-ui implementation (`buildInputSource` / `parseDataUrl`), which already handles the same three data forms

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langgraph exec vitest run` -> 174/174 green (6 new cases: url block emission asserting no `data` key, data URL normalization, blob fallback, raw base64 unchanged, incoming url/id blocks)
- [x] `pnpm --filter @assistant-ui/react-langchain exec vitest run` -> 108/108 green (same 6 mirrored cases)
- [x] `tsc --noEmit` clean in both packages; `oxlint` and `oxfmt --check` clean on the changed files
- [x] `pnpm api-surface` regenerated and `node scripts/check-api-surface.mjs` passes; the surface diff is exactly the two wire type unions, no core change

### reviewer should verify

- [ ] send a message with an attachment adapter that returns `{ type: "file", data: "https://..." }` through `useLangGraphRuntime` and confirm the human message content reaching the graph carries `{ source_type: "url", url: "https://..." }` with no `data` key

## notes

- supersedes #4795, which kept the url/id value in the `data` key; that shape fails `is_data_content_block` in langchain-core (python) and breaks `fromStandardFileBlock` in @langchain/openai (JS reads `block.url`), so it fixed nothing at the wire level
- an explicit per-part source type override (needed for provider file ids, which cannot be sniffed) is deferred until there is a real request for it; ids are accepted on the incoming path already

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

