### PR TITLE
fix(core): keep tool-args key-order caches independent for dotted keys

### DIFF
--- a/.changeset/tool-args-dotted-keys.md
+++ b/.changeset/tool-args-dotted-keys.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep tool-args key-order caches independent for keys containing dots or brackets

--- a/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
+++ b/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
@@ -82,6 +82,9 @@ describe("stableStringifyToolArgs", () => {
     expect(
       stableStringifyToolArgs(cache, "key", { "x[0]": { n: 3, m: 4 } }),
     ).toBe(JSON.stringify({ "x[0]": { n: 3, m: 4 } }));
+    expect(stableStringifyToolArgs(cache, "key", { x: [{ n: 5, m: 6 }] })).toBe(
+      JSON.stringify({ x: [{ m: 6, n: 5 }] }),
+    );
   });
 });
 

--- a/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
+++ b/packages/core/src/utils/json/stable-stringify-tool-args.test.ts
@@ -64,6 +64,25 @@ describe("stableStringifyToolArgs", () => {
       JSON.stringify({ b: 3, a: 4 }),
     );
   });
+
+  it("keeps dotted keys independent from nested paths", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", { a: { b: { p: 1, q: 2 } } });
+    expect(
+      stableStringifyToolArgs(cache, "key", { "a.b": { q: 3, p: 4 } }),
+    ).toBe(JSON.stringify({ "a.b": { q: 3, p: 4 } }));
+    expect(
+      stableStringifyToolArgs(cache, "key", { a: { b: { q: 9, p: 8 } } }),
+    ).toBe(JSON.stringify({ a: { b: { p: 8, q: 9 } } }));
+  });
+
+  it("keeps bracket-mimic keys independent from array paths", () => {
+    const cache = new Map<string, Map<string, string[]>>();
+    stableStringifyToolArgs(cache, "key", { x: [{ m: 1, n: 2 }] });
+    expect(
+      stableStringifyToolArgs(cache, "key", { "x[0]": { n: 3, m: 4 } }),
+    ).toBe(JSON.stringify({ "x[0]": { n: 3, m: 4 } }));
+  });
 });
 
 describe("trackToolArgsKeyOrder", () => {

--- a/packages/core/src/utils/json/stable-stringify-tool-args.ts
+++ b/packages/core/src/utils/json/stable-stringify-tool-args.ts
@@ -27,7 +27,11 @@ const stabilizeToolArgsValue = (
     return Object.fromEntries(
       nextOrder.map((key) => [
         key,
-        stabilizeToolArgsValue(record[key], `${path}.${key}`, keyOrderByPath),
+        stabilizeToolArgsValue(
+          record[key],
+          `${path}.${JSON.stringify(key)}`,
+          keyOrderByPath,
+        ),
       ]),
     );
   }


### PR DESCRIPTION
closes #4941

## summary

- sibling tool-args structures no longer share a key-order cache entry when an object key contains a literal dot (`{ a: { b } }` vs `{ "a.b": {} }` both mapped to `$.a.b`) or mimics an array segment (`{ x: [{}] }` vs `{ "x[0]": {} }` both mapped to `$.x[0]`), so one object's first-seen key order can no longer reorder another's `argsText` during streaming
- the fix encodes the object key segment with `JSON.stringify` when building the cache path; quoted segments are self-delimiting, the array branch stays as is, and cache paths are internal to the per-call cache map so nothing outside the module changes
- shipped in both adapter copies since #3428/#3458; fixing it once is possible now that #4901 centralized the module in `@assistant-ui/core/internal`

## test plan

### already verified

- [x] `pnpm vitest run src/utils/json/` in packages/core -> 10/10 green (8 existing + 2 regression tests covering the dotted-key and bracket-mimic collisions)
- [x] `pnpm --filter @assistant-ui/core build` -> green
- [x] consumer regression: react-ai-sdk `convertMessage.test.ts` 26/26, react-langgraph `convertLangChainMessages.test.ts` 33/33, both untouched
- [x] oxlint and oxfmt clean on both touched files

### reviewer should verify

- [ ] stream a tool call whose args contain sibling objects with dotted keys and confirm `argsText` key order stays stable per object across partial updates

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

