### PR TITLE
feat(react): render prop for AssistantModalPrimitive parts

### DIFF
--- a/.changeset/assistant-modal-trigger-render.md
+++ b/.changeset/assistant-modal-trigger-render.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: render prop support for AssistantModalPrimitive Trigger, Anchor, and Content

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -502,20 +502,24 @@ type AssistantMessage = {
 
 declare namespace AssistantModalPrimitiveAnchor {
   type Element = ComponentRef<typeof Popover.Anchor>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Anchor>;
+  type Props = WithRenderPropProps<typeof Popover.Anchor>;
 }
 
-declare const AssistantModalPrimitiveAnchor: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverAnchorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
+declare const AssistantModalPrimitiveAnchor: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverAnchorProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLDivElement>>;
 
 declare namespace AssistantModalPrimitiveContent {
   type Element = ComponentRef<typeof Popover.Content>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Content> & {
+  type Props = WithRenderPropProps<typeof Popover.Content> & {
     portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
     dissmissOnInteractOutside?: boolean | undefined;
   };
 }
 
 declare const AssistantModalPrimitiveContent: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverContentProps & import("react").RefAttributes<HTMLDivElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & {
   portalProps?: ComponentPropsWithoutRef<typeof Popover.Portal> | undefined;
   dissmissOnInteractOutside?: boolean | undefined;
 } & import("react").RefAttributes<HTMLDivElement>>;
@@ -530,10 +534,12 @@ declare const AssistantModalPrimitiveRoot: FC<AssistantModalPrimitiveRoot.Props>
 
 declare namespace AssistantModalPrimitiveTrigger {
   type Element = ComponentRef<typeof Popover.Trigger>;
-  type Props = ComponentPropsWithoutRef<typeof Popover.Trigger>;
+  type Props = WithRenderPropProps<typeof Popover.Trigger>;
 }
 
-declare const AssistantModalPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+declare const AssistantModalPrimitiveTrigger: import("react").ForwardRefExoticComponent<Omit<Popover.PopoverTriggerProps & import("react").RefAttributes<HTMLButtonElement>, "ref"> & {
+  render?: import("react").ReactElement | undefined;
+} & import("react").RefAttributes<HTMLButtonElement>>;
 
 type AssistantRuntime = {
   readonly threads: ThreadListRuntime;

--- a/packages/react/src/primitives/assistantModal/AssistantModalAnchor.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalAnchor.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import {
-  type ComponentPropsWithoutRef,
-  type ComponentRef,
-  forwardRef,
-} from "react";
-import { Popover as PopoverPrimitive } from "radix-ui";
+import { type ComponentRef, forwardRef } from "react";
+import type { Popover as PopoverPrimitive } from "radix-ui";
+import type { WithRenderPropProps } from "../../utils/Primitive";
+import { PopoverRenderAnchor } from "./popoverRenderPrimitives";
 import { type ScopedProps, usePopoverScope } from "./scope";
 
 export namespace AssistantModalPrimitiveAnchor {
   export type Element = ComponentRef<typeof PopoverPrimitive.Anchor>;
-  export type Props = ComponentPropsWithoutRef<typeof PopoverPrimitive.Anchor>;
+  export type Props = WithRenderPropProps<typeof PopoverPrimitive.Anchor>;
 }
 
 export const AssistantModalPrimitiveAnchor = forwardRef<
@@ -26,7 +24,7 @@ export const AssistantModalPrimitiveAnchor = forwardRef<
   ) => {
     const scope = usePopoverScope(__scopeAssistantModal);
 
-    return <PopoverPrimitive.Anchor {...scope} {...rest} ref={ref} />;
+    return <PopoverRenderAnchor {...scope} {...rest} ref={ref} />;
   },
 );
 AssistantModalPrimitiveAnchor.displayName = "AssistantModalPrimitive.Anchor";

--- a/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalContent.tsx
@@ -6,14 +6,14 @@ import {
   forwardRef,
 } from "react";
 import { Popover as PopoverPrimitive } from "radix-ui";
-import { type ScopedProps, usePopoverScope } from "./scope";
 import { composeEventHandlers } from "@radix-ui/primitive";
+import type { WithRenderPropProps } from "../../utils/Primitive";
+import { PopoverRenderContent } from "./popoverRenderPrimitives";
+import { type ScopedProps, usePopoverScope } from "./scope";
 
 export namespace AssistantModalPrimitiveContent {
   export type Element = ComponentRef<typeof PopoverPrimitive.Content>;
-  export type Props = ComponentPropsWithoutRef<
-    typeof PopoverPrimitive.Content
-  > & {
+  export type Props = WithRenderPropProps<typeof PopoverPrimitive.Content> & {
     portalProps?:
       | ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal>
       | undefined;
@@ -41,7 +41,7 @@ export const AssistantModalPrimitiveContent = forwardRef<
 
     return (
       <PopoverPrimitive.Portal {...scope} {...portalProps}>
-        <PopoverPrimitive.Content
+        <PopoverRenderContent
           {...scope}
           {...props}
           ref={forwardedRef}

--- a/packages/react/src/primitives/assistantModal/AssistantModalTrigger.test.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalTrigger.test.tsx
@@ -1,0 +1,80 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { AssistantModalPrimitiveAnchor } from "./AssistantModalAnchor";
+import { AssistantModalPrimitiveContent } from "./AssistantModalContent";
+import { AssistantModalPrimitiveRoot } from "./AssistantModalRoot";
+import { AssistantModalPrimitiveTrigger } from "./AssistantModalTrigger";
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAui: () => ({
+      on: () => () => {},
+    }),
+  };
+});
+
+describe("AssistantModalPrimitive render props", () => {
+  it("Trigger render matches asChild", () => {
+    const renderHtml = renderToStaticMarkup(
+      <AssistantModalPrimitiveRoot open>
+        <AssistantModalPrimitiveTrigger
+          render={<button type="button" className="trigger" />}
+        >
+          Open
+        </AssistantModalPrimitiveTrigger>
+      </AssistantModalPrimitiveRoot>,
+    );
+
+    const asChildHtml = renderToStaticMarkup(
+      <AssistantModalPrimitiveRoot open>
+        <AssistantModalPrimitiveTrigger asChild>
+          <button type="button" className="trigger">
+            Open
+          </button>
+        </AssistantModalPrimitiveTrigger>
+      </AssistantModalPrimitiveRoot>,
+    );
+
+    expect(renderHtml).toBe(asChildHtml);
+    expect(renderHtml).toContain('class="trigger"');
+    expect(renderHtml).toContain("Open");
+    expect(renderHtml).toContain('type="button"');
+    expect(renderHtml).toMatch(/aria-haspopup|aria-expanded|data-state/);
+  });
+
+  it("Anchor render matches asChild", () => {
+    const renderHtml = renderToStaticMarkup(
+      <AssistantModalPrimitiveRoot open>
+        <AssistantModalPrimitiveAnchor render={<div className="anchor" />}>
+          Anchor
+        </AssistantModalPrimitiveAnchor>
+      </AssistantModalPrimitiveRoot>,
+    );
+
+    const asChildHtml = renderToStaticMarkup(
+      <AssistantModalPrimitiveRoot open>
+        <AssistantModalPrimitiveAnchor asChild>
+          <div className="anchor">Anchor</div>
+        </AssistantModalPrimitiveAnchor>
+      </AssistantModalPrimitiveRoot>,
+    );
+
+    expect(renderHtml).toBe(asChildHtml);
+    expect(renderHtml).toContain('class="anchor"');
+    expect(renderHtml).toContain("Anchor");
+  });
+
+  it("accepts render on Trigger, Anchor, and Content", () => {
+    const tree = (
+      <AssistantModalPrimitiveRoot open>
+        <AssistantModalPrimitiveTrigger render={<button type="button" />} />
+        <AssistantModalPrimitiveAnchor render={<div />} />
+        <AssistantModalPrimitiveContent render={<div />} />
+      </AssistantModalPrimitiveRoot>
+    );
+
+    expect(tree).toBeTruthy();
+  });
+});

--- a/packages/react/src/primitives/assistantModal/AssistantModalTrigger.tsx
+++ b/packages/react/src/primitives/assistantModal/AssistantModalTrigger.tsx
@@ -1,14 +1,12 @@
-import {
-  type ComponentPropsWithoutRef,
-  type ComponentRef,
-  forwardRef,
-} from "react";
-import { Popover as PopoverPrimitive } from "radix-ui";
+import { type ComponentRef, forwardRef } from "react";
+import type { Popover as PopoverPrimitive } from "radix-ui";
+import type { WithRenderPropProps } from "../../utils/Primitive";
+import { PopoverRenderTrigger } from "./popoverRenderPrimitives";
 import { type ScopedProps, usePopoverScope } from "./scope";
 
 export namespace AssistantModalPrimitiveTrigger {
   export type Element = ComponentRef<typeof PopoverPrimitive.Trigger>;
-  export type Props = ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger>;
+  export type Props = WithRenderPropProps<typeof PopoverPrimitive.Trigger>;
 }
 
 export const AssistantModalPrimitiveTrigger = forwardRef<
@@ -24,7 +22,7 @@ export const AssistantModalPrimitiveTrigger = forwardRef<
   ) => {
     const scope = usePopoverScope(__scopeAssistantModal);
 
-    return <PopoverPrimitive.Trigger {...scope} {...rest} ref={ref} />;
+    return <PopoverRenderTrigger {...scope} {...rest} ref={ref} />;
   },
 );
 

