### PR TITLE
refactor(assistant-stream): dedupe internal SSE event parsing

### DIFF
--- a/.changeset/assistant-stream-shared-sse-pipelines.md
+++ b/.changeset/assistant-stream-shared-sse-pipelines.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+refactor: back the internal SSE pipelines with the shared SSEEventDecoder

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -1,6 +1,9 @@
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import { LineDecoderStream } from "../../utils/stream/LineDecoderStream";
+import {
+  SSEEventDecoderStream,
+  type PipelineSSEEvent,
+} from "../../utils/stream/SSEEventDecoderStream";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
 /**
@@ -35,62 +38,6 @@ export class AssistantTransportEncoder
   }
 }
 
-type SSEEvent = {
-  event: string;
-  data: string;
-  id?: string | undefined;
-  retry?: number | undefined;
-};
-
-class SSEEventStream extends TransformStream<string, SSEEvent> {
-  constructor() {
-    let eventBuffer: Partial<SSEEvent> = {};
-    let dataLines: string[] = [];
-
-    super({
-      start() {
-        eventBuffer = {};
-        dataLines = [];
-      },
-      transform(line, controller) {
-        if (line.startsWith(":")) return; // Ignore comments
-
-        if (line === "") {
-          if (dataLines.length > 0) {
-            controller.enqueue({
-              event: eventBuffer.event || "message",
-              data: dataLines.join("\n"),
-              id: eventBuffer.id,
-              retry: eventBuffer.retry,
-            });
-          }
-          eventBuffer = {};
-          dataLines = [];
-          return;
-        }
-
-        const [field, ...rest] = line.split(":");
-        const value = rest.join(":").trimStart();
-
-        switch (field) {
-          case "event":
-            eventBuffer.event = value;
-            break;
-          case "data":
-            dataLines.push(value);
-            break;
-          case "id":
-            eventBuffer.id = value;
-            break;
-          case "retry":
-            eventBuffer.retry = Number(value);
-            break;
-        }
-      },
-    });
-  }
-}
-
 /**
  * AssistantTransportDecoder decodes SSE format into AssistantStreamChunks.
  * It stops decoding when it encounters [DONE].
@@ -105,10 +52,9 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
 
       return readable
         .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new LineDecoderStream())
-        .pipeThrough(new SSEEventStream())
+        .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
-          new TransformStream<SSEEvent, AssistantStreamChunk>({
+          new TransformStream<PipelineSSEEvent, AssistantStreamChunk>({
             transform(event, controller) {
               switch (event.event) {
                 case "message":

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -3,7 +3,10 @@ import type { ToolCallStreamController } from "../../modules/tool-call";
 import type { TextStreamController } from "../../modules/text";
 import { AssistantTransformStream } from "../../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
-import { LineDecoderStream } from "../../utils/stream/LineDecoderStream";
+import {
+  SSEEventDecoderStream,
+  type PipelineSSEEvent,
+} from "../../utils/stream/SSEEventDecoderStream";
 import type {
   UIMessageStreamChunk,
   UIMessageStreamDataChunk,
@@ -20,62 +23,6 @@ export type UIMessageStreamDecoderOptions = {
     transient?: boolean;
   }) => void;
 };
-
-type SSEEvent = {
-  event: string;
-  data: string;
-  id?: string | undefined;
-  retry?: number | undefined;
-};
-
-class SSEEventStream extends TransformStream<string, SSEEvent> {
-  constructor() {
-    let eventBuffer: Partial<SSEEvent> = {};
-    let dataLines: string[] = [];
-
-    super({
-      start() {
-        eventBuffer = {};
-        dataLines = [];
-      },
-      transform(line, controller) {
-        if (line.startsWith(":")) return;
-
-        if (line === "") {
-          if (dataLines.length > 0) {
-            controller.enqueue({
-              event: eventBuffer.event || "message",
-              data: dataLines.join("\n"),
-              id: eventBuffer.id,
-              retry: eventBuffer.retry,
-            });
-          }
-          eventBuffer = {};
-          dataLines = [];
-          return;
-        }
-
-        const [field, ...rest] = line.split(":");
-        const value = rest.join(":").trimStart();
-
-        switch (field) {
-          case "event":
-            eventBuffer.event = value;
-            break;
-          case "data":
-            dataLines.push(value);
-            break;
-          case "id":
-            eventBuffer.id = value;
-            break;
-          case "retry":
-            eventBuffer.retry = Number(value);
-            break;
-        }
-      },
-    });
-  }
-}
 
 const isDataChunk = (
   chunk: UIMessageStreamChunk,
@@ -261,10 +208,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
       return readable
         .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new LineDecoderStream())
-        .pipeThrough(new SSEEventStream())
+        .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
-          new TransformStream<SSEEvent, UIMessageStreamChunk>({
+          new TransformStream<PipelineSSEEvent, UIMessageStreamChunk>({
             transform(event, controller) {
               if (event.event !== "message") {
                 throw new Error(`Unknown SSE event type: ${event.event}`);

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -1,5 +1,8 @@
 import { PipeableTransformStream } from "./PipeableTransformStream";
-import { LineDecoderStream } from "./LineDecoderStream";
+import {
+  SSEEventDecoderStream,
+  type PipelineSSEEvent,
+} from "./SSEEventDecoderStream";
 
 export class SSEEncoder<T> extends PipeableTransformStream<
   T,
@@ -28,62 +31,6 @@ export class SSEEncoder<T> extends PipeableTransformStream<
   }
 }
 
-type SSEEvent = {
-  event: string;
-  data: string;
-  id?: string | undefined;
-  retry?: number | undefined;
-};
-
-class SSEEventStream extends TransformStream<string, SSEEvent> {
-  constructor() {
-    let eventBuffer: Partial<SSEEvent> = {};
-    let dataLines: string[] = [];
-
-    super({
-      start() {
-        eventBuffer = {};
-        dataLines = [];
-      },
-      transform(line, controller) {
-        if (line.startsWith(":")) return; // Ignore comments
-
-        if (line === "") {
-          if (dataLines.length > 0) {
-            controller.enqueue({
-              event: eventBuffer.event || "message",
-              data: dataLines.join("\n"),
-              id: eventBuffer.id,
-              retry: eventBuffer.retry,
-            });
-          }
-          eventBuffer = {};
-          dataLines = [];
-          return;
-        }
-
-        const [field, ...rest] = line.split(":");
-        const value = rest.join(":").trimStart();
-
-        switch (field) {
-          case "event":
-            eventBuffer.event = value;
-            break;
-          case "data":
-            dataLines.push(value);
-            break;
-          case "id":
-            eventBuffer.id = value;
-            break;
-          case "retry":
-            eventBuffer.retry = Number(value);
-            break;
-        }
-      },
-    });
-  }
-}
-
 export class SSEDecoder<T> extends PipeableTransformStream<
   Uint8Array<ArrayBuffer>,
   T
@@ -92,10 +39,9 @@ export class SSEDecoder<T> extends PipeableTransformStream<
     super((readable) =>
       readable
         .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new LineDecoderStream())
-        .pipeThrough(new SSEEventStream())
+        .pipeThrough(new SSEEventDecoderStream())
         .pipeThrough(
-          new TransformStream<SSEEvent, T>({
+          new TransformStream<PipelineSSEEvent, T>({
             transform(event, controller) {
               switch (event.event) {
                 case "message":

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  SSEEventDecoderStream,
+  type PipelineSSEEvent,
+} from "./SSEEventDecoderStream";
+
+const collectEvents = async (chunks: string[]): Promise<PipelineSSEEvent[]> => {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  }).pipeThrough(new SSEEventDecoderStream());
+
+  const events: PipelineSSEEvent[] = [];
+  for await (const event of stream as unknown as AsyncIterable<PipelineSSEEvent>) {
+    events.push(event);
+  }
+  return events;
+};
+
+describe("SSEEventDecoderStream", () => {
+  it("defaults unnamed events to message", async () => {
+    const events = await collectEvents(["data: hello\n\n"]);
+    expect(events).toEqual([{ event: "message", data: "hello" }]);
+  });
+
+  it("normalizes an explicit empty event field to message", async () => {
+    const events = await collectEvents(["event:\ndata: hello\n\n"]);
+    expect(events).toEqual([{ event: "message", data: "hello" }]);
+  });
+
+  it("passes named events through", async () => {
+    const events = await collectEvents(["event: custom\ndata: hello\n\n"]);
+    expect(events).toEqual([{ event: "custom", data: "hello" }]);
+  });
+
+  it("drops an unterminated trailing frame", async () => {
+    const events = await collectEvents(["data: partial\n"]);
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.ts
@@ -1,0 +1,34 @@
+import { SSEEventDecoder } from "./SSEEventDecoder";
+import type { SSEEvent } from "./SSEEventDecoder";
+
+export type PipelineSSEEvent = {
+  event: string;
+  data: string;
+  id?: string;
+  retry?: number;
+};
+
+export class SSEEventDecoderStream extends TransformStream<
+  string,
+  PipelineSSEEvent
+> {
+  constructor() {
+    const decoder = new SSEEventDecoder({ trailing: "drop" });
+    const normalize = (event: SSEEvent): PipelineSSEEvent => ({
+      ...event,
+      event: event.event ?? "message",
+    });
+
+    super({
+      transform(chunk, controller) {
+        for (const event of decoder.push(chunk)) {
+          controller.enqueue(normalize(event));
+        }
+      },
+      flush(controller) {
+        const event = decoder.flush();
+        if (event) controller.enqueue(normalize(event));
+      },
+    });
+  }
+}

--- a/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSEEventDecoderStream.ts
@@ -16,7 +16,7 @@ export class SSEEventDecoderStream extends TransformStream<
     const decoder = new SSEEventDecoder({ trailing: "drop" });
     const normalize = (event: SSEEvent): PipelineSSEEvent => ({
       ...event,
-      event: event.event ?? "message",
+      event: event.event || "message",
     });
 
     super({


### PR DESCRIPTION
closes #4946

## summary

- deletes the three byte-identical `SSEEventStream` copies (`SSE.ts`, `UIMessageStream.ts`, `AssistantTransport.ts`) in favor of the shared `SSEEventDecoder` from #4880, wrapped once in an internal `SSEEventDecoderStream` (`trailing: "drop"`, unnamed events normalized to `"message"` since all three downstream stages require it); net -123 lines
- each pipeline goes from two stages (`LineDecoderStream` + local `SSEEventStream`) to one, since the shared decoder does its own LF, CRLF, and CR line splitting with cross-chunk CRLF handling
- `DataStream` keeps `LineDecoderStream` for its line protocol; `LineDecoderStream` and its tests are untouched, and the wrapper is not exported from any public barrel
- #4875 had to apply the same flush deletion three times in parallel, which is the drift cost this removes; after it the EOF semantics of the copies match `trailing: "drop"` exactly, making this migration mechanical

## test plan

### already verified

- [x] full assistant-stream suite with ZERO test-file modifications as the oracle: `pnpm --filter assistant-stream test` -> 277 passed, 20 skipped (pins [DONE] handling, the `"message"` default, #4875's EOF drops, and #4876's line-ending coverage through the new pipeline)
- [x] `pnpm --filter assistant-stream build` -> green
- [x] oxlint and oxfmt clean on all touched files

### reviewer should verify

- [ ] stream an assistant-transport or UI message response end to end and confirm normal delivery plus a loud missing-[DONE] error on truncation

## notes

- the deleted local parsers had two spec deviations the shared decoder corrects, both invisible to the suites and to our own encoders: `value.trimStart()` stripped every leading space from field values where the spec strips at most one, and `retry: Number(value)` accepted arbitrary values including NaN where the shared decoder requires base-ten digits within safe-integer range
- one degenerate-input delta: a stream truncating mid-line previously threw LineDecoderStream's incomplete-line error from these pipelines; it now falls under the decoder's trailing drop, and assistant-transport plus UI message streams still fail loudly via their missing-[DONE] checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

