### PR TITLE
fix(assistant-stream): accept AI SDK v5+ delta text, source-url, file, and bare lifecycle chunks at the decode boundary

### DIFF
--- a/.changeset/fix-ui-message-stream-wire-normalization.md
+++ b/.changeset/fix-ui-message-stream-wire-normalization.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: accept the AI SDK v5+ `source-url`, flat `file`, and bare lifecycle chunks in UIMessageStreamDecoder
+fix: accept the AI SDK v5+ `delta` text chunks, `source-url`, flat `file`, and bare lifecycle chunks in UIMessageStreamDecoder

--- a/.changeset/fix-ui-message-stream-wire-normalization.md
+++ b/.changeset/fix-ui-message-stream-wire-normalization.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: accept the AI SDK v5+ `source-url`, flat `file`, and bare lifecycle chunks in UIMessageStreamDecoder

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -138,7 +138,50 @@ describe("UIMessageStreamDecoder", () => {
     expect(result?.result).toEqual({ temp: 72 });
   });
 
-  it("should decode source parts", async () => {
+  it("should decode source-url parts", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "source-url",
+        sourceId: "src_1",
+        url: "https://example.com",
+        title: "Example",
+      }),
+      JSON.stringify({
+        type: "source-url",
+        sourceId: "src_2",
+        url: "https://example.org",
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const sourceStarts = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "part-start" } =>
+        c.type === "part-start" && c.part.type === "source",
+    );
+    expect(sourceStarts).toHaveLength(2);
+    if (sourceStarts[0]?.part.type === "source") {
+      expect(sourceStarts[0].part.id).toBe("src_1");
+      expect(sourceStarts[0].part.url).toBe("https://example.com");
+      expect(sourceStarts[0].part.title).toBe("Example");
+    }
+    if (sourceStarts[1]?.part.type === "source") {
+      expect(sourceStarts[1].part.id).toBe("src_2");
+      expect(sourceStarts[1].part.url).toBe("https://example.org");
+      expect(sourceStarts[1].part.title).toBeUndefined();
+    }
+  });
+
+  it("should decode legacy source parts", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({
@@ -168,12 +211,44 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(sourceStart).toBeDefined();
     if (sourceStart?.part.type === "source") {
+      expect(sourceStart.part.id).toBe("src_1");
       expect(sourceStart.part.url).toBe("https://example.com");
       expect(sourceStart.part.title).toBe("Example");
     }
   });
 
   it("should decode file parts", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "file",
+        url: "https://example.com/image.png",
+        mediaType: "image/png",
+      }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const fileStart = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "part-start" } =>
+        c.type === "part-start" && c.part.type === "file",
+    );
+    expect(fileStart).toBeDefined();
+    if (fileStart?.part.type === "file") {
+      expect(fileStart.part.mimeType).toBe("image/png");
+      expect(fileStart.part.data).toBe("https://example.com/image.png");
+    }
+  });
+
+  it("should decode legacy file parts", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({
@@ -308,6 +383,96 @@ describe("UIMessageStreamDecoder", () => {
     );
     expect(stepFinish).toBeDefined();
     expect(stepFinish?.finishReason).toBe("stop");
+    expect(stepFinish?.usage).toEqual({ inputTokens: 10, outputTokens: 5 });
+    expect(stepFinish?.isContinued).toBe(false);
+  });
+
+  it("should handle the stock v6 lifecycle with bare step chunks", async () => {
+    const events = [
+      JSON.stringify({ type: "start" }),
+      JSON.stringify({ type: "start-step" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({ type: "finish-step" }),
+      JSON.stringify({ type: "finish", finishReason: "stop" }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const stepStarts = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "step-start" } =>
+        c.type === "step-start",
+    );
+    expect(stepStarts).toHaveLength(2);
+    expect(stepStarts[0]?.messageId).toBeTruthy();
+    expect(stepStarts[1]?.messageId).toBe(stepStarts[0]?.messageId);
+
+    const stepFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "step-finish" } =>
+        c.type === "step-finish",
+    );
+    expect(stepFinish?.finishReason).toBe("unknown");
+    expect(stepFinish?.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(stepFinish?.isContinued).toBe(false);
+
+    const messageFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "message-finish" } =>
+        c.type === "message-finish",
+    );
+    expect(messageFinish?.finishReason).toBe("stop");
+  });
+
+  it("should default finishReason on a bare finish chunk", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({ type: "finish" }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const messageFinish = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "message-finish" } =>
+        c.type === "message-finish",
+    );
+    expect(messageFinish?.finishReason).toBe("unknown");
+    expect(messageFinish?.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+
+  it("should ignore malformed legacy source and file chunks", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "source" }),
+      JSON.stringify({ type: "source", source: null }),
+      JSON.stringify({ type: "file" }),
+      JSON.stringify({ type: "file", file: null }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const partStarts = chunks.filter(
+      (c) =>
+        c.type === "part-start" &&
+        (c.part.type === "source" || c.part.type === "file"),
+    );
+    expect(partStarts).toHaveLength(0);
   });
 
   it("should handle errors", async () => {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -38,6 +38,34 @@ describe("UIMessageStreamDecoder", () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: " world" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const textDeltas = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+        c.type === "text-delta",
+    );
+    expect(textDeltas).toHaveLength(2);
+    expect(textDeltas[0]?.textDelta).toBe("Hello");
+    expect(textDeltas[1]?.textDelta).toBe(" world");
+  });
+
+  it("should decode legacy textDelta text deltas", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
       JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
       JSON.stringify({ type: "text-delta", textDelta: " world" }),
       JSON.stringify({ type: "text-end" }),
@@ -352,7 +380,7 @@ describe("UIMessageStreamDecoder", () => {
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({ type: "start-step", messageId: "step_1" }),
       JSON.stringify({ type: "text-start", id: "text_1" }),
-      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
       JSON.stringify({ type: "text-end" }),
       JSON.stringify({
         type: "finish-step",
@@ -392,7 +420,7 @@ describe("UIMessageStreamDecoder", () => {
       JSON.stringify({ type: "start" }),
       JSON.stringify({ type: "start-step" }),
       JSON.stringify({ type: "text-start", id: "text_1" }),
-      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
       JSON.stringify({ type: "text-end" }),
       JSON.stringify({ type: "finish-step" }),
       JSON.stringify({ type: "finish", finishReason: "stop" }),
@@ -430,7 +458,7 @@ describe("UIMessageStreamDecoder", () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),
       JSON.stringify({ type: "text-start", id: "text_1" }),
-      JSON.stringify({ type: "text-delta", textDelta: "Hello" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
       JSON.stringify({ type: "text-end" }),
       JSON.stringify({ type: "finish" }),
       "[DONE]",
@@ -496,8 +524,8 @@ describe("UIMessageStreamDecoder", () => {
   it("should throw when stream ends without [DONE]", async () => {
     const encoder = new TextEncoder();
     const sseText =
-      'data: {"type":"text-delta","textDelta":"Hello"}\n\n' +
-      'data: {"type":"text-delta","textDelta":" world"}\n\n';
+      'data: {"type":"text-delta","id":"text_1","delta":"Hello"}\n\n' +
+      'data: {"type":"text-delta","id":"text_1","delta":" world"}\n\n';
 
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -286,7 +286,54 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 return;
               }
 
-              controller.enqueue(JSON.parse(event.data));
+              const chunk = JSON.parse(event.data);
+              if (chunk.type === "start") {
+                controller.enqueue({
+                  ...chunk,
+                  messageId: chunk.messageId ?? generateId(),
+                });
+                return;
+              }
+              if (chunk.type === "source-url") {
+                controller.enqueue({
+                  type: "source",
+                  source: {
+                    sourceType: "url",
+                    id: chunk.sourceId,
+                    url: chunk.url,
+                    ...(chunk.title && { title: chunk.title }),
+                  },
+                });
+                return;
+              }
+              if (chunk.type === "source" && chunk.source == null) return;
+              if (chunk.type === "file" && chunk.file == null) {
+                if (chunk.url === undefined) return;
+                controller.enqueue({
+                  type: "file",
+                  file: { mimeType: chunk.mediaType, data: chunk.url },
+                });
+                return;
+              }
+              if (chunk.type === "finish-step") {
+                controller.enqueue({
+                  ...chunk,
+                  finishReason: chunk.finishReason ?? "unknown",
+                  usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+                  isContinued: chunk.isContinued ?? false,
+                });
+                return;
+              }
+              if (chunk.type === "finish") {
+                controller.enqueue({
+                  ...chunk,
+                  finishReason: chunk.finishReason ?? "unknown",
+                  usage: chunk.usage ?? { inputTokens: 0, outputTokens: 0 },
+                });
+                return;
+              }
+
+              controller.enqueue(chunk);
             },
             flush() {
               if (!receivedDone) {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -287,6 +287,14 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
               }
 
               const chunk = JSON.parse(event.data);
+              if (
+                chunk.type === "text-delta" &&
+                chunk.textDelta === undefined
+              ) {
+                const { delta, ...rest } = chunk;
+                controller.enqueue({ ...rest, textDelta: delta ?? "" });
+                return;
+              }
               if (chunk.type === "start") {
                 controller.enqueue({
                   ...chunk,


### PR DESCRIPTION
close #4676

## Summary

`UIMessageStreamDecoder` was written against a pre-stable wire format, so stock `toUIMessageStreamResponse()` endpoints break through `react-data-stream`:

- `text-delta` read `chunk.textDelta` while the wire sends `delta`, so assistant text rendered as `undefinedundefined...` (#4676)
- a spec-conformant `file` chunk (`{url, mediaType}`) crashed on `chunk.file.mimeType`
- `source-url` chunks were silently dropped
- bare `start`/`finish-step`/`finish` forwarded undefined into required internal fields

this fixes all four at the SSE parse boundary, in the shape prescribed in review: `UIMessageStreamChunk` stays byte-identical, and the real AI SDK v5/v6/v7 wire shapes (verified against `ai@6.0.221` and `ai@7.0.0-beta.178`) are normalized into the existing published members.

## Fix

- parse-boundary shim only: wire `delta` text chunks are rewritten to the existing `textDelta` shape, `source-url {sourceId, url, title?}` to the existing `source` member, and flat `file {url, mediaType}` to the existing nested `file` member
- missing fields are filled with defaults in the shim instead of loosening the type: `generateId()` for bare `start` (so bare `start-step` chunks correlate to the same messageId), `finishReason: "unknown"` (maps to complete status), zero usage, and `isContinued: false` for bare `finish-step`/`finish`
- malformed payloads (`{type:"source"}` without a source object, `{type:"file"}` with neither `file` nor `url`) are dropped instead of crashing
- decoder switch, `chunk-types.ts`, and the api-surface snapshot are untouched: zero published-surface diff, patch changeset

## Verification

decoder tests cover canonical and legacy wire shapes per member (including `delta` vs legacy `textDelta`), the stock v6 lifecycle with bare step chunks (messageId correlation), bare-finish defaults, and malformed chunks; the canonical-shape tests fail against the old source. 17/17 in the decoder suite, full assistant-stream suite green.

## Notes

supersedes #4851 (closed for changing the published type) and consolidates #4678 (the `delta` text fix, previously a separate PR guaranteed to conflict on the same shim region). part of #4676; the tool-input chunk half is tracked in #4692. when the wire omits usage the shim fabricates `{inputTokens: 0, outputTokens: 0}` because the internal chunk type requires it; the pre-existing double `step-start` from `start` + `start-step` on stock v6 streams is unchanged (separate design question, disclosed in #4851).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-light.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
