### PR TITLE
ci(template-metrics): compare against the merge-base instead of a cached baseline

### DIFF
--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - "templates/**"
       - "packages/ui/**"
+      - "scripts/template-metrics.mjs"
+      - ".github/workflows/template-metrics.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/template-metrics.yaml
+++ b/.github/workflows/template-metrics.yaml
@@ -1,11 +1,6 @@
 name: Template Metrics
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "templates/**"
-      - "packages/ui/**"
   pull_request:
     branches: [main]
     paths:
@@ -14,31 +9,52 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  # Templates to build for bundle-size measurement. LOC is measured for all
-  # templates regardless; only these are built (next build is the expensive part).
+  # Only these are built for bundle measurement; next build is the expensive part.
   BUNDLE_TEMPLATES: "default minimal"
-  # Per-template regression limits. A template that already exists on the main
-  # baseline fails the gate if it grows past either limit.
+  # Exceeding MAX_LOC_INCREASE only warns; MAX_LOC_HARD_INCREASE fails the gate.
   MAX_LOC_INCREASE: "50"
-  MAX_BUNDLE_INCREASE_KB: "10"
+  MAX_LOC_HARD_INCREASE: "300"
 
 jobs:
-  metrics:
-    name: LOC + Bundle Size
+  gate:
+    name: Footprint Gate
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 5
     steps:
       - name: Checkout code repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # LOC reads tracked sources only; no dependency install needed.
+      - name: Compare against merge-base
+        run: node scripts/template-metrics.mjs check .
+
+  report:
+    name: LOC + Bundle Size
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # ratchet:pnpm/action-setup@v4
@@ -58,15 +74,6 @@ jobs:
             ${{ runner.os }}-turbo-${{ github.ref }}-
             ${{ runner.os }}-turbo-
 
-      # Baseline is main's metrics, cached by the last run on main. PRs restore
-      # the newest one via the restore-keys prefix to compute deltas against main.
-      - name: Restore main baseline
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache/restore@v4
-        with:
-          path: install-footprint/branch/main/data.json
-          key: install-footprint-main-${{ github.sha }}
-          restore-keys: install-footprint-main-
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -85,17 +92,18 @@ jobs:
           pnpm turbo build $filters
 
       - name: Measure metrics
-        run: node scripts/template-metrics.mjs measure . metrics-head.json
+        run: |
+          node scripts/template-metrics.mjs measure . metrics-head.json
+          node scripts/template-metrics.mjs measure-base . metrics-base-main.json
 
       - name: Build report
         run: |
-          node scripts/template-metrics.mjs report install-footprint/branch/main/data.json metrics-head.json metrics-report.md metrics-gate.txt metrics-comment.txt
+          node scripts/template-metrics.mjs report metrics-base-main.json metrics-head.json metrics-report.md metrics-comment.txt
           cat metrics-report.md
 
-      # continue-on-error: a fork PR's read-only token makes commenting 403; that
-      # must not fail the check or skip the gate below.
+      # continue-on-error: a fork PR's read-only token makes commenting 403; the
+      # comment is informational, so that must not fail the job.
       - name: Post / update PR comment
-        if: github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
@@ -131,27 +139,3 @@ jobs:
                 body,
               });
             }
