### PR TITLE
fix: prevent logo context menu scroll shift

### DIFF
--- a/apps/docs/components/shared/header-brand-link.tsx
+++ b/apps/docs/components/shared/header-brand-link.tsx
@@ -50,7 +50,7 @@ export function HeaderBrandLink({
 
 function BrandAssetsMenu({ children }: BrandAssetsMenuProps) {
   return (
-    <ContextMenu>
+    <ContextMenu modal={false}>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 
       <ContextMenuContent className="w-56">


### PR DESCRIPTION
## Summary

- Opt the docs header logo context menu out of Radix modal behavior.
- Prevent opening the brand-assets context menu from applying page scroll lock / scrollbar compensation.

## Why

The logo menu is a lightweight brand-assets context menu. It does not need modal scroll locking, and the default modal behavior can shift the page/header when the menu opens.

## Validation

- `pnpm exec oxfmt --check apps/docs/components/shared/header-brand-link.tsx`
- `./node_modules/.bin/oxlint apps/docs/components/shared/header-brand-link.tsx`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

