### PR TITLE
fix(react-langgraph): forward threadId and initialThreadId to the thread list runtime

### DIFF
--- a/.changeset/langgraph-forward-threadid.md
+++ b/.changeset/langgraph-forward-threadid.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: forward `threadId` and `initialThreadId` from `useLangGraphRuntime` to the underlying thread list runtime, so URL-based thread routing (`threadId` in, `onThreadIdChange` out) works with LangGraph the same way it does with the base runtime

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -2087,6 +2087,8 @@ type Unstable_AudioMessagePart = {
 type Unsubscribe = () => void;
 
 type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
+  initialThreadId?: string | undefined;
+  threadId?: string | undefined;
   onThreadIdChange?: ((threadId: string | undefined) => void) | undefined;
   autoCancelPendingToolCalls?: boolean | undefined;
   unstable_allowCancellation?: boolean | undefined;

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -268,6 +268,19 @@ export type LangGraphRuntimeExtras = {
 
 export type UseLangGraphRuntimeOptions = ExternalStoreSharedOptions & {
   /**
+   * When provided, the runtime starts on this thread instead of creating a new
+   * empty thread. Useful for URL-based routing (e.g. `/chat/[threadId]`).
+   *
+   * @deprecated Use `threadId` instead, which also reacts to subsequent changes.
+   */
+  initialThreadId?: string | undefined;
+  /**
+   * The current thread ID to display. When this value changes, the runtime
+   * automatically switches to the specified thread. Set to `undefined` to
+   * switch to a new thread.
+   */
+  threadId?: string | undefined;
+  /**
    * Called whenever the active thread's canonical (remote) ID changes, so the
    * value can be treated as a managed/controlled variable (e.g. synced to a URL
    * query param). Only the settled remote ID is emitted: while a freshly created

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -647,6 +647,34 @@ describe("useLangGraphRuntime", () => {
     );
   });
 
+  it("forwards threadId so the runtime switches to the specified thread", async () => {
+    const fetch = vi.fn(async (threadId: string) => ({
+      status: "regular" as const,
+      remoteId: threadId,
+      externalId: threadId,
+    }));
+    // Empty list so switching has to fetch the routed thread instead of finding
+    // it already loaded.
+    const adapter: RemoteThreadListAdapter = {
+      ...makeThreadListAdapter(),
+      list: vi.fn(async () => ({ threads: [] })),
+      fetch,
+    };
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+
+    renderHook(() =>
+      useLangGraphRuntime({
+        stream: streamMock,
+        unstable_threadListAdapter: adapter,
+        threadId: "lg-thread-1",
+      }),
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith("lg-thread-1"));
+  });
+
   it("invokes user-provided create when stream calls initialize without cloud", async () => {
     const userCreate = vi.fn(async () => ({ externalId: "lg-thread-xyz" }));
 

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -609,6 +609,8 @@ export const useLangGraphRuntime = ({
   create,
   delete: deleteFn,
   onThreadIdChange,
+  threadId,
+  initialThreadId,
   ...options
 }: UseLangGraphRuntimeOptions) => {
   const aui = useAui();
@@ -637,5 +639,7 @@ export const useLangGraphRuntime = ({
     adapter,
     allowNesting: true,
     onThreadIdChange,
+    threadId,
+    initialThreadId,
   });
 };


### PR DESCRIPTION
Fixes #4889.

`useLangGraphRuntime` already forwards `onThreadIdChange` to `useRemoteThreadListRuntime`, where the reactive thread-switching logic lives, but `threadId` and `initialThreadId` fall into the `...options` rest spread. That only reaches `useLangGraphRuntimeImpl`, which doesn't read them, so they never get to `useRemoteThreadListRuntime`. The result is that URL-based thread routing (`threadId` in, `onThreadIdChange` out) works for the base `useRemoteThreadListRuntime` API but is a silent no-op through the LangGraph wrapper — and since `UseLangGraphRuntimeOptions` didn't declare the fields, passing them wasn't even a type error.

Destructured `threadId`/`initialThreadId` alongside `onThreadIdChange` and forwarded them the same way, and added both to `UseLangGraphRuntimeOptions`. The wrapper is thin over the same hook, so this just restores parity with the output half it already forwards.

Added a test that supplying `threadId` drives a switch to that thread (with an empty thread list so the switch has to fetch it); it fails on `main` and passes with the change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

