### PR TITLE
fix(core): serialize local thread storage mutations

### DIFF
--- a/.changeset/local-storage-mutations.md
+++ b/.changeset/local-storage-mutations.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve concurrent local thread metadata and history writes

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
@@ -207,7 +207,7 @@ describe("createLocalStorageAdapter", () => {
     ]);
   });
 
-  it("preserves concurrent thread metadata mutations", async () => {
+  it("preserves concurrent metadata mutations across adapters", async () => {
     const threadsKey = "@assistant-ui:threads";
     const values = new Map<string, string>();
     let metadataReads = 0;
@@ -239,11 +239,12 @@ describe("createLocalStorageAdapter", () => {
         values.delete(key);
       },
     };
-    const adapter = createLocalStorageAdapter({ storage });
+    const firstAdapter = createLocalStorageAdapter({ storage });
+    const secondAdapter = createLocalStorageAdapter({ storage });
 
-    const firstInitialization = adapter.initialize("thread-1");
+    const firstInitialization = firstAdapter.initialize("thread-1");
     await firstWriteStarted;
-    const secondInitialization = adapter.initialize("thread-2");
+    const secondInitialization = secondAdapter.initialize("thread-2");
     const readsWhileFirstWritePending = metadataReads;
 
     releaseFirstWrite();

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.test.ts
@@ -207,6 +207,87 @@ describe("createLocalStorageAdapter", () => {
     ]);
   });
 
+  it("preserves concurrent thread metadata mutations", async () => {
+    const threadsKey = "@assistant-ui:threads";
+    const values = new Map<string, string>();
+    let metadataReads = 0;
+    let metadataWrites = 0;
+    let markFirstWriteStarted!: () => void;
+    let releaseFirstWrite!: () => void;
+    const firstWriteStarted = new Promise<void>((resolve) => {
+      markFirstWriteStarted = resolve;
+    });
+    const firstWriteCanFinish = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const storage: AsyncStorageLike = {
+      getItem: async (key) => {
+        if (key === threadsKey) metadataReads += 1;
+        return values.get(key) ?? null;
+      },
+      setItem: async (key, value) => {
+        if (key === threadsKey) {
+          metadataWrites += 1;
+          if (metadataWrites === 1) {
+            markFirstWriteStarted();
+            await firstWriteCanFinish;
+          }
+        }
+        values.set(key, value);
+      },
+      removeItem: async (key) => {
+        values.delete(key);
+      },
+    };
+    const adapter = createLocalStorageAdapter({ storage });
+
+    const firstInitialization = adapter.initialize("thread-1");
+    await firstWriteStarted;
+    const secondInitialization = adapter.initialize("thread-2");
+    const readsWhileFirstWritePending = metadataReads;
+
+    releaseFirstWrite();
+    await Promise.all([firstInitialization, secondInitialization]);
+
+    expect(readsWhileFirstWritePending).toBe(1);
+    expect(JSON.parse(values.get(threadsKey) ?? "")).toEqual([
+      { remoteId: "thread-2", status: "regular" },
+      { remoteId: "thread-1", status: "regular" },
+    ]);
+  });
+
+  it("continues processing mutations after a storage failure", async () => {
+    const threadsKey = "@assistant-ui:threads";
+    const values = new Map<string, string>();
+    let shouldFail = true;
+    const storage: AsyncStorageLike = {
+      getItem: async (key) => values.get(key) ?? null,
+      setItem: async (key, value) => {
+        if (shouldFail) {
+          shouldFail = false;
+          throw new Error("Storage unavailable");
+        }
+        values.set(key, value);
+      },
+      removeItem: async (key) => {
+        values.delete(key);
+      },
+    };
+    const adapter = createLocalStorageAdapter({ storage });
+
+    await expect(adapter.initialize("thread-1")).rejects.toThrow(
+      "Storage unavailable",
+    );
+    await expect(adapter.initialize("thread-2")).resolves.toEqual({
+      remoteId: "thread-2",
+      externalId: undefined,
+    });
+
+    expect(JSON.parse(values.get(threadsKey) ?? "")).toEqual([
+      { remoteId: "thread-2", status: "regular" },
+    ]);
+  });
+
   it("includes the thread id when a stored thread cannot be fetched", async () => {
     const storage = createStorage({
       "@assistant-ui:threads": JSON.stringify([

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -43,6 +43,17 @@ class KeyedMutationQueue {
   }
 }
 
+const mutationQueues = new WeakMap<AsyncStorageLike, KeyedMutationQueue>();
+
+const getMutationQueue = (storage: AsyncStorageLike): KeyedMutationQueue => {
+  let queue = mutationQueues.get(storage);
+  if (!queue) {
+    queue = new KeyedMutationQueue();
+    mutationQueues.set(storage, queue);
+  }
+  return queue;
+};
+
 type LocalStorageAdapterOptions = {
   storage: AsyncStorageLike;
   prefix?: string | undefined;
@@ -335,7 +346,7 @@ export const createLocalStorageAdapter = (
 
   const threadsKey = `${prefix}threads`;
   const messagesKey = (threadId: string) => `${prefix}messages:${threadId}`;
-  const mutationQueue = new KeyedMutationQueue();
+  const mutationQueue = getMutationQueue(storage);
 
   const loadThreadMetadata = async (): Promise<StoredThreadMetadata[]> => {
     const raw = await storage.getItem(threadsKey);

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -23,6 +23,26 @@ export type AsyncStorageLike = {
   removeItem(key: string): Promise<void>;
 };
 
+class KeyedMutationQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  run<T>(key: string, mutation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key);
+    const result = previous ? previous.then(mutation) : mutation();
+    const tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    this.tails.set(key, tail);
+    void tail.then(() => {
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    });
+
+    return result;
+  }
+}
+
 type LocalStorageAdapterOptions = {
   storage: AsyncStorageLike;
   prefix?: string | undefined;
@@ -248,6 +268,7 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
     private storage: AsyncStorageLike,
     private aui: ReturnType<typeof useAui>,
     private prefix: string,
+    private mutationQueue: KeyedMutationQueue,
   ) {}
 
   private _messagesKey(remoteId: string) {
@@ -266,31 +287,34 @@ class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
     const { remoteId } = await this.aui.threadListItem().initialize();
 
     const key = this._messagesKey(remoteId);
-    const raw = await this.storage.getItem(key);
-    const repo = parseStoredMessageRepository(raw);
+    await this.mutationQueue.run(key, async () => {
+      const raw = await this.storage.getItem(key);
+      const repo = parseStoredMessageRepository(raw);
 
-    const idx = repo.messages.findIndex(
-      (m) => m.message.id === item.message.id,
-    );
-    if (idx >= 0) {
-      repo.messages[idx] = item;
-    } else {
-      repo.messages.push(item);
-    }
-    repo.headId = item.message.id;
+      const idx = repo.messages.findIndex(
+        (m) => m.message.id === item.message.id,
+      );
+      if (idx >= 0) {
+        repo.messages[idx] = item;
+      } else {
+        repo.messages.push(item);
+      }
+      repo.headId = item.message.id;
 
-    await this.storage.setItem(key, JSON.stringify(repo));
+      await this.storage.setItem(key, JSON.stringify(repo));
+    });
   }
 }
 
 const createHistoryProvider = (
   storage: AsyncStorageLike,
   prefix: string,
+  mutationQueue: KeyedMutationQueue,
 ): FC<PropsWithChildren> => {
   const Provider: FC<PropsWithChildren> = ({ children }) => {
     const aui = useAui();
     const history = useMemo(
-      () => new AsyncStorageHistoryAdapter(storage, aui, prefix),
+      () => new AsyncStorageHistoryAdapter(storage, aui, prefix, mutationQueue),
       [aui],
     );
     const adapters = useMemo(() => ({ history }), [history]);
@@ -311,6 +335,7 @@ export const createLocalStorageAdapter = (
 
   const threadsKey = `${prefix}threads`;
   const messagesKey = (threadId: string) => `${prefix}messages:${threadId}`;
+  const mutationQueue = new KeyedMutationQueue();
 
   const loadThreadMetadata = async (): Promise<StoredThreadMetadata[]> => {
     const raw = await storage.getItem(threadsKey);
@@ -324,7 +349,7 @@ export const createLocalStorageAdapter = (
   };
 
   const adapter: RemoteThreadListAdapter = {
-    unstable_Provider: createHistoryProvider(storage, prefix),
+    unstable_Provider: createHistoryProvider(storage, prefix, mutationQueue),
 
     async list(): Promise<RemoteThreadListResponse> {
       const threads = await loadThreadMetadata();
@@ -343,64 +368,78 @@ export const createLocalStorageAdapter = (
       threadId: string,
     ): Promise<RemoteThreadInitializeResponse> {
       const remoteId = threadId;
-      const threads = await loadThreadMetadata();
+      return mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
 
-      // Only add if not already present
-      if (!threads.some((t) => t.remoteId === remoteId)) {
-        threads.unshift({
-          remoteId,
-          status: "regular",
-        });
-        await saveThreadMetadata(threads);
-      }
+        // Only add if not already present
+        if (!threads.some((t) => t.remoteId === remoteId)) {
+          threads.unshift({
+            remoteId,
+            status: "regular",
+          });
+          await saveThreadMetadata(threads);
+        }
 
-      return { remoteId, externalId: undefined };
+        return { remoteId, externalId: undefined };
+      });
     },
 
     async rename(remoteId: string, newTitle: string): Promise<void> {
-      const threads = await loadThreadMetadata();
-      const thread = threads.find((t) => t.remoteId === remoteId);
-      if (thread) {
-        thread.title = newTitle;
-        await saveThreadMetadata(threads);
-      }
+      await mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
+        const thread = threads.find((t) => t.remoteId === remoteId);
+        if (thread) {
+          thread.title = newTitle;
+          await saveThreadMetadata(threads);
+        }
+      });
     },
 
     async updateCustom(
       remoteId: string,
       custom: Record<string, unknown> | undefined,
     ): Promise<void> {
-      const threads = await loadThreadMetadata();
-      const thread = threads.find((t) => t.remoteId === remoteId);
-      if (thread) {
-        thread.custom = custom;
-        await saveThreadMetadata(threads);
-      }
+      await mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
+        const thread = threads.find((t) => t.remoteId === remoteId);
+        if (thread) {
+          thread.custom = custom;
+          await saveThreadMetadata(threads);
+        }
+      });
     },
 
     async archive(remoteId: string): Promise<void> {
-      const threads = await loadThreadMetadata();
-      const thread = threads.find((t) => t.remoteId === remoteId);
-      if (thread) {
-        thread.status = "archived";
-        await saveThreadMetadata(threads);
-      }
+      await mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
+        const thread = threads.find((t) => t.remoteId === remoteId);
+        if (thread) {
+          thread.status = "archived";
+          await saveThreadMetadata(threads);
+        }
+      });
     },
 
     async unarchive(remoteId: string): Promise<void> {
-      const threads = await loadThreadMetadata();
-      const thread = threads.find((t) => t.remoteId === remoteId);
-      if (thread) {
-        thread.status = "regular";
-        await saveThreadMetadata(threads);
-      }
+      await mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
+        const thread = threads.find((t) => t.remoteId === remoteId);
+        if (thread) {
+          thread.status = "regular";
+          await saveThreadMetadata(threads);
+        }
+      });
     },
 
     async delete(remoteId: string): Promise<void> {
-      const threads = await loadThreadMetadata();
-      const filtered = threads.filter((t) => t.remoteId !== remoteId);
-      await saveThreadMetadata(filtered);
-      await storage.removeItem(messagesKey(remoteId));
+      await mutationQueue.run(threadsKey, async () => {
+        const threads = await loadThreadMetadata();
+        const filtered = threads.filter((t) => t.remoteId !== remoteId);
+        await saveThreadMetadata(filtered);
+      });
+      await mutationQueue.run(messagesKey(remoteId), () =>
+        storage.removeItem(messagesKey(remoteId)),
+      );
     },
 
     async fetch(threadId: string): Promise<RemoteThreadMetadata> {
@@ -427,12 +466,14 @@ export const createLocalStorageAdapter = (
         const title = await titleGenerator.generateTitle(messages);
 
         // Update the stored title
-        const threads = await loadThreadMetadata();
-        const thread = threads.find((t) => t.remoteId === remoteId);
-        if (thread) {
-          thread.title = title;
-          await saveThreadMetadata(threads);
-        }
+        await mutationQueue.run(threadsKey, async () => {
+          const threads = await loadThreadMetadata();
+          const thread = threads.find((t) => t.remoteId === remoteId);
+          if (thread) {
+            thread.title = title;
+            await saveThreadMetadata(threads);
+          }
+        });
 
         // Return a stream with a single text part
         return createAssistantStream((controller) => {

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -348,6 +348,20 @@ export const createLocalStorageAdapter = (
     await storage.setItem(threadsKey, JSON.stringify(threads));
   };
 
+  const updateThreadMetadata = async (
+    remoteId: string,
+    update: (thread: StoredThreadMetadata) => void,
+  ): Promise<void> => {
+    await mutationQueue.run(threadsKey, async () => {
+      const threads = await loadThreadMetadata();
+      const thread = threads.find((item) => item.remoteId === remoteId);
+      if (thread) {
+        update(thread);
+        await saveThreadMetadata(threads);
+      }
+    });
+  };
+
   const adapter: RemoteThreadListAdapter = {
     unstable_Provider: createHistoryProvider(storage, prefix, mutationQueue),
 
@@ -385,13 +399,8 @@ export const createLocalStorageAdapter = (
     },
 
     async rename(remoteId: string, newTitle: string): Promise<void> {
-      await mutationQueue.run(threadsKey, async () => {
-        const threads = await loadThreadMetadata();
-        const thread = threads.find((t) => t.remoteId === remoteId);
-        if (thread) {
-          thread.title = newTitle;
-          await saveThreadMetadata(threads);
-        }
+      await updateThreadMetadata(remoteId, (thread) => {
+        thread.title = newTitle;
       });
     },
 
@@ -399,35 +408,20 @@ export const createLocalStorageAdapter = (
       remoteId: string,
       custom: Record<string, unknown> | undefined,
     ): Promise<void> {
-      await mutationQueue.run(threadsKey, async () => {
-        const threads = await loadThreadMetadata();
-        const thread = threads.find((t) => t.remoteId === remoteId);
-        if (thread) {
-          thread.custom = custom;
-          await saveThreadMetadata(threads);
-        }
+      await updateThreadMetadata(remoteId, (thread) => {
+        thread.custom = custom;
       });
     },
 
     async archive(remoteId: string): Promise<void> {
-      await mutationQueue.run(threadsKey, async () => {
-        const threads = await loadThreadMetadata();
-        const thread = threads.find((t) => t.remoteId === remoteId);
-        if (thread) {
-          thread.status = "archived";
-          await saveThreadMetadata(threads);
-        }
+      await updateThreadMetadata(remoteId, (thread) => {
+        thread.status = "archived";
       });
     },
 
     async unarchive(remoteId: string): Promise<void> {
-      await mutationQueue.run(threadsKey, async () => {
-        const threads = await loadThreadMetadata();
-        const thread = threads.find((t) => t.remoteId === remoteId);
-        if (thread) {
-          thread.status = "regular";
-          await saveThreadMetadata(threads);
-        }
+      await updateThreadMetadata(remoteId, (thread) => {
+        thread.status = "regular";
       });
     },
 
@@ -437,9 +431,8 @@ export const createLocalStorageAdapter = (
         const filtered = threads.filter((t) => t.remoteId !== remoteId);
         await saveThreadMetadata(filtered);
       });
-      await mutationQueue.run(messagesKey(remoteId), () =>
-        storage.removeItem(messagesKey(remoteId)),
-      );
+      const key = messagesKey(remoteId);
+      await mutationQueue.run(key, () => storage.removeItem(key));
     },
 
     async fetch(threadId: string): Promise<RemoteThreadMetadata> {
@@ -466,13 +459,8 @@ export const createLocalStorageAdapter = (
         const title = await titleGenerator.generateTitle(messages);
 
         // Update the stored title
-        await mutationQueue.run(threadsKey, async () => {
-          const threads = await loadThreadMetadata();
-          const thread = threads.find((t) => t.remoteId === remoteId);
-          if (thread) {
-            thread.title = title;
-            await saveThreadMetadata(threads);
-          }
+        await updateThreadMetadata(remoteId, (thread) => {
+          thread.title = title;
         });
 
         // Return a stream with a single text part


### PR DESCRIPTION
## Summary

- serialize local thread metadata and message-history mutations per storage key
- preserve concurrency between unrelated thread histories
- allow later mutations to continue after a storage operation rejects

## Why

Local thread metadata and message histories are stored as JSON blobs using a read-modify-write cycle. When two mutations overlap, both can read the same old snapshot and then replace the complete blob. The write that finishes last silently removes the other update.

One real timing-dependent case is a slow async storage adapter combined with a fast model response: persistence of the user message is still in progress when persistence of the assistant response begins. Both appends can read the previous history, and after a reload either new message may be missing. Concurrent thread initialization or metadata updates can lose data in the same way.

This change queues the complete read-modify-write transaction by storage key. The first mutation starts immediately, and only another mutation targeting that same key waits. Message writes for different threads still run concurrently, so the fix does not introduce a global storage bottleneck.

## Testing

- added a deterministic regression test that pauses the first metadata write, starts a second initialization, and verifies the second read waits and both threads survive
- added coverage that a rejected mutation does not block the next mutation
- `pnpm --filter @assistant-ui/core test`
- `pnpm lint`
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

