### PR TITLE
feat: add Base UI variants for the six radix-importing registry items

### DIFF
--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -404,6 +404,26 @@ test("slot parity accepts identical slot sets and skips empty base variants", ()
   );
 });
 
+test("slot parity counts object-prop slots the same as jsx-attribute slots", () => {
+  assert.doesNotThrow(() =>
+    validateVariantSlotParity(
+      [
+        createBuilt("badge", [
+          ["components/badge.tsx", '<span data-slot="badge" />'],
+        ]),
+      ],
+      [
+        createBuilt("badge", [
+          [
+            "components/badge.tsx",
+            'useRender({ props: { "data-slot": "badge" } });',
+          ],
+        ]),
+      ],
+    ),
+  );
+});
+
 test("export parity reports exports present only in the radix content", () => {
   const radixBuilt = [
     createBuilt("widget", [

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -236,7 +236,7 @@ export function validateVariantTreesDiffer(
 
 function collectDataSlots(content: string) {
   const slots = new Set<string>();
-  for (const match of content.matchAll(/data-slot="([^"]+)"/g)) {
+  for (const match of content.matchAll(/"?data-slot"?\s*[:=]\s*"([^"]+)"/g)) {
     slots.add(match[1]!);
   }
   return slots;

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -21,6 +21,23 @@ const collapsibleStateCss = {
   },
 };
 
+const accordionKeyframesCss = {
+  "@keyframes accordion-down": {
+    from: { height: "0" },
+    to: {
+      height:
+        "var(--radix-accordion-content-height, var(--accordion-panel-height, auto))",
+    },
+  },
+  "@keyframes accordion-up": {
+    from: {
+      height:
+        "var(--radix-accordion-content-height, var(--accordion-panel-height, auto))",
+    },
+    to: { height: "0" },
+  },
+};
+
 export const registry: RegistryItem[] = [
   {
     name: "shimmer-style",
@@ -521,8 +538,9 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react",
       "lucide-react",
       "class-variance-authority",
-      "radix-ui",
     ],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: ["command", "popover"],
   },
   {
@@ -548,7 +566,9 @@ export const registry: RegistryItem[] = [
         sourcePath: "../../packages/ui/src/components/assistant-ui/select.tsx",
       },
     ],
-    dependencies: ["radix-ui", "lucide-react", "class-variance-authority"],
+    dependencies: ["lucide-react", "class-variance-authority"],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
   },
   {
@@ -561,7 +581,8 @@ export const registry: RegistryItem[] = [
         sourcePath: "../../packages/ui/src/components/ui/direction.tsx",
       },
     ],
-    dependencies: ["radix-ui"],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
   },
   {
@@ -574,7 +595,9 @@ export const registry: RegistryItem[] = [
         sourcePath: "../../packages/ui/src/components/assistant-ui/badge.tsx",
       },
     ],
-    dependencies: ["radix-ui", "class-variance-authority"],
+    dependencies: ["class-variance-authority"],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
   },
   {
@@ -587,7 +610,9 @@ export const registry: RegistryItem[] = [
         sourcePath: "../../packages/ui/src/components/assistant-ui/tabs.tsx",
       },
     ],
-    dependencies: ["radix-ui", "class-variance-authority"],
+    dependencies: ["class-variance-authority"],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
   },
   {
@@ -601,8 +626,11 @@ export const registry: RegistryItem[] = [
           "../../packages/ui/src/components/assistant-ui/accordion.tsx",
       },
     ],
-    dependencies: ["radix-ui", "lucide-react", "class-variance-authority"],
+    dependencies: ["lucide-react", "class-variance-authority"],
+    radixDependencies: ["radix-ui"],
+    baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
+    css: { ...accordionKeyframesCss },
   },
   {
     name: "dot-matrix",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -630,7 +630,7 @@ export const registry: RegistryItem[] = [
     radixDependencies: ["radix-ui"],
     baseDependencies: ["@base-ui/react"],
     registryDependencies: [],
-    css: { ...accordionKeyframesCss },
+    css: accordionKeyframesCss,
   },
   {
     name: "dot-matrix",

--- a/packages/ui/src/components/assistant-ui/accordion.base.tsx
+++ b/packages/ui/src/components/assistant-ui/accordion.base.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
+import { ChevronDownIcon } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const accordionVariants = cva(
+  "aui-accordion group/accordion flex w-full flex-col",
+  {
+    variants: {
+      variant: {
+        default: "",
+        outline: "rounded-lg border",
+        ghost: "gap-2",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+function Accordion({
+  className,
+  variant,
+  ...props
+}: AccordionPrimitive.Root.Props & VariantProps<typeof accordionVariants>) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      data-variant={variant ?? "default"}
+      className={cn(accordionVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn(
+        "aui-accordion-item group/accordion-item",
+        "group-data-[variant=default]/accordion:border-b group-data-[variant=default]/accordion:last:border-b-0",
+        "group-data-[variant=outline]/accordion:border-b group-data-[variant=outline]/accordion:last:border-b-0",
+        "group-data-[variant=ghost]/accordion:data-open:bg-muted/50 group-data-[variant=ghost]/accordion:rounded-lg",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Trigger.Props) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "aui-accordion-trigger group/accordion-trigger flex w-full flex-1 items-center justify-between gap-4 text-start text-sm font-medium transition-all outline-none disabled:pointer-events-none disabled:opacity-50",
+          "group-data-[variant=default]/accordion:focus-visible:ring-ring/50 group-data-[variant=default]/accordion:py-4 group-data-[variant=default]/accordion:hover:underline group-data-[variant=default]/accordion:focus-visible:ring-2",
+          "group-data-[variant=outline]/accordion:focus-visible:ring-ring/50 group-data-[variant=outline]/accordion:hover:bg-muted/50 group-data-[variant=outline]/accordion:px-4 group-data-[variant=outline]/accordion:py-3 group-data-[variant=outline]/accordion:focus-visible:ring-2 group-data-[variant=outline]/accordion:focus-visible:ring-inset",
+          "group-data-[variant=ghost]/accordion:focus-visible:ring-ring/50 group-data-[variant=ghost]/accordion:hover:bg-muted/50 group-data-[variant=ghost]/accordion:rounded-lg group-data-[variant=ghost]/accordion:px-4 group-data-[variant=ghost]/accordion:py-2 group-data-[variant=ghost]/accordion:focus-visible:ring-2",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200 ease-out group-data-panel-open/accordion-trigger:rotate-180" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  );
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Panel.Props) {
+  return (
+    <AccordionPrimitive.Panel
+      data-slot="accordion-content"
+      className="aui-accordion-content data-closed:animate-accordion-up data-open:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div
+        className={cn(
+          "group-data-[variant=default]/accordion:pb-4",
+          "group-data-[variant=outline]/accordion:border-t group-data-[variant=outline]/accordion:px-4 group-data-[variant=outline]/accordion:py-3",
+          "group-data-[variant=ghost]/accordion:px-4 group-data-[variant=ghost]/accordion:py-3",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitive.Panel>
+  );
+}
+
+export {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+  accordionVariants,
+};

--- a/packages/ui/src/components/assistant-ui/badge.base.tsx
+++ b/packages/ui/src/components/assistant-ui/badge.base.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import type { ComponentProps } from "react";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center gap-1 rounded-md text-xs font-medium transition-colors [&_svg]:size-3 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        outline:
+          "border-input text-muted-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground border bg-transparent",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/80",
+        muted:
+          "bg-muted text-muted-foreground [a&]:hover:bg-muted/80 [a&]:hover:text-foreground",
+        ghost:
+          "text-muted-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground bg-transparent",
+        info: "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300 [a&]:hover:bg-blue-100/80",
+        warning:
+          "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300 [a&]:hover:bg-amber-100/80",
+        success:
+          "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300 [a&]:hover:bg-emerald-100/80",
+        destructive:
+          "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300 [a&]:hover:bg-red-100/80",
+      },
+      size: {
+        sm: "px-1.5 py-0.5",
+        default: "px-2 py-1",
+        lg: "px-2.5 py-1.5 text-sm",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
+      size: "default",
+    },
+  },
+);
+
+export type BadgeProps = useRender.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants>;
+
+function Badge({ className, variant, size, render, ...props }: BadgeProps) {
+  const dataProps = {
+    "data-slot": "badge",
+    "data-variant": variant,
+    "data-size": size,
+  } as ComponentProps<"span">;
+
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      dataProps,
+      {
+        className: cn(badgeVariants({ variant, size }), className),
+      },
+      props,
+    ),
+    render,
+  });
+}
+
+export { Badge, badgeVariants };

--- a/packages/ui/src/components/assistant-ui/model-selector.base.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.base.tsx
@@ -406,7 +406,7 @@ function ModelSelectorContent({
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "bg-popover/95 w-72 min-w-(--radix-popover-trigger-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",
+        "bg-popover/95 w-72 min-w-(--anchor-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",
         className,
       )}
       {...props}

--- a/packages/ui/src/components/assistant-ui/model-selector.base.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.base.tsx
@@ -1,0 +1,740 @@
+"use client";
+
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  createContext,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+import { useAui } from "@assistant-ui/react";
+import { cn } from "@/lib/utils";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { RadioGroup } from "@base-ui/react/radio-group";
+import { Radio } from "@base-ui/react/radio";
+
+export type ModelSelectorEffortOption = {
+  id: string;
+  name: string;
+};
+
+export const DEFAULT_EFFORT_OPTIONS: readonly ModelSelectorEffortOption[] = [
+  { id: "low", name: "Low" },
+  { id: "medium", name: "Med" },
+  { id: "high", name: "High" },
+];
+
+export type ModelOption = {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: ReactNode;
+  disabled?: boolean;
+  /** Extra terms matched by ModelSelector.Search, in addition to id and name. */
+  keywords?: readonly string[];
+  /**
+   * Reasoning effort levels the model supports. Pass `true` for the default
+   * low/medium/high levels, or a custom list. Omit for models without
+   * configurable reasoning.
+   */
+  efforts?: boolean | readonly ModelSelectorEffortOption[];
+};
+
+function getModelEfforts(
+  model: ModelOption | undefined,
+): readonly ModelSelectorEffortOption[] | undefined {
+  if (!model?.efforts) return undefined;
+  return model.efforts === true ? DEFAULT_EFFORT_OPTIONS : model.efforts;
+}
+
+function resolveEffort(
+  efforts: readonly ModelSelectorEffortOption[] | undefined,
+  effort: string | undefined,
+): string | undefined {
+  if (effort === undefined) return undefined;
+  return efforts?.some((e) => e.id === effort) ? effort : undefined;
+}
+
+/**
+ * Returns the effort id if the given model supports it, otherwise undefined.
+ * Effort selection is kept sticky across model switches; this resolves what
+ * actually applies to the current model.
+ */
+export function resolveModelEffort(
+  models: readonly ModelOption[],
+  modelId: string | undefined,
+  effort: string | undefined,
+): string | undefined {
+  return resolveEffort(
+    getModelEfforts(models.find((m) => m.id === modelId)),
+    effort,
+  );
+}
+
+function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange,
+}: {
+  prop: T | undefined;
+  defaultProp: T | undefined;
+  onChange: ((next: T) => void) | undefined;
+}) {
+  const [internal, setInternal] = useState(defaultProp);
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : internal;
+  // Read onChange through a ref so inline callbacks don't recreate the setter
+  // (and with it the memoized context value) every render.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  });
+  const setValue = useCallback(
+    (next: T) => {
+      if (!isControlled) setInternal(next);
+      onChangeRef.current?.(next);
+    },
+    [isControlled],
+  );
+  return [value, setValue] as const;
+}
+
+type ModelSelectorContextValue = {
+  models: readonly ModelOption[];
+  value: string | undefined;
+  setValue: (value: string) => void;
+  /** The model matching `value`, derived once for all sub-components. */
+  selectedModel: ModelOption | undefined;
+  /** The selected model's effort levels, undefined when not configurable. */
+  efforts: readonly ModelSelectorEffortOption[] | undefined;
+  /** Effort resolved against the selected model's supported levels. */
+  effort: string | undefined;
+  setEffort: (effort: string) => void;
+  setOpen: (open: boolean) => void;
+};
+
+const ModelSelectorContext = createContext<ModelSelectorContextValue | null>(
+  null,
+);
+
+function useModelSelectorContext() {
+  const ctx = useContext(ModelSelectorContext);
+  if (!ctx) {
+    throw new Error(
+      "ModelSelector sub-components must be used within ModelSelector.Root",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * The selected model's effort levels and the active selection. Use it to build
+ * a custom effort UI inside ModelSelector.Content (e.g. a slider or a shadcn
+ * DropdownMenu) when the built-in ModelSelector.Effort layout doesn't fit.
+ * `efforts` is undefined for models without configurable reasoning.
+ */
+export function useModelSelectorEfforts(): {
+  efforts: readonly ModelSelectorEffortOption[] | undefined;
+  effort: string | undefined;
+  setEffort: (effort: string) => void;
+} {
+  const { efforts, effort, setEffort } = useModelSelectorContext();
+  return { efforts, effort, setEffort };
+}
+
+export type ModelSelectorRootProps = {
+  models: readonly ModelOption[];
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+  effort?: string;
+  defaultEffort?: string;
+  onEffortChange?: (effort: string) => void;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+};
+
+function ModelSelectorRoot({
+  models,
+  value: valueProp,
+  defaultValue,
+  onValueChange,
+  effort: effortProp,
+  defaultEffort,
+  onEffortChange,
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  children,
+}: ModelSelectorRootProps) {
+  const [value, setValue] = useControllableState({
+    prop: valueProp,
+    defaultProp: defaultValue ?? models[0]?.id,
+    onChange: onValueChange,
+  });
+  const [effort, setEffort] = useControllableState({
+    prop: effortProp,
+    defaultProp: defaultEffort,
+    onChange: onEffortChange,
+  });
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+  });
+
+  const selectedModel = models.find((m) => m.id === value);
+  const efforts = getModelEfforts(selectedModel);
+  const activeEffort = resolveEffort(efforts, effort);
+  const contextValue = useMemo(
+    () => ({
+      models,
+      value,
+      setValue,
+      selectedModel,
+      efforts,
+      effort: activeEffort,
+      setEffort,
+      setOpen,
+    }),
+    [
+      models,
+      value,
+      setValue,
+      selectedModel,
+      efforts,
+      activeEffort,
+      setEffort,
+      setOpen,
+    ],
+  );
+
+  return (
+    <ModelSelectorContext.Provider value={contextValue}>
+      <Popover open={open ?? false} onOpenChange={setOpen}>
+        {children}
+      </Popover>
+    </ModelSelectorContext.Provider>
+  );
+}
+
+export const modelSelectorTriggerVariants = cva(
+  "focus-visible:ring-ring/50 flex w-fit items-center justify-between gap-2 overflow-hidden rounded-md text-sm whitespace-nowrap transition-colors outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3.5",
+  {
+    variants: {
+      variant: {
+        outline:
+          "border-input hover:bg-accent hover:text-accent-foreground border bg-transparent",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        muted: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+      size: {
+        default: "h-9 px-3 py-2",
+        sm: "h-8 px-2.5 py-1.5 text-xs",
+        lg: "h-10 px-4 py-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
+      size: "default",
+    },
+  },
+);
+
+export type ModelSelectorTriggerProps = ComponentPropsWithoutRef<
+  typeof PopoverTrigger
+> &
+  VariantProps<typeof modelSelectorTriggerVariants>;
+
+function ModelSelectorTrigger({
+  className,
+  variant,
+  size,
+  children,
+  onKeyDown,
+  ...props
+}: ModelSelectorTriggerProps) {
+  const { setOpen } = useModelSelectorContext();
+
+  return (
+    <PopoverTrigger
+      data-slot="model-selector-trigger"
+      data-variant={variant ?? "outline"}
+      data-size={size ?? "default"}
+      role="combobox"
+      aria-haspopup="listbox"
+      className={cn(modelSelectorTriggerVariants({ variant, size }), className)}
+      onKeyDown={(e) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
+        // ARIA combobox: arrows open the listbox from a focused trigger.
+        // Popover leaves this to the consumer.
+        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          e.preventDefault();
+          setOpen(true);
+        }
+      }}
+      {...props}
+    >
+      {children ?? <ModelSelectorValue />}
+      <ChevronDownIcon className="size-4 opacity-50" />
+    </PopoverTrigger>
+  );
+}
+
+export type ModelSelectorValueProps = {
+  placeholder?: ReactNode;
+  /** Show the active effort level next to the model name. */
+  showEffort?: boolean;
+  className?: string;
+};
+
+function ModelIcon({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "flex size-3.5 shrink-0 items-center justify-center [&_svg]:size-3.5",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ModelSelectorValue({
+  placeholder = "Select model",
+  showEffort = true,
+  className,
+}: ModelSelectorValueProps) {
+  const { selectedModel, efforts, effort } = useModelSelectorContext();
+
+  if (!selectedModel) {
+    return (
+      <span
+        data-slot="model-selector-value"
+        className={cn("text-muted-foreground", className)}
+      >
+        {placeholder}
+      </span>
+    );
+  }
+
+  const effortName =
+    showEffort && effort !== undefined
+      ? efforts?.find((e) => e.id === effort)?.name
+      : undefined;
+
+  return (
+    <span
+      data-slot="model-selector-value"
+      className={cn("flex min-w-0 items-center gap-2", className)}
+    >
+      {selectedModel.icon && <ModelIcon>{selectedModel.icon}</ModelIcon>}
+      <span className="truncate font-medium">{selectedModel.name}</span>
+      {effortName && (
+        <span className="text-muted-foreground min-w-7.5 truncate text-center">
+          {effortName}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export type ModelSelectorContentProps = ComponentPropsWithoutRef<
+  typeof PopoverContent
+> & {
+  searchable?: boolean;
+};
+
+/**
+ * Hidden input that anchors cmdk's keyboard navigation, keeping the list
+ * keyboard-operable without a visible search box. ModelSelectorContent renders
+ * one automatically when unfiltered.
+ */
+function ModelSelectorFocusAnchor() {
+  return (
+    <div className="sr-only">
+      <CommandInput readOnly aria-label="Model" />
+    </div>
+  );
+}
+
+function ModelSelectorContent({
+  className,
+  align = "start",
+  sideOffset = 6,
+  searchable,
+  children,
+  ...props
+}: ModelSelectorContentProps) {
+  const { value } = useModelSelectorContext();
+  const unfiltered =
+    searchable === false || (!searchable && children === undefined);
+
+  return (
+    <PopoverContent
+      data-slot="model-selector-content"
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "bg-popover/95 w-72 min-w-(--radix-popover-trigger-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",
+        className,
+      )}
+      {...props}
+    >
+      <Command
+        className="bg-transparent"
+        shouldFilter={!unfiltered}
+        {...(value !== undefined ? { defaultValue: value } : {})}
+      >
+        {unfiltered && <ModelSelectorFocusAnchor />}
+        {children ?? (
+          <>
+            {searchable && <ModelSelectorSearch />}
+            <ModelSelectorList />
+            <ModelSelectorEffort />
+          </>
+        )}
+      </Command>
+    </PopoverContent>
+  );
+}
+
+export type ModelSelectorSearchProps = ComponentPropsWithoutRef<
+  typeof CommandInput
+>;
+
+function ModelSelectorSearch({
+  placeholder = "Search models...",
+  ...props
+}: ModelSelectorSearchProps) {
+  return (
+    <CommandInput
+      data-slot="model-selector-search"
+      placeholder={placeholder}
+      {...props}
+    />
+  );
+}
+
+export type ModelSelectorListProps = ComponentPropsWithoutRef<
+  typeof CommandList
+>;
+
+function ModelSelectorList({
+  className,
+  children,
+  ...props
+}: ModelSelectorListProps) {
+  const { models } = useModelSelectorContext();
+
+  return (
+    <CommandList
+      data-slot="model-selector-list"
+      className={cn(
+        "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <ModelSelectorEmpty />
+          <CommandGroup>
+            {models.map((model) => (
+              <ModelSelectorItem key={model.id} model={model} />
+            ))}
+          </CommandGroup>
+        </>
+      )}
+    </CommandList>
+  );
+}
+
+export type ModelSelectorEmptyProps = ComponentPropsWithoutRef<
+  typeof CommandEmpty
+>;
+
+function ModelSelectorEmpty({ children, ...props }: ModelSelectorEmptyProps) {
+  return (
+    <CommandEmpty data-slot="model-selector-empty" {...props}>
+      {children ?? "No models found."}
+    </CommandEmpty>
+  );
+}
+
+export type ModelSelectorGroupProps = ComponentPropsWithoutRef<
+  typeof CommandGroup
+>;
+
+function ModelSelectorGroup(props: ModelSelectorGroupProps) {
+  return <CommandGroup data-slot="model-selector-group" {...props} />;
+}
+
+export type ModelSelectorSeparatorProps = ComponentPropsWithoutRef<
+  typeof CommandSeparator
+>;
+
+function ModelSelectorSeparator(props: ModelSelectorSeparatorProps) {
+  return <CommandSeparator data-slot="model-selector-separator" {...props} />;
+}
+
+export type ModelSelectorItemProps = Omit<
+  ComponentPropsWithoutRef<typeof CommandItem>,
+  "value"
+> & {
+  model: ModelOption;
+};
+
+function ModelSelectorItem({
+  model,
+  className,
+  children,
+  onSelect,
+  ...props
+}: ModelSelectorItemProps) {
+  const { value, setValue, setOpen } = useModelSelectorContext();
+  const isSelected = value === model.id;
+
+  return (
+    <CommandItem
+      data-slot="model-selector-item"
+      value={model.id}
+      keywords={[model.name, ...(model.keywords ?? [])]}
+      {...(model.disabled ? { disabled: true } : undefined)}
+      onSelect={(selectedValue) => {
+        setValue(model.id);
+        setOpen(false);
+        onSelect?.(selectedValue);
+      }}
+      className={cn(
+        "relative items-start gap-2 rounded-lg py-2 ps-3 pe-9 [&_svg:not([class*='size-'])]:size-3.5",
+        className,
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          {model.icon && (
+            <ModelIcon className="mt-[3px]">{model.icon}</ModelIcon>
+          )}
+          <span className="flex min-w-0 flex-col">
+            <span className="truncate font-medium">{model.name}</span>
+            {model.description && (
+              <span className="text-muted-foreground truncate text-xs">
+                {model.description}
+              </span>
+            )}
+          </span>
+        </>
+      )}
+      {isSelected && (
+        <span className="absolute end-3 top-2.5 flex size-4 items-center justify-center">
+          <CheckIcon className="size-4" />
+        </span>
+      )}
+    </CommandItem>
+  );
+}
+
+export type ModelSelectorEffortProps = ComponentPropsWithoutRef<"div"> & {
+  label?: ReactNode;
+};
+
+function ModelSelectorEffort({
+  label = "Thinking",
+  className,
+  onKeyDown,
+  ...props
+}: ModelSelectorEffortProps) {
+  const { efforts, effort, setEffort } = useModelSelectorEfforts();
+
+  if (!efforts?.length) return null;
+
+  return (
+    <div
+      data-slot="model-selector-effort"
+      className={cn(
+        "flex items-center justify-between gap-3 border-t px-3 py-2",
+        className,
+      )}
+      onKeyDown={(e) => {
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
+        // cmdk's Command root claims Home/End to jump the model list; stop
+        // them here so only the radiogroup reacts.
+        if (e.key === "Home" || e.key === "End") e.stopPropagation();
+        // Vertical arrows refocus cmdk's input before the event bubbles to
+        // the Command root: the same keypress then moves the list highlight,
+        // and Enter selects again (cmdk's Enter is inert while a radio has
+        // focus, so the highlight would otherwise move with no way to act).
+        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+          e.currentTarget
+            .closest("[cmdk-root]")
+            ?.querySelector<HTMLInputElement>("[cmdk-input]")
+            ?.focus();
+        }
+      }}
+      {...props}
+    >
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <RadioGroup
+        value={effort ?? ""}
+        onValueChange={setEffort}
+        aria-label={typeof label === "string" ? label : "Reasoning effort"}
+        className="flex items-center gap-0.5"
+      >
+        {efforts.map((option) => (
+          <Radio.Root
+            key={option.id}
+            value={option.id}
+            className={cn(
+              "focus-visible:ring-ring/50 text-muted-foreground hover:text-foreground rounded-md px-2 py-1 text-xs transition-colors outline-none focus-visible:ring-2",
+              "data-checked:bg-accent data-checked:text-accent-foreground data-checked:font-medium",
+            )}
+          >
+            {option.name}
+          </Radio.Root>
+        ))}
+      </RadioGroup>
+    </div>
+  );
+}
+
+export type ModelSelectorProps = Omit<ModelSelectorRootProps, "children"> &
+  VariantProps<typeof modelSelectorTriggerVariants> & {
+    /** Render a search input above the model list. */
+    searchable?: boolean;
+    /** Alignment of the dropdown relative to the trigger. Use `"end"` when the
+     * trigger sits at the right edge of its container. */
+    align?: ModelSelectorContentProps["align"];
+    className?: string;
+    contentClassName?: string;
+  };
+
+/** Registers the selection with assistant-ui's ModelContext system. The
+ * context's effort is already resolved against the selected model. */
+function ModelSelectorModelContext() {
+  const { value, effort } = useModelSelectorContext();
+  const api = useAui();
+
+  useEffect(() => {
+    if (value === undefined) return;
+    const config = {
+      config: {
+        modelName: value,
+        ...(effort !== undefined ? { reasoningEffort: effort } : undefined),
+      },
+    };
+    return api.modelContext().register({
+      getModelContext: () => config,
+    });
+  }, [api, value, effort]);
+
+  return null;
+}
+
+const ModelSelectorImpl = ({
+  searchable,
+  variant,
+  size,
+  align,
+  className,
+  contentClassName,
+  ...rootProps
+}: ModelSelectorProps) => {
+  return (
+    <ModelSelectorRoot {...rootProps}>
+      <ModelSelectorModelContext />
+      <ModelSelectorTrigger
+        variant={variant}
+        size={size}
+        className={className}
+      />
+      <ModelSelectorContent
+        {...(align !== undefined ? { align } : {})}
+        className={contentClassName}
+        searchable={searchable ?? false}
+      />
+    </ModelSelectorRoot>
+  );
+};
+
+type ModelSelectorComponent = typeof ModelSelectorImpl & {
+  displayName?: string;
+  Root: typeof ModelSelectorRoot;
+  Trigger: typeof ModelSelectorTrigger;
+  Value: typeof ModelSelectorValue;
+  Content: typeof ModelSelectorContent;
+  Search: typeof ModelSelectorSearch;
+  FocusAnchor: typeof ModelSelectorFocusAnchor;
+  List: typeof ModelSelectorList;
+  Empty: typeof ModelSelectorEmpty;
+  Group: typeof ModelSelectorGroup;
+  Separator: typeof ModelSelectorSeparator;
+  Item: typeof ModelSelectorItem;
+  Effort: typeof ModelSelectorEffort;
+};
+
+const ModelSelector = memo(
+  ModelSelectorImpl,
+) as unknown as ModelSelectorComponent;
+
+ModelSelector.displayName = "ModelSelector";
+ModelSelector.Root = ModelSelectorRoot;
+ModelSelector.Trigger = ModelSelectorTrigger;
+ModelSelector.Value = ModelSelectorValue;
+ModelSelector.Content = ModelSelectorContent;
+ModelSelector.Search = ModelSelectorSearch;
+ModelSelector.FocusAnchor = ModelSelectorFocusAnchor;
+ModelSelector.List = ModelSelectorList;
+ModelSelector.Empty = ModelSelectorEmpty;
+ModelSelector.Group = ModelSelectorGroup;
+ModelSelector.Separator = ModelSelectorSeparator;
+ModelSelector.Item = ModelSelectorItem;
+ModelSelector.Effort = ModelSelectorEffort;
+
+export {
+  ModelSelector,
+  ModelSelectorRoot,
+  ModelSelectorTrigger,
+  ModelSelectorValue,
+  ModelSelectorContent,
+  ModelSelectorSearch,
+  ModelSelectorFocusAnchor,
+  ModelSelectorList,
+  ModelSelectorEmpty,
+  ModelSelectorGroup,
+  ModelSelectorSeparator,
+  ModelSelectorItem,
+  ModelSelectorEffort,
+};

--- a/packages/ui/src/components/assistant-ui/select.base.tsx
+++ b/packages/ui/src/components/assistant-ui/select.base.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { cva, type VariantProps } from "class-variance-authority";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const SelectRoot = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const selectTriggerVariants = cva(
+  "focus-visible:ring-ring/50 data-placeholder:text-muted-foreground flex w-fit items-center justify-between gap-2 rounded-md text-sm whitespace-nowrap transition-colors outline-none focus-visible:ring-2 disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:line-clamp-1",
+  {
+    variants: {
+      variant: {
+        outline:
+          "border-input hover:bg-accent hover:text-accent-foreground border bg-transparent",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        muted: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+      },
+      size: {
+        default: "h-9 px-3 py-2",
+        sm: "h-8 px-2.5 py-1.5 text-xs",
+        lg: "h-10 px-4 py-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "outline",
+      size: "default",
+    },
+  },
+);
+
+const SelectTrigger = ({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props &
+  VariantProps<typeof selectTriggerVariants>) => (
+  <SelectPrimitive.Trigger
+    data-slot="select-trigger"
+    data-variant={variant ?? "outline"}
+    data-size={size ?? "default"}
+    className={cn(selectTriggerVariants({ variant, size }), className)}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon
+      render={<ChevronDownIcon className="size-4 opacity-50" />}
+    />
+  </SelectPrimitive.Trigger>
+);
+
+const SelectScrollUpButton = ({
+  className,
+  ...props
+}: SelectPrimitive.ScrollUpArrow.Props) => (
+  <SelectPrimitive.ScrollUpArrow
+    data-slot="select-scroll-up-button"
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      "top-0 w-full",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUpIcon className="size-4" />
+  </SelectPrimitive.ScrollUpArrow>
+);
+
+const SelectScrollDownButton = ({
+  className,
+  ...props
+}: SelectPrimitive.ScrollDownArrow.Props) => (
+  <SelectPrimitive.ScrollDownArrow
+    data-slot="select-scroll-down-button"
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      "bottom-0 w-full",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDownIcon className="size-4" />
+  </SelectPrimitive.ScrollDownArrow>
+);
+
+const SelectContent = ({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 6,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = false,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Positioner
+      side={side}
+      sideOffset={sideOffset}
+      align={align}
+      alignOffset={alignOffset}
+      alignItemWithTrigger={alignItemWithTrigger}
+      className="isolate z-50"
+    >
+      <SelectPrimitive.Popup
+        data-slot="select-content"
+        className={cn(
+          "bg-popover/95 text-popover-foreground relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm",
+          "data-open:fade-in-0 data-open:zoom-in-95 data-open:animate-in",
+          "data-closed:fade-out-0 data-closed:zoom-out-95 data-closed:animate-out",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          !alignItemWithTrigger &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1 rtl:data-[side=left]:translate-x-1 rtl:data-[side=right]:-translate-x-1",
+          className,
+        )}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.List
+          className={cn(
+            !alignItemWithTrigger &&
+              "h-[var(--anchor-height)] w-full min-w-[var(--anchor-width)] scroll-my-1",
+          )}
+        >
+          {children}
+        </SelectPrimitive.List>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Popup>
+    </SelectPrimitive.Positioner>
+  </SelectPrimitive.Portal>
+);
+
+const SelectLabel = ({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) => (
+  <SelectPrimitive.GroupLabel
+    data-slot="select-label"
+    className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+    {...props}
+  />
+);
+
+const SelectItem = ({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) => (
+  <SelectPrimitive.Item
+    data-slot="select-item"
+    className={cn(
+      "relative flex w-full cursor-default items-center gap-2 rounded-lg py-2 ps-3 pe-9 text-sm outline-none select-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-disabled:pointer-events-none data-disabled:opacity-50",
+      "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+      className,
+    )}
+    {...props}
+  >
+    <SelectPrimitive.ItemIndicator
+      render={
+        <span className="absolute end-3 flex size-4 items-center justify-center" />
+      }
+    >
+      <CheckIcon className="size-4" />
+    </SelectPrimitive.ItemIndicator>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+);
+
+const SelectSeparator = ({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) => (
+  <SelectPrimitive.Separator
+    data-slot="select-separator"
+    className={cn("bg-border -mx-1 my-1 h-px", className)}
+    {...props}
+  />
+);
+
+export interface SelectOption {
+  value: string;
+  label: ReactNode;
+  textValue?: string;
+  disabled?: boolean;
+}
+
+export interface SelectProps extends Pick<
+  SelectPrimitive.Root.Props<string>,
+  "disabled"
+> {
+  value: string;
+  onValueChange: (value: string) => void;
+  options: readonly SelectOption[];
+  placeholder?: string;
+  className?: string;
+}
+
+function Select({
+  options,
+  placeholder,
+  className,
+  value,
+  onValueChange,
+  ...props
+}: SelectProps) {
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <SelectRoot
+      value={value}
+      onValueChange={(nextValue) => {
+        if (nextValue !== null) onValueChange(nextValue);
+      }}
+      {...props}
+    >
+      <SelectPrimitive.Trigger
+        className={cn(
+          "flex items-center gap-1.5 rounded-md py-1 ps-3 pe-2 text-sm transition-colors outline-none",
+          "text-muted-foreground hover:bg-muted hover:text-foreground",
+          "focus-visible:ring-ring/50 focus-visible:ring-2",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          !selectedOption && placeholder && "italic opacity-70",
+          className,
+        )}
+      >
+        <span>{selectedOption?.label ?? placeholder}</span>
+        <ChevronDownIcon className="size-3.5 opacity-50" />
+      </SelectPrimitive.Trigger>
+
+      <SelectContent>
+        {options.map(({ label, disabled, textValue, ...itemProps }) => (
+          <SelectItem
+            key={itemProps.value}
+            {...itemProps}
+            {...(disabled !== undefined ? { disabled } : {})}
+            label={
+              textValue ?? (typeof label === "string" ? label : itemProps.value)
+            }
+          >
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </SelectRoot>
+  );
+}
+
+export {
+  Select,
+  SelectRoot,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+  selectTriggerVariants,
+};

--- a/packages/ui/src/components/assistant-ui/tabs.base.tsx
+++ b/packages/ui/src/components/assistant-ui/tabs.base.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentProps,
+} from "react";
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+type IndicatorStyle = { left: string; width: string };
+
+type TabsListContextValue = {
+  registerTrigger: (value: string, element: HTMLElement | null) => void;
+  setHoveredValue: (value: string | null) => void;
+};
+
+const TabsListContext = createContext<TabsListContextValue | null>(null);
+
+function Tabs({
+  className,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("group/tabs flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list text-muted-foreground relative inline-flex w-fit items-center justify-center",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted gap-1 rounded-lg p-1",
+        line: "border-border gap-1 border-b bg-transparent pb-2",
+        ghost: "gap-1.5 bg-transparent",
+        pills: "gap-2 bg-transparent",
+        outline: "border-border gap-1 rounded-lg border p-1",
+      },
+      size: {
+        sm: "h-8",
+        default: "h-9",
+        lg: "h-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+const tabsActiveIndicatorVariants = cva(
+  "pointer-events-none absolute transition-all duration-300 ease-out",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-background dark:border-input dark:bg-input/30 inset-y-1 rounded-md shadow-sm dark:border",
+        line: "bg-foreground bottom-0 h-0.5",
+        ghost: "bg-foreground/8 inset-y-1 rounded-md",
+        pills: "bg-primary inset-y-0 rounded-full",
+        outline: "border-border bg-background inset-y-1 rounded-md border",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant,
+  size,
+  children,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  const resolvedVariant = variant ?? "default";
+  const resolvedSize = size ?? "default";
+
+  const triggerRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const listRef = useRef<HTMLDivElement>(null);
+  const [hoveredValue, setHoveredValue] = useState<string | null>(null);
+  const [activeStyle, setActiveStyle] = useState<IndicatorStyle>({
+    left: "0px",
+    width: "0px",
+  });
+  const [hoverStyle, setHoverStyle] = useState<IndicatorStyle>({
+    left: "0px",
+    width: "0px",
+  });
+
+  const registerTrigger = useCallback(
+    (value: string, element: HTMLElement | null) => {
+      if (element) {
+        triggerRefs.current.set(value, element);
+      } else {
+        triggerRefs.current.delete(value);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (hoveredValue) {
+      const element = triggerRefs.current.get(hoveredValue);
+      if (element) {
+        setHoverStyle({
+          left: `${element.offsetLeft}px`,
+          width: `${element.offsetWidth}px`,
+        });
+      }
+    }
+  }, [hoveredValue]);
+
+  useEffect(() => {
+    const listElement = listRef.current;
+    if (!listElement) return;
+
+    const updateActiveFromDOM = () => {
+      const activeElement = listElement.querySelector(
+        "[data-active]",
+      ) as HTMLElement | null;
+      if (activeElement) {
+        setActiveStyle({
+          left: `${activeElement.offsetLeft}px`,
+          width: `${activeElement.offsetWidth}px`,
+        });
+      }
+    };
+
+    requestAnimationFrame(updateActiveFromDOM);
+
+    const observer = new MutationObserver(updateActiveFromDOM);
+    observer.observe(listElement, {
+      attributes: true,
+      attributeFilter: ["data-active"],
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ registerTrigger, setHoveredValue }),
+    [registerTrigger],
+  );
+
+  return (
+    <TabsListContext.Provider value={contextValue}>
+      <TabsPrimitive.List
+        ref={listRef}
+        data-slot="tabs-list"
+        data-variant={resolvedVariant}
+        data-size={resolvedSize}
+        className={cn(
+          tabsListVariants({ variant: resolvedVariant, size: resolvedSize }),
+          className,
+        )}
+        {...props}
+      >
+        {resolvedVariant === "ghost" &&
+          hoveredValue !== null &&
+          hoverStyle.width !== "0px" && (
+            <div
+              data-slot="tabs-hover-indicator"
+              className="bg-foreground/8 pointer-events-none absolute inset-y-1 rounded-md transition-all duration-300 ease-out"
+              style={hoverStyle}
+            />
+          )}
+
+        {activeStyle.width !== "0px" && (
+          <div
+            data-slot="tabs-active-indicator"
+            className={tabsActiveIndicatorVariants({
+              variant: resolvedVariant,
+            })}
+            style={activeStyle}
+          />
+        )}
+
+        {children}
+      </TabsPrimitive.List>
+    </TabsListContext.Provider>
+  );
+}
+
+function TabsTrigger({
+  className,
+  value,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.Tab>) {
+  const context = useContext(TabsListContext);
+  const ref = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    context?.registerTrigger(value, ref.current);
+    return () => context?.registerTrigger(value, null);
+  }, [context, value]);
+
+  const handleMouseEnter = useCallback(() => {
+    context?.setHoveredValue(value);
+  }, [context, value]);
+
+  const handleMouseLeave = useCallback(() => {
+    context?.setHoveredValue(null);
+  }, [context]);
+
+  return (
+    <TabsPrimitive.Tab
+      ref={ref}
+      value={value}
+      data-slot="tabs-trigger"
+      data-value={value}
+      className={cn(
+        "text-foreground/60 hover:text-foreground focus-visible:ring-ring/50 data-active:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative z-10 inline-flex flex-1 cursor-pointer items-center justify-center gap-1.5 font-medium whitespace-nowrap transition-[color] duration-300 focus-visible:ring-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-active:font-medium [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=default]/tabs-list:rounded-md",
+        "group-data-[variant=line]/tabs-list:rounded-md group-data-[variant=line]/tabs-list:bg-transparent",
+        "group-data-[variant=ghost]/tabs-list:rounded-md group-data-[variant=ghost]/tabs-list:bg-transparent",
+        "group-data-[variant=pills]/tabs-list:data-active:text-primary-foreground dark:group-data-[variant=pills]/tabs-list:data-active:text-primary-foreground group-data-[variant=pills]/tabs-list:rounded-full",
+        "group-data-[variant=outline]/tabs-list:rounded-md",
+        "group-data-[size=sm]/tabs-list:h-[calc(100%-8px)] group-data-[size=sm]/tabs-list:px-2 group-data-[size=sm]/tabs-list:py-0.5 group-data-[size=sm]/tabs-list:text-xs",
+        "group-data-[size=default]/tabs-list:h-[calc(100%-8px)] group-data-[size=default]/tabs-list:px-3 group-data-[size=default]/tabs-list:py-1 group-data-[size=default]/tabs-list:text-sm",
+        "group-data-[size=lg]/tabs-list:h-[calc(100%-8px)] group-data-[size=lg]/tabs-list:px-4 group-data-[size=lg]/tabs-list:py-1.5 group-data-[size=lg]/tabs-list:text-sm",
+        className,
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: ComponentProps<typeof TabsPrimitive.Panel>) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  tabsListVariants,
+  tabsActiveIndicatorVariants,
+};

--- a/packages/ui/src/components/ui/direction.base.tsx
+++ b/packages/ui/src/components/ui/direction.base.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import type * as React from "react";
+import {
+  DirectionProvider as DirectionProviderPrimitive,
+  useDirection,
+} from "@base-ui/react/direction-provider";
+
+function DirectionProvider({
+  dir,
+  direction,
+  children,
+}: React.ComponentProps<typeof DirectionProviderPrimitive> & {
+  dir?: React.ComponentProps<typeof DirectionProviderPrimitive>["direction"];
+}) {
+  return (
+    <DirectionProviderPrimitive direction={direction ?? dir}>
+      {children}
+    </DirectionProviderPrimitive>
+  );
+}
+
+export { DirectionProvider, useDirection };


### PR DESCRIPTION
## summary

- select, tabs, accordion, badge, model-selector, and direction previously served their radix sources into the base registry tree and declared `radix-ui` as a shared dependency, so Base UI projects installed Radix; each now ships a `.base.tsx` variant built on the matching `@base-ui/react` primitive, with exports and `data-slot` surfaces identical to the radix side (enforced by the build's parity validators)
- registry metadata splits per style: `radix-ui` moves into `radixDependencies`, `@base-ui/react` rides the previously unused `baseDependencies`, and the accordion item injects dual-variable accordion keyframes so its collapse animation reads both libraries' height variables
- the slot parity collector now also recognizes the object-prop spelling `"data-slot": "x"` used by useRender-based components (badge), alongside the jsx attribute form

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/shadcn-registry build` -> green with all nine validators; per-item dist inspection shows the radix tree keeping `radix-ui`, the base tree carrying `@base-ui/react`, and zero `radix-ui` references in any base payload
- [x] `pnpm --filter @assistant-ui/shadcn-registry test` -> 21/21 (includes the new object-prop slot case)
- [x] `pnpm exec tsc --noEmit` in packages/ui -> clean; root `pnpm lint` -> clean
- [x] slot and export sets verified identical per pair (badge and model-selector caught real gaps during integration: the badge slot needed the literal prop form, and Base UI's RadioGroup has no `orientation` prop, both fixed)

### reviewer should verify

- [ ] on a base-nova test app, `shadcn add` select, tabs, accordion, and model-selector and exercise them: select popup opens and positions, tabs keyboard navigation moves the indicator, accordion collapse animates, model-selector reasoning-effort radios respond to arrow keys

## notes

- behavioral prop surfaces diverge where the primitives diverge, matching how shadcn's own dual trees behave: Base UI accordion uses `multiple` and array values instead of radix's `type`/`collapsible`, Base UI tabs emit `data-active` rather than `data-state="active"` (the indicator MutationObserver watches the right attribute per flavor), badge swaps `asChild` for `render`, and the base radio group drops radix's `orientation` (Base UI navigates all arrow axes)
- select's composable trigger keeps a `data-placeholder:` class that has no matching attribute under Base UI (inert there; the packaged `Select` styles its placeholder through its own conditional), left for a future placeholder-state alignment pass
- with these six closed, no fallback-served base payload imports radix anymore, which unblocks the planned fallback-content scan follow-up

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

