### PR TITLE
feat: add styled generative ui registry items

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -1246,7 +1246,6 @@ export const registry: RegistryItem[] = [
       "@assistant-ui/react-generative-ui",
       "react-markdown",
       "remark-gfm",
-      "zod",
     ],
     registryDependencies: [
       "https://r.assistant-ui.com/generative-ui-style.json",

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -38,6 +38,487 @@ const accordionKeyframesCss = {
   },
 };
 
+const auiHairlineBorder = "color-mix(in oklab, var(--border) 60%, transparent)";
+
+const generativeUiVocabularyCss = {
+  "[data-aui]": {
+    "box-sizing": "border-box",
+  },
+
+  '[data-aui="header"]': {
+    margin: "0",
+    "font-weight": "600",
+    "line-height": "1.4",
+  },
+  '[data-aui="text"]': {
+    "line-height": "1.5",
+  },
+  '[data-aui="caption"]': {
+    margin: "0",
+    "font-size": "0.75rem",
+    "line-height": "1.5",
+    color: "var(--muted-foreground)",
+  },
+
+  '[data-aui="text"][data-aui-size="sm"], [data-aui="header"][data-aui-size="sm"]':
+    { "font-size": "0.75rem" },
+  '[data-aui="text"][data-aui-size="md"], [data-aui="header"][data-aui-size="md"]':
+    { "font-size": "0.875rem" },
+  '[data-aui="text"][data-aui-size="lg"], [data-aui="header"][data-aui-size="lg"]':
+    { "font-size": "1.125rem" },
+  '[data-aui="text"][data-aui-size="xl"], [data-aui="header"][data-aui-size="xl"]':
+    { "font-size": "1.25rem" },
+  '[data-aui="text"][data-aui-size="2xl"], [data-aui="header"][data-aui-size="2xl"]':
+    { "font-size": "1.5rem" },
+  '[data-aui="text"][data-aui-size="3xl"], [data-aui="header"][data-aui-size="3xl"]':
+    { "font-size": "1.875rem" },
+
+  '[data-aui="text"][data-aui-weight="normal"]': { "font-weight": "400" },
+  '[data-aui="text"][data-aui-weight="medium"]': { "font-weight": "500" },
+  '[data-aui="text"][data-aui-weight="semibold"]': { "font-weight": "600" },
+  '[data-aui="text"][data-aui-weight="bold"]': { "font-weight": "700" },
+
+  '[data-aui="text"][data-aui-color="emphasis"]': {
+    color: "var(--foreground)",
+  },
+  '[data-aui="text"][data-aui-color="secondary"]': {
+    color: "var(--muted-foreground)",
+  },
+  '[data-aui="text"][data-aui-color="alpha-70"]': {
+    color: "color-mix(in oklab, var(--foreground) 70%, transparent)",
+  },
+  '[data-aui="text"][data-aui-color="white"]': { color: "white" },
+  '[data-aui="text"][data-aui-color="white-70"]': {
+    color: "color-mix(in oklab, white 70%, transparent)",
+  },
+  '[data-aui="text"][data-aui-color="white-50"]': {
+    color: "color-mix(in oklab, white 50%, transparent)",
+  },
+
+  '[data-aui="fact"]': { margin: "0" },
+  '[data-aui="fact-label"]': {
+    margin: "0",
+    "font-size": "0.75rem",
+    color: "var(--muted-foreground)",
+  },
+  '[data-aui="fact-value"]': {
+    margin: "0",
+    "font-size": "0.875rem",
+  },
+
+  '[data-aui="button"], [data-aui="card-confirm"], [data-aui="card-cancel"]': {
+    display: "inline-flex",
+    "align-items": "center",
+    "justify-content": "center",
+    gap: "0.375rem",
+    height: "2.25rem",
+    padding: "0 1rem",
+    "border-radius": "calc(var(--radius) - 2px)",
+    "font-size": "0.875rem",
+    "font-weight": "500",
+    border: "1px solid transparent",
+    cursor: "pointer",
+    "background-color": "var(--secondary)",
+    color: "var(--secondary-foreground)",
+    transition: "background-color 0.15s ease",
+  },
+  '[data-aui="button"]:focus-visible, [data-aui="card-confirm"]:focus-visible, [data-aui="card-cancel"]:focus-visible':
+    {
+      outline: "2px solid var(--ring)",
+      "outline-offset": "2px",
+    },
+  '[data-aui="button"][data-aui-style="primary"], [data-aui="card-confirm"]': {
+    "background-color": "var(--primary)",
+    color: "var(--primary-foreground)",
+  },
+  '[data-aui="button"][data-aui-style="primary"]:hover, [data-aui="card-confirm"]:hover':
+    {
+      "background-color":
+        "color-mix(in oklab, var(--primary) 90%, transparent)",
+    },
+  '[data-aui="button"][data-aui-style="secondary"]': {
+    "background-color": "var(--secondary)",
+    color: "var(--secondary-foreground)",
+  },
+  '[data-aui="button"][data-aui-style="secondary"]:hover': {
+    "background-color":
+      "color-mix(in oklab, var(--secondary) 90%, transparent)",
+  },
+  '[data-aui="button"][data-aui-style="outline"]': {
+    "background-color": "transparent",
+    color: "var(--foreground)",
+    "border-color": auiHairlineBorder,
+  },
+  '[data-aui="button"][data-aui-style="outline"]:hover': {
+    "background-color": "var(--accent)",
+    color: "var(--accent-foreground)",
+  },
+  '[data-aui="button"][data-aui-style="ghost"], [data-aui="card-cancel"]': {
+    "background-color": "transparent",
+    color: "var(--foreground)",
+  },
+  '[data-aui="button"][data-aui-style="ghost"]:hover, [data-aui="card-cancel"]:hover':
+    {
+      "background-color": "var(--accent)",
+      color: "var(--accent-foreground)",
+    },
+  '[data-aui="button"][data-aui-style="danger"]': {
+    "background-color": "var(--destructive)",
+    color: "var(--primary-foreground)",
+  },
+  '[data-aui="button"][data-aui-style="danger"]:hover': {
+    "background-color":
+      "color-mix(in oklab, var(--destructive) 90%, transparent)",
+  },
+  '[data-aui="button"][data-aui-block]': { width: "100%" },
+
+  '[data-aui="select"], [data-aui="input"], [data-aui="datepicker"]': {
+    display: "block",
+    width: "100%",
+    height: "2.25rem",
+    padding: "0 0.75rem",
+    "border-radius": "calc(var(--radius) - 2px)",
+    border: "1px solid var(--input)",
+    "background-color": "transparent",
+    "font-size": "0.875rem",
+    color: "var(--foreground)",
+  },
+  '[data-aui="input"][data-aui-multiline]': {
+    height: "auto",
+    "min-height": "2.25rem",
+    padding: "0.5rem 0.75rem",
+    "line-height": "1.5",
+    resize: "vertical",
+  },
+  '[data-aui="input"]::placeholder': { color: "var(--muted-foreground)" },
+  '[data-aui="select"]:focus-visible, [data-aui="input"]:focus-visible, [data-aui="datepicker"]:focus-visible':
+    {
+      outline: "2px solid var(--ring)",
+      "outline-offset": "2px",
+    },
+
+  '[data-aui="checkbox"]': {
+    display: "inline-flex",
+    "align-items": "center",
+    gap: "0.5rem",
+    cursor: "pointer",
+  },
+  '[data-aui="radiogroup-option"]': {
+    display: "flex",
+    "align-items": "center",
+    gap: "0.5rem",
+    cursor: "pointer",
+  },
+  '[data-aui="checkbox"] input, [data-aui="radiogroup-option"] input': {
+    "accent-color": "var(--primary)",
+    width: "1rem",
+    height: "1rem",
+    margin: "0",
+    cursor: "pointer",
+  },
+  '[data-aui="checkbox"] input:focus-visible, [data-aui="radiogroup-option"] input:focus-visible':
+    {
+      outline: "2px solid var(--ring)",
+      "outline-offset": "2px",
+    },
+  '[data-aui="radiogroup"]': {
+    border: "none",
+    margin: "0",
+    padding: "0",
+    display: "flex",
+    "flex-direction": "column",
+    gap: "0.375rem",
+  },
+
+  '[data-aui="card"]': {
+    "background-color": "var(--card)",
+    color: "var(--card-foreground)",
+    border: `1px solid ${auiHairlineBorder}`,
+    "border-radius": "var(--radius)",
+    padding: "1rem",
+    "box-shadow":
+      "0 1px 2px color-mix(in oklab, var(--foreground) 8%, transparent)",
+  },
+  '[data-aui="card-title"]': {
+    margin: "0 0 0.75rem 0",
+    "font-size": "0.875rem",
+    "font-weight": "600",
+  },
+  '[data-aui="card-footer"]': {
+    display: "flex",
+    "justify-content": "flex-end",
+    gap: "0.5rem",
+    "margin-top": "0.75rem",
+    "padding-top": "0.75rem",
+    "border-top": `1px solid ${auiHairlineBorder}`,
+  },
+  '[data-aui="card"][data-aui-padding="0"]': { padding: "0" },
+  '[data-aui="card"][data-aui-padding="1"]': { padding: "calc(1 * 4px)" },
+  '[data-aui="card"][data-aui-padding="2"]': { padding: "calc(2 * 4px)" },
+  '[data-aui="card"][data-aui-padding="3"]': { padding: "calc(3 * 4px)" },
+  '[data-aui="card"][data-aui-padding="4"]': { padding: "calc(4 * 4px)" },
+  '[data-aui="card"][data-aui-padding="5"]': { padding: "calc(5 * 4px)" },
+  '[data-aui="card"][data-aui-padding="6"]': { padding: "calc(6 * 4px)" },
+  '[data-aui="card"][data-aui-padding="7"]': { padding: "calc(7 * 4px)" },
+  '[data-aui="card"][data-aui-padding="8"]': { padding: "calc(8 * 4px)" },
+
+  '[data-aui="row"]': {
+    display: "flex",
+    "flex-direction": "row",
+    gap: "0.5rem",
+  },
+  '[data-aui="col"]': {
+    display: "flex",
+    "flex-direction": "column",
+    gap: "0.5rem",
+  },
+  '[data-aui="form"]': {
+    display: "flex",
+    "flex-direction": "column",
+    gap: "0.5rem",
+    margin: "0",
+  },
+  '[data-aui="spacer"]': { flex: "1" },
+
+  '[data-aui="row"][data-aui-align="start"], [data-aui="col"][data-aui-align="start"]':
+    { "align-items": "flex-start" },
+  '[data-aui="row"][data-aui-align="center"], [data-aui="col"][data-aui-align="center"]':
+    { "align-items": "center" },
+  '[data-aui="row"][data-aui-align="end"], [data-aui="col"][data-aui-align="end"]':
+    {
+      "align-items": "flex-end",
+    },
+  '[data-aui="row"][data-aui-justify="start"]': {
+    "justify-content": "flex-start",
+  },
+  '[data-aui="row"][data-aui-justify="center"]': {
+    "justify-content": "center",
+  },
+  '[data-aui="row"][data-aui-justify="end"]': { "justify-content": "flex-end" },
+  '[data-aui="row"][data-aui-justify="between"]': {
+    "justify-content": "space-between",
+  },
+
+  '[data-aui="row"][data-aui-gap="0"], [data-aui="col"][data-aui-gap="0"], [data-aui="form"][data-aui-gap="0"]':
+    { gap: "0" },
+  '[data-aui="row"][data-aui-gap="1"], [data-aui="col"][data-aui-gap="1"], [data-aui="form"][data-aui-gap="1"]':
+    { gap: "calc(1 * 4px)" },
+  '[data-aui="row"][data-aui-gap="2"], [data-aui="col"][data-aui-gap="2"], [data-aui="form"][data-aui-gap="2"]':
+    { gap: "calc(2 * 4px)" },
+  '[data-aui="row"][data-aui-gap="3"], [data-aui="col"][data-aui-gap="3"], [data-aui="form"][data-aui-gap="3"]':
+    { gap: "calc(3 * 4px)" },
+  '[data-aui="row"][data-aui-gap="4"], [data-aui="col"][data-aui-gap="4"], [data-aui="form"][data-aui-gap="4"]':
+    { gap: "calc(4 * 4px)" },
+  '[data-aui="row"][data-aui-gap="5"], [data-aui="col"][data-aui-gap="5"], [data-aui="form"][data-aui-gap="5"]':
+    { gap: "calc(5 * 4px)" },
+  '[data-aui="row"][data-aui-gap="6"], [data-aui="col"][data-aui-gap="6"], [data-aui="form"][data-aui-gap="6"]':
+    { gap: "calc(6 * 4px)" },
+  '[data-aui="row"][data-aui-gap="7"], [data-aui="col"][data-aui-gap="7"], [data-aui="form"][data-aui-gap="7"]':
+    { gap: "calc(7 * 4px)" },
+  '[data-aui="row"][data-aui-gap="8"], [data-aui="col"][data-aui-gap="8"], [data-aui="form"][data-aui-gap="8"]':
+    { gap: "calc(8 * 4px)" },
+
+  '[data-aui="alert"]': {
+    "border-width": "1px",
+    "border-style": "solid",
+    "border-radius": "var(--radius)",
+    padding: "0.75rem 1rem",
+  },
+  '[data-aui="alert"][data-aui-tone="info"]': {
+    "border-color": "color-mix(in oklab, var(--primary) 45%, transparent)",
+    "background-color": "color-mix(in oklab, var(--primary) 8%, transparent)",
+  },
+  '[data-aui="alert"][data-aui-tone="success"]': {
+    "border-color": "color-mix(in oklab, var(--aui-success) 45%, transparent)",
+    "background-color":
+      "color-mix(in oklab, var(--aui-success) 8%, transparent)",
+  },
+  '[data-aui="alert"][data-aui-tone="warning"]': {
+    "border-color": "color-mix(in oklab, var(--aui-warning) 45%, transparent)",
+    "background-color":
+      "color-mix(in oklab, var(--aui-warning) 8%, transparent)",
+  },
+  '[data-aui="alert"][data-aui-tone="danger"]': {
+    "border-color": "color-mix(in oklab, var(--destructive) 45%, transparent)",
+    "background-color":
+      "color-mix(in oklab, var(--destructive) 8%, transparent)",
+  },
+  '[data-aui="alert-title"]': { margin: "0 0 0.25rem 0", "font-weight": "500" },
+  '[data-aui="alert-desc"]': {
+    margin: "0",
+    color: "var(--muted-foreground)",
+    "font-size": "0.8125rem",
+  },
+
+  '[data-aui="table"]': { width: "100%", "border-collapse": "collapse" },
+  '[data-aui="table-col"]': {
+    "text-align": "left",
+    "font-size": "0.75rem",
+    "font-weight": "500",
+    color: "var(--muted-foreground)",
+    padding: "0.5rem 0.75rem",
+    "border-bottom": `1px solid ${auiHairlineBorder}`,
+  },
+  '[data-aui="table"] td': {
+    "font-size": "0.875rem",
+    padding: "0.5rem 0.75rem",
+    "text-align": "left",
+  },
+  '[data-aui="table"] tbody tr:not(:last-child) td': {
+    "border-bottom": `1px solid ${auiHairlineBorder}`,
+  },
+
+  '[data-aui="chart"]': {
+    display: "block",
+    width: "100%",
+    height: "3rem",
+    color: "var(--chart-1)",
+  },
+  '[data-aui="chart"] polyline': { "stroke-width": "1.5" },
+  '[data-aui="chart"][data-aui-color="emphasis"]': {
+    color: "var(--foreground)",
+  },
+  '[data-aui="chart"][data-aui-color="secondary"]': {
+    color: "var(--muted-foreground)",
+  },
+
+  '[data-aui="carousel"]': {
+    display: "flex",
+    "overflow-x": "auto",
+    "scroll-snap-type": "x mandatory",
+    "scroll-behavior": "smooth",
+    gap: "0.75rem",
+    "padding-bottom": "0.5rem",
+    "scrollbar-width": "thin",
+  },
+  '[data-aui="carousel"]:focus-visible': {
+    outline: "2px solid var(--ring)",
+    "outline-offset": "2px",
+  },
+  '[data-aui="carousel-slide"]': {
+    "scroll-snap-align": "start",
+    flex: "0 0 auto",
+    "min-width": "14rem",
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    '[data-aui="carousel"]': { "scroll-behavior": "auto" },
+  },
+
+  '[data-aui="listview"]': {
+    "list-style": "none",
+    margin: "0",
+    padding: "0",
+  },
+  '[data-aui="listview-item"] + [data-aui="listview-item"]': {
+    "border-top": `1px solid ${auiHairlineBorder}`,
+  },
+  '[data-aui="listview-item-trigger"]': {
+    padding: "0.625rem 0.75rem",
+    "border-radius": "calc(var(--radius) - 2px)",
+    cursor: "pointer",
+  },
+  '[data-aui="listview-item-trigger"]:hover': {
+    "background-color": "color-mix(in oklab, var(--muted) 50%, transparent)",
+  },
+  '[data-aui="listview-item-trigger"]:focus-visible': {
+    outline: "2px solid var(--ring)",
+    "outline-offset": "2px",
+  },
+
+  '[data-aui="divider"]': {
+    border: "none",
+    "border-top": `1px solid ${auiHairlineBorder}`,
+    margin: "0.75rem 0",
+  },
+  '[data-aui="divider"][data-aui-flush]': { margin: "0" },
+
+  '[data-aui="image"]': {
+    "max-width": "100%",
+    display: "block",
+    "border-radius": "calc(var(--radius) - 2px)",
+  },
+  '[data-aui="image"][data-aui-size="sm"]': { "max-width": "8rem" },
+  '[data-aui="image"][data-aui-size="md"]': { "max-width": "16rem" },
+  '[data-aui="image"][data-aui-size="lg"]': { "max-width": "24rem" },
+
+  '[data-aui="markdown"]': { "font-size": "0.875rem", "line-height": "1.6" },
+  '[data-aui="markdown"] p': { margin: "0 0 0.5rem 0" },
+  '[data-aui="markdown"] p:last-child': { "margin-bottom": "0" },
+  '[data-aui="markdown"] a': {
+    color: "var(--primary)",
+    "text-decoration": "underline",
+    "text-underline-offset": "2px",
+  },
+  '[data-aui="markdown"] code': {
+    "font-size": "0.8125em",
+    "background-color": "color-mix(in oklab, var(--muted) 60%, transparent)",
+    padding: "0.125rem 0.375rem",
+    "border-radius": "calc(var(--radius) - 4px)",
+    "font-family":
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  },
+  '[data-aui="markdown"] pre': {
+    "background-color": "color-mix(in oklab, var(--muted) 60%, transparent)",
+    padding: "0.75rem",
+    "border-radius": "calc(var(--radius) - 2px)",
+    "overflow-x": "auto",
+  },
+  '[data-aui="markdown"] pre code': {
+    "background-color": "transparent",
+    padding: "0",
+  },
+  '[data-aui="markdown"] ul, [data-aui="markdown"] ol': {
+    "padding-left": "1.25rem",
+  },
+  '[data-aui="markdown"] li': { margin: "0.25rem 0" },
+  '[data-aui="markdown"] h1, [data-aui="markdown"] h2, [data-aui="markdown"] h3':
+    {
+      margin: "0.75em 0 0.25em",
+      "font-weight": "600",
+    },
+  '[data-aui="markdown"] h1': { "font-size": "1.125em" },
+  '[data-aui="markdown"] h2': { "font-size": "1.0625em" },
+  '[data-aui="markdown"] h3': { "font-size": "1em" },
+  '[data-aui="markdown"] blockquote': {
+    "border-left": `2px solid ${auiHairlineBorder}`,
+    "padding-left": "0.75rem",
+    color: "var(--muted-foreground)",
+    margin: "0.5em 0",
+  },
+
+  '[data-aui="badge"]': {
+    display: "inline-flex",
+    "align-items": "center",
+    gap: "0.25rem",
+    "border-radius": "9999px",
+    padding: "0.125rem 0.5rem",
+    "font-size": "0.75rem",
+    "font-weight": "500",
+    "line-height": "1.4",
+    "background-color": "var(--muted)",
+    color: "var(--muted-foreground)",
+  },
+  '[data-aui="badge"][data-aui-variant="info"]': {
+    "background-color": "color-mix(in oklab, var(--primary) 15%, transparent)",
+    color: "var(--primary)",
+  },
+  '[data-aui="badge"][data-aui-variant="success"]': {
+    "background-color":
+      "color-mix(in oklab, var(--aui-success) 15%, transparent)",
+    color: "var(--aui-success)",
+  },
+  '[data-aui="badge"][data-aui-variant="warning"]': {
+    "background-color":
+      "color-mix(in oklab, var(--aui-warning) 15%, transparent)",
+    color: "var(--aui-warning)",
+  },
+  '[data-aui="badge"][data-aui-variant="danger"]': {
+    "background-color":
+      "color-mix(in oklab, var(--destructive) 15%, transparent)",
+    color: "var(--destructive)",
+  },
+};
+
 export const registry: RegistryItem[] = [
   {
     name: "shimmer-style",
@@ -734,5 +1215,41 @@ export const registry: RegistryItem[] = [
     ],
     dependencies: ["@assistant-ui/react", "lucide-react"],
     registryDependencies: ["https://r.assistant-ui.com/badge.json"],
+  },
+  {
+    name: "generative-ui-style",
+    type: "registry:style",
+    cssVars: {
+      light: {
+        "--aui-success": "oklch(0.6 0.15 149)",
+        "--aui-warning": "oklch(0.68 0.16 70)",
+      },
+      dark: {
+        "--aui-success": "oklch(0.72 0.17 149)",
+        "--aui-warning": "oklch(0.8 0.17 75)",
+      },
+    },
+    css: generativeUiVocabularyCss,
+  },
+  {
+    name: "generative-ui",
+    type: "registry:component",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/generative-ui.tsx",
+        sourcePath:
+          "../../packages/ui/src/components/assistant-ui/generative-ui.tsx",
+      },
+    ],
+    dependencies: [
+      "@assistant-ui/react-generative-ui",
+      "react-markdown",
+      "remark-gfm",
+      "zod",
+    ],
+    registryDependencies: [
+      "https://r.assistant-ui.com/generative-ui-style.json",
+    ],
   },
 ];

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-ai-sdk": "workspace:*",
+    "@assistant-ui/react-generative-ui": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",
     "@assistant-ui/react-mcp": "workspace:*",
     "@assistant-ui/react-syntax-highlighter": "workspace:*",