-
-      # always(): run even if the comment step failed (e.g. fork 403), so the
-      # gate verdict is never lost. Only blocks PRs; pushes refresh the baseline.
-      - name: Enforce regression gate
-        if: always() && github.event_name == 'pull_request'
-        run: |
-          if [ "$(cat metrics-gate.txt 2>/dev/null)" = "fail" ]; then
-            echo "::error::Template metrics regressed past the configured limits. See the PR comment."
-            exit 1
-          fi
-          echo "Template metrics within limits."
-
-      - name: Persist baseline (main only)
-        if: github.event_name == 'push'
-        run: |
-          mkdir -p install-footprint/branch/main
-          cp metrics-head.json install-footprint/branch/main/data.json
-
-      - name: Save baseline cache (main only)
-        if: github.event_name == 'push'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache/save@v4
-        with:
-          path: install-footprint/branch/main/data.json
-          key: install-footprint-main-${{ github.sha }}

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -189,10 +189,9 @@ function bundleGzipFor(root, name) {
 }
 
 function measure(root, outJson) {
-  const result = listTemplates(root).map((name) => ({
-    name,
-    ...footprintFor(root, name),
-    bundleGzip: bundleGzipFor(root, name),
+  const result = locMetrics(root).map((t) => ({
+    ...t,
+    bundleGzip: bundleGzipFor(root, t.name),
   }));
   writeFileSync(outJson, JSON.stringify(result, null, 2));
 }

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -230,7 +230,7 @@ function regression(t, base) {
   if (!base || base.ownLoc == null) return null;
   const locDelta = totalLoc(t) - totalLoc(base);
   if (locDelta > MAX_LOC_INCREASE) {
-    return [`LOC +${locDelta} > ${MAX_LOC_INCREASE}`];
+    return `LOC +${locDelta} > ${MAX_LOC_INCREASE}`;
   }
   return null;
 }
@@ -255,10 +255,12 @@ function measureAtMergeBase(root, baseRef) {
   try {
     return locMetrics(dir);
   } finally {
-    execFileSync("git", ["worktree", "remove", "--force", dir], {
-      cwd: root,
-      stdio: "ignore",
-    });
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", dir], {
+        cwd: root,
+        stdio: "ignore",
+      });
+    } catch {}
   }
 }
 
@@ -315,8 +317,8 @@ function report(baseJson, headJson, outMd, commentFile) {
   );
   const rows = head.map((t) => {
     const b = baseByName.get(t.name);
-    const reasons = regression(t, b);
-    if (reasons) regressions.push({ name: t.name, reasons });
+    const reason = regression(t, b);
+    if (reason) regressions.push({ name: t.name, reason });
     if (hasLocChange(t, b, hasBaseline)) hasAnyLocChange = true;
     return [
       t.name,
@@ -324,7 +326,7 @@ function report(baseJson, headJson, outMd, commentFile) {
       locCell(t.uiLoc, b?.uiLoc),
       locCell(totalLoc(t), b && b.ownLoc != null ? totalLoc(b) : null),
       bundleCell(t.bundleGzip),
-      reasons ? "⚠️" : "✅",
+      reason ? "⚠️" : "✅",
     ];
   });
 
@@ -332,7 +334,7 @@ function report(baseJson, headJson, outMd, commentFile) {
     "<!-- template-metrics -->",
     "## 📦 Template install footprint",
     "",
-    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). LOC cells show `current (Δ vs main)`. Bundle = gzipped client JS from `next build`, measured per run for a representative subset.",
+    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). LOC cells show `current (Δ vs merge-base)`. Bundle = gzipped client JS from `next build`, measured per run for a representative subset.",
     "",
     "| Template | Own LOC | /ui LOC | Total LOC | Bundle (gz) | Status |",
     "| --- | ---: | ---: | ---: | ---: | --- |",
