### PR TITLE
feat(react-ink): export flat Props aliases from the messagePart and statusBar barrels

### DIFF
--- a/.changeset/ink-barrel-props-aliases.md
+++ b/.changeset/ink-barrel-props-aliases.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat: export flat Props aliases from the messagePart and statusBar barrels

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -4535,7 +4535,7 @@ declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<T
 declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
 
 declare namespace messagePart_d_exports {
-  export { MessagePartPrimitiveData as Data, MessagePartPrimitiveFile as File, MessagePartPrimitiveImage as Image, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveReasoning as Reasoning, MessagePartPrimitiveSource as Source, MessagePartPrimitiveText as Text };
+  export { MessagePartPrimitiveData as Data, MessagePartPrimitiveDataProps as DataProps, MessagePartPrimitiveFile as File, MessagePartPrimitiveFileProps as FileProps, MessagePartPrimitiveImage as Image, MessagePartPrimitiveImageProps as ImageProps, MessagePartPrimitiveInProgress as InProgress, PartPrimitiveMessages as Messages, MessagePartPrimitiveReasoning as Reasoning, MessagePartPrimitiveReasoningProps as ReasoningProps, MessagePartPrimitiveSource as Source, MessagePartPrimitiveSourceProps as SourceProps, MessagePartPrimitiveText as Text, MessagePartPrimitiveTextProps as TextProps };
 }
 
 declare namespace message_d_exports {
@@ -4553,7 +4553,7 @@ declare const ringBell: () => void;
 declare const sendOSCNotification: (title: string, body?: string, variant?: OSCVariant) => void;
 
 declare namespace statusBar_d_exports {
-  export { StatusBarPrimitiveLatency as Latency, StatusBarPrimitiveMessageCount as MessageCount, StatusBarPrimitiveModelName as ModelName, StatusBarPrimitiveRoot as Root, StatusBarPrimitiveStatus as Status, StatusType, StatusBarPrimitiveTokenCount as TokenCount };
+  export { StatusBarPrimitiveLatency as Latency, StatusBarPrimitiveLatencyProps as LatencyProps, StatusBarPrimitiveMessageCount as MessageCount, StatusBarPrimitiveMessageCountProps as MessageCountProps, StatusBarPrimitiveModelName as ModelName, StatusBarPrimitiveModelNameProps as ModelNameProps, StatusBarPrimitiveRoot as Root, StatusBarPrimitiveRootProps as RootProps, StatusBarPrimitiveStatus as Status, StatusBarPrimitiveStatusProps as StatusProps, StatusType, StatusBarPrimitiveTokenCount as TokenCount, StatusBarPrimitiveTokenCountProps as TokenCountProps };
 }
 
 declare function stubTool(): never;

--- a/packages/react-ink/src/primitives/messagePart.ts
+++ b/packages/react-ink/src/primitives/messagePart.ts
@@ -1,9 +1,27 @@
-export { MessagePartPrimitiveText as Text } from "./messagePart/MessagePartText";
-export { MessagePartPrimitiveImage as Image } from "./messagePart/MessagePartImage";
-export { MessagePartPrimitiveFile as File } from "./messagePart/MessagePartFile";
-export { MessagePartPrimitiveSource as Source } from "./messagePart/MessagePartSource";
-export { MessagePartPrimitiveReasoning as Reasoning } from "./messagePart/MessagePartReasoning";
-export { MessagePartPrimitiveData as Data } from "./messagePart/MessagePartData";
+export {
+  MessagePartPrimitiveText as Text,
+  type MessagePartPrimitiveTextProps as TextProps,
+} from "./messagePart/MessagePartText";
+export {
+  MessagePartPrimitiveImage as Image,
+  type MessagePartPrimitiveImageProps as ImageProps,
+} from "./messagePart/MessagePartImage";
+export {
+  MessagePartPrimitiveFile as File,
+  type MessagePartPrimitiveFileProps as FileProps,
+} from "./messagePart/MessagePartFile";
+export {
+  MessagePartPrimitiveSource as Source,
+  type MessagePartPrimitiveSourceProps as SourceProps,
+} from "./messagePart/MessagePartSource";
+export {
+  MessagePartPrimitiveReasoning as Reasoning,
+  type MessagePartPrimitiveReasoningProps as ReasoningProps,
+} from "./messagePart/MessagePartReasoning";
+export {
+  MessagePartPrimitiveData as Data,
+  type MessagePartPrimitiveDataProps as DataProps,
+} from "./messagePart/MessagePartData";
 export {
   MessagePartPrimitiveInProgress as InProgress,
   PartPrimitiveMessages as Messages,

--- a/packages/react-ink/src/primitives/statusBar.ts
+++ b/packages/react-ink/src/primitives/statusBar.ts
@@ -1,9 +1,25 @@
-export { StatusBarPrimitiveRoot as Root } from "./statusBar/StatusBarRoot";
-export { StatusBarPrimitiveModelName as ModelName } from "./statusBar/StatusBarModelName";
-export { StatusBarPrimitiveMessageCount as MessageCount } from "./statusBar/StatusBarMessageCount";
-export { StatusBarPrimitiveTokenCount as TokenCount } from "./statusBar/StatusBarTokenCount";
-export { StatusBarPrimitiveLatency as Latency } from "./statusBar/StatusBarLatency";
+export {
+  StatusBarPrimitiveRoot as Root,
+  type StatusBarPrimitiveRootProps as RootProps,
+} from "./statusBar/StatusBarRoot";
+export {
+  StatusBarPrimitiveModelName as ModelName,
+  type StatusBarPrimitiveModelNameProps as ModelNameProps,
+} from "./statusBar/StatusBarModelName";
+export {
+  StatusBarPrimitiveMessageCount as MessageCount,
+  type StatusBarPrimitiveMessageCountProps as MessageCountProps,
+} from "./statusBar/StatusBarMessageCount";
+export {
+  StatusBarPrimitiveTokenCount as TokenCount,
+  type StatusBarPrimitiveTokenCountProps as TokenCountProps,
+} from "./statusBar/StatusBarTokenCount";
+export {
+  StatusBarPrimitiveLatency as Latency,
+  type StatusBarPrimitiveLatencyProps as LatencyProps,
+} from "./statusBar/StatusBarLatency";
 export {
   StatusBarPrimitiveStatus as Status,
+  type StatusBarPrimitiveStatusProps as StatusProps,
   type StatusType,
 } from "./statusBar/StatusBarStatus";


### PR DESCRIPTION
## What

Adds the missing flat `XxxProps` type re-exports to two react-ink primitive barrels: `messagePart.ts` gains TextProps, ImageProps, FileProps, SourceProps, ReasoningProps, and DataProps; `statusBar.ts` gains RootProps, ModelNameProps, MessageCountProps, TokenCountProps, LatencyProps, and StatusProps (the existing `StatusType` export stays). Each alias re-exports a flat props type that already exists in the corresponding component file, using the exact export shape the other barrels use.

## Why

react-ink's documented convention is flat `XxxProps` types with full Ink component pass-through, and every other primitive barrel (actionBar, composer, thread, branchPicker, and the rest) exports the aliases alongside the components. These two barrels accidentally omit them, so a consumer wrapping `MessagePartPrimitive.Text` or `StatusBarPrimitive.TokenCount` can only reach the legacy namespace-pattern `.Props` or fall back to `ComponentProps<typeof ...>`, instead of the documented `MessagePartPrimitive.TextProps` shape.

## Impact

- Purely additive and append-only: 12 type-only aliases, no export removed, renamed, or reshaped, no runtime output change.
- Verified in the built dts: `MessagePartPrimitive.TextProps`, `StatusBarPrimitive.StatusProps`, etc. now surface through the `export * as` namespaces in the package index.
- Full `pnpm turbo run build` green (86/86 tasks) and the react-ink suite passes (231 tests).
- Patch changeset for `@assistant-ui/react-ink`.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

