### PR TITLE
feat: shared agent state hooks for ag-ui and langgraph

### DIFF
--- a/.changeset/ag-ui-agent-state.md
+++ b/.changeset/ag-ui-agent-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: useAgUiState and useAgUiSetState hooks exposing shared agent state with optimistic updates that ride the next run

--- a/.changeset/langgraph-agent-state.md
+++ b/.changeset/langgraph-agent-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+feat: useLangGraphState and useLangGraphSetState hooks exposing graph values as shared agent state with optimistic updates that ride the next run input

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1568,12 +1568,16 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AgUiAssistantRuntime, AgUiInterrupt, AgUiInterruptReason, AgUiResumeEntry, AgUiRunFinishedOutcome, FromAgUiMessagesOptions, UseAgUiRuntimeAdapters, UseAgUiRuntimeOptions, UseAgUiThreadListAdapter, fromAgUiMessages, useAgUiInterrupts, useAgUiRuntime, useAgUiSteerAway, useAgUiSubmitInterruptResponses };
+  export { AgUiAssistantRuntime, AgUiInterrupt, AgUiInterruptReason, AgUiResumeEntry, AgUiRunFinishedOutcome, FromAgUiMessagesOptions, UseAgUiRuntimeAdapters, UseAgUiRuntimeOptions, UseAgUiThreadListAdapter, fromAgUiMessages, useAgUiInterrupts, useAgUiRuntime, useAgUiSetState, useAgUiState, useAgUiSteerAway, useAgUiSubmitInterruptResponses };
 }
 
 declare const useAgUiInterrupts: () => readonly AgUiInterrupt[];
 
 declare function useAgUiRuntime(options: UseAgUiRuntimeOptions): AgUiAssistantRuntime;
+
+declare const useAgUiSetState: <TState = ReadonlyJSONValue>() => (next: TState | ((prev: TState | undefined) => TState)) => void;
+
+declare const useAgUiState: <TState = ReadonlyJSONValue>() => TState | undefined;
 
 declare const useAgUiSteerAway: () => (message: CreateAppendMessage, responses?: readonly AgUiResumeEntry[]) => Promise<void>;
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -975,6 +975,7 @@ type LangGraphSendMessageConfig = {
   command?: LangGraphCommand;
   runConfig?: unknown;
   checkpointId?: string;
+  state?: Record<string, unknown>;
 };
 
 type LangGraphStateAccumulatorConfig<TMessage> = {
@@ -2154,7 +2155,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { CreateLangGraphStreamOptions, LangChainEvent, LangChainMessage, LangChainMessageChunk, LangChainToolCall, LangChainToolCallChunk, LangGraphCommand, LangGraphInterruptState, LangGraphMessageAccumulator, LangGraphMessagesEvent, LangGraphSendMessageConfig, LangGraphStreamCallback, LangGraphStreamClient, LangGraphTupleMetadata, OnCustomEventCallback, OnErrorEventCallback, OnInfoEventCallback, OnMessageChunkCallback, OnMetadataEventCallback, OnSubgraphErrorEventCallback, OnSubgraphUpdatesEventCallback, OnSubgraphValuesEventCallback, OnUpdatesEventCallback, OnValuesEventCallback, RemoveUIMessage, UIMessage, UseLangGraphRuntimeOptions, appendLangChainChunk, convertLangChainMessages, unstable_createLangGraphStream, useLangGraphInterruptState, useLangGraphMessageMetadata, useLangGraphMessages, useLangGraphRuntime, useLangGraphSend, useLangGraphSendCommand, useLangGraphStreamingTiming, useLangGraphUIMessages };
+  export { CreateLangGraphStreamOptions, LangChainEvent, LangChainMessage, LangChainMessageChunk, LangChainToolCall, LangChainToolCallChunk, LangGraphCommand, LangGraphInterruptState, LangGraphMessageAccumulator, LangGraphMessagesEvent, LangGraphSendMessageConfig, LangGraphStreamCallback, LangGraphStreamClient, LangGraphTupleMetadata, OnCustomEventCallback, OnErrorEventCallback, OnInfoEventCallback, OnMessageChunkCallback, OnMetadataEventCallback, OnSubgraphErrorEventCallback, OnSubgraphUpdatesEventCallback, OnSubgraphValuesEventCallback, OnUpdatesEventCallback, OnValuesEventCallback, RemoveUIMessage, UIMessage, UseLangGraphRuntimeOptions, appendLangChainChunk, convertLangChainMessages, unstable_createLangGraphStream, useLangGraphInterruptState, useLangGraphMessageMetadata, useLangGraphMessages, useLangGraphRuntime, useLangGraphSend, useLangGraphSendCommand, useLangGraphSetState, useLangGraphState, useLangGraphStreamingTiming, useLangGraphUIMessages };
 }
 
 declare const unstable_createLangGraphStream: (_param3: CreateLangGraphStreamOptions) => LangGraphStreamCallback<LangChainMessage>;
@@ -2213,12 +2214,14 @@ declare const useLangGraphMessages: <TMessage extends {
   };
 }) => {
   interrupt: LangGraphInterruptState | undefined;
+  values: Record<string, unknown> | undefined;
   messages: TMessage[];
   messageMetadata: Map<string, LangGraphTupleMetadata>;
   uiMessages: UIMessage[];
   sendMessage: (newMessages: TMessage[], config: LangGraphSendMessageConfig, onComplete?: () => void) => Promise<void>;
   cancel: () => void;
   setInterrupt: import("react").Dispatch<import("react").SetStateAction<LangGraphInterruptState | undefined>>;
+  setValues: import("react").Dispatch<import("react").SetStateAction<Record<string, unknown> | undefined>>;
   setMessages: (msgs: TMessage[]) => void;
   setUIMessages: (next: UIMessage[]) => void;
 };
@@ -2228,6 +2231,10 @@ declare const useLangGraphRuntime: (_param6: UseLangGraphRuntimeOptions) => Assi
 declare const useLangGraphSend: () => (messages: LangChainMessage[], config: LangGraphSendMessageConfig) => Promise<void>;
 
 declare const useLangGraphSendCommand: () => (command: LangGraphCommand) => Promise<void>;
