### PR TITLE
feat(react-mastra): add workflow lifecycle hook

### DIFF
--- a/.changeset/tender-pens-float.md
+++ b/.changeset/tender-pens-float.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mastra": patch
+---
+
+feat: add persisted Mastra workflow suspend and resume hooks

--- a/api-surface/assistant-ui__react-mastra.ts
+++ b/api-surface/assistant-ui__react-mastra.ts
@@ -1,6 +1,8 @@
 import { CreateUIMessage, UIMessage as UIMessage$1, useChat } from "@ai-sdk/react";
 
-import { MastraClient } from "@mastra/client-js";
+import { GetWorkflowRunByIdResponse, MastraClient, WorkflowRunResult } from "@mastra/client-js";
+
+import { WorkflowRunStatus } from "@mastra/core/workflows";
 
 import "@radix-ui/react-primitive";
 
@@ -1038,6 +1040,13 @@ type MastraHistoryAdapterOptions = {
   getThreadId: () => string | undefined;
 };
 
+type MastraSuspendedStep<TPayload = unknown> = {
+  stepId: string;
+  path: string[];
+  forEachIndex?: number | undefined;
+  payload: TPayload;
+};
+
 type MastraThreadListOptions = {
   client: MastraClient;
   agentId: string;
@@ -1048,6 +1057,25 @@ type MastraThreadListOptions = {
 };
 
 type MastraTitleGenerator = (messages: readonly ThreadMessage[]) => string | Promise<string>;
+
+type MastraWorkflowResumeOptions = {
+  forEachIndex?: number | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+};
+
+type MastraWorkflowStartOptions = {
+  initialState?: Record<string, unknown> | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+};
+
+type MastraWorkflowState<TResult = unknown, TSuspend = unknown> = {
+  runId: string | undefined;
+  status: "idle" | WorkflowRunStatus;
+  result: TResult | undefined;
+  error: Error | undefined;
+  suspendedSteps: MastraSuspendedStep<TSuspend>[];
+  raw: WorkflowRunResult | GetWorkflowRunByIdResponse | undefined;
+};
 
 type McpAppMetadata = {
   readonly resourceUri: string;
@@ -2085,6 +2113,16 @@ type UseMastraRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> = Omit<Us
   transportOptions?: Omit<Parameters<typeof createMastraChatTransport<UI_MESSAGE>>[0], "resourceId">;
 };
 
+type UseMastraWorkflowOptions<TResult = unknown, TSuspend = unknown> = {
+  client: MastraClient;
+  workflowId: string;
+  runId?: string | undefined;
+  resourceId?: string | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+  onRunIdChange?: ((runId: string) => void) | undefined;
+  onStateChange?: ((state: MastraWorkflowState<TResult, TSuspend>) => void) | undefined;
+};
+
 type ValidateClient<K extends keyof ScopeRegistry> = ScopeRegistry[K] extends {
   methods: ClientMethods;
 } ? "meta" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["meta"] extends ClientMetaType ? "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid meta type`> : "events" extends keyof ScopeRegistry[K] ? ScopeRegistry[K]["events"] extends ClientEventsType<K> ? ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid events type`> : ScopeRegistry[K] : ClientError<`ERROR: ${K & string} has invalid methods type`>;
@@ -2122,9 +2160,17 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { MastraChatTransportOptions, MastraThreadListOptions, MastraTitleGenerator, UseMastraRuntimeOptions, createMastraChatTransport, createMastraHistoryAdapter, createMastraThreadListAdapter, useMastraRuntime };
+  export { MastraChatTransportOptions, MastraSuspendedStep, MastraThreadListOptions, MastraTitleGenerator, MastraWorkflowResumeOptions, MastraWorkflowStartOptions, MastraWorkflowState, UseMastraRuntimeOptions, UseMastraWorkflowOptions, createMastraChatTransport, createMastraHistoryAdapter, createMastraThreadListAdapter, useMastraRuntime, useMastraWorkflow };
 }
 
 declare const useMastraRuntime: <UI_MESSAGE extends UIMessage = UIMessage>(_param5: UseMastraRuntimeOptions<UI_MESSAGE>) => AssistantRuntime;
+
+declare const useMastraWorkflow: <TInput extends Record<string, unknown> = Record<string, unknown>, TResume extends Record<string, unknown> = Record<string, unknown>, TResult = unknown, TSuspend = unknown>(_param6: UseMastraWorkflowOptions<TResult, TSuspend>) => {
+  state: MastraWorkflowState<TResult, TSuspend>;
+  start: (inputData: TInput, options?: MastraWorkflowStartOptions) => Promise<MastraWorkflowState<TResult, TSuspend>>;
+  resume: (step: string | string[] | MastraSuspendedStep<TSuspend>, resumeData: TResume, options?: MastraWorkflowResumeOptions) => Promise<MastraWorkflowState<TResult, TSuspend>>;
+  cancel: () => Promise<MastraWorkflowState<TResult, TSuspend>>;
+  refresh: () => Promise<MastraWorkflowState<TResult, TSuspend>>;
+};
 
 export { entry_root_exports as entry_root };

