### PR TITLE
docs: rework voice guides into realtime, dictation, and speech story

### DIFF
--- a/apps/docs/content/docs/guides/dictation.mdx
+++ b/apps/docs/content/docs/guides/dictation.mdx
@@ -6,19 +6,15 @@ platforms: ["react"]
 
 import { DictationSample } from "@/components/docs/samples/dictation";
 
-assistant-ui supports speech-to-text (dictation) via the `DictationAdapter` interface. This allows users to input messages using their voice.
+assistant-ui supports speech-to-text (dictation) via the `DictationAdapter` interface. Users speak into the microphone and transcribed text lands in the composer, either as interim preview or as committed final text.
+
+Dictation is the push-to-talk input mode. For a live duplex conversation, see [Realtime Voice](/docs/guides/voice). For reading messages aloud, see [Speech](/docs/guides/speech).
 
 <DictationSample />
 
-## DictationAdapter
+## WebSpeechDictationAdapter
 
-Currently, the following dictation adapters are supported:
-
-- `WebSpeechDictationAdapter`: Uses the browser's `Web Speech API` (SpeechRecognition)
-
-The `WebSpeechDictationAdapter` is supported in Chrome, Edge, and Safari. Check [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility) for details.
-
-## Configuration
+The zero-config built-in adapter uses the browser's Web Speech API (`SpeechRecognition` / `webkitSpeechRecognition`). It works in Chrome, Edge, and Safari. Check [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition#browser_compatibility) for details.
 
 ```tsx
 import { WebSpeechDictationAdapter } from "@assistant-ui/react";
@@ -26,18 +22,94 @@ import { WebSpeechDictationAdapter } from "@assistant-ui/react";
 const runtime = useChatRuntime({
   adapters: {
     dictation: new WebSpeechDictationAdapter({
-      // Optional configuration
-      language: "en-US",         // Language for recognition (default: browser language)
-      continuous: true,          // Keep recording after user stops (default: true)
-      interimResults: true,      // Return interim results (default: true)
+      language: "en-US", // default: browser language
+      continuous: true, // keep recording after pauses (default: true)
+      interimResults: true, // emit interim transcripts (default: true)
     }),
   },
 });
 ```
 
-## UI
+You can gate the feature on browser support:
 
-The dictation feature uses `ComposerPrimitive.Dictate` and `ComposerPrimitive.StopDictation` components.
+```tsx
+import { WebSpeechDictationAdapter } from "@assistant-ui/react";
+
+if (WebSpeechDictationAdapter.isSupported()) {
+  // Dictation is available
+}
+```
+
+## DictationAdapter interface
+
+Custom providers implement the same contract. The interface is defined in `@assistant-ui/core` and re-exported from `@assistant-ui/react`:
+
+```tsx
+import type { DictationAdapter } from "@assistant-ui/react";
+
+type DictationAdapter = {
+  listen: () => DictationAdapter.Session;
+  disableInputDuringDictation?: boolean;
+};
+
+namespace DictationAdapter {
+  type Status =
+    | { type: "starting" | "running" }
+    | {
+        type: "ended";
+        reason: "stopped" | "cancelled" | "error";
+      };
+
+  type Result = {
+    transcript: string;
+    isFinal?: boolean;
+  };
+
+  type Session = {
+    status: Status;
+    stop: () => Promise<void>;
+    cancel: () => void;
+    onSpeechStart: (callback: () => void) => Unsubscribe;
+    onSpeechEnd: (callback: (result: Result) => void) => Unsubscribe;
+    onSpeech: (callback: (result: Result) => void) => Unsubscribe;
+  };
+}
+```
+
+`listen()` starts a session. The session reports status, accepts `stop` / `cancel`, and emits speech events through the three `on*` methods (each returns an unsubscribe function).
+
+### Interim vs final results
+
+The `onSpeech` callback receives results with an optional `isFinal` flag:
+
+- `isFinal: true` (or omitted): text is committed into the composer input.
+- `isFinal: false`: text is shown as a preview that later interim results replace until a final result commits it.
+
+Both interim and final results render in the input field, similar to native dictation on mobile.
+
+### Disabling input during dictation
+
+Some services return cumulative transcripts that conflict with simultaneous typing. Set `disableInputDuringDictation` to block the text input while a session is active:
+
+```tsx
+import type { DictationAdapter } from "@assistant-ui/react";
+
+class MyAdapter implements DictationAdapter {
+  disableInputDuringDictation = true;
+
+  listen() {
+    // ...
+  }
+}
+```
+
+<Callout type="info">
+  When a message is sent during an active dictation session, the session is automatically stopped.
+</Callout>
+
+## UI: ComposerPrimitive.Dictate
+
+The dictation trigger is `ComposerPrimitive.Dictate`. Pair it with `ComposerPrimitive.StopDictation` to end the session. Both live under `ComposerPrimitive` in `@assistant-ui/react`.
 
 ```tsx
 import { AuiIf, ComposerPrimitive } from "@assistant-ui/react";
@@ -47,14 +119,12 @@ const ComposerWithDictation = () => (
   <ComposerPrimitive.Root>
     <ComposerPrimitive.Input />
 
-    {/* Show Dictate button when not dictating */}
     <AuiIf condition={(s) => s.composer.dictation == null}>
       <ComposerPrimitive.Dictate>
         <MicIcon />
       </ComposerPrimitive.Dictate>
     </AuiIf>
 
-    {/* Show Stop button when dictating */}
     <AuiIf condition={(s) => s.composer.dictation != null}>
       <ComposerPrimitive.StopDictation>
         <SquareIcon className="animate-pulse" />
@@ -66,305 +136,156 @@ const ComposerWithDictation = () => (
 );
 ```
 
-## Browser Compatibility Check
+`ComposerPrimitive.Dictate` is disabled when no dictation adapter is configured. For a separate interim transcript display, `ComposerPrimitive.DictationTranscript` and `composer.dictation?.transcript` are available.
 
-You can check if the browser supports dictation:
+## Server-side transcription
 
-```tsx
-import { WebSpeechDictationAdapter } from "@assistant-ui/react";
+Browser speech recognition is convenient, but production apps often need higher accuracy, more languages, or a consistent model across devices. Implement a custom `DictationAdapter` that records audio with `MediaRecorder`, then POST the blob to a Next.js route that calls the AI SDK's `transcribe` API.
 
-if (WebSpeechDictationAdapter.isSupported()) {
-  // Dictation is available
-}
-```
+### API route
 