+
+declare const useLangGraphSetState: <TState extends Record<string, unknown> = Record<string, unknown>>() => (next: TState | ((prev: TState | undefined) => TState)) => void;
+
+declare const useLangGraphState: <TState extends Record<string, unknown> = Record<string, unknown>>() => TState | undefined;
 
 declare const useLangGraphStreamingTiming: (messages: readonly LangChainMessage[], isRunning: boolean) => Record<string, MessageTiming>;
 

--- a/apps/docs/content/docs/runtimes/ag-ui/agent-state.mdx
+++ b/apps/docs/content/docs/runtimes/ag-ui/agent-state.mdx
@@ -1,0 +1,124 @@
+---
+title: Agent state
+description: Read and optimistically update agent-owned state with useAgUiState and useAgUiSetState over AG-UI.
+---
+
+`useAgUiState` mirrors the state your AG-UI agent owns. It updates live while the agent runs. `useAgUiSetState` lets you apply optimistic local updates that are sent with the next run.
+
+## Basic usage
+
+```tsx
+import { useAgUiState, useAgUiSetState } from "@assistant-ui/react-ag-ui";
+import { useAuiState } from "@assistant-ui/react";
+
+type ResearchState = {
+  topic: string;
+  sources: string[];
+};
+
+const state = useAgUiState<ResearchState>();
+// state: ResearchState | undefined  (latest agent state; updates live while the agent runs)
+
+const setState = useAgUiSetState<ResearchState>();
+// setState(next | (prev) => next)   (optimistic local update; sent with the NEXT run)
+
+const isRunning = useAuiState((s) => s.thread.isRunning);
+// isRunning: boolean                (whether the thread is currently running)
+```
+
+## Example
+
+Render agent state beside the chat and push an optimistic update from a control in your UI:
+
+```tsx
+"use client";
+
+import { useAgUiState, useAgUiSetState } from "@assistant-ui/react-ag-ui";
+import { useAuiState } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+type ResearchState = {
+  topic: string;
+  sources: string[];
+};
+
+export function ResearchAssistant() {
+  const state = useAgUiState<ResearchState>();
+  const setState = useAgUiSetState<ResearchState>();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+
+  return (
+    <div className="flex h-full">
+      <aside className="w-72 border-r p-4">
+        <h2>Research state</h2>
+        {state ? (
+          <ul>
+            <li>Topic: {state.topic}</li>
+            <li>Sources: {state.sources.join(", ") || "none"}</li>
+          </ul>
+        ) : (
+          <p>No agent state yet.</p>
+        )}
+        <button
+          type="button"
+          disabled={isRunning}
+          onClick={() =>
+            setState((prev) => ({
+              topic: prev?.topic ?? "market analysis",
+              sources: [...(prev?.sources ?? []), "sec-filings"],
+            }))
+          }
+        >
+          Prefer SEC filings
+        </button>
+        {isRunning && <p>Agent is running…</p>}
+      </aside>
+      <main className="flex-1">
+        <Thread />
+      </main>
+    </div>
+  );
+}
+```
+
+The panel re-renders as `STATE_SNAPSHOT` and `STATE_DELTA` events arrive. The button updates the local snapshot immediately; that value is included as the `state` field of the next run input.
+
+## How state is synced
+
+The AG-UI protocol delivers agent state on the wire:
+
+- `STATE_SNAPSHOT` replaces the full client-side snapshot.
+- `STATE_DELTA` applies a JSON Patch to the current snapshot.
+
+The runtime applies both client-side, so `useAgUiState` always reflects the latest merged snapshot. Calling the setter from `useAgUiSetState` updates that same local snapshot. On the next run, the runtime automatically includes it as the `state` field of the run input.
+
+This works with any AG-UI agent (Mastra, Pydantic AI, CrewAI, LangGraph via AG-UI adapters, and other AG-UI-compliant servers).
+
+## Write-back timing
+
+`useAgUiSetState` is optimistic and local first. The value reaches the agent only when the next run starts. It is not a live channel into a run that is already in progress. Use it to stage preferences, filters, or other agent-owned fields that the next turn should see.
+
+## Relationship to other state
+
+Keep the three state layers distinct:
+
+- **Your app state** stays yours (React state, URL, a store). assistant-ui does not own it.
+- **`useAuiState`** reads assistant-ui's client state (messages, composer, thread status).
+- **`useAgUiState` / `useAgUiSetState`** mirror state the **agent** owns, synced over the AG-UI wire via snapshots and deltas.
+
+Use `useAgUiState` and `useAgUiSetState` for fields your agent maintains as shared state on the protocol. Use `useAuiState` for UI that depends on the chat thread itself. Use your own state for everything else.
+
+## Next
+
+<Cards>
+  <Card
+    title="Runtime options"
+    description="useAgUiRuntime options, adapters, supported events."
+    href="/docs/runtimes/ag-ui/runtime-options"
+  />
+  <Card
+    title="Quickstart"
+    description="Minimal HttpAgent + useAgUiRuntime setup."
+    href="/docs/runtimes/ag-ui/quickstart"
+  />
+</Cards>

--- a/apps/docs/content/docs/runtimes/ag-ui/meta.json
+++ b/apps/docs/content/docs/runtimes/ag-ui/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "AG-UI Protocol",
   "description": "AG-UI runtime docs for connecting AG-UI agents to assistant-ui with streaming text, tool calls, state, and runtime options.",
-  "pages": ["overview", "quickstart", "runtime-options"]
+  "pages": ["overview", "quickstart", "runtime-options", "agent-state"]
 }

