### PR TITLE
docs: document useChatRuntime runtime options in the ai-sdk v7 guide

### DIFF
--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -595,6 +595,56 @@ const runtime = useChatRuntime({
 
 If you need a transport that does not inherit from `AssistantChatTransport`, you forfeit automatic system-message and frontend-tool forwarding; the transport is then a regular AI SDK `ChatTransport` and you control everything explicitly.
 
+## Runtime options
+
+Beyond transports and adapters, `useChatRuntime` accepts options that control thread routing, message grouping, and run resumption.
+
+### onThreadIdChange
+
+Called whenever the active thread's settled ID changes, e.g. to sync the active thread to a URL query param:
+
+```tsx
+const runtime = useChatRuntime({
+  onThreadIdChange: (threadId) => {
+    const url = new URL(window.location.href);
+    if (threadId) {
+      url.searchParams.set("thread", threadId);
+    } else {
+      url.searchParams.delete("thread");
+    }
+    window.history.replaceState(null, "", url);
+  },
+});
+```
+
+Only the settled ID is emitted: while a freshly created thread has not been initialized yet, the value is `undefined`, and the real ID is emitted once the thread initializes (with [AssistantCloud](/docs/cloud/ai-sdk-assistant-ui), this is the cloud thread ID). The transient local ID is never surfaced.
+
+### joinStrategy
+
+Controls how consecutive assistant messages are rendered:
+
+```tsx
+const runtime = useChatRuntime({
+  joinStrategy: "none",
+});
+```
+
+`"concat-content"` (the default) merges consecutive assistant messages into a single thread message. `"none"` keeps each assistant message as its own thread message, which is useful when a backend persists proactive or consecutive assistant messages as separate entries. See the [external store guide](/docs/runtimes/custom/external-store#useexternalmessageconverter-with-join-strategy) for the underlying join semantics.
+
+### onResume
+
+Called when `runtime.thread.resumeRun(config)` is invoked. Provide it to bridge resume invocations into a custom replay channel, for example an SSE reconnect endpoint keyed by turn id:
+
+```tsx
+const runtime = useChatRuntime({
+  onResume: async (config) => {
+    await reconnectToRun(config.runConfig);
+  },
+});
+```
+
+When omitted, `resumeRun` throws `"Runtime does not support resuming runs."`. For streams that should survive a page reload without a custom channel, use the built-in transport-level path instead: see [Resumable streams](/docs/guides/resumable-streams), which reconnects automatically on mount and reports failures via `onResumeError`.
+
 ## Advanced: useAISDKRuntime
 
 When you need direct access to the `useChat` instance (e.g. to share it with non-assistant-ui code), drop down to `useAISDKRuntime`:
@@ -608,6 +658,16 @@ const runtime = useAISDKRuntime(chat);
 ```
 
 `useAISDKRuntime` does not provide `cloud` or the higher-level adapter slots; those are part of `useChatRuntime`. If you need both your own `useChat` access AND cloud thread support, you generally want `useChatRuntime` and to read the chat state through assistant-ui hooks instead.
+
+`useAISDKRuntime` accepts `joinStrategy` and `onResume` (see [Runtime options](#runtime-options)) plus one option of its own, `cancelPendingToolCallsOnSend`:
+
+```tsx
+const runtime = useAISDKRuntime(chat, {
+  cancelPendingToolCallsOnSend: false,
+});
+```
+
+When enabled (the default), sending a new message marks any pending interactive tool calls as failed with an error indicating the user cancelled them. Set it to `false` to leave pending tool calls untouched when the user sends a new message.
 
 ## Adapter support
 


### PR DESCRIPTION
## What

Adds a "Runtime options" section to the AI SDK v7 guide covering `onThreadIdChange`, `joinStrategy`, and `onResume`, and extends the "Advanced: useAISDKRuntime" section with `cancelPendingToolCallsOnSend`.

## Why

These options ship on `useChatRuntime` / `useAISDKRuntime` (`onThreadIdChange` since #4515) but appear nowhere on the AI SDK guide. `joinStrategy` and `onResume` are documented only on the generic external store page, and `onThreadIdChange` is not documented anywhere in guide content, so today they are discoverable only by reading source. AGENTS.md requires docs to stay in lockstep with shipped hooks.

## Impact

- Docs only, single page touched: `apps/docs/content/docs/runtimes/ai-sdk/v7.mdx`
- No code changes, no published package touched, so no changeset (apps/docs is private)
- No change to the generated api-reference tree

## Rationale

Each option is documented where it actually exists. `cancelPendingToolCallsOnSend` is deliberately placed under the `useAISDKRuntime` section rather than the new `useChatRuntime` options list because `UseChatRuntimeOptions` does not accept it; it only exists on `useAISDKRuntime`'s options and `useChatRuntime` never forwards it.

Wording is verified against source rather than copied from the backlog claim:

- `onThreadIdChange` emits only the settled thread ID and `undefined` while a fresh thread is uninitialized (core `remote-thread-list/types.ts`); it works without `cloud` because the in-memory adapter settles `remoteId = threadId`, so the example needs no cloud setup
- `onResume` documents the `resumeRun` bridge and the exact `"Runtime does not support resuming runs."` throw when omitted (`external-store-thread-runtime-core.ts`), and points readers to the resumable streams guide for the built-in transport-level reload path, which does not go through `onResume`
- `joinStrategy` mirrors the external store page's semantics and cross-links it


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

