### PR TITLE
fix(ui): let checked flow through props in menu checkbox items

### DIFF
--- a/packages/ui/src/components/ui/radix/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/radix/dropdown-menu.tsx
@@ -85,7 +85,6 @@ function DropdownMenuItem({
 function DropdownMenuCheckboxItem({
   className,
   children,
-  checked,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
   return (
@@ -95,7 +94,6 @@ function DropdownMenuCheckboxItem({
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
-      checked={checked}
       {...props}
     >
       <span className="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center">

--- a/packages/ui/src/components/ui/radix/menubar.tsx
+++ b/packages/ui/src/components/ui/radix/menubar.tsx
@@ -114,7 +114,6 @@ function MenubarItem({
 function MenubarCheckboxItem({
   className,
   children,
-  checked,
   ...props
 }: React.ComponentProps<typeof MenubarPrimitive.CheckboxItem>) {
   return (
@@ -124,7 +123,6 @@ function MenubarCheckboxItem({
         "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-xs py-1.5 ps-8 pe-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
-      checked={checked}
       {...props}
     >
       <span className="pointer-events-none absolute start-2 flex size-3.5 items-center justify-center">


### PR DESCRIPTION
## summary

- `DropdownMenuCheckboxItem` (radix flavor) and `MenubarCheckboxItem` destructure the optional `checked` prop and re-pass it explicitly, which fails with TS2375 under `exactOptionalPropertyTypes` for any consumer that compiles the registry source from a strict tsconfig; this is the same defect fixed for the context menu in #4630.
- the fix deletes the destructure and lets `checked` ride through `...props`, which is behavior-identical at runtime (the prop still reaches the primitive through the spread).
- the base flavor dropdown is deliberately untouched: Base UI's own type declarations already carry `| undefined` on optional props, so its checkbox item compiles clean under `exactOptionalPropertyTypes` and changing it would be pure churn.

## test plan

### already verified

- [x] a throwaway probe module in apps/docs imported the three kit menu modules into the docs tsc graph: `tsc --noEmit` reported TS2375 at `radix/dropdown-menu.tsx(92)` and `radix/menubar.tsx(121)` before the fix and zero errors after (probe deleted, not part of the diff)
- [x] `oxfmt --check` and `oxlint` on both files -> clean

### reviewer should verify

- [ ] add a scratch `import "@assistant-ui/ui/components/ui/radix/dropdown-menu";` to any apps/docs module and run `pnpm --filter @assistant-ui/docs exec tsc --noEmit`: it fails with TS2375 on main and passes on this branch

## notes

- the affected audience is registry consumers running `shadcn add dropdown-menu` or `menubar` with a strict tsconfig; nothing in-repo currently compiles these two modules, which is why the errors stayed latent
- no changeset: `@assistant-ui/ui` is `private: true`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

