### PR TITLE
fix(assistant-stream): support LF, CRLF, and CR line endings

### DIFF
--- a/.changeset/assistant-stream-standard-sse-line-endings.md
+++ b/.changeset/assistant-stream-standard-sse-line-endings.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: parse all standard SSE line endings

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
@@ -40,6 +40,14 @@ describe("LineDecoderStream", () => {
     expect(lines).toEqual(["line1", "line2", "line3"]);
   });
 
+  it("should split lines on CR (\\r)", async () => {
+    const stream = createTextStream(["line1\rline2\rline3\r"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
   it("should handle CRLF split across chunks", async () => {
     // The \r is at the end of one chunk and \n at the start of the next
     const stream = createTextStream(["line1\r", "\nline2\r\n"]);
@@ -65,8 +73,16 @@ describe("LineDecoderStream", () => {
     expect(lines).toEqual(["line1", "", "line2"]);
   });
 
-  it("should handle mixed LF and CRLF", async () => {
-    const stream = createTextStream(["line1\nline2\r\nline3\n"]);
+  it("should handle empty lines with CR", async () => {
+    const stream = createTextStream(["line1\r\rline2\r"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "", "line2"]);
+  });
+
+  it("should handle mixed standard line endings", async () => {
+    const stream = createTextStream(["line1\nline2\r\nline3\r"]);
     const lines = await collectLines(
       stream.pipeThrough(new LineDecoderStream()),
     );

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.test.ts
@@ -48,6 +48,14 @@ describe("LineDecoderStream", () => {
     expect(lines).toEqual(["line1", "line2", "line3"]);
   });
 
+  it("should handle CR line endings split across chunks", async () => {
+    const stream = createTextStream(["line1\r", "line2\r", "line3\r"]);
+    const lines = await collectLines(
+      stream.pipeThrough(new LineDecoderStream()),
+    );
+    expect(lines).toEqual(["line1", "line2", "line3"]);
+  });
+
   it("should handle CRLF split across chunks", async () => {
     // The \r is at the end of one chunk and \n at the start of the next
     const stream = createTextStream(["line1\r", "\nline2\r\n"]);

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
@@ -1,25 +1,35 @@
 export class LineDecoderStream extends TransformStream<string, string> {
   private buffer = "";
+  private skipNextLineFeed = false;
 
   constructor() {
     super({
       transform: (chunk, controller) => {
-        this.buffer += chunk;
-        const lines = this.buffer.split("\n");
+        let lineStart = 0;
 
-        // Process all complete lines
-        for (let i = 0; i < lines.length - 1; i++) {
-          // Strip trailing \r to handle \r\n (CRLF) line endings per the SSE spec.
-          const line = lines[i]!;
-          controller.enqueue(line.endsWith("\r") ? line.slice(0, -1) : line);
+        for (let i = 0; i < chunk.length; i++) {
+          const character = chunk[i]!;
+
+          if (this.skipNextLineFeed) {
+            this.skipNextLineFeed = false;
+            if (character === "\n") {
+              lineStart = i + 1;
+              continue;
+            }
+          }
+
+          if (character === "\n" || character === "\r") {
+            this.buffer += chunk.slice(lineStart, i);
+            controller.enqueue(this.buffer);
+            this.buffer = "";
+            this.skipNextLineFeed = character === "\r";
+            lineStart = i + 1;
+          }
         }
 
-        // Keep the last incomplete line in the buffer
-        this.buffer = lines[lines.length - 1] || "";
+        this.buffer += chunk.slice(lineStart);
       },
       flush: () => {
-        // If there's content in the buffer when the stream ends, it means
-        // the stream ended with an incomplete line (no trailing newline)
         if (this.buffer) {
           throw new Error(
             `Stream ended with an incomplete line: "${this.buffer}"`,

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
@@ -1,33 +1,26 @@
 export class LineDecoderStream extends TransformStream<string, string> {
   private buffer = "";
-  private skipNextLineFeed = false;
+  private pendingLF = false;
 
   constructor() {
     super({
       transform: (chunk, controller) => {
-        let lineStart = 0;
+        if (chunk === "") return;
 
-        for (let i = 0; i < chunk.length; i++) {
-          const character = chunk[i]!;
-
-          if (this.skipNextLineFeed) {
-            this.skipNextLineFeed = false;
-            if (character === "\n") {
-              lineStart = i + 1;
-              continue;
-            }
-          }
-
-          if (character === "\n" || character === "\r") {
-            this.buffer += chunk.slice(lineStart, i);
-            controller.enqueue(this.buffer);
-            this.buffer = "";
-            this.skipNextLineFeed = character === "\r";
-            lineStart = i + 1;
-          }
+        // A chunk-trailing CR terminates its line immediately. Skip a leading
+        // LF in the next chunk so a split CRLF is counted only once.
+        if (this.pendingLF && chunk.startsWith("\n")) {
+          chunk = chunk.slice(1);
         }
+        this.pendingLF = chunk.endsWith("\r");
 
-        this.buffer += chunk.slice(lineStart);
+        this.buffer += chunk;
+        const lines = this.buffer.split(/\r\n|\r|\n/);
+        this.buffer = lines.pop()!;
+
+        for (const line of lines) {
+          controller.enqueue(line);
+        }
       },
       flush: () => {
         if (this.buffer) {

--- a/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/LineDecoderStream.ts
@@ -1,26 +1,33 @@
 export class LineDecoderStream extends TransformStream<string, string> {
   private buffer = "";
-  private pendingLF = false;
+  private skipNextLineFeed = false;
 
   constructor() {
     super({
       transform: (chunk, controller) => {
-        if (chunk === "") return;
+        let lineStart = 0;
 
-        // A chunk-trailing CR terminates its line immediately. Skip a leading
-        // LF in the next chunk so a split CRLF is counted only once.
-        if (this.pendingLF && chunk.startsWith("\n")) {
-          chunk = chunk.slice(1);
+        for (let i = 0; i < chunk.length; i++) {
+          const character = chunk[i]!;
+
+          if (this.skipNextLineFeed) {
+            this.skipNextLineFeed = false;
+            if (character === "\n") {
+              lineStart = i + 1;
+              continue;
+            }
+          }
+
+          if (character === "\n" || character === "\r") {
+            this.buffer += chunk.slice(lineStart, i);
+            controller.enqueue(this.buffer);
+            this.buffer = "";
+            this.skipNextLineFeed = character === "\r";
+            lineStart = i + 1;
+          }
         }
-        this.pendingLF = chunk.endsWith("\r");
 
-        this.buffer += chunk;
-        const lines = this.buffer.split(/\r\n|\r|\n/);
-        this.buffer = lines.pop()!;
-
-        for (const line of lines) {
-          controller.enqueue(line);
-        }
+        this.buffer += chunk.slice(lineStart);
       },
       flush: () => {
         if (this.buffer) {


### PR DESCRIPTION
## Summary
- parse all SSE-standard line endings in `LineDecoderStream`: LF, CRLF, and CR
- preserve CRLF as a single delimiter when `\r` and `\n` arrive in separate chunks
- add regression coverage for CR-delimited, empty, mixed, and chunk-split lines
- add a patch changeset for `assistant-stream`

## Why
This is another focused follow-up identified during merged PR #4819. `LineDecoderStream` currently splits only on `\n`, which handles LF directly and CRLF by stripping the preceding `\r`, but it cannot recognize standalone CR line endings.

Standalone CR is also valid SSE. A valid stream such as `data: hello\r\r` therefore remains buffered and ends with an incomplete-line error instead of dispatching the event. Fixing the shared line decoder applies consistently to object streams, assistant transport, UI message streams, and data streams.

This complements #4875 without overlapping it: #4875 discards genuinely unterminated events at EOF, while this PR recognizes events terminated by every valid SSE line-ending form.

## Implementation
The decoder scans each chunk character by character: `\n` or `\r` terminates the buffered line immediately, and a `skipNextLineFeed` flag set after `\r` swallows a leading `\n` in the same or the following chunk, so a CRLF pair split across chunks counts as one delimiter instead of two. CR-only lines dispatch as soon as they arrive, partial lines are buffered without rescanning on every chunk, and the strict flush error for a stream ending in an unterminated line is unchanged.

## Verification
- confirmed the CR-only and mixed-line-ending regressions fail on current `main` before the fix
- `pnpm --filter assistant-stream test` (251 passed, 20 skipped)
- `pnpm --filter assistant-stream build`
- scoped `oxlint` and `oxfmt --check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

