### PR TITLE
chore(turbo): remove dead deploy task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -37,9 +37,6 @@
     "test": {
       "dependsOn": ["^build"]
     },
-    "deploy": {
-      "dependsOn": ["build", "lint", "test"]
-    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## What

Remove the `deploy` task from `turbo.json`. One block, three lines deleted; nothing else changes.

## Why

No workspace defines a `deploy` script, so the task deploys nothing. It is not a harmless no-op either: on turbo v2 the task still materializes a per-package `deploy` node (`command: <NONEXISTENT>`) that keeps its `dependsOn: ["build", "lint", "test"]`. A `turbo deploy --dry=json` on the current tree shows a 372-node graph (93 deploy no-ops + 93 build with 86 real + 93 lint with 7 real + 93 test with 35 real), so `turbo deploy` actually runs the full build + lint + test suite across every package and then executes zero deploy scripts. That is dead config and a footgun for anyone who runs it.

Nothing invokes it. CI and Vercel deploys go through the Vercel CLI (`vercel build` / `vercel deploy --prebuilt` in `expo.yaml`, `ink.yaml`, `registry.yaml`), and every Vercel `buildCommand` calls `pnpm turbo build --filter=...`, never `turbo deploy`.

## Impact

- `turbo deploy` now errors with `Could not find task 'deploy' in project` instead of running a full no-output build+lint+test. Strictly clearer.
- The `deploy` block was the only `dependsOn` reference to the `lint` task; removing the block leaves `lint` standing with no dangling reference.

## Mechanics

- **No output / behavior change.** A task's hash includes its own resolved definition, not other tasks' definitions, so removing `deploy` changes no other task's hash. Verified: `turbo build --dry=json` produces identical `build` hashes across all 93 packages before and after, so no cache is invalidated and nothing rebuilds.
- **CI:** unaffected. No workflow references the `deploy` task; build/test/lint/dev behavior is untouched.
- **Changeset:** none. `turbo.json` is config, not a published package surface.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