@@ -344,8 +346,8 @@ function report(baseJson, headJson, outMd, commentFile) {
     lines.push("_No base measurements to diff against._");
   } else if (regressions.length) {
     lines.push(
-      `**Needs a deliberate look** - ${regressions.length} template(s) grew past +${MAX_LOC_INCREASE} LOC vs main:`,
-      ...regressions.map((r) => `- \`${r.name}\`: ${r.reasons.join("; ")}`),
+      `**Needs a deliberate look** - ${regressions.length} template(s) grew past +${MAX_LOC_INCREASE} LOC vs the merge-base:`,
+      ...regressions.map((r) => `- \`${r.name}\`: ${r.reason}`),
     );
   } else {
     lines.push(

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -10,10 +10,12 @@
 //
 // Usage:
 //   node scripts/template-metrics.mjs measure <rootDir> <outJson>
-//   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [gateFile] [commentFile]
+//   node scripts/template-metrics.mjs measure-base <rootDir> <outJson> [baseRef]
+//   node scripts/template-metrics.mjs check [rootDir] [baseRef]
+//   node scripts/template-metrics.mjs report <baseJson|""> <headJson> <outMd> [commentFile]
 //
-// report writes "pass"/"fail" to gateFile based on the regression thresholds
-// (env: MAX_LOC_INCREASE applied to total LOC, MAX_BUNDLE_INCREASE_KB).
+// Bundle size depends on the CI toolchain, so it is measured per run and
+// never gated.
 
 import { execFileSync } from "node:child_process";
 import {
@@ -22,7 +24,9 @@ import {
   readdirSync,
   existsSync,
   statSync,
+  mkdtempSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { gzipSync } from "node:zlib";
 import { join, extname, dirname, resolve } from "node:path";
 
@@ -201,21 +205,14 @@ function kb(bytes) {
   return `${(bytes / 1024).toFixed(1)} KB`;
 }
 
-function signedKb(bytes) {
-  return `${bytes >= 0 ? "+" : "-"}${kb(Math.abs(bytes))}`;
-}
-
 function locCell(cur, base) {
   if (base == null) return `${cur} (new)`;
   const d = cur - base;
   return `${cur} (${d === 0 ? "0" : `${d > 0 ? "+" : ""}${d}`})`;
 }
 
-function bundleCell(cur, base) {
-  if (cur == null) return "n/a";
-  if (base == null) return `${kb(cur)} (new)`;
-  const d = cur - base;
-  return `${kb(cur)} (${d === 0 ? "0" : signedKb(d)})`;
+function bundleCell(cur) {
+  return cur == null ? "n/a" : kb(cur);
 }
 
 function hasLocChange(t, base, hasBaseline) {
@@ -224,33 +221,85 @@ function hasLocChange(t, base, hasBaseline) {
   return t.ownLoc !== base.ownLoc || t.uiLoc !== base.uiLoc;
 }
 
-// Per-template thresholds (env-overridable). A template "regresses" when it
-// already existed on the baseline and grows past either limit. The LOC limit
-// applies to total footprint (own + /ui).
 const MAX_LOC_INCREASE = Number(process.env.MAX_LOC_INCREASE ?? 50);
-const MAX_BUNDLE_INCREASE_KB = Number(process.env.MAX_BUNDLE_INCREASE_KB ?? 10);
+const MAX_LOC_HARD_INCREASE = Number(process.env.MAX_LOC_HARD_INCREASE ?? 300);
 
 function regression(t, base) {
-  // base.ownLoc missing => incompatible/legacy baseline schema; treat as no
-  // baseline so the LOC gate can't silently fail open on a NaN comparison.
+  // base.ownLoc missing => incompatible/legacy base schema; treat as no base
+  // so the comparison can't silently produce NaN.
   if (!base || base.ownLoc == null) return null;
-  const reasons = [];
   const locDelta = totalLoc(t) - totalLoc(base);
   if (locDelta > MAX_LOC_INCREASE) {
-    reasons.push(`LOC +${locDelta} > ${MAX_LOC_INCREASE}`);
+    return [`LOC +${locDelta} > ${MAX_LOC_INCREASE}`];
   }
-  if (t.bundleGzip != null && base.bundleGzip != null) {
-    const bundleDelta = t.bundleGzip - base.bundleGzip;
-    if (bundleDelta > MAX_BUNDLE_INCREASE_KB * 1024) {
-      reasons.push(
-        `bundle ${signedKb(bundleDelta)} > +${MAX_BUNDLE_INCREASE_KB} KB`,
+  return null;
+}
+
+function locMetrics(root) {
+  return listTemplates(root).map((name) => ({
+    name,
+    ...footprintFor(root, name),
+  }));
+}
+
+function measureAtMergeBase(root, baseRef) {
+  const sha = execFileSync("git", ["merge-base", baseRef, "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
+  const dir = mkdtempSync(join(tmpdir(), "aui-template-metrics-"));
+  execFileSync("git", ["worktree", "add", "--detach", dir, sha], {
+    cwd: root,
+    stdio: "ignore",
+  });
+  try {
+    return locMetrics(dir);
+  } finally {
+    execFileSync("git", ["worktree", "remove", "--force", dir], {
+      cwd: root,
+      stdio: "ignore",
+    });
+  }
+}
+
+function measureBase(root, outJson, baseRef) {
+  writeFileSync(
+    outJson,
+    JSON.stringify(measureAtMergeBase(root, baseRef), null, 2),
+  );
+}
+
+function check(root, baseRef) {
+  const measured = locMetrics(root);
+  const base = measureAtMergeBase(root, baseRef);
+  const baseByName = new Map(base.map((t) => [t.name, t]));
+
+  const failures = [];
+  for (const t of measured) {
+    const b = baseByName.get(t.name);
+    // New templates are a product decision made in review, not bloat.
+    if (!b) continue;
+    const delta = totalLoc(t) - totalLoc(b);
+    if (delta > MAX_LOC_HARD_INCREASE) {
+      failures.push(`${t.name}: +${delta} LOC > ${MAX_LOC_HARD_INCREASE}`);
+    } else if (delta > MAX_LOC_INCREASE) {
+      console.log(
+        `::warning::${t.name} grew by ${delta} LOC vs the merge-base (attention threshold ${MAX_LOC_INCREASE}); give the footprint a deliberate look.`,
       );
     }
   }
-  return reasons.length ? reasons : null;
+
+  if (failures.length) {
+    for (const line of failures) console.error(`  ${line}`);
+    console.error(
+      `::error::Template install footprint grew past the hard ceiling (${MAX_LOC_HARD_INCREASE} LOC). If deliberate, raise MAX_LOC_HARD_INCREASE in .github/workflows/template-metrics.yaml within this PR.`,
+    );
+    process.exit(1);
+  }
+  console.log("Template install footprint is within the hard ceiling.");
 }
 
-function report(baseJson, headJson, outMd, gateFile, commentFile) {
+function report(baseJson, headJson, outMd, commentFile) {
   const head = JSON.parse(readFileSync(headJson, "utf8"));
   const base =
     baseJson && existsSync(baseJson)
@@ -274,7 +323,7 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
       locCell(t.ownLoc, b?.ownLoc),
       locCell(t.uiLoc, b?.uiLoc),
       locCell(totalLoc(t), b && b.ownLoc != null ? totalLoc(b) : null),
-      bundleCell(t.bundleGzip, b?.bundleGzip ?? null),
+      bundleCell(t.bundleGzip),
       reasons ? "⚠️" : "✅",
     ];
   });
@@ -283,7 +332,7 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
     "<!-- template-metrics -->",
     "## 📦 Template install footprint",
     "",
-    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). Bundle = gzipped client JS from `next build`. Each cell shows `current (Δ vs main)`.",
+    "Lines copied into your project on scaffold: **Own** (template glue) + **/ui** (shared `packages/ui` components it imports). LOC cells show `current (Δ vs main)`. Bundle = gzipped client JS from `next build`, measured per run for a representative subset.",
     "",
     "| Template | Own LOC | /ui LOC | Total LOC | Bundle (gz) | Status |",
     "| --- | ---: | ---: | ---: | ---: | --- |",
@@ -292,12 +341,10 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
   ];
 
   if (base.length === 0) {
-    lines.push(
-      "_No baseline found - deltas will appear once `main` has been measured._",
-    );
+    lines.push("_No base measurements to diff against._");
   } else if (regressions.length) {
     lines.push(
-      `**Gate failed** - ${regressions.length} template(s) regressed past the configured limits (LOC +${MAX_LOC_INCREASE}, bundle +${MAX_BUNDLE_INCREASE_KB} KB):`,
+      `**Needs a deliberate look** - ${regressions.length} template(s) grew past +${MAX_LOC_INCREASE} LOC vs main:`,
       ...regressions.map((r) => `- \`${r.name}\`: ${r.reasons.join("; ")}`),
     );
   } else {
@@ -307,7 +354,6 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
   }
 
   writeFileSync(outMd, lines.join("\n"));
-  if (gateFile) writeFileSync(gateFile, regressions.length ? "fail" : "pass");
   if (commentFile)
     writeFileSync(
       commentFile,
@@ -317,9 +363,13 @@ function report(baseJson, headJson, outMd, gateFile, commentFile) {
 
 const [cmd, ...args] = process.argv.slice(2);
 if (cmd === "measure") measure(args[0], args[1]);
-else if (cmd === "report")
-  report(args[0] || "", args[1], args[2], args[3], args[4]);
+else if (cmd === "measure-base")
+  measureBase(args[0] || ".", args[1], args[2] || "origin/main");
+else if (cmd === "check") check(args[0] || ".", args[1] || "origin/main");
+else if (cmd === "report") report(args[0] || "", args[1], args[2], args[3]);
 else {
-  console.error("usage: template-metrics.mjs measure|report ...");
+  console.error(
+    "usage: template-metrics.mjs measure|measure-base|check|report ...",
+  );
   process.exit(1);
 }

--- a/scripts/template-metrics.mjs
+++ b/scripts/template-metrics.mjs
@@ -216,7 +216,7 @@ function bundleCell(cur) {
 
 function hasLocChange(t, base, hasBaseline) {
   if (!hasBaseline) return false;
-  if (!base || base.ownLoc == null) return true;
+  if (!base) return true;
   return t.ownLoc !== base.ownLoc || t.uiLoc !== base.uiLoc;
 }
 
@@ -224,9 +224,7 @@ const MAX_LOC_INCREASE = Number(process.env.MAX_LOC_INCREASE ?? 50);
 const MAX_LOC_HARD_INCREASE = Number(process.env.MAX_LOC_HARD_INCREASE ?? 300);
 
 function regression(t, base) {
-  // base.ownLoc missing => incompatible/legacy base schema; treat as no base
-  // so the comparison can't silently produce NaN.
-  if (!base || base.ownLoc == null) return null;
+  if (!base) return null;
   const locDelta = totalLoc(t) - totalLoc(base);
   if (locDelta > MAX_LOC_INCREASE) {
     return `LOC +${locDelta} > ${MAX_LOC_INCREASE}`;
@@ -311,9 +309,7 @@ function report(baseJson, headJson, outMd, commentFile) {
   const hasBaseline = base.length > 0;
 
   const regressions = [];
-  let hasAnyLocChange = base.some(
-    (t) => t.ownLoc != null && !headByName.has(t.name),
-  );
+  let hasAnyLocChange = base.some((t) => !headByName.has(t.name));
   const rows = head.map((t) => {
     const b = baseByName.get(t.name);
     const reason = regression(t, b);
@@ -323,7 +319,7 @@ function report(baseJson, headJson, outMd, commentFile) {
       t.name,
       locCell(t.ownLoc, b?.ownLoc),
       locCell(t.uiLoc, b?.uiLoc),
-      locCell(totalLoc(t), b && b.ownLoc != null ? totalLoc(b) : null),
+      locCell(totalLoc(t), b ? totalLoc(b) : null),
       bundleCell(t.bundleGzip),
       reason ? "⚠️" : "✅",
     ];


### PR DESCRIPTION
## what

replaces the cached-baseline mechanism in the template metrics workflow with a stateless comparison: `check` measures LOC at HEAD and at a throwaway worktree of `merge-base(origin/main, HEAD)`, so the gate is deterministic from git state alone and nothing is stored between runs.

## why

the baseline lived in an actions cache, which is evictable by contract. when it vanished the gate passed silently and the inflated numbers were baked into the next baseline; that is how #4726's +64 landed without ever being compared against the limit, and it is the friction that produced #4757 and #4759. a gate whose correctness depends on state that can disappear generates workaround pressure instead of confidence.

## how

- `scripts/template-metrics.mjs` gains `check` (the gate) and `measure-base` (worktree measurement for the report); `report` loses the gate file, and bundle cells become per-run absolute values.
- two thresholds: exceeding `MAX_LOC_INCREASE` (50) warns and flags the row in the sticky comment; only `MAX_LOC_HARD_INCREASE` (300) fails the gate, and raising it in the same PR is itself a reviewable change. new templates are exempt from the hard gate; they are a product decision made in review.
- bundle size depends on the CI toolchain, so it is measured per run for the comment and never gated; the ±10 KB bundle gate retires with the cache.
- the workflow is pull_request-only now: the push trigger, cache restore/save, and persist steps are deleted. the gate job installs no dependencies and settles in seconds.
- least privilege: top-level permissions reduced to `contents: read` with `pull-requests: write` scoped to the report job, and both checkouts run with `persist-credentials: false`.

## verification

zero-delta check green; +60 LOC emits the warning and exits 0; +360 LOC fails with per-template detail and the actionable message; throwaway worktrees are cleaned up on success and failure paths. the report renders the delta table and skips the sticky comment when nothing changed. oxlint, oxfmt, and yaml validation clean. CI-only change, no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

