### PR TITLE
fix(cloud-ai-sdk): preserve mounted state in strict mode

### DIFF
--- a/.changeset/quiet-clouds-rest.md
+++ b/.changeset/quiet-clouds-rest.md
@@ -2,4 +2,4 @@
 "@assistant-ui/cloud-ai-sdk": patch
 ---
 
-fix: preserve mounted state when Strict Mode replays effects
+fix: preserve mounted state and ignore superseded thread refreshes when Strict Mode replays effects

--- a/.changeset/quiet-clouds-rest.md
+++ b/.changeset/quiet-clouds-rest.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: preserve mounted state when Strict Mode replays effects

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.test.ts
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useCloudChatCore } from "./useCloudChatCore";
+
+describe("useCloudChatCore", () => {
+  it("tracks mounted state when Strict Mode replays effects", () => {
+    const cloud = {} as never;
+    const { result, unmount } = renderHook(
+      () =>
+        useCloudChatCore(cloud, {
+          threads: {} as never,
+          chatConfig: {},
+        }),
+      { reactStrictMode: true },
+    );
+
+    const core = result.current;
+    expect(core.mountedRef.current).toBe(true);
+
+    unmount();
+    expect(core.mountedRef.current).toBe(false);
+  });
+});

--- a/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChatCore.ts
@@ -33,12 +33,12 @@ export function useCloudChatCore(
 
   // Track component lifetime for safe async operations
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
   core.mountedRef = mountedRef;
 
   const fallbackTransport = useRef<ChatTransport<UIMessage>>(

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -47,6 +47,41 @@ describe("useThreads", () => {
     });
   });
 
