### PR TITLE
ci: install root tooling for the template sync check

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -73,12 +73,24 @@ jobs:
   template-sync:
     name: Template Sync
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Checkout code repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
         with:
           fetch-depth: 1
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
+
+      - name: Setup node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install root tooling
+        run: pnpm install --frozen-lockfile --filter .
 
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh


### PR DESCRIPTION
## summary

- the Template Sync job gains pnpm, node, and a root-filtered install (oxfmt lives in root devDependencies) ahead of the flavor-aware sync-templates change, whose render step needs oxfmt to keep minimal's copies byte-comparable
- a no-op for the current bash-only script; sequenced first so the follow-up lands on a job that already has its tooling

no test plan, workflow-only change exercised by the follow-up PR's Template Sync run

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

