### PR TITLE
fix(cloud): normalize base urls across auth strategies

### DIFF
--- a/.changeset/cloud-base-url-normalization.md
+++ b/.changeset/cloud-base-url-normalization.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: normalize Cloud base URLs across authentication modes

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -65,8 +65,10 @@ type MakeRequestOptions = {
   body?: object | undefined;
 };
 
-const normalizeBaseUrl = (baseUrl: string) =>
-  baseUrl ? baseUrl.replace(/\/+$/, "") : baseUrl;
+const normalizeBaseUrl = (baseUrl: string) => {
+  if (!baseUrl || !baseUrl.endsWith("/")) return baseUrl;
+  return baseUrl.slice(0, -1);
+};
 
 export class AssistantCloudAPI {
   public _auth: AssistantCloudAuthStrategy;

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -65,26 +65,29 @@ type MakeRequestOptions = {
   body?: object | undefined;
 };
 
+const normalizeBaseUrl = (baseUrl: string) =>
+  baseUrl ? baseUrl.replace(/\/+$/, "") : baseUrl;
+
 export class AssistantCloudAPI {
   public _auth: AssistantCloudAuthStrategy;
   public _baseUrl;
 
   constructor(config: AssistantCloudConfig) {
     if ("authToken" in config) {
-      this._baseUrl = config.baseUrl;
+      this._baseUrl = normalizeBaseUrl(config.baseUrl);
       this._auth = new AssistantCloudJWTAuthStrategy(config.authToken);
     } else if ("apiKey" in config) {
-      this._baseUrl = (
-        config.baseUrl ?? "https://backend.assistant-api.com"
-      ).replace(/\/$/, "");
+      this._baseUrl = normalizeBaseUrl(
+        config.baseUrl ?? "https://backend.assistant-api.com",
+      );
       this._auth = new AssistantCloudAPIKeyAuthStrategy(
         config.apiKey,
         config.userId,
         config.workspaceId,
       );
     } else if ("anonymous" in config) {
-      this._baseUrl = config.baseUrl;
-      this._auth = new AssistantCloudAnonymousAuthStrategy(config.baseUrl);
+      this._baseUrl = normalizeBaseUrl(config.baseUrl);
+      this._auth = new AssistantCloudAnonymousAuthStrategy(this._baseUrl);
     } else {
       throw new Error(
         "Invalid configuration: Must provide authToken, apiKey, or anonymous configuration",

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -1,9 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssistantCloudAPI, CloudAPIError } from "../AssistantCloudAPI";
+
+const createJwt = () => {
+  const payload = Buffer.from(JSON.stringify({ exp: 4_102_444_800 })).toString(
+    "base64url",
+  );
+  return `header.${payload}.signature`;
+};
 
 describe("AssistantCloudAPI", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("serializes query params, merges auth headers, and sends JSON body", async () => {
@@ -88,6 +99,65 @@ describe("AssistantCloudAPI", () => {
 
     const [url] = fetchMock.mock.calls[0]!;
     expect(url.toString()).toBe("https://custom.example.com/v1/threads");
+  });
+
+  it("strips a trailing slash from a JWT baseUrl", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://custom.example.com/",
+      authToken: async () => createJwt(),
+    });
+
+    await api.makeRawRequest("/threads");
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url.toString()).toBe("https://custom.example.com/v1/threads");
+  });
+
+  it("strips a trailing slash from anonymous auth URLs", async () => {
+    const storage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    };
+    vi.stubGlobal("localStorage", storage);
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: createJwt(),
+          refresh_token: {
+            token: "refresh-token",
+            expires_at: "2100-01-01T00:00:00.000Z",
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://custom.example.com/",
+      anonymous: true,
+    });
+
+    await api.makeRawRequest("/threads");
+
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "https://custom.example.com/v1/auth/tokens/anonymous",
+    );
+    expect(fetchMock.mock.calls[1]![0].toString()).toBe(
+      "https://custom.example.com/v1/threads",
+    );
   });
 
   it("rejects before fetch when auth token callback returns null", async () => {


### PR DESCRIPTION
## Summary

- normalize custom Cloud base URLs for API-key, JWT, and anonymous authentication
- pass the normalized URL into anonymous token requests as well as regular API requests
- add regression coverage for JWT and anonymous auth while retaining API-key coverage

## Why

A custom base URL ending in a slash was normalized only for API-key auth. JWT and anonymous configurations could therefore request paths such as https://cloud.example.com//v1/threads, which strict proxies and routers may reject.

The normalizer removes trailing slashes from valid URLs while preserving the existing deferred behavior for falsy environment-backed values used during template prerendering.

## Verification

- pnpm --filter assistant-cloud test -- AssistantCloudAPI.test.ts
- pnpm --filter assistant-cloud build
- pnpm --filter assistant-ui-starter-cloud build
- pnpm lint
- pnpm build (86/86 tasks passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