+  it("loads threads when Strict Mode replays effects", async () => {
+    const cloud = {
+      threads: {
+        list: vi.fn().mockResolvedValue({
+          threads: [
+            {
+              id: "thread-1",
+              title: "Customer support",
+              is_archived: false,
+              external_id: null,
+              last_message_at: new Date("2026-01-01T00:00:00.000Z"),
+              created_at: new Date("2026-01-01T00:00:00.000Z"),
+              updated_at: new Date("2026-01-01T00:00:00.000Z"),
+            },
+          ],
+        }),
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+
+    const { result } = renderHook(() => useThreads({ cloud }), {
+      reactStrictMode: true,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.threads).toMatchObject([
+      { id: "thread-1", title: "Customer support" },
+    ]);
+  });
+
   it("avoids unmounted state updates during async refresh", async () => {
     const deferred = createDeferred<{ threads: never[] }>();
     const consoleErrorSpy = vi

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useThreads } from "./useThreads";
 
@@ -15,6 +15,22 @@ function createDeferred<T>(): Deferred<T> {
     resolve = res;
   });
   return { promise, resolve };
+}
+
+function createThreadListResponse(title: string) {
+  return {
+    threads: [
+      {
+        id: "thread-1",
+        title,
+        is_archived: false,
+        external_id: null,
+        last_message_at: new Date("2026-01-01T00:00:00.000Z"),
+        created_at: new Date("2026-01-01T00:00:00.000Z"),
+        updated_at: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ],
+  };
 }
 
 describe("useThreads", () => {
@@ -50,19 +66,9 @@ describe("useThreads", () => {
   it("loads threads when Strict Mode replays effects", async () => {
     const cloud = {
       threads: {
-        list: vi.fn().mockResolvedValue({
-          threads: [
-            {
-              id: "thread-1",
-              title: "Customer support",
-              is_archived: false,
-              external_id: null,
-              last_message_at: new Date("2026-01-01T00:00:00.000Z"),
-              created_at: new Date("2026-01-01T00:00:00.000Z"),
-              updated_at: new Date("2026-01-01T00:00:00.000Z"),
-            },
-          ],
-        }),
+        list: vi
+          .fn()
+          .mockResolvedValue(createThreadListResponse("Customer support")),
         get: vi.fn(),
         create: vi.fn(),
         delete: vi.fn(),
@@ -80,6 +86,45 @@ describe("useThreads", () => {
     expect(result.current.threads).toMatchObject([
       { id: "thread-1", title: "Customer support" },
     ]);
+  });
+
+  it("keeps the latest refresh when requests resolve out of order", async () => {
+    const first = createDeferred<ReturnType<typeof createThreadListResponse>>();
+    const second =
+      createDeferred<ReturnType<typeof createThreadListResponse>>();
+    const cloud = {
+      threads: {
+        list: vi
+          .fn()
+          .mockReturnValueOnce(first.promise)
+          .mockReturnValueOnce(second.promise),
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+
+    const { result } = renderHook(() => useThreads({ cloud, enabled: false }));
+
+    let firstRefresh!: Promise<boolean>;
+    let secondRefresh!: Promise<boolean>;
+    act(() => {
+      firstRefresh = result.current.refresh();
+      secondRefresh = result.current.refresh();
+    });
+
+    await act(async () => {
+      second.resolve(createThreadListResponse("Newest"));
+      await secondRefresh;
+    });
+    expect(result.current.threads[0]?.title).toBe("Newest");
+
+    await act(async () => {
+      first.resolve(createThreadListResponse("Stale"));
+      await firstRefresh;
+    });
+    expect(result.current.threads[0]?.title).toBe("Newest");
   });
 
   it("avoids unmounted state updates during async refresh", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -38,6 +38,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
 
   const mountedRef = useRef(true);
   useEffect(() => {
+    mountedRef.current = true;
     return () => {
       mountedRef.current = false;
     };

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -37,6 +37,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const [threadId, setThreadId] = useState<string | null>(null);
 
   const mountedRef = useRef(true);
+  const refreshRequestRef = useRef(0);
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -45,13 +46,17 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   }, []);
 
   const withAction = useCallback(
-    async <T>(action: () => Promise<T>, fallback: T): Promise<T> => {
+    async <T>(
+      action: () => Promise<T>,
+      fallback: T,
+      shouldUpdate: () => boolean = () => true,
+    ): Promise<T> => {
       try {
         const result = await action();
-        if (mountedRef.current) setError(null);
+        if (mountedRef.current && shouldUpdate()) setError(null);
         return result;
       } catch (err) {
-        if (mountedRef.current)
+        if (mountedRef.current && shouldUpdate())
           setError(err instanceof Error ? err : new Error(String(err)));
         return fallback;
       }
@@ -60,20 +65,26 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   );
 
   const refresh = useCallback(async (): Promise<boolean> => {
+    const requestId = ++refreshRequestRef.current;
+    const isLatest = () => requestId === refreshRequestRef.current;
     setIsLoading(true);
 
     try {
-      return await withAction(async () => {
-        const response = await cloud.threads.list(
-          includeArchived ? undefined : { is_archived: false },
-        );
-        if (mountedRef.current) {
-          setThreads(() => response.threads.map(toCloudThread));
-        }
-        return true;
-      }, false);
+      return await withAction(
+        async () => {
+          const response = await cloud.threads.list(
+            includeArchived ? undefined : { is_archived: false },
+          );
+          if (mountedRef.current && isLatest()) {
+            setThreads(() => response.threads.map(toCloudThread));
+          }
+          return true;
+        },
+        false,
+        isLatest,
+      );
     } finally {
-      if (mountedRef.current) {
+      if (mountedRef.current && isLatest()) {
         setIsLoading(false);
       }
     }


### PR DESCRIPTION
## Summary

- restore mounted refs during effect setup in `useThreads` and `useCloudChatCore`
- keep successful thread loads and persistence error reporting active after React Strict Mode replays effects
- ignore results from superseded thread refreshes
- add root-level Strict Mode and out-of-order response regression coverage

## Why

While testing `useThreads` under React Strict Mode, a successful Cloud response left `isLoading` stuck at `true`.

Strict Mode runs an extra setup -> cleanup -> setup cycle in development. Both hooks set their mounted ref to `false` during cleanup, but their setup never restored it to `true`. As a result, `useThreads` ignored successful list results and loading completion, while `useCloudChatCore` could suppress `onSyncError` callbacks.

Restoring the mounted state also means both Strict Mode refreshes may complete. Each refresh now receives a request ID so an older response cannot overwrite newer thread, loading, or error state.

The mounted-state regression test fails on current `main` with `expected true to be false`. The refresh-order regression separately reproduces `Newest` being overwritten by `Stale`. Both pass with this change, while a real unmount still sets the mounted ref to `false`.

## Verification

- `pnpm --filter @assistant-ui/cloud-ai-sdk test` (59 tests)
- `pnpm turbo build --filter=@assistant-ui/cloud-ai-sdk...`
- `pnpm lint`