### PR TITLE
fix(react-ink): wrap ThreadListPrimitive.Items rows in ThreadListItemByIndexProvider with keys

### DIFF
--- a/.changeset/ink-thread-list-item-scope.md
+++ b/.changeset/ink-thread-list-item-scope.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: wrap ThreadListPrimitive.Items rows in ThreadListItemByIndexProvider with keys

--- a/packages/react-ink/src/primitives/threadList/ThreadListItems.tsx
+++ b/packages/react-ink/src/primitives/threadList/ThreadListItems.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from "react";
 import { Box } from "ink";
 import { useAuiState } from "@assistant-ui/store";
+import { ThreadListItemByIndexProvider } from "@assistant-ui/core/react";
 
 export type ThreadListItemsProps = {
   renderItem: (props: { threadId: string; index: number }) => ReactElement;
@@ -11,9 +12,15 @@ export const ThreadListItems = ({ renderItem }: ThreadListItemsProps) => {
 
   return (
     <Box flexDirection="column">
-      {(threadIds as string[]).map((threadId, index) =>
-        renderItem({ threadId, index }),
-      )}
+      {threadIds.map((threadId, index) => (
+        <ThreadListItemByIndexProvider
+          key={threadId}
+          index={index}
+          archived={false}
+        >
+          {renderItem({ threadId, index })}
+        </ThreadListItemByIndexProvider>
+      ))}
     </Box>
   );
 };

--- a/packages/react-ink/src/tests/ThreadListItemScope.test.tsx
+++ b/packages/react-ink/src/tests/ThreadListItemScope.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup } from "ink-testing-library";
+import type { FC } from "react";
+import { Text } from "ink";
+import { useExternalStoreRuntime } from "@assistant-ui/core/react";
+import { renderFrame } from "./helpers";
+import {
+  AssistantRuntimeProvider,
+  ThreadListPrimitive,
+  useAuiState,
+} from "../index";
+
+const Row: FC = () => {
+  const id = useAuiState((s) => s.threadListItem.id);
+  return <Text>row:{id}</Text>;
+};
+
+const App: FC = () => {
+  const runtime = useExternalStoreRuntime({
+    isRunning: false,
+    messages: [],
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: "t-1",
+        threads: [
+          { id: "t-1", title: "First" },
+          { id: "t-2", title: "Second" },
+        ],
+        onSwitchToThread: async () => {},
+      },
+    },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadListPrimitive.Items renderItem={() => <Row />} />
+    </AssistantRuntimeProvider>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ThreadListPrimitive.Items thread list item scope", () => {
+  it("scopes each row to its own thread list item", async () => {
+    const frame = await renderFrame(<App />);
+
+    expect(frame).toContain("row:t-1");
+    expect(frame).toContain("row:t-2");
+  });
+});

