### PR TITLE
refactor: host the streaming-stable tool-args stringifier in @assistant-ui/core/internal

### DIFF
--- a/.changeset/shared-tool-args-stringifier.md
+++ b/.changeset/shared-tool-args-stringifier.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor: host the streaming-stable tool-args stringifier in @assistant-ui/core/internal

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5552,7 +5552,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, symbolInnerMessage, updateStatusReducer };
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, isAutoStatus, isErrorMessageId, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {
@@ -5607,6 +5607,8 @@ declare const splitLocalRuntimeOptions: <T extends LocalRuntimeOptions>(options:
   otherOptions: Omit<T, "adapters" | "cloud" | "initialMessages" | "maxSteps" | "unstable_enableMessageQueue" | "unstable_humanToolNames">;
 };
 
+declare const stableStringifyToolArgs: (keyOrderCache: Map<string, Map<string, string[]>> | undefined, cacheKey: string, args: ReadonlyJSONObject) => string;
+
 declare const stepStreamingTiming: <TMessage>(state: StreamingTimingState | null, messages: readonly TMessage[], isRunning: boolean, accessors: StreamingTimingAccessors<TMessage>, options: StreamingTimingOptions | undefined, now?: () => number) => {
   readonly state: StreamingTimingState | null;
   readonly timings: Record<string, MessageTiming>;
@@ -5623,6 +5625,8 @@ declare function tool<const TSchema extends StandardSchemaParameters, TResult = 
 }): Tool<StandardSchemaInput<TSchema>, TResult>;
 
 declare function tool<TArgs extends Record<string, unknown>, TResult = any>(tool: Tool<TArgs, TResult>): Tool<TArgs, TResult>;
