### PR TITLE
fix(assistant-stream): decode AI SDK v5+ source-url, file, and bare finish chunks in UIMessageStreamDecoder

### DIFF
--- a/.changeset/fix-ui-message-stream-chunk-shapes.md
+++ b/.changeset/fix-ui-message-stream-chunk-shapes.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): decode AI SDK v5+ source-url, file, and bare finish chunks in UIMessageStreamDecoder

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11787,7 +11787,8 @@ type TypePath<T> = [
 
 type UIMessageStreamChunk = {
   type: "start";
-  messageId: string;
+  messageId?: string;
+  messageMetadata?: ReadonlyJSONValue;
 } | {
   type: "text-start";
   id: string;
@@ -11805,19 +11806,14 @@ type UIMessageStreamChunk = {
 } | {
   type: "reasoning-end";
 } | {
-  type: "source";
-  source: {
-    sourceType: "url";
-    id: string;
-    url: string;
-    title?: string;
-  };
+  type: "source-url";
+  sourceId: string;
+  url: string;
+  title?: string;
 } | {
   type: "file";
-  file: {
-    mimeType: string;
-    data: string;
-  };
+  url: string;
+  mediaType: string;
 } | {
   type: "tool-call-start";
   id: string;
@@ -11839,13 +11835,14 @@ type UIMessageStreamChunk = {
   messageId?: string;
 } | {
   type: "finish-step";
-  finishReason: FinishReason;
-  usage: Usage;
-  isContinued: boolean;
+  finishReason?: FinishReason;
+  usage?: Usage;
+  isContinued?: boolean;
 } | {
   type: "finish";
-  finishReason: FinishReason;
-  usage: Usage;
+  finishReason?: FinishReason;
+  usage?: Usage;
+  messageMetadata?: ReadonlyJSONValue;
 } | {
   type: "error";
   errorText: string;

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -138,7 +138,50 @@ describe("UIMessageStreamDecoder", () => {
     expect(result?.result).toEqual({ temp: 72 });
   });
 
-  it("should decode source parts", async () => {
+  it("should decode source-url parts", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "source-url",
+        sourceId: "src_1",
+        url: "https://example.com",
+        title: "Example",
+      }),
+      JSON.stringify({
+        type: "source-url",
+        sourceId: "src_2",
+        url: "https://example.org",
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const sourceStarts = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "part-start" } =>
+        c.type === "part-start" && c.part.type === "source",
+    );
+    expect(sourceStarts).toHaveLength(2);
+    if (sourceStarts[0]?.part.type === "source") {
+      expect(sourceStarts[0].part.id).toBe("src_1");
+      expect(sourceStarts[0].part.url).toBe("https://example.com");
+      expect(sourceStarts[0].part.title).toBe("Example");
+    }
+    if (sourceStarts[1]?.part.type === "source") {
+      expect(sourceStarts[1].part.id).toBe("src_2");
+      expect(sourceStarts[1].part.url).toBe("https://example.org");
+      expect(sourceStarts[1].part.title).toBeUndefined();
+    }
+  });
+
+  it("should decode legacy source parts", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({
@@ -168,12 +211,44 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(sourceStart).toBeDefined();
     if (sourceStart?.part.type === "source") {
+      expect(sourceStart.part.id).toBe("src_1");
       expect(sourceStart.part.url).toBe("https://example.com");
       expect(sourceStart.part.title).toBe("Example");
     }
   });
 
   it("should decode file parts", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "file",
+        url: "https://example.com/image.png",
+        mediaType: "image/png",
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const fileStart = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "part-start" } =>
+        c.type === "part-start" && c.part.type === "file",
+    );
+    expect(fileStart).toBeDefined();
+    if (fileStart?.part.type === "file") {
+      expect(fileStart.part.mimeType).toBe("image/png");
+      expect(fileStart.part.data).toBe("https://example.com/image.png");
+    }
+  });
+
+  it("should decode legacy file parts", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({
@@ -308,6 +383,96 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(stepFinish).toBeDefined();
     expect(stepFinish?.finishReason).toBe("stop");
+    expect(stepFinish?.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(stepFinish?.isContinued).toBe(false);
+  });
+
+  it("should handle the stock v6 lifecycle with bare step chunks", async () => {
+    const events = [
+      JSON.stringify({ type: "start" }),
+      JSON.stringify({ type: "start-step" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({ type: "finish-step" }),
+      JSON.stringify({ type: "finish", finishReason: "stop" }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const stepStarts = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "step-start" } =>
+        c.type === "step-start",
+    );
+    expect(stepStarts).toHaveLength(2);
+    expect(stepStarts[0]?.messageId).toBeTruthy();
+    expect(stepStarts[1]?.messageId).toBe(stepStarts[0]?.messageId);
+
+    const stepFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "step-finish" } =>
+        c.type === "step-finish",
+    );
+    expect(stepFinish?.finishReason).toBe("unknown");
+    expect(stepFinish?.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(stepFinish?.isContinued).toBe(false);
+
+    const messageFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "message-finish" } =>
+        c.type === "message-finish",
+    );
+    expect(messageFinish?.finishReason).toBe("stop");
+  });
+
+  it("should default finishReason on a bare finish chunk", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({ type: "finish" }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const messageFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "message-finish" } =>
+        c.type === "message-finish",
+    );
+    expect(messageFinish?.finishReason).toBe("unknown");
+    expect(messageFinish?.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+
+  it("should ignore malformed legacy source and file chunks", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "source" }),
+      JSON.stringify({ type: "source", source: null }),
+      JSON.stringify({ type: "file" }),
+      JSON.stringify({ type: "file", file: null }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const partStarts = chunks.filter(
+      (c) =>
+        c.type === "part-start" &&
+        (c.part.type === "source" || c.part.type === "file"),
+    );
+    expect(partStarts).toHaveLength(0);
   });
 
   it("should handle errors", async () => {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -134,14 +134,16 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
           }
 
           switch (type) {
-            case "start":
-              currentMessageId = chunk.messageId;
+            case "start": {
+              const messageId = chunk.messageId ?? generateId();
+              currentMessageId = messageId;
               controller.enqueue({
                 type: "step-start",
                 path: [],
-                messageId: chunk.messageId,
+                messageId,
               });
               break;
+            }
 
             case "text-start":
             case "text-end":
@@ -157,21 +159,21 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               controller.appendReasoning(chunk.delta);
               break;
 
-            case "source":
+            case "source-url":
               controller.appendSource({
                 type: "source",
-                sourceType: chunk.source.sourceType,
-                id: chunk.source.id,
-                url: chunk.source.url,
-                ...(chunk.source.title && { title: chunk.source.title }),
+                sourceType: "url",
+                id: chunk.sourceId,
+                url: chunk.url,
+                ...(chunk.title && { title: chunk.title }),
               });
               break;
 
             case "file":
               controller.appendFile({
                 type: "file",
-                mimeType: chunk.file.mimeType,
-                data: chunk.file.data,
+                mimeType: chunk.mediaType,
+                data: chunk.url,
               });
               break;
 
@@ -234,9 +236,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               controller.enqueue({
                 type: "step-finish",
                 path: [],
-                finishReason: chunk.finishReason,
-                usage: chunk.usage,
-                isContinued: chunk.isContinued,
+                finishReason: chunk.finishReason ?? "unknown",
+                usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+                isContinued: chunk.isContinued ?? false,
               });
               break;
 
@@ -244,8 +246,8 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               controller.enqueue({
                 type: "message-finish",
                 path: [],
-                finishReason: chunk.finishReason,
-                usage: chunk.usage,
+                finishReason: chunk.finishReason ?? "unknown",
+                usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
               });
               break;
 
@@ -286,7 +288,29 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 return;
               }
 
-              controller.enqueue(JSON.parse(event.data));
+              const chunk = JSON.parse(event.data);
+              if (chunk.type === "source" && chunk.source != null) {
+                controller.enqueue({
+                  type: "source-url",
+                  sourceId: chunk.source.id,
+                  url: chunk.source.url,
+                  ...(chunk.source.title && { title: chunk.source.title }),
+                });
+                return;
+              }
+              if (chunk.type === "file") {
+                if (chunk.file != null) {
+                  controller.enqueue({
+                    type: "file",
+                    url: chunk.file.data,
+                    mediaType: chunk.file.mimeType,
+                  });
+                  return;
+                }
+                if (chunk.url === undefined) return;
+              }
+
+              controller.enqueue(chunk);
             },
             flush() {
               if (!receivedDone) {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/chunk-types.ts
@@ -15,18 +15,19 @@ type Usage = {
 };
 
 export type UIMessageStreamChunk =
-  | { type: "start"; messageId: string }
+  | {
+      type: "start";
+      messageId?: string;
+      messageMetadata?: ReadonlyJSONValue;
+    }
   | { type: "text-start"; id: string }
   | { type: "text-delta"; textDelta: string }
   | { type: "text-end" }
   | { type: "reasoning-start"; id: string }
   | { type: "reasoning-delta"; delta: string }
   | { type: "reasoning-end" }
-  | {
-      type: "source";
-      source: { sourceType: "url"; id: string; url: string; title?: string };
-    }
-  | { type: "file"; file: { mimeType: string; data: string } }
+  | { type: "source-url"; sourceId: string; url: string; title?: string }
+  | { type: "file"; url: string; mediaType: string }
   | {
       type: "tool-call-start";
       id: string;
@@ -45,11 +46,16 @@ export type UIMessageStreamChunk =
   | { type: "start-step"; messageId?: string }
   | {
       type: "finish-step";
-      finishReason: FinishReason;
-      usage: Usage;
-      isContinued: boolean;
+      finishReason?: FinishReason;
+      usage?: Usage;
+      isContinued?: boolean;
     }
-  | { type: "finish"; finishReason: FinishReason; usage: Usage }
+  | {
+      type: "finish";
+      finishReason?: FinishReason;
+      usage?: Usage;
+      messageMetadata?: ReadonlyJSONValue;
+    }
   | { type: "error"; errorText: string }
   | UIMessageStreamDataChunk;
 


### PR DESCRIPTION
## What

`UIMessageStreamDecoder` and the published `UIMessageStreamChunk` type were written against a pre-stable v5 canary format. This aligns the `source`, `file`, `finish-step`, `start`, and `finish` members with the real AI SDK v5/v6/v7 wire format (verified against `ai@6.0.221` and `ai@7.0.0-beta.178`), using the pattern from the #4678 review: canonical shape in the published type, legacy shapes normalized at the SSE parse boundary.

## Why

Stock `toUIMessageStreamResponse()` endpoints hit this decoder through `react-data-stream` today:

- a spec-conformant `file` chunk (`{url, mediaType}`) crashes the stream: the decoder reads `chunk.file.mimeType` on undefined
- `source-url` chunks are silently dropped: the decoder only knows a `source` type that no released AI SDK emits
- bare v6 `finish-step`/`finish` and `start` without `messageId` forward undefined fields into internal chunks that require them

## How

- `chunk-types.ts`: `source` replaced with canonical `source-url {sourceId, url, title?}`, `file` with `{url, mediaType}`; `start`/`finish-step`/`finish` fields become optional per spec. `text-delta` (#4678) and tool members (#4692) untouched
- parse boundary: legacy `{source: {...}}` / `{file: {...}}` shapes normalized to canonical with `!= null` guards; malformed payloads are dropped or ignored, never throw
- decoder defaults: `finishReason ?? "unknown"` (maps to complete status), zero usage, `isContinued: false`; `start` resolves `messageId ?? generateId()` and keeps `currentMessageId` in sync so bare `start-step` chunks correlate
- tests: canonical + legacy per member, stock-v6 lifecycle, bare finish, malformed chunks
- changeset (patch), api-surface regenerated

## Notes for review

Replacing the `source`/`file` members is a stronger published-type change than #4678's field rename. Runtime keeps accepting the legacy wire, but producers typed against the old members need the canonical shapes. This follows the #4678 review prescription (normalize to v5 as canonical, no type widening). `finish-step`/`finish` keep their legacy fields as optional because v6 deleted them from the wire with no canonical home, so legacy usage data stays typed instead of dropped.

Known trade-offs, disclosed rather than solved here:

- when the wire omits usage, the decoder fabricates `{0, 0}` (internal chunk type requires it); the cloud usage fallback aggregation counts that as measured. Possible follow-up: skip all-zero step usage there
- `source-document`, `abort`, `message-metadata`, `reasoning-file` stay forward-compat ignored (no internal representation)
- pre-existing: `start` and `start-step` both map to `step-start`, leaving one dangling "started" step per stock v6 stream; separate design question


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