-## Disabling Input During Dictation
+```ts title="app/api/transcribe/route.ts"
+import { transcribe } from "ai";
+import { openai } from "@ai-sdk/openai";
 
-Some dictation services (like ElevenLabs Scribe) return cumulative transcripts that conflict with simultaneous typing. You can disable the text input during dictation:
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const audio = formData.get("audio");
 
-```tsx
-import type { DictationAdapter } from "@assistant-ui/react";
-
-class MyAdapter implements DictationAdapter {
-  // Set to true to disable typing while dictating
-  disableInputDuringDictation = true;
-
-  listen() { /* ... */ }
-}
-```
-
-<Callout type="info">
-  When a message is sent during an active dictation session, the session is automatically stopped.
-</Callout>
-
-## Custom Adapters
-
-You can create custom adapters to integrate with any dictation service by implementing the `DictationAdapter` interface.
-
-### DictationAdapter Interface
-
-```tsx
-import type { DictationAdapter } from "@assistant-ui/react";
-
-class MyCustomDictationAdapter implements DictationAdapter {
-  // Optional: disable text input while dictating (default: false)
-  disableInputDuringDictation?: boolean;
-
-  listen(): DictationAdapter.Session {
-    // Return a session object that manages the dictation
-    return {
-      status: { type: "starting" },
-
-      stop: async () => {
-        // Stop recognition and finalize results
-      },
-
-      cancel: () => {
-        // Cancel recognition without finalizing
-      },
-
-      onSpeechStart: (callback) => {
-        // Called when speech is detected
-        return () => {}; // Return unsubscribe function
-      },
-
-      onSpeechEnd: (callback) => {
-        // Called when recognition ends with final result
-        return () => {};
-      },
-
-      onSpeech: (callback) => {
-        // Called with transcription results
-        // callback({ transcript: "text", isFinal: true })
-        //
-        // isFinal: true  → Append to composer input (default)
-        // isFinal: false → Show as preview only
-        return () => {};
-      },
-    };
-  }
-}
-```
-
-### Interim vs Final Results
-
-The `onSpeech` callback receives results with an optional `isFinal` flag:
-
-```tsx
-onSpeech: (callback) => {
-  // callback({ transcript: "text", isFinal: true })
-  // - isFinal: true  → Text is committed to the input
-  // - isFinal: false → Text is shown as preview in the input
-  return () => {};
-},
-```
-
-**Both interim and final results are displayed directly in the input field**, just like native dictation on iOS/Android. Interim results replace each other until a final result commits the text. This provides seamless real-time feedback while the user speaks.
-
-### Example: ElevenLabs Scribe v2 Realtime
-
-[ElevenLabs Scribe](https://elevenlabs.io/docs/capabilities/speech-to-text) provides ultra-low latency (~150ms) real-time transcription via WebSocket.
-
-#### Install Dependencies
-
-```bash
-npm install @elevenlabs/client
-```
-
-#### Backend API Route
-
-Create an API route to generate single-use tokens:
-
-```ts title="app/api/scribe-token/route.ts"
-export async function POST() {
-  const response = await fetch(
-    "https://api.elevenlabs.io/v1/single-use-token/realtime_scribe",
-    {
-      method: "POST",
-      headers: {
-        "xi-api-key": process.env.ELEVENLABS_API_KEY!,
-      },
-    }
-  );
-
-  const data = await response.json();
-  return Response.json({ token: data.token });
-}
-```
-
-#### Frontend Adapter
-
-```tsx title="lib/elevenlabs-scribe-adapter.ts"
-import type { DictationAdapter } from "@assistant-ui/react";
-import { Scribe, RealtimeEvents } from "@elevenlabs/client";
-
-export class ElevenLabsScribeAdapter implements DictationAdapter {
-  private tokenEndpoint: string;
-  private languageCode: string;
-
-  // ElevenLabs returns cumulative transcripts, so we disable typing during dictation
-  public disableInputDuringDictation: boolean;
-
-  constructor(options: {
-    tokenEndpoint: string;
-    languageCode?: string;
-    disableInputDuringDictation?: boolean;
-  }) {
-    this.tokenEndpoint = options.tokenEndpoint;
-    this.languageCode = options.languageCode ?? "en";
-    this.disableInputDuringDictation = options.disableInputDuringDictation ?? true;
+  if (!(audio instanceof Blob)) {
+    return Response.json({ error: "audio required" }, { status: 400 });
   }
 
-  listen(): DictationAdapter.Session {
-    const callbacks = {
-      start: new Set<() => void>(),
-      end: new Set<(r: DictationAdapter.Result) => void>(),
-      speech: new Set<(r: DictationAdapter.Result) => void>(),
-    };
+  const result = await transcribe({
+    model: openai.transcription("whisper-1"),
+    audio: new Uint8Array(await audio.arrayBuffer()),
+  });
 
-    let connection: ReturnType<typeof Scribe.connect> | null = null;
-    let fullTranscript = "";
+  return Response.json({ text: result.text });
+}
+```
+
+`transcribe` is the stable export on the `ai` package. It accepts a transcription model and audio as `DataContent` (for example a `Uint8Array`) or a `URL`, and returns a `TranscriptionResult` whose `text` field is the full transcript.
+
+### Adapter
+
+```tsx title="lib/server-dictation-adapter.ts"
+import type { DictationAdapter } from "@assistant-ui/react";
+
+export class ServerDictationAdapter implements DictationAdapter {
+  constructor(private endpoint = "/api/transcribe") {}
+
+  listen(): DictationAdapter.Session {
+    const speechStart = new Set<() => void>();
+    const speechEnd = new Set<(r: DictationAdapter.Result) => void>();
+    const speech = new Set<(r: DictationAdapter.Result) => void>();
+
+    let mediaRecorder: MediaRecorder | null = null;
+    let stream: MediaStream | null = null;
+    const chunks: BlobPart[] = [];
 
     const session: DictationAdapter.Session = {
       status: { type: "starting" },
 
       stop: async () => {
-        if (connection) {
-          connection.commit();
-          await new Promise((r) => setTimeout(r, 500));
-          connection.close();
-        }
-        if (fullTranscript) {
-          for (const cb of callbacks.end) cb({ transcript: fullTranscript });
-        }
+        mediaRecorder?.stop();
       },
 
       cancel: () => {
-        connection?.close();
+        mediaRecorder?.stop();
+        stream?.getTracks().forEach((t) => t.stop());
+        session.status = { type: "ended", reason: "cancelled" };
       },
 
       onSpeechStart: (cb) => {
-        callbacks.start.add(cb);
-        return () => callbacks.start.delete(cb);
+        speechStart.add(cb);
+        return () => speechStart.delete(cb);
       },
-
       onSpeechEnd: (cb) => {
-        callbacks.end.add(cb);
-        return () => callbacks.end.delete(cb);
+        speechEnd.add(cb);
+        return () => speechEnd.delete(cb);
       },
-
       onSpeech: (cb) => {
-        callbacks.speech.add(cb);
-        return () => callbacks.speech.delete(cb);
+        speech.add(cb);
+        return () => speech.delete(cb);
       },
     };
 
-    this.connect(session, callbacks, {
-      setConnection: (c) => { connection = c; },
-      getFullTranscript: () => fullTranscript,
-      setFullTranscript: (t) => { fullTranscript = t; },
-    });
+    void (async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        mediaRecorder = new MediaRecorder(stream);
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data.size > 0) chunks.push(e.data);
+        };
+        mediaRecorder.onstart = () => {
+          session.status = { type: "running" };
+          for (const cb of speechStart) cb();
+        };
+        mediaRecorder.onstop = async () => {
+          stream?.getTracks().forEach((t) => t.stop());
+          try {
+            const blob = new Blob(chunks, {
+              type: mediaRecorder?.mimeType || "audio/webm",
+            });
+            const body = new FormData();
+            body.append("audio", blob, "dictation.webm");
+
+            const res = await fetch(this.endpoint, {
+              method: "POST",
+              body,
+            });
+            if (!res.ok) throw new Error("transcription failed");
+
+            const { text } = (await res.json()) as { text: string };
+            const result: DictationAdapter.Result = {
+              transcript: text,
+              isFinal: true,
+            };
+            for (const cb of speech) cb(result);
+            for (const cb of speechEnd) cb(result);
+            session.status = { type: "ended", reason: "stopped" };
+          } catch {
+            session.status = { type: "ended", reason: "error" };
+          }
+        };
+        mediaRecorder.start();
+      } catch {
+        session.status = { type: "ended", reason: "error" };
+      }
+    })();
 
     return session;
