### PR TITLE
refactor(react-ai-sdk): emit file tool output parts instead of deprecated image-data/file-data

### DIFF
--- a/.changeset/tool-output-file-parts.md
+++ b/.changeset/tool-output-file-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+refactor: emit file tool output parts instead of deprecated image-data/file-data

--- a/packages/react-ai-sdk/src/frontendTools.test.ts
+++ b/packages/react-ai-sdk/src/frontendTools.test.ts
@@ -49,16 +49,16 @@ describe("frontendTools", () => {
       value: [
         { type: "text", text: "PDF contents:" },
         {
-          type: "file-data",
+          type: "file",
           mediaType: "application/pdf",
-          data: "JVBERi0xLjQK",
+          data: { type: "data", data: "JVBERi0xLjQK" },
           filename: "doc.pdf",
         },
       ],
     });
   });
 
-  it("emits image-data for image media types", async () => {
+  it("emits a file part for image media types", async () => {
     const tools = frontendTools({
       screenshot: {
         parameters: { type: "object" },
@@ -86,8 +86,8 @@ describe("frontendTools", () => {
       type: "content",
       value: [
         {
-          type: "image-data",
-          data: "iVBORw0KGgo=",
+          type: "file",
+          data: { type: "data", data: "iVBORw0KGgo=" },
           mediaType: "image/png",
         },
       ],

--- a/packages/react-ai-sdk/src/toolOutputConversion.test.ts
+++ b/packages/react-ai-sdk/src/toolOutputConversion.test.ts
@@ -10,7 +10,7 @@ describe("toAISDKContent", () => {
     });
   });
 
-  it("maps an image file part to image-data and drops the filename", () => {
+  it("maps an image file part to a file entry and keeps the filename", () => {
     const parts: ToolModelContentPart[] = [
       {
         type: "file",
@@ -21,23 +21,30 @@ describe("toAISDKContent", () => {
     ];
     expect(toAISDKContent(parts)).toEqual({
       type: "content",
-      value: [{ type: "image-data", data: "AAAA", mediaType: "image/png" }],
+      value: [
+        {
+          type: "file",
+          data: { type: "data", data: "AAAA" },
+          mediaType: "image/png",
+          filename: "shot.png",
+        },
+      ],
     });
   });
 
-  it("maps a non-image file part without a filename to file-data", () => {
+  it("maps a file part without a filename to a file entry", () => {
     const result = toAISDKContent([
       { type: "file", data: "BBBB", mediaType: "application/pdf" },
     ]);
     expect(result.value[0]).toEqual({
-      type: "file-data",
-      data: "BBBB",
+      type: "file",
+      data: { type: "data", data: "BBBB" },
       mediaType: "application/pdf",
     });
     expect(result.value[0]).not.toHaveProperty("filename");
   });
 
-  it("includes the filename for a non-image file part when present", () => {
+  it("includes the filename for a file part when present", () => {
     expect(
       toAISDKContent([
         {
@@ -51,8 +58,8 @@ describe("toAISDKContent", () => {
       type: "content",
       value: [
         {
-          type: "file-data",
-          data: "CCCC",
+          type: "file",
+          data: { type: "data", data: "CCCC" },
           mediaType: "application/pdf",
           filename: "report.pdf",
         },
@@ -68,7 +75,7 @@ describe("toAISDKContent", () => {
     ]);
     expect(result.value.map((part) => part.type)).toEqual([
       "text",
-      "image-data",
+      "file",
       "text",
     ]);
   });
@@ -83,8 +90,8 @@ describe("toAISDKContent", () => {
       type: "content",
       value: [
         {
-          type: "file-data",
-          data: "DDDD",
+          type: "file",
+          data: { type: "data", data: "DDDD" },
           mediaType: "application/octet-stream",
         },
       ],
@@ -97,8 +104,8 @@ describe("toAISDKContent", () => {
       type: "content",
       value: [
         {
-          type: "file-data",
-          data: "EEEE",
+          type: "file",
+          data: { type: "data", data: "EEEE" },
           mediaType: "application/octet-stream",
         },
       ],
@@ -109,7 +116,7 @@ describe("toAISDKContent", () => {
     const parts = [{ type: "widget" } as any];
     const result = toAISDKContent(parts);
     expect(result.value[0]).toMatchObject({
-      type: "file-data",
+      type: "file",
       mediaType: "application/octet-stream",
     });
   });

--- a/packages/react-ai-sdk/src/toolOutputConversion.ts
+++ b/packages/react-ai-sdk/src/toolOutputConversion.ts
@@ -11,19 +11,12 @@ export const toAISDKContent = (parts: readonly ToolModelContentPart[]) => ({
       typeof part.mediaType === "string"
         ? part.mediaType
         : "application/octet-stream";
-    const isImage = mediaType.startsWith("image/");
-    return isImage
-      ? {
-          type: "image-data" as const,
-          data: part.data,
-          mediaType,
-        }
-      : {
-          type: "file-data" as const,
-          data: part.data,
-          mediaType,
-          ...(part.filename !== undefined && { filename: part.filename }),
-        };
+    return {
+      type: "file" as const,
+      data: { type: "data" as const, data: part.data },
+      mediaType,
+      ...(part.filename !== undefined && { filename: part.filename }),
+    };
   }),
 });
 


### PR DESCRIPTION
## What

`toAISDKContent` in `toolOutputConversion.ts` emitted the deprecated ai v7 tool-output content types `image-data` and `file-data`. It now emits the non-deprecated `file` shape (`{ type: "file", data: { type: "data", data }, mediaType, filename? }`) directly. Since both deprecated types converge to the same `file` part, the image/file branch disappears and the converter collapses to a single mapping. The `mediaType` guard from #4899 stays verbatim.

## Why

Every request through `frontendTools()` / `generativeTools()` that returns file content pushes a per-request deprecation warning in ai v7 ("The \"image-data\" type for tool result content is deprecated. Use the \"file\" type with mediaType and { type: 'data', data } instead.", same message for `file-data`), and the SDK converts both internally to an equivalent `file` part. Emitting the maintained shape removes the warning at its root and moves the converter onto the type the SDK will keep. react-ai-sdk is v7-only (`ai: ^7.0.22` since #4654), so there is no v6 shape to preserve.

## Impact

- For well-formed base64 with accurate media types, the provider-visible part is identical to before; the deprecation warning disappears.
- `filename` is now preserved for image parts. The old drop was an artifact of the deprecated `image-data` type having no filename field; the `file` type carries `filename?` for all media types, matching the SDK's own `file-data` to `file` conversion.
- The #4899 degrade path is unchanged: schema validation in `standardizePrompt` runs before part mapping, so junk parts with `data: undefined` fail as the same `InvalidPromptError` as before. No new guard needed.
- No public surface change, no export changes. Patch changeset (`refactor:` prefix, matching #4651's changeset for the `addToolResult` to `addToolOutput` deprecation swap).
- Tests updated in place: `toolOutputConversion.test.ts` and two shape assertions in `frontendTools.test.ts`. Full react-ai-sdk suite (156) and full turbo build green.

## Known SDK-side behavior deltas

The non-deprecated `file` case routes through the SDK's `convertPartToLanguageModelPart`, which the deprecated blind-passthrough cases skipped. Three deltas, none affecting well-formed payloads:

- The SDK sniffs image signatures on string data and may normalize a mislabeled `mediaType` (a PNG labeled `application/octet-stream` reaches the provider as `image/png`). This is normalization of already-mislabeled input.
- Malformed base64 strings now fail client-side during signature detection instead of failing at the provider as an API error. The payload was already broken; it fails earlier.
- Data-URL strings are rejected client-side (`InvalidDataContentError`) instead of being shipped to the provider. Same class: broken input fails earlier.

## Rationale

- Single mapping over two branches: the media-type distinction no longer selects an output shape, so keeping the branch would preserve dead structure.
- The new shape is first-class in both the runtime schema and the compile-time `ToolResultOutput` type in `@ai-sdk/provider-utils`, verified against the installed `ai@7.0.22`.
- Same deprecation-cleanup family as merged #4651; direct follow-up to #4899, which hardened this converter in place.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

