### PR TITLE
feat: support quote exclusions via data-aui-quote-selectable="false"

### DIFF
--- a/.changeset/quote-selectable-false.md
+++ b/.changeset/quote-selectable-false.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: support data-aui-quote-selectable="false" exclusions

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/selection-toolbar.mdx
@@ -33,7 +33,7 @@ Place this component inside `ThreadPrimitive.Root`:
 </ThreadPrimitive.Root>
 ```
 
-To prevent tool cards or other message UI from being quoted, wrap the message text in `data-aui-quote-selectable`. If a message contains that marker, the toolbar only appears for selections inside the same marked region.
+To prevent tool cards or other message UI from being quoted, wrap the message text in `data-aui-quote-selectable`. If a message contains that marker, the toolbar only appears for selections inside the same marked region. Set the attribute to `"false"` to exclude an element instead; on the message root it disables quoting for the whole message.
 {/* api-manual:end */}
 
 {/* api-reference:start */}

--- a/apps/docs/content/docs/primitives/selection-toolbar.mdx
+++ b/apps/docs/content/docs/primitives/selection-toolbar.mdx
@@ -76,6 +76,18 @@ By default, any selected text inside a message can be quoted. For rich messages 
 </MessagePrimitive.Root>
 ```
 
+Set `data-aui-quote-selectable="false"` to exclude an element instead: on the message root it disables quoting for the entire message, and inside a quotable region it carves that subtree out. The nearest marker wins, and any value other than `"false"` (including empty) marks a quotable region.
+
+Apps know the message role at render time, so a role gate is a conditional attribute:
+
+```tsx
+const UserMessage = () => (
+  <MessagePrimitive.Root data-aui-quote-selectable="false">
+    <MessagePrimitive.Parts />
+  </MessagePrimitive.Root>
+);
+```
+
 ### Quote Action
 
 The `Quote` button does two things on click:

--- a/packages/react/src/utils/getSelectionMessageId.test.ts
+++ b/packages/react/src/utils/getSelectionMessageId.test.ts
@@ -71,6 +71,51 @@ describe("getSelectionMessageId", () => {
     ).toBe("message-1");
   });
 
