### PR TITLE
fix(cli): include installed assistant-ui packages in info

### DIFF
--- a/.changeset/cli-info-installed-packages.md
+++ b/.changeset/cli-info-installed-packages.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: include declared assistant-ui packages in info output

--- a/.changeset/cli-info-semver-ranges.md
+++ b/.changeset/cli-info-semver-ranges.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: validate peer dependency ranges using semver

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,8 @@
     "detect-package-manager": "^3.0.2",
     "giget": "^3.3.0",
     "glob": "^13.0.6",
-    "jscodeshift": "^17.3.0"
+    "jscodeshift": "^17.3.0",
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
@@ -51,6 +52,7 @@
     "@types/debug": "^4.1.13",
     "@types/jscodeshift": "^17.3.0",
     "@types/node": "^26.1.1",
+    "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^4.1.10",
     "vitest": "^4.1.10"
   },

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
+import { satisfies } from "semver";
 
 const ASSISTANT_UI_PACKAGES = [
   // Distribution
@@ -198,27 +199,8 @@ async function getPackageManagerInfo(
   return { name: pm, version };
 }
 
-function satisfiesRange(version: string, range: string): boolean {
-  if (range === "*" || range === "any") return true;
-
-  const clean = (v: string) => v.replace(/^[^\d]*/, "");
-  const major = (v: string) => parseInt(clean(v).split(".")[0]!, 10);
-
-  if (range.includes("||")) {
-    return range
-      .split("||")
-      .some((part) => satisfiesRange(version, part.trim()));
-  }
-
-  const rangeMajor = major(range);
-  const versionMajor = major(version);
-
-  if (Number.isNaN(rangeMajor) || Number.isNaN(versionMajor)) return true;
-
-  if (range.startsWith("^")) return versionMajor >= rangeMajor;
-  if (range.startsWith(">=")) return versionMajor >= rangeMajor;
-
-  return versionMajor >= rangeMajor;
+export function satisfiesRange(version: string, range: string): boolean {
+  return range === "any" || satisfies(version, range);
 }
 
 interface PackageInfo {

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -117,6 +117,16 @@ function readProjectDeps(
   };
 }
 
+function getAssistantUiPackageNames(
+  projectPkg: Record<string, unknown>,
+): string[] {
+  const declaredPackages = Object.keys(readProjectDeps(projectPkg))
+    .filter((name) => name.startsWith("@assistant-ui/"))
+    .sort();
+
+  return [...new Set([...ASSISTANT_UI_PACKAGES, ...declaredPackages])];
+}
+
 function getSpecifiedRange(
   pkg: string,
   projectPkg: Record<string, unknown>,
@@ -288,7 +298,11 @@ async function collectInfo(
   projectPkg: Record<string, unknown>,
 ): Promise<InfoData> {
   const pm = await getPackageManagerInfo(cwd);
-  const packages = collectPackages(ASSISTANT_UI_PACKAGES, cwd, projectPkg);
+  const packages = collectPackages(
+    getAssistantUiPackageNames(projectPkg),
+    cwd,
+    projectPkg,
+  );
   const ecosystem = collectPackages(ECOSYSTEM_PACKAGES, cwd, projectPkg);
   const warnings = collectWarnings(packages, cwd, projectPkg);
 

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { satisfiesRange } from "../../src/commands/info";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { info, satisfiesRange } from "../../src/commands/info";
+
+function writePackage(
+  root: string,
+  name: string,
+  packageJson: Record<string, unknown>,
+) {
+  const directory = path.join(root, "node_modules", ...name.split("/"));
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, "package.json"),
+    JSON.stringify({ name, ...packageJson }),
+  );
+}
 
 describe("satisfiesRange", () => {
   it.each([
@@ -24,5 +40,53 @@ describe("satisfiesRange", () => {
 
   it.each(["*", "any"])("accepts the unrestricted %s range", (range) => {
     expect(satisfiesRange("20.0.0", range)).toBe(true);
+  });
+});
+
+describe("info command", () => {
+  it("includes declared assistant-ui integrations and their peer warnings", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-"));
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          name: "fixture",
+          dependencies: {
+            "@assistant-ui/react-mcp": "0.0.17",
+            "assistant-stream": "0.3.25",
+            react: "20.0.0",
+          },
+          devDependencies: {
+            "@assistant-ui/react-generative-ui": "0.0.7",
+          },
+        }),
+      );
+      writePackage(root, "@assistant-ui/react-mcp", {
+        version: "0.0.17",
+        peerDependencies: { react: "^18 || ^19" },
+      });
+      writePackage(root, "@assistant-ui/react-generative-ui", {
+        version: "0.0.7",
+      });
+      writePackage(root, "assistant-stream", { version: "0.3.25" });
+      writePackage(root, "react", { version: "20.0.0" });
+
+      await info.parseAsync(["node", "info", "--cwd", root], {
+        from: "node",
+      });
+
+      const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("@assistant-ui/react-mcp");
+      expect(output).toContain("@assistant-ui/react-generative-ui");
+      expect(output).toContain("assistant-stream");
+      expect(output).toContain(
+        "@assistant-ui/react-mcp requires react ^18 || ^19, found 20.0.0",
+      );
+    } finally {
+      consoleLog.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { satisfiesRange } from "../../src/commands/info";
+
+describe("satisfiesRange", () => {
+  it.each([
+    ["18.3.1", "^18 || ^19"],
+    ["19.2.0", "^18 || ^19"],
+    ["7.0.0", "^5 || ^6 || ^7"],
+    ["0.15.4", "^0.15.0"],
+    ["0.5.0", ">=0.5.0"],
+  ])("accepts %s for %s", (version, range) => {
+    expect(satisfiesRange(version, range)).toBe(true);
+  });
+
+  it.each([
+    ["20.0.0", "^18 || ^19"],
+    ["8.0.0", "^5 || ^6 || ^7"],
+    ["0.14.9", "^0.15.0"],
+    ["0.16.0", "^0.15.0"],
+    ["0.4.9", ">=0.5.0"],
+  ])("rejects %s for %s", (version, range) => {
+    expect(satisfiesRange(version, range)).toBe(false);
+  });
+
+  it.each(["*", "any"])("accepts the unrestricted %s range", (range) => {
+    expect(satisfiesRange("20.0.0", range)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3402,6 +3402,9 @@ importers:
       jscodeshift:
         specifier: ^17.3.0
         version: 17.3.0
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
     devDependencies:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
@@ -3421,6 +3424,9 @@ importers:
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@vitest/coverage-v8':
         specifier: ^4.1.10
         version: 4.1.10(vitest@4.1.10)


### PR DESCRIPTION
> Follow-up to #4886. This PR targets `main` and should merge after #4886 because it builds on the semver diagnostics change.

## Summary

- preserve the known package list, including `assistant-stream`, `assistant-cloud`, and transitive core packages
- append declared dependencies and devDependencies whose names start with `@assistant-ui/`
- deduplicate package names and keep newly discovered integrations in deterministic order
- run existing peer-dependency diagnostics for those integrations

## Problem

While testing `assistant-ui info` in a project using `@assistant-ui/react-mcp`, I found that the command omitted the integration entirely because package discovery only iterated a hardcoded list. The same applied to packages such as `@assistant-ui/react-generative-ui`, `@assistant-ui/react-pi`, and `@assistant-ui/react-opencode`.

A fixture containing `@assistant-ui/react-mcp`, `@assistant-ui/react-generative-ui`, and `assistant-stream` previously printed only:

```text
Packages:
  assistant-stream  0.3.25
```

Because peer warnings are computed from the collected package list, the omitted MCP integration's incompatible React peer was also never reported.

## Result

The same fixture now includes all three packages and reports:

```text
Warnings:
  ! @assistant-ui/react-mcp requires react ^18 || ^19, found 20.0.0
```

## Verification

- reproduced the missing integrations with the end-to-end CLI test before changing discovery
- 13 focused `info` tests pass
- all 225 CLI tests pass
- CLI package build passes
- targeted oxlint and oxfmt checks pass
- manually ran the built command against the fixture and verified its rendered package list and warning