### PR TITLE
fix(cloud-ai-sdk): retry interrupted history loads

### DIFF
--- a/.changeset/cloud-ai-sdk-history-load-cancellation.md
+++ b/.changeset/cloud-ai-sdk-history-load-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: retry interrupted thread history loads

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.switch.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UseThreadsResult } from "../types";
+import { CloudChatCore } from "../core/CloudChatCore";
 import { useCloudChat } from "./useCloudChat";
 
 function createThreads(
@@ -28,6 +29,10 @@ function createThreads(
 }
 
 describe("useCloudChat thread switching", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("resets visible chat messages immediately when switching to new chat (threadId -> null)", () => {
     const mockCloud = {
       threads: {
@@ -59,5 +64,47 @@ describe("useCloudChat thread switching", () => {
     rerender({ tid: null });
 
     expect(result.current.messages).toHaveLength(0);
+  });
+
+  it("retries an interrupted history load when switching back to a thread", () => {
+    const interruptedLoad = new Promise<void>(() => {});
+    let threadALoads = 0;
+    const loadThreadMessages = vi
+      .spyOn(CloudChatCore.prototype, "loadThreadMessages")
+      .mockImplementation((threadId) => {
+        if (threadId === "thread-a") {
+          threadALoads += 1;
+          if (threadALoads === 1) return interruptedLoad;
+        }
+        return Promise.resolve();
+      });
+
+    const mockCloud = {
+      threads: {
+        create: vi.fn(),
+        list: vi.fn(),
+        get: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    const threads = createThreads(mockCloud, "thread-a");
+
+    const { rerender } = renderHook(
+      ({ tid }) => {
+        threads.threadId = tid;
+        return useCloudChat({ threads });
+      },
+      { initialProps: { tid: "thread-a" as string | null } },
+    );
+
+    rerender({ tid: "thread-b" });
+    rerender({ tid: "thread-a" });
+
+    expect(
+      loadThreadMessages.mock.calls.filter(
+        ([threadId]) => threadId === "thread-a",
+      ),
+    ).toHaveLength(2);
   });
 });

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -92,15 +92,19 @@ function useThreadMessageLoader(
     }
 
     const cancelledRef = { cancelled: false };
-    meta.loading = core.loadThreadMessages(
+    const loading = core.loadThreadMessages(
       threadId,
       chatKey,
       registry,
       cancelledRef,
     );
+    meta.loading = loading;
 
     return () => {
       cancelledRef.cancelled = true;
+      if (meta.loading === loading) {
+        meta.loading = null;
+      }
     };
   }, [threadId, registry, core]);
 }

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -97,4 +97,26 @@ describe("CloudChatCore", () => {
     expect(onSyncError).toHaveBeenCalledWith(failure);
     expect(meta.loading).toBeNull();
   });
+
+  it("does not clear a replacement load after a cancelled load fails", async () => {
+    loadMessagesMock.mockRejectedValue(new Error("cancelled load"));
+
+    const core = createCore();
+    const replacementLoad = Promise.resolve();
+    const meta = {
+      threadId: "thread-1",
+      loading: replacementLoad,
+      loaded: false,
+    };
+    const registry = {
+      getOrCreateMeta: vi.fn().mockReturnValue(meta),
+      getOrCreate: vi.fn().mockReturnValue({ messages: [] }),
+    } as never;
+
+    await core.loadThreadMessages("thread-1", "chat-1", registry, {
+      cancelled: true,
+    });
+
+    expect(meta.loading).toBe(replacementLoad);
+  });
 });

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -131,7 +131,9 @@ export class CloudChatCore {
         this.handleSyncError(err);
       }
     }
-    meta.loading = null;
+    if (!cancelledRef.cancelled) {
+      meta.loading = null;
+    }
   }
 
   createTransport(


### PR DESCRIPTION
## Summary

- release a thread's pending history-load marker when navigation interrupts that request
- prevent a cancelled failed request from clearing a newer replacement load
- add regressions for switching back to a thread and for the replacement-load race

## Why

While playing around with Cloud-backed thread switching locally, I switched from thread A to thread B and back to A before A's history request had finished. I hit an empty thread that would not retry its history load. The effect cleanup cancelled the original request, but left its promise in `meta.loading`, so A continued to look like it was already loading.

The cleanup now releases only the promise it started. This allows A to load again immediately without letting the older cancelled request overwrite or clear the replacement request.

## Validation

- `pnpm --filter @assistant-ui/cloud-ai-sdk test` (58 tests)
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm lint`

The A → B → A regression reproduced on `main` as one load for A instead of two, and passes with this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->