### PR TITLE
feat(react-ink-markdown): declare color, tableTruncate, and tableEllipsis on MarkdownTextProps

### DIFF
--- a/.changeset/ink-markdown-render-option-props.md
+++ b/.changeset/ink-markdown-render-option-props.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink-markdown": patch
+---
+
+feat: declare color, tableTruncate, and tableEllipsis on MarkdownTextProps

--- a/api-surface/assistant-ui__react-ink-markdown.ts
+++ b/api-surface/assistant-ui__react-ink-markdown.ts
@@ -24,9 +24,12 @@ type MarkdownTextProps = {
   codeGutter?: boolean;
   codeWrap?: boolean;
   hyperlinks?: boolean;
+  color?: boolean;
   tableBorder?: "ascii" | "none" | "unicode";
   tablePadding?: number;
   tableDense?: boolean;
+  tableTruncate?: boolean;
+  tableEllipsis?: string;
   quotePrefix?: string;
   listIndent?: number;
 };

--- a/examples/with-react-ink-web/app/thread.tsx
+++ b/examples/with-react-ink-web/app/thread.tsx
@@ -12,7 +12,6 @@ import { MarkdownText } from "@assistant-ui/react-ink-markdown";
 
 // markdansi defaults width and color from process.stdout, which does not
 // exist in the browser bundle; pass both explicitly so it never reads it.
-// color is forwarded to markdansi but not yet declared on MarkdownTextProps.
 const BrowserMarkdownText = ({ text }: { text: string }) => {
   const { stdout } = useStdout();
   return (
@@ -20,7 +19,7 @@ const BrowserMarkdownText = ({ text }: { text: string }) => {
       text={text}
       width={(stdout?.columns ?? 80) - 4}
       hyperlinks={false}
-      {...{ color: true }}
+      color
     />
   );
 };

--- a/packages/react-ink-markdown/src/MarkdownText.tsx
+++ b/packages/react-ink-markdown/src/MarkdownText.tsx
@@ -31,12 +31,18 @@ export type MarkdownTextProps = {
   codeWrap?: boolean;
   /** Enable OSC 8 hyperlinks (default: auto-detect). */
   hyperlinks?: boolean;
+  /** Enable ANSI colors (default: auto-detect). */
+  color?: boolean;
   /** Table border style. */
   tableBorder?: "unicode" | "ascii" | "none";
   /** Table cell padding. */
   tablePadding?: number;
   /** Dense table rendering. */
   tableDense?: boolean;
+  /** Truncate table cells to fit column width (default: true). */
+  tableTruncate?: boolean;
+  /** Ellipsis text for table cell truncation (default: "…"). */
+  tableEllipsis?: string;
   /** Blockquote prefix (default: "\u2502 "). */
   quotePrefix?: string;
   /** List indentation (default: 2). */

--- a/packages/react-ink-markdown/src/__tests__/MarkdownText.test.tsx
+++ b/packages/react-ink-markdown/src/__tests__/MarkdownText.test.tsx
@@ -112,14 +112,36 @@ describe("MarkdownText", () => {
     expect(lastFrame()).not.toContain("FIRST:");
   });
 
-  it("forwards undeclared markdansi options", () => {
+  it("passes table options to markdansi", () => {
     const table =
       "| column |\n| --- |\n| a very long cell value that must truncate |";
 
     const { lastFrame } = render(
-      <MarkdownText text={table} width={20} {...{ tableEllipsis: ">>>" }} />,
+      <MarkdownText text={table} width={20} tableEllipsis=">>>" />,
     );
     expect(lastFrame()).toContain(">>>");
+  });
+
+  it("wraps table cells when tableTruncate is disabled", () => {
+    const table =
+      "| column |\n| --- |\n| a very long cell value that must truncate |";
+
+    const { lastFrame } = render(
+      <MarkdownText text={table} width={20} tableTruncate={false} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain("truncate");
+    expect(frame).not.toContain("…");
+  });
+
+  it("emits ANSI colors when color is enabled", () => {
+    const { lastFrame } = render(<MarkdownText text="# Head" color />);
+    expect(lastFrame()).toContain("[");
+  });
+
+  it("strips ANSI colors when color is disabled", () => {
+    const { lastFrame } = render(<MarkdownText text="# Head" color={false} />);
+    expect(lastFrame()).not.toContain("[");
   });
 
   it("re-wraps memoized output when the terminal is resized", async () => {


### PR DESCRIPTION
## What

Declares the three markdansi `RenderOptions` keys missing from `MarkdownTextProps`: `color`, `tableTruncate`, and `tableEllipsis`. The props type now covers all 16 options of markdansi 0.3.2. No runtime change: the component already rest-spreads every prop into `render()`.

## Why

The options worked but were invisible to TypeScript, so two in-repo consumers smuggled them past the type: `examples/with-react-ink-web/app/thread.tsx` passed `{...{ color: true }}` and the #4867 regression test passed `tableEllipsis` the same way. Declaring the props closes the gap at the root and removes both smuggles.

## Impact

- Three new optional props, purely additive and append-only safe.
- `MarkdownTextPrimitiveProps` inherits them automatically via `Omit<MarkdownTextProps, "text">`.
- No output change for existing callers; undeclared-key spreading still works.
- Patch changeset for `@assistant-ui/react-ink-markdown`.

## Tests

- The "forwards undeclared markdansi options" test lost its premise (no undeclared key remains); renamed to "passes table options to markdansi" with `tableEllipsis` as a declared prop, same rest-spread path and assertion, so the #4867 regression coverage survives.
- New: `tableTruncate={false}` wraps the cell instead of truncating; `color` emits ANSI escapes and `color={false}` strips them. Color is always set explicitly since the default auto-detects from `process.stdout.isTTY` and would flake between dev and CI.
- 23/23 tests pass.

## Rationale

Flat declared props with doc comments match how the existing 13 options are declared and keep the package in control of its documented surface. The example cleanup ships here because the smuggle existed only to work around the missing declaration; the example's explicit-width/resize behavior is left untouched as a separate concern.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

