### PR TITLE
ci: allow autofix-ci pushes to trigger claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -119,6 +119,7 @@ jobs:
         uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # ratchet:anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: autofix-ci
           prompt: ${{ env.REVIEW_PROMPT }}
           use_sticky_comment: ${{ fromJSON(env.USE_STICKY_COMMENT) }}
           track_progress: ${{ fromJSON(env.TRACK_PROGRESS) }}


### PR DESCRIPTION
## Summary

When autofix.ci pushes a commit (lint fix or regenerated api-surface snapshot), the `synchronize` event it triggers is actored by `autofix-ci[bot]`, and claude-code-action refuses bot actors: `Workflow initiated by non-human actor: autofix-ci (type: Bot)`. Since the concurrency group already cancelled the run on the human commit, the PR ends up with a red `claude-review` check and no review (e.g. #4888, run 29266747057).

This adds `allowed_bots: autofix-ci` to the Review step, the action's supported allowlist for exactly this case. Scoped to the one bot rather than `*`, so arbitrary bot pushes still can't trigger a review; the action's write-permission gate already passes `[bot]` actors, so this is the only change needed. As a bonus the review now runs against the autofix-amended head, which is the code that actually merges.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

