### PR TITLE
fix(react-ai-sdk): guard toolOutputConversion against non-string mediaType

### DIFF
--- a/.changeset/tool-output-mediatype-guard.md
+++ b/.changeset/tool-output-mediatype-guard.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: guard toolOutputConversion against missing mediaType on non-spec tool output

--- a/packages/react-ai-sdk/src/toolOutputConversion.test.ts
+++ b/packages/react-ai-sdk/src/toolOutputConversion.test.ts
@@ -76,6 +76,43 @@ describe("toAISDKContent", () => {
   it("returns an empty value array for empty input", () => {
     expect(toAISDKContent([])).toEqual({ type: "content", value: [] });
   });
+
+  it("falls back to application/octet-stream when mediaType is missing", () => {
+    const parts = [{ type: "file", data: "DDDD" } as any];
+    expect(toAISDKContent(parts)).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "file-data",
+          data: "DDDD",
+          mediaType: "application/octet-stream",
+        },
+      ],
+    });
+  });
+
+  it("falls back to application/octet-stream when mediaType is not a string", () => {
+    const parts = [{ type: "file", data: "EEEE", mediaType: 42 } as any];
+    expect(toAISDKContent(parts)).toEqual({
+      type: "content",
+      value: [
+        {
+          type: "file-data",
+          data: "EEEE",
+          mediaType: "application/octet-stream",
+        },
+      ],
+    });
+  });
+
+  it("does not throw on a part with an unknown type and no mediaType", () => {
+    const parts = [{ type: "widget" } as any];
+    const result = toAISDKContent(parts);
+    expect(result.value[0]).toMatchObject({
+      type: "file-data",
+      mediaType: "application/octet-stream",
+    });
+  });
 });
 
 describe("toAISDKDefaultOutput", () => {

--- a/packages/react-ai-sdk/src/toolOutputConversion.ts
+++ b/packages/react-ai-sdk/src/toolOutputConversion.ts
@@ -7,17 +7,21 @@ export const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
     if (part.type === "text") {
       return { type: "text" as const, text: part.text };
     }
-    const isImage = part.mediaType.startsWith("image/");
+    const mediaType =
+      typeof part.mediaType === "string"
+        ? part.mediaType
+        : "application/octet-stream";
+    const isImage = mediaType.startsWith("image/");
     return isImage
       ? {
           type: "image-data" as const,
           data: part.data,
-          mediaType: part.mediaType,
+          mediaType,
         }
       : {
           type: "file-data" as const,
           data: part.data,
-          mediaType: part.mediaType,
+          mediaType,
           ...(part.filename !== undefined && { filename: part.filename }),
         };
   }),


### PR DESCRIPTION
## What

`toAISDKContent` in `toolOutputConversion.ts` read `part.mediaType.startsWith("image/")` undefended. Any non-text part whose `mediaType` is missing or not a string threw a `TypeError` inside the user's server route handler. The read is now guarded: `mediaType` falls back to `application/octet-stream` when it is not a string, and the guarded value is emitted in both the `image-data` and `file-data` branches so the provider-bound payload always carries a string MIME type.

## Why

This path is reachable from raw wire data, server side. `frontendTools()` installs `defaultToModelOutput` as the AI SDK `toModelOutput` for every frontend tool, and the `output` it receives comes from the client. `unwrapModelContentEnvelope` only checks `Array.isArray` on the envelope key, so individual parts are never validated: a client sending `{ __aui_modelContent: [{ type: "file", data: "x" }] }` crashed the route with an unhandled TypeError. `generativeTools` / `AISDKToolkit` hit the same line via `toAISDKToModelOutput`, both from the wire envelope and from a user's JS `toModelOutput` returning non-spec parts.

This is the one converter that #4648 (guard converters against missing parts and mediaType) deliberately skipped, completing that merged hardening pattern per the AGENTS.md defensive-converter rule.

## Impact

- Before: a malformed part is an unhandled TypeError (500) inside the user's route handler.
- After: well-formed-enough parts convert normally, and junk without usable data degrades to an SDK-managed validation error instead of an unhandled crash.
- Spec-compliant inputs produce byte-identical output; the fallback only engages on inputs that previously threw.
- No public surface change, no export changes. Patch changeset for `@assistant-ui/react-ai-sdk`.
- Tests: three new cases in the colocated suite (missing `mediaType`, non-string `mediaType`, unknown part type), full react-ai-sdk suite and full turbo build green.

## Rationale

- `typeof` instead of `??`: the input is raw client JSON, so `mediaType: 42` is as reachable as `undefined` and throws the same TypeError through a nullish check.
- Fallback is mandatory: the ai v7 tool-output schema requires `mediaType` to be a string, so passing `undefined` through just moves the crash to `standardizePrompt`.
- `application/octet-stream` matches core's outbound fallback (`packages/core/src/adapters/attachment.ts`) and the AI SDK's own; #4648's `unknown/unknown` is inbound display metadata, not a provider-bound MIME type.
- Null entries inside the parts array stay out of scope, mirroring #4648's array-level guard; the array level here is already covered by `isModelContentEnvelope`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

