### PR TITLE
fix: preserve file data in message conversion

### DIFF
--- a/.changeset/calm-files-stay.md
+++ b/.changeset/calm-files-stay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: preserve base64 file data during AI SDK message conversion

--- a/packages/react-data-stream/package.json
+++ b/packages/react-data-stream/package.json
@@ -28,7 +28,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/provider": "^3.0.10 || ^4.0.0",
@@ -49,7 +50,8 @@
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/json-schema": "^7.0.15",
     "@types/react": "^19.2.17",
-    "react": "^19.2.7"
+    "react": "^19.2.7",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-data-stream/src/converters/toLanguageModelMessages.test.ts
+++ b/packages/react-data-stream/src/converters/toLanguageModelMessages.test.ts
@@ -1,0 +1,43 @@
+import type { ThreadMessage } from "@assistant-ui/core";
+import { describe, expect, it } from "vitest";
+import { toLanguageModelMessages } from "./toLanguageModelMessages";
+
+const createFileMessage = (data: string): ThreadMessage => ({
+  id: "user-1",
+  role: "user",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  content: [{ type: "file", data, mimeType: "text/plain" }],
+  attachments: [],
+  metadata: { custom: {} },
+});
+
+const convertFileData = (data: string) => {
+  const [message] = toLanguageModelMessages([createFileMessage(data)]);
+  if (message?.role !== "user") throw new Error("Expected a user message");
+
+  const [part] = message.content;
+  if (part?.type !== "file") throw new Error("Expected a file part");
+
+  return part.data;
+};
+
+describe("toLanguageModelMessages", () => {
+  it("preserves base64 file data as a string", () => {
+    expect(convertFileData("SGVsbG8=")).toBe("SGVsbG8=");
+  });
+
+  it("preserves absolute file URLs", () => {
+    const data = convertFileData("https://example.com/file.txt");
+
+    expect(data).toBeInstanceOf(URL);
+    expect(String(data)).toBe("https://example.com/file.txt");
+  });
+
+  it("preserves data URLs", () => {
+    const url = "data:text/plain;base64,SGVsbG8=";
+    const data = convertFileData(url);
+
+    expect(data).toBeInstanceOf(URL);
+    expect(String(data)).toBe(url);
+  });
+});

--- a/packages/react-data-stream/src/converters/toLanguageModelMessages.ts
+++ b/packages/react-data-stream/src/converters/toLanguageModelMessages.ts
@@ -15,16 +15,6 @@ import {
   type GenericToolResultPart,
 } from "assistant-stream";
 
-function toUrl(value: string | URL): URL {
-  if (value instanceof URL) return value;
-  try {
-    return new URL(value);
-  } catch {
-    // For relative URLs, create URL with a dummy base
-    return new URL(value, "file://");
-  }
-}
-
 function convertUserContent(
   content: GenericMessage & { role: "user" },
 ): (LanguageModelV2TextPart | LanguageModelV2FilePart)[] {
@@ -34,7 +24,7 @@ function convertUserContent(
     }
     return {
       type: "file",
-      data: toUrl(part.data),
+      data: part.data,
       mediaType: part.mediaType,
     };
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3921,6 +3921,9 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/react-devtools:
     dependencies:


### PR DESCRIPTION
## Summary

- preserve the `string | URL` file data produced by `assistant-stream`
- stop converting non-URL strings into synthetic `file://` URLs
- add regression coverage for raw base64, HTTPS URLs, and data URLs

## Why

While testing direct file-part conversion locally, I found that raw base64 data such as `SGVsbG8=` became `file:///SGVsbG8=`. The AI SDK accepts the original base64 string, but rejects the fabricated URL value as invalid data content.

`toGenericMessages()` already performs the intended normalization: real URLs and data URLs become `URL` objects, while non-URL strings remain strings. Keeping that result fixes the base64 case without changing existing URL behavior.

## Verification

- `pnpm --filter @assistant-ui/react-data-stream test`
- `pnpm turbo build --filter=@assistant-ui/react-data-stream...`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