-  }
-
-  private async connect(
-    session: DictationAdapter.Session,
-    callbacks: {
-      start: Set<() => void>;
-      end: Set<(r: DictationAdapter.Result) => void>;
-      speech: Set<(r: DictationAdapter.Result) => void>;
-    },
-    refs: {
-      setConnection: (c: ReturnType<typeof Scribe.connect>) => void;
-      getFullTranscript: () => string;
-      setFullTranscript: (t: string) => void;
-    }
-  ) {
-    try {
-      // 1. Get token from backend
-      const tokenRes = await fetch(this.tokenEndpoint, { method: "POST" });
-      const { token } = await tokenRes.json();
-
-      // 2. Connect to Scribe with microphone
-      const connection = Scribe.connect({
-        token,
-        modelId: "scribe_v2_realtime",
-        languageCode: this.languageCode,
-        microphone: {
-          echoCancellation: true,
-          noiseSuppression: true,
-        },
-      });
-      refs.setConnection(connection);
-
-      // 3. Handle events
-      connection.on(RealtimeEvents.SESSION_STARTED, () => {
-        (session as { status: DictationAdapter.Status }).status = {
-          type: "running",
-        };
-        for (const cb of callbacks.start) cb();
-      });
-
-      // Partial transcripts → preview (isFinal: false)
-      connection.on(RealtimeEvents.PARTIAL_TRANSCRIPT, (data) => {
-        if (data.text) {
-          for (const cb of callbacks.speech)
-            cb({ transcript: data.text, isFinal: false });
-        }
-      });
-
-      // Committed transcripts → append to input (isFinal: true)
-      connection.on(RealtimeEvents.COMMITTED_TRANSCRIPT, (data) => {
-        if (data.text?.trim()) {
-          refs.setFullTranscript(refs.getFullTranscript() + data.text + " ");
-          for (const cb of callbacks.speech)
-            cb({ transcript: data.text, isFinal: true });
-        }
-      });
-
-      connection.on(RealtimeEvents.ERROR, (error) => {
-        console.error("Scribe error:", error);
-        (session as { status: DictationAdapter.Status }).status = {
-          type: "ended",
-          reason: "error",
-        };
-      });
-
-    } catch (error) {
-      console.error("ElevenLabs Scribe connection failed:", error);
-      (session as { status: DictationAdapter.Status }).status = {
-        type: "ended",
-        reason: "error",
-      };
-    }
   }
 }
 ```
 
-#### Usage
+Wire it like any other adapter:
 
 ```tsx
