### PR TITLE
feat(react-lexical): support custom Lexical plugins via children

### DIFF
--- a/.changeset/lexical-composer-children.md
+++ b/.changeset/lexical-composer-children.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+feat: render children as custom Lexical plugins in LexicalComposerInput

--- a/api-surface/assistant-ui__react-lexical.ts
+++ b/api-surface/assistant-ui__react-lexical.ts
@@ -49,7 +49,7 @@ type DirectivePluginProps = {
   onDirectiveSelect?: ((item: Unstable_TriggerItem) => void) | undefined;
 };
 
-declare const LexicalComposerInput: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref">, "autoFocus"> & {
+declare const LexicalComposerInput: import("react").ForwardRefExoticComponent<Omit<Omit<import("react").DetailedHTMLProps<import("react").HTMLAttributes<HTMLDivElement>, HTMLDivElement>, "ref">, "autoFocus" | "children"> & {
   submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
   cancelOnEscape?: boolean | undefined;
   placeholder?: string | undefined;
@@ -57,9 +57,10 @@ declare const LexicalComposerInput: import("react").ForwardRefExoticComponent<Om
   directivePluginProps?: DirectivePluginProps | undefined;
   directiveChip?: FC<DirectiveChipProps> | undefined;
   formatter?: Unstable_DirectiveFormatter | undefined;
+  children?: ReactNode | undefined;
 } & import("react").RefAttributes<HTMLDivElement>>;
 
