### PR TITLE
fix(react-ai-sdk): retry failed history appends

### DIFF
--- a/.changeset/retry-ai-sdk-history-appends.md
+++ b/.changeset/retry-ai-sdk-history-appends.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: retry history messages after a failed persistence append

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AssistantRuntime,
   MessageFormatAdapter,
@@ -9,6 +9,7 @@ import type {
   ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
+import { bindExternalStoreMessage } from "@assistant-ui/core";
 
 vi.mock("@assistant-ui/store", () => ({
   useAui: () => ({
@@ -45,6 +46,10 @@ const storageFormat: MessageFormatAdapter<unknown, Record<string, unknown>> = {
 
 const toThreadMessages = (_messages: unknown[]): ThreadMessage[] => [];
 const onSetMessages = () => {};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useExternalHistory withFormat contract", () => {
   it("throws when the adapter omits withFormat", () => {
@@ -162,5 +167,124 @@ describe("toExportedMessageRepository", () => {
     expect(result.messages).toHaveLength(0);
     expect(result.headId).toBeNull();
     expect(() => new MessageRepository().import(result)).not.toThrow();
+  });
+});
+
+describe("useExternalHistory persistence", () => {
+  it("retries a failed append before persisting descendant messages", async () => {
+    const failure = new Error("temporary storage failure");
+    const append = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValue(undefined);
+    const formattedAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+    };
+    const historyAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue(formattedAdapter),
+    } as unknown as ThreadHistoryAdapter;
+
+    const makeMessage = (id: string, innerId: string): ThreadMessage => {
+      const message: ThreadMessage = {
+        id,
+        role: "assistant",
+        content: [{ type: "text", text: id }],
+        status: { type: "complete", reason: "stop" },
+        createdAt: new Date(),
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+        },
+      };
+      bindExternalStoreMessage(message, { id: innerId });
+      return message;
+    };
+
+    const messages = [
+      makeMessage("parent", "inner-parent"),
+      makeMessage("child", "inner-child"),
+    ];
+    let isRunning = false;
+    let notify: (() => void) | undefined;
+    const thread = {
+      subscribe: vi.fn((listener: () => void) => {
+        notify = listener;
+        return () => {};
+      }),
+      getState: () => ({ isRunning, messages }),
+      import: vi.fn(),
+      export: vi.fn(),
+    } as unknown as AssistantRuntime["thread"];
+    const testRuntimeRef = {
+      current: { thread } as AssistantRuntime,
+    };
+    const storageAdapter: MessageFormatAdapter<
+      { id: string },
+      Record<string, unknown>
+    > = {
+      format: "test",
+      encode: ({ message }) => message,
+      decode: (stored) => ({
+        parentId: stored.parent_id,
+        message: stored.content as { id: string },
+      }),
+      getId: (message) => message.id,
+    };
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    renderHook(() =>
+      useExternalHistory(
+        testRuntimeRef,
+        historyAdapter,
+        () => messages,
+        storageAdapter,
+        () => {},
+      ),
+    );
+
+    const finishRun = () => {
+      act(() => {
+        isRunning = true;
+        notify?.();
+        isRunning = false;
+        notify?.();
+      });
+    };
+
+    finishRun();
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+    expect(append).toHaveBeenLastCalledWith({
+      parentId: null,
+      message: { id: "inner-parent" },
+    });
+
+    finishRun();
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(3));
+    expect(append.mock.calls).toEqual([
+      [
+        {
+          parentId: null,
+          message: { id: "inner-parent" },
+        },
+      ],
+      [
+        {
+          parentId: null,
+          message: { id: "inner-parent" },
+        },
+      ],
+      [
+        {
+          parentId: "inner-parent",
+          message: { id: "inner-child" },
+        },
+      ],
+    ]);
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -268,12 +268,16 @@ export const useExternalHistory = <TMessage>(
               getLastInnerId(innerMessages) ?? lastInnerMessageId;
             continue;
           }
-          historyIds.current.add(message.id);
-
           const batchItems = toBatchItems(innerMessages);
-          for (const item of batchItems) {
-            await formatAdapter.append(item);
+          try {
+            for (const item of batchItems) {
+              await formatAdapter.append(item);
+            }
+          } catch (error) {
+            console.error("Failed to persist message history:", error);
+            return;
           }
+          historyIds.current.add(message.id);
 
           lastInnerMessageId =
             getLastInnerId(innerMessages) ?? lastInnerMessageId;


### PR DESCRIPTION
## Summary

- mark an external history message as persisted only after every formatted append succeeds
- stop the current persistence pass after a failed append so descendants are not written ahead of a missing parent
- add a regression test covering a transient parent append failure and the following retry

## Use case

An assistant response can render successfully in the current chat while its history write fails because of a brief network interruption or temporary storage outage. The message remains visible until reload, but the old bookkeeping marked it as persisted anyway. When a later run completed, the missing parent was skipped and a newer descendant could be attempted instead, leaving incomplete Cloud or custom-adapter history after reload. This change keeps the failed parent eligible for the next persistence pass and retries it before continuing with descendants.

## Why

`useExternalHistory` previously added a message ID to its in-memory persisted set before awaiting `formatAdapter.append()`. If that append rejected, later persistence passes treated the message as already stored and skipped it.

The bookkeeping now happens after the append batch succeeds. A failed write is reported and remains eligible for the next persistence pass.

## Test plan

- `pnpm --filter @assistant-ui/react-ai-sdk test` (140 tests)
- `pnpm lint`
- `pnpm turbo build --filter=@assistant-ui/react-ai-sdk`
- verified the new regression test fails against the original ordering and passes with this change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
