### PR TITLE
docs: document turbo build commands for pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,12 @@ pnpm turbo build
 
 (some packages rely on build outputs from other packages, even if you want to start the project in development mode)
 
+### Building for a pull request
+
+- `pnpm turbo build --filter='./packages/*'` builds every package under `packages/` (no example or template apps). Use it before pushing a change to `packages/*` to catch cross-package export breakage.
+- `pnpm turbo build --affected` builds only the packages you changed plus their dependents, approximating what CI runs on your PR. Fastest check on a feature branch. It compares against your local `main`, so run `git fetch origin main:main` first if yours is stale or missing.
+- `pnpm turbo build` builds everything including the example and template apps. Use it only when you touch `examples/`, `templates/`, or `turbo.json`.
+
 ### Running the project
 
 To run the docs project in development mode:


### PR DESCRIPTION
## What

Adds a short "Building for a pull request" section to CONTRIBUTING.md documenting the raw turbo commands for the three common build scopes: packages-only, affected-only, and the full graph. Docs-only; no `package.json` or build behavior changes.

## Why

Follow-up to #4799, which added these as root script aliases and was closed to keep the root script surface minimal — with the note that documenting the raw turbo commands in CONTRIBUTING would be welcome as its own small PR. The wording carries over the review fixes from that PR ("every package under `packages/`", "approximating what CI runs").

No changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

