### PR TITLE
feat(react-ag-ui): surface ACTIVITY_SNAPSHOT results on tool parts

### DIFF
--- a/.changeset/surface-mcp-app-snapshots.md
+++ b/.changeset/surface-mcp-app-snapshots.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: surface the mcp-apps ACTIVITY_SNAPSHOT CallToolResult on the tool part result while preserving the model-facing text for subsequent runs

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -1,7 +1,10 @@
 "use client";
 
 import type { InputContent } from "@ag-ui/client";
-import type { ThreadMessageLike as CoreThreadMessageLike } from "@assistant-ui/core";
+import type {
+  ThreadMessageLike as CoreThreadMessageLike,
+  ToolModelContentPart,
+} from "@assistant-ui/core";
 import { getAutoStatus } from "@assistant-ui/core/internal";
 import { type Tool, toToolsJSONSchema } from "assistant-stream";
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
@@ -59,6 +62,7 @@ type ToolCallPart = {
   args?: ReadonlyJSONObject;
   result?: unknown;
   isError?: boolean;
+  modelContent?: readonly ToolModelContentPart[];
   unstable_toolMessageId?: string;
 };
 
@@ -715,10 +719,16 @@ function convertAssistantMessage(
   for (const { id: toolCallId, part } of toolCalls) {
     if (part.result === undefined) continue;
 
+    const modelContent = part.modelContent?.filter(
+      (content): content is Extract<ToolModelContentPart, { type: "text" }> =>
+        content.type === "text",
+    );
     const resultContent =
-      typeof part.result === "string"
-        ? part.result
-        : JSON.stringify(part.result);
+      modelContent && modelContent.length > 0
+        ? modelContent.map((content) => content.text).join("\n")
+        : typeof part.result === "string"
+          ? part.result
+          : JSON.stringify(part.result);
 
     const toolMessage: AgUiMessage = {
       id: part.unstable_toolMessageId ?? `${toolCallId}:tool`,

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -719,13 +719,10 @@ function convertAssistantMessage(
   for (const { id: toolCallId, part } of toolCalls) {
     if (part.result === undefined) continue;
 
-    const modelContent = part.modelContent?.filter(
-      (content): content is Extract<ToolModelContentPart, { type: "text" }> =>
-        content.type === "text",
-    );
+    const modelText = extractText(part.modelContent);
     const resultContent =
-      modelContent && modelContent.length > 0
-        ? modelContent.map((content) => content.text).join("\n")
+      modelText.length > 0
+        ? modelText
         : typeof part.result === "string"
           ? part.result
           : JSON.stringify(part.result);

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -6,6 +6,7 @@ import {
   type MessageTiming,
   type ThreadAssistantMessagePart,
   type ToolCallMessagePart,
+  type ToolModelContentPart,
 } from "@assistant-ui/core";
 import type { AgUiEvent, AgUiInterrupt } from "../types";
 import type { Logger } from "../logger";
@@ -28,9 +29,13 @@ type ToolCallState = {
   parentMessageId?: string;
   toolMessageId?: string;
   mcpAppResourceUri?: string;
+  modelContent?: ToolModelContentPart[];
 };
 
 const MCP_APPS_ACTIVITY_TYPE = "mcp-apps";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
 
 export type RunAggregatorOptions = {
   showThinking: boolean;
@@ -236,8 +241,13 @@ export class RunAggregator {
       }
       case "ACTIVITY_SNAPSHOT": {
         if (event.activityType !== MCP_APPS_ACTIVITY_TYPE) break;
-        const id = this.lastResolvedToolCallId;
-        const entry = id ? this.toolCalls.get(id) : undefined;
+        const toolCallId = event.content.toolCallId;
+        const entry =
+          typeof toolCallId === "string"
+            ? this.toolCalls.get(toolCallId)
+            : this.lastResolvedToolCallId
+              ? this.toolCalls.get(this.lastResolvedToolCallId)
+              : undefined;
         const resourceUri = event.content.resourceUri;
         if (
           entry &&
@@ -245,6 +255,27 @@ export class RunAggregator {
           isMcpAppUri(resourceUri)
         ) {
           entry.mcpAppResourceUri = resourceUri;
+          const result = event.content.result;
+          if (isPlainObject(result)) {
+            if (
+              entry.result !== undefined &&
+              entry.modelContent === undefined
+            ) {
+              entry.modelContent = [
+                {
+                  type: "text",
+                  text:
+                    typeof entry.result === "string"
+                      ? entry.result
+                      : JSON.stringify(entry.result),
+                },
+              ];
+            }
+            entry.result = result;
+            if (typeof result.isError === "boolean") {
+              entry.isError = result.isError;
+            }
+          }
           this.emit();
         }
         break;
@@ -460,6 +491,9 @@ export class RunAggregator {
         args: (entry.parsedArgs ?? {}) as any,
         argsText: entry.argsText,
         ...(entry.result !== undefined ? { result: entry.result } : {}),
+        ...(entry.modelContent !== undefined
+          ? { modelContent: entry.modelContent }
+          : {}),
         ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
         ...(entry.mcpAppResourceUri
           ? { mcp: { app: { resourceUri: entry.mcpAppResourceUri } } }

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -30,6 +30,7 @@ type ToolCallState = {
   toolMessageId?: string;
   mcpAppResourceUri?: string;
   modelContent?: ToolModelContentPart[];
+  snapshotResultApplied: boolean;
 };
 
 const MCP_APPS_ACTIVITY_TYPE = "mcp-apps";
@@ -272,6 +273,7 @@ export class RunAggregator {
               ];
             }
             entry.result = result;
+            entry.snapshotResultApplied = true;
             if (typeof result.isError === "boolean") {
               entry.isError = result.isError;
             }
@@ -374,6 +376,7 @@ export class RunAggregator {
       parsedArgs: undefined,
       result: undefined,
       isError: undefined,
+      snapshotResultApplied: false,
     };
     if (parentMessageId) {
       state.parentMessageId = parentMessageId;
@@ -442,6 +445,7 @@ export class RunAggregator {
         parsedArgs: undefined,
         result: undefined,
         isError: undefined,
+        snapshotResultApplied: false,
       };
       this.toolCalls.set(id, entry);
     }
@@ -452,8 +456,17 @@ export class RunAggregator {
     ) {
       this.partOrder.push({ kind: "tool-call", toolCallId: id });
     }
-    entry.result = tryParseJSON(content);
-    entry.isError = isError;
+    if (entry.snapshotResultApplied) {
+      if (entry.modelContent === undefined) {
+        entry.modelContent = [{ type: "text", text: content }];
+      }
+      if (entry.isError === undefined) {
+        entry.isError = isError;
+      }
+    } else {
+      entry.result = tryParseJSON(content);
+      entry.isError = isError;
+    }
     if (toolMessageId) {
       entry.toolMessageId = toolMessageId;
     }

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -139,6 +139,86 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("preserves mcp app snapshot results and model content for subsequent runs", async () => {
+    const runInputs: any[] = [];
+    const callToolResult = {
+      content: [
+        { type: "text", text: "ok" },
+        { type: "image", data: "aGk=", mimeType: "image/png" },
+      ],
+      structuredContent: { ok: true },
+      isError: false,
+    };
+    const runAgent = vi.fn(async (input, subscriber) => {
+      runInputs.push(JSON.parse(JSON.stringify(input)));
+      if (runInputs.length === 1) {
+        subscriber.onToolCallStartEvent?.({
+          event: {
+            type: "TOOL_CALL_START",
+            toolCallId: "call-1",
+            toolCallName: "show_map",
+          },
+        });
+        subscriber.onToolCallArgsEvent?.({
+          event: {
+            type: "TOOL_CALL_ARGS",
+            toolCallId: "call-1",
+            delta: '{"city":"sf"}',
+          },
+        });
+        subscriber.onToolCallResultEvent?.({
+          event: {
+            type: "TOOL_CALL_RESULT",
+            toolCallId: "call-1",
+            content: "ok",
+            role: "tool",
+          },
+        });
+        subscriber.onActivitySnapshotEvent?.({
+          event: {
+            type: "ACTIVITY_SNAPSHOT",
+            activityType: "mcp-apps",
+            content: {
+              result: callToolResult,
+              resourceUri: "ui://srv/mcp-app.html",
+              serverHash: "h",
+              serverId: "s",
+              toolInput: { city: "sf" },
+            },
+          },
+        });
+      }
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    await core.append(createAppendMessage());
+
+    const assistant = core
+      .getMessages()
+      .find(
+        (message) => message.role === "assistant",
+      ) as ThreadAssistantMessage;
+    const toolPart = assistant.content.find(
+      (part) => part.type === "tool-call",
+    ) as any;
+    expect(toolPart.result).toEqual(callToolResult);
+    expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
+
+    await core.resume({
+      parentId: assistant.id,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+    });
+
+    const toolMessage = runInputs[1]?.messages.find(
+      (message: { role: string }) => message.role === "tool",
+    );
+    expect(toolMessage?.content).toBe("ok");
+    expect(toolMessage?.content).not.toBe(JSON.stringify(callToolResult));
+  });
+
   it("preserves tool message IDs when rerunning imported snapshots", async () => {
     const runAgent = vi.fn(async (_input, subscriber) => {
       if (runAgent.mock.calls.length === 1) {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -106,6 +106,38 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("uses modelContent text for completed tool messages", () => {
+    const result = toAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-42",
+            toolName: "show_map",
+            argsText: '{"city":"sf"}',
+            result: {
+              content: [
+                { type: "text", text: "joined text" },
+                { type: "image", data: "aGk=", mimeType: "image/png" },
+              ],
+              structuredContent: { ok: true },
+              isError: false,
+            },
+            modelContent: [{ type: "text", text: "joined text" }],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[1]).toMatchObject({
+      role: "tool",
+      toolCallId: "call-42",
+      content: "joined text",
+    });
+  });
+
   it("merges tool role snapshot messages back into assistant tool-call parts", () => {
     const result = fromAgUiMessages([
       {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -230,6 +230,48 @@ describe("RunAggregator", () => {
     });
   });
 
+  it("preserves an identified mcp app snapshot result when the tool result arrives later", () => {
+    const aggregator = createAggregator(false);
+    const result = {
+      content: [{ type: "text", text: "snapshot" }],
+      structuredContent: { location: "San Francisco" },
+      isError: false,
+    };
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        toolCallId: "tool1",
+        result,
+        resourceUri: "ui://srv/mcp-app.html",
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "late text",
+      role: "tool",
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.result).toEqual(result);
+    expect(toolPart.modelContent).toEqual([
+      { type: "text", text: "late text" },
+    ]);
+    expect(toolPart.mcp).toEqual({
+      app: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+  });
+
   it("preserves model content across repeated mcp app snapshots", () => {
     const aggregator = createAggregator(false);
     const firstResult = {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -185,6 +185,209 @@ describe("RunAggregator", () => {
     expect((toolPart as any).result).toEqual({ ok: true });
   });
 
+  it("uses the mcp app snapshot result while preserving the model-facing result", () => {
+    const aggregator = createAggregator(false);
+    const result = {
+      content: [
+        { type: "text", text: "ok" },
+        { type: "image", data: "aGk=", mimeType: "image/png" },
+      ],
+      structuredContent: { ok: true },
+      isError: false,
+    };
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "ok",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        result,
+        resourceUri: "ui://srv/mcp-app.html",
+        serverHash: "h",
+        serverId: "s",
+        toolInput: { city: "sf" },
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.result).toEqual(result);
+    expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
+    expect(toolPart.mcp).toEqual({
+      app: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+  });
+
+  it("preserves model content across repeated mcp app snapshots", () => {
+    const aggregator = createAggregator(false);
+    const firstResult = {
+      content: [{ type: "text", text: "first" }],
+      structuredContent: { value: 1 },
+      isError: false,
+    };
+    const secondResult = {
+      content: [{ type: "text", text: "second" }],
+      structuredContent: { value: 2 },
+      isError: false,
+    };
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "ok",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        result: firstResult,
+        resourceUri: "ui://srv/first.html",
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        result: secondResult,
+        resourceUri: "ui://srv/second.html",
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.result).toEqual(secondResult);
+    expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("uses a snapshot toolCallId instead of the last resolved tool call", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool2",
+      toolCallName: "show_chart",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "map",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool2",
+      content: "chart",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        toolCallId: "tool1",
+        resourceUri: "ui://srv/map.html",
+      },
+    } as AgUiEvent);
+
+    const parts = results
+      .at(-1)
+      ?.content?.filter((part) => part.type === "tool-call") as any[];
+    expect(parts.find((part) => part.toolCallId === "tool1").mcp).toEqual({
+      app: { resourceUri: "ui://srv/map.html" },
+    });
+    expect(
+      parts.find((part) => part.toolCallId === "tool2").mcp,
+    ).toBeUndefined();
+  });
+
+  it("ignores snapshots with an unknown toolCallId", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "ok",
+      role: "tool",
+    } as AgUiEvent);
+
+    const before = results.at(-1);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        toolCallId: "missing",
+        result: { content: [{ type: "text", text: "different" }] },
+        resourceUri: "ui://srv/mcp-app.html",
+      },
+    } as AgUiEvent);
+
+    expect(results.at(-1)).toBe(before);
+  });
+
+  it("maps an mcp app snapshot error result onto the tool call", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "failed",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        result: {
+          content: [{ type: "text", text: "failed" }],
+          isError: true,
+        },
+        resourceUri: "ui://srv/mcp-app.html",
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.isError).toBe(true);
+  });
+
   it("maps each snapshot to its own tool when multiple ui tools resolve", () => {
     const aggregator = createAggregator(false);
 


### PR DESCRIPTION
closes #4884

## summary

- the mcp-apps `ACTIVITY_SNAPSHOT`'s `content.result` (the faithful MCP `CallToolResult`) now lands on the tool part's `result`, so `McpAppRenderer` widgets receive images and `structuredContent` instead of the text-only `TOOL_CALL_RESULT` content, matching what the AI-SDK runtime already exposes
- the original model-facing text is captured once per tool call on `modelContent`, and `toAgUiMessages` prefers it when serializing tool history, so subsequent runs keep sending the middleware's text extraction instead of a stringified `CallToolResult` (base64 image payloads never reach the model)
- snapshots correlate on `content.toolCallId` when present (unknown ids are ignored) and fall back to the existing `lastResolvedToolCallId` stream order; `result.isError` maps onto the part

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 6 files, 200/200 passing (new coverage: snapshot result surfacing with modelContent preservation, toolCallId correlation, unknown toolCallId no-op, isError mapping, repeated snapshots keeping the first captured text, and an end-to-end runtime core test asserting the next run's tool message carries the original text)
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> build complete
- [x] `pnpm lint` -> oxlint and format checks clean

### reviewer should verify

- [ ] with `@ag-ui/mcp-apps-middleware`, run a UI tool whose `CallToolResult` contains image or `structuredContent` parts and confirm the widget's `output` receives the full result while the following run's tool message stays the text extraction

## notes

- `content.toolCallId` does not exist in today's `@ag-ui/mcp-apps-middleware` payload (checked against ag-ui-protocol/ag-ui main and the published 0.0.3 dist), so the correlation branch is forward compatibility; stream order remains the effective path
- `serverId` plumbing for multi-MCP host routing stays with #4879

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