--- a/api-surface/package.json
+++ b/api-surface/package.json
@@ -14,6 +14,7 @@
     "@langchain/langgraph-sdk": "^1.9.25",
     "@langchain/react": "^1.0.26",
     "@mastra/client-js": "^1.32.0",
+    "@mastra/core": "^1.51.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.18.1",
     "@radix-ui/react-popper": "^1.3.3",

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/react-mastra.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/react-mastra.mdx
@@ -3,7 +3,7 @@ title: "@assistant-ui/react-mastra"
 description: Mastra memory thread adapters, chat transport, and durable workflow hooks for assistant-ui React applications.
 ---
 
-import { reactMastra_useMastraRuntime } from "@/generated/integrationTypeDocs";
+import { reactMastra_useMastraRuntime, reactMastra_useMastraWorkflow } from "@/generated/integrationTypeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -35,4 +35,8 @@ const createMastraThreadListAdapter: ({ client, agentId, resourceId, perPage, me
 ### useMastraRuntime
 
 <ParametersTable {...reactMastra_useMastraRuntime} />
+
+### useMastraWorkflow
+
+<ParametersTable {...reactMastra_useMastraWorkflow} />
 {/* api-reference:end */}

--- a/apps/docs/content/docs/integrations/frameworks/mastra/full-stack.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/full-stack.mdx
@@ -164,19 +164,19 @@ Open `http://localhost:3000`, send a message like *"What can I make with eggs an
 </Step>
 </Steps>
 
-## Persisted threads
+## Persisted threads and workflows
 
 The route above is the canonical chat-only setup. Tools, RAG, model routing, and other server-side agent features need no Mastra-specific client code.
 
-Persisted thread lists are different: the browser must call Mastra's memory APIs. Expose those APIs from the same origin or run the [separate Mastra server](/docs/integrations/frameworks/mastra/separate-server), then configure `useMastraRuntime` with a `MastraClient`, an `agentId`, and a stable `resourceId`. See [Persisted threads](/docs/integrations/frameworks/mastra/threads) for the complete client wiring.
+Persisted thread lists and interactive workflow suspension are different: the browser must call Mastra's memory and workflow APIs. Expose those APIs from the same origin or run the [separate Mastra server](/docs/integrations/frameworks/mastra/separate-server), then configure `useMastraRuntime` with a `MastraClient`, an `agentId`, and a stable `resourceId`. See [Persisted threads](/docs/integrations/frameworks/mastra/threads) and [Durable workflows](/docs/integrations/frameworks/mastra/workflows) for the complete client wiring.
 
-Use the authenticated account or tenant ID for `resourceId`, not a random value per render. The active assistant-ui thread ID is sent separately as Mastra's memory thread ID. Your server must authorize both values before reading history.
+Use the authenticated account or tenant ID for `resourceId`, not a random value per render. The active assistant-ui thread ID is sent separately as Mastra's memory thread ID. Your server must authorize thread and workflow run ownership before reading history or resuming a workflow.
 
 ## Notes
 
 - **Errors in the route bubble to the client as a stream error.** Wrap `agent.stream()` in `try/catch` if you need to log structured errors before they reach the client.
 - **Pin compatible versions.** `@mastra/ai-sdk` tracks the AI SDK v6 contract. If you upgrade `ai` to a future major, verify the `toAISdkStream` shape against Mastra's release notes.
-- **Server-only features** such as tools, RAG, model routing, workflows, and evals need no extra frontend integration. Memory thread navigation does require the client APIs described above.
+- **Server-only features** such as tools, RAG, model routing, and evals need no extra frontend integration. Memory thread navigation and interactive workflow suspension require the client APIs described above.
 
 ## Related
 

--- a/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
@@ -2,5 +2,5 @@
   "title": "Mastra",
   "description": "Mastra integration docs for wiring Mastra agents to assistant-ui through Next.js API routes or a separate server.",
   "platforms": ["react"],
-  "pages": ["overview", "full-stack", "separate-server", "threads"]
+  "pages": ["overview", "full-stack", "separate-server", "threads", "workflows"]
 }

--- a/apps/docs/content/docs/integrations/frameworks/mastra/overview.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mastra Integration
-description: Connect Mastra agents and persisted memory threads to assistant-ui.
+description: Connect Mastra agents, persisted memory threads, and durable workflows to assistant-ui.
 ---
 
 import { MastraIcon } from "@/components/icons/mastra";