+import { ServerDictationAdapter } from "@/lib/server-dictation-adapter";
+
 const runtime = useChatRuntime({
   adapters: {
-    dictation: new ElevenLabsScribeAdapter({
-      tokenEndpoint: "/api/scribe-token",
-      languageCode: "en", // Optional: supports 90+ languages
-      disableInputDuringDictation: true, // Default: true (recommended for ElevenLabs)
-    }),
+    dictation: new ServerDictationAdapter("/api/transcribe"),
   },
 });
 ```
 
-#### Real-time Preview
+This pattern records until the user stops dictation, then commits a single final transcript. For streaming partials, keep the same `DictationAdapter` surface and emit `isFinal: false` results as your provider produces them.
 
-The transcription is displayed directly in the input field as the user speaks — just like native dictation. No additional UI components are needed for basic use cases.
+## Custom realtime providers
 
-<Callout type="info">
-  For advanced customization, `composer.dictation?.transcript` contains the current interim transcript, and `ComposerPrimitive.DictationTranscript` can display it separately if desired.
-</Callout>
+You can implement `DictationAdapter` against any streaming STT service. [ElevenLabs Scribe](https://elevenlabs.io/docs/capabilities/speech-to-text) is one option for low-latency WebSocket transcription; scaffold a full example with:
 
-<Callout type="info">
-  For more details, see the [ElevenLabs Scribe documentation](https://elevenlabs.io/docs/capabilities/speech-to-text).
-</Callout>
+```bash
+npx assistant-ui create my-app -e with-elevenlabs-scribe
+```
 
+Cumulative transcript services should set `disableInputDuringDictation: true` so interim text does not fight the user's keyboard.
+
+## Related guides
+
+- [Realtime Voice](/docs/guides/voice): duplex voice sessions (`RealtimeVoiceAdapter`, `createVoiceSession`, voice UI component).
+- [Speech](/docs/guides/speech): text-to-speech for assistant messages.
+- [Speech and Dictation API reference](/docs/api-reference/voice/speech-dictation): generated type docs.

--- a/apps/docs/content/docs/guides/dictation.mdx
+++ b/apps/docs/content/docs/guides/dictation.mdx
@@ -216,6 +216,10 @@ export class ServerDictationAdapter implements DictationAdapter {
     void (async () => {
       try {
         stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
         mediaRecorder = new MediaRecorder(stream);
         mediaRecorder.ondataavailable = (e) => {
           if (e.data.size > 0) chunks.push(e.data);

--- a/apps/docs/content/docs/guides/dictation.mdx
+++ b/apps/docs/content/docs/guides/dictation.mdx
@@ -182,6 +182,7 @@ export class ServerDictationAdapter implements DictationAdapter {
 
     let mediaRecorder: MediaRecorder | null = null;
     let stream: MediaStream | null = null;
+    let cancelled = false;
     const chunks: BlobPart[] = [];
 
     const session: DictationAdapter.Session = {
@@ -192,6 +193,7 @@ export class ServerDictationAdapter implements DictationAdapter {
       },
 
       cancel: () => {
+        cancelled = true;
         mediaRecorder?.stop();
         stream?.getTracks().forEach((t) => t.stop());
         session.status = { type: "ended", reason: "cancelled" };
@@ -224,6 +226,7 @@ export class ServerDictationAdapter implements DictationAdapter {
         };
         mediaRecorder.onstop = async () => {
           stream?.getTracks().forEach((t) => t.stop());
+          if (cancelled) return;
           try {
             const blob = new Blob(chunks, {
               type: mediaRecorder?.mimeType || "audio/webm",

--- a/apps/docs/content/docs/guides/speech.mdx
+++ b/apps/docs/content/docs/guides/speech.mdx
@@ -8,11 +8,13 @@ import { SpeechSample } from "@/components/docs/samples/speech";
 
 assistant-ui supports text-to-speech via the `SpeechSynthesisAdapter` interface. When a speech adapter is configured, users can trigger playback for any assistant message.
 
+Speech is the read-aloud mode: one message at a time, text to audio. For a live duplex conversation, see [Realtime Voice](/docs/guides/voice). For push-to-talk input into the composer, see [Dictation](/docs/guides/dictation).
+
 <SpeechSample />
 
 ## SpeechSynthesisAdapter
 
-The `SpeechSynthesisAdapter` interface has a single method:
+The adapter has a single method. The type lives in `@assistant-ui/core` and is re-exported from `@assistant-ui/react`:
 
 ```tsx
 import type { SpeechSynthesisAdapter } from "@assistant-ui/react";
@@ -22,25 +24,29 @@ type SpeechSynthesisAdapter = {
 };
 ```
 
-`speak` is called with the plain text of an assistant message and must return an `Utterance` object:
+`speak` receives the plain text of an assistant message and returns an `Utterance`:
 
 ```tsx
-type Utterance = {
-  status: SpeechSynthesisAdapter.Status;
-  cancel: () => void;
-  subscribe: (callback: () => void) => Unsubscribe;
-};
+namespace SpeechSynthesisAdapter {
+  type Status =
+    | { type: "starting" | "running" }
+    | {
+        type: "ended";
+        reason: "finished" | "cancelled" | "error";
+        error?: unknown;
+      };
 
-type Status =
-  | { type: "starting" | "running" }
-  | { type: "ended"; reason: "finished" | "cancelled" | "error"; error?: unknown };
+  type Utterance = {
+    status: Status;
+    cancel: () => void;
+    subscribe: (callback: () => void) => Unsubscribe;
+  };
+}
 ```
 
-Currently the following built-in adapter is available:
-
-- `WebSpeechSynthesisAdapter`: uses the browser's `Web Speech API` (`SpeechSynthesis`)
-
 ## WebSpeechSynthesisAdapter
+
+The built-in adapter uses the browser's Web Speech API (`SpeechSynthesis` / `SpeechSynthesisUtterance`):
 
 ```tsx
 import { WebSpeechSynthesisAdapter } from "@assistant-ui/react";
@@ -52,7 +58,9 @@ const runtime = useChatRuntime({
 });
 ```
 
-## UI
+When a speech adapter is provided, `capabilities.speech` is set to `true` automatically.
+
+## UI: ActionBarPrimitive.Speak
 
 The default action bar does not include a speech button. Add `ActionBarPrimitive.Speak` and `ActionBarPrimitive.StopSpeaking` to your assistant message action bar:
 
@@ -79,21 +87,17 @@ const AssistantActionBar = () => {
 };
 ```
 
-`ActionBarPrimitive.Speak` is automatically disabled when no speech adapter is configured.
+`ActionBarPrimitive.Speak` is disabled when no speech adapter is configured. While playback is active, `message.speech` holds the current speech state so the UI can switch to `StopSpeaking`.
 
-## Custom Adapters
+## Custom adapters
 
-Implement `SpeechSynthesisAdapter` to call any external TTS API:
+Implement `SpeechSynthesisAdapter` to call any external TTS provider. Fetch audio from your API, play it with `HTMLAudioElement`, and drive utterance status through `subscribe`:
 
 ```tsx title="lib/custom-tts-adapter.ts"
 import type { SpeechSynthesisAdapter } from "@assistant-ui/react";
 
 export class CustomTTSAdapter implements SpeechSynthesisAdapter {
-  private apiUrl: string;
-
-  constructor(options: { apiUrl: string }) {
-    this.apiUrl = options.apiUrl;
-  }
+  constructor(private apiUrl: string) {}
 
   speak(text: string): SpeechSynthesisAdapter.Utterance {
     const subscribers = new Set<() => void>();
@@ -104,7 +108,10 @@ export class CustomTTSAdapter implements SpeechSynthesisAdapter {
       for (const cb of subscribers) cb();
     };
 
-    const finish = (reason: "finished" | "cancelled" | "error", error?: unknown) => {
+    const finish = (
+      reason: "finished" | "cancelled" | "error",
+      error?: unknown,
+    ) => {
       if (status.type === "ended") return;
       status = { type: "ended", reason, error };
       notify();
@@ -122,12 +129,14 @@ export class CustomTTSAdapter implements SpeechSynthesisAdapter {
         notify();
         audio.onended = () => finish("finished");
         audio.onerror = (e) => finish("error", e);
-        audio.play();
+        void audio.play();
       })
       .catch((err) => finish("error", err));
 
     return {
-      get status() { return status; },
+      get status() {
+        return status;
+      },
       cancel: () => {
         audio?.pause();
         finish("cancelled");
@@ -141,14 +150,22 @@ export class CustomTTSAdapter implements SpeechSynthesisAdapter {
 }
 ```
 
