### PR TITLE
chore: add @AVGVSTVS96 to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,7 @@
 
 # Public API surface snapshots require maintainer review.
 /api-surface/ @Yonom @okisdev @AVGVSTVS96
+
+# Public UI components and template changes require maintainer review.
+/packages/ui/ @Yonom @okisdev @AVGVSTVS96
+/templates/ @Yonom @okisdev @AVGVSTVS96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,3 @@
 
 # Public API surface snapshots require maintainer review.
 /api-surface/ @Yonom @okisdev @AVGVSTVS96
-
-# Public UI components and template changes require maintainer review.
-/packages/ui/ @Yonom @okisdev @AVGVSTVS96
-/templates/ @Yonom @okisdev @AVGVSTVS96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CI and repository policy changes require maintainer review.
-/.github/CODEOWNERS @Yonom @okisdev
+/.github/CODEOWNERS @Yonom @okisdev @AVGVSTVS96
 /.github/actions/ @assistant-ui/maintainers
 /.github/workflows/ @assistant-ui/maintainers
 
 # Public API surface snapshots require maintainer review.
-/api-surface/ @Yonom @okisdev
+/api-surface/ @Yonom @okisdev @AVGVSTVS96


### PR DESCRIPTION
Adds @AVGVSTVS96 as a code owner alongside @Yonom and @okisdev for the existing protected paths:

- `/.github/CODEOWNERS`
- `/api-surface/`

No new CODEOWNERS paths are introduced.