@@ -9,7 +9,7 @@ import { VercelIcon } from "@/components/icons/vercel";
 [Mastra](https://mastra.ai/) is an open-source TypeScript agent framework. It provides primitives for AI applications: agents with memory and tool calling, deterministic LLM workflows, RAG, model routing, workflow graphs, and automated evals.
 
 <Callout type="info">
-For streaming chat only, keep using the standard [AI SDK runtime](/docs/runtimes/ai-sdk/v7). Add `@assistant-ui/react-mastra` when the UI must enumerate Mastra memory threads and restore persisted messages.
+For streaming chat only, keep using the standard [AI SDK runtime](/docs/runtimes/ai-sdk/v7). Add `@assistant-ui/react-mastra` when the UI must enumerate Mastra memory threads, restore persisted messages, or control a durable workflow run.
 </Callout>
 
 ## Pick a pattern
@@ -19,14 +19,17 @@ For streaming chat only, keep using the standard [AI SDK runtime](/docs/runtimes
 | [Full-stack](/docs/integrations/frameworks/mastra/full-stack) | One Next.js app: API routes call Mastra in-process. Simpler deployment, single repo. |
 | [Separate server](/docs/integrations/frameworks/mastra/separate-server) | Mastra runs as its own service; the Next.js frontend hits its API. Independent scaling, clearer separation of concerns. |
 | [Persisted threads](/docs/integrations/frameworks/mastra/threads) | Add Mastra-backed thread navigation and history to either deployment pattern. |
+| [Durable workflows](/docs/integrations/frameworks/mastra/workflows) | Render suspended workflow steps and resume persisted runs after reload. |
 
-Both chat patterns use the AI SDK protocol. `useMastraRuntime` composes that chat runtime with Mastra's memory APIs.
+Both chat patterns use the AI SDK protocol. `useMastraRuntime` composes that chat runtime with Mastra's memory APIs; `useMastraWorkflow` uses Mastra's workflow client directly beside the chat runtime.
 
 ## Architecture
 
 Mastra integrates at the LLM-client layer on the server. assistant-ui talks to a `chatRoute` or custom API route through the AI SDK protocol. `@mastra/ai-sdk` provides the protocol conversion, and `@assistant-ui/react-ai-sdk` renders the streaming chat state.
 
 When persistence is enabled, `@assistant-ui/react-mastra` adds a remote thread-list adapter and history adapter backed by `MastraClient`. It sends the active assistant-ui thread ID as Mastra's memory thread and a stable application identity as the memory resource.
+
+Workflow runs remain a separate lifecycle so a suspended approval can be rendered and resumed without coupling it to a chat message.
 
 ## Requirements
 
@@ -55,5 +58,11 @@ When persistence is enabled, `@assistant-ui/react-mastra` adds a remote thread-l
     title="Persisted threads"
     description="Persist conversations in Mastra memory."
     href="/docs/integrations/frameworks/mastra/threads"
+  />
+  <Card
+    icon={<VercelIcon width={20} height={20} />}
+    title="Durable workflows"
+    description="Resume human-in-the-loop workflow runs."
+    href="/docs/integrations/frameworks/mastra/workflows"
   />
 </Cards>

--- a/apps/docs/content/docs/integrations/frameworks/mastra/separate-server.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/separate-server.mdx
@@ -227,11 +227,13 @@ export function MyRuntimeProvider({ children }: PropsWithChildren) {
 
 Set `NEXT_PUBLIC_MASTRA_URL` to the server origin, such as `http://localhost:4111`, rather than the individual chat route. Continue with [Persisted threads](/docs/integrations/frameworks/mastra/threads) for storage setup and identity guidance.
 
+Use `useMastraWorkflow` beside the chat runtime when the UI must start, reconnect to, or resume a durable workflow run. The same server origin exposes the workflow APIs; see [Durable workflows](/docs/integrations/frameworks/mastra/workflows) for the lifecycle contract.
+
 ## Notes
 
-- **Auth between frontend and Mastra**: the examples above are open. In production, gate every chat and memory endpoint. Derive or validate `resourceId` from the authenticated identity; a client-provided resource ID is not an authorization boundary. Forward credentials through `transportOptions` and configure `MastraClient` with the same authenticated request policy.
+- **Auth between frontend and Mastra**: the examples above are open. In production, gate every chat, memory, and workflow endpoint. Derive or validate `resourceId` from the authenticated identity; a client-provided resource ID is not an authorization boundary. Verify workflow run ownership before resume or cancel. Forward credentials through `transportOptions` and configure `MastraClient` with the same authenticated request policy.
 - **Single agent vs router**: `chatRoute({ path: "/chat/:agentId" })` works for any agent registered on the `Mastra` instance. Switching agents from the frontend is a matter of pointing `NEXT_PUBLIC_MASTRA_URL` at a different agent ID.
-- **Server-only features** such as tools, RAG, model routing, workflows, and evals need no extra frontend integration. Memory thread navigation uses the Mastra-specific client APIs.
+- **Server-only features** such as tools, RAG, model routing, and evals need no extra frontend integration. Memory thread navigation and interactive workflow suspension use the Mastra-specific client APIs.
 
 ## Related
 

--- a/apps/docs/content/docs/integrations/frameworks/mastra/workflows.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/workflows.mdx
@@ -1,0 +1,107 @@
+---
+title: Durable workflows
+description: Render and resume persisted Mastra workflow suspensions.
+platforms: ["react"]
+---
+
+`useMastraWorkflow` exposes a Mastra workflow run beside the chat runtime. It starts a run, normalizes suspended steps, resumes the exact step path, and reconnects to an existing run ID after reload.
+
+<InstallCommand npm={["@assistant-ui/react-mastra@latest", "@mastra/client-js@latest"]} />
+
+## Register the workflow
+
+Register the workflow and storage on the same `Mastra` instance that serves its HTTP APIs:
+
+```ts title="src/mastra/index.ts"
+import { Mastra } from "@mastra/core/mastra";
+import { LibSQLStore } from "@mastra/libsql";
+import { releaseReviewWorkflow } from "./workflows/release-review";
+
+const storage = new LibSQLStore({
+  id: "app-storage",
+  url: "file:./mastra.db",
+});
+
+export const mastra = new Mastra({
+  storage,
+  workflows: { releaseReviewWorkflow },
+});
+```
+
+The browser must be able to reach Mastra's workflow APIs. A separate Mastra server exposes them directly. In a full-stack deployment, mount or proxy those APIs under the same origin.
+
+## Render workflow suspension
+
+Store the run ID independently from the selected chat thread. Passing it back to the hook reconnects to the persisted run:
+
+```tsx title="components/release-approval.tsx"
+"use client";
+
+import { useMastraWorkflow } from "@assistant-ui/react-mastra";
+import { MastraClient } from "@mastra/client-js";
+import { useEffect, useState } from "react";
+
+type Input = { project: string; summary: string };
+type Resume = { approved: boolean; note: string };
+type Result = { outcome: "published" | "changes-requested" };
+type Suspend = { title: string; description: string };
+
+const client = new MastraClient({ baseUrl: "http://localhost:4111" });
+
+export function ReleaseApproval() {
+  const [runId, setRunId] = useState<string>();
+
+  useEffect(() => {
+    setRunId(window.localStorage.getItem("release-run") ?? undefined);
+  }, []);
+
+  const workflow = useMastraWorkflow<Input, Resume, Result, Suspend>({
+    client,
+    workflowId: "releaseReviewWorkflow",
+    runId,
+    resourceId: "authenticated-user-id",
+    onRunIdChange: (nextRunId) => {
+      setRunId(nextRunId);
+      window.localStorage.setItem("release-run", nextRunId);
+    },
+  });
+  const suspended = workflow.state.suspendedSteps[0];
+
+  if (workflow.state.status === "suspended" && suspended) {
+    return (
+      <section>
+        <h2>{suspended.payload.title}</h2>
+        <p>{suspended.payload.description}</p>
+        <button
+          onClick={() =>
+            void workflow.resume(suspended, { approved: true, note: "" })
+          }
+        >
+          Approve
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <button
+      disabled={workflow.state.status === "running"}
+      onClick={() =>
+        void workflow.start({ project: "Web", summary: "Publish release" })
+      }
+    >
+      Start review
+    </button>
+  );
+}
+```
+
+Passing a stored `runId` causes the hook to fetch the current run, so a suspended checkpoint returns after reload. Pass the complete suspended-step object to `resume`; it preserves nested paths and `forEachIndex` for workflows with parallel steps.
+
+The hook exposes `start`, `resume`, `refresh`, and `cancel`. Render from `state.status`, `state.suspendedSteps`, `state.result`, and `state.error`; do not infer workflow state from chat messages.
+
+## Security
+
+Workflow IDs and run IDs are identifiers, not authorization. Authenticate every workflow endpoint, derive or validate `resourceId` from the caller, and verify that the caller owns a run before reading, resuming, or cancelling it. Do not expose provider keys to the browser.
+
+See the [`@assistant-ui/react-mastra` API reference](/docs/api-reference/integrations/react-mastra) for the complete hook contract.

--- a/packages/react-mastra/README.md
+++ b/packages/react-mastra/README.md
@@ -27,3 +27,19 @@ export function RuntimeProvider({ children }: React.PropsWithChildren) {
 The `/api/chat` route should use `chatRoute` from `@mastra/ai-sdk`. Chat
 messages are persisted by Mastra while this package maps memory threads and
 stored messages to assistant-ui's thread list and history contracts.
+
+Use `useMastraWorkflow` beside the chat runtime for persisted workflow runs:
+
+```tsx
+const workflow = useMastraWorkflow({
+  client,
+  workflowId: "approval-workflow",
+  runId,
+  onRunIdChange: setRunId,
+});
+
+await workflow.start({ request: "Review this change" });
+await workflow.resume(workflow.state.suspendedSteps[0], {
+  approved: true,
+});
+```

--- a/packages/react-mastra/src/index.ts
+++ b/packages/react-mastra/src/index.ts
@@ -2,9 +2,15 @@ export { createMastraChatTransport } from "./createMastraChatTransport";
 export { createMastraHistoryAdapter } from "./createMastraHistoryAdapter";
 export { createMastraThreadListAdapter } from "./createMastraThreadListAdapter";
 export { useMastraRuntime } from "./useMastraRuntime";
+export { useMastraWorkflow } from "./useMastraWorkflow";
 export type {
   MastraChatTransportOptions,
+  MastraSuspendedStep,
   MastraThreadListOptions,
   MastraTitleGenerator,
+  MastraWorkflowResumeOptions,
+  MastraWorkflowStartOptions,
+  MastraWorkflowState,
   UseMastraRuntimeOptions,
+  UseMastraWorkflowOptions,
 } from "./types";

--- a/packages/react-mastra/src/types.ts
+++ b/packages/react-mastra/src/types.ts
@@ -1,4 +1,9 @@
-import type { MastraClient } from "@mastra/client-js";
+import type {
+  GetWorkflowRunByIdResponse,
+  MastraClient,
+  WorkflowRunResult,
+} from "@mastra/client-js";
+import type { WorkflowRunStatus } from "@mastra/core/workflows";
 import type { ThreadMessage } from "@assistant-ui/react";
 import type { ChatTransport, UIMessage } from "ai";
 import type { UseChatRuntimeOptions } from "@assistant-ui/react-ai-sdk";
@@ -37,3 +42,41 @@ export type UseMastraRuntimeOptions<UI_MESSAGE extends UIMessage = UIMessage> =
         "resourceId"
       >;
     };
+
+export type MastraSuspendedStep<TPayload = unknown> = {
+  stepId: string;
+  path: string[];
+  forEachIndex?: number | undefined;
+  payload: TPayload;
+};
+
+export type MastraWorkflowState<TResult = unknown, TSuspend = unknown> = {
+  runId: string | undefined;
+  status: "idle" | WorkflowRunStatus;
+  result: TResult | undefined;
+  error: Error | undefined;
+  suspendedSteps: MastraSuspendedStep<TSuspend>[];
+  raw: WorkflowRunResult | GetWorkflowRunByIdResponse | undefined;
+};
+
+export type UseMastraWorkflowOptions<TResult = unknown, TSuspend = unknown> = {
+  client: MastraClient;
+  workflowId: string;
+  runId?: string | undefined;
+  resourceId?: string | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+  onRunIdChange?: ((runId: string) => void) | undefined;
+  onStateChange?:
+    | ((state: MastraWorkflowState<TResult, TSuspend>) => void)
+    | undefined;
+};
+
+export type MastraWorkflowStartOptions = {
+  initialState?: Record<string, unknown> | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+};
+
+export type MastraWorkflowResumeOptions = {
+  forEachIndex?: number | undefined;
+  requestContext?: Record<string, unknown> | undefined;
+};

--- a/packages/react-mastra/src/useMastraWorkflow.test.tsx
+++ b/packages/react-mastra/src/useMastraWorkflow.test.tsx
@@ -1,0 +1,244 @@
+import type { MastraClient } from "@mastra/client-js";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useMastraWorkflow } from "./useMastraWorkflow";
+
+const success = (result: Record<string, unknown>) => ({
+  status: "success" as const,
+  input: {},
+  result,
+  steps: {},
+});
+
+const suspended = (stepId: string, payload: Record<string, unknown>) => ({
+  status: "suspended" as const,
+  input: {},
+  steps: {
+    [stepId]: { status: "suspended", suspendPayload: payload },
+  },
+  suspendPayload: payload,
+  suspended: [[stepId]],
+  resumeLabels: { approval: { stepId } },
+});
+
+const failed = (message: string) => ({
+  status: "failed" as const,
+  input: {},
+  steps: {},
+  error: new Error(message),
+});
+
+const createClient = () => {
+  const run = {
+    runId: "run-1",
+    startAsync: vi.fn(),
+    resumeAsync: vi.fn(),
+    cancel: vi.fn(async () => ({ message: "Workflow run canceled" })),
+  };
+  const workflow = {
+    createRun: vi.fn(async () => run),
+    runById: vi.fn(),
+  };
+  const client = {
+    getWorkflow: vi.fn(() => workflow),
+  } as unknown as MastraClient;
+  return { client, workflow, run };
+};
+
+describe("useMastraWorkflow", () => {
+  it("starts a run and stores its successful result", async () => {
+    const { client, workflow, run } = createClient();
+    const onRunIdChange = vi.fn();
+    run.startAsync.mockResolvedValue(success({ approved: true }));
+    const { result } = renderHook(() =>
+      useMastraWorkflow<
+        { request: string },
+        { approved: boolean },
+        { approved: boolean }
+      >({
+        client,
+        workflowId: "approval",
+        resourceId: "user-1",
+        onRunIdChange,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.start({ request: "Review" });
+    });
+
+    expect(workflow.createRun).toHaveBeenCalledWith({ resourceId: "user-1" });
+    expect(run.startAsync).toHaveBeenCalledWith({
+      inputData: { request: "Review" },
+      initialState: undefined,
+      requestContext: undefined,
+    });
+    expect(onRunIdChange).toHaveBeenCalledWith("run-1");
+    expect(result.current.state).toMatchObject({
+      runId: "run-1",
+      status: "success",
+      result: { approved: true },
+    });
+  });
+
+  it("represents a returned workflow failure", async () => {
+    const { client, run } = createClient();
+    run.startAsync.mockResolvedValue(failed("step failed"));
+    const { result } = renderHook(() =>
+      useMastraWorkflow({ client, workflowId: "approval" }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    expect(result.current.state.status).toBe("failed");
+    expect(result.current.state.error?.message).toBe("step failed");
+  });
+
+  it("supports a second suspension and resume in the same run", async () => {
+    const { client, workflow, run } = createClient();
+    run.startAsync.mockResolvedValue(
+      suspended("screening-approval", { score: 8 }),
+    );
+    run.resumeAsync
+      .mockResolvedValueOnce(
+        suspended("interview-approval", { recommendation: "hire" }),
+      )
+      .mockResolvedValueOnce(success({ hired: true }));
+    const { result } = renderHook(() =>
+      useMastraWorkflow<
+        Record<string, unknown>,
+        { approved: boolean },
+        { hired: boolean },
+        Record<string, unknown>
+      >({ client, workflowId: "hiring" }),
+    );
+
+    await act(async () => {
+      await result.current.start({});
+    });
+    expect(result.current.state.suspendedSteps[0]).toEqual({
+      stepId: "screening-approval",
+      path: ["screening-approval"],
+      forEachIndex: undefined,
+      payload: { score: 8 },
+    });
+
+    await act(async () => {
+      await result.current.resume(result.current.state.suspendedSteps[0]!, {
+        approved: true,
+      });
+    });
+    expect(result.current.state.suspendedSteps[0]?.stepId).toBe(
+      "interview-approval",
+    );
+
+    await act(async () => {
+      await result.current.resume(result.current.state.suspendedSteps[0]!, {
+        approved: true,
+      });
+    });
+
+    expect(workflow.createRun).toHaveBeenLastCalledWith({
+      runId: "run-1",
+      resourceId: undefined,
+    });
+    expect(run.resumeAsync).toHaveBeenNthCalledWith(1, {
+      step: ["screening-approval"],
+      resumeData: { approved: true },
+      forEachIndex: undefined,
+      requestContext: undefined,
+    });
+    expect(result.current.state).toMatchObject({
+      status: "success",
+      result: { hired: true },
+      suspendedSteps: [],
+    });
+  });
+
+  it("restores a persisted suspended run by run ID", async () => {
+    const { client, workflow } = createClient();
+    workflow.runById.mockResolvedValue({
+      runId: "persisted-run",
+      workflowName: "approval",
+      status: "suspended",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      steps: {
+        approval: {
+          status: "suspended",
+          suspendPayload: { question: "Ship it?" },
+        },
+      },
+      resumeLabels: { approval: { stepId: "approval" } },
+    });
+    const { result } = renderHook(() =>
+      useMastraWorkflow({
+        client,
+        workflowId: "approval",
+        runId: "persisted-run",
+      }),
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe("suspended"));
+
+    expect(workflow.runById).toHaveBeenCalledWith("persisted-run", {
+      requestContext: undefined,
+    });
+    expect(result.current.state.suspendedSteps[0]).toMatchObject({
+      stepId: "approval",
+      payload: { question: "Ship it?" },
+    });
+  });
+
+  it("cancels the current server run explicitly", async () => {
+    const { client, run } = createClient();
+    run.startAsync.mockResolvedValue(suspended("approval", {}));
+    const { result } = renderHook(() =>
+      useMastraWorkflow({ client, workflowId: "approval" }),
+    );
+    await act(async () => {
+      await result.current.start({});
+    });
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    expect(run.cancel).toHaveBeenCalledOnce();
+    expect(result.current.state.status).toBe("canceled");
+  });
+
+  it("does not cancel or commit a server run after unmount", async () => {
+    const { client, run } = createClient();
+    let resolveRun: ((value: ReturnType<typeof success>) => void) | undefined;
+    run.startAsync.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRun = resolve;
+      }),
+    );
+    const onStateChange = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useMastraWorkflow({
+        client,
+        workflowId: "approval",
+        onStateChange,
+      }),
+    );
+
+    let startPromise: ReturnType<typeof result.current.start> | undefined;
+    act(() => {
+      startPromise = result.current.start({});
+    });
+    await waitFor(() => expect(result.current.state.status).toBe("running"));
+    unmount();
+    resolveRun?.(success({ done: true }));
+    await startPromise;
+
+    expect(run.cancel).not.toHaveBeenCalled();
+    expect(onStateChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "success" }),
+    );
+  });
+});

