### PR TITLE
fix(tap): keep root lifecycle state out of useMemo

### DIFF
--- a/.changeset/tap-root-lifetime-state.md
+++ b/.changeset/tap-root-lifetime-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: keep tap root scheduler, fiber, queue, and subscribers in React state for the full component lifetime

--- a/packages/tap/src/hooks/useTapRoot.ts
+++ b/packages/tap/src/hooks/useTapRoot.ts
@@ -12,7 +12,7 @@ import {
   setRootVersion,
 } from "../core/helpers/root";
 import { cloneCurrentTapContext, withTapContextRoot } from "../core/context";
-import { useEffect, useEffectEvent, useMemo, useRef } from "react";
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
 import { useDevStrictMode } from "./utils/useDevStrictMode";
 
 export namespace useTapRoot {
@@ -34,14 +34,12 @@ export namespace useTapRoot {
 const useHostRoot = <R>(render: () => R): R => render();
 
 export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
-  const scheduler = useMemo(
-    () => new UpdateScheduler(() => handleUpdate()),
-    [],
-  );
-  const queue = useMemo(() => [] as (() => boolean)[], []);
+  // oxlint-disable-next-line react-hooks/rules-of-hooks -- updates run through the component's Effect Event after the scheduler is initialized
+  const [scheduler] = useState(() => new UpdateScheduler(() => handleUpdate()));
+  const [queue] = useState<(() => boolean)[]>(() => []);
 
   const getDevStrictMode = useDevStrictMode();
-  const fiber = useMemo(() => {
+  const [fiber] = useState(() => {
     const root = createResourceFiberRoot((evaluate, apply) => {
       if (!scheduler.isDirty) {
         if (!evaluate()) return;
@@ -58,7 +56,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
       undefined,
       getDevStrictMode(),
     );
-  }, [queue, scheduler, getDevStrictMode]);
+  });
 
   const context = cloneCurrentTapContext();
 
@@ -70,7 +68,7 @@ export const useTapRoot = <R>(render: () => R): useTapRoot.Root<R> => {
   const isMountedRef = useRef(false);
   const committedArgsRef = useRef([render] as const);
   const valueRef = useRef<R>(render2);
-  const subscribers = useMemo(() => new Set<() => void>(), []);
+  const [subscribers] = useState(() => new Set<() => void>());
 
   const publish = (output: R) => {
     if (scheduler.isDirty || valueRef.current === output) return;


### PR DESCRIPTION
Fixes #4915

## What

Store the tap root scheduler, pending queue, resource fiber, and subscriber set in lazy React state instead of useMemo. The public root facade remains memoized because its identity is only an optimization.

## Why

These objects form one mutable state machine and must survive for the entire mounted component lifetime. React treats useMemo as a discardable optimization, so correctness cannot rely on those memo cells retaining their allocations.

## Scope

This only changes allocation ownership. Scheduling, commit behavior, subscriptions, Strict Mode handling, and the public API are unchanged.

## Verification

- pnpm --filter @assistant-ui/tap exec vitest run src/__tests__/react/useResource.test.tsx src/__tests__/react/concurrent-pending-updates.test.tsx src/__tests__/react/concurrent-render-phase.test.tsx
- pnpm --filter @assistant-ui/tap build
- pnpm exec oxlint packages/tap/src/hooks/useTapRoot.ts
- pnpm exec oxfmt --check packages/tap/src/hooks/useTapRoot.ts .changeset/tap-root-lifetime-state.md
- pnpm changeset status --since upstream/main
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

