### PR TITLE
feat: converge collapsible variants on neutral state selectors

### DIFF
--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -9,6 +9,34 @@
 @import "./fumadocs.css";
 @import "./animate.css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @plugin "tailwind-scrollbar";
 
 @source "../../../packages/ui/src";

--- a/apps/registry/app/globals.css
+++ b/apps/registry/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -17,7 +17,7 @@ const {
 const createBuilt = (
   name,
   files,
-  { readPaths = [], baseVariantOutputPaths } = {},
+  { readPaths = [], baseVariantOutputPaths, sourceContentsByOutputPath } = {},
 ) => ({
   payload: {
     $schema: "https://ui.shadcn.com/schema/registry-item.json",
@@ -32,6 +32,9 @@ const createBuilt = (
   readPaths,
   baseVariantOutputPaths:
     baseVariantOutputPaths ?? files.map(([filePath]) => filePath),
+  sourceContentsByOutputPath:
+    sourceContentsByOutputPath ??
+    new Map(files.map(([filePath, content]) => [filePath, content])),
 });
 
 test("base registry item merges, rewrites, and deduplicates dependencies in order", () => {
@@ -245,7 +248,7 @@ test("radix source validation aggregates every base variant path read", () => {
   );
 });
 
-test("variant tree validation aggregates identical radix and base content", () => {
+test("variant tree validation aggregates identical radix and base sources", () => {
   const radixBuilt = [
     createBuilt("first", [["components/first.tsx", "same first"]]),
     createBuilt("second", [["components/second.tsx", "same second"]]),
@@ -261,17 +264,36 @@ test("variant tree validation aggregates identical radix and base content", () =
       assert.equal(error instanceof Error, true);
       assert.ok(
         error.message.includes(
-          "- first: radix and base content for components/first.tsx are identical despite a .base.tsx variant",
+          "- first: radix and base sources for components/first.tsx are identical despite a .base.tsx variant",
         ),
       );
       assert.ok(
         error.message.includes(
-          "- second: radix and base content for components/second.tsx are identical despite a .base.tsx variant",
+          "- second: radix and base sources for components/second.tsx are identical despite a .base.tsx variant",
         ),
       );
       return true;
     },
   );
+});
+
+test("variant tree validation accepts identical emitted content when sources differ", () => {
+  const radixBuilt = [
+    createBuilt("widget", [["components/widget.tsx", "shared emitted"]], {
+      sourceContentsByOutputPath: new Map([
+        ["components/widget.tsx", 'import "@/components/ui/collapsible";'],
+      ]),
+    }),
+  ];
+  const baseBuilt = [
+    createBuilt("widget", [["components/widget.tsx", "shared emitted"]], {
+      sourceContentsByOutputPath: new Map([
+        ["components/widget.tsx", 'import "@/components/ui-base/collapsible";'],
+      ]),
+    }),
+  ];
+
+  assert.doesNotThrow(() => validateVariantTreesDiffer(radixBuilt, baseBuilt));
 });
 
 test("radix registry item merges and dedupes radixDependencies into dependencies", () => {

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -78,6 +78,7 @@ type BuiltRegistryPayload = {
   payload: RegistryOutputItem;
   readPaths: string[];
   baseVariantOutputPaths: string[];
+  sourceContentsByOutputPath: Map<string, string>;
 };
 
 export function validateBaseVariantContent(built: BuiltRegistryPayload[]) {
@@ -114,6 +115,7 @@ function createRegistryPayload(
 ): BuiltRegistryPayload {
   const readPaths: string[] = [];
   const baseVariantOutputPaths: string[] = [];
+  const sourceContentsByOutputPath = new Map<string, string>();
   const files = item.files?.map((file) => {
     const sourcePath = file.sourcePath ?? file.path;
     const baseVariantPath = useBaseVariants
@@ -128,6 +130,7 @@ function createRegistryPayload(
       baseVariantOutputPaths.push(file.path);
     }
     let content = readFileSync(path.join(process.cwd(), readPath), "utf8");
+    sourceContentsByOutputPath.set(file.path, content);
 
     if (usesBaseVariant) {
       content = content.replace(
@@ -155,6 +158,7 @@ function createRegistryPayload(
     payload: files ? { ...payload, files } : payload,
     readPaths,
     baseVariantOutputPaths,
+    sourceContentsByOutputPath,
   };
 }
 
@@ -203,12 +207,12 @@ export function validateVariantTreesDiffer(
     }
 
     for (const filePath of base.baseVariantOutputPaths) {
-      const radixContent = radix.payload.files?.find(
-        (file) => file.path === filePath,
-      )?.content;
-      const baseContent = base.payload.files?.find(
-        (file) => file.path === filePath,
-      )?.content;
+      const radixContent =
+        radix.sourceContentsByOutputPath?.get(filePath) ??
+        radix.payload.files?.find((file) => file.path === filePath)?.content;
+      const baseContent =
+        base.sourceContentsByOutputPath?.get(filePath) ??
+        base.payload.files?.find((file) => file.path === filePath)?.content;
 
       if (radixContent === undefined || baseContent === undefined) {
         findings.add(
@@ -219,7 +223,7 @@ export function validateVariantTreesDiffer(
 
       if (radixContent === baseContent) {
         findings.add(
-          `${base.payload.name}: radix and base content for ${filePath} are identical despite a .base.tsx variant`,
+          `${base.payload.name}: radix and base sources for ${filePath} are identical despite a .base.tsx variant`,
         );
       }
     }

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -207,16 +207,12 @@ export function validateVariantTreesDiffer(
     }
 
     for (const filePath of base.baseVariantOutputPaths) {
-      const radixContent =
-        radix.sourceContentsByOutputPath?.get(filePath) ??
-        radix.payload.files?.find((file) => file.path === filePath)?.content;
-      const baseContent =
-        base.sourceContentsByOutputPath?.get(filePath) ??
-        base.payload.files?.find((file) => file.path === filePath)?.content;
+      const radixContent = radix.sourceContentsByOutputPath.get(filePath);
+      const baseContent = base.sourceContentsByOutputPath.get(filePath);
 
       if (radixContent === undefined || baseContent === undefined) {
         findings.add(
-          `${base.payload.name}: missing emitted content for ${filePath} while comparing radix and base trees`,
+          `${base.payload.name}: missing source content for ${filePath} while comparing radix and base trees`,
         );
         continue;
       }

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1,5 +1,26 @@
 import type { RegistryItem } from "./schema";
 
+const collapsibleStateCss = {
+  '@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])))':
+    {},
+  '@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])))':
+    {},
+  "@keyframes collapsible-down": {
+    from: { height: "0" },
+    to: {
+      height:
+        "var(--radix-collapsible-content-height, var(--collapsible-panel-height, auto))",
+    },
+  },
+  "@keyframes collapsible-up": {
+    from: {
+      height:
+        "var(--radix-collapsible-content-height, var(--collapsible-panel-height, auto))",
+    },
+    to: { height: "0" },
+  },
+};
+
 export const registry: RegistryItem[] = [
   {
     name: "shimmer-style",
@@ -135,6 +156,7 @@ export const registry: RegistryItem[] = [
     ],
     css: {
       '@import "tw-shimmer"': {},
+      ...collapsibleStateCss,
     },
   },
   {
@@ -324,6 +346,7 @@ export const registry: RegistryItem[] = [
     registryDependencies: ["button", "collapsible"],
     css: {
       '@import "tw-shimmer"': {},
+      ...collapsibleStateCss,
     },
   },
   {
@@ -346,6 +369,7 @@ export const registry: RegistryItem[] = [
     registryDependencies: ["collapsible"],
     css: {
       '@import "tw-shimmer"': {},
+      ...collapsibleStateCss,
     },
   },
   {

--- a/examples/with-pi/app/globals.css
+++ b/examples/with-pi/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/ui/src/components/assistant-ui/reasoning.base.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.base.tsx
@@ -208,6 +208,7 @@ function ReasoningTrigger({
           "aui-reasoning-trigger-chevron mt-0.5 size-4 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           "-rotate-90",
+          "group-data-open/trigger:rotate-0",
           "group-data-panel-open/trigger:rotate-0",
         )}
       />
@@ -228,7 +229,6 @@ function ReasoningContent({
       className={cn(
         "aui-reasoning-content text-muted-foreground relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "[--radix-collapsible-content-height:var(--collapsible-panel-height)]",
         "data-closed:animate-collapsible-up",
         "data-open:animate-collapsible-down",
         "data-closed:fill-mode-forwards",

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -207,8 +207,9 @@ function ReasoningTrigger({
         className={cn(
           "aui-reasoning-trigger-chevron mt-0.5 size-4 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+          "-rotate-90",
+          "group-data-open/trigger:rotate-0",
+          "group-data-panel-open/trigger:rotate-0",
         )}
       />
     </CollapsibleTrigger>
@@ -228,12 +229,12 @@ function ReasoningContent({
       className={cn(
         "aui-reasoning-content text-muted-foreground relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "data-[state=closed]:animate-collapsible-up",
-        "data-[state=open]:animate-collapsible-down",
-        "data-[state=closed]:fill-mode-forwards",
-        "data-[state=closed]:pointer-events-none",
-        "data-[state=open]:duration-(--animation-duration)",
-        "data-[state=closed]:duration-(--animation-duration)",
+        "data-closed:animate-collapsible-up",
+        "data-open:animate-collapsible-down",
+        "data-closed:fill-mode-forwards",
+        "data-closed:pointer-events-none",
+        "data-open:duration-(--animation-duration)",
+        "data-closed:duration-(--animation-duration)",
         className,
       )}
       {...props}
@@ -276,16 +277,16 @@ function ReasoningText({
         "aui-reasoning-text relative z-0 max-h-64 overflow-y-auto ps-6 pt-2 pb-2 leading-relaxed text-pretty",
         "transform-gpu transition-[transform,opacity] ease-[cubic-bezier(0.32,0.72,0,1)]",
         "motion-reduce:animate-none",
-        "group-data-[state=open]/collapsible-content:animate-in",
-        "group-data-[state=closed]/collapsible-content:animate-out",
-        "group-data-[state=open]/collapsible-content:fade-in-0",
-        "group-data-[state=closed]/collapsible-content:fade-out-0",
-        "group-data-[state=open]/collapsible-content:slide-in-from-top-4",
-        "group-data-[state=closed]/collapsible-content:slide-out-to-top-4",
-        "group-data-[state=open]/collapsible-content:blur-in-[2px]",
-        "group-data-[state=closed]/collapsible-content:blur-out-[2px]",
-        "group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
-        "group-data-[state=closed]/collapsible-content:duration-(--animation-duration)",
+        "group-data-open/collapsible-content:animate-in",
+        "group-data-closed/collapsible-content:animate-out",
+        "group-data-open/collapsible-content:fade-in-0",
+        "group-data-closed/collapsible-content:fade-out-0",
+        "group-data-open/collapsible-content:slide-in-from-top-4",
+        "group-data-closed/collapsible-content:slide-out-to-top-4",
+        "group-data-open/collapsible-content:blur-in-[2px]",
+        "group-data-closed/collapsible-content:blur-out-[2px]",
+        "group-data-open/collapsible-content:duration-(--animation-duration)",
+        "group-data-closed/collapsible-content:duration-(--animation-duration)",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/assistant-ui/tool-fallback.base.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.base.tsx
@@ -185,6 +185,7 @@ function ToolFallbackTrigger({
           "aui-tool-fallback-trigger-chevron size-4 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           "-rotate-90",
+          "group-data-open/trigger:rotate-0",
           "group-data-panel-open/trigger:rotate-0",
         )}
       />
@@ -203,7 +204,6 @@ function ToolFallbackContent({
       className={cn(
         "aui-tool-fallback-content relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "[--radix-collapsible-content-height:var(--collapsible-panel-height)]",
         "data-closed:animate-collapsible-up",
         "data-open:animate-collapsible-down",
         "data-closed:fill-mode-forwards",

--- a/packages/ui/src/components/assistant-ui/tool-fallback.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-fallback.tsx
@@ -184,8 +184,9 @@ function ToolFallbackTrigger({
         className={cn(
           "aui-tool-fallback-trigger-chevron size-4 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+          "-rotate-90",
+          "group-data-open/trigger:rotate-0",
+          "group-data-panel-open/trigger:rotate-0",
         )}
       />
     </CollapsibleTrigger>
@@ -203,12 +204,12 @@ function ToolFallbackContent({
       className={cn(
         "aui-tool-fallback-content relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "data-[state=closed]:animate-collapsible-up",
-        "data-[state=open]:animate-collapsible-down",
-        "data-[state=closed]:fill-mode-forwards",
-        "data-[state=closed]:pointer-events-none",
-        "data-[state=open]:duration-(--animation-duration)",
-        "data-[state=closed]:duration-(--animation-duration)",
+        "data-closed:animate-collapsible-up",
+        "data-open:animate-collapsible-down",
+        "data-closed:fill-mode-forwards",
+        "data-closed:pointer-events-none",
+        "data-open:duration-(--animation-duration)",
+        "data-closed:duration-(--animation-duration)",
         className,
       )}
       {...props}
@@ -216,9 +217,9 @@ function ToolFallbackContent({
       <div
         className={cn(
           "flex flex-col gap-2 ps-6 pt-1 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-          "group-data-[state=open]/collapsible-content:animate-in group-data-[state=open]/collapsible-content:fade-in-0 group-data-[state=open]/collapsible-content:blur-in-[2px] group-data-[state=open]/collapsible-content:slide-in-from-top-1",
-          "group-data-[state=closed]/collapsible-content:animate-out group-data-[state=closed]/collapsible-content:fade-out-0 group-data-[state=closed]/collapsible-content:blur-out-[2px] group-data-[state=closed]/collapsible-content:slide-out-to-top-1",
-          "group-data-[state=closed]/collapsible-content:duration-(--animation-duration) group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
+          "group-data-open/collapsible-content:animate-in group-data-open/collapsible-content:fade-in-0 group-data-open/collapsible-content:blur-in-[2px] group-data-open/collapsible-content:slide-in-from-top-1",
+          "group-data-closed/collapsible-content:animate-out group-data-closed/collapsible-content:fade-out-0 group-data-closed/collapsible-content:blur-out-[2px] group-data-closed/collapsible-content:slide-out-to-top-1",
+          "group-data-closed/collapsible-content:duration-(--animation-duration) group-data-open/collapsible-content:duration-(--animation-duration)",
         )}
       >
         {children}

--- a/packages/ui/src/components/assistant-ui/tool-group.base.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-group.base.tsx
@@ -147,6 +147,7 @@ function ToolGroupTrigger({
           "aui-tool-group-trigger-chevron size-3 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
           "-rotate-90",
+          "group-data-open/trigger:rotate-0",
           "group-data-panel-open/trigger:rotate-0",
         )}
       />
@@ -165,7 +166,6 @@ function ToolGroupContent({
       className={cn(
         "aui-tool-group-content relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "[--radix-collapsible-content-height:var(--collapsible-panel-height)]",
         "data-closed:animate-collapsible-up",
         "data-open:animate-collapsible-down",
         "data-closed:fill-mode-forwards",

--- a/packages/ui/src/components/assistant-ui/tool-group.tsx
+++ b/packages/ui/src/components/assistant-ui/tool-group.tsx
@@ -146,8 +146,9 @@ function ToolGroupTrigger({
         className={cn(
           "aui-tool-group-trigger-chevron size-3 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+          "-rotate-90",
+          "group-data-open/trigger:rotate-0",
+          "group-data-panel-open/trigger:rotate-0",
         )}
       />
     </CollapsibleTrigger>
@@ -165,12 +166,12 @@ function ToolGroupContent({
       className={cn(
         "aui-tool-group-content relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "data-[state=closed]:animate-collapsible-up",
-        "data-[state=open]:animate-collapsible-down",
-        "data-[state=closed]:fill-mode-forwards",
-        "data-[state=closed]:pointer-events-none",
-        "data-[state=open]:duration-(--animation-duration)",
-        "data-[state=closed]:duration-(--animation-duration)",
+        "data-closed:animate-collapsible-up",
+        "data-open:animate-collapsible-down",
+        "data-closed:fill-mode-forwards",
+        "data-closed:pointer-events-none",
+        "data-open:duration-(--animation-duration)",
+        "data-closed:duration-(--animation-duration)",
         className,
       )}
       {...props}

--- a/templates/cloud-clerk/app/globals.css
+++ b/templates/cloud-clerk/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/cloud/app/globals.css
+++ b/templates/cloud/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/default/app/globals.css
+++ b/templates/default/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/eve/app/globals.css
+++ b/templates/eve/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/langchain/app/globals.css
+++ b/templates/langchain/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/mcp/app/globals.css
+++ b/templates/mcp/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @source "../../../packages/ui/src";
 
 @custom-variant dark (&:is(.dark *));

--- a/templates/minimal/app/globals.css
+++ b/templates/minimal/app/globals.css
@@ -1,6 +1,34 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/templates/minimal/components/assistant-ui/tool-fallback.tsx
+++ b/templates/minimal/components/assistant-ui/tool-fallback.tsx
@@ -184,8 +184,9 @@ function ToolFallbackTrigger({
         className={cn(
           "aui-tool-fallback-trigger-chevron size-4 shrink-0",
           "transition-transform duration-(--animation-duration) ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
-          "group-data-[state=closed]/trigger:-rotate-90",
-          "group-data-[state=open]/trigger:rotate-0",
+          "-rotate-90",
+          "group-data-open/trigger:rotate-0",
+          "group-data-panel-open/trigger:rotate-0",
         )}
       />
     </CollapsibleTrigger>
@@ -203,12 +204,12 @@ function ToolFallbackContent({
       className={cn(
         "aui-tool-fallback-content relative overflow-hidden text-sm outline-none",
         "group/collapsible-content ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-        "data-[state=closed]:animate-collapsible-up",
-        "data-[state=open]:animate-collapsible-down",
-        "data-[state=closed]:fill-mode-forwards",
-        "data-[state=closed]:pointer-events-none",
-        "data-[state=open]:duration-(--animation-duration)",
-        "data-[state=closed]:duration-(--animation-duration)",
+        "data-closed:animate-collapsible-up",
+        "data-open:animate-collapsible-down",
+        "data-closed:fill-mode-forwards",
+        "data-closed:pointer-events-none",
+        "data-open:duration-(--animation-duration)",
+        "data-closed:duration-(--animation-duration)",
         className,
       )}
       {...props}
@@ -216,9 +217,9 @@ function ToolFallbackContent({
       <div
         className={cn(
           "flex flex-col gap-2 ps-6 pt-1 pb-2 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:animate-none",
-          "group-data-[state=open]/collapsible-content:animate-in group-data-[state=open]/collapsible-content:fade-in-0 group-data-[state=open]/collapsible-content:blur-in-[2px] group-data-[state=open]/collapsible-content:slide-in-from-top-1",
-          "group-data-[state=closed]/collapsible-content:animate-out group-data-[state=closed]/collapsible-content:fade-out-0 group-data-[state=closed]/collapsible-content:blur-out-[2px] group-data-[state=closed]/collapsible-content:slide-out-to-top-1",
-          "group-data-[state=closed]/collapsible-content:duration-(--animation-duration) group-data-[state=open]/collapsible-content:duration-(--animation-duration)",
+          "group-data-open/collapsible-content:animate-in group-data-open/collapsible-content:fade-in-0 group-data-open/collapsible-content:blur-in-[2px] group-data-open/collapsible-content:slide-in-from-top-1",
+          "group-data-closed/collapsible-content:animate-out group-data-closed/collapsible-content:fade-out-0 group-data-closed/collapsible-content:blur-out-[2px] group-data-closed/collapsible-content:slide-out-to-top-1",
+          "group-data-closed/collapsible-content:duration-(--animation-duration) group-data-open/collapsible-content:duration-(--animation-duration)",
         )}
       >
         {children}


### PR DESCRIPTION
## summary

- reasoning, tool-group, and tool-fallback now share one class vocabulary across their radix and base variants: dual-matching `data-open` / `data-closed` custom variants (matching Radix's `data-state` attributes and Base UI's bare attributes, the same definitions shadcn ships upstream) replace the `data-[state=]` selectors, and each pair now differs only by its primitive import lines
- dual-variable collapsible keyframes (`--radix-collapsible-content-height` with a `--collapsible-panel-height` fallback) replace the base-side height shim, and the trigger chevron carries both libraries' open selectors (one inert class per library, a few bytes of generated CSS)
- the definitions reach user projects through the three registry items' `css` field (at-rule injection, deduped by name and params by the shadcn CLI, so installing all three lands one copy) and reach in-repo consumers through the ten globals.css files that already import tw-animate-css
- `validateVariantTreesDiffer` now compares pre-rewrite sources instead of emitted content: a converged pair legitimately emits byte-identical content into both trees once the `ui-base/` import rewrite runs, while the wrong-file-read bug class the validator was built for still produces identical sources and still fails

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/shadcn-registry test` -> 20/20 (includes a new case: identical emitted content with differing sources passes)
- [x] `pnpm --filter @assistant-ui/shadcn-registry build` -> green; `dist/{reasoning,tool-group,tool-fallback}.json` each carry the two custom variants and two keyframes in `css`, and their radix and base emitted contents are byte-identical
- [x] `git diff --no-index` per pair -> only the collapsible import differs (tool-fallback also its Button import)
- [x] Tailwind v4 compile probe against the updated globals -> `data-open:` emits both the `[data-state="open"]` and `[data-open]` arms, `group-data-open/collapsible-content:` composes, and the winning `collapsible-down` keyframes contain both height variables
- [x] `pnpm lint` green at the root; `pnpm sync-templates` re-synced the minimal template copy

### reviewer should verify

- [ ] run any template app, open a thread with a long reasoning part, and toggle the reasoning disclosure: collapse animation and open/closed styling behave exactly as before on the Radix tree

## notes

- the emitted trees for these three items are now byte-identical, so deleting the three `.base.tsx` files becomes a provable no-op on dist; deliberately left out of this PR
- non-paired components still using `data-[state=]` (thread, thread-list, tabs, select, accordion, model-selector, assistant-modal) migrate together with their Base UI variants in follow-ups
- the injected css block rides only the three collapsible items; installing any other item does not add it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