--- a/packages/react-ink/src/tests/ThreadListItemScope.test.tsx
+++ b/packages/react-ink/src/tests/ThreadListItemScope.test.tsx
@@ -24,8 +24,8 @@ const App: FC = () => {
       threadList: {
         threadId: "t-1",
         threads: [
-          { id: "t-1", title: "First" },
-          { id: "t-2", title: "Second" },
+          { id: "t-1", title: "First", status: "regular" },
+          { id: "t-2", title: "Second", status: "regular" },
         ],
         onSwitchToThread: async () => {},
       },

--- a/packages/react-ink/src/tests/ThreadListItems.test.tsx
+++ b/packages/react-ink/src/tests/ThreadListItems.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup } from "ink-testing-library";
+import type { ReactNode } from "react";
+import { Text } from "ink";
+import { renderFrame, type UseAuiStateSelector } from "./helpers";
+
+const capturedProviderProps = vi.fn();
+const mockUseAuiState = vi.fn();
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: (selector: UseAuiStateSelector) => mockUseAuiState(selector),
+  };
+});
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@assistant-ui/core/react")>();
+  return {
+    ...actual,
+    ThreadListItemByIndexProvider: ({
+      index,
+      archived,
+      children,
+    }: {
+      index: number;
+      archived: boolean;
+      children?: ReactNode;
+    }) => {
+      capturedProviderProps({ index, archived });
+      return <>{children}</>;
+    },
+  };
+});
+
+const { ThreadListPrimitive } = await import("../index");
+
+const mockThreadIds = (threadIds: string[]) => {
+  mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) =>
+    selector({ threads: { threadIds } } as never),
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ThreadListPrimitive.Items", () => {
+  it("renders rows without a missing-key warning", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockThreadIds(["t-1", "t-2"]);
+
+    await renderFrame(
+      <ThreadListPrimitive.Items
+        renderItem={({ threadId }) => <Text>{threadId}</Text>}
+      />,
+    );
+
+    const keyWarnings = errorSpy.mock.calls.filter((call) =>
+      String(call[0]).includes('unique "key" prop'),
+    );
+    expect(keyWarnings).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it("wraps each row in ThreadListItemByIndexProvider with its index", async () => {
+    mockThreadIds(["t-1", "t-2", "t-3"]);
+
+    const frame = await renderFrame(
+      <ThreadListPrimitive.Items
+        renderItem={({ threadId }) => <Text>{threadId}</Text>}
+      />,
+    );
+
+    expect(capturedProviderProps.mock.calls.map((call) => call[0])).toEqual([
+      { index: 0, archived: false },
+      { index: 1, archived: false },
+      { index: 2, archived: false },
+    ]);
+    expect(frame).toContain("t-1");
+    expect(frame).toContain("t-3");
+  });
+
+  it("passes threadId and index to renderItem", async () => {
+    const renderItem = vi.fn(
+      ({ threadId }: { threadId: string; index: number }) => (
+        <Text>{threadId}</Text>
+      ),
+    );
+    mockThreadIds(["a", "b"]);
+
+    await renderFrame(<ThreadListPrimitive.Items renderItem={renderItem} />);
+
+    expect(renderItem.mock.calls.map((call) => call[0])).toEqual([
+      { threadId: "a", index: 0 },
+      { threadId: "b", index: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

`ThreadListPrimitive.Items` in react-ink now wraps each `renderItem` row in `ThreadListItemByIndexProvider` (imported from `@assistant-ui/core/react`) with a React key. The `renderItem` prop and its signature are unchanged.

## Why

Rows were rendered with no per-item scope provider and no keys. The root scope only registers `threads`, so any `ThreadListItemPrimitive.*` used inside `renderItem` throws (`The current scope does not have a "threadListItem" property.`): Title crashes the render, and Trigger, Delete, Archive, and Unarchive throw on press. This is exactly the composition the ink docs show for ThreadList, so the documented thread list is unusable today. The missing keys additionally trigger React's missing-key warning and positional reconciliation hazards on list mutation.

## Impact

- The documented composition (ink `primitives.mdx` ThreadList and ThreadListItem examples) now works as written; no docs change needed because no documented claim changes.
- No new public surface: `ThreadListItemsProps` is byte-identical, and no new exports (the provider was already re-exported from ink's barrel).
- No layout or output change: the provider renders no host element, only context.
- No consumer regression possible: the previous behavior was a crash, and no in-repo example or template uses ink's `ThreadListPrimitive.Items`.
- New tests in `src/tests/ThreadListItems.test.tsx`: provider wrapping with correct per-row index and `archived: false`, `renderItem` receiving `{threadId, index}`, and a missing-key warning regression guard. Both wiring tests fail against the old code and pass with the fix.
- Changeset: patch on `@assistant-ui/react-ink`.
- Full react-ink suite (234 tests), repo lint, and full turbo build (86 tasks) all pass.

## Rationale

The fix mirrors core's shared `ThreadListPrimitiveItems` implementation, which wraps each row in `ThreadListItemByIndexProvider` keyed by index.  use threadId rather than index (per review): core keys by index only because it subscribes to list length alone and never has the ids in hand, while this already maps over threadIds, so keying by thread id is free and keeps React row identity (and any row-local state in renderItem) with the thread across/delete/reorder. The provider stays index-addressed; its index prop updates from the map callback in the same render.`archived={false}` is correct rather than a guessed default because `s.threads.threadIds` contains only non-archived threads (`archivedThreadIds` is a separate field on the threads scope). Archived list support and a children render-fn API for core parity are deliberately out of scope here since they add new public surface; they can follow as their own PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

