### PR TITLE
feat(registry): enforce radix/base variant parity at build time

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -460,6 +460,95 @@ test("export parity treats export { A as B } as B and accepts identical sets", (
   );
 });
 
+test("export parity records default exports as default regardless of local name", () => {
+  assert.throws(
+    () =>
+      validateVariantExportParity(
+        [
+          createBuilt("widget", [
+            ["components/widget.tsx", "export default function Widget() {}"],
+          ]),
+        ],
+        [
+          createBuilt("widget", [
+            ["components/widget.tsx", "export function Widget() {}"],
+          ]),
+        ],
+      ),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.ok(error.message.includes("radix-only: default"));
+      assert.ok(error.message.includes("base-only: Widget"));
+      return true;
+    },
+  );
+
+  assert.doesNotThrow(() =>
+    validateVariantExportParity(
+      [
+        createBuilt("widget", [
+          ["components/widget.tsx", "export default function RadixWidget() {}"],
+        ]),
+      ],
+      [
+        createBuilt("widget", [
+          ["components/widget.tsx", "export default function BaseWidget() {}"],
+        ]),
+      ],
+    ),
+  );
+});
+
+test("export parity tracks star and namespace re-exports", () => {
+  assert.throws(
+    () =>
+      validateVariantExportParity(
+        [
+          createBuilt("widget", [
+            [
+              "components/widget.tsx",
+              'export function Widget() {}\nexport * from "./extra";',
+            ],
+          ]),
+        ],
+        [
+          createBuilt("widget", [
+            ["components/widget.tsx", "export function Widget() {}"],
+          ]),
+        ],
+      ),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.ok(error.message.includes("radix-only: *:./extra"));
+      return true;
+    },
+  );
+
+  assert.throws(
+    () =>
+      validateVariantExportParity(
+        [
+          createBuilt("widget", [
+            [
+              "components/widget.tsx",
+              'export * as Helpers from "./extra";\nexport function Widget() {}',
+            ],
+          ]),
+        ],
+        [
+          createBuilt("widget", [
+            ["components/widget.tsx", "export function Widget() {}"],
+          ]),
+        ],
+      ),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.ok(error.message.includes("radix-only: Helpers"));
+      return true;
+    },
+  );
+});
+
 test("style-scoped dependencies flag deps used only by the opposite tree", () => {
   const radixOnlyImport = createBuilt("tooltip", [
     [

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -8,6 +8,9 @@ const {
   getBaseVariantSourcePath,
   validateBaseVariantContent,
   validateRadixPassDidNotReadBaseSources,
+  validateStyleScopedDependencies,
+  validateVariantExportParity,
+  validateVariantSlotParity,
   validateVariantTreesDiffer,
 } = await import("./build-registry.ts");
 
@@ -268,5 +271,272 @@ test("variant tree validation aggregates identical radix and base content", () =
       );
       return true;
     },
+  );
+});
+
+test("radix registry item merges and dedupes radixDependencies into dependencies", () => {
+  assert.deepEqual(
+    createRadixRegistryItem({
+      name: "example",
+      type: "registry:ui",
+      dependencies: ["lucide-react", "radix-ui"],
+      radixDependencies: ["radix-ui", "class-variance-authority"],
+      baseDependencies: ["@base-ui/react"],
+      baseRegistryDependencies: ["popover"],
+    }),
+    {
+      name: "example",
+      type: "registry:ui",
+      dependencies: ["lucide-react", "radix-ui", "class-variance-authority"],
+    },
+  );
+});
+
+test("radix registry item omits dependencies when neither source list exists", () => {
+  assert.deepEqual(
+    createRadixRegistryItem({
+      name: "example",
+      type: "registry:ui",
+      baseDependencies: ["@base-ui/react"],
+      baseRegistryDependencies: ["popover"],
+    }),
+    {
+      name: "example",
+      type: "registry:ui",
+    },
+  );
+});
+
+test("base registry item merges baseDependencies and drops radixDependencies", () => {
+  assert.deepEqual(
+    createBaseRegistryItem({
+      name: "example",
+      type: "registry:ui",
+      dependencies: ["lucide-react", "@base-ui/react"],
+      baseDependencies: ["@base-ui/react", "clsx"],
+      radixDependencies: ["radix-ui"],
+    }),
+    {
+      name: "example",
+      type: "registry:ui",
+      dependencies: ["lucide-react", "@base-ui/react", "clsx"],
+    },
+  );
+});
+
+test("slot parity reports mismatched data-slot attributes", () => {
+  const radixBuilt = [
+    createBuilt("button", [
+      [
+        "components/button.tsx",
+        '<button data-slot="button" data-slot="button-icon" />',
+      ],
+    ]),
+  ];
+  const baseBuilt = [
+    createBuilt("button", [
+      ["components/button.tsx", '<button data-slot="button" />'],
+    ]),
+  ];
+
+  assert.throws(
+    () => validateVariantSlotParity(radixBuilt, baseBuilt),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid variant slot parity:/);
+      assert.ok(error.message.includes("button"));
+      assert.ok(error.message.includes("components/button.tsx"));
+      assert.ok(error.message.includes("button-icon"));
+      assert.ok(
+        error.message.includes(
+          "- button: data-slot attributes differ for components/button.tsx (radix-only: button-icon)",
+        ),
+      );
+      return true;
+    },
+  );
+});
+
+test("slot parity accepts identical slot sets and skips empty base variants", () => {
+  assert.doesNotThrow(() =>
+    validateVariantSlotParity(
+      [
+        createBuilt("button", [
+          ["components/button.tsx", '<button data-slot="button" />'],
+        ]),
+        createBuilt("plain", [["components/plain.tsx", "export const x = 1;"]]),
+      ],
+      [
+        createBuilt("button", [
+          ["components/button.tsx", '<div data-slot="button" />'],
+        ]),
+        createBuilt(
+          "plain",
+          [["components/plain.tsx", "export const y = 2;"]],
+          {
+            baseVariantOutputPaths: [],
+          },
+        ),
+      ],
+    ),
+  );
+});
+
+test("export parity reports exports present only in the radix content", () => {
+  const radixBuilt = [
+    createBuilt("widget", [
+      [
+        "components/widget.tsx",
+        "export function Widget() {}\nexport function Helper() {}",
+      ],
+    ]),
+  ];
+  const baseBuilt = [
+    createBuilt("widget", [
+      ["components/widget.tsx", "export function Widget() {}"],
+    ]),
+  ];
+
+  assert.throws(
+    () => validateVariantExportParity(radixBuilt, baseBuilt),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid variant export parity:/);
+      assert.ok(error.message.includes("widget"));
+      assert.ok(error.message.includes("components/widget.tsx"));
+      assert.ok(error.message.includes("Helper"));
+      assert.ok(
+        error.message.includes(
+          "- widget: exported symbols differ for components/widget.tsx (radix-only: Helper)",
+        ),
+      );
+      return true;
+    },
+  );
+});
+
+test("export parity treats export { A as B } as B and accepts identical sets", () => {
+  assert.throws(
+    () =>
+      validateVariantExportParity(
+        [
+          createBuilt("alias", [
+            ["components/alias.tsx", "const A = 1;\nexport { A as B };"],
+          ]),
+        ],
+        [
+          createBuilt("alias", [
+            ["components/alias.tsx", "export function Other() {}"],
+          ]),
+        ],
+      ),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.ok(error.message.includes("radix-only: B"));
+      assert.ok(error.message.includes("base-only: Other"));
+      return true;
+    },
+  );
+
+  assert.doesNotThrow(() =>
+    validateVariantExportParity(
+      [
+        createBuilt("same", [
+          [
+            "components/same.tsx",
+            "export function Same() {}\nconst A = 1;\nexport { A as B };",
+          ],
+        ]),
+      ],
+      [
+        createBuilt("same", [
+          [
+            "components/same.tsx",
+            "export function Same() {}\nexport function B() {}",
+          ],
+        ]),
+      ],
+    ),
+  );
+});
+
+test("style-scoped dependencies flag deps used only by the opposite tree", () => {
+  const radixOnlyImport = createBuilt("tooltip", [
+    [
+      "components/tooltip.tsx",
+      'import { Tooltip } from "radix-ui";\nexport const TooltipButton = Tooltip;',
+    ],
+  ]);
+  const baseOnlyImport = createBuilt("tooltip", [
+    [
+      "components/tooltip.tsx",
+      'import { Tooltip } from "@base-ui/react";\nexport const TooltipButton = Tooltip;',
+    ],
+  ]);
+  const bothImport = createBuilt("shared", [
+    [
+      "components/shared.tsx",
+      'import { clsx } from "clsx";\nexport const cx = clsx;',
+    ],
+  ]);
+  const neitherImport = createBuilt("unused", [
+    ["components/unused.tsx", "export const value = 1;"],
+  ]);
+
+  radixOnlyImport.payload.dependencies = ["radix-ui"];
+  baseOnlyImport.payload.dependencies = ["radix-ui"];
+  bothImport.payload.dependencies = ["clsx"];
+  neitherImport.payload.dependencies = ["lodash"];
+
+  assert.throws(
+    () => validateStyleScopedDependencies([radixOnlyImport], [baseOnlyImport]),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.match(error.message, /^Invalid style-scoped dependencies:/);
+      assert.ok(error.message.includes("radixDependencies"));
+      assert.ok(
+        error.message.includes(
+          '- tooltip: dependency "radix-ui" is declared for the base tree but only used by the radix tree; move it to radixDependencies',
+        ),
+      );
+      return true;
+    },
+  );
+
+  const radixDeclaresBaseOnly = createBuilt("panel", [
+    ["components/panel.tsx", "export const P = true;"],
+  ]);
+  const baseUsesBaseOnly = createBuilt("panel", [
+    [
+      "components/panel.tsx",
+      'import { Panel } from "@base-ui/react";\nexport const P = Panel;',
+    ],
+  ]);
+  radixDeclaresBaseOnly.payload.dependencies = ["@base-ui/react"];
+
+  assert.throws(
+    () =>
+      validateStyleScopedDependencies(
+        [radixDeclaresBaseOnly],
+        [baseUsesBaseOnly],
+      ),
+    (error) => {
+      assert.equal(error instanceof Error, true);
+      assert.ok(error.message.includes("baseDependencies"));
+      assert.ok(
+        error.message.includes(
+          '- panel: dependency "@base-ui/react" is declared for the radix tree but only used by the base tree; move it to baseDependencies',
+        ),
+      );
+      return true;
+    },
+  );
+
+  assert.doesNotThrow(() =>
+    validateStyleScopedDependencies([bothImport], [bothImport]),
+  );
+
+  assert.doesNotThrow(() =>
+    validateStyleScopedDependencies([neitherImport], [neitherImport]),
   );
 });

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -27,7 +27,10 @@ const PROJECT_PACKAGE_IMPORTS = new Set([
 ]);
 
 type RegistryFile = NonNullable<RegistryItem["files"]>[number];
