### PR TITLE
docs(react-ai-sdk): move the resumable streams cross-links into jsdoc

### DIFF
--- a/.changeset/api-ref-resumable-jsdoc-links.md
+++ b/.changeset/api-ref-resumable-jsdoc-links.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+docs: move the resumable streams cross-links into jsdoc so the api-reference generator preserves them

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx
@@ -63,11 +63,11 @@ export async function POST(req: Request) {
 
 ### RESUMABLE_STREAM_ID_HEADER
 
+Response header used by the [Resumable Streams](/docs/guides/resumable-streams) server and client wiring.
+
 ```ts
 const RESUMABLE_STREAM_ID_HEADER: "x-resumable-stream-id";
 ```
-
-Response header used by the [Resumable Streams](/docs/guides/resumable-streams) server and client wiring.
 
 ### unstable_injectInteractableContext
 

--- a/packages/react-ai-sdk/src/ui/resumable.ts
+++ b/packages/react-ai-sdk/src/ui/resumable.ts
@@ -1,6 +1,9 @@
 "use client";
 
-export { RESUMABLE_STREAM_ID_HEADER } from "assistant-stream/resumable";
+import { RESUMABLE_STREAM_ID_HEADER as RESUMABLE_STREAM_ID_HEADER_VALUE } from "assistant-stream/resumable";
+
+/** Response header used by the [Resumable Streams](/docs/guides/resumable-streams) server and client wiring. */
+export const RESUMABLE_STREAM_ID_HEADER = RESUMABLE_STREAM_ID_HEADER_VALUE;
 
 const DEFAULT_STORAGE_KEY = "aui-resumable-stream-id";
 
@@ -10,7 +13,7 @@ export type ResumableClientStorage = {
   clear(): void;
 };
 
-/** `sessionStorage`-backed storage for the pending resumable stream id. */
+/** `sessionStorage`-backed storage for the pending resumable stream id. See the [Resumable Streams](/docs/guides/resumable-streams) guide for end-to-end wiring. */
 export function createResumableSessionStorage(options?: {
   key?: string;
 }): ResumableClientStorage {


### PR DESCRIPTION
## summary

- #4838 hand-wrote the two resumable streams guide cross-links inside the auto-generated block of the react-ai-sdk api-reference page, so the next generate:api-reference run would silently delete them; this moves the sentences into the JSDoc of createResumableSessionStorage and RESUMABLE_STREAM_ID_HEADER so the generator produces them itself.
- RESUMABLE_STREAM_ID_HEADER becomes a local const wrapping the assistant-stream re-export, because the generator's extractor cannot read JSDoc through a cross-package re-export (this is also why the export never had a rendered description). name, literal type, and runtime value are unchanged.
- the mdx page is the regenerated output, and a patch changeset for @assistant-ui/react-ai-sdk is included.

## test plan

### already verified

- [x] `pnpm -C apps/docs generate:api-reference` run twice on this tree; react-ai-sdk.mdx is byte-stable across runs, so the cross-links now survive regeneration.
- [x] `pnpm lint` reports nothing for the touched files.

### reviewer should verify

- [ ] run `pnpm -C apps/docs generate:api-reference` and confirm `git diff` stays empty on `apps/docs/content/docs/(reference)/api-reference/integrations/react-ai-sdk.mdx`.

## notes

- the RESUMABLE_STREAM_ID_HEADER description now renders above the signature block instead of below it, which is the generator's canonical placement for every entry; the hand edit had put it below.
- a follow-up PR adds a CI drift gate that regenerates the api-reference in strict mode, which would have caught the original hand edit at PR time.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