--- a/apps/docs/content/docs/runtimes/langgraph/agent-state.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/agent-state.mdx
@@ -1,0 +1,181 @@
+---
+title: Agent state
+description: Read and optimistically update graph state with useLangGraphState and useLangGraphSetState in LangGraph.
+---
+
+`useLangGraphState` mirrors the graph's values object that LangGraph streams to the client. It updates live while the agent runs (when the `values` stream mode is enabled). `useLangGraphSetState` lets you apply optimistic local updates that ride the next send.
+
+## Enable the `values` stream mode
+
+<Callout type="warn">
+The default stream setup does **not** include the `values` stream mode. Without it, `useLangGraphState` never receives live graph state.
+</Callout>
+
+When you call `client.runs.stream` yourself, request `values` alongside the modes you already use:
+
+```ts
+client.runs.stream(threadId, assistantId, {
+  input,
+  streamMode: ["messages", "updates", "custom", "values"],
+});
+```
+
+If you use `unstable_createLangGraphStream`, its default stream modes do **not** include `values` either. Pass the option explicitly:
+
+```ts
+const stream = unstable_createLangGraphStream({
+  client,
+  assistantId: ASSISTANT_ID,
+  streamMode: ["messages", "updates", "custom", "values"],
+});
+```
+
+## Basic usage
+
+```tsx
+import {
+  useLangGraphState,
+  useLangGraphSetState,
+} from "@assistant-ui/react-langgraph";
+import { useAuiState } from "@assistant-ui/react";
+
+type GraphState = {
+  messages: unknown[];
+  filters: { region: string; maxResults: number };
+};
+
+const state = useLangGraphState<GraphState>();
+// state: GraphState | undefined  (latest agent state; updates live while the agent runs)
+
+const setState = useLangGraphSetState<GraphState>();
+// setState(next | (prev) => next)   (optimistic local update; sent with the NEXT run)
+
+const isRunning = useAuiState((s) => s.thread.isRunning);
+// isRunning: boolean                (whether the thread is currently running)
+```
+
+## Example
+
+Render graph state beside the chat and stage an optimistic filter update:
+
+```tsx
+"use client";
+
+import {
+  useLangGraphState,
+  useLangGraphSetState,
+} from "@assistant-ui/react-langgraph";
+import { useAuiState } from "@assistant-ui/react";
+import { Thread } from "@/components/assistant-ui/thread";
+
+type GraphState = {
+  filters: { region: string; maxResults: number };
+  lastQuery?: string;
+};
+
+export function CatalogAssistant() {
+  const state = useLangGraphState<GraphState>();
+  const setState = useLangGraphSetState<GraphState>();
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+
+  return (
+    <div className="flex h-full">
+      <aside className="w-72 border-r p-4">
+        <h2>Graph state</h2>
+        {state ? (
+          <ul>
+            <li>Region: {state.filters.region}</li>
+            <li>Max results: {state.filters.maxResults}</li>
+            {state.lastQuery && <li>Last query: {state.lastQuery}</li>}
+          </ul>
+        ) : (
+          <p>No graph state yet. Ensure streamMode includes "values".</p>
+        )}
+        <button
+          type="button"
+          disabled={isRunning}
+          onClick={() =>
+            setState((prev) => ({
+              ...prev,
+              filters: {
+                region: "eu",
+                maxResults: prev?.filters.maxResults ?? 10,
+              },
+            }))
+          }
+        >
+          Prefer EU region
+        </button>
+        {isRunning && <p>Agent is running…</p>}
+      </aside>
+      <main className="flex-1">
+        <Thread />
+      </main>
+    </div>
+  );
+}
+```
+
+The panel tracks the latest `values` events from the graph. The button updates the local overlay immediately; that update object is merged into the run `input` on the next send so LangGraph applies it through the graph's state reducers and input schema.
+
+## How state is synced
+
+LangGraph state is the graph's values object. When `streamMode` includes `"values"`, each `values` event updates the client-side snapshot that `useLangGraphState` exposes.
+
+The setter from `useLangGraphSetState` overlays that snapshot locally. On the next send, the runtime merges the update object into the run `input`, so LangGraph reduces it through the graph's state reducers and input schema.
+
+If you supply a custom `stream` callback, the staged update is available as `config.state`. Forward it into your run input yourself:
+
+```ts
+const runtime = useLangGraphRuntime({
+  stream: async (messages, { initialize, ...config }) => {
+    const { externalId } = await initialize();
+    if (!externalId) throw new Error("Thread not found");
+
+    const client = createClient();
+    return client.runs.stream(externalId, ASSISTANT_ID, {
+      input: {
+        ...(config.state ?? {}),
+        messages,
+      },
+      streamMode: ["messages", "updates", "custom", "values"],
+    });
+  },
+});
+```
+
+The built-in path that uses the package helpers performs this merge for you. Custom `stream` callbacks must do it explicitly.
+
+## Write-back timing
+
+`useLangGraphSetState` is optimistic and local first. The value reaches the agent only when the next run starts. It is not a live channel into a run that is already in progress. Stage filters, preferences, or other graph fields that the next turn should apply through reducers; do not expect an in-flight run to observe mid-run setter calls.
+
+## Relationship to other state
+
+Keep the three state layers distinct:
+
+- **Your app state** stays yours (React state, URL, a store). assistant-ui does not own it.
+- **`useAuiState`** reads assistant-ui's client state (messages, composer, thread status).
+- **`useLangGraphState` / `useLangGraphSetState`** mirror state the **agent** (your LangGraph graph) owns, synced over the wire via `values` events.
+
+Use `useLangGraphState` and `useLangGraphSetState` for fields that live in the graph state schema. Use `useAuiState` for UI that depends on the chat thread itself. Use your own state for everything else.
+
+## Next
+
+<Cards>
+  <Card
+    title="Streaming"
+    description="Event handlers, message metadata, generative UI."
+    href="/docs/runtimes/langgraph/streaming"
+  />
+  <Card
+    title="Quickstart"
+    description="From-template and manual setup paths."
+    href="/docs/runtimes/langgraph/quickstart"
+  />
+  <Card
+    title="Generative UI"
+    description="Structured UI components emitted by your graph."
+    href="/docs/runtimes/langgraph/generative-ui"
+  />
+</Cards>

--- a/apps/docs/content/docs/runtimes/langgraph/meta.json
+++ b/apps/docs/content/docs/runtimes/langgraph/meta.json
@@ -8,6 +8,7 @@
     "generative-ui",
     "interrupts",
     "threads",
