### PR TITLE
refactor(react-ag-ui): back thread state with MessageRepository

### DIFF
--- a/.changeset/ag-ui-repository-ssot.md
+++ b/.changeset/ag-ui-repository-ssot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+refactor: back AG-UI thread state with a MessageRepository source of truth

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -597,8 +597,7 @@ export class AgUiThreadRuntimeCore {
 
   private clearPendingInterrupts(messageId: string): void {
     const touched = this.updateMessage(messageId, (message) => {
-      if (message.id !== messageId || message.role !== "assistant")
-        return message;
+      if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       if (
         assistant.status?.type !== "requires-action" ||
@@ -647,8 +646,7 @@ export class AgUiThreadRuntimeCore {
 
   private cancelUnresolvedToolCalls(messageId: string): void {
     const updated = this.updateMessage(messageId, (message) => {
-      if (message.id !== messageId || message.role !== "assistant")
-        return message;
+      if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       const content = assistant.content.map((part) => {
         if (part.type !== "tool-call" || isResolvedToolCall(part)) return part;
@@ -665,8 +663,7 @@ export class AgUiThreadRuntimeCore {
 
   addToolResult(options: AddToolResultOptions): void {
     const updated = this.updateMessage(options.messageId, (message) => {
-      if (message.id !== options.messageId || message.role !== "assistant")
-        return message;
+      if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
       const content = assistant.content.map((part) => {
@@ -1193,8 +1190,7 @@ export class AgUiThreadRuntimeCore {
   ): string {
     let latestStatus: MessageStatus | undefined;
     const touched = this.updateMessage(messageId, (message) => {
-      if (message.id !== messageId || message.role !== "assistant")
-        return message;
+      if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       const metadata = update.metadata
         ? this.mergeAssistantMetadata(assistant.metadata, update.metadata)
@@ -1343,8 +1339,7 @@ export class AgUiThreadRuntimeCore {
     event: Extract<AgUiEvent, { type: "TOOL_CALL_RESULT" }>,
   ): void {
     const updated = this.updateMessage(messageId, (message) => {
-      if (message.id !== messageId || message.role !== "assistant")
-        return message;
+      if (message.role !== "assistant") return message;
       const assistant = message as ThreadAssistantMessage;
       let matchedToolCall = false;
       const content = assistant.content.map((part) => {
@@ -1428,7 +1423,7 @@ export class AgUiThreadRuntimeCore {
     if (!this.history) return;
     const parentId = this.assistantHistoryParents.get(messageId);
     if (parentId === undefined) return;
-    const message = this.getMessages().find((item) => item.id === messageId);
+    const message = this.tryGetMessage(messageId)?.message;
     if (!message || message.role !== "assistant") return;
     if (!this.isPersistableStatus(message.status)) return;
     this.assistantHistoryParents.delete(messageId);

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -181,20 +181,13 @@ export class AgUiThreadRuntimeCore {
     messageId: string,
     replacementId?: string | null,
   ): void {
-    if (replacementId === undefined) {
-      this.repository.deleteMessage(messageId);
-    } else {
-      this.repository.deleteMessage(messageId, replacementId);
-    }
+    this.repository.deleteMessage(messageId, replacementId);
     this.exportedRepository = undefined;
   }
 
-  private tryDeleteMessage(
-    messageId: string,
-    replacementId?: string | null,
-  ): boolean {
+  private tryDeleteMessage(messageId: string): boolean {
     if (!this.hasMessage(messageId)) return false;
-    this.deleteMessage(messageId, replacementId);
+    this.deleteMessage(messageId);
     return true;
   }
 
@@ -300,9 +293,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private appendEntry(message: AppendMessage): string {
-    if (message.sourceId && this.hasMessage(message.sourceId)) {
-      this.deleteMessage(message.sourceId);
-    }
+    if (message.sourceId) this.tryDeleteMessage(message.sourceId);
 
     const threadMessage = this.toThreadMessage(message);
     const parentId =

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -15,6 +15,7 @@ import type {
   ThreadMessage,
   ToolCallMessagePart,
 } from "@assistant-ui/core";
+import { MessageRepository } from "@assistant-ui/core/internal";
 import type { AbstractAgent } from "@ag-ui/client";
 import jsonpatch, { type Operation } from "fast-json-patch";
 import type { Logger } from "./logger";
@@ -68,57 +69,6 @@ type CoreOptions = {
 
 const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
-const getRepositoryHeadId = (
-  repository: ExportedMessageRepository,
-): string | null =>
-  repository.headId ?? repository.messages.at(-1)?.message.id ?? null;
-
-const getRepositoryBranchMessages = (
-  repository: ExportedMessageRepository,
-  headId = getRepositoryHeadId(repository),
-): readonly ThreadMessage[] | null => {
-  if (headId === null) return [];
-
-  const byId = new Map<string, ExportedMessageRepository["messages"][number]>();
-  for (const item of repository.messages) {
-    const id = item.message.id;
-    if (byId.has(id)) return null;
-    byId.set(id, item);
-  }
-
-  const branch: ThreadMessage[] = [];
-  const visited = new Set<string>();
-  let item = byId.get(headId);
-
-  if (!item) return null;
-
-  while (true) {
-    const id = item.message.id;
-    if (visited.has(id)) return null;
-
-    visited.add(id);
-    branch.push(item.message);
-
-    if (item.parentId === null) break;
-    item = byId.get(item.parentId);
-    if (!item) return null;
-  }
-
-  return branch.reverse();
-};
-
-const sameMessagePath = (
-  left: readonly ThreadMessage[],
-  right: readonly ThreadMessage[],
-) =>
-  left.length === right.length &&
-  left.every((message, index) => message.id === right[index]?.id);
-
-const repositoryHasMessageId = (
-  repository: ExportedMessageRepository,
-  messageId: string,
-) => repository.messages.some(({ message }) => message.id === messageId);
-
 export class AgUiThreadRuntimeCore {
   private agent: AbstractAgent;
   private logger: Logger;
@@ -129,8 +79,8 @@ export class AgUiThreadRuntimeCore {
   private readonly notifyUpdate: () => void;
 
   private runtime: AssistantRuntime | undefined;
-  private messages: ThreadMessage[] = [];
-  private messageRepository: ExportedMessageRepository | undefined;
+  private readonly repository = new MessageRepository();
+  private exportedRepository: ExportedMessageRepository | undefined;
   private isRunningFlag = false;
   private abortController: AbortController | null = null;
   private stateSnapshot: ReadonlyJSONValue | undefined;
@@ -175,11 +125,104 @@ export class AgUiThreadRuntimeCore {
   }
 
   getMessages(): readonly ThreadMessage[] {
-    return this.messages;
+    return this.repository.getMessages();
   }
 
-  getMessageRepository(): ExportedMessageRepository | undefined {
-    return this.messageRepository;
+  getMessageRepository(): ExportedMessageRepository {
+    if (this.exportedRepository) return this.exportedRepository;
+
+    const exportedRepository = this.repository.export();
+    let parentId: string | null = null;
+    for (const message of this.repository.getMessages()) {
+      if (message.metadata.isOptimistic) {
+        exportedRepository.messages.push({ parentId, message });
+      }
+      parentId = message.id;
+    }
+
+    this.exportedRepository = {
+      ...exportedRepository,
+      headId: this.repository.headId,
+    };
+    return this.exportedRepository;
+  }
+
+  private tryGetMessage(messageId: string) {
+    try {
+      return this.repository.getMessage(messageId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private tryGetMessages(
+    messageId: string,
+  ): readonly ThreadMessage[] | undefined {
+    try {
+      return this.repository.getMessages(messageId);
+    } catch {
+      return undefined;
+    }
+  }
+
+  private hasMessage(messageId: string): boolean {
+    return this.tryGetMessage(messageId) !== undefined;
+  }
+
+  private addOrUpdateMessage(
+    parentId: string | null,
+    message: ThreadMessage,
+  ): void {
+    this.repository.addOrUpdateMessage(parentId, message);
+    this.exportedRepository = undefined;
+  }
+
+  private deleteMessage(
+    messageId: string,
+    replacementId?: string | null,
+  ): void {
+    if (replacementId === undefined) {
+      this.repository.deleteMessage(messageId);
+    } else {
+      this.repository.deleteMessage(messageId, replacementId);
+    }
+    this.exportedRepository = undefined;
+  }
+
+  private tryDeleteMessage(
+    messageId: string,
+    replacementId?: string | null,
+  ): boolean {
+    if (!this.hasMessage(messageId)) return false;
+    this.deleteMessage(messageId, replacementId);
+    return true;
+  }
+
+  private switchToBranch(messageId: string): void {
+    this.repository.switchToBranch(messageId);
+    this.exportedRepository = undefined;
+  }
+
+  private resetRepositoryHead(messageId: string | null): void {
+    this.repository.resetHead(messageId);
+    this.exportedRepository = undefined;
+  }
+
+  private clearRepository(): void {
+    this.repository.clear();
+    this.exportedRepository = undefined;
+  }
+
+  private updateMessage(
+    messageId: string,
+    updater: (message: ThreadMessage) => ThreadMessage,
+  ): boolean {
+    const item = this.tryGetMessage(messageId);
+    if (!item) return false;
+    const message = updater(item.message);
+    if (message === item.message) return false;
+    this.addOrUpdateMessage(item.parentId, message);
+    return true;
   }
 
   getState(): ReadonlyJSONValue | undefined {
@@ -212,7 +255,7 @@ export class AgUiThreadRuntimeCore {
         }
 
         if (repo.unstable_resume) {
-          const parentId = repo.headId ?? this.messages.at(-1)?.id ?? null;
+          const parentId = repo.headId ?? this.repository.headId;
           const resumeStream = this.history?.resume?.bind(this.history);
           await this.startRun(
             parentId,
@@ -248,9 +291,6 @@ export class AgUiThreadRuntimeCore {
     await this.startRun(threadMessageId, message.runConfig);
   }
 
-  // Must run before appendEntry/resetHead: a parentId that points at an
-  // ancestor would truncate the pending assistant away before its tool calls
-  // can be cancelled, stranding it with a status that history never persists.
   private maybeAutoCancelPendingToolCalls(): void {
     if (this.autoCancelPendingToolCalls === false) return;
     const pending = this.getPendingToolCalls();
@@ -260,17 +300,21 @@ export class AgUiThreadRuntimeCore {
   }
 
   private appendEntry(message: AppendMessage): string {
-    if (message.sourceId) {
-      this.messages = this.messages.filter(
-        (entry) => entry.id !== message.sourceId,
-      );
+    if (message.sourceId && this.hasMessage(message.sourceId)) {
+      this.deleteMessage(message.sourceId);
     }
-    this.resetHead(message.parentId);
 
     const threadMessage = this.toThreadMessage(message);
-    this.messages = [...this.messages, threadMessage];
+    const parentId =
+      message.parentId === null
+        ? null
+        : message.parentId && this.hasMessage(message.parentId)
+          ? message.parentId
+          : this.repository.headId;
+    this.addOrUpdateMessage(parentId, threadMessage);
+    this.switchToBranch(threadMessage.id);
     this.notifyUpdate();
-    this.recordHistoryEntry(message.parentId ?? null, threadMessage);
+    this.recordHistoryEntry(parentId, threadMessage);
     return threadMessage.id;
   }
 
@@ -284,8 +328,6 @@ export class AgUiThreadRuntimeCore {
   ): Promise<void> {
     this.assertNoPendingInterrupts();
     this.maybeAutoCancelPendingToolCalls();
-    this.resetHead(parentId, { preserveMessageRepository: true });
-    this.notifyUpdate();
     await this.startRun(parentId, config.runConfig);
   }
 
@@ -338,9 +380,9 @@ export class AgUiThreadRuntimeCore {
   private findRequiresActionAssistant(
     reason: "interrupt" | "tool-calls",
   ): ThreadAssistantMessage | null {
-    const assistant = this.messages.findLast((m) => m.role === "assistant") as
-      | ThreadAssistantMessage
-      | undefined;
+    const assistant = this.getMessages().findLast(
+      (message) => message.role === "assistant",
+    ) as ThreadAssistantMessage | undefined;
     if (
       !assistant ||
       assistant.status?.type !== "requires-action" ||
@@ -496,9 +538,6 @@ export class AgUiThreadRuntimeCore {
     }
 
     const normalized = this.toAppendMessage(message);
-    // Clear before appendEntry so the interrupted assistant is still in
-    // this.messages when its status is flipped; a parentId that points at an
-    // ancestor would otherwise truncate it away before it can be cleared.
     this.clearPendingInterrupts(pending.messageId);
     const threadMessageId = this.appendEntry(normalized);
     await this.startRun(threadMessageId, normalized.runConfig, resume);
@@ -543,7 +582,7 @@ export class AgUiThreadRuntimeCore {
     if (typeof message === "string") {
       return {
         createdAt: new Date(),
-        parentId: this.messages.at(-1)?.id ?? null,
+        parentId: this.repository.headId,
         sourceId: null,
         runConfig: {},
         role: "user",
@@ -554,7 +593,7 @@ export class AgUiThreadRuntimeCore {
     }
     return {
       createdAt: message.createdAt ?? new Date(),
-      parentId: message.parentId ?? this.messages.at(-1)?.id ?? null,
+      parentId: message.parentId ?? this.repository.headId,
       sourceId: message.sourceId ?? null,
       role: message.role ?? "user",
       content: message.content,
@@ -566,8 +605,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private clearPendingInterrupts(messageId: string): void {
-    let touched = false;
-    this.messages = this.messages.map((message) => {
+    const touched = this.updateMessage(messageId, (message) => {
       if (message.id !== messageId || message.role !== "assistant")
         return message;
       const assistant = message as ThreadAssistantMessage;
@@ -577,7 +615,6 @@ export class AgUiThreadRuntimeCore {
       ) {
         return assistant;
       }
-      touched = true;
       const aguiMeta = assistant.metadata.custom[AG_UI_METADATA_NAMESPACE] as
         | AgUiCustomMetadata
         | undefined;
@@ -595,15 +632,15 @@ export class AgUiThreadRuntimeCore {
       };
     });
     if (touched) {
-      this.syncMessageRepositoryWithMessages();
       this.notifyUpdate();
     }
   }
 
   findMessageIdForToolCall(toolCallId: string): string | undefined {
     let fallbackMessageId: string | undefined;
-    for (let index = this.messages.length - 1; index >= 0; index--) {
-      const message = this.messages[index];
+    const messages = this.getMessages();
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const message = messages[index];
       if (!message || message.role !== "assistant") continue;
       for (const part of message.content) {
         if (part.type !== "tool-call" || part.toolCallId !== toolCallId)
@@ -618,7 +655,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private cancelUnresolvedToolCalls(messageId: string): void {
-    this.messages = this.messages.map((message) => {
+    const updated = this.updateMessage(messageId, (message) => {
       if (message.id !== messageId || message.role !== "assistant")
         return message;
       const assistant = message as ThreadAssistantMessage;
@@ -632,13 +669,11 @@ export class AgUiThreadRuntimeCore {
       });
       return { ...assistant, content };
     });
-    this.syncMessageRepositoryWithMessages();
-    this.notifyUpdate();
+    if (updated) this.notifyUpdate();
   }
 
   addToolResult(options: AddToolResultOptions): void {
-    let updated = false;
-    this.messages = this.messages.map((message) => {
+    const updated = this.updateMessage(options.messageId, (message) => {
       if (message.id !== options.messageId || message.role !== "assistant")
         return message;
       const assistant = message as ThreadAssistantMessage;
@@ -655,12 +690,10 @@ export class AgUiThreadRuntimeCore {
         };
       });
       if (!matchedToolCall) return message;
-      updated = true;
       return { ...assistant, content };
     });
 
     if (!updated) return;
-    this.syncMessageRepositoryWithMessages();
     this.notifyUpdate();
     this.maybeResumeAfterToolResults(options.messageId);
   }
@@ -681,7 +714,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   private maybeCompleteAfterToolResults(messageId: string): boolean {
-    const message = this.messages.find((m) => m.id === messageId);
+    const message = this.tryGetMessage(messageId)?.message;
     if (!message || message.role !== "assistant") return false;
     const assistant = message as ThreadAssistantMessage;
     if (
@@ -695,15 +728,15 @@ export class AgUiThreadRuntimeCore {
     );
     if (!allResolved) return false;
 
-    this.messages = this.messages.map((m) =>
-      m.id === messageId && m.role === "assistant"
+    const updated = this.updateMessage(messageId, (current) =>
+      current.role === "assistant"
         ? {
-            ...(m as ThreadAssistantMessage),
+            ...(current as ThreadAssistantMessage),
             status: { type: "complete" as const, reason: "unknown" as const },
           }
-        : m,
+        : current,
     );
-    this.syncMessageRepositoryWithMessages();
+    if (!updated) return false;
     this.notifyUpdate();
     this.persistAssistantHistory(messageId);
     return true;
@@ -717,78 +750,114 @@ export class AgUiThreadRuntimeCore {
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
     this.assistantHistoryParents.clear();
-    this.messages = [...messages];
-    this.messageRepository = this.getUpdatedRepositoryForMessages(messages);
+
+    if (messages.length === 0) {
+      this.clearRepository();
+    } else {
+      let expectedParentId: string | null = null;
+      let lastAppliedId: string | null = null;
+      let hardReplace = false;
+      const seen = new Set<string>();
+
+      for (const message of messages) {
+        if (seen.has(message.id)) continue;
+        seen.add(message.id);
+        const existing = this.tryGetMessage(message.id);
+        if (existing && existing.parentId !== expectedParentId) {
+          hardReplace = true;
+          break;
+        }
+        this.addOrUpdateMessage(expectedParentId, message);
+        expectedParentId = message.id;
+        lastAppliedId = message.id;
+      }
+
+      if (hardReplace) {
+        this.clearRepository();
+        expectedParentId = null;
+        lastAppliedId = null;
+        seen.clear();
+        for (const message of messages) {
+          if (seen.has(message.id)) continue;
+          seen.add(message.id);
+          this.addOrUpdateMessage(expectedParentId, message);
+          expectedParentId = message.id;
+          lastAppliedId = message.id;
+        }
+      }
+
+      this.resetRepositoryHead(lastAppliedId);
+    }
+
     this.recordedHistoryIds.clear();
-    const recordedMessages = this.messageRepository
-      ? this.messageRepository.messages.map((item) => item.message)
-      : this.messages;
-    for (const message of recordedMessages) {
+    for (const { message } of this.getMessageRepository().messages) {
       this.recordedHistoryIds.add(message.id);
     }
     this.notifyUpdate();
   }
 
   private applyExternalMessageRepository(
-    repository: ExportedMessageRepository,
+    loaded: ExportedMessageRepository,
   ): void {
-    const headId = getRepositoryHeadId(repository);
-    const branch = getRepositoryBranchMessages(repository, headId);
-    if (branch === null) {
-      this.applyExternalMessages(
-        repository.messages.map(({ message }) => message),
-      );
-      return;
+    const headId = loaded.headId ?? loaded.messages.at(-1)?.message.id ?? null;
+    const ids = new Set<string>();
+    let degenerate = false;
+    for (const { message } of loaded.messages) {
+      if (ids.has(message.id)) {
+        degenerate = true;
+        break;
+      }
+      ids.add(message.id);
+    }
+    if (headId !== null && !ids.has(headId)) degenerate = true;
+
+    if (!degenerate) {
+      this.clearRepository();
+      let pending = [...loaded.messages];
+      const importedIds = new Set<string>();
+
+      while (pending.length > 0) {
+        const unresolved: typeof pending = [];
+        let progressed = false;
+        for (const item of pending) {
+          if (item.parentId !== null && !importedIds.has(item.parentId)) {
+            unresolved.push(item);
+            continue;
+          }
+          this.addOrUpdateMessage(item.parentId, item.message);
+          importedIds.add(item.message.id);
+          progressed = true;
+        }
+        if (!progressed) {
+          degenerate = true;
+          break;
+        }
+        pending = unresolved;
+      }
+    }
+
+    if (degenerate) {
+      this.clearRepository();
+      let previousId: string | null = null;
+      for (const { message } of loaded.messages) {
+        const existing = this.tryGetMessage(message.id);
+        this.addOrUpdateMessage(
+          existing ? existing.parentId : previousId,
+          message,
+        );
+        previousId = message.id;
+      }
+      this.resetRepositoryHead(previousId);
+    } else {
+      this.resetRepositoryHead(headId);
     }
 
     this.assistantHistoryParents.clear();
-    this.messageRepository = { ...repository, headId };
-    this.messages = [...branch];
     this.recordedHistoryIds.clear();
-    for (const { message } of repository.messages) {
+    for (const { message } of loaded.messages) {
       this.recordedHistoryIds.add(message.id);
     }
     this.notifyUpdate();
-  }
-
-  private getUpdatedRepositoryForMessages(
-    messages: readonly ThreadMessage[],
-  ): ExportedMessageRepository | undefined {
-    if (!this.messageRepository) return undefined;
-    if (messages.length === 0) return undefined;
-
-    const headId = messages[messages.length - 1]!.id;
-    const repositoryMessages = getRepositoryBranchMessages(
-      this.messageRepository,
-      headId,
-    );
-
-    if (
-      repositoryMessages === null ||
-      !sameMessagePath(messages, repositoryMessages)
-    ) {
-      return undefined;
-    }
-
-    const incomingMessages = new Map(
-      messages.map((message) => [message.id, message]),
-    );
-
-    return {
-      ...this.messageRepository,
-      headId,
-      messages: this.messageRepository.messages.map((item) => ({
-        ...item,
-        message: incomingMessages.get(item.message.id) ?? item.message,
-      })),
-    };
-  }
-
-  private syncMessageRepositoryWithMessages(): void {
-    if (!this.messageRepository) return;
-    this.messageRepository = this.getUpdatedRepositoryForMessages(
-      this.messages,
-    );
   }
 
   loadExternalState(state: ReadonlyJSONValue): void {
@@ -804,11 +873,19 @@ export class AgUiThreadRuntimeCore {
   ): Promise<void> {
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
-    this.resetHead(parentId, { preserveMessageRepository: true });
-    const historicalMessages = [...this.messages];
+    const parent = parentId === null ? undefined : this.tryGetMessage(parentId);
+    const shouldEagerlyInsertAssistant =
+      parentId !== null &&
+      parent !== undefined &&
+      parentId !== this.repository.headId;
+    const historicalMessages = [
+      ...(shouldEagerlyInsertAssistant
+        ? (this.tryGetMessages(parentId) ?? this.repository.getMessages())
+        : this.repository.getMessages()),
+    ];
 
     this.pendingError = null;
-    const assistantParentId = parentId ?? this.messages.at(-1)?.id ?? null;
+    const assistantParentId = parent ? parentId : this.repository.headId;
     let assistantMessageId: string | undefined;
     const ensureAssistant = () => {
       if (assistantMessageId) return assistantMessageId;
@@ -819,6 +896,8 @@ export class AgUiThreadRuntimeCore {
       this.markPendingAssistantHistory(created, assistantParentId ?? null);
       return created;
     };
+
+    if (shouldEagerlyInsertAssistant) ensureAssistant();
 
     const applyUpdate = (update: ChatModelRunResult) => {
       const resolved = this.updateAssistantMessage(ensureAssistant(), update);
@@ -834,8 +913,9 @@ export class AgUiThreadRuntimeCore {
       onServerMessageId: (serverId) => {
         const placeholder = ensureAssistant();
         if (placeholder === serverId) return;
-        this.reassignAssistantId(placeholder, serverId);
-        assistantMessageId = serverId;
+        if (this.reassignAssistantId(placeholder, serverId)) {
+          assistantMessageId = serverId;
+        }
       },
     });
     const dispatch = (event: AgUiEvent) => this.handleEvent(aggregator, event);
@@ -955,7 +1035,7 @@ export class AgUiThreadRuntimeCore {
       unstable_threadId: ctx.threadId,
       unstable_parentId: ctx.parentId,
       unstable_getMessage: () => {
-        const message = this.messages.find((m) => m.id === currentId());
+        const message = this.tryGetMessage(currentId())?.message;
         if (!message) {
           throw new Error(
             "[agui] resume stream requested the assistant message before it existed",
@@ -982,7 +1062,7 @@ export class AgUiThreadRuntimeCore {
     }
 
     if (ctx.abortSignal.aborted) return;
-    const current = this.messages.find((m) => m.id === currentId());
+    const current = this.tryGetMessage(currentId())?.message;
     if (!current || current.status?.type === "running") {
       ctx.applyUpdate({ status: { type: "complete", reason: "unknown" } });
     }
@@ -995,7 +1075,9 @@ export class AgUiThreadRuntimeCore {
     resume?: AgUiResumeEntry[],
   ) {
     const threadId = this.agent.threadId || "main";
-    const messages = toAgUiMessages(historyMessages ?? this.messages);
+    const messages = toAgUiMessages(
+      historyMessages ?? this.repository.getMessages(),
+    );
     const context = this.runtime?.thread.getModelContext();
     return {
       threadId,
@@ -1065,72 +1147,34 @@ export class AgUiThreadRuntimeCore {
         custom: {},
       },
     };
-    this.messages = [...this.messages, assistant];
-    if (this.messageRepository) {
-      this.messageRepository = {
-        ...this.messageRepository,
-        headId: id,
-        messages: [
-          ...this.messageRepository.messages,
-          { parentId, message: assistant },
-        ],
-      };
-    }
+    this.addOrUpdateMessage(parentId ?? this.repository.headId, assistant);
+    this.switchToBranch(id);
     this.notifyUpdate();
     return id;
   }
 
-  private reassignAssistantId(oldId: string, newId: string): void {
-    if (oldId === newId) return;
+  private reassignAssistantId(oldId: string, newId: string): boolean {
+    if (oldId === newId) return true;
+    const oldItem = this.tryGetMessage(oldId);
+    if (!oldItem) return false;
 
-    const collidesWithExisting =
-      this.messages.some((m) => m.id === newId) ||
-      (this.messageRepository
-        ? repositoryHasMessageId(this.messageRepository, newId)
-        : false);
+    const collidesWithExisting = this.hasMessage(newId);
 
     if (collidesWithExisting) {
       this.logger.debug?.(
         "[agui] reassignAssistantId: server id already present in messages or repository, dropping placeholder",
         { oldId, newId },
       );
-      this.messages = this.messages.filter((m) => m.id !== oldId);
+      this.deleteMessage(oldId, oldItem.parentId ?? null);
     } else {
-      this.messages = this.messages.map((m) => {
-        if (m.id !== oldId) return m;
-        const { isOptimistic: _, ...metadata } = m.metadata;
-        return { ...m, id: newId, metadata } as ThreadMessage;
-      });
-    }
-
-    if (this.messageRepository) {
-      const oldRepositoryItem = this.messageRepository.messages.find(
-        (item) => item.message.id === oldId,
-      );
-      const messagesById = new Map(
-        this.messages.map((message) => [message.id, message]),
-      );
-      this.messageRepository = {
-        ...this.messageRepository,
-        headId:
-          this.messageRepository.headId === oldId
-            ? collidesWithExisting
-              ? (oldRepositoryItem?.parentId ?? null)
-              : newId
-            : this.messageRepository.headId,
-        messages: this.messageRepository.messages.flatMap((item) => {
-          if (collidesWithExisting && item.message.id === oldId) return [];
-          const id = item.message.id === oldId ? newId : item.message.id;
-          const message = messagesById.get(id) ?? item.message;
-          return [
-            {
-              ...item,
-              parentId: item.parentId === oldId ? newId : item.parentId,
-              message,
-            },
-          ];
-        }),
-      };
+      const { isOptimistic: _, ...metadata } = oldItem.message.metadata;
+      this.addOrUpdateMessage(oldItem.parentId, {
+        ...oldItem.message,
+        id: newId,
+        metadata,
+      } as ThreadMessage);
+      this.switchToBranch(newId);
+      this.tryDeleteMessage(oldId);
     }
 
     const pendingParent = this.assistantHistoryParents.get(oldId);
@@ -1149,18 +1193,17 @@ export class AgUiThreadRuntimeCore {
     }
 
     this.notifyUpdate();
+    return !collidesWithExisting;
   }
 
   private updateAssistantMessage(
     messageId: string,
     update: ChatModelRunResult,
   ): string {
-    let touched = false;
     let latestStatus: MessageStatus | undefined;
-    this.messages = this.messages.map((message) => {
+    const touched = this.updateMessage(messageId, (message) => {
       if (message.id !== messageId || message.role !== "assistant")
         return message;
-      touched = true;
       const assistant = message as ThreadAssistantMessage;
       const metadata = update.metadata
         ? this.mergeAssistantMetadata(assistant.metadata, update.metadata)
@@ -1190,7 +1233,6 @@ export class AgUiThreadRuntimeCore {
       this.reassignAssistantId(messageId, stableId);
       resolvedMessageId = stableId;
     } else {
-      this.syncMessageRepositoryWithMessages();
       this.notifyUpdate();
     }
     if (this.isPersistableStatus(latestStatus)) {
@@ -1309,8 +1351,7 @@ export class AgUiThreadRuntimeCore {
     messageId: string,
     event: Extract<AgUiEvent, { type: "TOOL_CALL_RESULT" }>,
   ): void {
-    let updated = false;
-    this.messages = this.messages.map((message) => {
+    const updated = this.updateMessage(messageId, (message) => {
       if (message.id !== messageId || message.role !== "assistant")
         return message;
       const assistant = message as ThreadAssistantMessage;
@@ -1329,12 +1370,10 @@ export class AgUiThreadRuntimeCore {
         };
       });
       if (!matchedToolCall) return message;
-      updated = true;
       return { ...assistant, content };
     });
 
     if (!updated) return;
-    this.syncMessageRepositoryWithMessages();
     this.notifyUpdate();
     // Not maybeResumeAfterToolResults: the delivering run is already in
     // flight, and a resume from the owner would reset the head past it.
@@ -1373,41 +1412,6 @@ export class AgUiThreadRuntimeCore {
     );
   }
 
-  private resetHead(
-    parentId: string | null | undefined,
-    options: { preserveMessageRepository?: boolean } = {},
-  ) {
-    if (
-      options.preserveMessageRepository &&
-      parentId &&
-      this.messageRepository
-    ) {
-      const branch = getRepositoryBranchMessages(
-        this.messageRepository,
-        parentId,
-      );
-      if (branch !== null && branch.at(-1)?.id === parentId) {
-        this.messageRepository = {
-          ...this.messageRepository,
-          headId: parentId,
-        };
-        this.messages = [...branch];
-        return;
-      }
-    }
-
-    this.messageRepository = undefined;
-    if (!parentId) {
-      if (this.messages.length) {
-        this.messages = [];
-      }
-      return;
-    }
-    const idx = this.messages.findIndex((message) => message.id === parentId);
-    if (idx === -1) return;
-    this.messages = this.messages.slice(0, idx + 1);
-  }
-
   private isTerminalStatus(status?: MessageStatus): boolean {
     return status?.type === "complete" || status?.type === "incomplete";
   }
@@ -1433,7 +1437,7 @@ export class AgUiThreadRuntimeCore {
     if (!this.history) return;
     const parentId = this.assistantHistoryParents.get(messageId);
     if (parentId === undefined) return;
-    const message = this.messages.find((m) => m.id === messageId);
+    const message = this.getMessages().find((item) => item.id === messageId);
     if (!message || message.role !== "assistant") return;
     if (!this.isPersistableStatus(message.status)) return;
     this.assistantHistoryParents.delete(messageId);

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -134,14 +134,11 @@ export function useAgUiRuntime(
   const store = useMemo(
     () => {
       void _version; // rerender on version change
-      const messageRepository = core.getMessageRepository();
 
       return {
         ...shared,
         isLoading: core.isLoading,
-        ...(messageRepository
-          ? { messageRepository }
-          : { messages: core.getMessages() }),
+        messageRepository: core.getMessageRepository(),
         state: core.getState(),
         isRunning: core.isRunning() || hasExecutingTools,
         extras: agUiExtras.provide({

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1418,7 +1418,10 @@ describe("AGUIThreadRuntimeCore", () => {
 
     core.applyExternalMessages([]);
 
-    expect(core.getMessageRepository()).toBeUndefined();
+    expect(core.getMessageRepository()).toMatchObject({
+      headId: null,
+      messages: [],
+    });
   });
 
   it("preserves branchable history while resuming loaded history", async () => {
@@ -1603,7 +1606,7 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(append).not.toHaveBeenCalled();
   });
 
-  it("falls back to flat loaded history when branchable history has duplicate ids", async () => {
+  it("collapses duplicate ids while falling back to linear loaded history", async () => {
     const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
     const userMessage: ThreadMessage = {
       id: "msg-1",
@@ -1650,12 +1653,21 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(core.getMessages().map((message) => message.id)).toEqual([
       "msg-1",
       "msg-2",
-      "msg-2",
     ]);
-    expect(core.getMessageRepository()).toBeUndefined();
+    expect(core.getMessages()[1]?.content[0]).toMatchObject({
+      type: "text",
+      text: "Option B",
+    });
+    expect(core.getMessageRepository()).toMatchObject({
+      headId: "msg-2",
+      messages: [
+        { message: { id: "msg-1" }, parentId: null },
+        { message: { id: "msg-2" }, parentId: "msg-1" },
+      ],
+    });
   });
 
-  it("falls back to linear history when a new turn is appended after load", async () => {
+  it("retains branchable history when a new turn is appended after load", async () => {
     const runAgent = vi.fn(async (_input, subscriber) => {
       subscriber.onRunFinalized?.();
     });
@@ -1701,13 +1713,20 @@ describe("AGUIThreadRuntimeCore", () => {
 
     await core.append(createAppendMessage({ parentId: "msg-2b" }));
 
-    expect(core.getMessageRepository()).toBeUndefined();
+    const messages = core.getMessages();
+    const newUser = messages[2]!;
+    const newAssistant = messages[3]!;
+    expect(messages.map((message) => message.id)).toEqual([
+      "msg-1",
+      "msg-2b",
+      newUser.id,
+      newAssistant.id,
+    ]);
+    const updatedRepository = core.getMessageRepository();
+    expect(updatedRepository).toBeDefined();
     expect(
-      core
-        .getMessages()
-        .map((message) => message.id)
-        .slice(0, 2),
-    ).toEqual(["msg-1", "msg-2b"]);
+      updatedRepository.messages.find(({ message }) => message.id === "msg-2a"),
+    ).toMatchObject({ parentId: "msg-1", message: { id: "msg-2a" } });
   });
 
   it("returns existing promise if __internal_load called multiple times", async () => {
@@ -3399,14 +3418,24 @@ describe("AGUIThreadRuntimeCore", () => {
     core.applyExternalMessages([existingMessage as ThreadMessage]);
     await core.append(createAppendMessage());
 
-    const collidedMessages = core
-      .getMessages()
-      .filter((m) => m.id === serverId);
-    expect(collidedMessages).toHaveLength(1);
+    expect(core.getMessages()).toMatchObject([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+      },
+    ]);
+    expect(core.getMessages().some((message) => message.id === serverId)).toBe(
+      false,
+    );
     const optimisticLingerers = core
       .getMessages()
       .filter((m) => m.id.startsWith("__optimistic__"));
     expect(optimisticLingerers).toHaveLength(0);
+    expect(
+      core
+        .getMessageRepository()
+        .messages.filter((item) => item.message.id === serverId),
+    ).toHaveLength(1);
   });
 
   it("marks the placeholder as optimistic and clears the flag once the server id arrives", async () => {
@@ -3454,5 +3483,116 @@ describe("AGUIThreadRuntimeCore", () => {
     const assistant = core.getMessages().at(-1) as ThreadAssistantMessage;
     expect(assistant.id.startsWith("__optimistic__")).toBe(false);
     expect(assistant.metadata.isOptimistic).toBeUndefined();
+  });
+
+  it("keeps the active turn visible when a server id collides on a disjoint branch", async () => {
+    const serverId = "srv-1";
+    const historyMessage: ThreadAssistantMessage = {
+      id: serverId,
+      role: "assistant",
+      createdAt: new Date(),
+      status: { type: "complete", reason: "unknown" },
+      content: [{ type: "text", text: "from history" }],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_START",
+            messageId: serverId,
+            role: "assistant",
+          },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: serverId,
+            delta: "streaming",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const history: ThreadHistoryAdapter = {
+      load: vi
+        .fn()
+        .mockResolvedValue(
+          ExportedMessageRepository.fromBranchableArray(
+            [{ parentId: null, message: historyMessage }],
+            { headId: serverId },
+          ),
+        ),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, { history });
+    await core.__internal_load();
+
+    await core.append(createAppendMessage({ parentId: null }));
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: "hi" }],
+    });
+    expect(
+      messages.some((message) => message.id.startsWith("__optimistic__")),
+    ).toBe(false);
+    expect(core.getMessageRepository().messages).toContainEqual({
+      parentId: null,
+      message: historyMessage,
+    });
+  });
+
+  it("skips duplicate ids in flat snapshots", () => {
+    const core = createCore({ runAgent: vi.fn() } as unknown as HttpAgent);
+    const firstMessage: ThreadMessage = {
+      id: "dup-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "first" }],
+      metadata: { custom: {} },
+    };
+    const secondMessage: ThreadAssistantMessage = {
+      id: "msg-2",
+      role: "assistant",
+      createdAt: new Date(),
+      status: { type: "complete", reason: "unknown" },
+      content: [{ type: "text", text: "second" }],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    const duplicateMessage: ThreadMessage = {
+      id: "dup-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "duplicate" }],
+      metadata: { custom: {} },
+    };
+
+    expect(() => {
+      core.applyExternalMessages([
+        firstMessage,
+        secondMessage,
+        duplicateMessage,
+      ]);
+    }).not.toThrow();
+    expect(core.getMessages().map((message) => message.id)).toEqual([
+      "dup-1",
+      "msg-2",
+    ]);
+    expect(core.getMessageRepository().headId).toBe("msg-2");
   });
 });

--- a/packages/react-ag-ui/test/branch-flows.spec.ts
+++ b/packages/react-ag-ui/test/branch-flows.spec.ts
@@ -1,0 +1,363 @@
+"use client";
+
+import { describe, expect, it, vi } from "vitest";
+import { ExportedMessageRepository } from "@assistant-ui/core";
+import type {
+  AppendMessage,
+  ChatModelRunResult,
+  ThreadAssistantMessage,
+  ThreadHistoryAdapter,
+  ThreadMessage,
+} from "@assistant-ui/core";
+import type { HttpAgent } from "@ag-ui/client";
+import { AgUiThreadRuntimeCore } from "../src/runtime/AgUiThreadRuntimeCore";
+import { makeLogger } from "../src/runtime/logger";
+
+const createAppendMessage = (
+  overrides: Partial<AppendMessage> = {},
+): AppendMessage => ({
+  role: "user",
+  content: [{ type: "text" as const, text: "hi" }],
+  attachments: [],
+  metadata: { custom: {} },
+  createdAt: new Date(),
+  parentId: overrides.parentId ?? null,
+  sourceId: overrides.sourceId ?? null,
+  runConfig: overrides.runConfig ?? {},
+  startRun: overrides.startRun ?? true,
+});
+
+const noopLogger = makeLogger();
+
+const createCore = (
+  agent: HttpAgent,
+  hooks: { history?: ThreadHistoryAdapter } = {},
+) =>
+  new AgUiThreadRuntimeCore({
+    agent,
+    logger: noopLogger,
+    showThinking: true,
+    ...(hooks.history ? { history: hooks.history } : {}),
+    notifyUpdate: () => {},
+  });
+
+const finalizingAgent = (text: string) =>
+  ({
+    runAgent: vi.fn(async (_input, subscriber) => {
+      subscriber.onTextMessageContentEvent?.({
+        event: { type: "TEXT_MESSAGE_CONTENT", delta: text },
+      });
+      subscriber.onRunFinalized?.();
+    }),
+  }) as unknown as HttpAgent;
+
+describe("AgUiThreadRuntimeCore branch flows", () => {
+  it("append: records the visible pair and persists user then assistant with correct parents", async () => {
+    const agent = finalizingAgent("Hello");
+    const append = vi.fn().mockResolvedValue(undefined);
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    await core.append(createAppendMessage());
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[1]!.role).toBe("assistant");
+
+    const userId = messages[0]!.id;
+    const assistantId = messages[1]!.id;
+
+    expect(append.mock.calls[0]?.[0]).toMatchObject({
+      parentId: null,
+      message: { id: userId, role: "user" },
+    });
+    expect(append.mock.calls[1]?.[0]).toMatchObject({
+      parentId: userId,
+      message: { id: assistantId, role: "assistant" },
+    });
+  });
+
+  it("append at the root again replaces the visible pair with a fresh sibling turn", async () => {
+    let callCount = 0;
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        callCount++;
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            delta: callCount === 1 ? "first reply" : "second reply",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const append = vi.fn().mockResolvedValue(undefined);
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+    };
+    const core = createCore(agent, { history: historyAdapter });
+
+    await core.append(createAppendMessage());
+    const firstUserId = core.getMessages()[0]!.id;
+    const firstAssistantId = core.getMessages()[1]!.id;
+
+    append.mockClear();
+    await core.append(createAppendMessage({ parentId: null }));
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages.map((m) => m.id)).not.toContain(firstUserId);
+    expect(messages.map((m) => m.id)).not.toContain(firstAssistantId);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[1]!.role).toBe("assistant");
+
+    const newUserId = messages[0]!.id;
+    expect(append.mock.calls[0]?.[0]).toMatchObject({
+      parentId: null,
+      message: { id: newUserId, role: "user" },
+    });
+  });
+
+  it("reload: regenerates the assistant reply and persists it under the same parent", async () => {
+    let callCount = 0;
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        callCount++;
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            delta: callCount === 1 ? "first" : "second",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const append = vi.fn().mockResolvedValue(undefined);
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+    };
+    const core = createCore(agent, { history: historyAdapter });
+
+    await core.append(createAppendMessage());
+    const userId = core.getMessages()[0]!.id;
+
+    append.mockClear();
+    await core.reload(userId);
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.id).toBe(userId);
+    const newAssistant = messages[1] as ThreadAssistantMessage;
+    expect(newAssistant.content[0]).toMatchObject({
+      type: "text",
+      text: "second",
+    });
+
+    expect(append.mock.calls.at(-1)?.[0]).toMatchObject({
+      parentId: userId,
+      message: { id: newAssistant.id, role: "assistant" },
+    });
+  });
+
+  it("reload: runAgent input reflects only the visible message path", async () => {
+    const runInputs: any[] = [];
+    let callCount = 0;
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runInputs.push(input);
+        callCount++;
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            delta: callCount === 1 ? "first" : "second",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+    const userId = core.getMessages()[0]!.id;
+
+    await core.reload(userId);
+
+    const secondInput = runInputs[1];
+    expect(secondInput.messages).toHaveLength(1);
+    expect(secondInput.messages[0]).toMatchObject({ id: userId, role: "user" });
+  });
+
+  it("append after a branchable load persists the new turn under the visible head", async () => {
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const repository = ExportedMessageRepository.fromBranchableArray(
+      [
+        {
+          message: {
+            id: "u1",
+            role: "user",
+            content: [{ type: "text", text: "Hello" }],
+          },
+          parentId: null,
+        },
+        {
+          message: {
+            id: "a1",
+            role: "assistant",
+            content: [{ type: "text", text: "Option A" }],
+          },
+          parentId: "u1",
+        },
+        {
+          message: {
+            id: "a2",
+            role: "assistant",
+            content: [{ type: "text", text: "Option B" }],
+          },
+          parentId: "u1",
+        },
+      ],
+      { headId: "a2" },
+    );
+
+    const append = vi.fn().mockResolvedValue(undefined);
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue(repository),
+      append,
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    await core.__internal_load();
+
+    await core.append(createAppendMessage({ parentId: "a2" }));
+
+    const messages = core.getMessages();
+    expect(messages[0]!.id).toBe("u1");
+    expect(messages[1]!.id).toBe("a2");
+    expect(messages[2]!.role).toBe("user");
+
+    const newUserId = messages[2]!.id;
+    expect(append.mock.calls[0]?.[0]).toMatchObject({
+      parentId: "a2",
+      message: { id: newUserId, role: "user" },
+    });
+  });
+
+  it("MESSAGES_SNAPSHOT echoing the appended user id refreshes the visible path with the server assistant", async () => {
+    let echoedUserId = "";
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        echoedUserId = input.messages.find(
+          (m: { role: string }) => m.role === "user",
+        ).id;
+        subscriber.onMessagesSnapshotEvent?.({
+          event: {
+            type: "MESSAGES_SNAPSHOT",
+            messages: [
+              { id: echoedUserId, role: "user", content: "hi" },
+              {
+                id: "server-assistant-1",
+                role: "assistant",
+                content: "hello there",
+              },
+            ],
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    const messages = core.getMessages();
+    expect(messages).toHaveLength(2);
+    expect(messages[0]!.id).toBe(echoedUserId);
+    expect(messages[0]!.role).toBe("user");
+    const assistant = messages[1] as ThreadAssistantMessage;
+    expect(assistant.id).toBe("server-assistant-1");
+    expect(assistant.content[0]).toMatchObject({
+      type: "text",
+      text: "hello there",
+    });
+  });
+
+  it("resume after loading a linear two-message history replays without re-running the agent", async () => {
+    const runAgent = vi.fn(async (_input, subscriber) => {
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const userMessage: ThreadMessage = {
+      id: "msg-1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Hello" }],
+      metadata: { custom: {} },
+    };
+    const assistantMessage: ThreadAssistantMessage = {
+      id: "msg-2",
+      role: "assistant",
+      createdAt: new Date(),
+      status: { type: "complete", reason: "unknown" },
+      content: [{ type: "text", text: "partial" }],
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    const resume = vi.fn(async function* (): AsyncGenerator<
+      ChatModelRunResult,
+      void,
+      unknown
+    > {
+      yield { content: [{ type: "text", text: "resumed content" }] };
+      yield { status: { type: "complete", reason: "unknown" } };
+    });
+
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({
+        headId: "msg-2",
+        messages: [
+          { message: userMessage, parentId: null },
+          { message: assistantMessage, parentId: "msg-1" },
+        ],
+        unstable_resume: true,
+      }),
+      resume,
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const core = createCore(agent, { history: historyAdapter });
+    await core.__internal_load();
+
+    expect(runAgent).not.toHaveBeenCalled();
+    expect(resume).toHaveBeenCalledTimes(1);
+
+    const messages = core.getMessages();
+    const tail = messages.at(-1) as ThreadAssistantMessage;
+    expect(messages.map((m) => m.id).slice(0, 2)).toEqual(["msg-1", "msg-2"]);
+    expect(tail.content.at(-1)).toMatchObject({
+      type: "text",
+      text: "resumed content",
+    });
+    expect(tail.metadata.isOptimistic).toBeUndefined();
+    expect(tail.id.startsWith("__optimistic__")).toBe(false);
+  });
+});


### PR DESCRIPTION
closes #4904

## summary

- branch structure now survives the full thread lifecycle: after loading branchable history, new turns, edits, regenerates, and interrupt resumes all keep sibling branches reachable instead of dropping to a linear view on the first mutation
- replaces the flat message array plus the hand-synced `ExportedMessageRepository` mirror (and its `syncMessageRepositoryWithMessages()` calls at 8 mutation sites) with a single `MessageRepository` from `@assistant-ui/core/internal`; the linear view is derived via `getMessages()` and every mutation writes through small lenient helpers
- `useAgUiRuntime` now always passes `messageRepository` to `useExternalStoreRuntime` (the react-opencode/react-pi mode); `setMessages` stays so the switchToBranch capability is preserved
- per-token streaming cost on the adapter side drops from O(messages) array rebuilds to O(1) repository updates with a memoized export payload, which resolves the perf note raised on #4776

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui exec vitest run` -> 217/217 green across 7 files, including 7 characterization tests committed before the refactor to pin the surviving flows (visible paths, history adapter parentIds, run inputs)
- [x] `pnpm --filter @assistant-ui/react-ag-ui build` -> type generation green
- [x] oxlint and oxfmt clean on all touched files
- [x] adversarial review pass: id-collision head recovery in the disjoint-branch case and duplicate-id flat snapshots both got dedicated regression tests

### reviewer should verify

- [ ] load a branchable history via a `ThreadHistoryAdapter` (two assistants sharing one parent), confirm `BranchPicker` shows 2/2, send a new message, and confirm the picker on the old turn still works
- [ ] regenerate an answer on loaded history and confirm the previous answer remains reachable as a sibling branch

## notes

- deliberate behavior changes, each pinned by an updated test: duplicate ids in a degenerate load now collapse (last write wins) instead of rendering two messages with the same React key; `parentId: null` appends create a root sibling and keep the prior conversation as a branch, matching what core's external store already retained end to end; `getMessageRepository()` always returns a payload (empty repo instead of undefined)
- the collision semantics pinned on #4776 (server reusing a hidden sibling id drops the streamed content and protects the existing message) are preserved unchanged

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

