### PR TITLE
fix: base select popup rendering and dual-flavor docs polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Broad model support out of the box (OpenAI, Anthropic, Google Gemini, Mistral, P
 
 ## Customization
 
-Radix-style: instead of a single monolithic chat component, you compose primitives and bring your own styles. The CLI ships a great starter; you control everything else.
+Instead of a single monolithic chat component, you compose primitives and bring your own styles. The CLI ships a great starter in your choice of Base UI (the default) or Radix UI flavor; you control everything else.
 
 ![Overview of components](https://raw.githubusercontent.com/assistant-ui/assistant-ui/main/.github/assets/components.png)
 

--- a/apps/docs/components/docs/fumadocs/install/component-source.tsx
+++ b/apps/docs/components/docs/fumadocs/install/component-source.tsx
@@ -70,6 +70,12 @@ async function readLocalShadcnComponent(
   name: string,
   flavor: RegistryFlavor,
 ): Promise<string | null> {
+  const uiPath = path.join(
+    process.cwd(),
+    "../../packages/ui/src/components/ui",
+    `${name}.tsx`,
+  );
+
   if (flavor === "base") {
     const vendoredPath = path.join(
       process.cwd(),
@@ -84,24 +90,13 @@ async function readLocalShadcnComponent(
       );
     }
 
-    const fallbackPath = path.join(
-      process.cwd(),
-      "../../packages/ui/src/components/ui",
-      `${name}.tsx`,
-    );
-    const fallbackContent = await readFile(fallbackPath);
+    const fallbackContent = await readFile(uiPath);
     return fallbackContent !== null && !RADIX_IMPORT.test(fallbackContent)
       ? fallbackContent
       : null;
   }
 
-  const localPath = path.join(
-    process.cwd(),
-    "../../packages/ui/src/components/ui",
-    `${name}.tsx`,
-  );
-
-  return readFile(localPath);
+  return readFile(uiPath);
 }
 
 function parseRegistryDependency(dep: string): {

--- a/apps/docs/components/docs/fumadocs/install/component-source.tsx
+++ b/apps/docs/components/docs/fumadocs/install/component-source.tsx
@@ -30,15 +30,22 @@ export type ResolvedGroup = {
 };
 
 export type ResolvedComponents = {
-  /** Main component files (the requested components) */
   main: ResolvedGroup;
-  /** assistant-ui dependency files */
   auiDeps: ResolvedGroup;
-  /** shadcn/ui dependency files */
   shadcn: ResolvedGroup;
 };
 
 export type RegistryFlavor = "radix" | "base";
+
+const RADIX_IMPORT = /(?:from|import)\s*\(?\s*["'](?:radix-ui["']|@radix-ui\/)/;
+
+async function readFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
 
 async function readLocalRegistry(
   name: string,
@@ -69,21 +76,32 @@ async function readLocalShadcnComponent(
       "../../packages/ui/src/components/ui-base",
       `${name}.tsx`,
     );
-    try {
-      const content = await fs.readFile(vendoredPath, "utf-8");
-      return content.replaceAll("@/components/ui-base/", "@/components/ui/");
-    } catch {
-      return null;
+    const vendoredContent = await readFile(vendoredPath);
+    if (vendoredContent !== null) {
+      return vendoredContent.replaceAll(
+        "@/components/ui-base/",
+        "@/components/ui/",
+      );
     }
+
+    const fallbackPath = path.join(
+      process.cwd(),
+      "../../packages/ui/src/components/ui",
+      `${name}.tsx`,
+    );
+    const fallbackContent = await readFile(fallbackPath);
+    return fallbackContent !== null && !RADIX_IMPORT.test(fallbackContent)
+      ? fallbackContent
+      : null;
   }
 
-  const localPath = path.join(process.cwd(), "components/ui", `${name}.tsx`);
+  const localPath = path.join(
+    process.cwd(),
+    "../../packages/ui/src/components/ui",
+    `${name}.tsx`,
+  );
 
-  try {
-    return await fs.readFile(localPath, "utf-8");
-  } catch {
-    return null;
-  }
+  return readFile(localPath);
 }
 
 function parseRegistryDependency(dep: string): {
@@ -99,12 +117,9 @@ function parseRegistryDependency(dep: string): {
         .replace(".json", ""),
     };
   }
-  // Plain name = shadcn component
   return { source: "shadcn", name: dep };
 }
 
-// Known shadcn component dependencies (npm packages). The primitive package
-// is flavor-resolved: radix-ui on Radix styles, @base-ui/react on base styles.
 const PRIMITIVE_BACKED_SHADCN = new Set([
   "button",
   "tooltip",
@@ -169,7 +184,6 @@ export async function resolveAllComponents(
     shadcn: { files: [], dependencies: [] },
   };
 
-  // Collect dependencies for a component (returns them in order: component first, then its deps)
   async function resolveAssistantUI(
     name: string,
     isMain: boolean,
@@ -181,7 +195,6 @@ export async function resolveAllComponents(
     const item = await readLocalRegistry(name, flavor);
     if (!item) return;
 
-    // Collect npm dependencies
     if (item.dependencies) {
       for (const dep of item.dependencies) {
         if (isMain) {
@@ -192,11 +205,9 @@ export async function resolveAllComponents(
       }
     }
 
-    // First add all files from this component (skip if no files - e.g. style items)
     if (item.files) {
       for (const file of item.files) {
         const filePath = file.target ?? file.path;
-        // Skip lib/utils.ts
         if (filePath === "lib/utils.ts") continue;
 
         const targetGroup = isMain ? result.main : result.auiDeps;
@@ -208,7 +219,6 @@ export async function resolveAllComponents(
       }
     }
 
-    // Then resolve dependencies (component first, then its deps)
     if (item.registryDependencies) {
       for (const dep of item.registryDependencies) {
         const parsed = parseRegistryDependency(dep);
@@ -229,7 +239,6 @@ export async function resolveAllComponents(
     const content = await readLocalShadcnComponent(name, flavor);
     if (!content) return;
 
-    // Collect npm dependencies for shadcn components
     const deps = shadcnDependencies(name, flavor);
     if (deps) {
       for (const dep of deps) {
@@ -244,15 +253,12 @@ export async function resolveAllComponents(
     });
   }
 
-  // Resolve all requested components (mark them as main)
   for (const component of components) {
     await resolveAssistantUI(component, true);
   }
 
-  // Dependencies to ignore (assume user already has them)
   const ignoredDeps = new Set(["clsx", "tailwind-merge", "lucide-react"]);
 
-  // Convert sets to sorted arrays, filtering out ignored deps
   result.main.dependencies = Array.from(mainNpmDeps)
     .filter((dep) => !ignoredDeps.has(dep))
     .sort();
@@ -290,7 +296,6 @@ export async function ComponentSource({
   let code = item.files[0].content;
   const filePath = item.files[0].target ?? item.files[0].path;
 
-  // Clean up the code - similar to shadcn's transforms
   code = code.replaceAll("export default", "export");
 
   const lang = (filePath.split(".").pop() ?? "tsx") as "tsx" | "ts" | "js";
@@ -323,7 +328,6 @@ export function ComponentSourceFromFile({
 }) {
   let code = file.content;
 
-  // Clean up the code
   code = code.replaceAll("export default", "export");
 
   const lang = (file.path.split(".").pop() ?? "tsx") as "tsx" | "ts" | "js";

--- a/apps/docs/components/docs/samples/select.base.tsx
+++ b/apps/docs/components/docs/samples/select.base.tsx
@@ -20,6 +20,36 @@ const fruits = [
   { value: "orange", label: "Orange" },
 ];
 
+const frameworks = [
+  { value: "react", label: "React" },
+  { value: "vue", label: "Vue" },
+  { value: "svelte", label: "Svelte" },
+];
+
+const backends = [
+  { value: "node", label: "Node.js" },
+  { value: "python", label: "Python" },
+];
+
+const northAmericaTimezones = [
+  { value: "est", label: "Eastern Standard Time (EST)" },
+  { value: "cst", label: "Central Standard Time (CST)" },
+  { value: "mst", label: "Mountain Standard Time (MST)" },
+  { value: "pst", label: "Pacific Standard Time (PST)" },
+];
+
+const europeTimezones = [
+  { value: "gmt", label: "Greenwich Mean Time (GMT)" },
+  { value: "cet", label: "Central European Time (CET)" },
+  { value: "eet", label: "Eastern European Time (EET)" },
+];
+
+const asiaTimezones = [
+  { value: "ist", label: "India Standard Time (IST)" },
+  { value: "cst_china", label: "China Standard Time (CST)" },
+  { value: "jst", label: "Japan Standard Time (JST)" },
+];
+
 export function SelectSample() {
   const [value, setValue] = useState("apple");
 
@@ -92,6 +122,7 @@ export function SelectGroupsSample() {
       <SelectRoot
         value={value}
         onValueChange={(value) => value !== null && setValue(value)}
+        items={[...frameworks, ...backends]}
       >
         <SelectTrigger className="w-48">
           <SelectValue placeholder="Select a framework..." />
@@ -99,15 +130,20 @@ export function SelectGroupsSample() {
         <SelectContent>
           <SelectGroup>
             <SelectLabel>Frontend</SelectLabel>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectGroup>
           <SelectSeparator />
           <SelectGroup>
             <SelectLabel>Backend</SelectLabel>
-            <SelectItem value="node">Node.js</SelectItem>
-            <SelectItem value="python">Python</SelectItem>
+            {backends.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectGroup>
         </SelectContent>
       </SelectRoot>
@@ -127,14 +163,17 @@ export function SelectVariantsSample() {
         <SelectRoot
           value={outlineValue}
           onValueChange={(value) => value !== null && setOutlineValue(value)}
+          items={frameworks}
         >
           <SelectTrigger variant="outline" className="w-32">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </SelectRoot>
       </div>
@@ -143,14 +182,17 @@ export function SelectVariantsSample() {
         <SelectRoot
           value={ghostValue}
           onValueChange={(value) => value !== null && setGhostValue(value)}
+          items={frameworks}
         >
           <SelectTrigger variant="ghost" className="w-32">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </SelectRoot>
       </div>
@@ -159,14 +201,17 @@ export function SelectVariantsSample() {
         <SelectRoot
           value={mutedValue}
           onValueChange={(value) => value !== null && setMutedValue(value)}
+          items={frameworks}
         >
           <SelectTrigger variant="muted" className="w-32">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </SelectRoot>
       </div>
@@ -185,14 +230,17 @@ export function SelectSizesSample() {
         <SelectRoot
           value={defaultValue}
           onValueChange={(value) => value !== null && setDefaultValue(value)}
+          items={frameworks}
         >
           <SelectTrigger size="default" className="w-36">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </SelectRoot>
       </div>
@@ -201,14 +249,17 @@ export function SelectSizesSample() {
         <SelectRoot
           value={smValue}
           onValueChange={(value) => value !== null && setSmValue(value)}
+          items={frameworks}
         >
           <SelectTrigger size="sm" className="w-36">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="react">React</SelectItem>
-            <SelectItem value="vue">Vue</SelectItem>
-            <SelectItem value="svelte">Svelte</SelectItem>
+            {frameworks.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </SelectRoot>
       </div>
@@ -224,6 +275,7 @@ export function SelectScrollableSample() {
       <SelectRoot
         value={value}
         onValueChange={(value) => value !== null && setValue(value)}
+        items={[...northAmericaTimezones, ...europeTimezones, ...asiaTimezones]}
       >
         <SelectTrigger className="w-64">
           <SelectValue placeholder="Select a timezone..." />
@@ -231,22 +283,27 @@ export function SelectScrollableSample() {
         <SelectContent>
           <SelectGroup>
             <SelectLabel>North America</SelectLabel>
-            <SelectItem value="est">Eastern Standard Time (EST)</SelectItem>
-            <SelectItem value="cst">Central Standard Time (CST)</SelectItem>
-            <SelectItem value="mst">Mountain Standard Time (MST)</SelectItem>
-            <SelectItem value="pst">Pacific Standard Time (PST)</SelectItem>
+            {northAmericaTimezones.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectGroup>
           <SelectGroup>
             <SelectLabel>Europe</SelectLabel>
-            <SelectItem value="gmt">Greenwich Mean Time (GMT)</SelectItem>
-            <SelectItem value="cet">Central European Time (CET)</SelectItem>
-            <SelectItem value="eet">Eastern European Time (EET)</SelectItem>
+            {europeTimezones.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectGroup>
           <SelectGroup>
             <SelectLabel>Asia</SelectLabel>
-            <SelectItem value="ist">India Standard Time (IST)</SelectItem>
-            <SelectItem value="cst_china">China Standard Time (CST)</SelectItem>
-            <SelectItem value="jst">Japan Standard Time (JST)</SelectItem>
+            {asiaTimezones.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
+              </SelectItem>
+            ))}
           </SelectGroup>
         </SelectContent>
       </SelectRoot>

--- a/apps/docs/content/docs/ui/assistant-modal.mdx
+++ b/apps/docs/content/docs/ui/assistant-modal.mdx
@@ -47,7 +47,7 @@ export default function Home() {
 
 ## Anatomy
 
-The `AssistantModal` component is built with the following primitives:
+The Radix flavor of `AssistantModal` is built with the following primitives. The Base UI flavor composes your project's Base UI Popover instead.
 
 ```tsx
 import { AssistantModalPrimitive } from "@assistant-ui/react";
@@ -65,7 +65,7 @@ import { AssistantModalPrimitive } from "@assistant-ui/react";
 
 ### Root
 
-Contains all parts of the modal. Based on Radix UI Popover.
+Contains all parts of the modal when using `AssistantModalPrimitive` (the Radix flavor). The Base UI flavor uses your project's Base UI Popover instead.
 
 <ParametersTable
   type="AssistantModalPrimitiveRootProps"

--- a/apps/docs/content/docs/ui/badge.mdx
+++ b/apps/docs/content/docs/ui/badge.mdx
@@ -83,7 +83,7 @@ Badges automatically style SVG icons.
 
 ### As Link
 
-Use the `asChild` prop to render the badge as a different element, like a link.
+Compose with `render` (Base UI) or `asChild` (Radix) to render the badge as a different element, like a link.
 
 <PreviewCode file="components/docs/samples/badge" name="BadgeAsLinkSample" base={<BadgeBaseSamples.BadgeAsLinkSample />}>
   <BadgeAsLinkSample />
@@ -117,10 +117,15 @@ Combine with CSS transitions for scroll and color animations.
       description: "The size of the badge.",
     },
     {
+      name: "render",
+      type: "ReactElement | function",
+      description: "Base UI: compose as a different element instead of rendering a span.",
+    },
+    {
       name: "asChild",
       type: "boolean",
       default: "false",
-      description: "Merge props with child element instead of rendering a span.",
+      description: "Radix: merge props with a child element instead of rendering a span.",
     },
     {
       name: "className",

--- a/apps/docs/content/docs/ui/select.mdx
+++ b/apps/docs/content/docs/ui/select.mdx
@@ -137,6 +137,8 @@ Use the composable API for grouped options:
 | `SelectScrollUpButton` | Scroll indicator for long lists. |
 | `SelectScrollDownButton` | Scroll indicator for long lists. |
 
+With the Base UI flavor, `SelectValue` resolves the trigger label from the `items` prop on `SelectRoot`; pass the same array you map into `SelectItem` children. The Radix flavor reads the label from the selected item's text automatically.
+
 ### Select
 
 A convenience component that renders a complete select with options.

--- a/apps/docs/content/docs/ui/sources.mdx
+++ b/apps/docs/content/docs/ui/sources.mdx
@@ -109,7 +109,7 @@ Root container rendered as an `<a>` tag. Accepts all `<a>` props plus `variant` 
 | `size` | `"sm" \| "default" \| "lg"` | `"default"` | Size of the badge |
 | `target` | `string` | `"_blank"` | Link target |
 | `rel` | `string` | `"noopener noreferrer"` | Link rel attribute |
-| `asChild` | `boolean` | `false` | Merge props with a child element instead of rendering an anchor |
+| `asChild` | `boolean` | `false` | Merge props with a child element instead of rendering an anchor. Effective with the Radix badge; the Base UI badge ignores it |
 | `className` | `string` | — | Additional CSS classes |
 
 ### `SourceIcon`

--- a/apps/docs/content/docs/ui/sources.mdx
+++ b/apps/docs/content/docs/ui/sources.mdx
@@ -109,7 +109,7 @@ Root container rendered as an `<a>` tag. Accepts all `<a>` props plus `variant` 
 | `size` | `"sm" \| "default" \| "lg"` | `"default"` | Size of the badge |
 | `target` | `string` | `"_blank"` | Link target |
 | `rel` | `string` | `"noopener noreferrer"` | Link rel attribute |
-| `asChild` | `boolean` | `false` | Render as a child element using Radix Slot |
+| `asChild` | `boolean` | `false` | Merge props with a child element instead of rendering an anchor |
 | `className` | `string` | — | Additional CSS classes |
 
 ### `SourceIcon`

--- a/apps/docs/content/docs/ui/tabs.mdx
+++ b/apps/docs/content/docs/ui/tabs.mdx
@@ -104,7 +104,7 @@ Use `value` and `onValueChange` for controlled tab state.
 
 ### As Link
 
-Use the `asChild` prop on `TabsTrigger` to render as a different element, like a navigation link.
+Compose with `render` (Base UI) or `asChild` (Radix) on `TabsTrigger` to render as a different element, like a navigation link.
 
 <PreviewCode file="components/docs/samples/tabs" name="TabsAsLinkSample" base={<TabsBaseSamples.TabsAsLinkSample />}>
   <TabsAsLinkSample />
@@ -208,10 +208,15 @@ An individual tab button.
       description: "The unique value for this tab.",
     },
     {
+      name: "render",
+      type: "ReactElement | function",
+      description: "Base UI: compose as a different element instead of rendering a button.",
+    },
+    {
       name: "asChild",
       type: "boolean",
       default: "false",
-      description: "Merge props with child element instead of rendering a button.",
+      description: "Radix: merge props with a child element instead of rendering a button.",
     },
     {
       name: "disabled",

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -70,6 +70,14 @@ function validateRegistrySchema(registry: RegistryItem[]) {
   }
 }
 
+function throwIfFindings(header: string, findings: Set<string>): void {
+  if (findings.size > 0) {
+    throw new Error(
+      `${header}\n${[...findings].map((finding) => `- ${finding}`).join("\n")}`,
+    );
+  }
+}
+
 export function getBaseVariantSourcePath(sourcePath: string) {
   if (!sourcePath.endsWith(".tsx")) return null;
 
@@ -102,13 +110,7 @@ export function validateBaseVariantContent(built: BuiltRegistryPayload[]) {
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid base variant content:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid base variant content:", findings);
 }
 
 export function validateBaseTreeRadixImports(
@@ -126,13 +128,7 @@ export function validateBaseTreeRadixImports(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid base tree imports:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid base tree imports:", findings);
 }
 
 function createRegistryPayload(
@@ -203,13 +199,7 @@ export function validateRadixPassDidNotReadBaseSources(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid radix registry source reads:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid radix registry source reads:", findings);
 }
 
 export function validateVariantTreesDiffer(
@@ -251,13 +241,7 @@ export function validateVariantTreesDiffer(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid registry variant trees:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid registry variant trees:", findings);
 }
 
 function collectDataSlots(content: string) {
@@ -331,13 +315,7 @@ export function validateVariantSlotParity(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid variant slot parity:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid variant slot parity:", findings);
 }
 
 function collectExportedNames(content: string, filePath: string) {
@@ -458,13 +436,7 @@ export function validateVariantExportParity(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid variant export parity:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid variant export parity:", findings);
 }
 
 function collectUsedPackages(payload: RegistryOutputItem) {
@@ -517,13 +489,7 @@ export function validateStyleScopedDependencies(
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid style-scoped dependencies:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid style-scoped dependencies:", findings);
 }
 
 function getAssistantRegistryDependencyName(dependency: string) {
@@ -790,13 +756,7 @@ function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
     }
   }
 
-  if (findings.size > 0) {
-    throw new Error(
-      `Invalid registry install metadata:\n${[...findings]
-        .map((finding) => `- ${finding}`)
-        .join("\n")}`,
-    );
-  }
+  throwIfFindings("Invalid registry install metadata:", findings);
 }
 
 async function buildRegistry(registry: RegistryItem[]) {

--- a/packages/ui/src/components/assistant-ui/select.base.tsx
+++ b/packages/ui/src/components/assistant-ui/select.base.tsx
@@ -117,7 +117,7 @@ const SelectContent = ({
       <SelectPrimitive.Popup
         data-slot="select-content"
         className={cn(
-          "bg-popover/95 text-popover-foreground relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm",
+          "bg-popover/95 text-popover-foreground relative z-50 max-h-[min(24rem,var(--available-height))] min-w-[8rem] min-w-[var(--anchor-width)] overflow-x-hidden overflow-y-auto rounded-xl border p-1.5 shadow-lg backdrop-blur-sm",
           "data-open:fade-in-0 data-open:zoom-in-95 data-open:animate-in",
           "data-closed:fade-out-0 data-closed:zoom-out-95 data-closed:animate-out",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
@@ -128,12 +128,7 @@ const SelectContent = ({
         {...props}
       >
         <SelectScrollUpButton />
-        <SelectPrimitive.List
-          className={cn(
-            !alignItemWithTrigger &&
-              "h-[var(--anchor-height)] w-full min-w-[var(--anchor-width)] scroll-my-1",
-          )}
-        >
+        <SelectPrimitive.List className="scroll-my-1">
           {children}
         </SelectPrimitive.List>
         <SelectScrollDownButton />

--- a/packages/ui/src/components/assistant-ui/select.base.tsx
+++ b/packages/ui/src/components/assistant-ui/select.base.tsx
@@ -117,7 +117,7 @@ const SelectContent = ({
       <SelectPrimitive.Popup
         data-slot="select-content"
         className={cn(
-          "bg-popover/95 text-popover-foreground relative z-50 max-h-[min(24rem,var(--available-height))] min-w-[8rem] min-w-[var(--anchor-width)] overflow-x-hidden overflow-y-auto rounded-xl border p-1.5 shadow-lg backdrop-blur-sm",
+          "bg-popover/95 text-popover-foreground relative z-50 max-h-[min(24rem,var(--available-height))] min-w-[max(8rem,var(--anchor-width))] overflow-x-hidden overflow-y-auto rounded-xl border p-1.5 shadow-lg backdrop-blur-sm",
           "data-open:fade-in-0 data-open:zoom-in-95 data-open:animate-in",
           "data-closed:fade-out-0 data-closed:zoom-out-95 data-closed:animate-out",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/packages/ui/src/components/ui-base/badge.tsx
+++ b/packages/ui/src/components/ui-base/badge.tsx
@@ -1,0 +1,51 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90 text-white",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props,
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  });
+}
+
+export { Badge, badgeVariants };

--- a/packages/ui/src/components/ui-base/label.tsx
+++ b/packages/ui/src/components/ui-base/label.tsx
@@ -1,0 +1,18 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };


### PR DESCRIPTION
## summary

- fixes the Base UI select: the open popup was clamped to the trigger height (one visible row plus scroll arrows), and composable triggers rendered the raw value instead of the label; the popup now sizes by min(24rem, available height) and the samples pass items on the root as Base UI requires, with the divergence documented in the api reference
- renders the Manual tab's shadcn dependency files for both flavors: the radix read targeted a docs-local directory that never existed, and the base tree lacked badge and label (now vendored from base-nova) plus resizable (served via a radix-free fallback from the kit)
- neutralizes radix-only prose (asChild and Radix Slot wording) on kit pages that serve both flavors, refreshes the readme positioning line, and extracts a shared throwIfFindings helper in the registry build script

## test plan

### already verified

- [x] registry: node --test 22/22 and build exit 0; dist diff vs production shows exactly one payload delta (base/select.json popup classes), radix tree identical, zero radix imports across the base tree
- [x] CLI e2e on two fresh create-next-app beds against a local registry server with the production rewrite semantics: styles/{style} resolves base-nova to the base tree and new-york to the radix tree, the installed base select carries @base-ui/react plus the new popup classes and no radix import, dependencies stay flavor-pure per bed, model-selector pulls command.tsx with the rewritten dialog import, and the direct-url flow exits 0 with 7 files (bed tsc fails only on @/lib/utils, an artifact of skipping shadcn init and the sandbox having no ui.shadcn.com network; real installs get lib/utils from init)
- [x] docs: production build exit 0; 33 component pages x (html, .md, .md?view=radix-ui) = 99/99 with 14/14 targeted flavor assertions (select.md shows items usage on base and radix-ui on the radix view, mcp-config manual tab lists badge.tsx and label.tsx with @base-ui/react, assistant-sidebar lists resizable.tsx)
- [x] browser review on the dev server: select popup lists all items with labels in both flavors and scrollable groups cap at 24rem with internal scroll, model-selector search filters with provider groups and effort switching updates the trigger, accordion, tabs, badge, assistant-modal, and attachment interactions verified, the flavor toggle flips the whole page both directions, console clean
- [x] repo battery: oxlint 0 errors, oxfmt no drift on changed files, packages/ui and apps/docs tsc clean, sync-templates green

### reviewer should verify

- [ ] open /docs/ui/select, open the Variants select: the popup lists React, Vue, and Svelte and the closed trigger shows the label, in both flavors

## notes

- base/sources.json passes asChild to the useRender badge on the base tree; this is pre-existing on production (not introduced here) and tracked as a follow-up because the fix needs a composition decision in a single-source file
- no changeset: only private packages and apps are touched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

