### PR TITLE
fix(ui): initialize Radix sidebar skeleton width as state

### DIFF
--- a/packages/ui/src/components/ui/radix/sidebar.tsx
+++ b/packages/ui/src/components/ui/radix/sidebar.tsx
@@ -605,10 +605,9 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
+  const [width] = React.useState(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  });
 
   return (
     <div


### PR DESCRIPTION
Fixes #4917

## What

Use a lazy useState initializer for the Radix SidebarMenuSkeleton random width, matching the Base UI sibling.

## Why

The width is mount state, not a derived calculation. useMemo is discardable, so recalculation can visibly change the skeleton width without a remount. Server and client renders can also independently generate different random values.

## Scope

One component and one hook substitution. No API, styling range, or registry behavior changes. The package is private, so no changeset is required.

## Verification

- pnpm exec oxlint packages/ui/src/components/ui/radix/sidebar.tsx
- pnpm exec oxfmt --check packages/ui/src/components/ui/radix/sidebar.tsx
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

