### PR TITLE
fix(cloud): guard localStorage access in anonymous auth strategy

### DIFF
--- a/.changeset/cloud-auth-storage-guard.md
+++ b/.changeset/cloud-auth-storage-guard.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: guard localStorage access in anonymous auth strategy

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -109,6 +109,49 @@ export class AssistantCloudAPIKeyAuthStrategy implements AssistantCloudAuthStrat
 
 const AUI_REFRESH_TOKEN_NAME = "aui:refresh_token";
 
+const getLocalStorage = (): Storage | null => {
+  if (!("localStorage" in globalThis)) return null;
+  try {
+    return (globalThis as { localStorage: Storage }).localStorage;
+  } catch {
+    return null;
+  }
+};
+
+const readRefreshToken = ():
+  | { token: string; expires_at: string }
+  | undefined => {
+  const storage = getLocalStorage();
+  if (!storage) return undefined;
+  try {
+    const value = storage.getItem(AUI_REFRESH_TOKEN_NAME);
+    return value
+      ? (JSON.parse(value) as { token: string; expires_at: string })
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const writeRefreshToken = (refreshToken: {
+  token: string;
+  expires_at: string;
+}): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(AUI_REFRESH_TOKEN_NAME, JSON.stringify(refreshToken));
+  } catch {}
+};
+
+const removeRefreshToken = (): void => {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(AUI_REFRESH_TOKEN_NAME);
+  } catch {}
+};
+
 export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthStrategy {
   public readonly strategy = "anon";
 
@@ -119,15 +162,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
     this.baseUrl = baseUrl;
     this.jwtStrategy = new AssistantCloudJWTAuthStrategy(async () => {
       const currentTime = Date.now();
-      const storedRefreshTokenJson = localStorage.getItem(
-        AUI_REFRESH_TOKEN_NAME,
-      );
-      const storedRefreshToken = storedRefreshTokenJson
-        ? (JSON.parse(storedRefreshTokenJson) as {
-            token: string;
-            expires_at: string;
-          })
-        : undefined;
+      const storedRefreshToken = readRefreshToken();
 
       if (storedRefreshToken) {
         const refreshExpiry = new Date(storedRefreshToken.expires_at).getTime();
@@ -145,15 +180,12 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
             const data = await response.json();
             const { access_token, refresh_token } = data;
             if (refresh_token) {
-              localStorage.setItem(
-                AUI_REFRESH_TOKEN_NAME,
-                JSON.stringify(refresh_token),
-              );
+              writeRefreshToken(refresh_token);
             }
             return access_token;
           }
         } else {
-          localStorage.removeItem(AUI_REFRESH_TOKEN_NAME);
+          removeRefreshToken();
         }
       }
 
@@ -169,10 +201,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
 
       if (!access_token || !refresh_token) return null;
 
-      localStorage.setItem(
-        AUI_REFRESH_TOKEN_NAME,
-        JSON.stringify(refresh_token),
-      );
+      writeRefreshToken(refresh_token);
       return access_token;
     });
   }

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantCloudAnonymousAuthStrategy } from "../AssistantCloudAuthStrategy";
+
+const baseUrl = "https://test.example.com";
+const accessToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(JSON.stringify({ exp: 4102444800 })).toString("base64url")}.sig`;
+const refreshToken = { token: "r1", expires_at: "2099-01-01" };
+
+let originalLocalStorageDescriptor: PropertyDescriptor | undefined;
+
+const installLocalStorage = (storage: Storage): void => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+};
+
+const mockAnonymousTokenFetch = () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: vi.fn().mockResolvedValue({
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+describe("AssistantCloudAnonymousAuthStrategy", () => {
+  beforeEach(() => {
+    originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "localStorage",
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        "localStorage",
+        originalLocalStorageDescriptor,
+      );
+    } else {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    }
+  });
+
+  it("persists the refresh token and returns the anonymous access token", async () => {
+    const values = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    const fetchMock = mockAnonymousTokenFetch();
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(values.get("aui:refresh_token")).toBe(JSON.stringify(refreshToken));
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseUrl}/v1/auth/tokens/anonymous`,
+      { method: "POST" },
+    );
+  });
+
+  it("returns an anonymous access token without localStorage", async () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    mockAnonymousTokenFetch();
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+  });
+
+  it("returns an anonymous access token when localStorage access is blocked", async () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException("blocked", "SecurityError");
+      },
+    });
+    mockAnonymousTokenFetch();
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+  });
+
+  it("returns an anonymous access token when storage methods throw", async () => {
+    const getItem = vi
+      .fn<(key: string) => string | null>()
+      .mockReturnValueOnce(JSON.stringify(refreshToken))
+      .mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+    const setItem = vi.fn(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    const removeItem = vi.fn(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    installLocalStorage({ getItem, setItem, removeItem } as Storage);
+    mockAnonymousTokenFetch();
+
+    const originalDate = globalThis.Date;
+    const fixedDate = (originalDate as unknown as () => Date)();
+    const fixedTime = originalDate.now();
+    globalThis.Date = Object.assign(
+      function Date() {
+        return fixedDate;
+      },
+      { now: () => fixedTime },
+    ) as unknown as DateConstructor;
+
+    try {
+      await expect(
+        new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
+      ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
+      await expect(
+        new AssistantCloudAnonymousAuthStrategy(baseUrl).getAuthHeaders(),
+      ).resolves.toEqual({ Authorization: `Bearer ${accessToken}` });
+    } finally {
+      globalThis.Date = originalDate;
+    }
+    expect(getItem).toHaveBeenCalledTimes(2);
+    expect(setItem).toHaveBeenCalledTimes(2);
+    expect(removeItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats corrupted refresh token JSON as absent", async () => {
+    const values = new Map([["aui:refresh_token", "not-json{"]]);
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    mockAnonymousTokenFetch();
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(values.get("aui:refresh_token")).toBe(JSON.stringify(refreshToken));
+  });
+});


### PR DESCRIPTION
## summary

- `AssistantCloudAnonymousAuthStrategy` crashed whenever `localStorage` was unavailable: bare access throws `ReferenceError` in Node/SSR and `SecurityError` in sandboxed iframes or blocked-cookie browsers, rejecting every `getAuthHeaders()` call before a request could start
- adds a module-private `getLocalStorage()` access guard plus read/write/remove helpers with per-call try/catch, mirroring the established idiom in `react-mcp`'s `McpLocalStorage` and the resumable storage shipped in #4771
- corrupted stored refresh token JSON is now treated as absent instead of throwing on every call, so the anonymous flow overwrites it and self-heals
- with storage unavailable the strategy still resolves a fresh anonymous access token on each call (stateless degradation) instead of breaking auth entirely

## test plan

### already verified

- [x] `pnpm --filter assistant-cloud test` -> 5 files, 40 passed, 2 skipped (skips are pre-existing `it.skipIf` in `AssistantCloudFiles.test.ts`)
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both touched source files -> clean
- [x] `pnpm --filter assistant-cloud build` -> green

### reviewer should verify

- [ ] in a sandboxed iframe without `allow-same-origin` (or a browser with all cookies blocked), an app using `AssistantCloudAnonymousAuthStrategy` authenticates anonymously instead of throwing `SecurityError`

## notes

- follow-up noted in #4771's review; same double-guard pattern, applied to the cloud package

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

