### PR TITLE
fix(docs): raise Xulux prompt preview above canvas

### DIFF
--- a/apps/docs/components/xulux/chat/OpenInCard.tsx
+++ b/apps/docs/components/xulux/chat/OpenInCard.tsx
@@ -244,11 +244,12 @@ export function OpenInCard({
               align="start"
               sideOffset={8}
               collisionPadding={12}
+              className="z-[2147483647]"
             >
               <PreviewCard.Popup
                 id={promptPreviewId}
                 role="tooltip"
-                className="border-border bg-popover text-popover-foreground z-[2147483647] w-[min(24rem,calc(100vw-2rem))] rounded-lg border p-3 text-xs shadow-lg"
+                className="border-border bg-popover text-popover-foreground w-[min(24rem,calc(100vw-2rem))] rounded-lg border p-3 text-xs shadow-lg"
               >
                 <div className="text-muted-foreground mb-2 font-medium">
                   Prompt preview


### PR DESCRIPTION
## Summary

- raise the portaled `PreviewCard.Positioner` above Xulux canvas layers
- remove the ineffective maximum z-index from the nested popup
- preserve prompt-preview placement, collision handling, dimensions, and scrolling

Closes #4896

## Root cause

The popup's maximum z-index was scoped inside a positioner at `z-index: auto`. Adjacent Xulux canvas layers could therefore paint over the entire preview card. Applying elevation to the portaled positioner fixes the stacking boundary without changing shell overflow or canvas ownership.

## Validation

- Prettier check passed for `OpenInCard.tsx`
- no TypeScript diagnostics for `OpenInCard.tsx`
- `git diff --check`

## Visual validation checkpoint

Reproduce from an OpenIn card near the chat/canvas divider and confirm the full Prompt preview appears above the canvas at desktop width. Also confirm Base UI collision handling keeps the card in the viewport at narrower widths.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