+    "agent-state",
     "tutorial"
   ]
 }

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -2,6 +2,7 @@
 
 import { useAui } from "@assistant-ui/store";
 import type { CreateAppendMessage } from "@assistant-ui/core";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import { agUiExtras } from "./agUiExtras";
 import type { AgUiInterrupt, AgUiResumeEntry } from "./runtime/types";
 
@@ -43,4 +44,23 @@ export const useAgUiSteerAway = () => {
     message: CreateAppendMessage,
     responses?: readonly AgUiResumeEntry[],
   ): Promise<void> => agUiExtras.get(aui).steerAway(message, responses);
+};
+
+export const useAgUiState = <TState = ReadonlyJSONValue>():
+  | TState
+  | undefined =>
+  agUiExtras.use((e) => e.state as TState | undefined, undefined);
+
+export const useAgUiSetState = <TState = ReadonlyJSONValue>() => {
+  const aui = useAui();
+  return (next: TState | ((prev: TState | undefined) => TState)): void => {
+    const extras = agUiExtras.get(aui);
+    const resolved =
+      typeof next === "function"
+        ? (next as (prev: TState | undefined) => TState)(
+            extras.state as TState | undefined,
+          )
+        : next;
+    extras.setState(resolved as ReadonlyJSONValue);
+  };
 };

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -53,14 +53,12 @@ export const useAgUiState = <TState = ReadonlyJSONValue>():
 
 export const useAgUiSetState = <TState = ReadonlyJSONValue>() => {
   const aui = useAui();
-  return (next: TState | ((prev: TState | undefined) => TState)): void => {
-    const extras = agUiExtras.get(aui);
-    const resolved =
-      typeof next === "function"
-        ? (next as (prev: TState | undefined) => TState)(
-            extras.state as TState | undefined,
-          )
-        : next;
-    extras.setState(resolved as ReadonlyJSONValue);
-  };
+  return (next: TState | ((prev: TState | undefined) => TState)): void =>
+    agUiExtras
+      .get(aui)
+      .setState(
+        next as
+          | ReadonlyJSONValue
+          | ((prev: ReadonlyJSONValue | undefined) => ReadonlyJSONValue),
+      );
 };

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -4,6 +4,8 @@ export {
   useAgUiInterrupts,
   useAgUiSubmitInterruptResponses,
   useAgUiSteerAway,
+  useAgUiState,
+  useAgUiSetState,
 } from "./hooks";
 export { fromAgUiMessages } from "./runtime/adapter/conversions";
 export type { FromAgUiMessagesOptions } from "./runtime/adapter/conversions";

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -678,6 +678,11 @@ export class AgUiThreadRuntimeCore {
     this.notifyUpdate();
   }
 
+  resetState(): void {
+    this.stateSnapshot = undefined;
+    this.notifyUpdate();
+  }
+
   private async startRun(
     parentId: string | null,
     runConfig?: RunConfig,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -668,6 +668,11 @@ export class AgUiThreadRuntimeCore {
     this.notifyUpdate();
   }
 
+  setState(state: ReadonlyJSONValue): void {
+    this.stateSnapshot = state;
+    this.notifyUpdate();
+  }
+
   private async startRun(
     parentId: string | null,
     runConfig?: RunConfig,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -668,8 +668,13 @@ export class AgUiThreadRuntimeCore {
     this.notifyUpdate();
   }
 
-  setState(state: ReadonlyJSONValue): void {
-    this.stateSnapshot = state;
+  setState(
+    next:
+      | ReadonlyJSONValue
+      | ((prev: ReadonlyJSONValue | undefined) => ReadonlyJSONValue),
+  ): void {
+    this.stateSnapshot =
+      typeof next === "function" ? next(this.stateSnapshot) : next;
     this.notifyUpdate();
   }
 

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -106,6 +106,8 @@ export type AgUiRuntimeExtras = {
     message: CreateAppendMessage,
     responses?: readonly AgUiResumeEntry[],
   ) => Promise<void>;
+  state: ReadonlyJSONValue | undefined;
+  setState: (state: ReadonlyJSONValue) => void;
 };
 
 export type AgUiRunFinishedOutcome =

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -107,7 +107,11 @@ export type AgUiRuntimeExtras = {
     responses?: readonly AgUiResumeEntry[],
   ) => Promise<void>;
   state: ReadonlyJSONValue | undefined;
-  setState: (state: ReadonlyJSONValue) => void;
+  setState: (
+    next:
+      | ReadonlyJSONValue
+      | ((prev: ReadonlyJSONValue | undefined) => ReadonlyJSONValue),
+  ) => void;
 };
 
 export type AgUiRunFinishedOutcome =

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -97,6 +97,7 @@ export function useAgUiRuntime(
         ? async () => {
             await onSwitchToNewThread();
             core.applyExternalMessages([]);
+            core.resetState();
           }
         : undefined,
       onSwitchToThread: onSwitchToThread
@@ -108,6 +109,8 @@ export function useAgUiRuntime(
             core.applyExternalMessages(result.messages);
             if (result.state !== undefined) {
               core.loadExternalState(result.state);
+            } else {
+              core.resetState();
             }
             if (result.unstable_resume) {
               void core.resumeInFlightRun(result.messages);

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -148,7 +148,7 @@ export function useAgUiRuntime(
             core.submitInterruptResponses(responses),
           steerAway: (message, responses) => core.steerAway(message, responses),
           state: core.getState(),
-          setState: (state) => core.setState(state),
+          setState: (next) => core.setState(next),
         }),
         unstable_enableToolInvocations: true,
         setToolStatuses,

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -147,6 +147,8 @@ export function useAgUiRuntime(
           submitInterruptResponses: (responses) =>
             core.submitInterruptResponses(responses),
           steerAway: (message, responses) => core.steerAway(message, responses),
+          state: core.getState(),
+          setState: (state) => core.setState(state),
         }),
         unstable_enableToolInvocations: true,
         setToolStatuses,

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2701,6 +2701,54 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(stateAtRun).toEqual({ initial: false, snapshot: 42 });
   });
 
