### PR TITLE
feat: plumb serverId through MCP Apps for multi-MCP host routing

### DIFF
--- a/.changeset/plumb-mcp-server-identity.md
+++ b/.changeset/plumb-mcp-server-identity.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: plumb an optional serverId through MCP Apps metadata and host calls for multi-MCP routing

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2236,6 +2236,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpAppResourceOutput = {

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -587,6 +587,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -913,6 +913,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -639,6 +639,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -953,6 +953,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -818,6 +818,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -509,6 +509,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1252,6 +1252,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-hook-form.ts
+++ b/api-surface/assistant-ui__react-hook-form.ts
@@ -83,6 +83,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type MessageCommonProps = {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1822,6 +1822,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpAppResourceOutput = {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -966,6 +966,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1027,6 +1027,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1569,6 +1569,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpAppResourceOutput = {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -679,6 +679,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -679,6 +679,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 type McpServerConfig = {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2511,9 +2511,7 @@ type McpAppsHost = {
     uri: string;
     serverId?: string;
   }) => Promise<unknown>;
-  listResources: (params?: {
-    serverId?: string;
-  } & Record<string, unknown>) => Promise<unknown>;
+  listResources: (params?: unknown) => Promise<unknown>;
 };
 
 declare const McpAppsRemoteHost: Resource<McpAppsHost, [

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2447,6 +2447,7 @@ type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("app" | "model")[];
+  readonly serverId?: string;
 };
 
 declare const McpAppRenderer: Resource<{
@@ -2501,12 +2502,18 @@ type McpAppToolCallParams = {
 type McpAppsHost = {
   loadResource: (params: {
     uri: string;
+    serverId?: string;
   }) => Promise<McpAppResource>;
-  callTool: (params: McpAppToolCallParams) => Promise<unknown>;
+  callTool: (params: McpAppToolCallParams & {
+    serverId?: string;
+  }) => Promise<unknown>;
   readResource: (params: {
     uri: string;
+    serverId?: string;
   }) => Promise<unknown>;
-  listResources: (params?: unknown) => Promise<unknown>;
+  listResources: (params?: {
+    serverId?: string;
+  } & Record<string, unknown>) => Promise<unknown>;
 };
 
 declare const McpAppsRemoteHost: Resource<McpAppsHost, [

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -69,20 +69,32 @@ The route accepts `POST` requests with `{ method, params }` JSON bodies. Dispatc
 // app/api/mcp-apps/route.ts
 import { createMCPClient } from "@ai-sdk/mcp";
 
-let clientPromise: ReturnType<typeof createMCPClient> | undefined;
-const getClient = () => {
-  clientPromise ??= createMCPClient({
-    transport: { type: "sse", url: process.env.MCP_SERVER_URL! },
-  }).catch((error) => {
-    clientPromise = undefined;
-    throw error;
-  });
+const serverUrls = new Map([
+  ["search", process.env.SEARCH_MCP_SERVER_URL!],
+  ["calendar", process.env.CALENDAR_MCP_SERVER_URL!],
+]);
+const fallbackServerUrl = process.env.MCP_SERVER_URL!;
+const clientPromises = new Map<string, ReturnType<typeof createMCPClient>>();
+
+const getClient = (serverId?: string) => {
+  const url = serverId ? serverUrls.get(serverId) : fallbackServerUrl;
+  if (!url) throw new Error(`Unknown MCP server: ${serverId}`);
+  let clientPromise = clientPromises.get(url);
+  if (!clientPromise) {
+    clientPromise = createMCPClient({
+      transport: { type: "sse", url },
+    }).catch((error) => {
+      clientPromises.delete(url);
+      throw error;
+    });
+    clientPromises.set(url, clientPromise);
+  }
   return clientPromise;
 };
 
 export async function POST(req: Request) {
   const { method, params } = await req.json();
-  const client = await getClient();
+  const client = await getClient(params?.serverId);
 
   switch (method) {
     case "mcp-apps/read-resource": {
@@ -109,8 +121,10 @@ export async function POST(req: Request) {
     }
     case "resources/read":
       return Response.json(await client.readResource({ uri: params.uri }));
-    case "resources/list":
-      return Response.json(await client.listResources(params));
+    case "resources/list": {
+      const { serverId: _, ...listParams } = params ?? {};
+      return Response.json(await client.listResources(listParams));
+    }
     default:
       return Response.json({ error: "Unsupported method" }, { status: 400 });
   }
@@ -118,6 +132,10 @@ export async function POST(req: Request) {
 ```
 
 The renderer POSTs four method names: `mcp-apps/read-resource`, `tools/call`, `resources/read`, `resources/list`. Reject anything else server-side and apply your own auth / rate limiting in the route.
+
+### Multiple MCP servers
+
+When a tool part carries `mcp.app.serverId`, the renderer forwards it to the host operations as `params.serverId` so the route can select the MCP client that owns the resource or tool. The agent stack emits this routable identity in part metadata. For `@ag-ui/mcp-apps-middleware`, assistant-ui uses its configured `serverId`, falling back to `serverHash` when `serverId` is absent or empty. Omitting `serverId` preserves the single-server behavior, as shown by the fallback client in the route example.
 
 Per-name `setToolUI` registrations always win over the MCP fallback — you can still customize specific tools.
 

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -135,7 +135,7 @@ The renderer POSTs four method names: `mcp-apps/read-resource`, `tools/call`, `r
 
 ### Multiple MCP servers
 
-When a tool part carries `mcp.app.serverId`, the renderer forwards it to the host operations as `params.serverId` so the route can select the MCP client that owns the resource or tool. The agent stack emits this routable identity in part metadata. For `@ag-ui/mcp-apps-middleware`, assistant-ui uses its configured `serverId`, falling back to `serverHash` when `serverId` is absent or empty. Omitting `serverId` preserves the single-server behavior, as shown by the fallback client in the route example.
+When a tool part carries `mcp.app.serverId`, the renderer forwards it to the host operations as `params.serverId` so the route can select the MCP client that owns the resource or tool. The agent stack emits this routable identity in part metadata. For `@ag-ui/mcp-apps-middleware`, assistant-ui uses its configured `serverId`, falling back to `serverHash` when `serverId` is absent or empty. Match the route's map keys to whichever identity your setup emits: configure an explicit `serverId` on each middleware server, or key the map by the emitted hashes. Omitting `serverId` preserves the single-server behavior, as shown by the fallback client in the route example.
 
 Per-name `setToolUI` registrations always win over the MCP fallback — you can still customize specific tools.
 

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -128,6 +128,8 @@ export type McpAppMetadata = {
   readonly resourceUri: string;
   readonly mimeType?: string;
   readonly visibility?: readonly ("model" | "app")[];
+  /** Routable server identity emitted by the agent stack when multiple MCP servers back one agent; for @ag-ui/mcp-apps-middleware this is the configured serverId, falling back to its serverHash. */
+  readonly serverId?: string;
 };
 
 export const MCP_APP_URI_SCHEME = "ui://";

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -29,6 +29,7 @@ type ToolCallState = {
   parentMessageId?: string;
   toolMessageId?: string;
   mcpAppResourceUri?: string;
+  mcpAppServerId?: string;
   modelContent?: ToolModelContentPart[];
   snapshotResultApplied: boolean;
 };
@@ -256,6 +257,13 @@ export class RunAggregator {
           isMcpAppUri(resourceUri)
         ) {
           entry.mcpAppResourceUri = resourceUri;
+          const id = event.content.serverId;
+          const hash = event.content.serverHash;
+          if (typeof id === "string" && id.length > 0) {
+            entry.mcpAppServerId = id;
+          } else if (typeof hash === "string" && hash.length > 0) {
+            entry.mcpAppServerId = hash;
+          }
           const result = event.content.result;
           if (isPlainObject(result)) {
             if (
@@ -509,7 +517,16 @@ export class RunAggregator {
           : {}),
         ...(entry.isError !== undefined ? { isError: entry.isError } : {}),
         ...(entry.mcpAppResourceUri
-          ? { mcp: { app: { resourceUri: entry.mcpAppResourceUri } } }
+          ? {
+              mcp: {
+                app: {
+                  resourceUri: entry.mcpAppResourceUri,
+                  ...(entry.mcpAppServerId
+                    ? { serverId: entry.mcpAppServerId }
+                    : {}),
+                },
+              },
+            }
           : {}),
         ...(entry.parentMessageId ? { parentId: entry.parentMessageId } : {}),
         ...(entry.toolMessageId

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -205,6 +205,7 @@ describe("AGUIThreadRuntimeCore", () => {
     ) as any;
     expect(toolPart.result).toEqual(callToolResult);
     expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
+    expect(toolPart.mcp.app.serverId).toBe("s");
 
     await core.resume({
       parentId: assistant.id,

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -180,7 +180,7 @@ describe("RunAggregator", () => {
     const toolPart = last?.content?.find((part) => part.type === "tool-call");
     expect(toolPart).toBeTruthy();
     expect((toolPart as any).mcp).toEqual({
-      app: { resourceUri: "ui://srv/mcp-app.html" },
+      app: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },
     });
     expect((toolPart as any).result).toEqual({ ok: true });
   });
@@ -225,6 +225,67 @@ describe("RunAggregator", () => {
       ?.content?.find((part) => part.type === "tool-call") as any;
     expect(toolPart.result).toEqual(result);
     expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
+    expect(toolPart.mcp).toEqual({
+      app: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },
+    });
+  });
+
+  it("normalizes an mcp app serverHash into serverId", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "{}",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: {
+        resourceUri: "ui://srv/mcp-app.html",
+        serverHash: "h",
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.mcp).toEqual({
+      app: { resourceUri: "ui://srv/mcp-app.html", serverId: "h" },
+    });
+  });
+
+  it("omits mcp app serverId when the snapshot has no server identity", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "{}",
+      role: "tool",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
     expect(toolPart.mcp).toEqual({
       app: { resourceUri: "ui://srv/mcp-app.html" },
     });

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -746,6 +746,40 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
+  it("forwards callProviderMetadata.mcp.app.serverId onto ToolCallMessagePart.mcp.app", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-search",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: { query: "hi" },
+            output: { results: [] },
+            callProviderMetadata: {
+              mcp: {
+                app: {
+                  resourceUri: "ui://example/search",
+                  serverId: "search-server",
+                },
+              },
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://example/search",
+      serverId: "search-server",
+    });
+  });
+
   it("preserves providerMetadata on text and reasoning parts", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {
@@ -842,12 +876,12 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
-  it("memoizes MCP app metadata across conversions by resourceUri", () => {
+  it("memoizes MCP app metadata across conversions by serverId and resourceUri", () => {
     const metadata: AISDKMessageConverterMetadata = {
       mcpAppMetadataCache: new Map(),
     };
 
-    const buildMessage = (id: string) => ({
+    const buildMessage = (id: string, serverId: string) => ({
       id,
       role: "assistant" as const,
       parts: [
@@ -858,19 +892,26 @@ describe("AISDKMessageConverter", () => {
           input: { q: "hi" },
           output: {},
           callProviderMetadata: {
-            mcp: { app: { resourceUri: "ui://example/search" } },
+            mcp: {
+              app: { resourceUri: "ui://example/search", serverId },
+            },
           },
         } as any,
       ],
     });
 
     const first = AISDKMessageConverter.toThreadMessages(
-      [buildMessage("a1")],
+      [buildMessage("a1", "search-server")],
       false,
       metadata,
     );
     const second = AISDKMessageConverter.toThreadMessages(
-      [buildMessage("a2")],
+      [buildMessage("a2", "search-server")],
+      false,
+      metadata,
+    );
+    const third = AISDKMessageConverter.toThreadMessages(
+      [buildMessage("a3", "other-server")],
       false,
       metadata,
     );
@@ -881,8 +922,16 @@ describe("AISDKMessageConverter", () => {
     const secondApp = second[0]?.content.find(
       (p): p is any => p.type === "tool-call",
     )?.mcp?.app;
+    const thirdApp = third[0]?.content.find(
+      (p): p is any => p.type === "tool-call",
+    )?.mcp?.app;
     expect(firstApp).toBeDefined();
     expect(firstApp).toBe(secondApp);
+    expect(thirdApp).not.toBe(firstApp);
+    expect(thirdApp).toEqual({
+      resourceUri: "ui://example/search",
+      serverId: "other-server",
+    });
   });
 
   it("converts a reasoning-file part into a file part", () => {

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -780,6 +780,39 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
+  it("omits an empty callProviderMetadata.mcp.app.serverId", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-search",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: { query: "hi" },
+            output: { results: [] },
+            callProviderMetadata: {
+              mcp: {
+                app: {
+                  resourceUri: "ui://example/search",
+                  serverId: "",
+                },
+              },
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://example/search",
+    });
+  });
+
   it("preserves providerMetadata on text and reasoning parts", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -93,7 +93,8 @@ function extractMcpAppMetadata(
       (v): v is "model" | "app" => v === "model" || v === "app",
     );
   }
-  if (typeof a["serverId"] === "string") out.serverId = a["serverId"];
+  if (typeof a["serverId"] === "string" && a["serverId"].length > 0)
+    out.serverId = a["serverId"];
   if (cache) {
     if (cache.size >= MCP_APP_METADATA_CACHE_MAX) {
       const oldest = cache.keys().next().value;

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -77,10 +77,11 @@ function extractMcpAppMetadata(
   }
   if (typeof a["resourceUri"] !== "string") return undefined;
   if (!isMcpAppUri(a["resourceUri"])) return undefined;
-  const cached = cache?.get(a["resourceUri"]);
+  const cacheKey = `${typeof a["serverId"] === "string" ? a["serverId"] : ""} ${a["resourceUri"]}`;
+  const cached = cache?.get(cacheKey);
   if (cached) {
-    cache!.delete(a["resourceUri"]);
-    cache!.set(a["resourceUri"], cached);
+    cache!.delete(cacheKey);
+    cache!.set(cacheKey, cached);
     return cached;
   }
   const out: { -readonly [K in keyof McpAppMetadata]: McpAppMetadata[K] } = {
@@ -92,12 +93,13 @@ function extractMcpAppMetadata(
       (v): v is "model" | "app" => v === "model" || v === "app",
     );
   }
+  if (typeof a["serverId"] === "string") out.serverId = a["serverId"];
   if (cache) {
     if (cache.size >= MCP_APP_METADATA_CACHE_MAX) {
       const oldest = cache.keys().next().value;
       if (oldest !== undefined) cache.delete(oldest);
     }
-    cache.set(a["resourceUri"], out);
+    cache.set(cacheKey, out);
   }
   return out;
 }

--- a/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { resource, useResource } from "@assistant-ui/tap";
+import type { ToolCallMessagePartProps } from "@assistant-ui/core/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { McpAppBridgeHandlers, McpAppsHost } from "./types";
+
+const { framePropsMock } = vi.hoisted(() => ({ framePropsMock: vi.fn() }));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => ({
+    thread: () => ({ append: vi.fn() }),
+  }),
+}));
+
+vi.mock("./app-frame", () => ({
+  McpAppFrame: (props: unknown) => {
+    framePropsMock(props);
+    return null;
+  },
+}));
+
+import { McpAppRenderer } from "./McpAppRenderer";
+
+const useHost = ({ host }: { host: McpAppsHost }) => host;
+const Host = resource(useHost);
+
+const createPart = (serverId?: string): ToolCallMessagePartProps => ({
+  type: "tool-call",
+  toolCallId: "call-1",
+  toolName: "search",
+  args: {},
+  argsText: "{}",
+  status: { type: "complete" },
+  mcp: {
+    app: {
+      resourceUri: "ui://example/search",
+      ...(serverId !== undefined ? { serverId } : {}),
+    },
+  },
+  addResult: vi.fn(),
+  resume: vi.fn(),
+  respondToApproval: vi.fn(),
+});
+
+function Harness({ host, serverId }: { host: McpAppsHost; serverId?: string }) {
+  const renderer = useResource(
+    McpAppRenderer({
+      host: Host({ host }),
+    }),
+  );
+  const Renderer = renderer.render;
+  return <Renderer {...createPart(serverId)} />;
+}
+
+describe("McpAppRenderer", () => {
+  beforeEach(() => {
+    framePropsMock.mockReset();
+  });
+
+  it("injects serverId into loadResource and reloads when it changes", async () => {
+    const loadResource = vi.fn(async ({ uri }: { uri: string }) => ({
+      uri,
+      mimeType: "text/html;profile=mcp-app" as const,
+      html: "",
+    }));
+    const host: McpAppsHost = {
+      loadResource,
+      callTool: vi.fn(),
+      readResource: vi.fn(),
+      listResources: vi.fn(),
+    };
+
+    const view = render(<Harness host={host} serverId="server-a" />);
+    await waitFor(() =>
+      expect(loadResource).toHaveBeenCalledWith({
+        uri: "ui://example/search",
+        serverId: "server-a",
+      }),
+    );
+
+    view.rerender(<Harness host={host} serverId="server-b" />);
+    await waitFor(() => expect(loadResource).toHaveBeenCalledTimes(2));
+    expect(loadResource).toHaveBeenLastCalledWith({
+      uri: "ui://example/search",
+      serverId: "server-b",
+    });
+  });
+
+  it("gives the renderer serverId precedence in listResources", async () => {
+    const listResources = vi.fn();
+    const host: McpAppsHost = {
+      loadResource: vi.fn(async ({ uri }) => ({
+        uri,
+        mimeType: "text/html;profile=mcp-app" as const,
+        html: "",
+      })),
+      callTool: vi.fn(),
+      readResource: vi.fn(),
+      listResources,
+    };
+
+    render(<Harness host={host} serverId="host-server" />);
+    await waitFor(() => expect(framePropsMock).toHaveBeenCalled());
+    const handlers = framePropsMock.mock.lastCall?.[0]
+      .handlers as McpAppBridgeHandlers;
+
+    await handlers.listResources?.({
+      cursor: "next",
+      serverId: "widget-server",
+    });
+    expect(listResources).toHaveBeenCalledWith({
+      cursor: "next",
+      serverId: "host-server",
+    });
+  });
+
+  it("passes listResources params through unchanged without serverId", async () => {
+    const listResources = vi.fn();
+    const host: McpAppsHost = {
+      loadResource: vi.fn(async ({ uri }) => ({
+        uri,
+        mimeType: "text/html;profile=mcp-app" as const,
+        html: "",
+      })),
+      callTool: vi.fn(),
+      readResource: vi.fn(),
+      listResources,
+    };
+    const params = { cursor: "next" };
+
+    render(<Harness host={host} />);
+    await waitFor(() => expect(framePropsMock).toHaveBeenCalled());
+    const handlers = framePropsMock.mock.lastCall?.[0]
+      .handlers as McpAppBridgeHandlers;
+
+    await handlers.listResources?.(params);
+    expect(listResources).toHaveBeenCalledWith(params);
+  });
+});

--- a/packages/react/src/mcp-apps/McpAppRenderer.tsx
+++ b/packages/react/src/mcp-apps/McpAppRenderer.tsx
@@ -26,6 +26,7 @@ import type {
   McpAppsHost,
 } from "./types";
 import { getMcpAppFromToolPart } from "./utils";
+import { isRecord } from "../utils/json/is-json";
 
 export type McpAppRendererOptions = {
   /**
@@ -55,6 +56,7 @@ export type McpAppRendererOptions = {
 
 type LoadedResourceState = {
   resourceUri: string;
+  serverId?: string;
   resource?: McpAppResource;
   error?: Error;
 };
@@ -100,7 +102,11 @@ function InlineRenderer({
   const aui = useAui();
   const app = getMcpAppFromToolPart(part);
   const cachedAppRef = useRef<McpAppMetadata | undefined>(undefined);
-  if (app != null && cachedAppRef.current?.resourceUri !== app.resourceUri) {
+  if (
+    app != null &&
+    (cachedAppRef.current?.resourceUri !== app.resourceUri ||
+      cachedAppRef.current?.serverId !== app.serverId)
+  ) {
     cachedAppRef.current = app;
   }
   const appForRender = app ?? cachedAppRef.current;
@@ -108,21 +114,37 @@ function InlineRenderer({
   const [loadedResource, setLoadedResource] = useState<LoadedResourceState>();
 
   const resourceUri = appForRender?.resourceUri;
+  const serverId = appForRender?.serverId;
+  const serverIdRef = useRef<string | undefined>(undefined);
+  serverIdRef.current = serverId;
   useEffect(() => {
     if (appForRender == null || resourceUri == null) return;
     let cancelled = false;
     const targetUri = resourceUri;
+    const targetServerId = serverId;
 
     internalsRef.current.host
-      .loadResource({ uri: targetUri })
+      .loadResource({
+        uri: targetUri,
+        ...(targetServerId ? { serverId: targetServerId } : {}),
+      })
       .then((res) => {
         if (!cancelled)
-          setLoadedResource({ resourceUri: targetUri, resource: res });
+          setLoadedResource({
+            resourceUri: targetUri,
+            ...(targetServerId !== undefined
+              ? { serverId: targetServerId }
+              : {}),
+            resource: res,
+          });
       })
       .catch((error: unknown) => {
         if (!cancelled) {
           setLoadedResource({
             resourceUri: targetUri,
+            ...(targetServerId !== undefined
+              ? { serverId: targetServerId }
+              : {}),
             error: error instanceof Error ? error : new Error(String(error)),
           });
         }
@@ -131,8 +153,8 @@ function InlineRenderer({
     return () => {
       cancelled = true;
     };
-    // oxlint-disable-next-line react/exhaustive-deps -- re-fetch only when URI changes; appForRender identity is unstable and internalsRef is a stable ref
-  }, [resourceUri]);
+    // oxlint-disable-next-line react/exhaustive-deps -- re-fetch only when URI or server identity changes; appForRender identity is unstable and internalsRef is a stable ref
+  }, [resourceUri, serverId]);
 
   const bridgeHandlers = useMemo<McpAppBridgeHandlers>(
     () => ({
@@ -143,16 +165,32 @@ function InlineRenderer({
         aui.thread().append({ content: [{ type: "text", text }] });
         return { ok: true };
       },
-      callTool: (params) => internalsRef.current.host.callTool(params),
-      readResource: (params) => internalsRef.current.host.readResource(params),
-      listResources: (params) =>
-        internalsRef.current.host.listResources(params),
+      callTool: (params) =>
+        internalsRef.current.host.callTool({
+          ...params,
+          ...(serverIdRef.current ? { serverId: serverIdRef.current } : {}),
+        }),
+      readResource: (params) =>
+        internalsRef.current.host.readResource({
+          ...params,
+          ...(serverIdRef.current ? { serverId: serverIdRef.current } : {}),
+        }),
+      listResources: (params) => {
+        if (!serverIdRef.current) {
+          return internalsRef.current.host.listResources(params);
+        }
+        return internalsRef.current.host.listResources({
+          ...(isRecord(params) ? params : {}),
+          serverId: serverIdRef.current,
+        });
+      },
     }),
     [aui, internalsRef],
   );
 
   const loadedResourceForApp =
-    loadedResource?.resourceUri === appForRender?.resourceUri
+    loadedResource?.resourceUri === appForRender?.resourceUri &&
+    loadedResource?.serverId === appForRender?.serverId
       ? loadedResource
       : undefined;
   const appResource = loadedResourceForApp?.resource;

--- a/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
+++ b/packages/react/src/mcp-apps/McpAppsRemoteHost.test.ts
@@ -40,6 +40,51 @@ describe("McpAppsRemoteHost", () => {
     }
   });
 
+  it("posts serverId params verbatim for tool calls and resource loads", async () => {
+    const fetch = vi.fn(async () =>
+      Response.json({ content: [{ type: "text", text: "ok" }] }),
+    ) as unknown as typeof globalThis.fetch;
+    const root = mount(fetch);
+
+    try {
+      await root.getValue().callTool({
+        name: "search",
+        arguments: { query: "docs" },
+        serverId: "search-server",
+      });
+      await root.getValue().loadResource({
+        uri: "ui://example/search",
+        serverId: "search-server",
+      });
+
+      expect(fetch).toHaveBeenNthCalledWith(1, "/api/mcp-apps", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "tools/call",
+          params: {
+            name: "search",
+            arguments: { query: "docs" },
+            serverId: "search-server",
+          },
+        }),
+      });
+      expect(fetch).toHaveBeenNthCalledWith(2, "/api/mcp-apps", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          method: "mcp-apps/read-resource",
+          params: {
+            uri: "ui://example/search",
+            serverId: "search-server",
+          },
+        }),
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("includes method, url, status, and text body in host request errors", async () => {
     const fetch = vi.fn(
       async () =>

--- a/packages/react/src/mcp-apps/app-frame.tsx
+++ b/packages/react/src/mcp-apps/app-frame.tsx
@@ -246,7 +246,9 @@ export function McpAppFrame({
   return (
     <SandboxHost
       content={{ html: resource.html }}
-      contentKey={resource.uri}
+      contentKey={
+        app.serverId ? `${app.serverId} ${resource.uri}` : resource.uri
+      }
       sandbox={{ ...sandbox, product: sandbox?.product ?? DEFAULT_PRODUCT }}
       maxHeight={maxHeight}
       createBridge={createBridge}

--- a/packages/react/src/mcp-apps/types.ts
+++ b/packages/react/src/mcp-apps/types.ts
@@ -51,19 +51,29 @@ export type McpAppHostInfo = {
  * `McpAppsRemoteHost`.
  */
 export type McpAppsHost = {
-  loadResource: (params: { uri: string }) => Promise<McpAppResource>;
-  callTool: (params: McpAppToolCallParams) => Promise<unknown>;
-  readResource: (params: { uri: string }) => Promise<unknown>;
-  listResources: (params?: unknown) => Promise<unknown>;
+  loadResource: (params: {
+    uri: string;
+    serverId?: string;
+  }) => Promise<McpAppResource>;
+  callTool: (
+    params: McpAppToolCallParams & { serverId?: string },
+  ) => Promise<unknown>;
+  readResource: (params: {
+    uri: string;
+    serverId?: string;
+  }) => Promise<unknown>;
+  listResources: (
+    params?: { serverId?: string } & Record<string, unknown>,
+  ) => Promise<unknown>;
 };
 
 /**
  * Options for `McpAppsRemoteHost`. The host POSTs `{ method, params }` to
- * `url` and expects JSON responses. Method names sent:
- * - `mcp-apps/read-resource` (`{ uri }`) → `McpAppResource`
- * - `tools/call` (`{ name, arguments? }`) → tool result
- * - `resources/read` (`{ uri }`) → resource read result
- * - `resources/list` (`params?`) → list result
+ * `url` and expects JSON responses. Params may carry `serverId` for host-side routing. Method names sent:
+ * - `mcp-apps/read-resource` (`{ uri, serverId? }`) → `McpAppResource`
+ * - `tools/call` (`{ name, arguments?, serverId? }`) → tool result
+ * - `resources/read` (`{ uri, serverId? }`) → resource read result
+ * - `resources/list` (`{ serverId?, ...params }?`) → list result
  */
 export type McpAppsRemoteHostOptions = {
   url: string;

--- a/packages/react/src/mcp-apps/types.ts
+++ b/packages/react/src/mcp-apps/types.ts
@@ -62,9 +62,7 @@ export type McpAppsHost = {
     uri: string;
     serverId?: string;
   }) => Promise<unknown>;
-  listResources: (
-    params?: { serverId?: string } & Record<string, unknown>,
-  ) => Promise<unknown>;
+  listResources: (params?: unknown) => Promise<unknown>;
 };
 
 /**


### PR DESCRIPTION
closes #4879

## summary

- MCP Apps backed by multiple MCP servers become routable: tool parts carry an optional `mcp.app.serverId` and the renderer forwards it to every host operation as `params.serverId`, so one host route can select the MCP client that owns the resource or tool (including the first `mcp-apps/read-resource` call, which has no tool name to infer from)
- the AG-UI runtime normalizes the middleware's identity at the boundary (`content.serverId`, falling back to `content.serverHash`) and stamps it alongside `resourceUri`; the AI SDK runtime extracts `serverId` from `callProviderMetadata.mcp.app` and keys its metadata cache by server plus uri, so two servers sharing a `ui://` uri no longer inherit each other's metadata
- injection is renderer-side only: the widget bridge contract is untouched, widget-supplied `serverId` keeps being stripped for `tools/call` and `resources/read`, and the renderer's value takes precedence for `resources/list`
- `McpAppsHost` params widen with an optional field only; omitting `serverId` everywhere preserves single-server behavior

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 509/509 passing, build clean
- [x] `pnpm --filter @assistant-ui/react test` -> 455/455 passing including 3 new McpAppRenderer cases (loadResource injection plus reload on server change, listResources precedence, passthrough without serverId), build clean
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 145/145 passing with new extraction and composite-cache-key memoize cases, build clean
- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> all passing with new hash-fallback and absent-identity cases plus an end-to-end serverId assertion, build clean
- [x] `pnpm lint` -> oxlint and oxfmt clean; `pnpm -C apps/docs generate:api-reference` -> 429 exports, no tracked drift

### reviewer should verify

- [ ] with two MCP servers behind one agent (`@ag-ui/mcp-apps-middleware` with a `serverId` configured per server), confirm the host route receives `params.serverId` on the initial `mcp-apps/read-resource` call and routes to the owning server's client

## notes

- the docs host route example now shows a `serverId` to client map with a single-client fallback; `templates/mcp` deliberately stays single-server to keep the starter minimal
- the MCP Apps spec keeps server identity out of the widget wire, so `McpAppBridgeHandlers` and the bridge are untouched by design

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

