### PR TITLE
fix(cloud): await `initializeAuth` auth headers (#4807)

### DIFF
--- a/.changeset/cloud-initialize-auth.md
+++ b/.changeset/cloud-initialize-auth.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: await auth headers when initializing Assistant Cloud auth

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -93,7 +93,7 @@ export class AssistantCloudAPI {
   }
 
   public async initializeAuth() {
-    return !!this._auth.getAuthHeaders();
+    return !!(await this._auth.getAuthHeaders());
   }
 
   public async makeRawRequest(

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -105,6 +105,15 @@ describe("AssistantCloudAPI", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("returns false from initializeAuth when auth token callback returns null", async () => {
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://test.example.com",
+      authToken: async () => null,
+    });
+
+    await expect(api.initializeAuth()).resolves.toBe(false);
+  });
+
   it("throws APIError with parsed message for JSON error responses", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## What

Fix `AssistantCloudAPI.initializeAuth()` so it awaits `getAuthHeaders()` before converting the result to a boolean.

## Why

`getAuthHeaders()` returns a promise. The previous implementation checked the promise object itself, so `initializeAuth()` always resolved to `true` even when auth eventually returned `false` (for example, when an auth token callback returns `null`). `makeRawRequest()` already awaits the same method and correctly treats `false` as an authorization failure, so this aligns initialization with request-time auth behavior.

## Validation

- `pnpm --filter assistant-cloud test -- src/tests/AssistantCloudAPI.test.ts`
- `pnpm --filter assistant-cloud build`
- `pnpm exec oxfmt --check packages/cloud/src/AssistantCloudAPI.ts packages/cloud/src/tests/AssistantCloudAPI.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