-Wire it up the same way as the built-in adapter:
+Wire it on the same `adapters.speech` slot as the built-in adapter:
 
 ```tsx
 import { CustomTTSAdapter } from "@/lib/custom-tts-adapter";
 
 const runtime = useChatRuntime({
   adapters: {
-    speech: new CustomTTSAdapter({ apiUrl: "/api/tts" }),
+    speech: new CustomTTSAdapter("/api/tts"),
   },
 });
 ```
+
+Use this shape for any provider TTS (OpenAI, ElevenLabs, cloud speech APIs, and so on). Keep the server route responsible for API keys; the adapter only needs a URL that returns audio bytes.
+
+## Related guides
+
+- [Realtime Voice](/docs/guides/voice): duplex voice sessions with `RealtimeVoiceAdapter`, `createVoiceSession`, and the voice UI component.
+- [Dictation](/docs/guides/dictation): speech-to-text into the composer with `DictationAdapter` and `ComposerPrimitive.Dictate`.
+- [Speech and Dictation API reference](/docs/api-reference/voice/speech-dictation): generated type docs.

--- a/apps/docs/content/docs/guides/speech.mdx
+++ b/apps/docs/content/docs/guides/speech.mdx
@@ -129,7 +129,7 @@ export class CustomTTSAdapter implements SpeechSynthesisAdapter {
         notify();
         audio.onended = () => finish("finished");
         audio.onerror = (e) => finish("error", e);
-        void audio.play();
+        audio.play().catch((err) => finish("error", err));
       })
       .catch((err) => finish("error", err));
 

