### PR TITLE
fix(cloud): handle empty success responses for mutation action

### DIFF
--- a/.changeset/cloud-empty-success-responses.md
+++ b/.changeset/cloud-empty-success-responses.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: handle empty successful Cloud API responses

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -151,6 +151,15 @@ export class AssistantCloudAPI {
 
   public async makeRequest(endpoint: string, options: MakeRequestOptions = {}) {
     const response = await this.makeRawRequest(endpoint, options);
-    return response.json();
+    if (
+      response.status === 204 ||
+      response.headers.get("content-length") === "0"
+    )
+      return undefined;
+
+    const text = await response.text();
+    if (text.trim() === "") return undefined;
+
+    return JSON.parse(text);
   }
 }

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -166,7 +166,7 @@ describe("AssistantCloudAPI", () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       headers: new Headers(),
-      json: vi.fn().mockResolvedValue(responseData),
+      text: vi.fn().mockResolvedValue(JSON.stringify(responseData)),
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -178,5 +178,63 @@ describe("AssistantCloudAPI", () => {
 
     const result = await api.makeRequest("/threads");
     expect(result).toEqual(responseData);
+  });
+
+  it("makeRequest returns undefined from a successful empty response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+      text: vi.fn().mockResolvedValue(""),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    await expect(
+      api.makeRequest("/threads/t-1", { method: "DELETE" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("makeRequest returns undefined when content-length is zero", async () => {
+    const text = vi.fn().mockResolvedValue("");
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-length": "0" }),
+      text,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    await expect(api.makeRequest("/threads/t-1")).resolves.toBeUndefined();
+    expect(text).not.toHaveBeenCalled();
+  });
+
+  it("makeRequest returns undefined from a whitespace-only success body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers(),
+      text: vi.fn().mockResolvedValue("  "),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      apiKey: "test-key",
+      userId: "u-1",
+      workspaceId: "w-1",
+    });
+
+    await expect(api.makeRequest("/threads/t-1")).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Handle successful Assistant Cloud responses that intentionally return no body. `AssistantCloudAPI.makeRequest()` now returns `undefined` for `204 No Content`, `Content-Length: 0`, or an empty success body, while still parsing normal JSON responses.

## Why

Some Cloud SDK methods, like thread update/delete calls, are typed as `Promise<void>`. A server can correctly answer those requests with `204 No Content`, but the SDK previously always called `response.json()`, which turns a successful empty response into `SyntaxError: Unexpected end of JSON input`.

## Validation

- `pnpm --filter assistant-cloud test -- src/tests/AssistantCloudAPI.test.ts`
- `pnpm --filter assistant-cloud build`
- `pnpm exec oxfmt --check packages/cloud/src/AssistantCloudAPI.ts packages/cloud/src/tests/AssistantCloudAPI.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

