### PR TITLE
fix(react-a2a): validate stream response content type

### DIFF
--- a/.changeset/a2a-stream-content-type.md
+++ b/.changeset/a2a-stream-content-type.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: validate A2A stream response content types before parsing

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -14,18 +14,23 @@ function mockFetchResponse(body: unknown, ok = true, status = 200): Response {
   } as unknown as Response;
 }
 
-function mockSSETextResponse(text: string | string[]): Response {
+function mockSSETextResponse(
+  text: string | string[],
+  contentType: string | null = "text/event-stream",
+): Response {
   const encoder = new TextEncoder();
   const chunks = (Array.isArray(text) ? text : [text]).map((chunk) =>
     encoder.encode(chunk),
   );
   let index = 0;
+  const headers = new Headers();
+  if (contentType !== null) headers.set("content-type", contentType);
 
   return {
     ok: true,
     status: 200,
     statusText: "OK",
-    headers: new Headers({ "content-type": "text/event-stream" }),
+    headers,
     body: {
       getReader: () => ({
         read: vi.fn().mockImplementation(() => {
@@ -43,8 +48,11 @@ function mockSSETextResponse(text: string | string[]): Response {
   } as unknown as Response;
 }
 
-function mockSSEResponse(lines: string[]): Response {
-  return mockSSETextResponse(lines.join("\n"));
+function mockSSEResponse(
+  lines: string[],
+  contentType: string | null = "text/event-stream",
+): Response {
+  return mockSSETextResponse(lines.join("\n"), contentType);
 }
 
 const userMessage: A2AMessage = {
@@ -995,6 +1003,63 @@ describe("A2AClient", () => {
       }
 
       expect(events).toHaveLength(2);
+    });
+
+    it("accepts parameterized event-stream content types", async () => {
+      const sseData = JSON.stringify({
+        status_update: {
+          task_id: "t1",
+          context_id: "ctx-1",
+          status: { state: "TASK_STATE_COMPLETED" },
+        },
+      });
+
+      fetchMock.mockResolvedValue(
+        mockSSEResponse(
+          [`data: ${sseData}`, "", ""],
+          "text/event-stream; charset=utf-8",
+        ),
+      );
+
+      const events: A2AStreamEvent[] = [];
+      for await (const event of client.streamMessage(userMessage)) {
+        events.push(event);
+      }
+
+      expect(events).toHaveLength(1);
+    });
+
+    it("rejects successful responses that are not event streams", async () => {
+      fetchMock.mockResolvedValue(
+        mockSSETextResponse(
+          "<html><body>Please sign in</body></html>",
+          "text/html; charset=utf-8",
+        ),
+      );
+
+      const consumeStream = async () => {
+        for await (const event of client.streamMessage(userMessage)) {
+          void event;
+        }
+      };
+
+      await expect(consumeStream()).rejects.toThrow(
+        'Expected A2A stream response Content-Type "text/event-stream", received "text/html; charset=utf-8"',
+      );
+    });
+
+    it("rejects task subscriptions without a content type", async () => {
+      fetchMock.mockResolvedValue(mockSSETextResponse("", null));
+
+      const consumeStream = async () => {
+        for await (const event of client.subscribeToTask("t1")) {
+          void event;
+        }
+      };
+
+      await expect(consumeStream()).rejects.toThrow(
+        'Expected A2A stream response Content-Type "text/event-stream", received no Content-Type header',
+      );
     });
 
     it("normalizes 'content' array from v0.3 server response to 'parts' in SSE artifact update events", async () => {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -494,6 +494,17 @@ export class A2AClient {
   // --- SSE Parsing ---
 
   private async *parseSSE(response: Response): AsyncGenerator<A2AStreamEvent> {
+    const contentType = response.headers.get("Content-Type");
+    const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+    if (mediaType !== "text/event-stream") {
+      const received = contentType
+        ? `"${contentType}"`
+        : "no Content-Type header";
+      throw new Error(
+        `Expected A2A stream response Content-Type "text/event-stream", received ${received}`,
+      );
+    }
+
     const reader = response.body?.getReader();
     if (!reader) throw new Error("No response body");
 


### PR DESCRIPTION
## Summary

- validate successful A2A streaming responses before parsing their bodies
- accept `text/event-stream` with parameters such as `charset=utf-8`
- report the received or missing content type when the response is not an event stream
- cover both message streaming and task subscriptions through their shared parser

## Why

An A2A endpoint can return HTTP 200 with an HTML login page from a proxy or an ordinary JSON fallback from a misrouted endpoint. Previously, `response.ok` allowed that body into the SSE parser, where it could produce zero events and look like a successful empty assistant response.

## Implementation

`parseSSE()` now extracts the media type from the response `Content-Type`, compares it case-insensitively with `text/event-stream`, and throws a diagnostic error before acquiring the body reader when it does not match. Because `streamMessage()` and `subscribeToTask()` share this parser, both paths receive the same validation.

## Verification

- `vitest run packages/react-a2a/src` (127 tests)
- `tsc --noEmit -p packages/react-a2a/tsconfig.json`
- `aui-build` in `packages/react-a2a`
- `oxlint` and `oxfmt --check` on changed files
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

