### PR TITLE
fix(registry): resolve style-aware urls for nested item names

### DIFF
--- a/apps/registry/vercel.json
+++ b/apps/registry/vercel.json
@@ -3,20 +3,20 @@
   "ignoreCommand": "bash ../../scripts/vercel-ignore-changeset-release.sh",
   "rewrites": [
     {
-      "source": "/styles/base-:variant/:name.json",
-      "destination": "/base/:name.json"
+      "source": "/styles/base-:variant/:path(.+\\.json)",
+      "destination": "/base/:path"
     },
     {
-      "source": "/styles/base-:variant/:name",
-      "destination": "/base/:name.json"
+      "source": "/styles/base-:variant/:path(.+)",
+      "destination": "/base/:path.json"
     },
     {
-      "source": "/styles/:style/:name.json",
-      "destination": "/:name.json"
+      "source": "/styles/:style/:path(.+\\.json)",
+      "destination": "/:path"
     },
     {
-      "source": "/styles/:style/:name",
-      "destination": "/:name.json"
+      "source": "/styles/:style/:path(.+)",
+      "destination": "/:path.json"
     },
     {
       "source": "/:path*",


### PR DESCRIPTION
companion to the #4814 registry flavor work: the documented style-aware form `https://r.assistant-ui.com/styles/{style}/{name}.json` only matched single segment names, so nested items (the quick start block `chat/b/ai-sdk-quick-start/json`) fell through to the catch-all and 404ed. the shadcn CLI (verified in shadcn@4.13.0 source) accepts multi segment namespaced item names and substitutes them into registries templates without encoding, so this was a real hole in the public contract.

## summary

- the four /styles/ rewrites now use regex params (`:path(.+\.json)` and `:path(.+)`) that span path segments; within each pair the `.json` suffixed rule runs first so an existing extension is never doubled, and the `base-` pair stays ahead of the generic style pair
- single segment behavior is byte identical (hand traced against the old rules); static files keep being served filesystem first, and the trailing catch-all is untouched

## test plan

### already verified

- [x] json validity; hand evaluated request to destination table for 8 request shapes (single segment radix/base with and without extension, nested with and without extension, filesystem-first static hit, bare-name catch-all), all matching expectations

### reviewer should verify (authoritative, on this PR's vercel preview for the registry project)

- [ ] `curl -sI <preview>/styles/base-nova/thread.json` and `<preview>/styles/base-nova/thread` both 200 with base content (regression)
- [ ] `curl -sI <preview>/styles/base-nova/chat/b/ai-sdk-quick-start/json` 200 with base content (new capability; also the `.json` suffixed form)
- [ ] `curl -sI <preview>/styles/new-york/chat/b/ai-sdk-quick-start/json` 200 with radix content
- [ ] `curl -sI <preview>/base/thread.json` still served as the static file

i will run this checklist against the preview before merging.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