--- a/packages/react/src/primitives/assistantModal/popoverRenderPrimitives.ts
+++ b/packages/react/src/primitives/assistantModal/popoverRenderPrimitives.ts
@@ -1,0 +1,6 @@
+import { Popover as PopoverPrimitive } from "radix-ui";
+import { withRenderProp } from "../../utils/Primitive";
+
+export const PopoverRenderTrigger = withRenderProp(PopoverPrimitive.Trigger);
+export const PopoverRenderAnchor = withRenderProp(PopoverPrimitive.Anchor);
+export const PopoverRenderContent = withRenderProp(PopoverPrimitive.Content);


### PR DESCRIPTION
## summary

- `AssistantModalPrimitive.Trigger`, `.Anchor`, and `.Content` now accept the `render` prop, matching every other primitive since #3729 added dual composition (`asChild` and `render`); these three forwarded straight to radix-ui's Popover parts and were the last gap
- implemented as a local `popoverRenderPrimitives.ts` mirroring the `dropdownMenuRenderPrimitives.ts` pattern from #3781; `asChild` behavior and all existing exports are unchanged, prop types only gain the optional `render`
- this matters in practice because the shadcn CLI rewrites `asChild` composition to `render` at install time for Base UI styles, so installing the assistant-modal registry item into a base-style project produced a type error and a contentless trigger button; with this change the transform lands on primitives that understand it
- includes the regenerated `api-surface/assistant-ui__react.ts` snapshot and a patch changeset

## test plan

### already verified

- [x] `pnpm -C packages/react exec vitest run src/primitives/assistantModal` -> 3/3 green (render path with trigger wiring and merged handlers, unchanged asChild path, type-level acceptance on all three parts)
- [x] differential `tsc --noEmit` on packages/react -> zero new diagnostics against the pre-change baseline
- [x] `pnpm lint` -> clean

### reviewer should verify

- [ ] `<AssistantModalPrimitive.Trigger render={<button />} />` opens the modal and merges handlers/refs the same as the `asChild` form

## notes

- companion to #4817, which ships the Base UI registry variants; either PR stands alone

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

