### PR TITLE
chore: release the ai sdk v7 switch as a patch

### DIFF
--- a/.changeset/react-ai-sdk-v7.md
+++ b/.changeset/react-ai-sdk-v7.md
@@ -1,5 +1,5 @@
 ---
-"@assistant-ui/react-ai-sdk": major
+"@assistant-ui/react-ai-sdk": patch
 ---
 
-feat: upgrade to AI SDK v7 (ai@^7, @ai-sdk/react@^4, @ai-sdk/mcp@^2); v6 users stay on the 1.x line
+feat: upgrade to AI SDK v7 (ai@^7, @ai-sdk/react@^4, @ai-sdk/mcp@^2); pin the previous release to stay on v6


### PR DESCRIPTION
## what

flips the react-ai-sdk v7 changeset from `major` to `patch` and rewords the consumer note accordingly (staying on v6 means pinning the previous release, since the switch now ships within the current line).

## why

changesets in this repo are patch by default; non-patch tiers are a maintainer decision, and the decision here is patch across all three v7 changesets. the two satellite packages already declare patch, so this aligns the last one.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

