### PR TITLE
fix(react-devtools): resolve tailwind cli explicitly for windows

### DIFF
--- a/.changeset/devtools-windows-css-build.md
+++ b/.changeset/devtools-windows-css-build.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: resolve the tailwind cli entry explicitly so pnpm install completes on windows

--- a/packages/react-devtools/scripts/build-styles.mjs
+++ b/packages/react-devtools/scripts/build-styles.mjs
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -8,10 +9,23 @@ const input = resolve(root, "src/styles/panel.css");
 const tmp = resolve(root, "src/styles/.panel.out.css");
 const output = resolve(root, "src/styles/panel.generated.ts");
 
-execFileSync("tailwindcss", ["-i", input, "-o", tmp, "--minify"], {
-  cwd: root,
-  stdio: "inherit",
-});
+const require = createRequire(import.meta.url);
+const cliPackagePath = require.resolve("@tailwindcss/cli/package.json");
+const cliPackage = JSON.parse(readFileSync(cliPackagePath, "utf8"));
+const cliBin =
+  typeof cliPackage.bin === "string"
+    ? cliPackage.bin
+    : cliPackage.bin.tailwindcss;
+const tailwindCli = join(dirname(cliPackagePath), cliBin);
+
+execFileSync(
+  process.execPath,
+  [tailwindCli, "-i", input, "-o", tmp, "--minify"],
+  {
+    cwd: root,
+    stdio: "inherit",
+  },
+);
 
 let css = readFileSync(tmp, "utf8");
 rmSync(tmp, { force: true });


### PR DESCRIPTION
closes #4823

## summary

- a fresh `pnpm install` on Windows failed in the root prepare hook with `spawnSync tailwindcss ENOENT`: `packages/react-devtools/scripts/build-styles.mjs` spawned the bare name `tailwindcss` via `execFileSync`, and without a shell Windows CreateProcess does no PATHEXT resolution, so pnpm's `.CMD` shims in `node_modules/.bin` are never found
- the script now resolves `@tailwindcss/cli/package.json` via `createRequire`, reads the `bin` field (`./dist/index.mjs`), and invokes it with `process.execPath` and an args array; this is exactly what the POSIX shim did anyway, so all platforms share one code path
- zero new dependencies, no `shell: true` (so no quoting or path-with-spaces issues), no platform branching, and a missing dependency now fails with a named `require.resolve` error instead of a bare ENOENT; the package.json route is load-bearing because `@tailwindcss/cli` exports no main entry (bare `require.resolve` throws ERR_PACKAGE_PATH_NOT_EXPORTED)
- includes a patch changeset for `@assistant-ui/react-devtools`; `scripts/` is not part of the published dist, the changeset is included under the letter of the repo rule

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-devtools run build:css` -> regenerates `panel.generated.ts` byte-identical to the pre-change baseline (sha256 match on regenerated output)
- [x] `pnpm lint` -> clean
- [x] repo-wide grep -> this was the only bare-name spawn in build scripts

### reviewer should verify

- [ ] on Windows, a fresh `pnpm install` completes through the prepare hook (the mechanism is platform-independent by construction, absolute node path plus absolute script path with no PATH or PATHEXT involvement, but an end-to-end run by a Windows user is the definitive check)

## notes

- the bug predates today's registry work: the spawn call landed 2026-06-16 in #4433 and the root prepare trigger chain in #4499, so #4817 is unrelated despite the triage bot's attribution on the issue

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