-type RegistryBuildItem = Omit<RegistryItem, "baseRegistryDependencies">;
+type RegistryBuildItem = Omit<
+  RegistryItem,
+  "baseRegistryDependencies" | "radixDependencies" | "baseDependencies"
+>;
 type RegistryOutputFile = Omit<RegistryFile, "sourcePath"> & {
   content: string;
 };
@@ -231,34 +234,324 @@ export function validateVariantTreesDiffer(
   }
 }
 
+function collectDataSlots(content: string) {
+  const slots = new Set<string>();
+  for (const match of content.matchAll(/data-slot="([^"]+)"/g)) {
+    slots.add(match[1]!);
+  }
+  return slots;
+}
+
+function formatSetDifference(onlyInRadix: string[], onlyInBase: string[]) {
+  const parts: string[] = [];
+  if (onlyInRadix.length > 0) {
+    parts.push(`radix-only: ${onlyInRadix.join(", ")}`);
+  }
+  if (onlyInBase.length > 0) {
+    parts.push(`base-only: ${onlyInBase.join(", ")}`);
+  }
+  return parts.join("; ");
+}
+
+export function validateVariantSlotParity(
+  radixBuilt: BuiltRegistryPayload[],
+  baseBuilt: BuiltRegistryPayload[],
+) {
+  const radixByName = new Map(
+    radixBuilt.map((built) => [built.payload.name, built]),
+  );
+  const findings = new Set<string>();
+
+  for (const base of baseBuilt) {
+    if (base.baseVariantOutputPaths.length === 0) continue;
+
+    const radix = radixByName.get(base.payload.name);
+    if (!radix) {
+      findings.add(
+        `${base.payload.name}: base variant exists but radix payload is missing`,
+      );
+      continue;
+    }
+
+    for (const filePath of base.baseVariantOutputPaths) {
+      const radixContent = radix.payload.files?.find(
+        (file) => file.path === filePath,
+      )?.content;
+      const baseContent = base.payload.files?.find(
+        (file) => file.path === filePath,
+      )?.content;
+
+      if (radixContent === undefined || baseContent === undefined) {
+        findings.add(
+          `${base.payload.name}: missing emitted content for ${filePath} while comparing radix and base slots`,
+        );
+        continue;
+      }
+
+      const radixSlots = collectDataSlots(radixContent);
+      const baseSlots = collectDataSlots(baseContent);
+      const onlyInRadix = [...radixSlots]
+        .filter((slot) => !baseSlots.has(slot))
+        .sort();
+      const onlyInBase = [...baseSlots]
+        .filter((slot) => !radixSlots.has(slot))
+        .sort();
+
+      if (onlyInRadix.length > 0 || onlyInBase.length > 0) {
+        findings.add(
+          `${base.payload.name}: data-slot attributes differ for ${filePath} (${formatSetDifference(onlyInRadix, onlyInBase)})`,
+        );
+      }
+    }
+  }
+
+  if (findings.size > 0) {
+    throw new Error(
+      `Invalid variant slot parity:\n${[...findings]
+        .map((finding) => `- ${finding}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+function collectExportedNames(content: string, filePath: string) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    getScriptKind(filePath),
+  );
+  const names = new Set<string>();
+
+  for (const stmt of sourceFile.statements) {
+    if (
+      ts.isExportDeclaration(stmt) &&
+      stmt.exportClause &&
+      ts.isNamedExports(stmt.exportClause)
+    ) {
+      for (const element of stmt.exportClause.elements) {
+        names.add(element.name.text);
+      }
+    }
+
+    if (
+      ts.canHaveModifiers(stmt) &&
+      ts.getModifiers(stmt)?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      if (
+        (ts.isFunctionDeclaration(stmt) ||
+          ts.isClassDeclaration(stmt) ||
+          ts.isTypeAliasDeclaration(stmt) ||
+          ts.isInterfaceDeclaration(stmt) ||
+          ts.isEnumDeclaration(stmt)) &&
+        stmt.name
+      ) {
+        names.add(stmt.name.text);
+      } else if (ts.isVariableStatement(stmt)) {
+        for (const declaration of stmt.declarationList.declarations) {
+          if (ts.isIdentifier(declaration.name)) {
+            names.add(declaration.name.getText(sourceFile));
+          }
+        }
+      }
+    }
+
+    if (ts.isExportAssignment(stmt)) {
+      names.add("default");
+    }
+  }
+
+  return names;
+}
+
+export function validateVariantExportParity(
+  radixBuilt: BuiltRegistryPayload[],
+  baseBuilt: BuiltRegistryPayload[],
+) {
+  const radixByName = new Map(
+    radixBuilt.map((built) => [built.payload.name, built]),
+  );
+  const findings = new Set<string>();
+
+  for (const base of baseBuilt) {
+    if (base.baseVariantOutputPaths.length === 0) continue;
+
+    const radix = radixByName.get(base.payload.name);
+    if (!radix) {
+      findings.add(
+        `${base.payload.name}: base variant exists but radix payload is missing`,
+      );
+      continue;
+    }
+
+    for (const filePath of base.baseVariantOutputPaths) {
+      const radixContent = radix.payload.files?.find(
+        (file) => file.path === filePath,
+      )?.content;
+      const baseContent = base.payload.files?.find(
+        (file) => file.path === filePath,
+      )?.content;
+
+      if (radixContent === undefined || baseContent === undefined) {
+        findings.add(
+          `${base.payload.name}: missing emitted content for ${filePath} while comparing radix and base exports`,
+        );
+        continue;
+      }
+
+      const radixExports = collectExportedNames(radixContent, filePath);
+      const baseExports = collectExportedNames(baseContent, filePath);
+      const onlyInRadix = [...radixExports]
+        .filter((name) => !baseExports.has(name))
+        .sort();
+      const onlyInBase = [...baseExports]
+        .filter((name) => !radixExports.has(name))
+        .sort();
+
+      if (onlyInRadix.length > 0 || onlyInBase.length > 0) {
+        findings.add(
+          `${base.payload.name}: exported symbols differ for ${filePath} (${formatSetDifference(onlyInRadix, onlyInBase)})`,
+        );
+      }
+    }
+  }
+
+  if (findings.size > 0) {
+    throw new Error(
+      `Invalid variant export parity:\n${[...findings]
+        .map((finding) => `- ${finding}`)
+        .join("\n")}`,
+    );
+  }
+}
+
+function collectUsedPackages(payload: RegistryOutputItem) {
+  const packages = new Set<string>();
+
+  for (const file of payload.files ?? []) {
+    for (const specifier of collectModuleSpecifiers(file)) {
+      if (specifier.startsWith(".") || specifier.startsWith("@/")) continue;
+      packages.add(getPackageName(specifier));
+    }
+  }
+
+  for (const packageName of collectCssPackageImports(payload.css)) {
+    packages.add(packageName);
+  }
+
+  return packages;
+}
+
+export function validateStyleScopedDependencies(
+  radixBuilt: BuiltRegistryPayload[],
+  baseBuilt: BuiltRegistryPayload[],
+) {
+  const radixByName = new Map(
+    radixBuilt.map((built) => [built.payload.name, built]),
+  );
+  const findings = new Set<string>();
+
+  for (const base of baseBuilt) {
+    const radix = radixByName.get(base.payload.name);
+    if (!radix) continue;
+
+    const radixUsed = collectUsedPackages(radix.payload);
+    const baseUsed = collectUsedPackages(base.payload);
+
+    for (const dependency of radix.payload.dependencies ?? []) {
+      if (!radixUsed.has(dependency) && baseUsed.has(dependency)) {
+        findings.add(
+          `${base.payload.name}: dependency "${dependency}" is declared for the radix tree but only used by the base tree; move it to baseDependencies`,
+        );
+      }
+    }
+
+    for (const dependency of base.payload.dependencies ?? []) {
+      if (!baseUsed.has(dependency) && radixUsed.has(dependency)) {
+        findings.add(
+          `${base.payload.name}: dependency "${dependency}" is declared for the base tree but only used by the radix tree; move it to radixDependencies`,
+        );
+      }
+    }
+  }
+
+  if (findings.size > 0) {
+    throw new Error(
+      `Invalid style-scoped dependencies:\n${[...findings]
+        .map((finding) => `- ${finding}`)
+        .join("\n")}`,
+    );
+  }
+}
+
 function getAssistantRegistryDependencyName(dependency: string) {
   return ASSISTANT_REGISTRY_DEPENDENCY_RE.exec(dependency)?.[1] ?? null;
 }
 
 export function createRadixRegistryItem(item: RegistryItem): RegistryBuildItem {
-  const { baseRegistryDependencies: _, ...radixItem } = item;
-  return radixItem;
+  const {
+    baseRegistryDependencies: _,
+    radixDependencies,
+    baseDependencies: __,
+    ...radixItem
+  } = item;
+
+  const hasDependencies =
+    radixItem.dependencies !== undefined || radixDependencies !== undefined;
+
+  if (!hasDependencies) return radixItem;
+
+  return {
+    ...radixItem,
+    dependencies: [
+      ...new Set([
+        ...(radixItem.dependencies ?? []),
+        ...(radixDependencies ?? []),
+      ]),
+    ],
+  };
 }
 
 export function createBaseRegistryItem(item: RegistryItem): RegistryBuildItem {
-  const { baseRegistryDependencies, ...baseItem } = item;
+  const {
+    baseRegistryDependencies,
+    radixDependencies: _,
+    baseDependencies,
+    ...baseItem
+  } = item;
+
   const hasRegistryDependencies =
     baseItem.registryDependencies !== undefined ||
     baseRegistryDependencies !== undefined;
 
-  if (!hasRegistryDependencies) return baseItem;
+  const hasDependencies =
+    baseItem.dependencies !== undefined || baseDependencies !== undefined;
 
-  const registryDependencies = [
-    ...(baseItem.registryDependencies ?? []),
-    ...(baseRegistryDependencies ?? []),
-  ].map((dependency) => {
-    const name = getAssistantRegistryDependencyName(dependency);
-    return name ? `https://r.assistant-ui.com/base/${name}.json` : dependency;
-  });
+  let result = baseItem;
+
+  if (hasRegistryDependencies) {
+    const registryDependencies = [
+      ...(baseItem.registryDependencies ?? []),
+      ...(baseRegistryDependencies ?? []),
+    ].map((dependency) => {
+      const name = getAssistantRegistryDependencyName(dependency);
+      return name ? `https://r.assistant-ui.com/base/${name}.json` : dependency;
+    });
+
+    result = {
+      ...result,
+      registryDependencies: [...new Set(registryDependencies)],
+    };
+  }
+
+  if (!hasDependencies) return result;
 
   return {
-    ...baseItem,
-    registryDependencies: [...new Set(registryDependencies)],
+    ...result,
+    dependencies: [
+      ...new Set([...(result.dependencies ?? []), ...(baseDependencies ?? [])]),
+    ],
   };
 }
 
@@ -482,6 +775,9 @@ async function buildRegistry(registry: RegistryItem[]) {
   validateBaseVariantContent(baseBuilt);
   validateRadixPassDidNotReadBaseSources(radixBuilt);
   validateVariantTreesDiffer(radixBuilt, baseBuilt);
+  validateVariantSlotParity(radixBuilt, baseBuilt);
+  validateVariantExportParity(radixBuilt, baseBuilt);
+  validateStyleScopedDependencies(radixBuilt, baseBuilt);
 
   const payloads = radixBuilt.map((built) => built.payload);
   const basePayloads = baseBuilt.map((built) => built.payload);

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -325,14 +325,23 @@ function collectExportedNames(content: string, filePath: string) {
   const names = new Set<string>();
 
   for (const stmt of sourceFile.statements) {
+    if (ts.isExportDeclaration(stmt) && stmt.exportClause) {
+      if (ts.isNamedExports(stmt.exportClause)) {
+        for (const element of stmt.exportClause.elements) {
+          names.add(element.name.text);
+        }
+      } else if (ts.isNamespaceExport(stmt.exportClause)) {
+        names.add(stmt.exportClause.name.text);
+      }
+    }
+
     if (
       ts.isExportDeclaration(stmt) &&
-      stmt.exportClause &&
-      ts.isNamedExports(stmt.exportClause)
+      !stmt.exportClause &&
+      stmt.moduleSpecifier &&
+      isStringLiteralLike(stmt.moduleSpecifier)
     ) {
-      for (const element of stmt.exportClause.elements) {
-        names.add(element.name.text);
-      }
+      names.add(`*:${stmt.moduleSpecifier.text}`);
     }
 
     if (
@@ -347,7 +356,13 @@ function collectExportedNames(content: string, filePath: string) {
           ts.isEnumDeclaration(stmt)) &&
         stmt.name
       ) {
-        names.add(stmt.name.text);
+        names.add(
+          ts
+            .getModifiers(stmt)
+            ?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)
+            ? "default"
+            : stmt.name.text,
+        );
       } else if (ts.isVariableStatement(stmt)) {
         for (const declaration of stmt.declarationList.declarations) {
           if (ts.isIdentifier(declaration.name)) {

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -253,7 +253,7 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx",
       },
     ],
-    dependencies: ["radix-ui"],
+    radixDependencies: ["radix-ui"],
     registryDependencies: ["tooltip", "button"],
   },
   {

--- a/apps/registry/src/schema.ts
+++ b/apps/registry/src/schema.ts
@@ -44,6 +44,8 @@ export const registryItemSchema = z.object({
   devDependencies: z.array(z.string()).optional(),
   registryDependencies: z.array(z.string()).optional(),
   baseRegistryDependencies: z.array(z.string()).optional(),
+  radixDependencies: z.array(z.string()).optional(),
+  baseDependencies: z.array(z.string()).optional(),
   files: z.array(registryItemFileSchema).optional(),
   tailwind: registryItemTailwindSchema.optional(),
   cssVars: registryItemCssVarsSchema.optional(),


### PR DESCRIPTION
## summary

- the registry build now fails when a component's radix and base variants drift apart on their structural contract: mismatched `data-slot` sets, mismatched exported symbols, or an npm dependency that only one tree's content actually imports
- new optional schema fields `radixDependencies` / `baseDependencies` declare style-scoped npm dependencies; they merge into `dependencies` per tree at build time, mirroring the existing `baseRegistryDependencies` semantics
- `tooltip-icon-button` moves `radix-ui` into `radixDependencies`, so `dist/base/tooltip-icon-button.json` stops installing Radix into Base UI projects (its base variant never imports it)
- no new CI wiring: the validators run inside `build-registry.ts`, which the Build Changed Packages job already executes for any PR touching `packages/ui` or `apps/registry`, and the new tests ride the existing `pnpm test` script there

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/shadcn-registry test` -> 19/19 pass (covers the three validators, both dependency merge helpers, and the default/star re-export edge cases)
- [x] `pnpm --filter @assistant-ui/shadcn-registry build` -> green against the real registry; `dist/base/tooltip-icon-button.json` no longer lists `radix-ui` while `dist/tooltip-icon-button.json` still does
- [x] adversarial checks: applying the #4706 diff fails the build with the slot parity error naming the three missing slots; adding an export to `reasoning.tsx` alone fails export parity; keeping `radix-ui` in shared `dependencies` fails the dependency validator with the move to `radixDependencies` message

### reviewer should verify

- [ ] change any `data-slot` value in a paired component on one side only (for example `reasoning.tsx` without `reasoning.base.tsx`) and run `pnpm --filter @assistant-ui/shadcn-registry build`; the build should fail naming the item, file, and slot

## notes

- the drift class this guards against surfaced while reviewing #4706 (a radix-side-only ScrollArea change); that PR will fail the new slot parity check on its next CI run until its base variant is updated
- class-string-only styling drift between variants is deliberately out of scope (checking it would be all false positives); slots, exports, and dependencies are the structural contract
- `baseDependencies` has no user yet; it becomes relevant once a base variant imports `@base-ui/react` directly

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


