### PR TITLE
fix(react-pi): parse standard SSE line endings

### DIFF
--- a/.changeset/react-pi-standard-sse-line-endings.md
+++ b/.changeset/react-pi-standard-sse-line-endings.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: parse all standard SSE line endings

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -39,6 +39,24 @@ describe("createSseDecoder", () => {
     ]);
   });
 
+  it("handles CRLF line endings split across chunks", () => {
+    const decoder = createSseDecoder();
+    const frames = [
+      ...decoder.push("data: hello\r"),
+      ...decoder.push("\n\r"),
+      ...decoder.push("\n"),
+    ];
+
+    expect(frames).toEqual([{ data: "hello" }]);
+  });
+
+  it("handles CR-only line endings across chunks", () => {
+    const decoder = createSseDecoder();
+    expect(decoder.push("data: a\r")).toEqual([]);
+    expect(decoder.push("data: b\r")).toEqual([]);
+    expect(decoder.push("\r")).toEqual([{ data: "a\nb" }]);
+  });
+
   it("emits several frames from one chunk", () => {
     const decoder = createSseDecoder();
     expect(decoder.push("data: 1\n\ndata: 2\n\n")).toEqual([

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -31,11 +31,12 @@ export interface SseFrame {
 /**
  * Incremental SSE frame parser. `push(chunk)` returns every frame completed by
  * that chunk; partial trailing data is buffered until its terminating blank
- * line arrives. Handles `\n` and `\r\n` line endings, `:`-comment heartbeats,
+ * line arrives. Handles LF, CRLF, and CR line endings, `:`-comment heartbeats,
  * and multi-line `data:`.
  */
 export const createSseDecoder = () => {
   let buffer = "";
+  let skipNextLineFeed = false;
   let dataLines: string[] = [];
   let eventName: string | undefined;
   let lastId: string | undefined;
@@ -84,15 +85,30 @@ export const createSseDecoder = () => {
 
   return {
     push(chunk: string): SseFrame[] {
-      buffer += chunk;
       const out: SseFrame[] = [];
-      let idx: number;
-      while ((idx = buffer.indexOf("\n")) !== -1) {
-        let line = buffer.slice(0, idx);
-        if (line.endsWith("\r")) line = line.slice(0, -1);
-        buffer = buffer.slice(idx + 1);
-        handleLine(line, out);
+      let lineStart = 0;
+
+      for (let index = 0; index < chunk.length; index++) {
+        const character = chunk[index]!;
+
+        if (skipNextLineFeed) {
+          skipNextLineFeed = false;
+          if (character === "\n") {
+            lineStart = index + 1;
+            continue;
+          }
+        }
+
+        if (character === "\n" || character === "\r") {
+          buffer += chunk.slice(lineStart, index);
+          handleLine(buffer, out);
+          buffer = "";
+          skipNextLineFeed = character === "\r";
+          lineStart = index + 1;
+        }
       }
+
+      buffer += chunk.slice(lineStart);
       return out;
     },
   };


### PR DESCRIPTION
## Summary

- recognize CR as an SSE line ending in React Pi's incremental decoder
- continue treating CRLF as one line ending, including across chunk boundaries
- add regression tests for split CRLF and CR-only streams

## Why

While testing React Pi's HTTP/SSE transport, I found that a valid CR-only stream such as `data: a\rdata: b\r\r` never emitted a frame. The decoder searched only for LF, so the complete event remained buffered indefinitely.

The WHATWG SSE grammar permits CRLF, LF, or CR line endings. This updates the private React Pi decoder to support all three without changing its frame parsing or reconnection behavior.

This is separate from #4876: that PR updates `assistant-stream`'s shared line decoder, while React Pi currently uses its own `createSseDecoder()`.

## Verification

- `pnpm --filter @assistant-ui/react-pi exec vitest run src/client/eventSource.test.ts`
- `pnpm --filter @assistant-ui/react-pi test` (141 tests)
- `pnpm turbo build --filter=@assistant-ui/react-pi...`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