--- a/apps/docs/content/docs/guides/speech.mdx
+++ b/apps/docs/content/docs/guides/speech.mdx
@@ -124,6 +124,7 @@ export class CustomTTSAdapter implements SpeechSynthesisAdapter {
     })
       .then((res) => res.blob())
       .then((blob) => {
+        if (status.type === "ended") return;
         audio = new Audio(URL.createObjectURL(blob));
         status = { type: "running" };
         notify();

--- a/apps/docs/content/docs/guides/voice.mdx
+++ b/apps/docs/content/docs/guides/voice.mdx
@@ -1,60 +1,192 @@
 ---
 title: Realtime Voice Chat
-description: Build bidirectional voice conversations with AI in React — realtime audio streaming, interruption handling, and visual state, integrated via assistant-ui.
+description: Build bidirectional voice conversations with AI in React. Realtime audio streaming, interruption handling, and visual state, integrated via assistant-ui.
 platforms: ["react"]
 ---
 
 import { VoiceSample } from "@/components/docs/samples/voice";
 
-assistant-ui supports realtime bidirectional voice via the `RealtimeVoiceAdapter` interface. This enables live voice conversations where the user speaks into their microphone and the AI agent responds with audio, with transcripts appearing in the thread in real time.
+assistant-ui supports realtime bidirectional voice through the `RealtimeVoiceAdapter` interface. Users speak into their microphone, the agent answers with audio, and transcripts appear in the thread while the session runs.
 
 <VoiceSample />
 
-## How It Works
+## Three voice modes
 
-Unlike [Speech Synthesis](/docs/guides/speech) (text-to-speech) and [Dictation](/docs/guides/dictation) (speech-to-text), the voice adapter handles **both directions simultaneously** — the user's microphone audio is streamed to the agent, and the agent's audio response is played back, all while transcripts are appended to the message thread.
+assistant-ui ships three related but distinct voice capabilities. Choose the mode that matches the product surface:
 
-| Feature | Adapter | Direction |
-|---------|---------|-----------|
-| [Speech Synthesis](/docs/guides/speech) | `SpeechSynthesisAdapter` | Text → Audio (one message at a time) |
-| [Dictation](/docs/guides/dictation) | `DictationAdapter` | Audio → Text (into composer) |
-| **Realtime Voice** | `RealtimeVoiceAdapter` | Audio ↔ Audio (bidirectional, live) |
+| Mode | Guide | Adapter | Direction |
+|------|-------|---------|-----------|
+| **Realtime duplex** | this page | `RealtimeVoiceAdapter` | Audio ↔ audio, live session |
+| **Push-to-talk dictation** | [Dictation](/docs/guides/dictation) | `DictationAdapter` | Audio → text into the composer |
+| **Read-aloud** | [Speech](/docs/guides/speech) | `SpeechSynthesisAdapter` | Text → audio for one message |
+
+Realtime voice is the only mode that owns both directions at once. Dictation fills the composer; speech reads a finished message aloud.
+
+## RealtimeVoiceAdapter
+
+Implement `RealtimeVoiceAdapter` to connect any voice provider. The contract lives in `@assistant-ui/core` and is re-exported from `@assistant-ui/react`:
+
+```tsx
+import type { RealtimeVoiceAdapter } from "@assistant-ui/react";
+
+type RealtimeVoiceAdapter = {
+  connect: (options: {
+    abortSignal?: AbortSignal;
+  }) => RealtimeVoiceAdapter.Session;
+};
+```
+
+A session exposes connection state, mute controls, and event subscriptions:
+
+```tsx
+namespace RealtimeVoiceAdapter {
+  type Status =
+    | { type: "starting" | "running" }
+    | {
+        type: "ended";
+        reason: "finished" | "cancelled" | "error";
+        error?: unknown;
+      };
+
+  type Mode = "listening" | "speaking";
+
+  type TranscriptItem = {
+    role: "user" | "assistant";
+    text: string;
+    isFinal?: boolean;
+  };
+
+  type Session = {
+    status: Status;
+    isMuted: boolean;
+
+    disconnect: () => void;
+    mute: () => void;
+    unmute: () => void;
+
+    onStatusChange: (callback: (status: Status) => void) => Unsubscribe;
+    onTranscript: (
+      callback: (transcript: TranscriptItem) => void,
+    ) => Unsubscribe;
+    onModeChange: (callback: (mode: Mode) => void) => Unsubscribe;
+    onVolumeChange: (callback: (volume: number) => void) => Unsubscribe;
+  };
+}
+```
+
+Session status moves `starting` → `running` → `ended`. The `ended` status includes a reason: `"finished"`, `"cancelled"`, or `"error"` (with an optional `error` field).
+
+Transcripts from `onTranscript` are appended to the message thread automatically:
+
+- User transcripts (`role: "user"`, `isFinal: true`) become user messages.
+- Assistant transcripts (`role: "assistant"`) stream into an assistant message. The message stays in a running status until `isFinal: true`.
+
+`onModeChange` reports `"listening"` (user's turn) or `"speaking"` (agent's turn). `onVolumeChange` reports a real-time level from `0` to `1` for visual feedback such as the voice orb.
+
+## createVoiceSession
+
+`createVoiceSession` removes the manual callback-set boilerplate when you implement an adapter. Pass it the connect options and an async `setup` function that receives `VoiceSessionHelpers` and returns `VoiceSessionControls`:
+
+```tsx
+import {
+  createVoiceSession,
+  type RealtimeVoiceAdapter,
+  type VoiceSessionControls,
+  type VoiceSessionHelpers,
+} from "@assistant-ui/react";
+
+export class MyVoiceAdapter implements RealtimeVoiceAdapter {
+  connect(options: {
+    abortSignal?: AbortSignal;
+  }): RealtimeVoiceAdapter.Session {
+    return createVoiceSession(options, async (helpers: VoiceSessionHelpers) => {
+      const client = await MyVoiceClient.connect();
+
+      client.on("open", () => helpers.setStatus({ type: "running" }));
+      client.on("close", () => helpers.end("finished"));
+      client.on("error", (err: unknown) => helpers.end("error", err));
+      client.on("transcript", (item) => helpers.emitTranscript(item));
+      client.on("mode", (mode) => helpers.emitMode(mode));
+      client.on("volume", (v: number) => helpers.emitVolume(v));
+
+      const controls: VoiceSessionControls = {
+        disconnect: () => client.close(),
+        mute: () => client.setMuted(true),
+        unmute: () => client.setMuted(false),
+      };
+      return controls;
+    });
+  }
+}
+```
+
+`VoiceSessionHelpers` provides:
+
+| Helper | Role |
+|--------|------|
+| `setStatus(status)` | Update session status (for example to `{ type: "running" }`) |
+| `end(reason, error?)` | End the session and clean up subscribers |
+| `emitTranscript(item)` | Push a transcript into the thread |
+| `emitMode(mode)` | Report `"listening"` or `"speaking"` |
+| `emitVolume(volume)` | Report a level from `0` to `1` |
+| `isDisposed()` | Skip events after teardown |
+
+`createVoiceSession` wires status tracking, mute state, abort-signal disconnect, and all `on*` subscriptions for you.
 
 ## Configuration
 
-Pass a `RealtimeVoiceAdapter` implementation to the runtime via `adapters.voice`:
+Pass a `RealtimeVoiceAdapter` implementation on the runtime:
 
 ```tsx
 const runtime = useChatRuntime({
   adapters: {
-    voice: new MyVoiceAdapter({ /* ... */ }),
+    voice: new MyVoiceAdapter({ /* provider options */ }),
   },
 });
 ```
 
-When a voice adapter is provided, `capabilities.voice` is automatically set to `true`.
+When a voice adapter is provided, `capabilities.voice` is set to `true` automatically.
 
-## Hooks
+## React hooks
+
+These hooks are exported from `@assistant-ui/react` and read the active voice session on the current thread.
 
 ### useVoiceState
 
-Returns the current voice session state, or `undefined` when no session is active.
+Returns the current `VoiceSessionState`, or `undefined` when no session is active:
 
 ```tsx
-import { useVoiceState, useVoiceVolume } from "@assistant-ui/react";
+import { useVoiceState } from "@assistant-ui/react";
 
 const voiceState = useVoiceState();
-// voiceState?.status.type — "starting" | "running" | "ended"
-// voiceState?.isMuted — boolean
-// voiceState?.mode — "listening" | "speaking"
+// voiceState?.status.type: "starting" | "running" | "ended"
+// voiceState?.isMuted: boolean
+// voiceState?.mode: "listening" | "speaking"
+```
 
-const volume = useVoiceVolume();
-// volume — number (0–1, real-time audio level via separate subscription)
+`VoiceSessionState` is:
+
+```tsx
+type VoiceSessionState = {
+  readonly status: RealtimeVoiceAdapter.Status;
+  readonly isMuted: boolean;
+  readonly mode: RealtimeVoiceAdapter.Mode;
+};
+```
+
+### useVoiceVolume
+
+Subscribes to real-time audio level independently of session state:
+
+```tsx
+import { useVoiceVolume } from "@assistant-ui/react";
+
+const volume = useVoiceVolume(); // number from 0 to 1
 ```
 
 ### useVoiceControls
 
-Returns methods to control the voice session.
+Returns methods that drive the session:
 
 ```tsx
 import { useVoiceControls } from "@assistant-ui/react";
@@ -62,11 +194,9 @@ import { useVoiceControls } from "@assistant-ui/react";
 const { connect, disconnect, mute, unmute } = useVoiceControls();
 ```
 
-## UI Example
+### Headless control bar
 
-<Callout type="info">
-  For a ready-made control bar with a voice orb and call controls, see the [Voice component](/docs/ui/voice).
-</Callout>
+Build your own controls from the hooks when you need a custom layout:
 
 ```tsx
 import { useVoiceState, useVoiceControls } from "@assistant-ui/react";
@@ -102,263 +232,50 @@ function VoiceControls() {
 }
 ```
 
-## Custom Adapters
+## Voice UI component
 
-Implement the `RealtimeVoiceAdapter` interface to integrate with any voice provider.
+The fastest path is the styled `voice` registry component. It ships a `VoiceControl` bar, mute and disconnect buttons, status indicator, and animated `VoiceOrb` built on the hooks above.
 
-### RealtimeVoiceAdapter Interface
+### Install
 
-```tsx
-import type { RealtimeVoiceAdapter } from "@assistant-ui/react";
+<InstallCommand shadcn={["voice"]} />
 
-class MyVoiceAdapter implements RealtimeVoiceAdapter {
-  connect(options: {
-    abortSignal?: AbortSignal;
-  }): RealtimeVoiceAdapter.Session {
-    // Establish connection to your voice service
-    return {
-      get status() { /* ... */ },
-      get isMuted() { /* ... */ },
+This adds `/components/assistant-ui/voice.tsx` to your project. Adjust styling as needed.
 
-      disconnect: () => { /* ... */ },
-      mute: () => { /* ... */ },
-      unmute: () => { /* ... */ },
+### Use with a runtime
 
-      onStatusChange: (callback) => {
-        // Status: { type: "starting" } → { type: "running" } → { type: "ended", reason }
-        return () => {}; // Return unsubscribe
-      },
+```tsx title="app/page.tsx"
+import { Thread } from "@/components/assistant-ui/thread";
+import { VoiceControl } from "@/components/assistant-ui/voice";
+import { AuiIf } from "@assistant-ui/react";
 
-      onTranscript: (callback) => {
-        // callback({ role: "user" | "assistant", text: "...", isFinal: true })
-        // Transcripts are automatically appended as messages in the thread.
-        return () => {};
-      },
-
-      // Report who is speaking (drives the VoiceOrb speaking animation)
-      onModeChange: (callback) => {
-        // callback("listening") — user's turn
-        // callback("speaking") — agent's turn
-        return () => {};
-      },
-
-      // Report real-time audio level (0–1) for visual feedback
-      onVolumeChange: (callback) => {
-        // callback(0.72) — drives VoiceOrb amplitude and waveform bar heights
-        return () => {};
-      },
-    };
-  }
+export default function Chat() {
+  return (
+    <div className="flex h-full flex-col">
+      <AuiIf condition={(s) => s.thread.capabilities.voice}>
+        <VoiceControl />
+      </AuiIf>
+      <div className="min-h-0 flex-1">
+        <Thread />
+      </div>
+    </div>
+  );
 }
 ```
 
-### Session Lifecycle
-
-The session status follows the same pattern as other adapters:
-
-```mermaid
-flowchart LR
-    starting["starting"] --> running["running"] --> ended["ended"]
-```
-
-The `ended` status includes a `reason`:
-- `"finished"` — session ended normally
-- `"cancelled"` — session was cancelled by the user
-- `"error"` — session ended due to an error (includes `error` field)
-
-### Mode and Volume
-
-All adapters must implement `onModeChange` and `onVolumeChange`. If your provider doesn't support these, return a no-op unsubscribe:
-
-- **`onModeChange`** — Reports `"listening"` (user's turn) or `"speaking"` (agent's turn). The `VoiceOrb` switches to the active speaking animation.
-- **`onVolumeChange`** — Reports a real-time audio level (`0`–`1`). The `VoiceOrb` modulates its amplitude and glow, and waveform bars scale to match.
-
-When using `createVoiceSession`, these are handled automatically — call `session.emitMode()` and `session.emitVolume()` when your provider delivers data.
-
-### Transcript Handling
-
-Transcripts emitted via `onTranscript` are automatically appended to the message thread:
-
-- **User transcripts** (`role: "user"`, `isFinal: true`) are appended as user messages.
-- **Assistant transcripts** (`role: "assistant"`) are streamed into an assistant message. The message shows a "running" status until `isFinal: true` is received.
-
-## Example: ElevenLabs Conversational AI
-
-[ElevenLabs Conversational AI](https://elevenlabs.io/docs/agents-platform/overview) provides realtime voice agents via WebRTC.
-
-### Install Dependencies
-
-```bash
-npm install @elevenlabs/client
-```
-
-### Adapter
-
-```tsx title="lib/elevenlabs-voice-adapter.ts"
-import type { RealtimeVoiceAdapter, Unsubscribe } from "@assistant-ui/react";
-import { VoiceConversation } from "@elevenlabs/client";
-
-export class ElevenLabsVoiceAdapter implements RealtimeVoiceAdapter {
-  private _agentId: string;
-
-  constructor(options: { agentId: string }) {
-    this._agentId = options.agentId;
-  }
-
-  connect(options: {
-    abortSignal?: AbortSignal;
-  }): RealtimeVoiceAdapter.Session {
-    const statusCallbacks = new Set<(s: RealtimeVoiceAdapter.Status) => void>();
-    const transcriptCallbacks = new Set<(t: RealtimeVoiceAdapter.TranscriptItem) => void>();
-    const modeCallbacks = new Set<(m: RealtimeVoiceAdapter.Mode) => void>();
-    const volumeCallbacks = new Set<(v: number) => void>();
-
-    let currentStatus: RealtimeVoiceAdapter.Status = { type: "starting" };
-    let isMuted = false;
-    let conversation: VoiceConversation | null = null;
-    let disposed = false;
-
-    const updateStatus = (status: RealtimeVoiceAdapter.Status) => {
-      if (disposed) return;
-      currentStatus = status;
-      for (const cb of statusCallbacks) cb(status);
-    };
-
-    const cleanup = () => {
-      disposed = true;
-      conversation = null;
-      statusCallbacks.clear();
-      transcriptCallbacks.clear();
-      modeCallbacks.clear();
-      volumeCallbacks.clear();
-    };
-
-    const session: RealtimeVoiceAdapter.Session = {
-      get status() { return currentStatus; },
-      get isMuted() { return isMuted; },
-      disconnect: () => { conversation?.endSession(); cleanup(); },
-      mute: () => { conversation?.setMicMuted(true); isMuted = true; },
-      unmute: () => { conversation?.setMicMuted(false); isMuted = false; },
-      onStatusChange: (cb): Unsubscribe => {
-        statusCallbacks.add(cb);
-        return () => statusCallbacks.delete(cb);
-      },
-      onTranscript: (cb): Unsubscribe => {
-        transcriptCallbacks.add(cb);
-        return () => transcriptCallbacks.delete(cb);
-      },
-      onModeChange: (cb): Unsubscribe => {
-        modeCallbacks.add(cb);
-        return () => modeCallbacks.delete(cb);
-      },
-      onVolumeChange: (cb): Unsubscribe => {
-        volumeCallbacks.add(cb);
-        return () => volumeCallbacks.delete(cb);
-      },
-    };
-
-    if (options.abortSignal) {
-      options.abortSignal.addEventListener("abort", () => {
-        conversation?.endSession(); cleanup();
-      }, { once: true });
-    }
-
-    const doConnect = async () => {
-      if (disposed) return;
-      try {
-        conversation = await VoiceConversation.startSession({
-          agentId: this._agentId,
-          onConnect: () => updateStatus({ type: "running" }),
-          onDisconnect: () => { updateStatus({ type: "ended", reason: "finished" }); cleanup(); },
-          onError: (msg) => { updateStatus({ type: "ended", reason: "error", error: new Error(msg) }); cleanup(); },
-          onModeChange: ({ mode }) => {
-            if (disposed) return;
-            for (const cb of modeCallbacks) cb(mode === "speaking" ? "speaking" : "listening");
-          },
-          onMessage: (msg) => {
-            if (disposed) return;
-            for (const cb of transcriptCallbacks) {
-              cb({ role: msg.role === "user" ? "user" : "assistant", text: msg.message, isFinal: true });
-            }
-          },
-        });
-      } catch (error) {
-        updateStatus({ type: "ended", reason: "error", error }); cleanup();
-      }
-    };
-
-    doConnect();
-    return session;
-  }
-}
-```
-
-### Usage
-
-```tsx
-import { ElevenLabsVoiceAdapter } from "@/lib/elevenlabs-voice-adapter";
-
-const runtime = useChatRuntime({
-  adapters: {
-    voice: new ElevenLabsVoiceAdapter({
-      agentId: process.env.NEXT_PUBLIC_ELEVENLABS_AGENT_ID!,
-    }),
-  },
-});
-```
-
-## Using `createVoiceSession`
-
-`createVoiceSession` is a helper that eliminates the manual `Set<callback>` boilerplate shown in the ElevenLabs example above. Pass it an async `setup` function that receives a `helpers` object and returns `{ disconnect, mute, unmute }`. The helper wires up all callback sets, status tracking, and abort-signal handling for you.
-
-```tsx title="lib/my-voice-adapter.ts"
-import { createVoiceSession, type RealtimeVoiceAdapter } from "@assistant-ui/react";
-
-export class MyVoiceAdapter implements RealtimeVoiceAdapter {
-  connect(options: { abortSignal?: AbortSignal }): RealtimeVoiceAdapter.Session {
-    return createVoiceSession(options, async (helpers) => {
-      // Connect to your provider
-      const client = await MyVoiceClient.connect();
-
-      client.on("open", () => helpers.setStatus({ type: "running" }));
-      client.on("close", () => helpers.end("finished"));
-      client.on("error", (err) => helpers.end("error", err));
-
-      client.on("transcript", (item) => helpers.emitTranscript(item));
-      client.on("mode", (mode) => helpers.emitMode(mode));
-      client.on("volume", (v) => helpers.emitVolume(v));
-
-      // Return controls — createVoiceSession calls these on disconnect/mute/unmute
-      return {
-        disconnect: () => client.close(),
-        mute: () => client.setMuted(true),
-        unmute: () => client.setMuted(false),
-      };
-    });
-  }
-}
-```
-
-The `helpers` object exposes `setStatus`, `end`, `emitTranscript`, `emitMode`, `emitVolume`, and `isDisposed`. When `isDisposed()` is true the session has been torn down and you can skip further event handling.
+See the [Voice UI page](/docs/ui/voice) for anatomy, variants, and state samples.
 
 ## Example: LiveKit
 
-[LiveKit](https://livekit.io/) provides realtime voice via WebRTC rooms with transcription support. Unlike fully-hosted agent services, LiveKit follows a "bring-your-own-agent" model: the browser adapter only joins a room, and you run a separate **agent worker** that joins the same room and handles STT, LLM, and TTS. Without an agent in the room, the client will connect successfully but have nothing to talk to.
+[LiveKit](https://livekit.io/) provides realtime voice over WebRTC rooms with transcription support. The browser adapter joins a room; a separate agent worker (STT, LLM, TTS) joins the same room. Without an agent in the room, the client connects but has nothing to talk to.
 
-### Prerequisites
+The [`with-livekit`](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-livekit) example shows the full wiring:
 
-1. **A LiveKit server** — create a [LiveKit Cloud](https://cloud.livekit.io/) project (grab the URL, API Key, and API Secret from the project settings) or self-host `livekit-server`.
-2. **An agent worker** — built with the [LiveKit Agents SDK](https://docs.livekit.io/agents/) (Python or Node). The worker connects to your LiveKit server and is automatically dispatched into new rooms.
+1. **Adapter** (`examples/with-livekit/lib/livekit-voice-adapter.ts`): `LiveKitVoiceAdapter` implements `RealtimeVoiceAdapter`. `connect` calls `createVoiceSession`, connects a LiveKit `Room`, enables the local microphone, attaches remote audio tracks, and maps room events to helpers (`setStatus`, `end`, `emitMode`, `emitVolume`, `emitTranscript`).
+2. **Token route** (`examples/with-livekit/app/api/livekit-token/route.ts`): mints a short-lived room token server-side so secrets stay off the client.
+3. **Agent worker** (`examples/with-livekit/agent/`): a Python LiveKit Agents process that joins the room and runs the voice pipeline.
 
-### Install Dependencies
-
-```bash
-npm install livekit-client livekit-server-sdk
-```
-
-`livekit-client` powers the browser adapter; `livekit-server-sdk` is used server-side to mint access tokens.
-
-### Usage
+Minimal runtime wiring:
 
 ```tsx
 import { LiveKitVoiceAdapter } from "@/lib/livekit-voice-adapter";