+
+declare const trackToolArgsKeyOrder: (keyOrderCache: Map<string, Map<string, string[]>> | undefined, cacheKey: string, args: ReadonlyJSONObject) => void;
 
 declare const unstable_Interactables: Resource<ClientOutput<"unstable_interactables">, [
   (Unstable_InteractablesConfig | undefined)?

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -42,6 +42,13 @@ export { CompositeContextProvider } from "./utils/composite-context-provider";
 // FileReader fallback lives in one place.
 export { getFileDataURL } from "./adapters/attachment";
 
+// Streaming-stable tool-args stringifier, reused by framework adapters so the
+// key-order stabilization lives in one place.
+export {
+  stableStringifyToolArgs,
+  trackToolArgsKeyOrder,
+} from "./utils/json/stable-stringify-tool-args";
+
 // Runtime extras helper for external-store adapters. Internal because the
 // tap-native runtime path replaces the `thread.extras` side-channel it wraps.
 export {

--- a/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
+++ b/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  stableStringifyToolArgs,
+  trackToolArgsKeyOrder,
+} from "./stable-stringify-tool-args";
+
+describe("stableStringifyToolArgs", () => {
+  it("stringifies without a cache", () => {
+    expect(stableStringifyToolArgs(undefined, "key", { a: 1, b: 2 })).toBe(
+      JSON.stringify({ a: 1, b: 2 }),
+    );
+  });
+
+  it("keeps first-seen key order across reordered updates", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", { a: 1, b: 2 });
+    expect(stableStringifyToolArgs(cache, "key", { b: 3, a: 4 })).toBe(
+      JSON.stringify({ a: 4, b: 3 }),
+    );
+  });
+
+  it("appends new keys after previously seen keys", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", { b: 1 });
+    expect(stableStringifyToolArgs(cache, "key", { c: 2, a: 3, b: 4 })).toBe(
+      JSON.stringify({ b: 4, c: 2, a: 3 }),
+    );
+  });
+
+  it("drops keys absent from the current value", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", { a: 1, b: 2 });
+    expect(stableStringifyToolArgs(cache, "key", { b: 3 })).toBe(
+      JSON.stringify({ b: 3 }),
+    );
+    expect(stableStringifyToolArgs(cache, "key", { a: 5, b: 6 })).toBe(
+      JSON.stringify({ b: 6, a: 5 }),
+    );
+  });
+
+  it("stabilizes nested objects and array elements independently", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", {
+      list: [{ x: 1, y: 2 }],
+      nested: { p: 1, q: 2 },
+    });
+    expect(
+      stableStringifyToolArgs(cache, "key", {
+        nested: { q: 3, p: 4 },
+        list: [{ y: 5, x: 6 }],
+      }),
+    ).toBe(
+      JSON.stringify({
+        list: [{ x: 6, y: 5 }],
+        nested: { p: 4, q: 3 },
+      }),
+    );
+  });
+
+  it("keeps caches per cacheKey independent", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "one", { a: 1, b: 2 });
+    expect(stableStringifyToolArgs(cache, "two", { b: 3, a: 4 })).toBe(
+      JSON.stringify({ b: 3, a: 4 }),
+    );
+  });
+});
+
+describe("trackToolArgsKeyOrder", () => {
+  it("seeds the order a later stringify follows", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    trackToolArgsKeyOrder(cache, "key", { b: 1, a: 2 });
+    expect(stableStringifyToolArgs(cache, "key", { a: 3, b: 4 })).toBe(
+      JSON.stringify({ b: 4, a: 3 }),
+    );
+  });
+
+  it("is a no-op without a cache", () => {
+    expect(() =>
+      trackToolArgsKeyOrder(undefined, "key", { a: 1 }),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/utils/json/stable-stringify-tool-args.ts
+++ b/packages/core/src/utils/json/stable-stringify-tool-args.ts
@@ -1,0 +1,68 @@
+import type { ReadonlyJSONObject } from "assistant-stream/utils";
+
+const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
+
+const stabilizeToolArgsValue = (
+  value: unknown,
+  path: string,
+  keyOrderByPath: Map<string, string[]>,
+): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item, idx) =>
+      stabilizeToolArgsValue(item, `${path}[${idx}]`, keyOrderByPath),
+    );
+  }
+
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const currentKeys = Object.keys(record);
+    const previousOrder = keyOrderByPath.get(path) ?? [];
+    const previousOrderSet = new Set(previousOrder);
+    const nextOrder = [
+      ...previousOrder.filter((key) => hasOwn(record, key)),
+      ...currentKeys.filter((key) => !previousOrderSet.has(key)),
+    ];
+    keyOrderByPath.set(path, nextOrder);
+
+    return Object.fromEntries(
+      nextOrder.map((key) => [
+        key,
+        stabilizeToolArgsValue(record[key], `${path}.${key}`, keyOrderByPath),
+      ]),
+    );
+  }
+
+  return value;
+};
+
+const getToolArgsKeyOrder = (
+  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
+  cacheKey: string,
+): Map<string, string[]> => {
+  const keyOrderByPath = keyOrderCache?.get(cacheKey) ?? new Map();
+  keyOrderCache?.set(cacheKey, keyOrderByPath);
+  return keyOrderByPath;
+};
+
+export const trackToolArgsKeyOrder = (
+  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
+  cacheKey: string,
+  args: ReadonlyJSONObject,
+) => {
+  const keyOrderByPath = getToolArgsKeyOrder(keyOrderCache, cacheKey);
+  stabilizeToolArgsValue(args, "$", keyOrderByPath);
+};
+
+export const stableStringifyToolArgs = (
+  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
+  cacheKey: string,
+  args: ReadonlyJSONObject,
+): string => {
+  const keyOrderByPath = getToolArgsKeyOrder(keyOrderCache, cacheKey);
+  const stableArgs = stabilizeToolArgsValue(
+    args,
+    "$",
+    keyOrderByPath,
+  ) as ReadonlyJSONObject;
+  return JSON.stringify(stableArgs);
+};

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -22,6 +22,7 @@ import {
   type ThreadMessageLike,
   type McpAppMetadata,
 } from "@assistant-ui/core";
