### PR TITLE
feat(react-ai-sdk): forward onResumeToolCall to the external store

### DIFF
--- a/.changeset/ai-sdk-resume-tool-call.md
+++ b/.changeset/ai-sdk-resume-tool-call.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: forward onResumeToolCall to the external store adapter

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -13,6 +13,7 @@ type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
   toCreateMessage?: CustomToCreateMessageFunction;
   cancelPendingToolCallsOnSend?: boolean | undefined;
   onResume?: ExternalStoreAdapter["onResume"];
+  onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
   joinStrategy?: JoinStrategy | undefined;
 };
 
@@ -1969,6 +1970,7 @@ type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage$1 = UIMessage$1> = ChatI
   adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
   toCreateMessage?: CustomToCreateMessageFunction;
   onResume?: AISDKRuntimeAdapter["onResume"];
+  onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
   onResumeError?: ((error: unknown) => void) | undefined;
   joinStrategy?: AISDKRuntimeAdapter["joinStrategy"];
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -464,6 +464,79 @@ describe("useAISDKRuntime", () => {
     ).rejects.toThrow("Runtime does not support resuming runs.");
   });
 
+  it("forwards onResumeToolCall so runtime.thread.resumeToolCall is delivered to the adapter", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-weather",
+            toolCallId: "tc-42",
+            state: "input-available",
+            input: { city: "NYC" },
+          },
+        ],
+      },
+    ]);
+    const onResumeToolCall = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAISDKRuntime(chat, { onResumeToolCall }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    act(() => {
+      result.current.thread
+        .getMessageById("a1")
+        .getMessagePartByToolCallId("tc-42")
+        .resumeToolCall({ answer: "yes" });
+    });
+
+    expect(onResumeToolCall).toHaveBeenCalledTimes(1);
+    expect(onResumeToolCall).toHaveBeenCalledWith({
+      toolCallId: "tc-42",
+      payload: { answer: "yes" },
+    });
+  });
+
+  it("throws when resumeToolCall is called without an onResumeToolCall adapter", async () => {
+    const chat = createChatHelpers([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-weather",
+            toolCallId: "tc-missing",
+            state: "input-available",
+            input: { city: "NYC" },
+          },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() => useAISDKRuntime(chat));
+
+    await waitFor(() => {
+      expect(result.current.thread.getState().messages.length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    expect(() =>
+      result.current.thread
+        .getMessageById("a1")
+        .getMessagePartByToolCallId("tc-missing")
+        .resumeToolCall({ answer: "yes" }),
+    ).toThrow("Tool call tc-missing is not waiting for resume.");
+  });
+
   it("reload slices history and regenerates with metadata", async () => {
     const chat = createChatHelpers([
       { id: "u1", role: "user", parts: [{ type: "text", text: "first" }] },

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -84,6 +84,13 @@ export type AISDKRuntimeAdapter = ExternalStoreSharedOptions & {
    */
   onResume?: ExternalStoreAdapter["onResume"];
   /**
+   * Called when `runtime.thread.resumeToolCall(options)` is invoked for a tool call the in-process tracker does not own.
+   *
+   * When omitted, `resumeToolCall` throws `"Tool call ${toolCallId} is not waiting for resume."`.
+   * Provide this to bridge resume-tool-call invocations into a custom handler.
+   */
+  onResumeToolCall?: ExternalStoreAdapter["onResumeToolCall"];
+  /**
    * How consecutive assistant messages are rendered.
    *
    * `"concat-content"` (the default) merges them into a single thread message.
@@ -103,6 +110,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     toCreateMessage: customToCreateMessage,
     cancelPendingToolCallsOnSend = true,
     onResume,
+    onResumeToolCall,
     joinStrategy,
   } = adapter;
   const contextAdapters = useRuntimeAdapters();
@@ -380,6 +388,7 @@ export const useAISDKRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     },
     ...pickExternalStoreSharedOptions(adapter),
     ...(onResume && { onResume }),
+    ...(onResumeToolCall && { onResumeToolCall }),
     adapters: {
       attachments: vercelAttachmentAdapter,
       ...contextAdapters,

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -29,6 +29,7 @@ export type UseChatRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
       adapters?: AISDKRuntimeAdapter["adapters"] | undefined;
       toCreateMessage?: CustomToCreateMessageFunction;
       onResume?: AISDKRuntimeAdapter["onResume"];
+      onResumeToolCall?: AISDKRuntimeAdapter["onResumeToolCall"];
       /**
        * Called when `useChatRuntime` automatically attempts to resume a pending
        * resumable stream on mount and that reconnect fails. Use this to surface
@@ -87,6 +88,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     unstable_capabilities: _unstable_capabilities,
     suggestions: _suggestions,
     onResume,
+    onResumeToolCall,
     onResumeError,
     joinStrategy,
     ...chatOptions
@@ -114,6 +116,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...pickExternalStoreSharedOptions(options ?? {}),
     ...(toCreateMessage && { toCreateMessage }),
     ...(onResume && { onResume }),
+    ...(onResumeToolCall && { onResumeToolCall }),
     ...(joinStrategy && { joinStrategy }),
   });
 


### PR DESCRIPTION
## summary

- the external store adapter's resume family has two fields; `onResume` is surfaced and forwarded by the AI SDK runtime (the #3998 lineage), `onResumeToolCall` was not: an adapter passing it into `useChatRuntime` / `useAISDKRuntime` was silently ignored and `resumeToolCall` fell through to the "not waiting for resume" error
- adds `onResumeToolCall` to `AISDKRuntimeAdapter` and `UseChatRuntimeOptions`, forwarded with the identical conditional-spread pattern as `onResume`, with a JSDoc line that documents the actual absent-adapter behavior (it is not a capability throw like `resumeRun`; the in-process tool-invocation tracker is consulted first and the error is the same as "no pending resume")
- two mirror tests: the resume-tool-call invocation is delivered to the adapter, and the absent-adapter path surfaces the documented error

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 132/132 green (13 files), including the two new mirror cases
- [x] `pnpm --filter @assistant-ui/react-ai-sdk exec tsc --noEmit` clean, root `pnpm lint` green, api-surface regenerated (append-only)

### reviewer should verify

- [ ] with an external-store-style `onResumeToolCall` handler passed through `useChatRuntime({ onResumeToolCall })`, invoking resume on a pending human tool call reaches the handler instead of throwing

## notes

- mirrors the shipping shape of `onResume` exactly (type placement, JSDoc voice, forwarding, test structure), so the two resume-family fields now have parity across the AI SDK runtime surface

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