@@ -33,6 +34,7 @@
     "radix-ui": "^1.6.2",
     "react-day-picker": "^10.0.1",
     "react-hook-form": "^7.81.0",
+    "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.12.1",
     "react-shiki": "^0.10.1",
     "react-syntax-highlighter": "^16.1.1",

--- a/packages/ui/src/components/assistant-ui/generative-ui.tsx
+++ b/packages/ui/src/components/assistant-ui/generative-ui.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { z } from "zod";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { GenerativeUILibrary } from "@assistant-ui/react-generative-ui";
@@ -10,11 +9,8 @@ import { defaultGenerativeUILibrary } from "@assistant-ui/react-generative-ui";
 export const styledGenerativeUILibrary: GenerativeUILibrary = {
   ...defaultGenerativeUILibrary,
   Markdown: {
+    ...defaultGenerativeUILibrary.Markdown,
     description: "A markdown string, rendered with GitHub-flavored markdown.",
-    properties: z.object({
-      value: z.string().describe("Markdown source."),
-    }),
-    streamProperties: true,
     render: ({ value, children }) => (
       <div data-aui="markdown">
         <ReactMarkdown remarkPlugins={[remarkGfm]}>{value ?? ""}</ReactMarkdown>

--- a/packages/ui/src/components/assistant-ui/generative-ui.tsx
+++ b/packages/ui/src/components/assistant-ui/generative-ui.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { z } from "zod";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { GenerativeUILibrary } from "@assistant-ui/react-generative-ui";
+import { defaultGenerativeUILibrary } from "@assistant-ui/react-generative-ui";
+
+/** `MarkdownTextPrimitive` cannot be reused here: it reads from message-part context, not a prop string. */
+export const styledGenerativeUILibrary: GenerativeUILibrary = {
+  ...defaultGenerativeUILibrary,
+  Markdown: {
+    description: "A markdown string, rendered with GitHub-flavored markdown.",
+    properties: z.object({
+      value: z.string().describe("Markdown source."),
+    }),
+    streamProperties: true,
+    render: ({ value, children }) => (
+      <div data-aui="markdown">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{value ?? ""}</ReactMarkdown>
+        {children}
+      </div>
+    ),
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4679,6 +4679,9 @@ importers:
       '@assistant-ui/react-ai-sdk':
         specifier: workspace:*
         version: link:../react-ai-sdk
+      '@assistant-ui/react-generative-ui':
+        specifier: workspace:*
+        version: link:../react-generative-ui
       '@assistant-ui/react-markdown':
         specifier: workspace:*
         version: link:../react-markdown
@@ -4742,6 +4745,9 @@ importers:
       react-hook-form:
         specifier: ^7.81.0
         version: 7.81.0(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-resizable-panels:
         specifier: ^4.12.1
         version: 4.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## summary

- adds a styled distribution for the react-generative-ui vocabulary as two shadcn registry items: `generative-ui-style` (registry:style) carries 126 css rules over the `data-aui` selectors, driven entirely by the host's shadcn CSS variables (`--card`, `--border`, `--primary`, `--chart-*`, ...), plus `--aui-success`/`--aui-warning` via cssVars for the two alert tones the stock palette lacks
- adds the canonical `styledGenerativeUILibrary` source in packages/ui: spreads `defaultGenerativeUILibrary` and overrides only Markdown, rendering through `react-markdown` + `remark-gfm` (`MarkdownTextPrimitive` reads message-part context and cannot render a prop string, so it is not reusable here); Chart and Carousel need no component override, css covers them
- the unstyled npm package is untouched; users opt in via `shadcn add`, the style item's css merges into their globals.css on install, so restyling means editing a file they own
- packages/ui gains `@assistant-ui/react-generative-ui` (workspace) and `react-markdown` dependencies; the lockfile lines are exactly those two edges

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/shadcn-registry build` -> all registry validators pass, radix and base trees both emit the two items
- [x] `pnpm --filter @assistant-ui/shadcn-registry test` -> 24/24 green
- [x] `pnpm lint` and `bash scripts/sync-templates.sh` -> clean
- [x] `pnpm --filter @assistant-ui/ui exec tsc --noEmit` -> zero errors referencing the new file (pre-existing missing-dist errors in untouched files aside)
- [x] visual review of a rendered preview covering every component (form controls, alert tones, chart variants, table, listview, carousel, markdown) in light and dark

### reviewer should verify

- [ ] in a shadcn app, `shadcn add https://r.assistant-ui.com/generative-ui.json` lands the component file plus the style item's css/cssVars in globals.css with no unresolvable import

## notes

- a css-only registry item has no files, so the base/radix parity validators skip it by construction and both trees emit identical json for `generative-ui-style`
- every interactive selector carries a `:focus-visible` rule; `prefers-reduced-motion` downgrades the carousel's smooth scrolling
- both touched packages are private, so no changeset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

