### PR TITLE
docs: add missing migrations page

### DIFF
--- a/apps/docs/content/docs/migrations/index.mdx
+++ b/apps/docs/content/docs/migrations/index.mdx
@@ -1,0 +1,50 @@
+---
+title: Migration Guides
+description: Upgrade assistant-ui versions and migrate deprecated APIs and integrations.
+---
+
+Use these guides when upgrading assistant-ui or moving from APIs that have been deprecated or replaced.
+
+## Version upgrades
+
+<Cards>
+  <Card title="Migration to v0.14" href="/docs/migrations/v0-14">
+    Replace APIs removed after v0.11 and v0.12, and migrate primitive
+    `components` props to children render functions.
+  </Card>
+  <Card title="Migration to v0.12" href="/docs/migrations/v0-12">
+    Move from individual context hooks to the unified state API.
+  </Card>
+  <Card title="Migration to v0.11" href="/docs/migrations/v0-11">
+    Update code affected by the `ContentPart` to `MessagePart` rename.
+  </Card>
+</Cards>
+
+## APIs and integrations
+
+<Cards>
+  <Card title="Migrating Tools to Toolkits" href="/docs/migrations/toolkit-tools">
+    Move legacy tool and tool UI registrations to the toolkit API.
+  </Card>
+  <Card
+    title="Migrating to react-langgraph v0.7"
+    href="/docs/migrations/react-langgraph-v0-7"
+  >
+    Upgrade to the simplified LangGraph integration API.
+  </Card>
+  <Card
+    title="Using old React versions"
+    href="/docs/migrations/react-compatibility"
+  >
+    Review compatibility notes for React 18 and React 19.
+  </Card>
+</Cards>
+
+## Stability
+
+<Cards>
+  <Card title="Deprecation Policy" href="/docs/migrations/deprecation-policy">
+    Review stability guarantees and deprecation timelines for assistant-ui
+    features.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/migrations/meta.json
+++ b/apps/docs/content/docs/migrations/meta.json
@@ -3,6 +3,7 @@
   "icon": "ArrowLeftRight",
   "root": true,
   "pages": [
+    "index",
     "deprecation-policy",
     "toolkit-tools",
     "v0-11",


### PR DESCRIPTION
## Summary

- add a `/docs/migrations` landing page for the existing migration guides
- group version, API, integration, compatibility, and deprecation resources
- register the index in the Migrations sidebar navigation

## Why

The Stability page links to `/docs/migrations`, but the migrations directory only contained individual guides and sidebar metadata. The missing index document caused that link to open a route with no page.

This adds a concise table of contents using the exact existing guide titles and routes, so readers can choose the relevant migration without expanding the sidebar first.

## Testing

- `pnpm --filter @assistant-ui/docs build` (417 static pages generated, including `migrations.html`)
- `pnpm lint`
- verified the page in the browser at desktop and 390px mobile widths
- confirmed no horizontal overflow or browser console errors

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

