### PR TITLE
fix: show pointer cursor on navbar search triggers

### DIFF
--- a/apps/docs/components/docs/layout/docs-header.tsx
+++ b/apps/docs/components/docs/layout/docs-header.tsx
@@ -53,7 +53,7 @@ function HeaderSearch() {
         analytics.search.opened("header");
         setOpenSearch(true);
       }}
-      className="border-border/50 bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground flex h-8 w-full max-w-96 items-center gap-2 rounded-lg border px-3 text-sm transition-colors"
+      className="border-border/50 bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground flex h-8 w-full max-w-96 cursor-pointer items-center gap-2 rounded-lg border px-3 text-sm transition-colors"
     >
       <Search className="size-3.5 shrink-0" />
       <span className="flex-1 text-left">Search...</span>
@@ -208,7 +208,7 @@ export function DocsHeader({
               analytics.search.opened("header");
               setOpenSearch(true);
             }}
-            className="text-muted-foreground hover:text-foreground flex size-8 items-center justify-center transition-colors"
+            className="text-muted-foreground hover:text-foreground flex size-8 cursor-pointer items-center justify-center transition-colors"
             aria-label="Search"
           >
             <Search className="size-4" />
@@ -249,7 +249,7 @@ export function DocsHeader({
               analytics.search.opened("header");
               setOpenSearch(true);
             }}
-            className="text-muted-foreground hover:text-foreground flex size-8 items-center justify-center transition-colors"
+            className="text-muted-foreground hover:text-foreground flex size-8 cursor-pointer items-center justify-center transition-colors"
             aria-label="Search"
           >
             <Search className="size-4" />

--- a/apps/docs/components/shared/header.tsx
+++ b/apps/docs/components/shared/header.tsx
@@ -36,7 +36,7 @@ function SearchButton({ onToggle }: { onToggle: () => void }) {
     <button
       type="button"
       onClick={onToggle}
-      className="text-muted-foreground hover:text-foreground flex size-8 items-center justify-center transition-colors"
+      className="text-muted-foreground hover:text-foreground flex size-8 cursor-pointer items-center justify-center transition-colors"
       aria-label="Search (⌘K)"
     >
       <Search className="size-4" />


### PR DESCRIPTION
## Summary

- add `cursor-pointer` to docs navbar search triggers
- keep decorative search icons inside inputs/dialogs unchanged

## Why

The navbar search controls are clickable buttons, but hovering them did not show the pointer cursor, which made the interaction feel less clear.

## Test plan

- `pnpm exec oxfmt --check apps/docs/components/shared/header.tsx apps/docs/components/docs/layout/docs-header.tsx`
- `pnpm exec oxlint apps/docs/components/shared/header.tsx apps/docs/components/docs/layout/docs-header.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