--- a/packages/react-mastra/src/useMastraWorkflow.ts
+++ b/packages/react-mastra/src/useMastraWorkflow.ts
@@ -1,0 +1,308 @@
+"use client";
+
+import type {
+  GetWorkflowRunByIdResponse,
+  WorkflowRunResult,
+} from "@mastra/client-js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  MastraSuspendedStep,
+  MastraWorkflowResumeOptions,
+  MastraWorkflowStartOptions,
+  MastraWorkflowState,
+  UseMastraWorkflowOptions,
+} from "./types";
+
+type WorkflowSource = WorkflowRunResult | GetWorkflowRunByIdResponse;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const toError = (value: unknown): Error | undefined => {
+  if (value === undefined) return undefined;
+  if (value instanceof Error) return value;
+  if (isRecord(value) && typeof value.message === "string") {
+    return new Error(value.message);
+  }
+  return new Error(String(value));
+};
+
+const findResumeIndex = (
+  source: WorkflowSource,
+  stepId: string,
+  fallback?: number,
+) => {
+  const labels = source.resumeLabels;
+  if (!labels) return fallback;
+  return (
+    Object.values(labels).find(
+      (label) =>
+        label.stepId === stepId &&
+        (fallback === undefined || label.forEachIndex === fallback),
+    )?.forEachIndex ?? fallback
+  );
+};
+
+const toSuspendedStep = <TSuspend>(
+  source: WorkflowSource,
+  stepId: string,
+  path: string[],
+  step: unknown,
+  forEachIndex?: number,
+): MastraSuspendedStep<TSuspend> | undefined => {
+  if (!isRecord(step) || step.status !== "suspended") return undefined;
+  return {
+    stepId,
+    path,
+    forEachIndex: findResumeIndex(source, stepId, forEachIndex),
+    payload: step.suspendPayload as TSuspend,
+  };
+};
+
+const getSuspendedSteps = <TSuspend>(
+  source: WorkflowSource,
+): MastraSuspendedStep<TSuspend>[] => {
+  if (source.status !== "suspended" || !source.steps) return [];
+  const steps = source.steps as Record<string, unknown>;
+
+  if ("suspended" in source) {
+    return source.suspended.flatMap((path) => {
+      const stepId = path.at(-1);
+      if (!stepId) return [];
+      const step = steps[stepId];
+      if (Array.isArray(step)) {
+        return step.flatMap((item, index) => {
+          const suspended = toSuspendedStep<TSuspend>(
+            source,
+            stepId,
+            path,
+            item,
+            index,
+          );
+          return suspended ? [suspended] : [];
+        });
+      }
+      const suspended = toSuspendedStep<TSuspend>(source, stepId, path, step);
+      return suspended ? [suspended] : [];
+    });
+  }
+
+  return Object.entries(steps).flatMap(([stepId, step]) => {
+    if (Array.isArray(step)) {
+      return step.flatMap((item, index) => {
+        const suspended = toSuspendedStep<TSuspend>(
+          source,
+          stepId,
+          [stepId],
+          item,
+          index,
+        );
+        return suspended ? [suspended] : [];
+      });
+    }
+    const suspended = toSuspendedStep<TSuspend>(source, stepId, [stepId], step);
+    return suspended ? [suspended] : [];
+  });
+};
+
+const toWorkflowState = <TResult, TSuspend>(
+  runId: string,
+  source: WorkflowSource,
+): MastraWorkflowState<TResult, TSuspend> => ({
+  runId,
+  status: source.status,
+  result: ("result" in source ? source.result : undefined) as
+    | TResult
+    | undefined,
+  error: toError("error" in source ? source.error : undefined),
+  suspendedSteps: getSuspendedSteps<TSuspend>(source),
+  raw: source,
+});
+
+const idleState = <TResult, TSuspend>(): MastraWorkflowState<
+  TResult,
+  TSuspend
+> => ({
+  runId: undefined,
+  status: "idle",
+  result: undefined,
+  error: undefined,
+  suspendedSteps: [],
+  raw: undefined,
+});
+
+export const useMastraWorkflow = <
+  TInput extends Record<string, unknown> = Record<string, unknown>,
+  TResume extends Record<string, unknown> = Record<string, unknown>,
+  TResult = unknown,
+  TSuspend = unknown,
+>({
+  client,
+  workflowId,
+  runId: controlledRunId,
+  resourceId,
+  requestContext,
+  onRunIdChange,
+  onStateChange,
+}: UseMastraWorkflowOptions<TResult, TSuspend>) => {
+  const [state, setState] =
+    useState<MastraWorkflowState<TResult, TSuspend>>(idleState);
+  const operationRef = useRef(0);
+  const callbacksRef = useRef({ onRunIdChange, onStateChange });
+  useEffect(() => {
+    callbacksRef.current = { onRunIdChange, onStateChange };
+  });
+  useEffect(
+    () => () => {
+      operationRef.current += 1;
+    },
+    [],
+  );
+
+  const commit = useCallback(
+    (operation: number, nextState: MastraWorkflowState<TResult, TSuspend>) => {
+      if (operationRef.current !== operation) return false;
+      setState(nextState);
+      callbacksRef.current.onStateChange?.(nextState);
+      return true;
+    },
+    [],
+  );
+
+  const fail = useCallback(
+    (operation: number, runId: string | undefined, error: unknown) => {
+      const normalized = toError(error) ?? new Error("Workflow request failed");
+      commit(operation, {
+        runId,
+        status: "failed",
+        result: undefined,
+        error: normalized,
+        suspendedSteps: [],
+        raw: undefined,
+      });
+      return normalized;
+    },
+    [commit],
+  );
+
+  const refreshRun = useCallback(
+    async (runId: string) => {
+      const operation = ++operationRef.current;
+      try {
+        const source = await client
+          .getWorkflow(workflowId)
+          .runById(runId, { requestContext });
+        const nextState = toWorkflowState<TResult, TSuspend>(runId, source);
+        commit(operation, nextState);
+        return nextState;
+      } catch (error) {
+        throw fail(operation, runId, error);
+      }
+    },
+    [client, workflowId, requestContext, commit, fail],
+  );
+
+  useEffect(() => {
+    if (!controlledRunId) return;
+    void refreshRun(controlledRunId).catch(() => {});
+  }, [controlledRunId, refreshRun]);
+
+  const start = useCallback(
+    async (inputData: TInput, options: MastraWorkflowStartOptions = {}) => {
+      const operation = ++operationRef.current;
+      let runId: string | undefined;
+      try {
+        const workflow = client.getWorkflow(workflowId);
+        const run = await workflow.createRun({ resourceId });
+        runId = run.runId;
+        callbacksRef.current.onRunIdChange?.(runId);
+        commit(operation, {
+          runId,
+          status: "running",
+          result: undefined,
+          error: undefined,
+          suspendedSteps: [],
+          raw: undefined,
+        });
+        const source = await run.startAsync({
+          inputData,
+          initialState: options.initialState,
+          requestContext: options.requestContext ?? requestContext,
+        });
+        const nextState = toWorkflowState<TResult, TSuspend>(runId, source);
+        commit(operation, nextState);
+        return nextState;
+      } catch (error) {
+        throw fail(operation, runId, error);
+      }
+    },
+    [client, workflowId, resourceId, requestContext, commit, fail],
+  );
+
+  const resume = useCallback(
+    async (
+      step: string | string[] | MastraSuspendedStep<TSuspend>,
+      resumeData: TResume,
+      options: MastraWorkflowResumeOptions = {},
+    ) => {
+      const runId = state.runId;
+      if (!runId) throw new Error("Cannot resume a workflow without a run ID");
+      const operation = ++operationRef.current;
+      const suspendedStep = typeof step === "object" && !Array.isArray(step);
+      const path = suspendedStep ? step.path : step;
+      const forEachIndex = suspendedStep
+        ? (options.forEachIndex ?? step.forEachIndex)
+        : options.forEachIndex;
+      try {
+        commit(operation, { ...state, status: "running", error: undefined });
+        const run = await client
+          .getWorkflow(workflowId)
+          .createRun({ runId, resourceId });
+        const source = await run.resumeAsync({
+          step: path,
+          resumeData,
+          forEachIndex,
+          requestContext: options.requestContext ?? requestContext,
+        });
+        const nextState = toWorkflowState<TResult, TSuspend>(runId, source);
+        commit(operation, nextState);
+        return nextState;
+      } catch (error) {
+        throw fail(operation, runId, error);
+      }
+    },
+    [state, client, workflowId, resourceId, requestContext, commit, fail],
+  );
+
+  const cancel = useCallback(async () => {
+    const runId = state.runId;
+    if (!runId) throw new Error("Cannot cancel a workflow without a run ID");
+    const operation = ++operationRef.current;
+    try {
+      const run = await client
+        .getWorkflow(workflowId)
+        .createRun({ runId, resourceId });
+      await run.cancel();
+      const nextState: MastraWorkflowState<TResult, TSuspend> = {
+        runId,
+        status: "canceled",
+        result: undefined,
+        error: undefined,
+        suspendedSteps: [],
+        raw: undefined,
+      };
+      commit(operation, nextState);
+      return nextState;
+    } catch (error) {
+      throw fail(operation, runId, error);
+    }
+  }, [state.runId, client, workflowId, resourceId, commit, fail]);
+
+  const refresh = useCallback(() => {
+    const runId = state.runId ?? controlledRunId;
+    if (!runId) throw new Error("Cannot refresh a workflow without a run ID");
+    return refreshRun(runId);
+  }, [state.runId, controlledRunId, refreshRun]);
+
+  return { state, start, resume, cancel, refresh };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,10 @@ importers:
         version: 1.0.26(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.0))(openai@6.47.0(@aws-sdk/credential-provider-node@3.972.66)(@smithy/signature-v4@5.6.3)(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mastra/client-js':
         specifier: ^1.32.0
-        version: 1.32.0(@cfworker/json-schema@4.1.1)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+        version: 1.32.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
+      '@mastra/core':
+        specifier: ^1.51.0
+        version: 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -21344,11 +21347,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/client-js@1.32.0(@cfworker/json-schema@4.1.1)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+  '@mastra/client-js@1.32.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/ui-utils': 1.2.11(zod@4.4.3)
       '@lukeed/uuid': 2.0.1
-      '@mastra/core': 1.51.0(@cfworker/json-schema@4.1.1)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
+      '@mastra/core': 1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)
       '@mastra/schema-compat': 1.3.4(zod@4.4.3)
       canonicalize: 1.0.8
       jose: 6.2.3
@@ -21411,7 +21414,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/core@1.51.0(@cfworker/json-schema@4.1.1)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(zod@4.4.3)':
+  '@mastra/core@1.51.0(@bufbuild/protobuf@2.12.1)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(ai@7.0.28(zod@4.4.3))(express@5.2.1)(rxjs@7.8.2)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(@bufbuild/protobuf@2.12.1)(@grpc/grpc-js@1.14.4)(express@5.2.1)
       '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)'


### PR DESCRIPTION
Fixes #4925

## Why

Mastra workflows persist suspension and resume state independently from chat. The old integration parsed bespoke events and mixed workflow state into a large runtime hook; current Mastra exposes typed run lifecycle APIs directly.

## What changed

- add `useMastraWorkflow` with start, refresh, reconnect, resume, and cancel
- expose run ID, status, result, error, and suspended steps
- preserve nested step paths and `forEachIndex` for resume
- suppress stale React commits after a newer action or unmount without canceling the server run
- document durable start, suspension, reload restoration, and repeated resume
- regenerate the package API reference
- add a patch changeset for `@assistant-ui/react-mastra`

Normal suspension is represented as state, not an error, and workflow state remains separate from chat state.

## Stack

Depends on #4932. The next PR supplies the complete example.

## Verification

- `pnpm --filter @assistant-ui/react-mastra test` (4 files, 13 tests)
- `pnpm --filter @assistant-ui/react-mastra build`
- strict generated API reference
- `pnpm changeset status --since codex/mastra-threads --verbose`

Tests cover success, returned failure, two suspend/resume cycles, persisted reconnect, explicit cancellation, and unmount during an active run.

