### PR TITLE
ci: fix the template sync install and api-reference drift on main

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -90,7 +90,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install root tooling
-        run: pnpm install --frozen-lockfile --filter .
+        run: pnpm install --frozen-lockfile --filter . --ignore-scripts
 
       - name: Verify templates match packages/ui source
         run: bash scripts/sync-templates.sh

--- a/apps/docs/content/docs/(reference)/api-reference/generative-ui/rendering.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/generative-ui/rendering.mdx
@@ -18,10 +18,11 @@ import { GenerativeUIRender, GenerativeUIRenderContext, GenerativeUIRenderError,
 
 Builds the JSON schema for the `present` tool from a [GenerativeUILibrary](/docs/api-reference/generative-ui/components#generativeuilibrary).
 
-The model produces a node `{ $type,...props }` where `$type` selects a
-component and the rest are its props. The schema is a flat object: `$type` is
-an enum of the component names, every component's props are merged into one
-optional bag, and `children` recurses via `$defs` so the tree can nest.
+The model produces a node `{ $type, $key?,...props }` where `$type` selects
+a component, the optional `$key` pins a stable identity for list items that
+may reorder, and the rest are its props. The schema is a flat object: `$type`
+is an enum of the component names, every component's props are merged into
+one optional bag, and `children` recurses via `$defs` so the tree can nest.
 
 It is intentionally flat rather than a per-`$type` discriminated union. Tool /
 function-call schemas (OpenAI and others) require the top-level parameters to
@@ -62,6 +63,7 @@ Serializes a generative-UI node to a JSX-like string for display — the
 "view source" of a model-produced tree. The wire form
 `{ $type: "Weather", id: "x" }` becomes `<Weather id="x" />`, and nested
 `children` render between tags: `<Card title="Hi"><Text>hello</Text></Card>`.
+A model-provided `$key` becomes the JSX `key` attribute.
 
 It is a faithful textual rendering, not a parser: text children are emitted
 verbatim (not HTML/JSX-escaped), so the result is meant to be shown, not


### PR DESCRIPTION
## summary

- main's Code Quality workflow is red on two jobs since the latest merges; this makes both green again
- Template Sync: the root filtered install from #4836 triggers the root `prepare` script, which runs the react-devtools `build:css` without that package's dependencies installed and crashes the job before the sync check even runs; the install step now passes `--ignore-scripts` (oxfmt, the tooling #4836 wanted on the job, has no lifecycle scripts and stays available)
- API Reference Drift: #4657 updated the `$key` JSDoc in react-generative-ui without regenerating the reference page, which predates the drift gate from #4850, so the gate flags it on every main push; `rendering.mdx` is regenerated so the tree matches the generator output again

## test plan

### already verified

- [x] reproduced the Template Sync failure in a clean clone: `pnpm install --frozen-lockfile --filter .` fails with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL` on react-devtools `build:css`, and the same install with `--ignore-scripts` succeeds from an empty node_modules, after which `pnpm exec oxfmt --version` works and `bash scripts/sync-templates.sh` passes
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` on main produces exactly the committed `rendering.mdx` (byte identical to the diff the drift gate printed on run 29303639952) and leaves the rest of the tree clean

### reviewer should verify

- [ ] this PR's own Template Sync and API Reference Drift checks pass, which exercises both fixes end to end

## notes

- the Changesets job failure on the #4850 push was a separate transient (three back to back merges raced to push a stale workflow state to changeset-release/main, which the app token may not do); it resolved itself on the following runs and needs no change here
- no changeset, neither file belongs to a published package

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

