### PR TITLE
feat(react-native): export attachment Props aliases from the composerand message barrels

### DIFF
--- a/.changeset/native-attachment-props-aliases.md
+++ b/.changeset/native-attachment-props-aliases.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+feat: export attachment Props aliases from the composer and message barrels

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -868,6 +868,8 @@ type ComposerAddAttachmentProps = Omit<PressableProps, "onPress"> & {
 
 declare const ComposerAttachmentByIndex: import("react").FC<ComposerPrimitiveAttachmentByIndex.Props>;
 
+type ComposerAttachmentByIndexProps = ComposerPrimitiveAttachmentByIndex.Props;
+
 declare const ComposerAttachmentByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
@@ -886,6 +888,8 @@ type ComposerAttachmentsComponentConfig = {
   File?: ComponentType | undefined;
   Attachment?: ComponentType | undefined;
 };
+
+type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
 declare const ComposerCancel: (_param14: ComposerCancelProps) => import("react").JSX.Element;
 
@@ -1618,6 +1622,8 @@ type McpToolkitToolConfig = {
 
 declare const MessageAttachmentByIndex: import("react").FC<MessagePrimitiveAttachmentByIndex.Props>;
 
+type MessageAttachmentByIndexProps = MessagePrimitiveAttachmentByIndex.Props;
+
 declare const MessageAttachmentByIndexProvider: FC<PropsWithChildren<{
   index: number;
 }>>;
@@ -1639,6 +1645,8 @@ type MessageAttachmentsComponentConfig = {
   File?: ComponentType | undefined;
   Attachment?: ComponentType | undefined;
 };
+
+type MessageAttachmentsProps = MessagePrimitiveAttachments.Props;
 
 declare const MessageByIndexProvider: FC<PropsWithChildren<{
   index: number;
@@ -3932,7 +3940,7 @@ declare namespace chainOfThought_d_exports {
 }
 
 declare namespace composer_d_exports {
-  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachments as Attachments, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
+  export { ComposerAddAttachment as AddAttachment, ComposerAddAttachmentProps as AddAttachmentProps, ComposerAttachmentByIndex as AttachmentByIndex, ComposerAttachmentByIndexProps as AttachmentByIndexProps, ComposerAttachments as Attachments, ComposerAttachmentsProps as AttachmentsProps, ComposerCancel as Cancel, ComposerCancelProps as CancelProps, ComposerPrimitiveIf as If, ComposerInput as Input, ComposerInputProps as InputProps, ComposerRoot as Root, ComposerRootProps as RootProps, ComposerSend as Send, ComposerSendProps as SendProps };
 }
 
 declare function createVoiceSession(options: {
@@ -3999,7 +4007,7 @@ declare const makeAssistantToolUI: <TArgs, TResult>(tool: AssistantToolUIProps<T
 declare const mergeModelContexts: (configSet: Set<ModelContextProvider>) => ModelContext$1;
 
 declare namespace message_d_exports {
-  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachments as Attachments, MessageContent as Content, MessageContentProps as ContentProps, MessagePrimitiveGroupedParts as GroupedParts, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
+  export { MessageAttachmentByIndex as AttachmentByIndex, MessageAttachmentByIndexProps as AttachmentByIndexProps, MessageAttachments as Attachments, MessageAttachmentsProps as AttachmentsProps, MessageContent as Content, MessageContentProps as ContentProps, MessagePrimitiveGroupedParts as GroupedParts, MessageIf as If, MessageIfProps as IfProps, MessagePrimitivePartByIndex as PartByIndex, MessagePrimitiveParts as Parts, MessageRoot as Root, MessageRootProps as RootProps };
 }
 
 declare function providerTool(_config: ProviderToolConfig): never;

--- a/packages/react-native/src/primitives/composer.ts
+++ b/packages/react-native/src/primitives/composer.ts
@@ -4,7 +4,9 @@ export {
 } from "./composer/ComposerRoot";
 export {
   ComposerAttachments as Attachments,
+  type ComposerAttachmentsProps as AttachmentsProps,
   ComposerAttachmentByIndex as AttachmentByIndex,
+  type ComposerAttachmentByIndexProps as AttachmentByIndexProps,
 } from "./composer/ComposerAttachments";
 export {
   ComposerInput as Input,

--- a/packages/react-native/src/primitives/composer/ComposerAttachments.tsx
+++ b/packages/react-native/src/primitives/composer/ComposerAttachments.tsx
@@ -1,24 +1,12 @@
-import type { ComponentType } from "react";
 import {
   ComposerPrimitiveAttachments,
   ComposerPrimitiveAttachmentByIndex,
 } from "@assistant-ui/core/react";
 
-export type AttachmentComponents = {
-  Image?: ComponentType | undefined;
-  Document?: ComponentType | undefined;
-  File?: ComponentType | undefined;
-  Attachment?: ComponentType | undefined;
-};
+export type ComposerAttachmentsProps = ComposerPrimitiveAttachments.Props;
 
-export type ComposerAttachmentsProps = {
-  components: AttachmentComponents | undefined;
-};
-
-export type ComposerAttachmentByIndexProps = {
-  index: number;
-  components?: AttachmentComponents | undefined;
-};
+export type ComposerAttachmentByIndexProps =
+  ComposerPrimitiveAttachmentByIndex.Props;
 
 export const ComposerAttachmentByIndex = ComposerPrimitiveAttachmentByIndex;
 

--- a/packages/react-native/src/primitives/message.ts
+++ b/packages/react-native/src/primitives/message.ts
@@ -17,5 +17,7 @@ export {
 } from "./message/MessageIf";
 export {
   MessageAttachments as Attachments,
+  type MessageAttachmentsProps as AttachmentsProps,
   MessageAttachmentByIndex as AttachmentByIndex,
+  type MessageAttachmentByIndexProps as AttachmentByIndexProps,
 } from "./message/MessageAttachments";

--- a/packages/react-native/src/primitives/message/MessageAttachments.tsx
+++ b/packages/react-native/src/primitives/message/MessageAttachments.tsx
@@ -2,16 +2,11 @@ import {
   MessagePrimitiveAttachments,
   MessagePrimitiveAttachmentByIndex,
 } from "@assistant-ui/core/react";
-import type { AttachmentComponents } from "../composer/ComposerAttachments";
 
-export type MessageAttachmentsProps = {
-  components: AttachmentComponents | undefined;
-};
+export type MessageAttachmentsProps = MessagePrimitiveAttachments.Props;
 
-export type MessageAttachmentByIndexProps = {
-  index: number;
-  components?: AttachmentComponents | undefined;
-};
+export type MessageAttachmentByIndexProps =
+  MessagePrimitiveAttachmentByIndex.Props;
 
 export const MessageAttachmentByIndex = MessagePrimitiveAttachmentByIndex;
 


### PR DESCRIPTION

## What

react-native sibling of #4906. Adds the four missing flat Props aliases to the `composer.ts` and `message.ts` barrels: `AttachmentsProps` and `AttachmentByIndexProps` on both `ComposerPrimitive` and `MessagePrimitive`. Before aliasing, re-points the local flat types at core's namespace Props so the published aliases are accurate, and deletes the local `AttachmentComponents` type that becomes dead as a result.

## Why

The two attachment files were byte-identical to react-ink's pre-#4906 files, so the same gap applies: the `const` re-exports from `@assistant-ui/core/react` drop the namespace merge (so `.Props` is unreachable) and the barrels never exported the flat types, leaving these props unnameable. The existing flat types could not be aliased verbatim: they predate core's `Attachments` props becoming a components/children union, so they miss the `children` render-function arm and admit `components: undefined`, which the real component rejects. Deriving from core's Props fixes that, matching the existing in-package pattern in `message/MessageParts.tsx`. Cross-runtime parity: keeping the runtimes' type surface aligned is the point of shipping this as a mirror of #4906.

## Impact

- Type-only change, no runtime output change; the component consts are untouched.
- Append-only: barrels only gain exports. The reshaped flat types and deleted `AttachmentComponents` were never reachable from the published entries.
- `api-surface/assistant-ui__react-native.ts` regenerated, `api-surface:check` green.
- Patch changeset for `@assistant-ui/react-native`.
- Gates on raw exit codes: full `turbo run build`, react-native vitest (147 passed), `pnpm lint`.

## Rationale

Same calls as #4906: rewriting the types as accurate local unions would recreate the hand-mirror drift this fixes, and `AttachmentComponents` is deleted rather than exported because core keeps its equivalent config type module-private; consumers can reach it as `NonNullable<AttachmentByIndexProps["components"]>`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

