### PR TITLE
docs: point install snippets at the style-aware registry

### DIFF
--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -445,7 +445,7 @@ export default function MyApp() {
 ```
 
 ```tsx title="/app/page.tsx" tab="AssistantModal"
-// run `npx shadcn@latest add https://r.assistant-ui.com/assistant-modal.json`
+// run `npx shadcn@latest add @assistant-ui/assistant-modal`
 
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useChatRuntime, AssistantChatTransport } from "@assistant-ui/react-ai-sdk";

--- a/apps/docs/content/docs/(docs)/rtl.mdx
+++ b/apps/docs/content/docs/(docs)/rtl.mdx
@@ -4,7 +4,7 @@ description: Use assistant-ui with right-to-left languages like Arabic, Hebrew, 
 platforms: ["react"]
 ---
 
-Components shipped through `@assistant-ui/ui` (npm) and the shadcn registry (`npx shadcn@latest add https://r.assistant-ui.com/...`) use logical Tailwind classes (`ms-*`, `pe-*`, `text-start`, `end-*`, `border-s`, ...). They flip automatically under `dir="rtl"` and render byte-identically under `dir="ltr"` (the default) — there is nothing to opt out of.
+Components shipped through `@assistant-ui/ui` (npm) and the shadcn registry (`npx shadcn@latest add @assistant-ui/<name>`) use logical Tailwind classes (`ms-*`, `pe-*`, `text-start`, `end-*`, `border-s`, ...). They flip automatically under `dir="rtl"` and render byte-identically under `dir="ltr"` (the default) — there is nothing to opt out of.
 
 If you scaffolded from one of our templates (e.g. `npx assistant-ui@latest create -t default`), the generated `components/` folder still uses physical classes (`ml-*`, `text-left`, ...). Run shadcn's built-in migration **once** to convert both the shadcn primitives and assistant-ui's wrappers:
 
@@ -24,9 +24,7 @@ After migrating, follow the setup below.
 
 ### 1. Install the `direction` component
 
-```sh
-npx shadcn@latest add https://r.assistant-ui.com/direction.json
-```
+<InstallCommand shadcn={["direction"]} />
 
 This adds `components/ui/direction.tsx`, a thin re-export of Radix UI's `DirectionProvider` and `useDirection`. It ensures Radix popovers, dropdowns, and menus pick up the current direction.
 

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -410,7 +410,7 @@ npx assistant-ui@latest add thread-list
   <Tab>
 
 ```sh
-npx shadcn@latest add https://r.assistant-ui.com/thread-list.json
+npx shadcn@latest add @assistant-ui/thread-list
 ```
 
   </Tab>

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -413,6 +413,8 @@ npx assistant-ui@latest add thread-list
 npx shadcn@latest add @assistant-ui/thread-list
 ```
 
+The `@assistant-ui` namespace resolves through the registry entry configured in [Manual Setup](/docs/installation#manual-setup).
+
   </Tab>
   <Tab>
 

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -25,9 +25,7 @@ Under the hood, mentions are one kind of [trigger popover](/docs/guides/slash-co
 
 The fastest path is the pre-built [Mention UI components](/docs/ui/composer-trigger-popover), which wire everything together with two shadcn components — the popover picker and the message-side chip renderer:
 
-```bash
-npx shadcn@latest add "https://r.assistant-ui.com/composer-trigger-popover" "https://r.assistant-ui.com/directive-text"
-```
+<InstallCommand shadcn={["composer-trigger-popover", "directive-text"]} />
 
 See the [Composer Trigger Popover](/docs/ui/composer-trigger-popover) and [Directive Text](/docs/ui/directive-text) guides for setup steps.
 

--- a/apps/docs/content/docs/guides/resumable-streams.mdx
+++ b/apps/docs/content/docs/guides/resumable-streams.mdx
@@ -218,6 +218,4 @@ npx assistant-ui create my-app -e with-resumable-stream
 
 To drop the resumable chat and resume routes into an existing project (in-memory store only; upgrade via [Storage choices](#storage-choices)):
 
-```sh
-npx shadcn@latest add https://r.assistant-ui.com/ai-sdk-backend-resumable
-```
+<InstallCommand shadcn={["ai-sdk-backend-resumable"]} />

--- a/apps/docs/content/docs/utilities/heat-graph.mdx
+++ b/apps/docs/content/docs/utilities/heat-graph.mdx
@@ -20,9 +20,9 @@ import { HeatGraphDemo } from "@/app/(demos)/heat-graph/heat-graph-demo";
 <Tabs items={["shadcn", "npm", "pnpm", "yarn"]}>
   <Tab value="shadcn">
     ```sh
-    npx shadcn@latest add https://r.assistant-ui.com/heat-graph
+    npx shadcn@latest add @assistant-ui/heat-graph
     ```
-    This installs a pre-styled `HeatGraph` component to `components/assistant-ui/heat-graph.tsx` along with the `heat-graph` package.
+    This installs a pre-styled `HeatGraph` component to `components/assistant-ui/heat-graph.tsx` along with the `heat-graph` package. The `@assistant-ui` namespace resolves through the registry entry configured in [Manual Setup](/docs/installation#manual-setup).
   </Tab>
   <Tab value="npm">
     ```sh


### PR DESCRIPTION
companion to the cli fix for the registry flavor gap reported in #4814 (comment): several docs pages hardcoded the plain `https://r.assistant-ui.com/<name>.json` form, which always serves the radix flavor, so base ui readers copying those commands installed radix components.

## summary

- mentions, resumable-streams, and rtl now render installs through the existing `InstallCommand` component, which shows the namespaced command and flavor correct direct urls
- heat-graph keeps its surrounding package manager tabs (nesting the full widget would stack three levels of tabs) and switches to the namespaced `npx shadcn@latest add @assistant-ui/heat-graph` with a pointer to the registry setup section
- the langgraph page's "shadcn (namespace)" tab now actually shows the namespaced command instead of duplicating the direct url tab, and an installation page code comment uses the namespace form
- blog posts are historical and stay untouched; no changeset needed since apps/docs is private

## test plan

### already verified

- [x] all six edited routes compile and serve 200 on a local dev server (two curls each)
- [x] rendered check on /docs/rtl: the install widget shows `npx shadcn@latest add @assistant-ui/direction` with the package manager tabs

### reviewer should verify

- [ ] open /docs/guides/mentions and /docs/rtl on the preview deployment and confirm the install widgets render with the namespaced command and both flavor urls

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

