### PR TITLE
fix(react-google-adk): normalize session api urls

### DIFF
--- a/.changeset/google-adk-session-api-urls.md
+++ b/.changeset/google-adk-session-api-urls.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: normalize trailing slashes in ADK session API URLs

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -342,19 +342,22 @@ describe("createAdkSessionAdapter - load", () => {
 // ── URL construction ──
 
 describe("createAdkSessionAdapter - URL construction", () => {
-  it("normalizes a trailing slash in apiUrl", async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify([]), { status: 200 }),
-    );
+  it.each(["http://localhost:8000/", "http://localhost:8000//"])(
+    "normalizes trailing slashes in apiUrl: %s",
+    async (apiUrl) => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify([]), { status: 200 }),
+      );
 
-    const { adapter } = createAdkSessionAdapter({
-      ...baseOptions,
-      apiUrl: "http://localhost:8000/",
-    });
-    await adapter.list();
+      const { adapter } = createAdkSessionAdapter({
+        ...baseOptions,
+        apiUrl,
+      });
+      await adapter.list();
 
-    expect(mockFetch.mock.calls[0]![0]).toBe(expectedBaseUrl);
-  });
+      expect(mockFetch.mock.calls[0]![0]).toBe(expectedBaseUrl);
+    },
+  );
 
   it("encodes special characters in appName and userId", async () => {
     mockFetch.mockResolvedValueOnce(

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -339,9 +339,23 @@ describe("createAdkSessionAdapter - load", () => {
   });
 });
 
-// ── URL encoding ──
+// ── URL construction ──
 
-describe("createAdkSessionAdapter - URL encoding", () => {
+describe("createAdkSessionAdapter - URL construction", () => {
+  it("normalizes a trailing slash in apiUrl", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    const { adapter } = createAdkSessionAdapter({
+      ...baseOptions,
+      apiUrl: "http://localhost:8000/",
+    });
+    await adapter.list();
+
+    expect(mockFetch.mock.calls[0]![0]).toBe(expectedBaseUrl);
+  });
+
   it("encodes special characters in appName and userId", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify([]), { status: 200 }),

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -79,7 +79,8 @@ export function createAdkSessionAdapter(
   options: AdkSessionAdapterOptions,
 ): AdkSessionAdapterResult {
   const { apiUrl, appName, userId } = options;
-  const baseUrl = `${apiUrl}/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`;
+  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+  const baseUrl = `${normalizedApiUrl}/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`;
 
   const getHeaders = async (): Promise<Record<string, string>> => {
     if (!options.headers) return {};

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -56,6 +56,12 @@ type AdkSessionAdapterResult = {
   };
 };
 
+const trimTrailingSlashes = (value: string) => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+};
+
 /**
  * Creates a `RemoteThreadListAdapter` backed by ADK's session REST API,
  * plus a `load` function that reconstructs messages from session events.
@@ -79,7 +85,7 @@ export function createAdkSessionAdapter(
   options: AdkSessionAdapterOptions,
 ): AdkSessionAdapterResult {
   const { apiUrl, appName, userId } = options;
-  const normalizedApiUrl = apiUrl.replace(/\/+$/, "");
+  const normalizedApiUrl = trimTrailingSlashes(apiUrl);
   const baseUrl = `${normalizedApiUrl}/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`;
 
   const getHeaders = async (): Promise<Record<string, string>> => {

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -79,7 +79,7 @@ export function createAdkSessionAdapter(
   options: AdkSessionAdapterOptions,
 ): AdkSessionAdapterResult {
   const { apiUrl, appName, userId } = options;
-  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+  const normalizedApiUrl = apiUrl.replace(/\/+$/, "");
   const baseUrl = `${normalizedApiUrl}/apps/${encodeURIComponent(appName)}/users/${encodeURIComponent(userId)}/sessions`;
 
   const getHeaders = async (): Promise<Record<string, string>> => {


### PR DESCRIPTION
## Summary

- strip trailing slashes from the Google ADK `apiUrl` before constructing session endpoints
- keep existing URL encoding for app, user, session, and artifact identifiers
- add regression coverage for `apiUrl` values ending in one or multiple slashes
- add a patch changeset for `@assistant-ui/react-google-adk`

## Problem

While configuring a local ADK server with:

```ts
apiUrl: "http://localhost:8000/"
```

I found that session requests were constructed with a double slash:

```text
http://localhost:8000//apps/my-app/users/user-1/sessions
```

Permissive development servers may normalize this silently, but strict routers and reverse proxies can treat `//apps/...` as a different path, return a 404, or redirect the request. A redirect is especially problematic for session creation because some redirect responses can change a `POST` into a `GET`.

## Fix

Normalize the configured API URL once before building the shared session base URL. All session and artifact operations then inherit the canonical path, while configurations without trailing slashes remain unchanged.

## Verification

- focused `AdkSessionAdapter` suite: 26 tests passed
- full `@assistant-ui/react-google-adk` suite: 186 tests passed
- package and dependency builds passed
- full repository lint and format checks passed
- changeset validation reports a patch bump
- real local HTTP smoke tests confirmed inputs ending in `/` and `//` both reach `/apps/my%20app/users/user-1/sessions`, not `//apps/...`