### PR TITLE
fix(react-ai-sdk): expose initialized thread ID

### DIFF
--- a/.changeset/mastra-transport-thread-id.md
+++ b/.changeset/mastra-transport-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: expose the initialized remote thread ID to custom chat request preparation

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { AssistantChatTransport } from "./AssistantChatTransport";
+
+const makeResponse = () =>
+  new Response('data: {"type":"finish"}\n\n', {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+
+const sendMessages = (transport: AssistantChatTransport) =>
+  transport.sendMessages({
+    trigger: "submit-message",
+    chatId: "local-thread",
+    messageId: undefined,
+    messages: [],
+    abortSignal: undefined,
+  });
+
+describe("AssistantChatTransport", () => {
+  it("passes the initialized remote thread ID to request preparation", async () => {
+    const prepareSendMessagesRequest = vi.fn((options) => ({
+      body: { id: options.id, messages: options.messages },
+    }));
+    const transport = new AssistantChatTransport({
+      fetch: vi.fn(async () => makeResponse()),
+      prepareSendMessagesRequest,
+    });
+    const initialize = vi.fn(async () => ({
+      remoteId: "remote-thread",
+      externalId: undefined,
+    }));
+    transport.__internal_setGetThreadListItem(() => ({ initialize }));
+
+    await sendMessages(transport);
+
+    expect(initialize).toHaveBeenCalledOnce();
+    expect(prepareSendMessagesRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "remote-thread" }),
+    );
+  });
+
+  it("keeps the initialized remote thread ID in the default request body", async () => {
+    const fetch = vi.fn(async () => makeResponse());
+    const transport = new AssistantChatTransport({ fetch });
+    transport.__internal_setGetThreadListItem(() => ({
+      initialize: async () => ({
+        remoteId: "remote-thread",
+        externalId: undefined,
+      }),
+    }));
+
+    await sendMessages(transport);
+
+    const init = fetch.mock.calls[0]?.[1];
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      id: "remote-thread",
+      messages: [],
+      trigger: "submit-message",
+    });
+  });
+});

--- a/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/AssistantChatTransport.ts
@@ -55,6 +55,7 @@ export class AssistantChatTransport<
 
         const optionsEx = {
           ...options,
+          id,
           body: {
             callSettings: context?.callSettings,
             system: context?.system,


### PR DESCRIPTION
Fixes #4929

## Why

Provider integrations need the remote thread ID selected during `AssistantChatTransport` initialization when preparing a request. The callback currently receives the unresolved caller ID, so adapters cannot reliably populate provider memory identity for new threads.

## What changed

- pass the settled remote thread ID to `prepareSendMessagesRequest`
- preserve the default request body and transport behavior
- cover both custom and default request preparation
- add a patch changeset for `@assistant-ui/react-ai-sdk`

## Stack

Depends on #4994. The next PR adds the Mastra thread and history adapter.

## Verification

- `pnpm --filter @assistant-ui/react-ai-sdk test` (16 files, 158 tests)
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `pnpm changeset status --since codex/mastra --verbose`