+  it("setState updates getState immediately", () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.setState({ count: 7 });
+    expect(core.getState()).toEqual({ count: 7 });
+  });
+
+  it("setState rides the next run as input.state", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.setState({ count: 3, label: "optimistic" });
+    await core.append(createAppendMessage());
+
+    expect(runInputs[0].state).toEqual({ count: 3, label: "optimistic" });
+  });
+
+  it("applies STATE_DELTA on top of a setState snapshot", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onStateDeltaEvent?.({
+          event: {
+            type: "STATE_DELTA",
+            delta: [{ op: "replace", path: "/count", value: 2 }],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.setState({ count: 1, label: "base" });
+    await core.append(createAppendMessage());
+
+    expect(core.getState()).toEqual({ count: 2, label: "base" });
+  });
+
   it("adopts TEXT_MESSAGE_START.messageId as the ThreadAssistantMessage.id", async () => {
     const serverId = "11111111-1111-1111-1111-111111111111";
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -227,6 +227,36 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(core.getState()).toEqual({ count: 1, label: "initial" });
   });
 
+  it("resetState clears the snapshot so the next run sends null state", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      if (runAgent.mock.calls.length === 1) {
+        subscriber.onStateSnapshotEvent?.({
+          event: {
+            type: "STATE_SNAPSHOT",
+            snapshot: { count: 1 },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    expect(core.getState()).toEqual({ count: 1 });
+
+    core.resetState();
+    expect(core.getState()).toBeUndefined();
+
+    await core.resume({
+      parentId: null,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+    });
+
+    expect(runAgent.mock.calls[1]?.[0].state).toBeNull();
+  });
+
   it("applies deltas before a snapshot from an empty state object", async () => {
     const runInputs: any[] = [];
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2729,6 +2729,29 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runInputs[0].state).toEqual({ count: 3, label: "optimistic" });
   });
 
+  it("composes chained functional setState updaters in the same tick", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    core.setState({ count: 0 });
+    core.setState((prev) => ({
+      count: ((prev as { count?: number } | undefined)?.count ?? 0) + 1,
+    }));
+    core.setState((prev) => ({
+      count: ((prev as { count?: number } | undefined)?.count ?? 0) + 1,
+    }));
+    expect(core.getState()).toEqual({ count: 2 });
+
+    await core.append(createAppendMessage());
+    expect(runInputs[0].state).toEqual({ count: 2 });
+  });
+
   it("applies STATE_DELTA on top of a setState snapshot", async () => {
     const agent = {
       runAgent: vi.fn(async (_input, subscriber) => {

--- a/packages/react-ag-ui/test/useAgUiState.spec.ts
+++ b/packages/react-ag-ui/test/useAgUiState.spec.ts
@@ -64,7 +64,7 @@ describe("useAgUiSetState", () => {
     expect(setState).toHaveBeenCalledWith({ count: 5 });
   });
 
-  it("resolves a functional updater against the current extras state", () => {
+  it("forwards a functional updater to extras.setState", () => {
     const setState = vi.fn();
     const extras = agUiExtras.provide({
       interrupts: [],
@@ -78,10 +78,11 @@ describe("useAgUiSetState", () => {
       thread: () => ({ getState: () => ({ extras }) }),
     });
 
-    useAgUiSetState<{ count: number }>()((prev) => ({
+    const updater = (prev: { count: number } | undefined) => ({
       count: (prev?.count ?? 0) + 1,
-    }));
+    });
+    useAgUiSetState<{ count: number }>()(updater);
 
-    expect(setState).toHaveBeenCalledWith({ count: 3 });
+    expect(setState).toHaveBeenCalledWith(updater);
   });
 });

--- a/packages/react-ag-ui/test/useAgUiState.spec.ts
+++ b/packages/react-ag-ui/test/useAgUiState.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+
+const { mockUseAuiState, mockUseAui } = vi.hoisted(() => ({
+  mockUseAuiState: vi.fn(),
+  mockUseAui: vi.fn(),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAuiState: ((selector: (s: unknown) => unknown) =>
+    mockUseAuiState(
+      selector,
+    )) as typeof import("@assistant-ui/store").useAuiState,
+  useAui: (() => mockUseAui()) as typeof import("@assistant-ui/store").useAui,
+}));
+
+import { agUiExtras } from "../src/agUiExtras";
+import { useAgUiState, useAgUiSetState } from "../src/hooks";
+
+const againstState = (extras: unknown) =>
+  mockUseAuiState.mockImplementation((selector: (s: unknown) => unknown) =>
+    selector({ thread: { extras } }),
+  );
+
+describe("useAgUiState", () => {
+  it("returns state from extras when the thread is backed by ag-ui", () => {
+    againstState(
+      agUiExtras.provide({
+        interrupts: [],
+        submitInterruptResponses: vi.fn(),
+        steerAway: vi.fn(),
+        state: { count: 1 },
+        setState: vi.fn(),
+      }),
+    );
+
+    expect(useAgUiState<{ count: number }>()).toEqual({ count: 1 });
+  });
+
+  it("returns undefined state when extras are absent", () => {
+    againstState(undefined);
+
+    expect(useAgUiState()).toBeUndefined();
+  });
+});
+
+describe("useAgUiSetState", () => {
+  it("calls extras.setState with a value", () => {
+    const setState = vi.fn();
+    const extras = agUiExtras.provide({
+      interrupts: [],
+      submitInterruptResponses: vi.fn(),
+      steerAway: vi.fn(),
+      state: { count: 0 },
+      setState,
+    });
+    againstState(extras);
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras }) }),
+    });
+
+    useAgUiSetState<{ count: number }>()({ count: 5 });
+
+    expect(setState).toHaveBeenCalledWith({ count: 5 });
+  });
+
+  it("resolves a functional updater against the current extras state", () => {
+    const setState = vi.fn();
+    const extras = agUiExtras.provide({
+      interrupts: [],
+      submitInterruptResponses: vi.fn(),
+      steerAway: vi.fn(),
+      state: { count: 2 },
+      setState,
+    });
+    againstState(extras);
+    mockUseAui.mockReturnValue({
+      thread: () => ({ getState: () => ({ extras }) }),
+    });
+
+    useAgUiSetState<{ count: number }>()((prev) => ({
+      count: (prev?.count ?? 0) + 1,
+    }));
+
+    expect(setState).toHaveBeenCalledWith({ count: 3 });
+  });
+});

--- a/packages/react-langgraph/src/createLangGraphStream.test.ts
+++ b/packages/react-langgraph/src/createLangGraphStream.test.ts
@@ -119,6 +119,50 @@ describe("unstable_createLangGraphStream", () => {
     );
   });
 
+  it("sends state as input without messages", async () => {
+    const { client, stream } = makeClient();
+    const callback = unstable_createLangGraphStream({
+      client,
+      assistantId: "graph-1",
+    });
+
+    await callback([], {
+      abortSignal: new AbortController().signal,
+      state: { theme: "dark" },
+      initialize,
+    });
+
+    expect(stream).toHaveBeenCalledWith(
+      "t-1",
+      "graph-1",
+      expect.objectContaining({
+        input: { theme: "dark" },
+      }),
+    );
+  });
+
+  it("merges state and messages with messages taking precedence", async () => {
+    const { client, stream } = makeClient();
+    const callback = unstable_createLangGraphStream({
+      client,
+      assistantId: "graph-1",
+    });
+
+    await callback([humanMessage], {
+      abortSignal: new AbortController().signal,
+      state: { messages: ["stale"], theme: "dark" },
+      initialize,
+    });
+
+    expect(stream).toHaveBeenCalledWith(
+      "t-1",
+      "graph-1",
+      expect.objectContaining({
+        input: { messages: [humanMessage], theme: "dark" },
+      }),
+    );
+  });
+
   it("wraps checkpointId as checkpoint.checkpoint_id", async () => {
     const { client, stream } = makeClient();
     const callback = unstable_createLangGraphStream({

--- a/packages/react-langgraph/src/createLangGraphStream.ts
+++ b/packages/react-langgraph/src/createLangGraphStream.ts
@@ -39,7 +39,11 @@ export const unstable_createLangGraphStream = ({
     }
 
     const payload = {
-      input: messages.length ? { messages } : null,
+      input: config.state
+        ? { ...config.state, ...(messages.length ? { messages } : {}) }
+        : messages.length
+          ? { messages }
+          : null,
       streamMode,
       signal: config.abortSignal,
       onDisconnect,

--- a/packages/react-langgraph/src/hooks.ts
+++ b/packages/react-langgraph/src/hooks.ts
@@ -15,6 +15,29 @@ import type {
 const EMPTY_UI_MESSAGES: readonly UIMessage[] = Object.freeze([]);
 const EMPTY_MESSAGE_METADATA: Map<string, LangGraphTupleMetadata> = new Map();
 
+/** Read the graph's shared state streamed via values events. */
+export const useLangGraphState = <
+  TState extends Record<string, unknown> = Record<string, unknown>,
+>(): TState | undefined =>
+  langGraphExtras.use((e) => e.state as TState | undefined, undefined);
+
+/** Stage an optimistic graph state update that rides the next run input. */
+export const useLangGraphSetState = <
+  TState extends Record<string, unknown> = Record<string, unknown>,
+>() => {
+  const aui = useAui();
+  return (next: TState | ((prev: TState | undefined) => TState)): void => {
+    const extras = langGraphExtras.get(aui);
+    const resolved =
+      typeof next === "function"
+        ? (next as (prev: TState | undefined) => TState)(
+            extras.state as TState | undefined,
+          )
+        : next;
+    extras.setState(resolved);
+  };
+};
+
 /** Read the current LangGraph interrupt state from the runtime extras. */
 export const useLangGraphInterruptState = () =>
   langGraphExtras.use((e) => e.interrupt, undefined);

--- a/packages/react-langgraph/src/hooks.ts
+++ b/packages/react-langgraph/src/hooks.ts
@@ -26,16 +26,16 @@ export const useLangGraphSetState = <
   TState extends Record<string, unknown> = Record<string, unknown>,
 >() => {
   const aui = useAui();
-  return (next: TState | ((prev: TState | undefined) => TState)): void => {
-    const extras = langGraphExtras.get(aui);
-    const resolved =
-      typeof next === "function"
-        ? (next as (prev: TState | undefined) => TState)(
-            extras.state as TState | undefined,
-          )
-        : next;
-    extras.setState(resolved);
-  };
+  return (next: TState | ((prev: TState | undefined) => TState)): void =>
+    langGraphExtras
+      .get(aui)
+      .setState(
+        next as
+          | Record<string, unknown>
+          | ((
+              prev: Record<string, unknown> | undefined,
+            ) => Record<string, unknown>),
+      );
 };
 
 /** Read the current LangGraph interrupt state from the runtime extras. */

--- a/packages/react-langgraph/src/index.ts
+++ b/packages/react-langgraph/src/index.ts
@@ -1,6 +1,8 @@
 export { useLangGraphRuntime } from "./useLangGraphRuntime";
 
 export {
+  useLangGraphState,
+  useLangGraphSetState,
   useLangGraphSend,
   useLangGraphSendCommand,
   useLangGraphInterruptState,

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -262,6 +262,8 @@ export type LangGraphRuntimeExtras = {
     config: LangGraphSendMessageConfig,
   ) => Promise<void>;
   interrupt: LangGraphInterruptState | undefined;
+  state: Record<string, unknown> | undefined;
+  setState: (next: Record<string, unknown>) => void;
   messageMetadata: Map<string, LangGraphTupleMetadata>;
   uiMessages: readonly UIMessage[];
 };

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -263,7 +263,13 @@ export type LangGraphRuntimeExtras = {
   ) => Promise<void>;
   interrupt: LangGraphInterruptState | undefined;
   state: Record<string, unknown> | undefined;
-  setState: (next: Record<string, unknown>) => void;
+  setState: (
+    next:
+      | Record<string, unknown>
+      | ((
+          prev: Record<string, unknown> | undefined,
+        ) => Record<string, unknown>),
+  ) => void;
   messageMetadata: Map<string, LangGraphTupleMetadata>;
   uiMessages: readonly UIMessage[];
 };

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -56,6 +56,7 @@ export type LangGraphSendMessageConfig = {
   command?: LangGraphCommand;
   runConfig?: unknown;
   checkpointId?: string;
+  state?: Record<string, unknown>;
 };
 
 export type LangGraphMessagesEvent<TMessage> = {
@@ -173,6 +174,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
     LangGraphInterruptState | undefined
   >();
   const [messages, _setMessages] = useState<TMessage[]>([]);
+  const [values, setValues] = useState<Record<string, unknown> | undefined>();
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
 
@@ -274,6 +276,7 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
                 onSubgraphValues?.(eventNamespace, chunk.data);
                 break;
               }
+              setValues(chunk.data as Record<string, unknown>);
               onValues?.(chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;
@@ -452,12 +455,14 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
 
   return {
     interrupt,
+    values,
     messages,
     messageMetadata,
     uiMessages,
     sendMessage,
     cancel,
     setInterrupt,
+    setValues,
     setMessages: setMessagesImmediate,
     setUIMessages: setUIMessagesImmediate,
   };

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -74,6 +74,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     uiComponents,
   } = options;
   const aui = useAui();
+  const pendingStateRef = useRef<Record<string, unknown> | undefined>(
+    undefined,
+  );
+  const [optimisticState, setOptimisticState] = useState<
+    Record<string, unknown> | undefined
+  >();
 
   // Attachments the composer handed to onNew/onEdit, keyed by the staged human
   // message id. The wire message only carries flattened `content` (so the model
@@ -159,12 +165,17 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
           runErrorBalanceRef.current--;
           return eventHandlers?.onSubgraphError?.(namespace, error);
         },
+        onValues: (values: unknown) => {
+          setOptimisticState(undefined);
+          return eventHandlers?.onValues?.(values);
+        },
       }) satisfies UseLangGraphRuntimeOptions["eventHandlers"],
     [eventHandlers],
   );
 
   const {
     interrupt,
+    values,
     setInterrupt,
     messages,
     messageMetadata,
@@ -172,6 +183,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     sendMessage,
     cancel,
     setMessages,
+    setValues,
     setUIMessages,
   } = useLangGraphMessages({
     appendMessage: appendLangChainChunk,
@@ -267,7 +279,25 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const handleSendMessage = (
     messages: LangChainMessage[],
     config: LangGraphSendMessageConfig,
-  ) => runQueue.enqueue({ messages, config });
+  ) => {
+    const state = pendingStateRef.current;
+    pendingStateRef.current = undefined;
+    return runQueue.enqueue({
+      messages,
+      config: state ? { ...config, state } : config,
+    });
+  };
+
+  const state = useMemo(
+    () =>
+      optimisticState ? { ...(values ?? {}), ...optimisticState } : values,
+    [optimisticState, values],
+  );
+
+  const setState = (next: Record<string, unknown>) => {
+    pendingStateRef.current = next;
+    setOptimisticState(next);
+  };
 
   const runUserMessage = async (msg: AppendMessage) => {
     // A new turn abandons any half-collected parallel tool batch and any
@@ -409,6 +439,8 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
     },
     extras: langGraphExtras.provide({
       interrupt,
+      state,
+      setState,
       messageMetadata,
       uiMessages,
       send: handleSendMessage,
@@ -576,6 +608,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       // drop stale callbacks and abort the pending load on thread switch/unmount
       const controller = new AbortController();
       toolResultBufferRef.current.clear();
+      pendingStateRef.current = undefined;
+      setOptimisticState(undefined);
+      setValues(undefined);
       setIsLoadingThread(true);
       load(externalId, { signal: controller.signal })
         .then(({ messages, interrupts, uiMessages }) => {
@@ -597,7 +632,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
         controller.abort();
         setIsLoadingThread(false);
       };
-    }, [aui, setMessages, setUIMessages, setInterrupt]);
+    }, [aui, setMessages, setUIMessages, setInterrupt, setValues]);
   }
 
   return runtime;

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -77,6 +77,9 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   const pendingStateRef = useRef<Record<string, unknown> | undefined>(
     undefined,
   );
+  const effectiveStateRef = useRef<Record<string, unknown> | undefined>(
+    undefined,
+  );
   const [optimisticState, setOptimisticState] = useState<
     Record<string, unknown> | undefined
   >();
@@ -293,10 +296,20 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       optimisticState ? { ...(values ?? {}), ...optimisticState } : values,
     [optimisticState, values],
   );
+  effectiveStateRef.current = state;
 
-  const setState = (next: Record<string, unknown>) => {
-    pendingStateRef.current = next;
-    setOptimisticState(next);
+  const setState = (
+    next:
+      | Record<string, unknown>
+      | ((
+          prev: Record<string, unknown> | undefined,
+        ) => Record<string, unknown>),
+  ) => {
+    const resolved =
+      typeof next === "function" ? next(effectiveStateRef.current) : next;
+    effectiveStateRef.current = resolved;
+    pendingStateRef.current = resolved;
+    setOptimisticState(resolved);
   };
 
   const runUserMessage = async (msg: AppendMessage) => {
@@ -609,6 +622,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
       const controller = new AbortController();
       toolResultBufferRef.current.clear();
       pendingStateRef.current = undefined;
+      effectiveStateRef.current = undefined;
       setOptimisticState(undefined);
       setValues(undefined);
       setIsLoadingThread(true);

--- a/packages/react-langgraph/src/useLangGraphState.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphState.test.tsx
@@ -136,4 +136,33 @@ describe("useLangGraphState", () => {
       });
     });
   });
+
+  it("composes chained functional setState updaters in the same act", async () => {
+    const stream = vi.fn(() => mockStreamCallbackFactory([])());
+    const { result } = renderAgentState(stream);
+    await waitForRuntime();
+
+    act(() => {
+      result.current.setState({ count: 0 });
+      result.current.setState((prev) => ({
+        count: ((prev?.count as number | undefined) ?? 0) + 1,
+      }));
+      result.current.setState((prev) => ({
+        count: ((prev?.count as number | undefined) ?? 0) + 1,
+      }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ count: 2 });
+    });
+
+    await act(async () => {
+      await result.current.send([humanMessage], {});
+    });
+
+    expect(stream).toHaveBeenCalledWith(
+      [expect.objectContaining(humanMessage)],
+      expect.objectContaining({ state: { count: 2 } }),
+    );
+  });
 });