@@ -377,4 +294,17 @@ const runtime = useChatRuntime({
 });
 ```
 
-See the [`with-livekit` example](https://github.com/assistant-ui/assistant-ui/tree/main/examples/with-livekit) for a complete implementation: the browser adapter, the token endpoint, and a minimal Python agent worker using the OpenAI Realtime API.
+Clone the example for the adapter source, token endpoint, and agent worker rather than re-implementing the full LiveKit event map from scratch.
+
+You can also scaffold it with the CLI:
+
+```bash
+npx assistant-ui create my-app -e with-livekit
+```
+
+## Related guides
+
+- [Dictation](/docs/guides/dictation): push-to-talk speech-to-text into the composer (`DictationAdapter`, `ComposerPrimitive.Dictate`).
+- [Speech](/docs/guides/speech): read-aloud for assistant messages (`SpeechSynthesisAdapter`, `ActionBarPrimitive.Speak`).
+- [Voice UI](/docs/ui/voice): registry component reference for `VoiceControl` and `VoiceOrb`.
+- [Voice API reference](/docs/api-reference/voice): generated types for sessions, speech, and dictation.


### PR DESCRIPTION
## summary

- reworks the three voice guide pages into one coherent story with a shared "three modes" framing: realtime duplex (`voice.mdx` as the hub), push-to-talk dictation (`dictation.mdx`), and read-aloud (`speech.mdx`), cross-linked from each page
- voice hub now documents the real `RealtimeVoiceAdapter` / `createVoiceSession` type shapes, the `useVoiceState` / `useVoiceVolume` / `useVoiceControls` hooks, the styled `voice` registry component as the fastest path (gated on `capabilities.voice`), and the LiveKit example wiring pattern
- dictation adds a server-side transcription recipe: a custom `DictationAdapter` recording via MediaRecorder and a Next.js route calling the AI SDK's stable `transcribe` export (available since ai v6; `experimental_transcribe` is a deprecated alias)
- speech documents `SpeechSynthesisAdapter` / `WebSpeechSynthesisAdapter`, `ActionBarPrimitive.Speak` / `StopSpeaking`, and a custom provider TTS sketch

no test plan, docs only

## notes

- every quoted type shape and API name was verified against the source (`packages/core/src/adapters/{voice,speech}.ts`, primitives, `packages/ui` voice component, `examples/with-livekit`); no new pages, slugs, or meta.json changes, so no redirects needed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

