### PR TITLE
fix(cli): resolve base ui flavored registry urls in add

### DIFF
--- a/.changeset/base-registry-url.md
+++ b/.changeset/base-registry-url.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: resolve base ui flavored registry urls in add when the project style starts with base-

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -2,14 +2,16 @@ import { Command } from "commander";
 import { logger } from "../lib/utils/logger";
 import { hasConfig } from "../lib/utils/config";
 import {
+  getComponentsJsonStyle,
+  resolveRegistryItemUrl,
+} from "../lib/utils/registry";
+import {
   dlxCommand,
   resolvePackageManager,
   resolvePackageManagerForCwd,
   type PackageManagerName,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
-
-const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
 export interface AddComponentsPlan {
   command: string;
@@ -23,12 +25,13 @@ export function createAddComponentsPlan(params: {
   overwrite?: boolean;
   cwd?: string;
   path?: string;
+  style?: string;
 }): AddComponentsPlan {
   const componentsToAdd = params.components.map((c) => {
     if (!/^[a-zA-Z0-9-/]+$/.test(c)) {
       throw new Error(`Invalid component name: ${c}`);
     }
-    return `${REGISTRY_BASE_URL}/${encodeURIComponent(c)}.json`;
+    return resolveRegistryItemUrl(c, params.style);
   });
 
   const [command, dlxArgs] = dlxCommand(params.packageManager);
@@ -75,6 +78,7 @@ export const add = new Command()
       opts.cwd,
       resolvePackageManager(opts),
     );
+    const style = getComponentsJsonStyle(opts.cwd);
     const { command, args } = createAddComponentsPlan({
       components,
       packageManager,
@@ -82,6 +86,7 @@ export const add = new Command()
       overwrite: opts.overwrite,
       cwd: opts.cwd,
       path: opts.path,
+      ...(style === undefined ? {} : { style }),
     });
 
     try {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,10 +1,7 @@
 import { Command } from "commander";
 import { logger } from "../lib/utils/logger";
-import { hasConfig } from "../lib/utils/config";
-import {
-  getComponentsJsonStyle,
-  resolveRegistryItemUrl,
-} from "../lib/utils/registry";
+import { getConfig, hasConfig } from "../lib/utils/config";
+import { resolveRegistryItemUrl } from "../lib/utils/registry";
 import {
   dlxCommand,
   resolvePackageManager,
@@ -78,7 +75,7 @@ export const add = new Command()
       opts.cwd,
       resolvePackageManager(opts),
     );
-    const style = getComponentsJsonStyle(opts.cwd);
+    const style = getConfig(opts.cwd)?.style;
     const { command, args } = createAddComponentsPlan({
       components,
       packageManager,

--- a/packages/cli/src/lib/utils/registry.test.ts
+++ b/packages/cli/src/lib/utils/registry.test.ts
@@ -1,0 +1,62 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getComponentsJsonStyle, resolveRegistryItemUrl } from "./registry";
+
+describe("resolveRegistryItemUrl", () => {
+  it("uses the style scoped URL for base styles", () => {
+    expect(resolveRegistryItemUrl("thread", "base-nova")).toBe(
+      "https://r.assistant-ui.com/styles/base-nova/thread.json",
+    );
+  });
+
+  it("uses the plain URL for non-base styles", () => {
+    expect(resolveRegistryItemUrl("thread", "nova")).toBe(
+      "https://r.assistant-ui.com/thread.json",
+    );
+  });
+
+  it("uses the plain URL without a style", () => {
+    expect(resolveRegistryItemUrl("thread")).toBe(
+      "https://r.assistant-ui.com/thread.json",
+    );
+  });
+});
+
+describe("getComponentsJsonStyle", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "assistant-ui-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("reads the style from components.json", () => {
+    fs.writeFileSync(
+      path.join(cwd, "components.json"),
+      JSON.stringify({ style: "base-nova" }),
+    );
+
+    expect(getComponentsJsonStyle(cwd)).toBe("base-nova");
+  });
+
+  it("falls back when components.json is missing", () => {
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+
+  it("falls back when components.json cannot be read", () => {
+    fs.mkdirSync(path.join(cwd, "components.json"));
+
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+
+  it("falls back when components.json cannot be parsed", () => {
+    fs.writeFileSync(path.join(cwd, "components.json"), "{");
+
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+});

--- a/packages/cli/src/lib/utils/registry.test.ts
+++ b/packages/cli/src/lib/utils/registry.test.ts
@@ -1,8 +1,5 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { getComponentsJsonStyle, resolveRegistryItemUrl } from "./registry";
+import { describe, expect, it } from "vitest";
+import { resolveRegistryItemUrl } from "./registry";
 
 describe("resolveRegistryItemUrl", () => {
   it("uses the style scoped URL for base styles", () => {
@@ -22,41 +19,10 @@ describe("resolveRegistryItemUrl", () => {
       "https://r.assistant-ui.com/thread.json",
     );
   });
-});
 
-describe("getComponentsJsonStyle", () => {
-  let cwd: string;
-
-  beforeEach(() => {
-    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "assistant-ui-cli-"));
-  });
-
-  afterEach(() => {
-    fs.rmSync(cwd, { recursive: true, force: true });
-  });
-
-  it("reads the style from components.json", () => {
-    fs.writeFileSync(
-      path.join(cwd, "components.json"),
-      JSON.stringify({ style: "base-nova" }),
+  it("keeps the style inside a single path segment", () => {
+    expect(resolveRegistryItemUrl("thread", "base-nova?preview=1")).toBe(
+      "https://r.assistant-ui.com/styles/base-nova%3Fpreview%3D1/thread.json",
     );
-
-    expect(getComponentsJsonStyle(cwd)).toBe("base-nova");
-  });
-
-  it("falls back when components.json is missing", () => {
-    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
-  });
-
-  it("falls back when components.json cannot be read", () => {
-    fs.mkdirSync(path.join(cwd, "components.json"));
-
-    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
-  });
-
-  it("falls back when components.json cannot be parsed", () => {
-    fs.writeFileSync(path.join(cwd, "components.json"), "{");
-
-    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
   });
 });

--- a/packages/cli/src/lib/utils/registry.ts
+++ b/packages/cli/src/lib/utils/registry.ts
@@ -1,0 +1,28 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
+
+export function resolveRegistryItemUrl(
+  component: string,
+  style?: string,
+): string {
+  const registryUrl = style?.startsWith("base-")
+    ? `${REGISTRY_BASE_URL}/styles/${style}`
+    : REGISTRY_BASE_URL;
+
+  return `${registryUrl}/${encodeURIComponent(component)}.json`;
+}
+
+export function getComponentsJsonStyle(cwd: string): string | undefined {
+  try {
+    const configPath = path.join(cwd, "components.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+      style?: unknown;
+    };
+
+    return typeof config.style === "string" ? config.style : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/cli/src/lib/utils/registry.ts
+++ b/packages/cli/src/lib/utils/registry.ts
@@ -1,6 +1,3 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
-
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
 export function resolveRegistryItemUrl(
@@ -8,21 +5,8 @@ export function resolveRegistryItemUrl(
   style?: string,
 ): string {
   const registryUrl = style?.startsWith("base-")
-    ? `${REGISTRY_BASE_URL}/styles/${style}`
+    ? `${REGISTRY_BASE_URL}/styles/${encodeURIComponent(style)}`
     : REGISTRY_BASE_URL;
 
   return `${registryUrl}/${encodeURIComponent(component)}.json`;
-}
-
-export function getComponentsJsonStyle(cwd: string): string | undefined {
-  try {
-    const configPath = path.join(cwd, "components.json");
-    const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
-      style?: unknown;
-    };
-
-    return typeof config.style === "string" ? config.style : undefined;
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,7 +4,11 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: ["test/**/*.test.ts", "src/codemods/**/__tests__/**/*.test.ts"],
+    include: [
+      "test/**/*.test.ts",
+      "src/**/*.test.ts",
+      "src/codemods/**/__tests__/**/*.test.ts",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
addresses the registry flavor gap reported in #4814 (comment): a base ui project running `npx assistant-ui add <component>` always received the radix flavor.

## summary

- `assistant-ui add` now reads the `style` field from components.json in the invoked cwd and resolves component urls through the style aware form `https://r.assistant-ui.com/styles/<style>/<name>.json` when the style starts with `base-`, so base ui projects get base flavored components
- any other style, a missing components.json, unreadable json, or a missing style field falls back to the existing plain url, which keeps serving the radix flavor; behavior for radix projects is unchanged
- the url resolution lives in a new pure helper (`src/lib/utils/registry.ts`) with colocated tests covering the base, non base, missing style, and missing/unreadable config cases; the vitest config now also picks up colocated `src/**/*.test.ts` files
- `init` is intentionally unchanged: its quick start block is a nested registry path that cannot resolve through the single segment `/styles/` rewrite, and `init` returns early when a components.json already exists, so there is no project style to read at the point it runs

## test plan

### already verified

- [x] `tsc -p packages/cli/tsconfig.json --noEmit` clean, `oxlint packages/cli/src` clean
- [x] `vitest run` in packages/cli: 18 files, 207 tests passing (6 new)

### reviewer should verify

- [ ] in a project whose components.json has `"style": "base-nova"`, `npx assistant-ui add thread` fetches `https://r.assistant-ui.com/styles/base-nova/thread.json`; in a project with `"style": "new-york"` or no components.json it fetches `https://r.assistant-ui.com/thread.json`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

