### PR TITLE
fix(react-mcp): validate persisted auth state

### DIFF
--- a/.changeset/react-mcp-auth-state-validation.md
+++ b/.changeset/react-mcp-auth-state-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: ignore malformed persisted MCP auth state

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -74,8 +74,12 @@ describe("normalizePersistedAuthState", () => {
       normalizePersistedAuthState({
         token: "",
         codeVerifier: 123,
-        tokens: "not-tokens",
-        clientInformation: { redirect_uris: ["http://localhost/callback"] },
+        tokens: {
+          access_token: "access-token",
+          token_type: "Bearer",
+          expires_in: Number.POSITIVE_INFINITY,
+        },
+        clientInformation: { client_id: "client-id" },
       }),
     ).toBeNull();
   });
@@ -122,7 +126,7 @@ describe("normalizePersistedAuthState", () => {
       normalizePersistedAuthState({
         token: "bearer-token",
         codeVerifier: 123,
-        tokens: { refresh_token: "missing-access-token" },
+        tokens: { access_token: "access-token" },
         clientInformation: "not-client-info",
       }),
     ).toEqual({

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -1,6 +1,11 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
 import { describe, expect, it } from "vitest";
 
-import { normalizeCustomServerRecords } from "./McpLocalStorage";
+import {
+  McpLocalStorage,
+  normalizeCustomServerRecords,
+  normalizePersistedAuthState,
+} from "./McpLocalStorage";
 
 const validRecord = {
   id: "docs",
@@ -54,5 +59,122 @@ describe("normalizeCustomServerRecords", () => {
         },
       ]),
     ).toHaveLength(2);
+  });
+});
+
+describe("normalizePersistedAuthState", () => {
+  it("returns null when the persisted value is not an object", () => {
+    expect(normalizePersistedAuthState(null)).toBeNull();
+    expect(normalizePersistedAuthState("bad")).toBeNull();
+    expect(normalizePersistedAuthState([])).toBeNull();
+  });
+
+  it("drops malformed auth state fields", () => {
+    expect(
+      normalizePersistedAuthState({
+        token: "",
+        codeVerifier: 123,
+        tokens: "not-tokens",
+        clientInformation: { redirect_uris: ["http://localhost/callback"] },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps valid bearer and OAuth callback state", () => {
+    expect(
+      normalizePersistedAuthState({
+        token: "bearer-token",
+        codeVerifier: "pkce-verifier",
+      }),
+    ).toEqual({
+      token: "bearer-token",
+      codeVerifier: "pkce-verifier",
+    });
+  });
+
+  it("keeps valid OAuth tokens and client information", () => {
+    const tokens = {
+      access_token: "access-token",
+      token_type: "Bearer",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+      scope: "docs.read",
+    };
+    const clientInformation = {
+      client_id: "client-id",
+      client_secret: "client-secret",
+      redirect_uris: ["http://localhost/callback"],
+    };
+
+    expect(
+      normalizePersistedAuthState({
+        tokens,
+        clientInformation,
+      }),
+    ).toEqual({
+      tokens,
+      clientInformation,
+    });
+  });
+
+  it("keeps valid fields when neighboring fields are malformed", () => {
+    expect(
+      normalizePersistedAuthState({
+        token: "bearer-token",
+        codeVerifier: 123,
+        tokens: { refresh_token: "missing-access-token" },
+        clientInformation: "not-client-info",
+      }),
+    ).toEqual({
+      token: "bearer-token",
+    });
+  });
+});
+
+const createStorage = (): Storage => {
+  const data = new Map<string, string>();
+  return {
+    get length() {
+      return data.size;
+    },
+    clear: () => {
+      data.clear();
+    },
+    getItem: (key) => data.get(key) ?? null,
+    key: (index) => Array.from(data.keys())[index] ?? null,
+    removeItem: (key) => {
+      data.delete(key);
+    },
+    setItem: (key, value) => {
+      data.set(key, value);
+    },
+  };
+};
+
+const loadStorage = (storage: Storage) =>
+  createTapRoot(function McpStorageRoot() {
+    return useResource(
+      McpLocalStorage({
+        keyPrefix: "test-mcp",
+        storage,
+      }),
+    );
+  }).getValue();
+
+describe("McpLocalStorage auth state", () => {
+  it("normalizes loaded auth state from localStorage", async () => {
+    const storage = createStorage();
+    storage.setItem(
+      "test-mcp:auth:docs",
+      JSON.stringify({
+        token: "bearer-token",
+        codeVerifier: 123,
+        tokens: "not-tokens",
+      }),
+    );
+
+    await expect(loadStorage(storage).loadAuthState("docs")).resolves.toEqual({
+      token: "bearer-token",
+    });
   });
 });

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -41,6 +41,9 @@ const isOptionalStringArray = (value: unknown): value is string[] | undefined =>
   value === undefined ||
   (Array.isArray(value) && value.every((item) => typeof item === "string"));
 
+const isOptionalNumber = (value: unknown): value is number | undefined =>
+  value === undefined || typeof value === "number";
+
 const isValidServerId = (id: string): boolean => {
   try {
     assertValidServerId(id);
@@ -94,6 +97,50 @@ export const normalizeCustomServerRecords = (
   return value.filter(isCustomServerRecord);
 };
 
+const normalizeOAuthTokens = (
+  value: unknown,
+): MCPPersistedAuthState["tokens"] | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (!isNonEmptyString(value.access_token)) return undefined;
+  if (!isOptionalString(value.token_type)) return undefined;
+  if (!isOptionalString(value.refresh_token)) return undefined;
+  if (!isOptionalNumber(value.expires_in)) return undefined;
+  if (!isOptionalString(value.scope)) return undefined;
+  return value as MCPPersistedAuthState["tokens"];
+};
+
+const normalizeClientInformation = (
+  value: unknown,
+): MCPPersistedAuthState["clientInformation"] | undefined => {
+  if (!isRecord(value)) return undefined;
+  if (!isNonEmptyString(value.client_id)) return undefined;
+  if (!isOptionalString(value.client_secret)) return undefined;
+  if (!isOptionalNumber(value.client_id_issued_at)) return undefined;
+  if (!isOptionalNumber(value.client_secret_expires_at)) return undefined;
+  if (!isOptionalStringArray(value.redirect_uris)) return undefined;
+  return value as MCPPersistedAuthState["clientInformation"];
+};
+
+export const normalizePersistedAuthState = (
+  value: unknown,
+): MCPPersistedAuthState | null => {
+  if (!isRecord(value)) return null;
+
+  const state: MCPPersistedAuthState = {};
+  if (isNonEmptyString(value.token)) state.token = value.token;
+  if (isNonEmptyString(value.codeVerifier)) {
+    state.codeVerifier = value.codeVerifier;
+  }
+
+  const tokens = normalizeOAuthTokens(value.tokens);
+  if (tokens) state.tokens = tokens;
+
+  const clientInformation = normalizeClientInformation(value.clientInformation);
+  if (clientInformation) state.clientInformation = clientInformation;
+
+  return Object.keys(state).length > 0 ? state : null;
+};
+
 const useMcpLocalStorage = (opts: McpLocalStorageOptions = {}): MCPStorage => {
   const prefix = opts.keyPrefix ?? "aui-mcp";
   const customServersKey = `${prefix}:custom-servers`;
@@ -136,7 +183,7 @@ const useMcpLocalStorage = (opts: McpLocalStorageOptions = {}): MCPStorage => {
       write(customServersKey, records);
     },
     loadAuthState: async (id) =>
-      read<MCPPersistedAuthState | null>(authKey(id), null),
+      normalizePersistedAuthState(read<unknown>(authKey(id), null)),
     saveAuthState: async (id, state) => {
       write(authKey(id), state);
     },

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -1,4 +1,8 @@
 import { resource } from "@assistant-ui/tap";
+import {
+  OAuthClientInformationFullSchema,
+  OAuthTokensSchema,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { MCPAuthConfig, MCPCustomServerRecord } from "../../mcp-scope";
 import type { MCPPersistedAuthState } from "../../auth/types";
 import { assertValidServerId } from "../../utils/serverId";
@@ -40,9 +44,6 @@ const isOptionalNonEmptyString = (
 const isOptionalStringArray = (value: unknown): value is string[] | undefined =>
   value === undefined ||
   (Array.isArray(value) && value.every((item) => typeof item === "string"));
-
-const isOptionalNumber = (value: unknown): value is number | undefined =>
-  value === undefined || typeof value === "number";
 
 const isValidServerId = (id: string): boolean => {
   try {
@@ -100,25 +101,15 @@ export const normalizeCustomServerRecords = (
 const normalizeOAuthTokens = (
   value: unknown,
 ): MCPPersistedAuthState["tokens"] | undefined => {
-  if (!isRecord(value)) return undefined;
-  if (!isNonEmptyString(value.access_token)) return undefined;
-  if (!isOptionalString(value.token_type)) return undefined;
-  if (!isOptionalString(value.refresh_token)) return undefined;
-  if (!isOptionalNumber(value.expires_in)) return undefined;
-  if (!isOptionalString(value.scope)) return undefined;
-  return value as MCPPersistedAuthState["tokens"];
+  const result = OAuthTokensSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 };
 
 const normalizeClientInformation = (
   value: unknown,
 ): MCPPersistedAuthState["clientInformation"] | undefined => {
-  if (!isRecord(value)) return undefined;
-  if (!isNonEmptyString(value.client_id)) return undefined;
-  if (!isOptionalString(value.client_secret)) return undefined;
-  if (!isOptionalNumber(value.client_id_issued_at)) return undefined;
-  if (!isOptionalNumber(value.client_secret_expires_at)) return undefined;
-  if (!isOptionalStringArray(value.redirect_uris)) return undefined;
-  return value as MCPPersistedAuthState["clientInformation"];
+  const result = OAuthClientInformationFullSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 };
 
 export const normalizePersistedAuthState = (


### PR DESCRIPTION
## Summary

- normalize persisted MCP auth state as it is loaded from localStorage
- ignore malformed auth fields while preserving valid bearer, OAuth token, client info, and PKCE verifier fields
- add regression coverage for malformed stored auth payloads and the storage load path

## Why

MCP auth state lives in localStorage, so it can become stale after package changes, be manually edited during local MCP debugging, or contain a partially written value. Without validation, malformed values like `tokens: "not-token-object"` or `codeVerifier: 123` can hydrate into the OAuth/bearer reconnect flow and cause confusing connection, callback, or refresh failures that are hard to recover from without clearing browser storage manually.

## Testing

- `pnpm --filter @assistant-ui/react-mcp test -- McpLocalStorage.test.ts`
- `pnpm --filter @assistant-ui/react-mcp build`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

