### PR TITLE
fix(ui): hide the context display tooltip arrow via a data slot

### DIFF
--- a/packages/ui/src/components/assistant-ui/context-display.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/context-display.radix.tsx
@@ -237,7 +237,7 @@ function ContextDisplayContent({
       sideOffset={8}
       data-slot="context-display-popover"
       className={cn(
-        "bg-popover text-popover-foreground w-56 rounded-lg border p-3 text-left shadow-md [&_span>svg]:hidden!",
+        "bg-popover text-popover-foreground w-56 rounded-lg border p-3 text-left shadow-md [&_[data-slot=tooltip-arrow]]:hidden",
         className,
       )}
     >

--- a/packages/ui/src/components/assistant-ui/context-display.tsx
+++ b/packages/ui/src/components/assistant-ui/context-display.tsx
@@ -242,7 +242,7 @@ function ContextDisplayContent({
       sideOffset={8}
       data-slot="context-display-popover"
       className={cn(
-        "bg-popover text-popover-foreground w-56 rounded-lg border p-3 text-left shadow-md [&_span>svg]:hidden!",
+        "bg-popover text-popover-foreground w-56 rounded-lg border p-3 text-left shadow-md [&_[data-slot=tooltip-arrow]]:hidden",
         className,
       )}
     >

--- a/packages/ui/src/components/ui/base/tooltip.tsx
+++ b/packages/ui/src/components/ui/base/tooltip.tsx
@@ -56,7 +56,10 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            data-slot="tooltip-arrow"
+            className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5"
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/packages/ui/src/components/ui/radix/tooltip.tsx
+++ b/packages/ui/src/components/ui/radix/tooltip.tsx
@@ -52,7 +52,10 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow
+          data-slot="tooltip-arrow"
+          className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]"
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/templates/minimal/components/ui/tooltip.tsx
+++ b/templates/minimal/components/ui/tooltip.tsx
@@ -56,7 +56,10 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow
+            data-slot="tooltip-arrow"
+            className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5"
+          />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
## summary

- the context usage ring tooltip showed a black diamond artifact: the base flavor tooltip arrow renders as a bare svg, so the structural `[&_span>svg]` hider in context-display never matched it
- tag `TooltipPrimitive.Arrow` with `data-slot="tooltip-arrow"` in both flavors and hide it by slot instead of by dom shape, which keeps the two flavors symmetric and survives upstream dom changes
- sync the rendered copy into templates/minimal via `pnpm sync-templates`

## test plan

### already verified

- [x] `bash scripts/sync-templates.sh` -> all template components in sync
- [x] oxlint + oxfmt on the touched files -> clean
- [x] verified in the docs app that the context usage tooltip renders without the arrow artifact (base flavor path; the radix flavor carries the mirrored change)

### reviewer should verify

- [ ] hover the context usage ring in the docs assistant panel and confirm no black diamond shows under the tooltip

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