+  it("disables quoting for the whole message when the root is marked false", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1" data-aui-quote-selectable="false">
+        <p id="text">message text</p>
+        <div id="tool">tool output</div>
+      </div>
+    `;
+
+    expect(getSelectionMessageId(selectText(textNode("#text")))).toBeNull();
+    expect(getSelectionMessageId(selectText(textNode("#tool")))).toBeNull();
+  });
+
+  it("excludes a false subtree while the rest of the message stays quotable", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <p id="text">message text</p>
+        <div id="tool" data-aui-quote-selectable="false">tool output</div>
+      </div>
+    `;
+
+    expect(getSelectionMessageId(selectText(textNode("#text")))).toBe(
+      "message-1",
+    );
+    expect(getSelectionMessageId(selectText(textNode("#tool")))).toBeNull();
+  });
+
+  it("carves a false region out of a quote-selectable region", () => {
+    document.body.innerHTML = `
+      <div data-message-id="message-1">
+        <div data-aui-quote-selectable="">
+          <p id="text">message text</p>
+          <span id="chip" data-aui-quote-selectable="false">citation chip</span>
+        </div>
+      </div>
+    `;
+
+    expect(getSelectionMessageId(selectText(textNode("#text")))).toBe(
+      "message-1",
+    );
+    expect(getSelectionMessageId(selectText(textNode("#chip")))).toBeNull();
+    expect(
+      getSelectionMessageId(selectText(textNode("#text"), textNode("#chip"))),
+    ).toBeNull();
+  });
+
   it("rejects selections outside quote-selectable regions when a message opts in", () => {
     document.body.innerHTML = `
       <div data-message-id="message-1">

--- a/packages/react/src/utils/getSelectionMessageId.ts
+++ b/packages/react/src/utils/getSelectionMessageId.ts
@@ -14,21 +14,33 @@ const findMessageElement = (node: Node | null): HTMLElement | null => {
   return null;
 };
 
-const hasQuoteSelectableRegion = (messageElement: HTMLElement) => {
-  return (
-    messageElement.matches(QUOTE_SELECTABLE_SELECTOR) ||
-    !!messageElement.querySelector(QUOTE_SELECTABLE_SELECTOR)
-  );
+const isExcluded = (marker: Element): boolean => {
+  return marker.getAttribute("data-aui-quote-selectable") === "false";
 };
 
-const findQuoteSelectableRegion = (
+const hasQuoteSelectableRegion = (messageElement: HTMLElement) => {
+  if (
+    messageElement.matches(QUOTE_SELECTABLE_SELECTOR) &&
+    !isExcluded(messageElement)
+  ) {
+    return true;
+  }
+  for (const marker of messageElement.querySelectorAll(
+    QUOTE_SELECTABLE_SELECTOR,
+  )) {
+    if (!isExcluded(marker)) return true;
+  }
+  return false;
+};
+
+const findQuoteMarker = (
   node: Node | null,
   messageElement: HTMLElement,
 ): HTMLElement | null => {
-  const region = getElement(node)?.closest(QUOTE_SELECTABLE_SELECTOR);
-  if (!(region instanceof HTMLElement)) return null;
-  if (!messageElement.contains(region)) return null;
-  return region;
+  const marker = getElement(node)?.closest(QUOTE_SELECTABLE_SELECTOR);
+  if (!(marker instanceof HTMLElement)) return null;
+  if (!messageElement.contains(marker)) return null;
+  return marker;
 };
 
 export const getSelectionMessageId = (selection: Selection): string | null => {
@@ -45,18 +57,15 @@ export const getSelectionMessageId = (selection: Selection): string | null => {
   const messageId = anchorMessageElement.getAttribute("data-message-id");
   if (!messageId) return null;
 
+  const anchorMarker = findQuoteMarker(anchorNode, anchorMessageElement);
+  const focusMarker = findQuoteMarker(focusNode, anchorMessageElement);
+
+  if (anchorMarker && isExcluded(anchorMarker)) return null;
+  if (focusMarker && isExcluded(focusMarker)) return null;
+
   if (!hasQuoteSelectableRegion(anchorMessageElement)) return messageId;
 
-  const anchorRegion = findQuoteSelectableRegion(
-    anchorNode,
-    anchorMessageElement,
-  );
-  const focusRegion = findQuoteSelectableRegion(
-    focusNode,
-    anchorMessageElement,
-  );
-
-  if (!anchorRegion || anchorRegion !== focusRegion) return null;
+  if (!anchorMarker || anchorMarker !== focusMarker) return null;
 
   return messageId;
 };


### PR DESCRIPTION
closes #4683

## summary

- `data-aui-quote-selectable="false"` now excludes an element from quoting: on the message root it disables the whole message, inside a quotable region it carves that subtree out, and the nearest marker wins.
- only non-false markers activate region scoping, so a message carrying nothing but exclusions keeps the default behavior for the rest of its content, and existing markers keep their exact semantics.
- this closes the whole-message and role gating half of #4683 without a `canQuote` predicate: apps set the value conditionally where they already know the role (example added to the primitive docs).
- docs updated in both places; the api-reference page went through `generate:api-reference` (the sentence lives in the api-manual block).

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react test` -> 451 passing, including three new cases (root-level disable, false subtree beside default content, carve-out inside a quotable region with cross-boundary rejection)
- [x] `oxfmt --check` and `oxlint` on the touched files -> clean
- [x] `tsc --noEmit` in packages/react -> only the pre-existing `ComposerRoot.test.tsx` `setMultiline` errors, untouched by this diff

### reviewer should verify

- [ ] in a message with `data-aui-quote-selectable="false"` on the root, selecting any text never shows the selection toolbar; with the attribute on a child, the sibling text still quotes

## notes

- the `canQuote` predicate and role exposure from #4683 are intentionally not implemented; the marker grammar covers gating without a new callback contract, and role-aware analytics would require publicizing the selection info hook, which goes against the current hooks surface direction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

