### PR TITLE
ci: skip claude review on bot pushes and scope concurrency to the job

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,10 +10,6 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
-concurrency:
-  group: claude-code-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 env:
   # Shared action configuration
   TRACK_PROGRESS: 'true'
@@ -97,7 +93,16 @@ env:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !endsWith(github.actor, '[bot]')
+    # Job-level so that runs skipped by the `if` guard never enter the group; a
+    # workflow-level group would cancel the in-flight review of the previous
+    # head before the guard is evaluated (e.g. on autofix.ci pushes).
+    concurrency:
+      group: claude-code-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,7 +96,7 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      !endsWith(github.actor, '[bot]')
+      github.event.sender.type != 'Bot'
     # Job-level so that runs skipped by the `if` guard never enter the group; a
     # workflow-level group would cancel the in-flight review of the previous
     # head before the guard is evaluated (e.g. on autofix.ci pushes).


### PR DESCRIPTION
## summary

- autofix.ci pushes re-trigger the claude review workflow, and the action hard-fails on non-human actors ("Workflow initiated by non-human actor: autofix-ci"), leaving a red check on every PR autofix touches
- worse, the workflow-level concurrency group cancels the in-flight review of the preceding human push before the bot-triggered run fails, so those PRs end up with a red X and no review at all (see the back-to-back cancelled/failure run pairs on the #4898 branch)
- the job `if` now skips runs whose event sender is a bot (`github.event.sender.type != 'Bot'`, the structural check rather than a login-suffix match), so bot pushes produce a neutral skip instead of a failure
- concurrency moves from the workflow level to the job level; runs skipped by the guard never enter the group, so they no longer cancel the in-flight review, while human pushes still cancel and restart the previous run as before

## test plan

### already verified

- [x] `actionlint .github/workflows/claude-code-review.yml` -> clean apart from the pre-existing blacksmith runner-label warning
- [x] yaml parse confirms the folded `if` collapses to a single expression and `concurrency` sits under the job
- [x] this PR's own claude review run executes the modified workflow from the head ref, so a green run here validates the guard for the human-actor path

### reviewer should verify

- [ ] on the next PR where autofix.ci pushes fixes, the bot-triggered claude review run shows as skipped and the in-flight review of the preceding human push completes and posts its comment

## notes

- alternative to the allowed_bots approach in #4890: allowing the bot actor re-runs a full review on a formatting-only delta and keeps the cancel-then-redo cost; skipping keeps exactly one review per human push

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