--- a/packages/react-langgraph/src/useLangGraphState.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphState.test.tsx
@@ -1,0 +1,139 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  useLangGraphState,
+  useLangGraphSetState,
+  useLangGraphSend,
+} from "./hooks";
+import { mockStreamCallbackFactory } from "./testUtils";
+import type { LangGraphStreamCallback } from "./useLangGraphMessages";
+import { useLangGraphRuntime } from "./useLangGraphRuntime";
+import type { LangChainMessage } from "./types";
+
+const wrapperFactory = (runtime: AssistantRuntime) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+  Wrapper.displayName = "TestWrapper";
+  return Wrapper;
+};
+
+const humanMessage = {
+  type: "human" as const,
+  content: "Hello",
+};
+
+const renderAgentState = (
+  stream: LangGraphStreamCallback<LangChainMessage>,
+) => {
+  const { result: runtimeResult } = renderHook(() =>
+    useLangGraphRuntime({ stream }),
+  );
+  const wrapper = wrapperFactory(runtimeResult.current);
+  return renderHook(
+    () => ({
+      state: useLangGraphState(),
+      setState: useLangGraphSetState(),
+      send: useLangGraphSend(),
+    }),
+    { wrapper },
+  );
+};
+
+const waitForRuntime = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe("useLangGraphState", () => {
+  it("reflects top-level values events", async () => {
+    const values = { count: 1, status: "ready" };
+    const stream = vi.fn(() =>
+      mockStreamCallbackFactory([{ event: "values", data: values }])(),
+    );
+    const { result } = renderAgentState(stream);
+    await waitForRuntime();
+
+    await act(async () => {
+      await result.current.send([humanMessage], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual(values);
+    });
+  });
+
+  it("applies optimistic state and sends it with the next run", async () => {
+    const stream = vi.fn(() => mockStreamCallbackFactory([])());
+    const { result } = renderAgentState(stream);
+    await waitForRuntime();
+
+    act(() => {
+      result.current.setState({ count: 2 });
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual({ count: 2 });
+    });
+
+    await act(async () => {
+      await result.current.send([humanMessage], {});
+    });
+
+    expect(stream).toHaveBeenCalledWith(
+      [expect.objectContaining(humanMessage)],
+      expect.objectContaining({ state: { count: 2 } }),
+    );
+  });
+
+  it("replaces the optimistic overlay with fresh values", async () => {
+    const stream = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        mockStreamCallbackFactory([
+          { event: "values", data: { count: 1, status: "initial" } },
+        ])(),
+      )
+      .mockImplementationOnce(() =>
+        mockStreamCallbackFactory([
+          { event: "values", data: { count: 3, status: "fresh" } },
+        ])(),
+      );
+    const { result } = renderAgentState(stream);
+    await waitForRuntime();
+
+    await act(async () => {
+      await result.current.send([humanMessage], {});
+    });
+
+    act(() => {
+      result.current.setState((state) => ({
+        ...state,
+        count: 2,
+      }));
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual({
+        count: 2,
+        status: "initial",
+      });
+    });
+
+    await act(async () => {
+      await result.current.send([humanMessage], {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.state).toEqual({
+        count: 3,
+        status: "fresh",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## summary

- adds package-prefixed read/write hook pairs for agent-owned shared state: `useAgUiState` / `useAgUiSetState` in `@assistant-ui/react-ag-ui` and `useLangGraphState` / `useLangGraphSetState` in `@assistant-ui/react-langgraph`
- ag-ui: the runtime already applies `STATE_SNAPSHOT` / `STATE_DELTA` events into an internal snapshot and sends it on every run input; this exposes that snapshot through the runtime extras and adds a `setState` write path on the core (optimistic local update, delivered as `input.state` on the next run)
- langgraph: tracks top-level `values` events as the state snapshot, widens `LangGraphSendMessageConfig` with `state`, and merges staged updates into the next run `input` so the graph applies them through its reducers; `unstable_createLangGraphStream` performs the merge, custom `stream` callbacks receive `config.state` and forward it themselves
- docs: new agent-state pages for both runtimes, including the LangGraph caveat that `values` must be added to `streamMode`, plus a section on how these relate to `useAuiState` and app-owned state

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 200/200 green (7 files), including new cases: setState is delivered as `input.state` on the next run, STATE_DELTA applies on top of a locally set snapshot
- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 179/179 green (10 files), including new cases: values reactivity, optimistic overlay, staged update rides the next send, fresh values reconcile the overlay
- [x] `tsc --noEmit` clean in both packages, root `pnpm lint` green, api-surface regenerated

### reviewer should verify

- [ ] with an AG-UI agent that emits state events, a panel using `useAgUiState` updates live during a run, and a value staged via `useAgUiSetState` reaches the agent as `input.state` on the next run
- [ ] with a LangGraph graph and `streamMode` including `values`, `useLangGraphState` reflects streamed graph state and a staged update lands in the next run input

## notes

- motivation: without these hooks, reading agent state required either subscribing to the raw `@ag-ui/client` agent instance outside assistant-ui or the unstable per-message `metadata.unstable_state` snapshot, and writing was effectively unreachable because the core overwrites `agent.state` from its own snapshot before each run; on langgraph, reads were limited to the fire-and-forget `onValues` callback and writes meant hand-rolling input merging in a custom stream callback
- hook shape follows the reduced-surface direction from #4762: package-prefixed single-purpose read/write pairs mirroring the existing interrupt hook split, no consolidated result object, and running status stays on `useAuiState((s) => s.thread.isRunning)`
- setState is optimistic and local first; it reaches the agent when the next run starts and is not a live channel into an in-flight run (documented on both pages)
- langgraph overlay semantics are last-snapshot-wins: any fresh `values` event replaces the local overlay (documented)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

