### PR TITLE
feat(react-ink): export attachment Props aliases from the composer and message barrels

### DIFF
--- a/.changeset/ink-attachment-props-aliases.md
+++ b/.changeset/ink-attachment-props-aliases.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+feat: export attachment Props aliases from the composer and message barrels

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -915,6 +915,8 @@ type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
 
 declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
 
+type ComposerAttachmentByIndexProps = ComposerPrimitiveAttachmentByIndex.Props;
+
 declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
@@ -933,6 +935,8 @@ type ComposerAttachmentsComponentConfig = {
   File?: ComponentType | undefined;
   Attachment?: ComponentType | undefined;
 };
+
+type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
 declare const ComposerCancel: (_param17: ComposerCancelProps) => import("react").JSX.Element;
 
@@ -1871,6 +1875,8 @@ type McpToolkitToolConfig = {
 
 declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
 
+type MessageAttachmentByIndexProps = MessagePrimitiveAttachmentByIndex.Props;
+
 declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
@@ -1892,6 +1898,8 @@ type MessageAttachmentsComponentConfig = {
   File?: ComponentType | undefined;
   Attachment?: ComponentType | undefined;
 };
+
+type MessageAttachmentsProps = MessagePrimitiveAttachments.Props;
 
 declare const MessageByIndexProvider: FC<PropsWithChildren<{
   index: number;
@@ -4462,7 +4470,7 @@ declare namespace checklist_d_exports {
 }
 
 declare namespace composer_d_exports {
-  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerPrimitiveQueue as Queue, ComposerQuote as Quote, ComposerQuoteDismiss as QuoteDismiss, ComposerQuoteDismissProps as QuoteDismissProps, ComposerQuoteProps as QuoteProps, ComposerQuoteText as QuoteText, ComposerQuoteTextProps as QuoteTextProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
+  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachmentByIndexProps as AttachmentByIndexProps, ComposerAttachments as Attachments, ComposerAttachmentsProps as AttachmentsProps, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerPrimitiveQueue as Queue, ComposerQuote as Quote, ComposerQuoteDismiss as QuoteDismiss, ComposerQuoteDismissProps as QuoteDismissProps, ComposerQuoteProps as QuoteProps, ComposerQuoteText as QuoteText, ComposerQuoteTextProps as QuoteTextProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
 }
 
 declare const createFileStorageAdapter: (options: CreateFileStorageAdapterOptions) => RemoteThreadListAdapter;
@@ -4543,7 +4551,7 @@ declare namespace messagePart_d_exports {
 }
 
 declare namespace message_d_exports {
-  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessageError as Error, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
+  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachmentByIndexProps as AttachmentByIndexProps, MessageAttachments as Attachments, MessageAttachmentsProps as AttachmentsProps, MessageContent as Content, MessageContentProps as ContentProps, MessageError as Error, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
 }
 
 declare function providerTool(config: ProviderToolConfig): never;

--- a/packages/react-ink/src/primitives/composer.ts
+++ b/packages/react-ink/src/primitives/composer.ts
@@ -4,7 +4,9 @@ export {
 } from "./composer/ComposerRoot";
 export {
   ComposerAttachments as Attachments,
+  type ComposerAttachmentsProps as AttachmentsProps,
   ComposerAttachmentByIndex as AttachmentByIndex,
+  type ComposerAttachmentByIndexProps as AttachmentByIndexProps,
 } from "./composer/ComposerAttachments";
 export {
   ComposerInput as Input,

--- a/packages/react-ink/src/primitives/composer/ComposerAttachments.tsx
+++ b/packages/react-ink/src/primitives/composer/ComposerAttachments.tsx
@@ -1,24 +1,12 @@
-import type { ComponentType } from "react";
 import {
   ComposerPrimitiveAttachments,
   ComposerPrimitiveAttachmentByIndex,
 } from "@assistant-ui/core/react";
 
-export type AttachmentComponents = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
+export type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
-export type ComposerAttachmentsProps = {
-  components: AttachmentComponents | undefined;
-};
-
-export type ComposerAttachmentByIndexProps = {
-  index: number;
-  components?: AttachmentComponents | undefined;
-};
+export type ComposerAttachmentByIndexProps =
+  ComposerPrimitiveAttachmentByIndex.Props;
 
 export const ComposerAttachmentByIndex = ComposerPrimitiveAttachmentByIndex;
 

--- a/packages/react-ink/src/primitives/message.ts
+++ b/packages/react-ink/src/primitives/message.ts
@@ -16,6 +16,8 @@ export {
 } from "./message/MessageIf";
 export {
   MessageAttachments as Attachments,
+  type MessageAttachmentsProps as AttachmentsProps,
   MessageAttachmentByIndex as AttachmentByIndex,
+  type MessageAttachmentByIndexProps as AttachmentByIndexProps,
 } from "./message/MessageAttachments";
 export { MessageError as Error } from "./message/MessageError";

--- a/packages/react-ink/src/primitives/message/MessageAttachments.tsx
+++ b/packages/react-ink/src/primitives/message/MessageAttachments.tsx
@@ -2,16 +2,11 @@ import {
   MessagePrimitiveAttachments,
   MessagePrimitiveAttachmentByIndex,
 } from "@assistant-ui/core/react";
-import type { AttachmentComponents } from "../composer/ComposerAttachments";
 
-export type MessageAttachmentsProps = {
-  components: AttachmentComponents | undefined;
-};
+export type MessageAttachmentsProps = MessagePrimitiveAttachments.Props;
 
-export type MessageAttachmentByIndexProps = {
-  index: number;
-  components?: AttachmentComponents | undefined;
-};
+export type MessageAttachmentByIndexProps =
+  MessagePrimitiveAttachmentByIndex.Props;
 
 export const MessageAttachmentByIndex = MessagePrimitiveAttachmentByIndex;
 


### PR DESCRIPTION
## What

Adds the four missing flat Props aliases to the `composer.ts` and `message.ts` barrels: `AttachmentsProps` and `AttachmentByIndexProps` on both `ComposerPrimitive` and `MessagePrimitive`. Before aliasing, re-points the local flat types at core's namespace Props so the published aliases are accurate, and deletes the local `AttachmentComponents` type that becomes dead as a result.

## Why

Direct sibling of #4888. These four components were the last in the package whose props could not be named at all: their `const` re-exports from `@assistant-ui/core/react` drop the namespace merge (so `.Props` is unreachable) and the barrels never exported the flat types. The existing flat types could not be aliased verbatim: they predate core's `Attachments` props becoming a components/children union, so they miss the `children` render-function arm and admit `components: undefined`, which the real component rejects. Deriving from core's Props fixes that, matching the existing pattern in `message/MessageParts.tsx`.

## Impact

- Type-only change, no runtime output change; the component consts are untouched.
- Append-only: barrels only gain exports. The reshaped flat types and deleted `AttachmentComponents` were never reachable from the published entries.
- `api-surface/assistant-ui__react-ink.ts` regenerated, `api-surface:check` green.
- Patch changeset for `@assistant-ui/react-ink`.
- Gates on raw exit codes: full `turbo run build`, react-ink vitest (231 passed), `pnpm lint`.

## Rationale

Rewriting the types as accurate local unions would recreate the hand-mirror drift this fixes, and skipping them (as #4888 did for `InProgress`/`Messages`) does not apply since those had reachable namespace `.Props` while these did not. `AttachmentComponents` is deleted rather than exported because core keeps its equivalent config type module-private; consumers can reach it as `NonNullable<AttachmentByIndexProps["components"]>`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

