### PR TITLE
fix(react-opencode): propagate SDK response errors

### DIFF
--- a/.changeset/opencode-response-errors.md
+++ b/.changeset/opencode-response-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: propagate OpenCode SDK response errors through runtime operations

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
 import { STREAM_RECONNECTED_EVENT_TYPE } from "./OpenCodeEventSource";
+import { rejectWhenThrowing } from "./testUtils";
 import type { OpenCodeServerEvent } from "./types";
 
 const createDeferred = <T>() => {
@@ -14,14 +15,6 @@ const createDeferred = <T>() => {
 
   return { promise, resolve, reject };
 };
-
-const rejectWhenThrowing = (error: Error) =>
-  vi.fn(
-    (_parameters: unknown, options?: { throwOnError?: boolean | undefined }) =>
-      options?.throwOnError
-        ? Promise.reject(error)
-        : Promise.resolve({ data: undefined, error }),
-  );
 
 const createEventSource = () => {
   let listener: ((event: OpenCodeServerEvent) => void) | undefined;
@@ -380,6 +373,44 @@ describe("OpenCodeThreadController", () => {
     await vi.waitFor(() => {
       expect(client.session.get).toHaveBeenCalledTimes(1);
       expect(client.session.status).toHaveBeenCalledTimes(1);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(controller.getState().sessionStatus).toMatchObject({
+      type: "busy",
+    });
+  });
+
+  it("keeps current state when reconnect probes fail via throwOnError", async () => {
+    const eventSource = createEventSource();
+    const status = rejectWhenThrowing(new Error("boom"));
+    const permissions = rejectWhenThrowing(new Error("boom"));
+    const questions = rejectWhenThrowing(new Error("boom"));
+    const client = createReconnectClient({ status, permissions, questions });
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit({
+      type: "session.status",
+      sessionId: "ses_1",
+      properties: { status: { type: "busy" } },
+      raw: {},
+    });
+
+    eventSource.emit(streamReconnected);
+
+    await vi.waitFor(() => {
+      expect(status).toHaveBeenCalledWith(undefined, { throwOnError: true });
+      expect(permissions).toHaveBeenCalledWith(undefined, {
+        throwOnError: true,
+      });
+      expect(questions).toHaveBeenCalledWith(undefined, {
+        throwOnError: true,
+      });
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -110,13 +110,14 @@ describe("OpenCodeThreadController", () => {
     ).resolves.toBe(false);
   });
 
-  it("keeps a staged message when sending it fails", async () => {
+  it("resets a failed staged message when retrying", async () => {
+    const retry = createDeferred<unknown>();
     const client = {
       session: {
         promptAsync: vi
           .fn()
           .mockRejectedValueOnce(new Error("boom"))
-          .mockResolvedValueOnce({}),
+          .mockReturnValueOnce(retry.promise),
       },
     };
     const controller = new OpenCodeThreadController(
@@ -140,10 +141,25 @@ describe("OpenCodeThreadController", () => {
     await expect(
       controller.sendStagedMessage(`local:${pendingId}`),
     ).rejects.toThrow("boom");
+    expect(controller.getState().pendingUserMessages[pendingId!]).toMatchObject(
+      {
+        status: "failed",
+        error: expect.any(Error),
+      },
+    );
 
-    await expect(
-      controller.sendStagedMessage(`local:${pendingId}`),
-    ).resolves.toBe(true);
+    const retryRequest = controller.sendStagedMessage(`local:${pendingId}`);
+    expect(controller.getState().pendingUserMessages[pendingId!]).toMatchObject(
+      {
+        status: "pending",
+      },
+    );
+    expect(
+      controller.getState().pendingUserMessages[pendingId!]?.error,
+    ).toBeUndefined();
+
+    retry.resolve({});
+    await expect(retryRequest).resolves.toBe(true);
   });
 
   it("marks a message failed when the OpenCode SDK returns an error", async () => {

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -15,6 +15,14 @@ const createDeferred = <T>() => {
   return { promise, resolve, reject };
 };
 
+const rejectWhenThrowing = (error: Error) =>
+  vi.fn(
+    (_parameters: unknown, options?: { throwOnError?: boolean | undefined }) =>
+      options?.throwOnError
+        ? Promise.reject(error)
+        : Promise.resolve({ data: undefined, error }),
+  );
+
 const createEventSource = () => {
   let listener: ((event: OpenCodeServerEvent) => void) | undefined;
   const unsubscribe = vi.fn();
@@ -89,11 +97,14 @@ describe("OpenCodeThreadController", () => {
       controller.sendStagedMessage(`local:${pendingId}`),
     ).resolves.toBe(true);
 
-    expect(client.session.promptAsync).toHaveBeenCalledWith({
-      sessionID: "ses_1",
-      parts: [{ type: "text", text: "hello" }],
-      model: { providerID: "anthropic", modelID: "claude" },
-    });
+    expect(client.session.promptAsync).toHaveBeenCalledWith(
+      {
+        sessionID: "ses_1",
+        parts: [{ type: "text", text: "hello" }],
+        model: { providerID: "anthropic", modelID: "claude" },
+      },
+      { throwOnError: true },
+    );
     await expect(
       controller.sendStagedMessage(`local:${pendingId}`),
     ).resolves.toBe(false);
@@ -133,6 +144,40 @@ describe("OpenCodeThreadController", () => {
     await expect(
       controller.sendStagedMessage(`local:${pendingId}`),
     ).resolves.toBe(true);
+  });
+
+  it("marks a message failed when the OpenCode SDK returns an error", async () => {
+    const error = new Error("Unauthorized");
+    const promptAsync = rejectWhenThrowing(error);
+    const controller = new OpenCodeThreadController(
+      { session: { promptAsync } } as never,
+      () => ({ subscribe: () => () => {} }),
+      "ses_1",
+    );
+
+    await expect(
+      controller.sendMessage({
+        role: "user",
+        parentId: null,
+        sourceId: null,
+        content: [{ type: "text", text: "hello" }],
+        attachments: [],
+        metadata: { custom: {} },
+        runConfig: {},
+        createdAt: new Date(),
+      }),
+    ).rejects.toBe(error);
+
+    expect(Object.values(controller.getState().pendingUserMessages)[0]).toEqual(
+      expect.objectContaining({ status: "failed", error }),
+    );
+    expect(promptAsync).toHaveBeenCalledWith(
+      {
+        sessionID: "ses_1",
+        parts: [{ type: "text", text: "hello" }],
+      },
+      { throwOnError: true },
+    );
   });
 
   it("re-subscribes through the provider after dispose", () => {
@@ -527,10 +572,13 @@ describe("OpenCodeThreadController", () => {
 
     await controller.replyToQuestion("question_1", [["Yes"]]);
 
-    expect(client.question.reply).toHaveBeenCalledWith({
-      requestID: "question_1",
-      answers: [["Yes"]],
-    });
+    expect(client.question.reply).toHaveBeenCalledWith(
+      {
+        requestID: "question_1",
+        answers: [["Yes"]],
+      },
+      { throwOnError: true },
+    );
     expect(
       controller.getState().interactions.questions.answered.question_1,
     ).toMatchObject({
@@ -575,9 +623,12 @@ describe("OpenCodeThreadController", () => {
 
     await controller.rejectQuestion("question_1");
 
-    expect(client.question.reject).toHaveBeenCalledWith({
-      requestID: "question_1",
-    });
+    expect(client.question.reject).toHaveBeenCalledWith(
+      {
+        requestID: "question_1",
+      },
+      { throwOnError: true },
+    );
     expect(
       controller.getState().interactions.questions.rejected.question_1,
     ).toBeDefined();

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -26,6 +26,7 @@ import {
   STREAM_RECONNECTED_EVENT_TYPE,
   type OpenCodeEventSource,
 } from "./OpenCodeEventSource";
+import { OPEN_CODE_REQUEST_OPTIONS } from "./openCodeRequestOptions";
 import { serializeUserParts } from "./serializeUserParts";
 
 type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
@@ -215,7 +216,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     const token = ++this.reconnectSyncToken;
 
     void this.client.session
-      .status()
+      .status(undefined, OPEN_CODE_REQUEST_OPTIONS)
       .catch(() => null)
       .then((response) => {
         if (!response || token !== this.reconnectSyncToken) return;
@@ -228,7 +229,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       });
 
     void this.client.permission
-      .list()
+      .list(undefined, OPEN_CODE_REQUEST_OPTIONS)
       .catch(() => null)
       .then((response) => {
         if (!response || token !== this.reconnectSyncToken) return;
@@ -243,7 +244,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       });
 
     void this.client.question
-      .list()
+      .list(undefined, OPEN_CODE_REQUEST_OPTIONS)
       .catch(() => null)
       .then((response) => {
         if (!response || token !== this.reconnectSyncToken) return;
@@ -287,8 +288,14 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     this.dispatch({ type: "history.loading" });
 
     const request = Promise.all([
-      this.client.session.get({ sessionID: this.sessionId }),
-      this.client.session.messages({ sessionID: this.sessionId }),
+      this.client.session.get(
+        { sessionID: this.sessionId },
+        OPEN_CODE_REQUEST_OPTIONS,
+      ),
+      this.client.session.messages(
+        { sessionID: this.sessionId },
+        OPEN_CODE_REQUEST_OPTIONS,
+      ),
     ])
       .then(([sessionResponse, messagesResponse]) => {
         if (this.loadPromise !== request) return;
@@ -348,16 +355,19 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     this.dispatch({ type: "run.started" });
 
     try {
-      await this.client.session.promptAsync({
-        sessionID: this.sessionId,
-        // The SDK currently infers a narrower payload shape than the runtime
-        // accepts here, so we cast at the boundary instead of widening types
-        // throughout the caller stack.
-        parts: getPromptParts(message) as never,
-        ...(options?.model ? { model: options.model } : {}),
-        ...(options?.agent ? { agent: options.agent } : {}),
-        ...(options?.noReply ? { noReply: options.noReply } : {}),
-      });
+      await this.client.session.promptAsync(
+        {
+          sessionID: this.sessionId,
+          // The SDK currently infers a narrower payload shape than the runtime
+          // accepts here, so we cast at the boundary instead of widening types
+          // throughout the caller stack.
+          parts: getPromptParts(message) as never,
+          ...(options?.model ? { model: options.model } : {}),
+          ...(options?.agent ? { agent: options.agent } : {}),
+          ...(options?.noReply ? { noReply: options.noReply } : {}),
+        },
+        OPEN_CODE_REQUEST_OPTIONS,
+      );
     } catch (error) {
       this.dispatch({
         type: "local.message.failed",
@@ -417,9 +427,12 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   public async cancel() {
     this.dispatch({ type: "run.cancelling" });
     try {
-      await this.client.session.abort({
-        sessionID: this.sessionId,
-      });
+      await this.client.session.abort(
+        {
+          sessionID: this.sessionId,
+        },
+        OPEN_CODE_REQUEST_OPTIONS,
+      );
     } catch (error) {
       this.dispatch({ type: "run.failed", error });
       throw error;
@@ -429,10 +442,13 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   public async revert(messageId: string) {
     this.dispatch({ type: "run.reverting" });
     try {
-      await this.client.session.revert({
-        sessionID: this.sessionId,
-        messageID: messageId,
-      });
+      await this.client.session.revert(
+        {
+          sessionID: this.sessionId,
+          messageID: messageId,
+        },
+        OPEN_CODE_REQUEST_OPTIONS,
+      );
     } catch (error) {
       this.dispatch({ type: "run.failed", error });
       throw error;
@@ -440,16 +456,22 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   }
 
   public async unrevert() {
-    await this.client.session.unrevert({
-      sessionID: this.sessionId,
-    });
+    await this.client.session.unrevert(
+      {
+        sessionID: this.sessionId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
   }
 
   public async fork(messageId: string) {
-    const response = await this.client.session.fork({
-      sessionID: this.sessionId,
-      messageID: messageId,
-    });
+    const response = await this.client.session.fork(
+      {
+        sessionID: this.sessionId,
+        messageID: messageId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
     if (!response.data?.id) {
       throw new Error("Failed to fork OpenCode session");
     }
@@ -460,10 +482,13 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     permissionId: string,
     response: OpenCodePermissionResponse,
   ) {
-    await this.client.permission.reply({
-      requestID: permissionId,
-      reply: response,
-    });
+    await this.client.permission.reply(
+      {
+        requestID: permissionId,
+        reply: response,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
 
     this.dispatch({
       type: "permission.replied",
@@ -476,10 +501,13 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     questionId: string,
     answers: readonly QuestionAnswer[],
   ) {
-    await this.client.question.reply({
-      requestID: questionId,
-      answers: answers.slice(),
-    });
+    await this.client.question.reply(
+      {
+        requestID: questionId,
+        answers: answers.slice(),
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
 
     this.dispatch({
       type: "question.replied",
@@ -489,9 +517,12 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   }
 
   public async rejectQuestion(questionId: string) {
-    await this.client.question.reject({
-      requestID: questionId,
-    });
+    await this.client.question.reject(
+      {
+        requestID: questionId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
 
     this.dispatch({
       type: "question.rejected",

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -415,6 +415,13 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     const staged = this.stagedMessages.get(parentId);
     if (!staged) return false;
 
+    if (
+      this.state.pendingUserMessages[staged.pending.clientId]?.status ===
+      "failed"
+    ) {
+      this.dispatch({ type: "local.message.queued", pending: staged.pending });
+    }
+
     await this.promptMessage(
       staged.message,
       staged.pending,

--- a/packages/react-opencode/src/openCodeRequestOptions.ts
+++ b/packages/react-opencode/src/openCodeRequestOptions.ts
@@ -1,0 +1,3 @@
+export const OPEN_CODE_REQUEST_OPTIONS = {
+  throwOnError: true,
+} as const;

--- a/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
+++ b/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createOpenCodeThreadListAdapter } from "./openCodeThreadListAdapter";
 import { rejectWhenThrowing } from "./testUtils";
 

--- a/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
+++ b/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createOpenCodeThreadListAdapter } from "./openCodeThreadListAdapter";
-
-const rejectWhenThrowing = (error: Error) =>
-  vi.fn(
-    (_parameters: unknown, options?: { throwOnError?: boolean | undefined }) =>
-      options?.throwOnError
-        ? Promise.reject(error)
-        : Promise.resolve({ data: undefined, error }),
-  );
+import { rejectWhenThrowing } from "./testUtils";
 
 describe("createOpenCodeThreadListAdapter", () => {
   it("propagates list errors returned by the OpenCode SDK", async () => {

--- a/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
+++ b/packages/react-opencode/src/openCodeThreadListAdapter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenCodeThreadListAdapter } from "./openCodeThreadListAdapter";
+
+const rejectWhenThrowing = (error: Error) =>
+  vi.fn(
+    (_parameters: unknown, options?: { throwOnError?: boolean | undefined }) =>
+      options?.throwOnError
+        ? Promise.reject(error)
+        : Promise.resolve({ data: undefined, error }),
+  );
+
+describe("createOpenCodeThreadListAdapter", () => {
+  it("propagates list errors returned by the OpenCode SDK", async () => {
+    const error = new Error("Unauthorized");
+    const list = rejectWhenThrowing(error);
+    const adapter = createOpenCodeThreadListAdapter({
+      experimental: { session: { list } },
+    } as never);
+
+    await expect(adapter.list()).rejects.toBe(error);
+    expect(list).toHaveBeenCalledWith(
+      { roots: true, archived: true },
+      { throwOnError: true },
+    );
+  });
+
+  it("propagates mutation errors returned by the OpenCode SDK", async () => {
+    const error = new Error("Session not found");
+    const update = rejectWhenThrowing(error);
+    const adapter = createOpenCodeThreadListAdapter({
+      session: { update },
+    } as never);
+
+    await expect(adapter.rename("session-1", "New title")).rejects.toBe(error);
+    expect(update).toHaveBeenCalledWith(
+      { sessionID: "session-1", title: "New title" },
+      { throwOnError: true },
+    );
+  });
+});

--- a/packages/react-opencode/src/openCodeThreadListAdapter.ts
+++ b/packages/react-opencode/src/openCodeThreadListAdapter.ts
@@ -2,6 +2,7 @@ import {
   createOpencodeClient,
   type GlobalSession,
 } from "@opencode-ai/sdk/v2/client";
+import { OPEN_CODE_REQUEST_OPTIONS } from "./openCodeRequestOptions";
 
 const isArchivedSession = (session: Pick<GlobalSession, "time">) => {
   return typeof session.time.archived === "number";
@@ -24,10 +25,13 @@ export const createOpenCodeThreadListAdapter = (
   client: ReturnType<typeof createOpencodeClient>,
 ) => ({
   list: async () => {
-    const response = await client.experimental.session.list({
-      roots: true,
-      archived: true,
-    });
+    const response = await client.experimental.session.list(
+      {
+        roots: true,
+        archived: true,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
     const sessions = new Map<string, GlobalSession>();
 
     for (const session of response.data ?? []) {
@@ -40,32 +44,44 @@ export const createOpenCodeThreadListAdapter = (
     };
   },
   rename: async (remoteId: string, newTitle: string) => {
-    await client.session.update({
-      sessionID: remoteId,
-      title: newTitle,
-    });
+    await client.session.update(
+      {
+        sessionID: remoteId,
+        title: newTitle,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
   },
   archive: async (remoteId: string) => {
-    await client.session.update({
-      sessionID: remoteId,
-      time: { archived: Date.now() },
-    });
+    await client.session.update(
+      {
+        sessionID: remoteId,
+        time: { archived: Date.now() },
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
   },
   unarchive: async (remoteId: string) => {
-    await client.session.update({
-      sessionID: remoteId,
-      // The SDK models archived timestamps as numbers, but OpenCode uses
-      // `null` here to clear the archived flag when unarchiving.
-      time: { archived: null as never } as never,
-    });
+    await client.session.update(
+      {
+        sessionID: remoteId,
+        // The SDK models archived timestamps as numbers, but OpenCode uses
+        // `null` here to clear the archived flag when unarchiving.
+        time: { archived: null as never } as never,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
   },
   delete: async (remoteId: string) => {
-    await client.session.delete({
-      sessionID: remoteId,
-    });
+    await client.session.delete(
+      {
+        sessionID: remoteId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
   },
   initialize: async () => {
-    const response = await client.session.create({});
+    const response = await client.session.create({}, OPEN_CODE_REQUEST_OPTIONS);
     if (!response.data?.id) {
       throw new Error("Failed to create OpenCode session");
     }
@@ -75,9 +91,12 @@ export const createOpenCodeThreadListAdapter = (
     };
   },
   generateTitle: async (remoteId: string) => {
-    await client.session.summarize({
-      sessionID: remoteId,
-    });
+    await client.session.summarize(
+      {
+        sessionID: remoteId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
     // Title updates arrive through the OpenCode event stream, so this
     // placeholder stream only satisfies the remote thread list contract.
     return new ReadableStream({
@@ -87,9 +106,12 @@ export const createOpenCodeThreadListAdapter = (
     }) as never;
   },
   fetch: async (threadId: string) => {
-    const response = await client.session.get({
-      sessionID: threadId,
-    });
+    const response = await client.session.get(
+      {
+        sessionID: threadId,
+      },
+      OPEN_CODE_REQUEST_OPTIONS,
+    );
     if (!response.data?.id) {
       throw new Error("OpenCode session not found");
     }

--- a/packages/react-opencode/src/testUtils.ts
+++ b/packages/react-opencode/src/testUtils.ts
@@ -1,0 +1,9 @@
+import { vi } from "vitest";
+
+export const rejectWhenThrowing = (error: Error) =>
+  vi.fn(
+    (_parameters: unknown, options?: { throwOnError?: boolean | undefined }) =>
+      options?.throwOnError
+        ? Promise.reject(error)
+        : Promise.resolve({ data: undefined, error }),
+  );


### PR DESCRIPTION
## Summary
- opt OpenCode REST requests into the SDK's `throwOnError` behavior
- propagate failures from thread-list mutations and controller operations
- mark failed prompts correctly instead of leaving them pending
- reset failed staged prompts to pending while they are retried
- add a patch changeset and regression coverage

## Why
While testing failed OpenCode requests, I found that the SDK resolves them as `{ data: undefined, error }` by default. The adapter only read `data`, so a failed list looked like an empty list, mutations such as rename appeared successful, and a failed prompt could remain pending.

Passing `throwOnError: true` per request also covers callers that provide their own default-configured OpenCode client. Authentication, server, and network response errors now reach the runtime's existing failure handling. Failed staged messages remain retryable and return to a pending state while a new request is in flight, allowing the successful server message to reconcile them normally.

## Verification
- `pnpm --filter @assistant-ui/react-opencode test` (49 tests)
- `pnpm exec turbo build --filter=@assistant-ui/react-opencode...`
- `pnpm lint`
