### PR TITLE
fix(cli): install the quick start from the flavor the initialized project uses

### DIFF
--- a/.changeset/base-init-quick-start.md
+++ b/.changeset/base-init-quick-start.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: install the base ui quick start from init when the initialized project uses a base style

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,7 +1,10 @@
 import { Command } from "commander";
 import { logger } from "../lib/utils/logger";
-import { getConfig, hasConfig } from "../lib/utils/config";
-import { resolveRegistryItemUrl } from "../lib/utils/registry";
+import { hasConfig } from "../lib/utils/config";
+import {
+  getComponentsJsonStyle,
+  resolveRegistryItemUrl,
+} from "../lib/utils/registry";
 import {
   dlxCommand,
   resolvePackageManager,
@@ -75,7 +78,7 @@ export const add = new Command()
       opts.cwd,
       resolvePackageManager(opts),
     );
-    const style = getConfig(opts.cwd)?.style;
+    const style = getComponentsJsonStyle(opts.cwd);
     const { command, args } = createAddComponentsPlan({
       components,
       packageManager,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,36 +7,27 @@ import {
   resolvePackageManagerForCwd,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
+import { getConfig } from "../lib/utils/config";
 import { logger } from "../lib/utils/logger";
+import { resolveQuickStartRegistryUrl } from "../lib/utils/registry";
 import { create } from "./create";
 
-const DEFAULT_REGISTRY_URL =
-  "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json";
-
 interface ExistingProjectInitPlan {
-  initArgs: string[] | null;
+  initArgs: string[];
   addArgs: string[];
 }
 
 export function createExistingProjectInitPlan(params: {
   yes: boolean;
   overwrite: boolean;
-  registryUrl: string;
 }): ExistingProjectInitPlan {
-  const { yes, overwrite, registryUrl } = params;
-
-  if (!yes) {
-    const addArgs = [`shadcn@latest`, "add"];
-    if (overwrite) addArgs.push("--overwrite");
-    addArgs.push(registryUrl);
-    return { initArgs: null, addArgs };
-  }
-
-  const initArgs = [`shadcn@latest`, "init", "--defaults", "--yes"];
-
-  const addArgs = [`shadcn@latest`, "add", "--yes"];
+  const { yes, overwrite } = params;
+  const initArgs = yes
+    ? [`shadcn@latest`, "init", "--defaults", "--yes"]
+    : [`shadcn@latest`, "init"];
+  const addArgs = [`shadcn@latest`, "add"];
+  if (yes) addArgs.push("--yes");
   if (overwrite) addArgs.push("--overwrite");
-  addArgs.push(registryUrl);
 
   return { initArgs, addArgs };
 }
@@ -106,7 +97,6 @@ export const init = new Command()
       return;
     }
 
-    const registryUrl = DEFAULT_REGISTRY_URL;
     logger.info("Initializing assistant-ui in existing project...");
     logger.break();
 
@@ -131,13 +121,13 @@ export const init = new Command()
       const { initArgs, addArgs } = createExistingProjectInitPlan({
         yes: opts.yes,
         overwrite: opts.overwrite,
-        registryUrl,
       });
 
-      if (initArgs) {
-        await runSpawn(dlxCmd, [...dlxArgs, ...initArgs], targetDir);
-      }
-      await runSpawn(dlxCmd, [...dlxArgs, ...addArgs], targetDir);
+      await runSpawn(dlxCmd, [...dlxArgs, ...initArgs], targetDir);
+      const registryUrl = resolveQuickStartRegistryUrl(
+        getConfig(targetDir)?.style,
+      );
+      await runSpawn(dlxCmd, [...dlxArgs, ...addArgs, registryUrl], targetDir);
 
       logger.break();
       logger.success("Project initialized successfully!");

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,9 +7,11 @@ import {
   resolvePackageManagerForCwd,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
-import { getConfig } from "../lib/utils/config";
 import { logger } from "../lib/utils/logger";
-import { resolveQuickStartRegistryUrl } from "../lib/utils/registry";
+import {
+  getComponentsJsonStyle,
+  resolveQuickStartRegistryUrl,
+} from "../lib/utils/registry";
 import { create } from "./create";
 
 interface ExistingProjectInitPlan {
@@ -125,7 +127,7 @@ export const init = new Command()
 
       await runSpawn(dlxCmd, [...dlxArgs, ...initArgs], targetDir);
       const registryUrl = resolveQuickStartRegistryUrl(
-        getConfig(targetDir)?.style,
+        getComponentsJsonStyle(targetDir),
       );
       await runSpawn(dlxCmd, [...dlxArgs, ...addArgs, registryUrl], targetDir);
 

--- a/packages/cli/src/lib/utils/registry.test.ts
+++ b/packages/cli/src/lib/utils/registry.test.ts
@@ -1,8 +1,65 @@
-import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getComponentsJsonStyle,
   resolveQuickStartRegistryUrl,
   resolveRegistryItemUrl,
 } from "./registry";
+
+describe("getComponentsJsonStyle", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "assistant-ui-cli-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("reads the style from components.json", () => {
+    fs.writeFileSync(
+      path.join(cwd, "components.json"),
+      JSON.stringify({ style: "base-nova" }),
+    );
+
+    expect(getComponentsJsonStyle(cwd)).toBe("base-nova");
+  });
+
+  it("ignores a stale assistant-ui.json", () => {
+    fs.writeFileSync(
+      path.join(cwd, "assistant-ui.json"),
+      JSON.stringify({ style: "new-york" }),
+    );
+    fs.writeFileSync(
+      path.join(cwd, "components.json"),
+      JSON.stringify({ style: "base-nova" }),
+    );
+
+    expect(getComponentsJsonStyle(cwd)).toBe("base-nova");
+  });
+
+  it("falls back when components.json is missing", () => {
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+
+  it("falls back when components.json cannot be parsed", () => {
+    fs.writeFileSync(path.join(cwd, "components.json"), "{");
+
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+
+  it("falls back when the style is not a string", () => {
+    fs.writeFileSync(
+      path.join(cwd, "components.json"),
+      JSON.stringify({ style: 7 }),
+    );
+
+    expect(getComponentsJsonStyle(cwd)).toBeUndefined();
+  });
+});
 
 describe("resolveQuickStartRegistryUrl", () => {
   it("uses the base quick start for base styles", () => {

--- a/packages/cli/src/lib/utils/registry.test.ts
+++ b/packages/cli/src/lib/utils/registry.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, it } from "vitest";
-import { resolveRegistryItemUrl } from "./registry";
+import {
+  resolveQuickStartRegistryUrl,
+  resolveRegistryItemUrl,
+} from "./registry";
+
+describe("resolveQuickStartRegistryUrl", () => {
+  it("uses the base quick start for base styles", () => {
+    expect(resolveQuickStartRegistryUrl("base-nova")).toBe(
+      "https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json",
+    );
+  });
+
+  it("uses the radix quick start for radix styles", () => {
+    expect(resolveQuickStartRegistryUrl("radix-nova")).toBe(
+      "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json",
+    );
+  });
+
+  it("uses the base quick start without a style", () => {
+    expect(resolveQuickStartRegistryUrl()).toBe(
+      "https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json",
+    );
+  });
+});
 
 describe("resolveRegistryItemUrl", () => {
   it("uses the style scoped URL for base styles", () => {

--- a/packages/cli/src/lib/utils/registry.ts
+++ b/packages/cli/src/lib/utils/registry.ts
@@ -1,5 +1,13 @@
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
+export function resolveQuickStartRegistryUrl(style?: string): string {
+  if (style === undefined || style.startsWith("base-")) {
+    return `${REGISTRY_BASE_URL}/base/chat/b/ai-sdk-quick-start/json`;
+  }
+
+  return `${REGISTRY_BASE_URL}/chat/b/ai-sdk-quick-start/json`;
+}
+
 export function resolveRegistryItemUrl(
   component: string,
   style?: string,

--- a/packages/cli/src/lib/utils/registry.ts
+++ b/packages/cli/src/lib/utils/registry.ts
@@ -1,6 +1,25 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
 const REGISTRY_BASE_URL = "https://r.assistant-ui.com";
 
+export function getComponentsJsonStyle(cwd: string): string | undefined {
+  try {
+    const configPath = path.join(cwd, "components.json");
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+      style?: unknown;
+    };
+
+    return typeof config.style === "string" ? config.style : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveQuickStartRegistryUrl(style?: string): string {
+  // The shadcn CLI appends a literal /json segment to fetched URLs containing
+  // /chat/b/ unless they already end with it, so this item must use the direct
+  // tree URLs rather than the /styles/ template.
   if (style === undefined || style.startsWith("base-")) {
     return `${REGISTRY_BASE_URL}/base/chat/b/ai-sdk-quick-start/json`;
   }

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -22,26 +22,20 @@ describe("init command", () => {
     );
   });
 
-  it("uses interactive add flow when --yes is not passed", () => {
+  it("uses interactive init and add flow when --yes is not passed", () => {
     const plan = createExistingProjectInitPlan({
       yes: false,
       overwrite: false,
-      registryUrl: "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json",
     });
 
-    expect(plan.initArgs).toBeNull();
-    expect(plan.addArgs).toEqual([
-      "shadcn@latest",
-      "add",
-      "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json",
-    ]);
+    expect(plan.initArgs).toEqual(["shadcn@latest", "init"]);
+    expect(plan.addArgs).toEqual(["shadcn@latest", "add"]);
   });
 
   it("uses non-interactive init+add flow when --yes is passed and config is missing", () => {
     const plan = createExistingProjectInitPlan({
       yes: true,
       overwrite: true,
-      registryUrl: "https://example.com/registry.json",
     });
 
     expect(plan.initArgs).toEqual([
@@ -55,7 +49,6 @@ describe("init command", () => {
       "add",
       "--yes",
       "--overwrite",
-      "https://example.com/registry.json",
     ]);
   });
 

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,11 +4,7 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
-    include: [
-      "test/**/*.test.ts",
-      "src/**/*.test.ts",
-      "src/codemods/**/__tests__/**/*.test.ts",
-    ],
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
follow-up to #4865 for the registry flavor gap tracked in #4814: `assistant-ui init` still always installed the radix quick start block, so a default init (shadcn defaults to base-nova since july 2026) produced a base project with radix flavored components. this was deterministic on the `--yes` path and the default outcome interactively.

## summary

- both init paths are now two phase: run `shadcn init` first (interactive without extra flags so shadcn prompts normally; `--yes` keeps `--defaults --yes`), then read the freshly written components.json style via the existing `getConfig` helper and add the quick start from the matching tree
- a new pure helper `resolveQuickStartRegistryUrl` maps the style: `base-*` or an unreadable/absent style resolves to `https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json` (base is the correct default since shadcn defaults every path to base-nova); any other style keeps the radix url
- the urls deliberately stay in the direct `/base/` form ending in `/json`: the shadcn CLI appends a literal `/json` segment to any fetched url containing `/chat/b/` that does not already end with it (a v0 share link heuristic, verified in shadcn@4.13.0 source), which would corrupt a `/styles/` templated form for this item
- also drops the redundant vitest include entry (`src/**/*.test.ts` subsumes the codemods glob)

## test plan

### already verified

- [x] `tsc -p packages/cli/tsconfig.json --noEmit` clean, `oxlint packages/cli/src` clean
- [x] `vitest run` in packages/cli: 18 files, 207 tests passing (new coverage for the helper's three branches and the reshaped two phase plans)

### reviewer should verify

- [ ] `assistant-ui init --yes` in a scratch next.js project without components.json: shadcn writes `"style": "base-nova"` and the quick start install fetches `https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

