### PR TITLE
fix(cloud): guard anonymous auth storage

### DIFF
--- a/.changeset/cloud-anonymous-storage.md
+++ b/.changeset/cloud-anonymous-storage.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: guard anonymous auth refresh token storage

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -109,6 +109,67 @@ export class AssistantCloudAPIKeyAuthStrategy implements AssistantCloudAuthStrat
 
 const AUI_REFRESH_TOKEN_NAME = "aui:refresh_token";
 
+type StoredRefreshToken = {
+  token: string;
+  expires_at: string;
+};
+
+const getLocalStorage = (): Storage | null => {
+  try {
+    return typeof localStorage === "undefined" ? null : localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const readRefreshToken = (): StoredRefreshToken | undefined => {
+  const storage = getLocalStorage();
+  if (!storage) return undefined;
+
+  try {
+    const raw = storage.getItem(AUI_REFRESH_TOKEN_NAME);
+    if (!raw) return undefined;
+
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "token" in parsed &&
+      "expires_at" in parsed &&
+      typeof parsed.token === "string" &&
+      typeof parsed.expires_at === "string"
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Ignore invalid or unavailable storage and fall back to a new anonymous token.
+  }
+
+  return undefined;
+};
+
+const writeRefreshToken = (refreshToken: StoredRefreshToken): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(AUI_REFRESH_TOKEN_NAME, JSON.stringify(refreshToken));
+  } catch {
+    // Storage is only a cache; the current access token can still be used.
+  }
+};
+
+const removeRefreshToken = (): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(AUI_REFRESH_TOKEN_NAME);
+  } catch {
+    // Ignore unavailable storage.
+  }
+};
+
 export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthStrategy {
   public readonly strategy = "anon";
 
@@ -119,15 +180,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
     this.baseUrl = baseUrl;
     this.jwtStrategy = new AssistantCloudJWTAuthStrategy(async () => {
       const currentTime = Date.now();
-      const storedRefreshTokenJson = localStorage.getItem(
-        AUI_REFRESH_TOKEN_NAME,
-      );
-      const storedRefreshToken = storedRefreshTokenJson
-        ? (JSON.parse(storedRefreshTokenJson) as {
-            token: string;
-            expires_at: string;
-          })
-        : undefined;
+      const storedRefreshToken = readRefreshToken();
 
       if (storedRefreshToken) {
         const refreshExpiry = new Date(storedRefreshToken.expires_at).getTime();
@@ -145,15 +198,12 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
             const data = await response.json();
             const { access_token, refresh_token } = data;
             if (refresh_token) {
-              localStorage.setItem(
-                AUI_REFRESH_TOKEN_NAME,
-                JSON.stringify(refresh_token),
-              );
+              writeRefreshToken(refresh_token);
             }
             return access_token;
           }
         } else {
-          localStorage.removeItem(AUI_REFRESH_TOKEN_NAME);
+          removeRefreshToken();
         }
       }
 
@@ -169,10 +219,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
 
       if (!access_token || !refresh_token) return null;
 
-      localStorage.setItem(
-        AUI_REFRESH_TOKEN_NAME,
-        JSON.stringify(refresh_token),
-      );
+      writeRefreshToken(refresh_token);
       return access_token;
     });
   }

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -139,7 +139,10 @@ const readRefreshToken = (): StoredRefreshToken | undefined => {
       typeof parsed.token === "string" &&
       typeof parsed.expires_at === "string"
     ) {
-      return parsed;
+      return {
+        token: parsed.token,
+        expires_at: parsed.expires_at,
+      };
     }
   } catch {
     // Ignore invalid or unavailable storage and fall back to a new anonymous token.

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -201,6 +201,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
             const data = await response.json();
             const { access_token, refresh_token } = data;
             if (refresh_token) {
+              removeRefreshToken();
               writeRefreshToken(refresh_token);
             }
             return access_token;

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -78,7 +78,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     });
   });
 
