### PR TITLE
fix(tap): preserve hosted resource fiber state

### DIFF
--- a/.changeset/tap-resource-fiber-lifetime.md
+++ b/.changeset/tap-resource-fiber-lifetime.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: preserve React-hosted tap resource roots and keyed fiber registries for the component lifetime

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -14,7 +14,7 @@ import {
   hasContextDepsChanged,
 } from "../core/context";
 import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
-import { useEffect, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 import { depsShallowEqual } from "./utils/depsShallowEqual";
 
@@ -73,7 +73,7 @@ const hasAnyChildContextDepsChanged = (
 export function useResources<E extends ResourceElement<any, any[]>>(
   elements: readonly E[],
 ): ExtractResourceReturnType<E>[] {
-  const fibers = useMemo(() => new Map<string | number, FiberState>(), []);
+  const [fibers] = useState(() => new Map<string | number, FiberState>());
 
   // Process each element
 

--- a/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
+++ b/packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
@@ -26,7 +26,7 @@ const useResourceFiberHostUtilsTap = () => {
 };
 
 const useResourceFiberHostUtilsReact = () => {
-  const root = useMemo(() => {
+  const [root] = useState(() => {
     return createResourceFiberRoot((evaluateUpdate, applyUpdate) => {
       let eagerBail = false;
 
@@ -39,7 +39,7 @@ const useResourceFiberHostUtilsReact = () => {
         apply(applyUpdate);
       }
     });
-  }, []);
+  });
 
   const [version, apply] = useReducer(
     (v: number, applyUpdate: () => boolean) => {


### PR DESCRIPTION
Fixes #4916

## What

Move the React-hosted tap root and the keyed useResources fiber registry from useMemo into lazy React state.

## Why

Both allocations hold correctness-bearing mutable lifecycle data: root versions, child fibers, dirty flags, committed values, and cleanup ownership. React may discard memoized values, while state is retained for the mounted component lifetime.

## Scope

The explicit keyed remount path is unchanged. This PR only changes ownership of the host root and registry allocations.

## Verification

- pnpm --filter @assistant-ui/tap exec vitest run src/__tests__/react/useResource.test.tsx src/__tests__/react/concurrent-pending-updates.test.tsx src/__tests__/react/concurrent-render-phase.test.tsx
- pnpm --filter @assistant-ui/tap build
- pnpm exec oxlint packages/tap/src/hooks/useResources.ts packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts
- pnpm exec oxfmt --check packages/tap/src/hooks/useResources.ts packages/tap/src/hooks/utils/useResourceFiberHostUtils.ts .changeset/tap-resource-fiber-lifetime.md
- pnpm changeset status --since upstream/main
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

