### PR TITLE
chore: require human maintainer review via CODEOWNERS catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Every change requires review from a human maintainer; approvals from apps or bots do not satisfy code owner review.
+* @assistant-ui/maintainers
+
 # CI and repository policy changes require maintainer review.
 /.github/CODEOWNERS @Yonom @okisdev
 /.github/actions/ @assistant-ui/maintainers


### PR DESCRIPTION
## summary

- adds a `* @assistant-ui/maintainers` catch-all rule to CODEOWNERS so every PR needs an approving review from a human maintainer before it can merge
- the Main ruleset already enforces require review from Code Owners, but only `.github/` and `api-surface/` paths had owners, so a PR touching anything else could merge on a bot approval alone; GitHub Apps can never be code owners, so bot approvals stop satisfying the review requirement everywhere
- the existing more specific rules stay below the catch-all and keep precedence

no test plan, CODEOWNERS only

## notes

- companion hardening already applied in repo settings: workflows can no longer approve PRs via GITHUB_TOKEN (allow GitHub Actions to create and approve pull requests is off)
- the gate applies to this PR itself; CODEOWNERS is owned by @Yonom and @okisdev, and since I opened it, it needs an approval from Yonom

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