-type LexicalComposerInputProps = Omit<ComponentPropsWithoutRef<"div">, "autoFocus"> & {
+type LexicalComposerInputProps = Omit<ComponentPropsWithoutRef<"div">, "autoFocus" | "children"> & {
   submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
   cancelOnEscape?: boolean | undefined;
   placeholder?: string | undefined;
@@ -67,6 +68,7 @@ type LexicalComposerInputProps = Omit<ComponentPropsWithoutRef<"div">, "autoFocu
   directivePluginProps?: DirectivePluginProps | undefined;
   directiveChip?: FC<DirectiveChipProps> | undefined;
   formatter?: Unstable_DirectiveFormatter | undefined;
+  children?: ReactNode | undefined;
 };
 
 type ReadonlyJSONArray = readonly ReadonlyJSONValue[];

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -414,7 +414,7 @@ import { LexicalComposerInput } from "@assistant-ui/react-lexical";
 
 ### Custom Lexical Plugins
 
-Children of `LexicalComposerInput` render inside the `LexicalComposer` context after the built-in plugins, so standard Lexical plugin components built on `useLexicalComposerContext` work for editor concerns the mention system does not cover, such as paste normalization or length limits. The example below registers an update listener that flags messages over a maximum length.
+Children of `LexicalComposerInput` render inside the `LexicalComposer` context after the built-in plugins, so standard Lexical plugin components built on `useLexicalComposerContext` work for editor concerns the mention system does not cover, such as paste normalization or length limits. Custom plugins import Lexical APIs directly, so install `lexical` and `@lexical/react` as direct dependencies of your app. The example below registers an update listener that flags messages over a maximum length.
 
 ```tsx
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";

--- a/apps/docs/content/docs/guides/mentions.mdx
+++ b/apps/docs/content/docs/guides/mentions.mdx
@@ -412,6 +412,36 @@ import { LexicalComposerInput } from "@assistant-ui/react-lexical";
 
 `LexicalComposerInput` automatically discovers every `Directive` trigger registered under `TriggerPopoverRoot` and renders their selections as inline chips.
 
+### Custom Lexical Plugins
+
+Children of `LexicalComposerInput` render inside the `LexicalComposer` context after the built-in plugins, so standard Lexical plugin components built on `useLexicalComposerContext` work for editor concerns the mention system does not cover, such as paste normalization or length limits. The example below registers an update listener that flags messages over a maximum length.
+
+```tsx
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEffect } from "react";
+import { $getRoot } from "lexical";
+
+function MaxLengthPlugin({ maxLength }: { maxLength: number }) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        if ($getRoot().getTextContent().length > maxLength) {
+          console.warn(`Message exceeds ${maxLength} characters`);
+        }
+      });
+    });
+  }, [editor, maxLength]);
+
+  return null;
+}
+
+<LexicalComposerInput placeholder="Ask anything...">
+  <MaxLengthPlugin maxLength={2000} />
+</LexicalComposerInput>
+```
+
 ## Rendering Mentions in Messages
 
 Use `DirectiveText` as the `Text` component for user messages so directives render as inline chips instead of raw syntax. See the [Directive Text](/docs/ui/directive-text) guide for setup and customization.

--- a/packages/react-lexical/README.md
+++ b/packages/react-lexical/README.md
@@ -26,6 +26,8 @@ export function Composer() {
 
 For custom chip rendering, pass a `directiveChip` render prop. Directives (e.g. `@user`, `/command`) survive cursor navigation, selection, and copy/paste as a single unit.
 
+Pass custom Lexical plugin components as `children` to hook into the editor via `useLexicalComposerContext`, for concerns like paste normalization or length limits.
+
 ## See also
 
 - `@assistant-ui/react-hook-form` for binding the composer to a form whose fields the assistant can read and fill.

--- a/packages/react-lexical/package.json
+++ b/packages/react-lexical/package.json
@@ -57,6 +57,7 @@
     "@assistant-ui/store": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "vitest": "^4.1.10"

--- a/packages/react-lexical/src/LexicalComposerInput.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $createParagraphNode, $getRoot, type LexicalEditor } from "lexical";
+import { LexicalComposerInput } from "./LexicalComposerInput";
+
+const setText = vi.fn<(text: string) => void>();
+const sendSpy = vi.fn<(options?: { steer?: boolean }) => void>();
+const cancelSpy = vi.fn<() => void>();
+
+const composerState = {
+  isEditing: true,
+  text: "",
+  type: "thread" as const,
+  isEmpty: true,
+  canCancel: false,
+  canSend: true,
+  dictation: undefined as undefined | { inputDisabled: boolean },
+};
+
+const threadState = {
+  isDisabled: false,
+  isRunning: false,
+};
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  const aui = {
+    composer: () => ({
+      setText,
+      getState: () => composerState,
+      cancel: cancelSpy,
+      send: sendSpy,
+    }),
+    thread: () => ({
+      getState: () => threadState,
+    }),
+    on: () => () => {},
+  };
+  type Selector<T> = (s: {
+    composer: typeof composerState;
+    thread: typeof threadState;
+  }) => T;
+  return {
+    ...actual,
+    useAui: () => aui,
+    useAuiState: <T,>(selector: Selector<T>) =>
+      selector({ composer: composerState, thread: threadState }),
+  };
+});
+
+describe("LexicalComposerInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    setText.mockReset();
+    sendSpy.mockReset();
+    cancelSpy.mockReset();
+    composerState.isEditing = true;
+    composerState.text = "";
+    composerState.isEmpty = true;
+    composerState.canSend = true;
+    composerState.dictation = undefined;
+    threadState.isDisabled = false;
+    threadState.isRunning = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders children inside the LexicalComposer context with a live editor", async () => {
+    let capturedEditor: LexicalEditor | null = null;
+    let updateListenerFired = false;
+
+    function ProbePlugin() {
+      const [editor] = useLexicalComposerContext();
+
+      useEffect(() => {
+        capturedEditor = editor;
+        return editor.registerUpdateListener(() => {
+          updateListenerFired = true;
+        });
+      }, [editor]);
+
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput>
+          <ProbePlugin />
+        </LexicalComposerInput>,
+      );
+    });
+
+    expect(capturedEditor).not.toBeNull();
+
+    await act(async () => {
+      capturedEditor!.update(() => {
+        $getRoot().append($createParagraphNode());
+      });
+    });
+    expect(updateListenerFired).toBe(true);
+  });
+
+  it("still renders the built-in contentEditable alongside children", async () => {
+    function ProbePlugin() {
+      useLexicalComposerContext();
+      return null;
+    }
+
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput>
+          <ProbePlugin />
+        </LexicalComposerInput>,
+      );
+    });
+
+    expect(container.querySelector(".aui-lexical-input")).not.toBeNull();
+  });
+});

--- a/packages/react-lexical/src/LexicalComposerInput.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.tsx
@@ -3,6 +3,7 @@
 import {
   type ComponentPropsWithoutRef,
   type FC,
+  type ReactNode,
   forwardRef,
   useEffect,
   useMemo,
@@ -42,7 +43,7 @@ import type { DirectivePluginProps } from "./plugins/DirectivePlugin";
 
 export type LexicalComposerInputProps = Omit<
   ComponentPropsWithoutRef<"div">,
-  "autoFocus"
+  "autoFocus" | "children"
 > & {
   /** Controls how Enter submits. @default "enter" */
   submitMode?: "enter" | "ctrlEnter" | "none" | undefined;
@@ -58,6 +59,8 @@ export type LexicalComposerInputProps = Omit<
   directiveChip?: FC<DirectiveChipProps> | undefined;
   /** Custom formatter for serializing/parsing directives. */
   formatter?: Unstable_DirectiveFormatter | undefined;
+  /** Custom Lexical plugins rendered inside the composer context, after the built-in plugins. */
+  children?: ReactNode | undefined;
 };
 
 function KeyboardPlugin({
@@ -269,6 +272,7 @@ export const LexicalComposerInput = forwardRef<
       directiveChip,
       formatter: formatterProp,
       className,
+      children,
       ...rest
     },
     ref,
@@ -324,6 +328,7 @@ export const LexicalComposerInput = forwardRef<
             <CursorPlugin />
             <FocusPlugin autoFocus={autoFocus} />
             <EditablePlugin isDisabled={!!isDisabled} />
+            {children}
           </div>
         </DirectiveChipProvider>
       </LexicalComposer>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4269,6 +4269,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.7
         version: 19.2.7


### PR DESCRIPTION
## summary

- `LexicalComposerInput` now renders its `children` inside the `LexicalComposer` context, after the built-in plugins, so consumers can mount custom Lexical plugin components (paste normalization, length limits, selection capture) without patching the package
- previously the props type already accepted `children` (inherited from `ComponentPropsWithoutRef<"div">`) but the value rode the rest spread onto the wrapper div and was silently overridden by its explicit JSX children, so it never rendered; this makes the existing prop functional and keeps the surface append-only
- documents the slot in the mentions guide and the package README, and adds a colocated jsdom test covering the slot (live editor via `useLexicalComposerContext`) alongside the built-in contentEditable

## test plan

### already verified

- [x] `pnpm exec turbo test --filter=@assistant-ui/react-lexical` -> 3 files, 27 tests green (2 new for the children slot)
- [x] `pnpm exec turbo build --filter=@assistant-ui/react-lexical` -> 10/10 tasks successful
- [x] `pnpm -C packages/react-lexical exec tsc --noEmit` -> clean
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean on all touched files

### reviewer should verify

- [ ] render `<LexicalComposerInput>` with a child plugin calling `useLexicalComposerContext()` (the MaxLengthPlugin example from the mentions guide works as-is) and confirm the plugin receives the editor while mention chips and Enter-to-send keep working

## notes

- motivation: a production consumer currently maintains a pnpm patch adding exactly this slot to attach their @-mention plugins; children of `LexicalComposer` is the idiomatic Lexical extension model, so this removes the need to patch without inventing new API

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

