### PR TITLE
feat(assistant-stream): python resumable stream layer

### DIFF
--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
 
 [project.optional-dependencies]
 langgraph = ["langchain-core>=0.3.0"]
-dev = ["pytest<8"]
+redis = ["redis>=5"]
+dev = ["pytest<8", "redis>=5"]
 
 [project.urls]
 Homepage = "https://github.com/assistant-ui/assistant-ui"

--- a/python/assistant-stream/src/assistant_stream/resumable/__init__.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/__init__.py
@@ -1,0 +1,58 @@
+from assistant_stream.resumable.context import (
+    ResumableStreamContext,
+    create_resumable_stream_context,
+)
+from assistant_stream.resumable.errors import (
+    DEFAULT_TTL_MS,
+    ResumableStreamError,
+    ResumableStreamErrorCode,
+    validate_stream_id,
+)
+from assistant_stream.resumable.response import (
+    RESUMABLE_STREAM_ID_HEADER,
+    create_resumable_assistant_stream_response,
+    create_resume_assistant_stream_response,
+)
+from assistant_stream.resumable.stores.in_memory import (
+    create_in_memory_resumable_stream_store,
+)
+from assistant_stream.resumable.types import (
+    CancellationSignal,
+    ResumableStreamEntry,
+    ResumableStreamRole,
+    ResumableStreamStatus,
+    ResumableStreamStore,
+)
+
+__all__ = [
+    "CancellationSignal",
+    "DEFAULT_TTL_MS",
+    "RESUMABLE_STREAM_ID_HEADER",
+    "ResumableStreamContext",
+    "ResumableStreamEntry",
+    "ResumableStreamError",
+    "ResumableStreamErrorCode",
+    "ResumableStreamRole",
+    "ResumableStreamStatus",
+    "ResumableStreamStore",
+    "create_in_memory_resumable_stream_store",
+    "create_resumable_assistant_stream_response",
+    "create_resumable_stream_context",
+    "create_resume_assistant_stream_response",
+    "validate_stream_id",
+]
+
+try:
+    from assistant_stream.resumable.stores.redis import (
+        RedisLikeClient,
+        RedisResumableStreamStore,
+        create_redis_resumable_stream_store,
+    )
+
+    __all__ += [
+        "RedisLikeClient",
+        "RedisResumableStreamStore",
+        "create_redis_resumable_stream_store",
+    ]
+except ImportError:
+    pass

