### PR TITLE
fix(assistant-stream): discard unterminated sse frames

### DIFF
--- a/.changeset/assistant-stream-unterminated-sse-frames.md
+++ b/.changeset/assistant-stream-unterminated-sse-frames.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: discard unterminated SSE frames

--- a/packages/assistant-stream/src/core/object/ObjectStream.test.ts
+++ b/packages/assistant-stream/src/core/object/ObjectStream.test.ts
@@ -50,6 +50,26 @@ async function encodeAndDecode(
 }
 
 describe("ObjectStream serialization and deserialization", () => {
+  it("should discard an unterminated SSE event", async () => {
+    const operations: ObjectStreamChunk["operations"] = [
+      { type: "set", path: ["status"], value: "complete" },
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(`data: ${JSON.stringify(operations)}\n`),
+        );
+        controller.close();
+      },
+    });
+
+    const chunks = await collectChunks(
+      stream.pipeThrough(new ObjectStreamDecoder()),
+    );
+
+    expect(chunks).toEqual([]);
+  });
+
   it("should correctly serialize and deserialize simple objects", async () => {
     // Create an object stream with simple operations
     const stream = createObjectStream({

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
@@ -186,6 +186,21 @@ describe("AssistantTransportDecoder", () => {
     });
   });
 
+  it("should discard an unterminated [DONE] event", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n"));
+        controller.close();
+      },
+    });
+
+    const decodedStream = stream.pipeThrough(new AssistantTransportDecoder());
+
+    await expect(collectChunks(decodedStream)).rejects.toThrow(
+      "Stream ended abruptly without receiving [DONE] marker",
+    );
+  });
+
   it("should throw error when stream ends without [DONE]", async () => {
     // Manually create an SSE stream without [DONE]
     const sseText =

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -87,16 +87,6 @@ class SSEEventStream extends TransformStream<string, SSEEvent> {
             break;
         }
       },
-      flush(controller) {
-        if (dataLines.length > 0) {
-          controller.enqueue({
-            event: eventBuffer.event || "message",
-            data: dataLines.join("\n"),
-            id: eventBuffer.id,
-            retry: eventBuffer.retry,
-          });
-        }
-      },
     });
   }
 }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -541,6 +541,21 @@ describe("UIMessageStreamDecoder", () => {
     );
   });
 
+  it("should discard an unterminated [DONE] event", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: [DONE]\n"));
+        controller.close();
+      },
+    });
+
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+
+    await expect(collectChunks(decodedStream)).rejects.toThrow(
+      "Stream ended abruptly without receiving [DONE] marker",
+    );
+  });
+
   it("should ignore unknown chunk types for forward compatibility", async () => {
     const events = [
       JSON.stringify({ type: "start", messageId: "msg_123" }),

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -73,16 +73,6 @@ class SSEEventStream extends TransformStream<string, SSEEvent> {
             break;
         }
       },
-      flush(controller) {
-        if (dataLines.length > 0) {
-          controller.enqueue({
-            event: eventBuffer.event || "message",
-            data: dataLines.join("\n"),
-            id: eventBuffer.id,
-            retry: eventBuffer.retry,
-          });
-        }
-      },
     });
   }
 }

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -80,16 +80,6 @@ class SSEEventStream extends TransformStream<string, SSEEvent> {
             break;
         }
       },
-      flush(controller) {
-        if (dataLines.length > 0) {
-          controller.enqueue({
-            event: eventBuffer.event || "message",
-            data: dataLines.join("\n"),
-            id: eventBuffer.id,
-            retry: eventBuffer.retry,
-          });
-        }
-      },
     });
   }
 }


### PR DESCRIPTION
## Summary
- discard pending SSE data when a stream ends without the blank line that terminates an event
- apply the behavior consistently to object streams, assistant transport, and UI message streams
- add regression coverage for all three decoding paths and a patch changeset

## Why
This is a separate follow-up to #4819. That merged A2A parser fix and its review identified another SSE compliance gap in `assistant-stream`: its internal `SSEEventStream.flush()` implementations dispatched buffered data at EOF.

SSE events are dispatched by a blank line, while pending event data must be discarded when the stream ends. Previously, a truncated frame such as `data: [DONE]\n` was treated as a valid completion marker. Assistant and UI message decoders could therefore accept an incomplete response instead of reporting the missing `[DONE]`, while object streams could apply data from an incomplete frame.

## Implementation
The EOF dispatch was removed from each of the three existing internal SSE event parsers. Complete blank-line-terminated events and normal `[DONE]` handling are unchanged. Parser consolidation remains separate from this behavior fix.

## Verification
- confirmed all three regression tests fail on the #4819 merge commit before the fix
- `pnpm --filter assistant-stream test` (251 passed, 20 skipped)
- `pnpm --filter assistant-stream build`
- scoped `oxlint` and `oxfmt --check`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