-  it("uses a valid cached refresh token even when storing the rotated token fails", async () => {
+  it("removes a cached refresh token before storing the rotated token", async () => {
     class ConstructableDate {
       constructor(private readonly value?: string) {}
 
@@ -126,6 +126,10 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ refresh_token: "refresh-old" }),
       },
+    );
+    expect(storage.removeItem).toHaveBeenCalledWith("aui:refresh_token");
+    expect(storage.removeItem.mock.invocationCallOrder[0]).toBeLessThan(
+      storage.setItem.mock.invocationCallOrder[0]!,
     );
   });
 });

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantCloudAnonymousAuthStrategy } from "../AssistantCloudAuthStrategy";
+
+const createJwt = () => {
+  const payload = Buffer.from(JSON.stringify({ exp: 4_102_444_800 })).toString(
+    "base64url",
+  );
+  return `header.${payload}.signature`;
+};
+
+const createTokenResponse = () => ({
+  ok: true,
+  json: vi.fn().mockResolvedValue({
+    access_token: createJwt(),
+    refresh_token: {
+      token: "refresh-next",
+      expires_at: "2100-01-01T00:00:00.000Z",
+    },
+  }),
+});
+
+describe("AssistantCloudAnonymousAuthStrategy", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to a new anonymous token when the cached refresh token is malformed", async () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue("not-json"),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+
+    const fetchMock = vi.fn().mockResolvedValue(createTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(
+      "https://cloud.example.com",
+    );
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${createJwt()}`,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.example.com/v1/auth/tokens/anonymous",
+      { method: "POST" },
+    );
+  });
+
+  it("continues when browser storage access throws", async () => {
+    const storage = {
+      getItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+      setItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+      removeItem: vi.fn(() => {
+        throw new Error("storage blocked");
+      }),
+    };
+    vi.stubGlobal("localStorage", storage);
+
+    const fetchMock = vi.fn().mockResolvedValue(createTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(
+      "https://cloud.example.com",
+    );
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${createJwt()}`,
+    });
+  });
+
+  it("uses a valid cached refresh token even when storing the rotated token fails", async () => {
+    class ConstructableDate {
+      constructor(private readonly value?: string) {}
+
+      getTime() {
+        if (this.value === "2100-01-01T00:00:00.000Z") {
+          return 4_102_444_800_000;
+        }
+        return 1_672_531_200_000;
+      }
+
+      static now() {
+        return 1_672_531_200_000;
+      }
+    }
+    vi.stubGlobal("Date", ConstructableDate);
+
+    const storage = {
+      getItem: vi.fn().mockReturnValue(
+        JSON.stringify({
+          token: "refresh-old",
+          expires_at: "2100-01-01T00:00:00.000Z",
+        }),
+      ),
+      setItem: vi.fn(() => {
+        throw new Error("storage full");
+      }),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+
+    const fetchMock = vi.fn().mockResolvedValue(createTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(
+      "https://cloud.example.com",
+    );
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${createJwt()}`,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cloud.example.com/v1/auth/tokens/refresh",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: "refresh-old" }),
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- treat anonymous Cloud auth localStorage access as best-effort cache reads/writes
- fall back to a new anonymous token when the cached refresh token is malformed or storage is unavailable
- keep the existing valid refresh-token path working even when rotated-token storage fails

## Why
Anonymous Cloud auth stores the refresh token in `localStorage`, but browser storage is not guaranteed to be available or well-formed. A user can have a corrupt `aui:refresh_token` value from an older build/manual testing, or storage can throw in Safari private mode, embedded contexts, strict privacy settings, or when quota is unavailable.

The refresh-token cache should not be a hard dependency for auth. If reading/parsing/removing/writing storage fails, the SDK can still request a fresh anonymous token or use the access token it just received.

## Verification
- Added regressions for malformed cached refresh token JSON
- Added regressions for throwing browser storage access
- Added coverage that the valid cached refresh-token path still uses the refresh endpoint when storing the rotated token fails
- `pnpm --filter assistant-cloud test`
- `pnpm --filter assistant-cloud build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