--- a/python/assistant-stream/src/assistant_stream/resumable/__init__.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/__init__.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 from assistant_stream.resumable.context import (
     ResumableStreamContext,
     create_resumable_stream_context,
@@ -42,7 +44,7 @@ __all__ = [
     "validate_stream_id",
 ]
 
-try:
+with suppress(ImportError):
     from assistant_stream.resumable.stores.redis import (
         RedisLikeClient,
         RedisResumableStreamStore,
@@ -54,5 +56,3 @@ try:
         "RedisResumableStreamStore",
         "create_redis_resumable_stream_store",
     ]
-except ImportError:
-    pass

--- a/python/assistant-stream/src/assistant_stream/resumable/context.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/context.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator, Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from assistant_stream.resumable.errors import ResumableStreamError
 from assistant_stream.resumable.types import (
@@ -14,6 +14,7 @@ from assistant_stream.resumable.types import (
 )
 
 logger = logging.getLogger(__name__)
+_hook_logger = logging.getLogger("assistant_stream.resumable")
 
 MakeStream = Callable[[], AsyncIterator[bytes]]
 WaitUntil = Callable[[asyncio.Task[None]], None]
@@ -21,6 +22,15 @@ OnAcquire = Callable[[str, ResumableStreamRole], None]
 OnAppend = Callable[[str, int], None]
 OnFinalize = Callable[[str, Literal["done", "error"], str | None], None]
 OnError = Callable[[str, object], None]
+
+
+def _call_hook(hook: Callable[..., Any] | None, /, *args: Any) -> None:
+    if hook is None:
+        return
+    try:
+        hook(*args)
+    except Exception:
+        _hook_logger.debug("resumable stream hook failed: %r", hook, exc_info=True)
 
 
 @dataclass
@@ -41,11 +51,7 @@ class ResumableStreamContext:
             stream_id,
             ttl_ms=self._ttl_ms,
         )
-        if self._on_acquire is not None:
-            try:
-                self._on_acquire(stream_id, role)
-            except Exception:
-                pass
+        _call_hook(self._on_acquire, stream_id, role)
         if role == "producer":
             _start_producer_task(
                 self._store,
@@ -117,31 +123,15 @@ def _start_producer_task(
         try:
             async for chunk in make_stream():
                 await store.append(stream_id, chunk)
-                if on_append is not None:
-                    try:
-                        on_append(stream_id, len(chunk))
-                    except Exception:
-                        pass
+                _call_hook(on_append, stream_id, len(chunk))
             await store.finalize(stream_id, "done")
-            if on_finalize is not None:
-                try:
-                    on_finalize(stream_id, "done", None)
-                except Exception:
-                    pass
+            _call_hook(on_finalize, stream_id, "done", None)
         except Exception as err:
-            if on_error is not None:
-                try:
-                    on_error(stream_id, err)
-                except Exception:
-                    pass
+            _call_hook(on_error, stream_id, err)
             message = str(err) if str(err) else repr(err)
             try:
                 await store.finalize(stream_id, "error", message)
-                if on_finalize is not None:
-                    try:
-                        on_finalize(stream_id, "error", message)
-                    except Exception:
-                        pass
+                _call_hook(on_finalize, stream_id, "error", message)
             except Exception as finalize_err:
                 logger.error(
                     "resumable stream finalize failed: %s", finalize_err

--- a/python/assistant-stream/src/assistant_stream/resumable/context.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from assistant_stream.resumable.errors import ResumableStreamError
@@ -32,6 +32,7 @@ class ResumableStreamContext:
     _on_append: OnAppend | None
     _on_finalize: OnFinalize | None
     _on_error: OnError | None
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set, repr=False)
 
     async def run(
         self, stream_id: str, make_stream: MakeStream
@@ -41,12 +42,16 @@ class ResumableStreamContext:
             ttl_ms=self._ttl_ms,
         )
         if self._on_acquire is not None:
-            self._on_acquire(stream_id, role)
+            try:
+                self._on_acquire(stream_id, role)
+            except Exception:
+                pass
         if role == "producer":
             _start_producer_task(
                 self._store,
                 stream_id,
                 make_stream,
+                tasks=self._tasks,
                 wait_until=self._wait_until,
                 on_append=self._on_append,
                 on_finalize=self._on_finalize,
@@ -102,6 +107,7 @@ def _start_producer_task(
     stream_id: str,
     make_stream: MakeStream,
     *,
+    tasks: set[asyncio.Task[None]],
     wait_until: WaitUntil | None,
     on_append: OnAppend | None,
     on_finalize: OnFinalize | None,
@@ -112,24 +118,38 @@ def _start_producer_task(
             async for chunk in make_stream():
                 await store.append(stream_id, chunk)
                 if on_append is not None:
-                    on_append(stream_id, len(chunk))
+                    try:
+                        on_append(stream_id, len(chunk))
+                    except Exception:
+                        pass
             await store.finalize(stream_id, "done")
             if on_finalize is not None:
-                on_finalize(stream_id, "done", None)
+                try:
+                    on_finalize(stream_id, "done", None)
+                except Exception:
+                    pass
         except Exception as err:
             if on_error is not None:
-                on_error(stream_id, err)
+                try:
+                    on_error(stream_id, err)
+                except Exception:
+                    pass
             message = str(err) if str(err) else repr(err)
             try:
                 await store.finalize(stream_id, "error", message)
                 if on_finalize is not None:
-                    on_finalize(stream_id, "error", message)
+                    try:
+                        on_finalize(stream_id, "error", message)
+                    except Exception:
+                        pass
             except Exception as finalize_err:
                 logger.error(
                     "resumable stream finalize failed: %s", finalize_err
                 )
 
     task = asyncio.create_task(_pump())
+    tasks.add(task)
+    task.add_done_callback(tasks.discard)
     if wait_until is not None:
         wait_until(task)
 

--- a/python/assistant-stream/src/assistant_stream/resumable/context.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/context.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from assistant_stream.resumable.errors import ResumableStreamError
+from assistant_stream.resumable.types import (
+    ResumableStreamRole,
+    ResumableStreamStatus,
+    ResumableStreamStore,
+)
+
+logger = logging.getLogger(__name__)
+
+MakeStream = Callable[[], AsyncIterator[bytes]]
+WaitUntil = Callable[[asyncio.Task[None]], None]
+OnAcquire = Callable[[str, ResumableStreamRole], None]
+OnAppend = Callable[[str, int], None]
+OnFinalize = Callable[[str, Literal["done", "error"], str | None], None]
+OnError = Callable[[str, object], None]
+
+
+@dataclass
+class ResumableStreamContext:
+    _store: ResumableStreamStore
+    _ttl_ms: int | None
+    _wait_until: WaitUntil | None
+    _on_acquire: OnAcquire | None
+    _on_append: OnAppend | None
+    _on_finalize: OnFinalize | None
+    _on_error: OnError | None
+
+    async def run(
+        self, stream_id: str, make_stream: MakeStream
+    ) -> AsyncIterator[bytes]:
+        role = await self._store.acquire(
+            stream_id,
+            ttl_ms=self._ttl_ms,
+        )
+        if self._on_acquire is not None:
+            self._on_acquire(stream_id, role)
+        if role == "producer":
+            _start_producer_task(
+                self._store,
+                stream_id,
+                make_stream,
+                wait_until=self._wait_until,
+                on_append=self._on_append,
+                on_finalize=self._on_finalize,
+                on_error=self._on_error,
+            )
+        return _read_from_store(self._store, stream_id)
+
+    async def resume(self, stream_id: str) -> AsyncIterator[bytes] | None:
+        status = await self._store.status(stream_id)
+        if status == "missing":
+            return None
+        return _read_from_store(self._store, stream_id)
+
+    async def require_resume(self, stream_id: str) -> AsyncIterator[bytes]:
+        status = await self._store.status(stream_id)
+        if status == "missing":
+            raise ResumableStreamError(
+                "missing",
+                f"resumable stream not found: {stream_id}",
+            )
+        return _read_from_store(self._store, stream_id)
+
+    async def status(self, stream_id: str) -> ResumableStreamStatus:
+        return await self._store.status(stream_id)
+
+    async def delete(self, stream_id: str) -> None:
+        await self._store.delete(stream_id)
+
+
+def create_resumable_stream_context(
+    *,
+    store: ResumableStreamStore,
+    ttl_ms: int | None = None,
+    wait_until: WaitUntil | None = None,
+    on_acquire: OnAcquire | None = None,
+    on_append: OnAppend | None = None,
+    on_finalize: OnFinalize | None = None,
+    on_error: OnError | None = None,
+) -> ResumableStreamContext:
+    return ResumableStreamContext(
+        _store=store,
+        _ttl_ms=ttl_ms,
+        _wait_until=wait_until,
+        _on_acquire=on_acquire,
+        _on_append=on_append,
+        _on_finalize=on_finalize,
+        _on_error=on_error,
+    )
+
+
+def _start_producer_task(
+    store: ResumableStreamStore,
+    stream_id: str,
+    make_stream: MakeStream,
+    *,
+    wait_until: WaitUntil | None,
+    on_append: OnAppend | None,
+    on_finalize: OnFinalize | None,
+    on_error: OnError | None,
+) -> None:
+    async def _pump() -> None:
+        try:
+            async for chunk in make_stream():
+                await store.append(stream_id, chunk)
+                if on_append is not None:
+                    on_append(stream_id, len(chunk))
+            await store.finalize(stream_id, "done")
+            if on_finalize is not None:
+                on_finalize(stream_id, "done", None)
+        except Exception as err:
+            if on_error is not None:
+                on_error(stream_id, err)
+            message = str(err) if str(err) else repr(err)
+            try:
+                await store.finalize(stream_id, "error", message)
+                if on_finalize is not None:
+                    on_finalize(stream_id, "error", message)
+            except Exception as finalize_err:
+                logger.error(
+                    "resumable stream finalize failed: %s", finalize_err
+                )
+
+    task = asyncio.create_task(_pump())
+    if wait_until is not None:
+        wait_until(task)
+
+    def _done_callback(done_task: asyncio.Task[None]) -> None:
+        try:
+            exc = done_task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            logger.error("resumable producer task failed: %s", exc)
+
+    task.add_done_callback(_done_callback)
+
+
+async def _read_from_store(
+    store: ResumableStreamStore, stream_id: str
+) -> AsyncIterator[bytes]:
+    signal = asyncio.Event()
+    try:
+        async for entry in store.read(stream_id, "", signal):
+            yield entry.chunk
+    finally:
+        signal.set()

--- a/python/assistant-stream/src/assistant_stream/resumable/errors.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/errors.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+
+ResumableStreamErrorCode = Literal["missing", "exists", "finalized", "invalid-id"]
+
+DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+_STREAM_ID_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,256}$")
+
+
+class ResumableStreamError(Exception):
+    def __init__(self, code: ResumableStreamErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def validate_stream_id(stream_id: str) -> None:
+    if not _STREAM_ID_PATTERN.match(stream_id):
+        raise ResumableStreamError(
+            "invalid-id",
+            f"Invalid streamId: {stream_id} (must match {_STREAM_ID_PATTERN.pattern})",
+        )

--- a/python/assistant-stream/src/assistant_stream/resumable/errors.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/errors.py
@@ -18,7 +18,7 @@ class ResumableStreamError(Exception):
 
 
 def validate_stream_id(stream_id: str) -> None:
-    if not _STREAM_ID_PATTERN.match(stream_id):
+    if not _STREAM_ID_PATTERN.fullmatch(stream_id):
         raise ResumableStreamError(
             "invalid-id",
             f"Invalid streamId: {stream_id} (must match {_STREAM_ID_PATTERN.pattern})",

--- a/python/assistant-stream/src/assistant_stream/resumable/response.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/response.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
+from typing import Any
+
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from assistant_stream.create_run import RunController, create_run
+from assistant_stream.resumable.context import ResumableStreamContext
+from assistant_stream.serialization.data_stream import DataStreamEncoder
+from assistant_stream.serialization.stream_encoder import StreamEncoder
+
+RESUMABLE_STREAM_ID_HEADER = "x-resumable-stream-id"
+
+
+async def create_resumable_assistant_stream_response(
+    *,
+    context: ResumableStreamContext,
+    stream_id: str,
+    callback: Callable[[RunController], Coroutine[Any, Any, None]],
+    encoder: StreamEncoder | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> Response:
+    resolved_encoder = encoder if encoder is not None else DataStreamEncoder()
+
+    def make_stream() -> AsyncIterator[bytes]:
+        async def _gen() -> AsyncIterator[bytes]:
+            async for frame in resolved_encoder.encode_stream(create_run(callback)):
+                yield frame.encode("utf-8")
+
+        return _gen()
+
+    body = await context.run(stream_id, make_stream)
+    return StreamingResponse(
+        body,
+        media_type=resolved_encoder.get_media_type(),
+        headers=_merge_headers(headers, stream_id),
+    )
+
+
+async def create_resume_assistant_stream_response(
+    *,
+    context: ResumableStreamContext,
+    stream_id: str,
+    encoder: StreamEncoder | None = None,
+    headers: Mapping[str, str] | None = None,
+    missing_response: Callable[[], Response] | None = None,
+) -> Response:
+    body = await context.resume(stream_id)
+    if body is None:
+        if missing_response is not None:
+            return missing_response()
+        return JSONResponse({"error": "stream not found"}, status_code=404)
+
+    resolved_encoder = encoder if encoder is not None else DataStreamEncoder()
+    return StreamingResponse(
+        body,
+        media_type=resolved_encoder.get_media_type(),
+        headers=_merge_headers(headers, stream_id),
+    )
+
+
+def _merge_headers(
+    extra: Mapping[str, str] | None, stream_id: str
+) -> dict[str, str]:
+    merged: dict[str, str] = {}
+    if extra is not None:
+        merged.update(dict(extra))
+    merged[RESUMABLE_STREAM_ID_HEADER] = stream_id
+    return merged

--- a/python/assistant-stream/src/assistant_stream/resumable/response.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/response.py
@@ -23,12 +23,9 @@ async def create_resumable_assistant_stream_response(
 ) -> Response:
     resolved_encoder = encoder if encoder is not None else DataStreamEncoder()
 
-    def make_stream() -> AsyncIterator[bytes]:
-        async def _gen() -> AsyncIterator[bytes]:
-            async for frame in resolved_encoder.encode_stream(create_run(callback)):
-                yield frame.encode("utf-8")
-
-        return _gen()
+    async def make_stream() -> AsyncIterator[bytes]:
+        async for frame in resolved_encoder.encode_stream(create_run(callback)):
+            yield frame.encode("utf-8")
 
     body = await context.run(stream_id, make_stream)
     return StreamingResponse(
@@ -65,6 +62,8 @@ def _merge_headers(
 ) -> dict[str, str]:
     merged: dict[str, str] = {}
     if extra is not None:
-        merged.update(dict(extra))
+        for key, value in extra.items():
+            if key.lower() != RESUMABLE_STREAM_ID_HEADER:
+                merged[key] = value
     merged[RESUMABLE_STREAM_ID_HEADER] = stream_id
     return merged

--- a/python/assistant-stream/src/assistant_stream/resumable/response.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/response.py
@@ -7,6 +7,7 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from assistant_stream.create_run import RunController, create_run
 from assistant_stream.resumable.context import ResumableStreamContext
+from assistant_stream.resumable.errors import ResumableStreamError
 from assistant_stream.serialization.data_stream import DataStreamEncoder
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 
@@ -43,7 +44,12 @@ async def create_resume_assistant_stream_response(
     headers: Mapping[str, str] | None = None,
     missing_response: Callable[[], Response] | None = None,
 ) -> Response:
-    body = await context.resume(stream_id)
+    try:
+        body = await context.resume(stream_id)
+    except ResumableStreamError as err:
+        if err.code != "invalid-id":
+            raise
+        body = None
     if body is None:
         if missing_response is not None:
             return missing_response()

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/__init__.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/__init__.py
@@ -1,0 +1,7 @@
+from assistant_stream.resumable.stores.in_memory import (
+    create_in_memory_resumable_stream_store,
+)
+
+__all__ = [
+    "create_in_memory_resumable_stream_store",
+]

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/__init__.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/__init__.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 from assistant_stream.resumable.stores.in_memory import (
     create_in_memory_resumable_stream_store,
 )
@@ -5,3 +7,12 @@ from assistant_stream.resumable.stores.in_memory import (
 __all__ = [
     "create_in_memory_resumable_stream_store",
 ]
+
+with suppress(ImportError):
+    from assistant_stream.resumable.stores.redis import (
+        create_redis_resumable_stream_store,
+    )
+
+    __all__ += [
+        "create_redis_resumable_stream_store",
+    ]

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/in_memory.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/in_memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -152,26 +153,16 @@ class _InMemoryResumableStreamStore:
             tasks.add(asyncio.create_task(asyncio.sleep(wake_by / 1000.0)))
 
         try:
-            done, pending = await asyncio.wait(
-                tasks, return_when=asyncio.FIRST_COMPLETED
-            )
-            for task in pending:
-                task.cancel()
-            for task in pending:
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
-            for task in done:
-                try:
-                    await task
-                except Exception:
-                    pass
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         finally:
-            try:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            for task in tasks:
+                with suppress(asyncio.CancelledError):
+                    await task
+            with suppress(ValueError):
                 state.waiters.remove(event)
-            except ValueError:
-                pass
 
     def _require_active(self, stream_id: str) -> _StreamState:
         self._evict_expired()

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/in_memory.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/in_memory.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass, field
+from typing import Literal
+
+from assistant_stream.resumable.errors import (
+    DEFAULT_TTL_MS,
+    ResumableStreamError,
+    validate_stream_id,
+)
+from assistant_stream.resumable.types import (
+    CancellationSignal,
+    ResumableStreamEntry,
+    ResumableStreamRole,
+    ResumableStreamStatus,
+)
+
+
+@dataclass
+class _FinalizeMarker:
+    kind: Literal["done", "error"]
+    error: str | None = None
+
+
+@dataclass
+class _StreamState:
+    entries: list[ResumableStreamEntry] = field(default_factory=list)
+    next_seq: int = 1
+    expires_at: float = 0.0
+    ttl_ms: int = 0
+    final: _FinalizeMarker | None = None
+    waiters: list[asyncio.Event] = field(default_factory=list)
+
+
+def _cursor_of(seq: int) -> str:
+    if seq == 0:
+        return "0"
+    alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+    n = seq
+    chars: list[str] = []
+    while n:
+        n, rem = divmod(n, 36)
+        chars.append(alphabet[rem])
+    return "".join(reversed(chars))
+
+
+def _seq_from_cursor(cursor: str) -> int:
+    if cursor == "":
+        return 0
+    try:
+        return int(cursor, 36)
+    except ValueError:
+        return 0
+
+
+class _InMemoryResumableStreamStore:
+    def __init__(
+        self,
+        *,
+        default_ttl_ms: int,
+        now: Callable[[], float],
+        max_chunk_bytes: int | None,
+        max_entries_per_stream: int | None,
+        max_streams: int | None,
+        gc_interval_ms: int | None,
+    ) -> None:
+        self._streams: dict[str, _StreamState] = {}
+        self._default_ttl_ms = default_ttl_ms
+        self._now = now
+        self._max_chunk_bytes = max_chunk_bytes
+        self._max_entries_per_stream = max_entries_per_stream
+        self._max_streams = max_streams
+        self._gc_interval_ms = gc_interval_ms
+        self._gc_task: asyncio.Task[None] | None = None
+        self._disposed = False
+
+    def _ensure_gc(self) -> None:
+        if (
+            self._gc_interval_ms is None
+            or self._disposed
+            or self._gc_task is not None
+        ):
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        interval_s = self._gc_interval_ms / 1000.0
+
+        async def _gc_loop() -> None:
+            while True:
+                await asyncio.sleep(interval_s)
+                self._evict_expired()
+
+        self._gc_task = loop.create_task(_gc_loop())
+
+    def _evict_expired(self) -> None:
+        t = self._now()
+        expired: list[tuple[str, _StreamState]] = []
+        for stream_id, state in self._streams.items():
+            if state.expires_at <= t:
+                expired.append((stream_id, state))
+        for stream_id, state in expired:
+            del self._streams[stream_id]
+            if state.final is None:
+                state.final = _FinalizeMarker(kind="error", error="Stream expired")
+            self._notify(state)
+
+    def _notify(self, state: _StreamState) -> None:
+        waiters = state.waiters
+        state.waiters = []
+        for event in waiters:
+            event.set()
+
+    def _find_start_index(self, state: _StreamState, cursor: str) -> int:
+        if cursor == "":
+            return 0
+        after = _seq_from_cursor(cursor)
+        lo = 0
+        hi = len(state.entries)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            seq = _seq_from_cursor(state.entries[mid].cursor)
+            if seq <= after:
+                lo = mid + 1
+            else:
+                hi = mid
+        return lo
+
+    async def _wait_for_update(
+        self,
+        state: _StreamState,
+        signal: CancellationSignal,
+        wake_by: float | None,
+    ) -> None:
+        if signal.is_set():
+            return
+        if wake_by is not None and wake_by <= 0:
+            return
+
+        event = asyncio.Event()
+        state.waiters.append(event)
+
+        notify_task = asyncio.create_task(event.wait())
+        signal_task = asyncio.create_task(signal.wait())
+        tasks: set[asyncio.Task[object]] = {notify_task, signal_task}
+        if wake_by is not None:
+            tasks.add(asyncio.create_task(asyncio.sleep(wake_by / 1000.0)))
+
+        try:
+            done, pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            for task in pending:
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            for task in done:
+                try:
+                    await task
+                except Exception:
+                    pass
+        finally:
+            try:
+                state.waiters.remove(event)
+            except ValueError:
+                pass
+
+    def _require_active(self, stream_id: str) -> _StreamState:
+        self._evict_expired()
+        state = self._streams.get(stream_id)
+        if state is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+        if state.final is not None:
+            raise ResumableStreamError(
+                "finalized",
+                f"Stream already finalized: {stream_id}",
+            )
+        return state
+
+    async def acquire(
+        self, stream_id: str, *, ttl_ms: int | None = None
+    ) -> ResumableStreamRole:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        self._evict_expired()
+        if stream_id in self._streams:
+            return "consumer"
+
+        if self._max_streams is not None and len(self._streams) >= self._max_streams:
+            raise RuntimeError("maxStreams exceeded")
+
+        resolved_ttl = ttl_ms if ttl_ms is not None else self._default_ttl_ms
+        self._streams[stream_id] = _StreamState(
+            entries=[],
+            next_seq=1,
+            expires_at=self._now() + resolved_ttl,
+            ttl_ms=resolved_ttl,
+            final=None,
+            waiters=[],
+        )
+        return "producer"
+
+    async def append(self, stream_id: str, chunk: bytes) -> None:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        if (
+            self._max_chunk_bytes is not None
+            and len(chunk) > self._max_chunk_bytes
+        ):
+            raise RuntimeError(f"Chunk exceeds maxChunkBytes: {len(chunk)}")
+        state = self._require_active(stream_id)
+        if (
+            self._max_entries_per_stream is not None
+            and len(state.entries) >= self._max_entries_per_stream
+        ):
+            raise RuntimeError(f"Stream exceeded maxEntriesPerStream: {stream_id}")
+        seq = state.next_seq
+        state.next_seq += 1
+        state.entries.append(ResumableStreamEntry(cursor=_cursor_of(seq), chunk=chunk))
+        state.expires_at = self._now() + state.ttl_ms
+        self._notify(state)
+
+    async def finalize(
+        self,
+        stream_id: str,
+        status: Literal["done", "error"],
+        error: str | None = None,
+    ) -> None:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        self._evict_expired()
+        state = self._streams.get(stream_id)
+        if state is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+        if state.final is not None:
+            return
+        if status == "done":
+            state.final = _FinalizeMarker(kind="done")
+        else:
+            state.final = _FinalizeMarker(
+                kind="error", error=error if error is not None else "Stream errored"
+            )
+        state.expires_at = self._now() + state.ttl_ms
+        self._notify(state)
+
+    async def read(
+        self, stream_id: str, cursor: str, signal: CancellationSignal
+    ) -> AsyncIterator[ResumableStreamEntry]:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        self._evict_expired()
+        state = self._streams.get(stream_id)
+        if state is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+
+        idx = self._find_start_index(state, cursor)
+
+        while True:
+            if signal.is_set():
+                return
+
+            while idx < len(state.entries):
+                if signal.is_set():
+                    return
+                yield state.entries[idx]
+                idx += 1
+
+            if state.final is not None:
+                if state.final.kind == "error":
+                    raise RuntimeError(state.final.error or "Stream errored")
+                return
+
+            wake_by = state.expires_at - self._now()
+            await self._wait_for_update(state, signal, wake_by)
+            self._evict_expired()
+
+    async def status(self, stream_id: str) -> ResumableStreamStatus:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        self._evict_expired()
+        state = self._streams.get(stream_id)
+        if state is None:
+            return "missing"
+        if state.final is None:
+            return "streaming"
+        return "error" if state.final.kind == "error" else "done"
+
+    async def delete(self, stream_id: str) -> None:
+        self._ensure_gc()
+        validate_stream_id(stream_id)
+        state = self._streams.get(stream_id)
+        if state is None:
+            return
+        del self._streams[stream_id]
+        if state.final is None:
+            state.final = _FinalizeMarker(kind="done")
+        self._notify(state)
+
+    def dispose(self) -> None:
+        self._disposed = True
+        if self._gc_task is not None:
+            self._gc_task.cancel()
+            self._gc_task = None
+
+
+def create_in_memory_resumable_stream_store(
+    *,
+    default_ttl_ms: int = DEFAULT_TTL_MS,
+    now: Callable[[], float] | None = None,
+    max_chunk_bytes: int | None = None,
+    max_entries_per_stream: int | None = None,
+    max_streams: int | None = None,
+    gc_interval_ms: int | None = None,
+) -> _InMemoryResumableStreamStore:
+    return _InMemoryResumableStreamStore(
+        default_ttl_ms=default_ttl_ms,
+        now=now if now is not None else (lambda: time.time() * 1000),
+        max_chunk_bytes=max_chunk_bytes,
+        max_entries_per_stream=max_entries_per_stream,
+        max_streams=max_streams,
+        gc_interval_ms=gc_interval_ms,
+    )

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
@@ -247,7 +247,7 @@ def _parse_meta(value: str) -> dict[str, Any] | None:
 async def _sleep(ms: int, signal: CancellationSignal) -> None:
     if signal.is_set():
         return
-    with suppress(TimeoutError):
+    with suppress(asyncio.TimeoutError):
         await asyncio.wait_for(signal.wait(), timeout=ms / 1000.0)
 
 

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+from collections.abc import AsyncIterator, Mapping
+from typing import Any, Literal, Protocol
+
+from assistant_stream.resumable.errors import (
+    DEFAULT_TTL_MS,
+    ResumableStreamError,
+    validate_stream_id,
+)
+from assistant_stream.resumable.types import (
+    CancellationSignal,
+    ResumableStreamEntry,
+    ResumableStreamRole,
+    ResumableStreamStatus,
+)
+
+DEFAULT_POLL_INTERVAL_MS = 100
+DEFAULT_KEY_PREFIX = "aui:resumable"
+
+FIELD_CHUNK = "c"
+FIELD_FIN = "fin"
+FIELD_ERROR = "error"
+
+FIN_DONE = "done"
+FIN_ERROR = "error"
+
+STREAM_START_ID = "0-0"
+
+
+class RedisLikeClient(Protocol):
+    async def set_nx(self, key: str, value: str, ttl_sec: int) -> bool: ...
+
+    async def set(self, key: str, value: str, ttl_sec: int) -> None: ...
+
+    async def get(self, key: str) -> str | None: ...
+
+    async def expire(self, key: str, ttl_sec: int) -> None: ...
+
+    async def exists(self, key: str) -> bool: ...
+
+    async def delete(self, keys: list[str]) -> None: ...
+
+    async def xadd(
+        self, key: str, fields: Mapping[str, str | bytes]
+    ) -> str: ...
+
+    async def xrange(
+        self, key: str, start: str, end: str
+    ) -> list[dict[str, Any]]: ...
+
+    async def pipeline(self, commands: list[dict[str, Any]]) -> None: ...
+
+
+class RedisResumableStreamStore:
+    def __init__(
+        self,
+        client: RedisLikeClient,
+        *,
+        key_prefix: str = DEFAULT_KEY_PREFIX,
+        default_ttl_ms: int = DEFAULT_TTL_MS,
+        poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS,
+        max_chunk_bytes: int | None = None,
+    ) -> None:
+        self._client = client
+        self._key_prefix = key_prefix
+        self._default_ttl_ms = default_ttl_ms
+        self._poll_interval_ms = poll_interval_ms
+        self._max_chunk_bytes = max_chunk_bytes
+
+    def _meta_key(self, stream_id: str) -> str:
+        return f"{self._key_prefix}:{{{stream_id}}}:meta"
+
+    def _data_key(self, stream_id: str) -> str:
+        return f"{self._key_prefix}:{{{stream_id}}}:data"
+
+    async def _read_meta(self, stream_id: str) -> dict[str, Any] | None:
+        raw = await self._client.get(self._meta_key(stream_id))
+        if raw is None:
+            return None
+        return _parse_meta(raw)
+
+    async def acquire(
+        self, stream_id: str, *, ttl_ms: int | None = None
+    ) -> ResumableStreamRole:
+        validate_stream_id(stream_id)
+        ttl_sec = _ms_to_sec(ttl_ms if ttl_ms is not None else self._default_ttl_ms)
+        meta = json.dumps({"status": "streaming", "ttlSec": ttl_sec})
+        acquired = await self._client.set_nx(self._meta_key(stream_id), meta, ttl_sec)
+        if acquired:
+            await self._client.delete([self._data_key(stream_id)])
+            return "producer"
+        return "consumer"
+
+    async def append(self, stream_id: str, chunk: bytes) -> None:
+        validate_stream_id(stream_id)
+        if (
+            self._max_chunk_bytes is not None
+            and len(chunk) > self._max_chunk_bytes
+        ):
+            raise RuntimeError(
+                f"Chunk exceeds maxChunkBytes ({len(chunk)} > {self._max_chunk_bytes})"
+            )
+        data_key = self._data_key(stream_id)
+        meta_key = self._meta_key(stream_id)
+        meta = await self._read_meta(stream_id)
+        if meta is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+        if meta.get("status") != "streaming":
+            raise ResumableStreamError(
+                "finalized",
+                f"Stream already finalized: {stream_id}",
+            )
+        ttl_sec = meta.get("ttlSec")
+        if not isinstance(ttl_sec, int):
+            ttl_sec = _ms_to_sec(self._default_ttl_ms)
+        await self._client.pipeline(
+            [
+                {"type": "xAdd", "key": data_key, "fields": {FIELD_CHUNK: chunk}},
+                {"type": "expire", "key": data_key, "ttlSec": ttl_sec},
+                {"type": "expire", "key": meta_key, "ttlSec": ttl_sec},
+            ]
+        )
+
+    async def finalize(
+        self,
+        stream_id: str,
+        status: Literal["done", "error"],
+        error: str | None = None,
+    ) -> None:
+        validate_stream_id(stream_id)
+        data_key = self._data_key(stream_id)
+        meta_key = self._meta_key(stream_id)
+        existing = await self._read_meta(stream_id)
+        if existing is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+        if existing.get("status") != "streaming":
+            return
+        ttl_sec = existing.get("ttlSec")
+        if not isinstance(ttl_sec, int):
+            ttl_sec = _ms_to_sec(self._default_ttl_ms)
+        if status == "error":
+            meta = json.dumps(
+                {
+                    "status": "error",
+                    "error": error if error is not None else "Stream errored",
+                    "ttlSec": ttl_sec,
+                }
+            )
+        else:
+            meta = json.dumps({"status": "done", "ttlSec": ttl_sec})
+        fields: dict[str, str] = {
+            FIELD_FIN: FIN_ERROR if status == "error" else FIN_DONE,
+        }
+        if status == "error":
+            fields[FIELD_ERROR] = error if error is not None else "Stream errored"
+        await self._client.pipeline(
+            [
+                {"type": "set", "key": meta_key, "value": meta, "ttlSec": ttl_sec},
+                {"type": "xAdd", "key": data_key, "fields": fields},
+                {"type": "expire", "key": data_key, "ttlSec": ttl_sec},
+            ]
+        )
+
+    async def read(
+        self, stream_id: str, cursor: str, signal: CancellationSignal
+    ) -> AsyncIterator[ResumableStreamEntry]:
+        validate_stream_id(stream_id)
+        data_key = self._data_key(stream_id)
+        meta_key = self._meta_key(stream_id)
+        initial_meta = await self._client.get(meta_key)
+        if initial_meta is None:
+            raise RuntimeError(f"Stream not found: {stream_id}")
+
+        last_id = STREAM_START_ID if cursor == "" else cursor
+
+        while True:
+            if signal.is_set():
+                return
+
+            start = "-" if last_id == STREAM_START_ID else f"({last_id}"
+            entries = await self._client.xrange(data_key, start, "+")
+
+            for entry in entries:
+                if signal.is_set():
+                    return
+                entry_id = entry["id"]
+                fields = entry["fields"]
+                last_id = entry_id
+
+                fin = _read_string(fields.get(FIELD_FIN))
+                if fin == FIN_DONE:
+                    return
+                if fin == FIN_ERROR:
+                    raise RuntimeError(
+                        _read_string(fields.get(FIELD_ERROR)) or "Stream errored"
+                    )
+
+                raw = fields.get(FIELD_CHUNK)
+                if raw is None:
+                    continue
+                yield ResumableStreamEntry(cursor=entry_id, chunk=_to_bytes(raw))
+
+            if len(entries) > 0:
+                continue
+
+            still_exists = await self._client.exists(meta_key)
+            if not still_exists:
+                return
+
+            await _sleep(self._poll_interval_ms, signal)
+
+    async def status(self, stream_id: str) -> ResumableStreamStatus:
+        validate_stream_id(stream_id)
+        meta = await self._client.get(self._meta_key(stream_id))
+        if meta is None:
+            return "missing"
+        parsed = _parse_meta(meta)
+        if parsed is None:
+            return "missing"
+        status = parsed.get("status")
+        if status == "streaming":
+            return "streaming"
+        if status == "done":
+            return "done"
+        if status == "error":
+            return "error"
+        return "missing"
+
+    async def delete(self, stream_id: str) -> None:
+        validate_stream_id(stream_id)
+        await self._client.delete(
+            [self._meta_key(stream_id), self._data_key(stream_id)]
+        )
+
+
+def _ms_to_sec(ms: int) -> int:
+    return max(1, math.ceil(ms / 1000))
+
+
+def _parse_meta(value: str) -> dict[str, Any] | None:
+    try:
+        parsed = json.loads(value)
+        if isinstance(parsed, dict):
+            return parsed
+        return None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+async def _sleep(ms: int, signal: CancellationSignal) -> None:
+    if signal.is_set():
+        return
+    sleep_task = asyncio.create_task(asyncio.sleep(ms / 1000.0))
+    signal_task = asyncio.create_task(signal.wait())
+    done, pending = await asyncio.wait(
+        {sleep_task, signal_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    for task in done:
+        try:
+            await task
+        except Exception:
+            pass
+
+
+def _read_string(value: str | bytes | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return value.decode("utf-8")
+
+
+def _to_bytes(value: str | bytes) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    return value.encode("utf-8")
+
+
+class _RedisAsyncioAdapter:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    async def set_nx(self, key: str, value: str, ttl_sec: int) -> bool:
+        result = await self._client.set(key, value, nx=True, ex=ttl_sec)
+        return result is True or result == b"OK" or result == "OK"
+
+    async def set(self, key: str, value: str, ttl_sec: int) -> None:
+        await self._client.set(key, value, ex=ttl_sec)
+
+    async def get(self, key: str) -> str | None:
+        value = await self._client.get(key)
+        if value is None:
+            return None
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return str(value)
+
+    async def expire(self, key: str, ttl_sec: int) -> None:
+        await self._client.expire(key, ttl_sec)
+
+    async def exists(self, key: str) -> bool:
+        result = await self._client.exists(key)
+        return int(result) > 0
+
+    async def delete(self, keys: list[str]) -> None:
+        if not keys:
+            return
+        await self._client.delete(*keys)
+
+    async def xadd(self, key: str, fields: Mapping[str, str | bytes]) -> str:
+        result = await self._client.xadd(key, dict(fields))
+        if isinstance(result, bytes):
+            return result.decode("utf-8")
+        return str(result)
+
+    async def xrange(
+        self, key: str, start: str, end: str
+    ) -> list[dict[str, Any]]:
+        reply = await self._client.xrange(key, min=start, max=end)
+        out: list[dict[str, Any]] = []
+        for entry_id, fields in reply:
+            if isinstance(entry_id, bytes):
+                entry_id = entry_id.decode("utf-8")
+            parsed_fields: dict[str, str | bytes] = {}
+            for field_key, field_value in fields.items():
+                if isinstance(field_key, bytes):
+                    field_key = field_key.decode("utf-8")
+                parsed_fields[field_key] = field_value
+            out.append({"id": entry_id, "fields": parsed_fields})
+        return out
+
+    async def pipeline(self, commands: list[dict[str, Any]]) -> None:
+        if not commands:
+            return
+        pipe = self._client.pipeline()
+        for cmd in commands:
+            cmd_type = cmd["type"]
+            if cmd_type == "xAdd":
+                pipe.xadd(cmd["key"], dict(cmd["fields"]))
+            elif cmd_type == "expire":
+                pipe.expire(cmd["key"], cmd["ttlSec"])
+            elif cmd_type == "set":
+                pipe.set(cmd["key"], cmd["value"], ex=cmd["ttlSec"])
+        await pipe.execute()
+
+
+def create_redis_resumable_stream_store(
+    client: Any,
+    *,
+    key_prefix: str = DEFAULT_KEY_PREFIX,
+    default_ttl_ms: int = DEFAULT_TTL_MS,
+    poll_interval_ms: int = DEFAULT_POLL_INTERVAL_MS,
+    max_chunk_bytes: int | None = None,
+) -> RedisResumableStreamStore:
+    """Create a store backed by a ``redis.asyncio.Redis`` client."""
+    try:
+        import redis.asyncio  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "redis is required for create_redis_resumable_stream_store; "
+            "install with: pip install assistant-stream[redis]"
+        ) from exc
+
+    return RedisResumableStreamStore(
+        _RedisAsyncioAdapter(client),
+        key_prefix=key_prefix,
+        default_ttl_ms=default_ttl_ms,
+        poll_interval_ms=poll_interval_ms,
+        max_chunk_bytes=max_chunk_bytes,
+    )

--- a/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/stores/redis.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import json
 import math
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator
+from contextlib import suppress
 from typing import Any, Literal, Protocol
 
 from assistant_stream.resumable.errors import (
@@ -34,19 +35,11 @@ STREAM_START_ID = "0-0"
 class RedisLikeClient(Protocol):
     async def set_nx(self, key: str, value: str, ttl_sec: int) -> bool: ...
 
-    async def set(self, key: str, value: str, ttl_sec: int) -> None: ...
-
     async def get(self, key: str) -> str | None: ...
-
-    async def expire(self, key: str, ttl_sec: int) -> None: ...
 
     async def exists(self, key: str) -> bool: ...
 
     async def delete(self, keys: list[str]) -> None: ...
-
-    async def xadd(
-        self, key: str, fields: Mapping[str, str | bytes]
-    ) -> str: ...
 
     async def xrange(
         self, key: str, start: str, end: str
@@ -254,22 +247,8 @@ def _parse_meta(value: str) -> dict[str, Any] | None:
 async def _sleep(ms: int, signal: CancellationSignal) -> None:
     if signal.is_set():
         return
-    sleep_task = asyncio.create_task(asyncio.sleep(ms / 1000.0))
-    signal_task = asyncio.create_task(signal.wait())
-    done, pending = await asyncio.wait(
-        {sleep_task, signal_task}, return_when=asyncio.FIRST_COMPLETED
-    )
-    for task in pending:
-        task.cancel()
-        try:
-            await task
-        except (asyncio.CancelledError, Exception):
-            pass
-    for task in done:
-        try:
-            await task
-        except Exception:
-            pass
+    with suppress(TimeoutError):
+        await asyncio.wait_for(signal.wait(), timeout=ms / 1000.0)
 
 
 def _read_string(value: str | bytes | None) -> str | None:
@@ -294,9 +273,6 @@ class _RedisAsyncioAdapter:
         result = await self._client.set(key, value, nx=True, ex=ttl_sec)
         return result is True or result == b"OK" or result == "OK"
 
-    async def set(self, key: str, value: str, ttl_sec: int) -> None:
-        await self._client.set(key, value, ex=ttl_sec)
-
     async def get(self, key: str) -> str | None:
         value = await self._client.get(key)
         if value is None:
@@ -304,9 +280,6 @@ class _RedisAsyncioAdapter:
         if isinstance(value, bytes):
             return value.decode("utf-8")
         return str(value)
-
-    async def expire(self, key: str, ttl_sec: int) -> None:
-        await self._client.expire(key, ttl_sec)
 
     async def exists(self, key: str) -> bool:
         result = await self._client.exists(key)
@@ -316,12 +289,6 @@ class _RedisAsyncioAdapter:
         if not keys:
             return
         await self._client.delete(*keys)
-
-    async def xadd(self, key: str, fields: Mapping[str, str | bytes]) -> str:
-        result = await self._client.xadd(key, dict(fields))
-        if isinstance(result, bytes):
-            return result.decode("utf-8")
-        return str(result)
 
     async def xrange(
         self, key: str, start: str, end: str
@@ -370,6 +337,17 @@ def create_redis_resumable_stream_store(
             "redis is required for create_redis_resumable_stream_store; "
             "install with: pip install assistant-stream[redis]"
         ) from exc
+
+    connection_pool = getattr(client, "connection_pool", None)
+    if connection_pool is not None:
+        connection_kwargs = getattr(connection_pool, "connection_kwargs", None)
+        if isinstance(connection_kwargs, dict) and connection_kwargs.get(
+            "decode_responses"
+        ):
+            raise ValueError(
+                "redis client must be constructed without decode_responses "
+                "(decode_responses=True cannot round-trip binary stream chunks)"
+            )
 
     return RedisResumableStreamStore(
         _RedisAsyncioAdapter(client),

--- a/python/assistant-stream/src/assistant_stream/resumable/types.py
+++ b/python/assistant-stream/src/assistant_stream/resumable/types.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+ResumableStreamRole = Literal["producer", "consumer"]
+ResumableStreamStatus = Literal["streaming", "done", "error", "missing"]
+
+
+@dataclass(frozen=True)
+class ResumableStreamEntry:
+    cursor: str
+    chunk: bytes
+
+
+class CancellationSignal(Protocol):
+    def is_set(self) -> bool: ...
+
+    async def wait(self) -> bool: ...
+
+
+class ResumableStreamStore(Protocol):
+    async def acquire(
+        self, stream_id: str, *, ttl_ms: int | None = None
+    ) -> ResumableStreamRole: ...
+
+    async def append(self, stream_id: str, chunk: bytes) -> None: ...
+
+    async def finalize(
+        self,
+        stream_id: str,
+        status: Literal["done", "error"],
+        error: str | None = None,
+    ) -> None: ...
+
+    def read(
+        self, stream_id: str, cursor: str, signal: CancellationSignal
+    ) -> AsyncIterator[ResumableStreamEntry]: ...
+
+    async def status(self, stream_id: str) -> ResumableStreamStatus: ...
+
+    async def delete(self, stream_id: str) -> None: ...

--- a/python/assistant-stream/tests/test_resumable_context.py
+++ b/python/assistant-stream/tests/test_resumable_context.py
@@ -262,3 +262,37 @@ async def test_on_finalize_and_on_error_fire_on_failure() -> None:
     assert len(errors) == 1
     assert errors[0]["id"] == "a"
     assert str(errors[0]["error"]) == "boom"
+
+
+@pytest.mark.anyio
+async def test_raising_on_acquire_does_not_break_producer_pipeline() -> None:
+    def boom_acquire(_id: str, _role: str) -> None:
+        raise RuntimeError("hook-acquire-boom")
+
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_acquire=boom_acquire,
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["hello ", "world"]))
+    assert await _collect(stream) == "hello world"
+    assert await ctx.status("a") == "done"
+
+
+@pytest.mark.anyio
+async def test_raising_on_error_still_finalizes_error_status() -> None:
+    def boom_error(_id: str, _err: object) -> None:
+        raise RuntimeError("hook-error-boom")
+
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_error=boom_error,
+    )
+
+    async def failing() -> AsyncIterator[bytes]:
+        yield _bytes("partial;")
+        raise Exception("producer-failed")
+
+    stream = await ctx.run("a", lambda: failing())
+    with pytest.raises(Exception, match="producer-failed"):
+        await _collect(stream)
+    assert await ctx.status("a") == "error"

--- a/python/assistant-stream/tests/test_resumable_context.py
+++ b/python/assistant-stream/tests/test_resumable_context.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from assistant_stream.resumable import (
+    ResumableStreamError,
+    create_in_memory_resumable_stream_store,
+    create_resumable_stream_context,
+)
+
+
+def _bytes(s: str) -> bytes:
+    return s.encode("utf-8")
+
+
+async def _collect(stream: AsyncIterator[bytes]) -> str:
+    out = bytearray()
+    async for chunk in stream:
+        out.extend(chunk)
+    return out.decode("utf-8")
+
+
+def _make_string_stream(parts: list[str]) -> AsyncIterator[bytes]:
+    async def gen() -> AsyncIterator[bytes]:
+        for part in parts:
+            yield _bytes(part)
+            await asyncio.sleep(0)
+
+    return gen()
+
+
+@pytest.mark.anyio
+async def test_producer_receives_full_byte_stream() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["hello ", "world"]))
+    assert await _collect(stream) == "hello world"
+
+
+@pytest.mark.anyio
+async def test_second_caller_is_consumer_with_identical_bytes() -> None:
+    store = create_in_memory_resumable_stream_store()
+    ctx = create_resumable_stream_context(store=store)
+    make_stream_calls = 0
+
+    def make_producer() -> AsyncIterator[bytes]:
+        nonlocal make_stream_calls
+        make_stream_calls += 1
+        return _make_string_stream(["one ", "two ", "three"])
+
+    def make_unused() -> AsyncIterator[bytes]:
+        nonlocal make_stream_calls
+        make_stream_calls += 1
+        return _make_string_stream(["should-not-run"])
+
+    producer_stream = await ctx.run("a", make_producer)
+    consumer_stream = await ctx.run("a", make_unused)
+
+    a, b = await asyncio.gather(
+        _collect(producer_stream), _collect(consumer_stream)
+    )
+    assert a == "one two three"
+    assert b == "one two three"
+    assert make_stream_calls == 1
+
+
+@pytest.mark.anyio
+async def test_late_consumer_after_done_replays_via_resume() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    producer = await ctx.run(
+        "a", lambda: _make_string_stream(["alpha", "beta", "gamma"])
+    )
+    assert await _collect(producer) == "alphabetagamma"
+
+    replay = await ctx.resume("a")
+    assert replay is not None
+    assert await _collect(replay) == "alphabetagamma"
+
+
+@pytest.mark.anyio
+async def test_resume_returns_none_for_missing() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    assert await ctx.resume("nope") is None
+
+
+@pytest.mark.anyio
+async def test_require_resume_raises_missing() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    with pytest.raises(ResumableStreamError) as exc:
+        await ctx.require_resume("nope")
+    assert exc.value.code == "missing"
+
+
+@pytest.mark.anyio
+async def test_require_resume_returns_replay_when_exists() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    producer = await ctx.run("a", lambda: _make_string_stream(["hi"]))
+    assert await _collect(producer) == "hi"
+
+    replay = await ctx.require_resume("a")
+    assert await _collect(replay) == "hi"
+
+
+@pytest.mark.anyio
+async def test_status_tracks_lifecycle() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    assert await ctx.status("a") == "missing"
+    stream = await ctx.run("a", lambda: _make_string_stream(["x"]))
+    await _collect(stream)
+    assert await ctx.status("a") == "done"
+
+
+@pytest.mark.anyio
+async def test_delete_removes_stream_state() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["x"]))
+    await _collect(stream)
+    assert await ctx.status("a") == "done"
+    await ctx.delete("a")
+    assert await ctx.status("a") == "missing"
+
+
+@pytest.mark.anyio
+async def test_producer_keeps_writing_after_consumer_closes_early() -> None:
+    store = create_in_memory_resumable_stream_store()
+    ctx = create_resumable_stream_context(store=store)
+
+    producer_emitted = 0
+
+    async def slow_stream() -> AsyncIterator[bytes]:
+        nonlocal producer_emitted
+        for i in range(5):
+            await asyncio.sleep(0.01)
+            yield _bytes(f"chunk{i};")
+            producer_emitted += 1
+
+    stream = await ctx.run("a", lambda: slow_stream())
+    first = await anext(stream)
+    assert first == _bytes("chunk0;")
+    await stream.aclose()
+
+    while producer_emitted < 5:
+        await asyncio.sleep(0.01)
+    while await ctx.status("a") == "streaming":
+        await asyncio.sleep(0.01)
+
+    replay = await ctx.resume("a")
+    assert replay is not None
+    assert await _collect(replay) == "chunk0;chunk1;chunk2;chunk3;chunk4;"
+
+
+@pytest.mark.anyio
+async def test_propagates_producer_errors_to_consumers() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+
+    async def failing() -> AsyncIterator[bytes]:
+        yield _bytes("partial;")
+        raise Exception("oops")
+
+    stream = await ctx.run("a", lambda: failing())
+    with pytest.raises(Exception, match="oops"):
+        await _collect(stream)
+    assert await ctx.status("a") == "error"
+
+
+@pytest.mark.anyio
+async def test_wait_until_receives_the_task() -> None:
+    tasks: list[asyncio.Task[None]] = []
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        wait_until=lambda t: tasks.append(t),
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["x"]))
+    assert await _collect(stream) == "x"
+    assert len(tasks) == 1
+    await asyncio.gather(*tasks)
+
+
+@pytest.mark.anyio
+async def test_on_acquire_fires_for_producer_and_consumer() -> None:
+    calls: list[dict[str, str]] = []
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_acquire=lambda id, role: calls.append({"id": id, "role": role}),
+    )
+    producer = await ctx.run("a", lambda: _make_string_stream(["x"]))
+    consumer = await ctx.run("a", lambda: _make_string_stream(["unused"]))
+    await asyncio.gather(_collect(producer), _collect(consumer))
+    assert calls == [
+        {"id": "a", "role": "producer"},
+        {"id": "a", "role": "consumer"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_on_append_fires_per_chunk_with_byte_length() -> None:
+    calls: list[dict[str, object]] = []
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_append=lambda id, n: calls.append({"id": id, "byteLength": n}),
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["ab", "cde"]))
+    assert await _collect(stream) == "abcde"
+    assert calls == [
+        {"id": "a", "byteLength": 2},
+        {"id": "a", "byteLength": 3},
+    ]
+
+
+@pytest.mark.anyio
+async def test_on_finalize_fires_on_success() -> None:
+    calls: list[dict[str, object]] = []
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_finalize=lambda id, status, error: calls.append(
+            {"id": id, "status": status, "error": error}
+        ),
+    )
+    stream = await ctx.run("a", lambda: _make_string_stream(["x"]))
+    await _collect(stream)
+    assert calls == [{"id": "a", "status": "done", "error": None}]
+
+
+@pytest.mark.anyio
+async def test_on_finalize_and_on_error_fire_on_failure() -> None:
+    finalize_calls: list[dict[str, object]] = []
+    errors: list[dict[str, object]] = []
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store(),
+        on_finalize=lambda id, status, error: finalize_calls.append(
+            {"id": id, "status": status, "error": error}
+        ),
+        on_error=lambda id, error: errors.append({"id": id, "error": error}),
+    )
+
+    async def failing() -> AsyncIterator[bytes]:
+        raise Exception("boom")
+        yield b""  # pragma: no cover
+
+    stream = await ctx.run("a", lambda: failing())
+    with pytest.raises(Exception, match="boom"):
+        await _collect(stream)
+    assert finalize_calls == [{"id": "a", "status": "error", "error": "boom"}]
+    assert len(errors) == 1
+    assert errors[0]["id"] == "a"
+    assert str(errors[0]["error"]) == "boom"

--- a/python/assistant-stream/tests/test_resumable_in_memory.py
+++ b/python/assistant-stream/tests/test_resumable_in_memory.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from assistant_stream.resumable import (
+    ResumableStreamError,
+    create_in_memory_resumable_stream_store,
+)
+from assistant_stream.resumable.types import ResumableStreamEntry
+
+
+def _bytes(s: str) -> bytes:
+    return s.encode("utf-8")
+
+
+def _decode(chunk: bytes) -> str:
+    return chunk.decode("utf-8")
+
+
+async def _drain(iter_) -> list[str]:
+    out: list[str] = []
+    async for entry in iter_:
+        out.append(_decode(entry.chunk))
+    return out
+
+
+@pytest.mark.anyio
+async def test_elects_exactly_one_producer_per_stream_id() -> None:
+    store = create_in_memory_resumable_stream_store()
+    first = await store.acquire("a")
+    second = await store.acquire("a")
+    third = await store.acquire("a")
+    assert first == "producer"
+    assert second == "consumer"
+    assert third == "consumer"
+
+
+@pytest.mark.anyio
+async def test_post_finalize_acquire_is_consumer() -> None:
+    store = create_in_memory_resumable_stream_store()
+    assert await store.acquire("a") == "producer"
+    await store.finalize("a", "done")
+    assert await store.acquire("a") == "consumer"
+
+
+@pytest.mark.anyio
+async def test_isolates_streams_by_id() -> None:
+    store = create_in_memory_resumable_stream_store()
+    assert await store.acquire("a") == "producer"
+    assert await store.acquire("b") == "producer"
+
+
+@pytest.mark.anyio
+async def test_replays_buffered_entries_and_tails_until_finalize() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.append("a", _bytes("hello "))
+    await store.append("a", _bytes("world"))
+
+    signal = asyncio.Event()
+    collected: list[str] = []
+
+    async def reading() -> None:
+        async for entry in store.read("a", "", signal):
+            collected.append(_decode(entry.chunk))
+            if len(collected) == 3:
+                await store.finalize("a", "done")
+
+    task = asyncio.create_task(reading())
+    await store.append("a", _bytes("!"))
+    await task
+    assert collected == ["hello ", "world", "!"]
+
+
+@pytest.mark.anyio
+async def test_status_transitions_missing_streaming_done() -> None:
+    store = create_in_memory_resumable_stream_store()
+    assert await store.status("a") == "missing"
+    await store.acquire("a")
+    assert await store.status("a") == "streaming"
+    await store.finalize("a", "done")
+    assert await store.status("a") == "done"
+
+
+@pytest.mark.anyio
+async def test_status_reports_error_after_error_finalize() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.finalize("a", "error", "boom")
+    assert await store.status("a") == "error"
+
+
+@pytest.mark.anyio
+async def test_read_throws_after_error_finalize_after_draining() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.append("a", _bytes("partial"))
+    await store.finalize("a", "error", "boom")
+
+    signal = asyncio.Event()
+    seen: list[str] = []
+    with pytest.raises(Exception, match="boom"):
+        async for entry in store.read("a", "", signal):
+            seen.append(_decode(entry.chunk))
+    assert seen == ["partial"]
+
+
+@pytest.mark.anyio
+async def test_late_consumer_after_done_replays_everything() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.append("a", _bytes("a"))
+    await store.append("a", _bytes("b"))
+    await store.append("a", _bytes("c"))
+    await store.finalize("a", "done")
+
+    signal = asyncio.Event()
+    assert await _drain(store.read("a", "", signal)) == ["a", "b", "c"]
+
+
+@pytest.mark.anyio
+async def test_cursor_advances_and_skips_already_seen() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.append("a", _bytes("1"))
+    await store.append("a", _bytes("2"))
+    await store.append("a", _bytes("3"))
+    await store.finalize("a", "done")
+
+    signal = asyncio.Event()
+    seen: list[ResumableStreamEntry] = []
+    async for entry in store.read("a", "", signal):
+        seen.append(entry)
+    assert [_decode(s.chunk) for s in seen] == ["1", "2", "3"]
+
+    after_first = seen[0].cursor
+    assert await _drain(store.read("a", after_first, signal)) == ["2", "3"]
+
+
+@pytest.mark.anyio
+async def test_signal_set_terminates_read_without_raising() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    signal = asyncio.Event()
+    collected: list[str] = []
+
+    async def reading() -> None:
+        async for entry in store.read("a", "", signal):
+            collected.append(_decode(entry.chunk))
+
+    task = asyncio.create_task(reading())
+    await store.append("a", _bytes("x"))
+    await asyncio.sleep(0.01)
+    signal.set()
+    await task
+    assert collected == ["x"]
+
+
+@pytest.mark.anyio
+async def test_multiple_consumers_read_concurrently() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    signal = asyncio.Event()
+    a = asyncio.create_task(_drain(store.read("a", "", signal)))
+    b = asyncio.create_task(_drain(store.read("a", "", signal)))
+    await store.append("a", _bytes("x"))
+    await store.append("a", _bytes("y"))
+    await store.finalize("a", "done")
+    assert await a == ["x", "y"]
+    assert await b == ["x", "y"]
+
+
+@pytest.mark.anyio
+async def test_delete_ends_in_flight_reads_and_status_missing() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    signal = asyncio.Event()
+    reading = asyncio.create_task(_drain(store.read("a", "", signal)))
+    await store.append("a", _bytes("x"))
+    await asyncio.sleep(0)
+    await store.delete("a")
+    assert await reading == ["x"]
+    assert await store.status("a") == "missing"
+
+
+@pytest.mark.anyio
+async def test_expired_streams_evicted_on_next_access() -> None:
+    now = 1_000.0
+
+    def clock() -> float:
+        return now
+
+    store = create_in_memory_resumable_stream_store(default_ttl_ms=100, now=clock)
+    await store.acquire("a")
+    await store.append("a", _bytes("hi"))
+    assert await store.status("a") == "streaming"
+    now += 200
+    assert await store.status("a") == "missing"
+
+
+@pytest.mark.anyio
+async def test_appending_refreshes_ttl() -> None:
+    now = 1_000.0
+
+    def clock() -> float:
+        return now
+
+    store = create_in_memory_resumable_stream_store(default_ttl_ms=100, now=clock)
+    await store.acquire("a")
+    now += 80
+    await store.append("a", _bytes("x"))
+    now += 80
+    assert await store.status("a") == "streaming"
+
+
+@pytest.mark.anyio
+async def test_rejects_append_on_finalized_stream() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.finalize("a", "done")
+    with pytest.raises(ResumableStreamError, match="already finalized") as exc:
+        await store.append("a", _bytes("late"))
+    assert exc.value.code == "finalized"
+
+
+@pytest.mark.anyio
+async def test_rejects_append_on_missing_stream() -> None:
+    store = create_in_memory_resumable_stream_store()
+    with pytest.raises(Exception, match="Stream not found"):
+        await store.append("a", _bytes("x"))
+
+
+@pytest.mark.anyio
+async def test_finalize_is_idempotent() -> None:
+    store = create_in_memory_resumable_stream_store()
+    await store.acquire("a")
+    await store.finalize("a", "done")
+    await store.finalize("a", "done")
+    assert await store.status("a") == "done"
+
+
+@pytest.mark.anyio
+async def test_rejects_append_when_chunk_exceeds_max_chunk_bytes() -> None:
+    store = create_in_memory_resumable_stream_store(max_chunk_bytes=4)
+    await store.acquire("a")
+    with pytest.raises(Exception, match="Chunk exceeds maxChunkBytes: 5"):
+        await store.append("a", _bytes("hello"))
+    await store.append("a", _bytes("ok"))
+    assert await store.status("a") == "streaming"
+
+
+@pytest.mark.anyio
+async def test_rejects_append_when_stream_reaches_max_entries() -> None:
+    store = create_in_memory_resumable_stream_store(max_entries_per_stream=2)
+    await store.acquire("a")
+    await store.append("a", _bytes("1"))
+    await store.append("a", _bytes("2"))
+    with pytest.raises(Exception, match="Stream exceeded maxEntriesPerStream: a"):
+        await store.append("a", _bytes("3"))
+
+
+@pytest.mark.anyio
+async def test_rejects_acquire_when_max_streams_exceeded() -> None:
+    store = create_in_memory_resumable_stream_store(max_streams=2)
+    await store.acquire("a")
+    await store.acquire("b")
+    with pytest.raises(Exception, match="maxStreams exceeded"):
+        await store.acquire("c")
+    assert await store.acquire("a") == "consumer"
+
+
+@pytest.mark.anyio
+async def test_gc_sweeper_evicts_expired_streams() -> None:
+    now = 1_000.0
+
+    def clock() -> float:
+        return now
+
+    store = create_in_memory_resumable_stream_store(
+        default_ttl_ms=100,
+        gc_interval_ms=50,
+        now=clock,
+    )
+    await store.acquire("a")
+    await store.append("a", _bytes("hi"))
+    now += 200
+    await asyncio.sleep(0.08)
+    assert await store.status("a") == "missing"
+    store.dispose()
+
+
+@pytest.mark.anyio
+async def test_dispose_clears_gc_and_is_noop_without_gc() -> None:
+    store = create_in_memory_resumable_stream_store(gc_interval_ms=50)
+    await store.acquire("a")
+    store.dispose()
+    store2 = create_in_memory_resumable_stream_store()
+    store2.dispose()

--- a/python/assistant-stream/tests/test_resumable_in_memory.py
+++ b/python/assistant-stream/tests/test_resumable_in_memory.py
@@ -38,6 +38,14 @@ async def test_elects_exactly_one_producer_per_stream_id() -> None:
 
 
 @pytest.mark.anyio
+async def test_stream_id_with_trailing_newline_is_invalid() -> None:
+    store = create_in_memory_resumable_stream_store()
+    with pytest.raises(ResumableStreamError) as exc:
+        await store.acquire("valid-id\n")
+    assert exc.value.code == "invalid-id"
+
+
+@pytest.mark.anyio
 async def test_post_finalize_acquire_is_consumer() -> None:
     store = create_in_memory_resumable_stream_store()
     assert await store.acquire("a") == "producer"

--- a/python/assistant-stream/tests/test_resumable_redis.py
+++ b/python/assistant-stream/tests/test_resumable_redis.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import uuid
+
+import pytest
+
+REDIS_URL = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379")
+REDIS_TESTS_DISABLED = (
+    os.environ.get("REDIS_URL") is None and os.environ.get("REDIS_TESTS") != "1"
+)
+
+pytestmark = pytest.mark.skipif(
+    REDIS_TESTS_DISABLED,
+    reason="set REDIS_URL or REDIS_TESTS=1 to run redis adapter tests",
+)
+
+
+def _bytes(s: str) -> bytes:
+    return s.encode("utf-8")
+
+
+def _decode(chunk: bytes) -> str:
+    return chunk.decode("utf-8")
+
+
+@pytest.fixture
+async def redis_store():
+    import redis.asyncio as redis
+
+    from assistant_stream.resumable import create_redis_resumable_stream_store
+
+    client = redis.from_url(REDIS_URL)
+    key_prefix = f"aui:resumable:test:{int(time.time() * 1000)}:{uuid.uuid4().hex[:8]}"
+    store = create_redis_resumable_stream_store(
+        client,
+        key_prefix=key_prefix,
+        poll_interval_ms=25,
+    )
+    try:
+        yield store, client, key_prefix
+    finally:
+        keys = [key async for key in client.scan_iter(match=f"{key_prefix}:*")]
+        if keys:
+            await client.delete(*keys)
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_elects_exactly_one_producer(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    first = await store.acquire(stream_id)
+    second = await store.acquire(stream_id)
+    assert first == "producer"
+    assert second == "consumer"
+
+
+@pytest.mark.anyio
+async def test_replays_buffered_and_tails_until_done(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    await store.acquire(stream_id)
+    await store.append(stream_id, _bytes("hello"))
+    await store.append(stream_id, _bytes(" world"))
+
+    signal = asyncio.Event()
+    collected: list[str] = []
+
+    async def reading() -> None:
+        async for entry in store.read(stream_id, "", signal):
+            collected.append(_decode(entry.chunk))
+            if len(collected) == 3:
+                await store.finalize(stream_id, "done")
+
+    task = asyncio.create_task(reading())
+    await asyncio.sleep(0.05)
+    await store.append(stream_id, _bytes("!"))
+    await task
+    assert "".join(collected) == "hello world!"
+
+
+@pytest.mark.anyio
+async def test_error_finalize_raises_after_draining(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    await store.acquire(stream_id)
+    await store.append(stream_id, _bytes("partial"))
+    await store.finalize(stream_id, "error", "boom")
+
+    signal = asyncio.Event()
+    seen: list[str] = []
+    with pytest.raises(Exception, match="boom"):
+        async for entry in store.read(stream_id, "", signal):
+            seen.append(_decode(entry.chunk))
+    assert seen == ["partial"]
+
+
+@pytest.mark.anyio
+async def test_cursor_skip(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    await store.acquire(stream_id)
+    await store.append(stream_id, _bytes("1"))
+    await store.append(stream_id, _bytes("2"))
+    await store.append(stream_id, _bytes("3"))
+    await store.finalize(stream_id, "done")
+
+    signal = asyncio.Event()
+    seen: list[tuple[str, str]] = []
+    async for entry in store.read(stream_id, "", signal):
+        seen.append((entry.cursor, _decode(entry.chunk)))
+    assert [t for _, t in seen] == ["1", "2", "3"]
+
+    out: list[str] = []
+    async for entry in store.read(stream_id, seen[0][0], signal):
+        out.append(_decode(entry.chunk))
+    assert out == ["2", "3"]
+
+
+@pytest.mark.anyio
+async def test_delete_removes_stream(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    await store.acquire(stream_id)
+    await store.append(stream_id, _bytes("x"))
+    assert await store.status(stream_id) == "streaming"
+    await store.delete(stream_id)
+    assert await store.status(stream_id) == "missing"
+
+
+@pytest.mark.anyio
+async def test_binary_round_trip_0_to_255(redis_store) -> None:
+    store, _, _ = redis_store
+    stream_id = f"id-{uuid.uuid4().hex}"
+    await store.acquire(stream_id)
+
+    producer = bytes(i & 0xFF for i in range(512))
+    half = len(producer) // 2
+    await store.append(stream_id, producer[:half])
+    await store.append(stream_id, producer[half:])
+    await store.finalize(stream_id, "done")
+
+    signal = asyncio.Event()
+    replayed = bytearray()
+    async for entry in store.read(stream_id, "", signal):
+        replayed.extend(entry.chunk)
+    assert bytes(replayed) == producer

--- a/python/assistant-stream/tests/test_resumable_redis.py
+++ b/python/assistant-stream/tests/test_resumable_redis.py
@@ -148,3 +148,17 @@ async def test_binary_round_trip_0_to_255(redis_store) -> None:
     async for entry in store.read(stream_id, "", signal):
         replayed.extend(entry.chunk)
     assert bytes(replayed) == producer
+
+
+@pytest.mark.anyio
+async def test_decode_responses_true_is_rejected() -> None:
+    import redis.asyncio as redis
+
+    from assistant_stream.resumable import create_redis_resumable_stream_store
+
+    client = redis.from_url(REDIS_URL, decode_responses=True)
+    try:
+        with pytest.raises(ValueError, match="decode_responses"):
+            create_redis_resumable_stream_store(client)
+    finally:
+        await client.aclose()

--- a/python/assistant-stream/tests/test_resumable_response.py
+++ b/python/assistant-stream/tests/test_resumable_response.py
@@ -92,6 +92,20 @@ async def test_resume_returns_404_json_when_missing() -> None:
 
 
 @pytest.mark.anyio
+async def test_resume_returns_404_json_for_invalid_stream_id() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    response = await create_resume_assistant_stream_response(
+        context=ctx,
+        stream_id="x" * 300,
+    )
+    assert response.status_code == 404
+    body = response.body
+    assert b"stream not found" in body
+
+
+@pytest.mark.anyio
 async def test_assistant_transport_encoder_round_trips() -> None:
     ctx = create_resumable_stream_context(
         store=create_in_memory_resumable_stream_store()

--- a/python/assistant-stream/tests/test_resumable_response.py
+++ b/python/assistant-stream/tests/test_resumable_response.py
@@ -141,3 +141,23 @@ async def test_user_headers_merge_but_cannot_override_id() -> None:
     assert response.headers["cache-control"] == "private, max-age=0"
     assert response.headers[RESUMABLE_STREAM_ID_HEADER] == "s1"
     await response.body_iterator.aclose()
+
+
+@pytest.mark.anyio
+async def test_differently_cased_user_id_header_is_filtered() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+
+    async def callback(controller: RunController) -> None:
+        controller.append_text("hi")
+
+    response = await create_resumable_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        headers={"X-RESUMABLE-STREAM-ID": "spoof"},
+        callback=callback,
+    )
+    assert response.headers[RESUMABLE_STREAM_ID_HEADER] == "s1"
+    assert "spoof" not in response.headers.values()
+    await response.body_iterator.aclose()

--- a/python/assistant-stream/tests/test_resumable_response.py
+++ b/python/assistant-stream/tests/test_resumable_response.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import pytest
+from starlette.responses import StreamingResponse
+
+from assistant_stream.create_run import RunController
+from assistant_stream.resumable import (
+    RESUMABLE_STREAM_ID_HEADER,
+    create_in_memory_resumable_stream_store,
+    create_resumable_assistant_stream_response,
+    create_resumable_stream_context,
+    create_resume_assistant_stream_response,
+)
+from assistant_stream.serialization.assistant_transport import (
+    AssistantTransportEncoder,
+)
+
+
+async def _collect_body(response: StreamingResponse) -> bytes:
+    parts: list[bytes] = []
+    async for chunk in response.body_iterator:
+        if isinstance(chunk, str):
+            parts.append(chunk.encode("utf-8"))
+        else:
+            parts.append(bytes(chunk))
+    return b"".join(parts)
+
+
+@pytest.mark.anyio
+async def test_producer_response_carries_id_header_and_media_type() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+
+    async def callback(controller: RunController) -> None:
+        controller.append_text("hello ")
+        controller.append_text("world")
+
+    response = await create_resumable_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        callback=callback,
+    )
+    assert isinstance(response, StreamingResponse)
+    assert response.headers[RESUMABLE_STREAM_ID_HEADER] == "s1"
+    assert "text/plain" in response.media_type
+    body = await _collect_body(response)
+    assert b"hello " in body
+    assert b"world" in body
+
+
+@pytest.mark.anyio
+async def test_resume_replays_byte_for_byte() -> None:
+    store = create_in_memory_resumable_stream_store()
+    ctx = create_resumable_stream_context(store=store)
+
+    async def callback(controller: RunController) -> None:
+        controller.append_text("alpha")
+        tool = await controller.add_tool_call("echo", "t1")
+        tool.append_args_text('{"v": 1}')
+        tool.set_response({"ok": True})
+
+    first = await create_resumable_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        callback=callback,
+    )
+    first_bytes = await _collect_body(first)
+
+    second = await create_resume_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+    )
+    second_bytes = await _collect_body(second)
+
+    assert second_bytes == first_bytes
+    assert second.headers[RESUMABLE_STREAM_ID_HEADER] == "s1"
+
+
+@pytest.mark.anyio
+async def test_resume_returns_404_json_when_missing() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+    response = await create_resume_assistant_stream_response(
+        context=ctx,
+        stream_id="missing",
+    )
+    assert response.status_code == 404
+    body = response.body
+    assert b"stream not found" in body
+
+
+@pytest.mark.anyio
+async def test_assistant_transport_encoder_round_trips() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+
+    async def callback(controller: RunController) -> None:
+        controller.append_text("hi")
+
+    response = await create_resumable_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        encoder=AssistantTransportEncoder(),
+        callback=callback,
+    )
+    assert response.media_type == "text/event-stream"
+    text = (await _collect_body(response)).decode("utf-8")
+    assert "text-delta" in text
+    assert "[DONE]" in text
+
+    resume = await create_resume_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        encoder=AssistantTransportEncoder(),
+    )
+    resume_text = (await _collect_body(resume)).decode("utf-8")
+    assert resume_text == text
+
+
+@pytest.mark.anyio
+async def test_user_headers_merge_but_cannot_override_id() -> None:
+    ctx = create_resumable_stream_context(
+        store=create_in_memory_resumable_stream_store()
+    )
+
+    async def callback(controller: RunController) -> None:
+        controller.append_text("hi")
+
+    response = await create_resumable_assistant_stream_response(
+        context=ctx,
+        stream_id="s1",
+        headers={
+            "Cache-Control": "private, max-age=0",
+            RESUMABLE_STREAM_ID_HEADER: "spoofed",
+        },
+        callback=callback,
+    )
+    assert response.headers["cache-control"] == "private, max-age=0"
+    assert response.headers[RESUMABLE_STREAM_ID_HEADER] == "s1"
+    await response.body_iterator.aclose()

--- a/python/assistant-stream/uv.lock
+++ b/python/assistant-stream/uv.lock
@@ -36,18 +36,33 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "redis" },
 ]
 langgraph = [
     { name = "langchain-core" },
+]
+redis = [
+    { name = "redis" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", marker = "extra == 'langgraph'", specifier = ">=0.3.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "<8" },
+    { name = "redis", marker = "extra == 'dev'", specifier = ">=5" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5" },
     { name = "starlette", specifier = ">=0.37.2" },
 ]
-provides-extras = ["langgraph", "dev"]
+provides-extras = ["langgraph", "redis", "dev"]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
 
 [[package]]
 name = "certifi"
@@ -617,6 +632,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## summary

- ports the TS resumable stream layer to python as `assistant_stream.resumable`, mirroring the `assistant-stream/resumable` subpath: the six-method `ResumableStreamStore` protocol, `create_resumable_stream_context` (atomic producer election, byte-identical fan-out where every caller including the producer reads back through the store), and starlette response helpers (`create_resumable_assistant_stream_response` / `create_resume_assistant_stream_response` with the `x-resumable-stream-id` header forced after user headers)
- two store implementations with TS-parity semantics: in-memory (base36 cursors, waiter fan-out, TTL eviction with injectable clock, max guards with identical error messages, optional lazily started GC task with `dispose()`) and Redis (`{prefix}:{stream_id}:meta/data` hash-tagged keys, SET NX EX election, pipelined XADD+EXPIRE, exclusive `(id` XRANGE cursor advance, 100ms tail poll)
- `redis>=5` ships as an optional extra following the existing `langgraph` extra precedent (guarded import; core and in-memory work without it); cancellation uses a `CancellationSignal` protocol structurally compatible with the package's existing `ReadOnlyCancellationSignal`
- package version untouched (the pypi-publish workflow owns releases); no changeset (python package)

## test plan

### already verified

- [x] `uv sync --all-extras && uv run pytest` -> 84/84 green including the previously existing suite; the 6 redis cases run against a real Redis 7 container (`REDIS_URL` gated, skip-by-default in CI mirroring the TS suite's gating)
- [x] end-to-end drive against real Redis via uvicorn + httpx (10/10 scenarios): producer survives client abandonment (XLEN kept growing after disconnect, 4 -> 11), resume replays the abandoned prefix byte-identically then tails to completion, two concurrent mid-stream resumes byte-identical, 404 JSON on missing stream, meta TTL 86400 and `status: done` with the fin entry appended after finalize

### reviewer should verify

- [ ] with the docs guide's storage recipe pointed at `redis.asyncio`, a FastAPI/starlette route pair built on the two response helpers survives a mid-stream reload and replays byte-for-byte

## notes

- intentional deviations from the TS layer, each following python idiom or repo precedent: single `redis.asyncio` adapter instead of the node-redis/ioredis split, lazily started asyncio GC task instead of `setInterval`, encoder passed as an instance rather than a factory, store operational errors raised as `RuntimeError` with the TS-identical messages while coded failures keep `ResumableStreamError`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

