### PR TITLE
fix(assistant-stream): accept event stream content type parameters

### DIFF
--- a/.changeset/assistant-stream-content-type-parameters.md
+++ b/.changeset/assistant-stream-content-type-parameters.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: accept parameterized event-stream content types

--- a/packages/assistant-stream/src/core/object/ObjectStreamResponse.test.ts
+++ b/packages/assistant-stream/src/core/object/ObjectStreamResponse.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { fromObjectStreamResponse } from "./ObjectStreamResponse";
+
+const createResponse = (contentType?: string) => {
+  const headers = new Headers({
+    "Assistant-Stream-Format": "object-stream/v0",
+  });
+  if (contentType) headers.set("Content-Type", contentType);
+
+  return new Response(new Uint8Array(), { headers });
+};
+
+describe("fromObjectStreamResponse", () => {
+  it.each([
+    "text/event-stream",
+    "text/event-stream; charset=utf-8",
+    "Text/Event-Stream; Charset=UTF-8",
+  ])("accepts the event-stream content type %s", (contentType) => {
+    expect(() =>
+      fromObjectStreamResponse(createResponse(contentType)),
+    ).not.toThrow();
+  });
+
+  it.each([undefined, "application/json", "text/event-streaming"])(
+    "rejects the content type %s",
+    (contentType) => {
+      expect(() =>
+        fromObjectStreamResponse(createResponse(contentType)),
+      ).toThrow("Response is not an event stream");
+    },
+  );
+});

--- a/packages/assistant-stream/src/core/object/ObjectStreamResponse.ts
+++ b/packages/assistant-stream/src/core/object/ObjectStreamResponse.ts
@@ -99,7 +99,12 @@ export const fromObjectStreamResponse = (
   if (!response.ok)
     throw new Error(`Response failed, status ${response.status}`);
   if (!response.body) throw new Error("Response body is null");
-  if (response.headers.get("Content-Type") !== "text/event-stream") {
+  const mediaType = response.headers
+    .get("Content-Type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (mediaType !== "text/event-stream") {
     throw new Error("Response is not an event stream");
   }
   if (response.headers.get("Assistant-Stream-Format") !== "object-stream/v0") {


### PR DESCRIPTION
## Summary

- accept `text/event-stream` responses with parameters such as `charset=utf-8`
- normalize the media type casing and surrounding whitespace before validation
- continue rejecting missing, unrelated, and lookalike content types

## Why

`fromObjectStreamResponse()` compared the complete `Content-Type` header to `text/event-stream`. A valid response such as:

```http
Content-Type: text/event-stream; charset=utf-8
```

was therefore rejected with `Response is not an event stream`. Frameworks and proxies may append charset parameters, so a valid object stream could fail before decoding began.

## Implementation

The validation now extracts the media type before the first parameter, trims it, and compares it case-insensitively. It still requires the exact `text/event-stream` media type, so values such as `application/json` and `text/event-streaming` remain invalid.

## Test plan

- added focused coverage for exact, parameterized, and mixed-case event-stream content types
- added rejection coverage for missing, unrelated, and lookalike content types
- confirmed the parameterized cases fail with the old exact comparison and pass with this change
- `pnpm test` in `packages/assistant-stream` (254 passed, 20 skipped)
- `pnpm build` in `packages/assistant-stream`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

