### PR TITLE
feat: extract a shared SSE event decoder into assistant-stream

### DIFF
--- a/.changeset/a2a-shared-sse-decoder.md
+++ b/.changeset/a2a-shared-sse-decoder.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+refactor: consume the shared SSE event decoder

--- a/.changeset/adk-shared-sse-decoder.md
+++ b/.changeset/adk-shared-sse-decoder.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+refactor: consume the shared SSE event decoder

--- a/.changeset/assistant-stream-sse-event-decoder.md
+++ b/.changeset/assistant-stream-sse-event-decoder.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+feat: export a spec-complete SSE event decoder from assistant-stream/utils

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11470,6 +11470,31 @@ interface ResumableStreamStore {
 
 declare type RetryStrategy = ((times: number) => number | void | null) | null | undefined;
 
+type SSEEvent = {
+  event?: string;
+  data: string;
+  id?: string;
+  retry?: number;
+};
+
+declare class SSEEventDecoder {
+  private lineBuffer;
+  private dataLines;
+  private eventName;
+  private lastEventId;
+  private retry;
+  private pendingLF;
+  private readonly trailing;
+  constructor(options?: {
+    trailing?: "dispatch" | "drop";
+  });
+  push(text: string): SSEEvent[];
+  flush(): SSEEvent | null;
+  private processLine;
+  private dispatchEvent;
+  private resetFrame;
+}
+
 declare class ScanStream extends Readable {
   private opt;
   private _redisCursor;
@@ -11948,7 +11973,7 @@ declare function toolResultStream(tools: Record<string, Tool> | (() => Record<st
 declare function unstable_runPendingTools(message: AssistantMessage, tools: Record<string, Tool> | undefined, abortSignal: AbortSignal, human: (toolCallId: string, payload: unknown) => Promise<unknown>): Promise<AssistantMessage>;
 
 declare namespace entry_utils_exports {
-  export { AssistantMetaTransformStream, AssistantTransformStream, AsyncIterableStream, ReadonlyJSONArray, ReadonlyJSONObject, ReadonlyJSONValue, asAsyncIterableStream, getPartialJsonObjectFieldState, getPartialJsonObjectMeta, parsePartialJsonObject };
+  export { AssistantMetaTransformStream, AssistantTransformStream, AsyncIterableStream, ReadonlyJSONArray, ReadonlyJSONObject, ReadonlyJSONValue, SSEEvent, SSEEventDecoder, asAsyncIterableStream, getPartialJsonObjectFieldState, getPartialJsonObjectMeta, parsePartialJsonObject };
 }
 
 export { entry_resumable_exports as entry_resumable, entry_resumable_ioredis_exports as entry_resumable_ioredis, entry_resumable_redis_exports as entry_resumable_redis, entry_root_exports as entry_root, entry_utils_exports as entry_utils };

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -81,6 +81,34 @@ describe("SSEEventDecoder", () => {
     ]);
   });
 
+  it("ignores ids containing NUL and keeps ids containing spaces", () => {
+    const decoder = new SSEEventDecoder();
+    expect(
+      decoder.push(
+        "id: ok\ndata: a\n\nid: bad\u0000id\ndata: b\n\nid: spaced id\ndata: c\n\n",
+      ),
+    ).toEqual([
+      { data: "a", id: "ok" },
+      { data: "b", id: "ok" },
+      { data: "c", id: "spaced id" },
+    ]);
+  });
+
+  it("ignores non-digit retry values", () => {
+    const decoder = new SSEEventDecoder();
+    expect(
+      decoder.push(
+        "retry: 1000\ndata: a\n\nretry: -1\ndata: b\n\nretry: 1.5\ndata: c\n\nretry: 1e3\ndata: d\n\nretry:\ndata: e\n\n",
+      ),
+    ).toEqual([
+      { data: "a", retry: 1000 },
+      { data: "b", retry: 1000 },
+      { data: "c", retry: 1000 },
+      { data: "d", retry: 1000 },
+      { data: "e", retry: 1000 },
+    ]);
+  });
+
   it("does not dispatch blank frames", () => {
     const decoder = new SSEEventDecoder();
     expect(decoder.push("event: update\n\ndata: x\n\n")).toEqual([

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -94,11 +94,12 @@ describe("SSEEventDecoder", () => {
     ]);
   });
 
-  it("ignores non-digit retry values", () => {
+  it("ignores non-digit and unsafe-integer retry values", () => {
     const decoder = new SSEEventDecoder();
     expect(
       decoder.push(
-        "retry: 1000\ndata: a\n\nretry: -1\ndata: b\n\nretry: 1.5\ndata: c\n\nretry: 1e3\ndata: d\n\nretry:\ndata: e\n\n",
+        "retry: 1000\ndata: a\n\nretry: -1\ndata: b\n\nretry: 1.5\ndata: c\n\nretry: 1e3\ndata: d\n\nretry:\ndata: e\n\n" +
+          `retry: ${"9".repeat(400)}\ndata: f\n\n`,
       ),
     ).toEqual([
       { data: "a", retry: 1000 },
@@ -106,6 +107,7 @@ describe("SSEEventDecoder", () => {
       { data: "c", retry: 1000 },
       { data: "d", retry: 1000 },
       { data: "e", retry: 1000 },
+      { data: "f", retry: 1000 },
     ]);
   });
 

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { SSEEventDecoder } from "./SSEEventDecoder";
+
+describe("SSEEventDecoder", () => {
+  it("decodes LF terminated events", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\n\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("decodes CRLF terminated events", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\r\n\r\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("decodes CR terminated events", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\r\r")).toEqual([{ data: "x" }]);
+  });
+
+  it("handles CRLF split across pushes", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\r")).toEqual([]);
+    expect(decoder.push("\n\r\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("handles CR terminated lines split across pushes", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\r")).toEqual([]);
+    expect(decoder.push("\r")).toEqual([{ data: "x" }]);
+  });
+
+  it("decodes multiple events in one push", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: first\n\ndata: second\n\n")).toEqual([
+      { data: "first" },
+      { data: "second" },
+    ]);
+  });
+
+  it("joins multiple data lines with a newline", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: first\ndata: second\n\n")).toEqual([
+      { data: "first\nsecond" },
+    ]);
+  });
+
+  it("preserves data values without a space after the colon", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data:x\n\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("skips comment lines", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push(": heartbeat\ndata: x\n\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("captures event fields and clears them after dispatch", () => {
+    const decoder = new SSEEventDecoder();
+    expect(
+      decoder.push("event: update\ndata: first\n\ndata: second\n\n"),
+    ).toEqual([{ event: "update", data: "first" }, { data: "second" }]);
+  });
+
+  it("persists IDs across frames", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("id: 1\ndata: first\n\ndata: second\n\n")).toEqual([
+      { data: "first", id: "1" },
+      { data: "second", id: "1" },
+    ]);
+  });
+
+  it("parses numeric retries and ignores non-numeric retries", () => {
+    const decoder = new SSEEventDecoder();
+    expect(
+      decoder.push(
+        "retry: 1000\ndata: first\n\nretry: invalid\ndata: second\n\n",
+      ),
+    ).toEqual([
+      { data: "first", retry: 1000 },
+      { data: "second", retry: 1000 },
+    ]);
+  });
+
+  it("does not dispatch blank frames", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("event: update\n\ndata: x\n\n")).toEqual([
+      { data: "x" },
+    ]);
+  });
+
+  it("preserves a pending LF across empty pushes", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x\r")).toEqual([]);
+    expect(decoder.push("")).toEqual([]);
+    expect(decoder.push("\n\r\n")).toEqual([{ data: "x" }]);
+  });
+
+  it("drops unterminated trailing data by default", () => {
+    const decoder = new SSEEventDecoder();
+    expect(decoder.push("data: x")).toEqual([]);
+    expect(decoder.flush()).toBeNull();
+  });
+
+  it("dispatches an unterminated final data line when configured", () => {
+    const decoder = new SSEEventDecoder({ trailing: "dispatch" });
+    expect(decoder.push("data: x")).toEqual([]);
+    expect(decoder.flush()).toEqual({ data: "x" });
+  });
+
+  it("makes flush idempotent", () => {
+    const decoder = new SSEEventDecoder({ trailing: "dispatch" });
+    decoder.push("data: x");
+    expect(decoder.flush()).toEqual({ data: "x" });
+    expect(decoder.flush()).toBeNull();
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -76,9 +76,13 @@ export class SSEEventDecoder {
       case "id":
         if (!value.includes("\u0000")) this.lastEventId = value;
         break;
-      case "retry":
-        if (/^\d+$/.test(value)) this.retry = Number(value);
+      case "retry": {
+        const retry = Number(value);
+        if (/^\d+$/.test(value) && Number.isSafeInteger(retry)) {
+          this.retry = retry;
+        }
         break;
+      }
     }
 
     return null;

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -1,0 +1,107 @@
+export type SSEEvent = {
+  event?: string;
+  data: string;
+  id?: string;
+  retry?: number;
+};
+
+export class SSEEventDecoder {
+  private lineBuffer = "";
+  private dataLines: string[] = [];
+  private eventName: string | undefined;
+  private lastEventId: string | undefined;
+  private retry: number | undefined;
+  private pendingLF = false;
+  private readonly trailing: "drop" | "dispatch";
+
+  constructor(options?: { trailing?: "drop" | "dispatch" }) {
+    this.trailing = options?.trailing ?? "drop";
+  }
+
+  push(text: string): SSEEvent[] {
+    const events: SSEEvent[] = [];
+    if (text === "") return events;
+
+    // Lines end with LF, CRLF, or CR. A chunk-trailing "\r" terminates its
+    // line immediately; pendingLF then swallows the leading "\n" of the next
+    // chunk so a CRLF split across chunks is not counted twice.
+    if (this.pendingLF && text.startsWith("\n")) text = text.slice(1);
+    this.pendingLF = text.endsWith("\r");
+
+    this.lineBuffer += text;
+    const lines = this.lineBuffer.split(/\r\n|\r|\n/);
+    this.lineBuffer = lines.pop()!;
+
+    for (const line of lines) {
+      const event = this.processLine(line);
+      if (event) events.push(event);
+    }
+
+    return events;
+  }
+
+  flush(): SSEEvent | null {
+    if (this.trailing === "drop") {
+      this.resetFrame();
+      this.lineBuffer = "";
+      this.pendingLF = false;
+      return null;
+    }
+
+    if (this.lineBuffer.length > 0) {
+      this.processLine(this.lineBuffer);
+    }
+
+    this.lineBuffer = "";
+    this.pendingLF = false;
+    return this.dispatchEvent();
+  }
+
+  private processLine(line: string): SSEEvent | null {
+    if (line === "") return this.dispatchEvent();
+    if (line.startsWith(":")) return null;
+
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    let value = separator === -1 ? "" : line.slice(separator + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+
+    switch (field) {
+      case "data":
+        this.dataLines.push(value);
+        break;
+      case "event":
+        this.eventName = value;
+        break;
+      case "id":
+        this.lastEventId = value;
+        break;
+      case "retry": {
+        const retry = Number(value);
+        if (Number.isFinite(retry)) this.retry = retry;
+        break;
+      }
+    }
+
+    return null;
+  }
+
+  private dispatchEvent(): SSEEvent | null {
+    if (this.dataLines.length === 0) {
+      this.resetFrame();
+      return null;
+    }
+
+    const event: SSEEvent = { data: this.dataLines.join("\n") };
+    if (this.eventName !== undefined) event.event = this.eventName;
+    if (this.lastEventId !== undefined) event.id = this.lastEventId;
+    if (this.retry !== undefined) event.retry = this.retry;
+    this.resetFrame();
+    return event;
+  }
+
+  private resetFrame() {
+    this.dataLines = [];
+    this.eventName = undefined;
+  }
+}

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoder.ts
@@ -74,13 +74,11 @@ export class SSEEventDecoder {
         this.eventName = value;
         break;
       case "id":
-        this.lastEventId = value;
+        if (!value.includes("\u0000")) this.lastEventId = value;
         break;
-      case "retry": {
-        const retry = Number(value);
-        if (Number.isFinite(retry)) this.retry = retry;
+      case "retry":
+        if (/^\d+$/.test(value)) this.retry = Number(value);
         break;
-      }
     }
 
     return null;

--- a/packages/assistant-stream/src/utils.ts
+++ b/packages/assistant-stream/src/utils.ts
@@ -15,3 +15,7 @@ export type {
 
 export { AssistantTransformStream } from "./core/utils/stream/AssistantTransformStream";
 export { AssistantMetaTransformStream } from "./core/utils/stream/AssistantMetaTransformStream";
+export {
+  SSEEventDecoder,
+  type SSEEvent,
+} from "./core/utils/stream/SSEEventDecoder";

--- a/packages/react-a2a/package.json
+++ b/packages/react-a2a/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@assistant-ui/core": "^0.2.20",
-    "@assistant-ui/store": "^0.2.19"
+    "@assistant-ui/store": "^0.2.19",
+    "assistant-stream": "^0.3.25"
   },
   "peerDependencies": {
     "@types/react": "*",

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -1,3 +1,4 @@
+import { SSEEventDecoder, type SSEEvent } from "assistant-stream/utils";
 import type {
   A2AAgentCard,
   A2AErrorInfo,
@@ -497,15 +498,11 @@ export class A2AClient {
     if (!reader) throw new Error("No response body");
 
     const decoder = new TextDecoder();
-    let lineBuffer = "";
-    let dataLines: string[] = [];
-    let pendingLF = false;
+    const sseDecoder = new SSEEventDecoder();
 
-    const readEvent = (): A2AStreamEvent | null => {
-      if (dataLines.length === 0) return null;
-
+    const readEvent = (event: SSEEvent): A2AStreamEvent | null => {
       try {
-        let parsed = JSON.parse(dataLines.join("\n"));
+        let parsed = JSON.parse(event.data);
 
         if (
           parsed &&
@@ -523,63 +520,22 @@ export class A2AClient {
       }
     };
 
-    const processLine = (line: string): A2AStreamEvent | null => {
-      if (line === "") {
-        const event = readEvent();
-        dataLines = [];
-        return event;
-      }
-
-      if (line.startsWith(":")) return null;
-
-      const separator = line.indexOf(":");
-      const field = separator === -1 ? line : line.slice(0, separator);
-      let value = separator === -1 ? "" : line.slice(separator + 1);
-      if (value.startsWith(" ")) value = value.slice(1);
-
-      if (field === "data") {
-        dataLines.push(value);
-      }
-
-      return null;
-    };
-
-    // Lines end with LF, CRLF, or CR. A chunk-trailing "\r" terminates its
-    // line immediately; pendingLF then swallows the leading "\n" of the next
-    // chunk so a CRLF split across chunks is not counted twice.
-    const processText = (text: string): A2AStreamEvent[] => {
-      const events: A2AStreamEvent[] = [];
-      if (text === "") return events;
-
-      if (pendingLF && text.startsWith("\n")) text = text.slice(1);
-      pendingLF = text.endsWith("\r");
-
-      lineBuffer += text;
-      const lines = lineBuffer.split(/\r\n|\r|\n/);
-      lineBuffer = lines.pop()!;
-
-      for (const line of lines) {
-        const event = processLine(line);
-        if (event) events.push(event);
-      }
-
-      return events;
-    };
-
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) {
-          for (const event of processText(decoder.decode())) {
-            yield event;
+          for (const event of sseDecoder.push(decoder.decode())) {
+            const parsed = readEvent(event);
+            if (parsed) yield parsed;
           }
           break;
         }
 
-        for (const event of processText(
+        for (const event of sseDecoder.push(
           decoder.decode(value, { stream: true }),
         )) {
-          yield event;
+          const parsed = readEvent(event);
+          if (parsed) yield parsed;
         }
       }
     } finally {

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -1,3 +1,4 @@
+import { SSEEventDecoder } from "assistant-stream/utils";
 import { contentToParts } from "./contentToParts";
 import type {
   AdkEvent,
@@ -213,79 +214,27 @@ function messagesToProxyBody(
 async function* parseSSEResponse(response: Response): AsyncGenerator<AdkEvent> {
   const reader = response.body!.getReader();
   const decoder = new TextDecoder();
-  let lineBuffer = "";
-  let dataLines: string[] = [];
-  let pendingLF = false;
-
-  const flushEvent = (): AdkEvent | null => {
-    if (dataLines.length === 0) return null;
-
-    const event = JSON.parse(dataLines.join("\n")) as AdkEvent;
-    dataLines = [];
-    return event;
-  };
-
-  const processLine = (line: string): AdkEvent | null => {
-    if (line === "") return flushEvent();
-    if (line.startsWith(":")) return null;
-
-    const separator = line.indexOf(":");
-    const field = separator === -1 ? line : line.slice(0, separator);
-    let value = separator === -1 ? "" : line.slice(separator + 1);
-    if (value.startsWith(" ")) value = value.slice(1);
-
-    if (field === "data") {
-      dataLines.push(value);
-    }
-
-    return null;
-  };
-
-  // Lines end with LF, CRLF, or CR. A chunk-trailing "\r" terminates its
-  // line immediately; pendingLF then swallows the leading "\n" of the next
-  // chunk so a CRLF split across chunks is not counted twice.
-  const processText = (text: string): AdkEvent[] => {
-    const events: AdkEvent[] = [];
-    if (text === "") return events;
-
-    if (pendingLF && text.startsWith("\n")) text = text.slice(1);
-    pendingLF = text.endsWith("\r");
-
-    lineBuffer += text;
-    const lines = lineBuffer.split(/\r\n|\r|\n/);
-    lineBuffer = lines.pop()!;
-
-    for (const line of lines) {
-      const event = processLine(line);
-      if (event) events.push(event);
-    }
-
-    return events;
-  };
+  const sseDecoder = new SSEEventDecoder({ trailing: "dispatch" });
 
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) {
-        for (const event of processText(decoder.decode())) {
-          yield event;
+        for (const event of sseDecoder.push(decoder.decode())) {
+          yield JSON.parse(event.data) as AdkEvent;
         }
         break;
       }
 
-      for (const event of processText(
+      for (const event of sseDecoder.push(
         decoder.decode(value, { stream: true }),
       )) {
-        yield event;
+        yield JSON.parse(event.data) as AdkEvent;
       }
     }
 
-    if (lineBuffer.length > 0) {
-      processLine(lineBuffer);
-    }
-
-    const trailing = flushEvent();
-    if (trailing) yield trailing;
+    const trailing = sseDecoder.flush();
+    if (trailing !== null) yield JSON.parse(trailing.data) as AdkEvent;
   } finally {
     reader.releaseLock();
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3779,6 +3779,9 @@ importers:
       '@assistant-ui/store':
         specifier: ^0.2.19
         version: link:../store
+      assistant-stream:
+        specifier: ^0.3.25
+        version: link:../assistant-stream
     devDependencies:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*


### PR DESCRIPTION
## summary

- `assistant-stream/utils` now exports `SSEEventDecoder`, a spec-complete incremental SSE parser: LF, CRLF, and CR line endings (including CRLF pairs split across chunks), comment skip, first-colon field split with single-space strip, multi-line `data:` joined per spec, `id`/`retry` persisting across frames, and a `trailing: "drop" | "dispatch"` option for what happens to an unterminated final frame at end of stream
- `react-a2a` and `react-google-adk` drop their hand-rolled parsers (deliberately converged to byte-identical shape in #4819/#4821) and consume the shared decoder; a2a keeps its skip-malformed-JSON tolerance and spec-strict drop mode, adk keeps its throw-on-malformed contract and legacy `dispatch` mode for unterminated trailing frames
- net -87 lines across the two adapters; `react-pi`'s decoder and assistant-stream's internal `SSE.ts` are untouched (follow-up: migrate them onto this utility, which needs the flush-mode option shipped here)

## test plan

### already verified

- [x] `vitest run` in assistant-stream -> 265 passed | 20 skipped (new decoder suite covers every line-ending variant, split delimiters, field rules, id/retry persistence, both trailing modes, flush idempotence)
- [x] `vitest run` in react-a2a -> 124/124 and react-google-adk -> 184/184, both suites unmodified (migration oracle: observable behavior unchanged)
- [x] `aui-build` green for all three packages; oxlint and oxfmt clean on touched files

### reviewer should verify

- [ ] a CRLF-delimited A2A or ADK stream still renders events as they arrive (both adapters' liveness tests cover this, but a real proxy round-trip is the end-to-end check)

## notes

- the lockfile delta is the minimal three-line entry for react-a2a's new assistant-stream dependency
- consolidation context: four SSE parser copies existed in the repo; this lands the shared one and retires two copies, with react-pi and the internal `SSE.ts` (whose flush currently dispatches unterminated frames, unlike the spec) as recorded follow-ups

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