+import { stableStringifyToolArgs } from "@assistant-ui/core/internal";
 import {
   parsePartialJsonObject,
   type ReadonlyJSONObject,
@@ -103,57 +104,6 @@ function extractMcpAppMetadata(
     cache.set(cacheKey, out);
   }
   return out;
-}
-
-const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
-
-const stabilizeToolArgsValue = (
-  value: unknown,
-  path: string,
-  keyOrderByPath: Map<string, string[]>,
-): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((item, idx) =>
-      stabilizeToolArgsValue(item, `${path}[${idx}]`, keyOrderByPath),
-    );
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const currentKeys = Object.keys(record);
-    const previousOrder = keyOrderByPath.get(path) ?? [];
-    const previousOrderSet = new Set(previousOrder);
-    const nextOrder = [
-      ...previousOrder.filter((key) => hasOwn(record, key)),
-      ...currentKeys.filter((key) => !previousOrderSet.has(key)),
-    ];
-    keyOrderByPath.set(path, nextOrder);
-
-    return Object.fromEntries(
-      nextOrder.map((key) => [
-        key,
-        stabilizeToolArgsValue(record[key], `${path}.${key}`, keyOrderByPath),
-      ]),
-    );
-  }
-
-  return value;
-};
-
-function stableStringifyToolArgs(
-  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
-  cacheKey: string,
-  args: ReadonlyJSONObject,
-): string {
-  const keyOrderByPath = keyOrderCache?.get(cacheKey) ?? new Map();
-  keyOrderCache?.set(cacheKey, keyOrderByPath);
-
-  const stableArgs = stabilizeToolArgsValue(
-    args,
-    "$",
-    keyOrderByPath,
-  ) as ReadonlyJSONObject;
-  return JSON.stringify(stableArgs);
 }
 
 function getToolApprovalAndInterrupt(

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -10,6 +10,10 @@ import type {
   ToolCallMessagePart,
 } from "@assistant-ui/core";
 import type { useExternalMessageConverter } from "@assistant-ui/core/react";
+import {
+  stableStringifyToolArgs,
+  trackToolArgsKeyOrder,
+} from "@assistant-ui/core/internal";
 import type {
   LangChainMessage,
   LangChainToolCall,
@@ -34,73 +38,6 @@ const uiMessageToDataPart = (ui: UIMessage): DataMessagePart => ({
   name: ui.name,
   data: ui.props,
 });
-
-const hasOwn = (value: object, key: string) => Object.hasOwn(value, key);
-
-const stabilizeToolArgsValue = (
-  value: unknown,
-  path: string,
-  keyOrderByPath: Map<string, string[]>,
-): unknown => {
-  if (Array.isArray(value)) {
-    return value.map((item, idx) =>
-      stabilizeToolArgsValue(item, `${path}[${idx}]`, keyOrderByPath),
-    );
-  }
-
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const currentKeys = Object.keys(record);
-    const previousOrder = keyOrderByPath.get(path) ?? [];
-    const previousOrderSet = new Set(previousOrder);
-    const nextOrder = [
-      ...previousOrder.filter((key) => hasOwn(record, key)),
-      ...currentKeys.filter((key) => !previousOrderSet.has(key)),
-    ];
-    keyOrderByPath.set(path, nextOrder);
-
-    return Object.fromEntries(
-      nextOrder.map((key) => [
-        key,
-        stabilizeToolArgsValue(record[key], `${path}.${key}`, keyOrderByPath),
-      ]),
-    );
-  }
-
-  return value;
-};
-
-const getToolArgsKeyOrder = (
-  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
-  cacheKey: string,
-): Map<string, string[]> => {
-  const keyOrderByPath = keyOrderCache?.get(cacheKey) ?? new Map();
-  keyOrderCache?.set(cacheKey, keyOrderByPath);
-  return keyOrderByPath;
-};
-
-const trackToolArgsKeyOrder = (
-  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
-  cacheKey: string,
-  args: ReadonlyJSONObject,
-) => {
-  const keyOrderByPath = getToolArgsKeyOrder(keyOrderCache, cacheKey);
-  stabilizeToolArgsValue(args, "$", keyOrderByPath);
-};
-
-const stableStringifyToolArgs = (
-  keyOrderCache: Map<string, Map<string, string[]>> | undefined,
-  cacheKey: string,
-  args: ReadonlyJSONObject,
-): string => {
-  const keyOrderByPath = getToolArgsKeyOrder(keyOrderCache, cacheKey);
-  const stableArgs = stabilizeToolArgsValue(
-    args,
-    "$",
-    keyOrderByPath,
-  ) as ReadonlyJSONObject;
-  return JSON.stringify(stableArgs);
-};
 
 const getToolArgsCacheKey = (
   messageId: string | undefined,


### PR DESCRIPTION
## What

Extracts the streaming-stable tool-args stringifier (`stabilizeToolArgsValue`, `hasOwn`, `stableStringifyToolArgs`, plus langgraph's `getToolArgsKeyOrder`/`trackToolArgsKeyOrder`) into a single module at `packages/core/src/utils/json/stable-stringify-tool-args.ts`, exported from `@assistant-ui/core/internal`. Both react-ai-sdk's `convertMessage.ts` and react-langgraph's `convertLangChainMessages.ts` now import it instead of carrying their own copy.

## Why

The helpers were duplicated verbatim (byte-identical `hasOwn` and `stabilizeToolArgsValue`; react-ai-sdk's `stableStringifyToolArgs` just inlines the two cache-lookup lines langgraph factors into `getToolArgsKeyOrder`). This is pure JSON machinery with no adapter-specific logic: a per-tool-call key-order cache keyed by JSON path that keeps object key order stable across streaming updates so `argsText` does not jitter as partial JSON re-parses. Any fix to one copy would silently miss the other.

`@assistant-ui/core/internal` is the established home for exactly this kind of shared adapter helper, following the same pattern as `getFileDataURL` and `createRuntimeExtras`. Both adapters already import values from that subpath (`vercelAttachmentAdapter.ts`, `runtimeExtras.ts`).

## Impact

- Net -102 lines; one canonical implementation.
- No behavior change: the hosted module is the langgraph version verbatim, which is behaviorally identical to react-ai-sdk's copy for the functions it had. Existing key-order tests in both adapters (`convertMessage.test.ts`, `convertLangChainMessages.test.ts`) pass untouched and lock this in.
- No new public surface: exports land only on `/internal`, which is documented as not part of the public API.
- Adapter-local concerns (cache keys, delete-on-final lifecycle) stay in the adapters; only the pure stringify/track machinery moves.

## Mechanics

- New colocated unit test `stable-stringify-tool-args.test.ts` covers first-seen key-order stability, new-key append, dropped keys, nested object/array paths, per-cacheKey isolation, undefined-cache behavior, and the track-then-stringify flow langgraph uses for provider-supplied argsText.
- `api-surface/assistant-ui__core.ts` is left to the CI autofix regeneration; the only surface delta is the two new internal exports.
- Patch changeset for `@assistant-ui/core`, `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-langgraph`; the changeset dependency bump keeps adapters from pairing with an older core that lacks the export.
- Verified: full `pnpm turbo run build`, `pnpm api-surface`, `pnpm lint`, and all three package test suites green (core 517, react-ai-sdk 146, react-langgraph 175).

## Rationale

The langgraph copy was hosted rather than the react-ai-sdk one because it is the strictly more general, already-factored superset (react-ai-sdk only needs `stableStringifyToolArgs`; langgraph also needs `trackToolArgsKeyOrder` for its provider-argsText flow). No `ToolArgsKeyOrderCache` type alias is exported: the inline `Map<string, Map<string, string[]>>` spelling appears in files under active development by other open PRs, and rewriting those aliases here would widen the diff and create conflicts for zero behavior gain.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

