### PR TITLE
fix(react-ai-sdk): stale useVercelAIThreadState name in sliceMessagesUntil error

### DIFF
--- a/.changeset/slice-messages-until-error-message.md
+++ b/.changeset/slice-messages-until-error-message.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: replace stale useVercelAIThreadState name in the sliceMessagesUntil error and include the missing id

--- a/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.test.ts
@@ -14,7 +14,7 @@ describe("sliceMessagesUntil", () => {
 
   it("throws when the message id is not found", () => {
     expect(() => sliceMessagesUntil([msg("u1", "user")], "missing")).toThrow(
-      "Message not found",
+      'sliceMessagesUntil: Message "missing" not found in AI SDK messages. This is likely an internal bug in assistant-ui.',
     );
   });
 

--- a/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.ts
+++ b/packages/react-ai-sdk/src/ui/utils/sliceMessagesUntil.ts
@@ -9,7 +9,7 @@ export const sliceMessagesUntil = <UI_MESSAGE extends UIMessage = UIMessage>(
   let messageIdx = messages.findIndex((m) => m.id === messageId);
   if (messageIdx === -1)
     throw new Error(
-      "useVercelAIThreadState: Message not found. This is likely an internal bug in assistant-ui.",
+      `sliceMessagesUntil: Message "${messageId}" not found in AI SDK messages. This is likely an internal bug in assistant-ui.`,
     );
 
   while (messages[messageIdx + 1]?.role === "assistant") {


### PR DESCRIPTION


## What

`sliceMessagesUntil` (react-ai-sdk internal util, reached from `useAISDKRuntime`'s `onEdit`/`onReload` paths) throws `"useVercelAIThreadState: Message not found. This is likely an internal bug in assistant-ui."` when a `parentId` is not in the AI SDK message list. This PR rewords it to name the throwing unit and include the id that was not found:

```
sliceMessagesUntil: Message "<id>" not found in AI SDK messages. This is likely an internal bug in assistant-ui.
```

## Why

`useVercelAIThreadState` has not existed for many major versions, so when this invariant trips in production the error sends users hunting for a hook that is not in their code, and without the id the report is not actionable. Error-message quality on an internal invariant: the message should identify where it fired and what was missing.

## Impact

- Message text only; the throw-on-missing-id behavior is unchanged (the degrade-vs-throw question is tracked separately, issue-first).
- No public surface: the util is not exported from the package barrel or exports map; only `useAISDKRuntime` calls it.
- Colocated test assertion tightened to the new message including the interpolated id.
- Patch changeset for `@assistant-ui/react-ai-sdk`.
- No other consumer matches the old string: repo-wide, `"Message not found"` matchers outside this util all target core's `MessageRepository` errors, and `useVercelAIThreadState` appears nowhere else in src/apps/examples.

## Rationale for the wording

Repo precedent names the throwing unit in internal-invariant errors, never the caller: `MessageRepository(updateMessage): Message not found. This is likely an internal bug in assistant-ui.` (12 instances in core's message-repository), `useClientLookup: Key "..." not found` in store. Naming the caller is exactly what made the old string rot when the calling hook was renamed, so the fix prefixes `sliceMessagesUntil:` and lets the stack trace supply the caller. The quoted-id, subject-first format matches existing strings like `Thread "${threadId}" not found`, and the stock tail sentence is kept verbatim.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

