### PR TITLE
fix(react-lexical): forward Delete removes directive chips as one unit

### DIFF
--- a/.changeset/directive-forward-delete.md
+++ b/.changeset/directive-forward-delete.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: delete directive chips as one unit with forward Delete and on mobile backspace

--- a/packages/react-lexical/src/plugins/DirectivePlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/DirectivePlugin.test.tsx
@@ -280,12 +280,17 @@ describe("DirectivePlugin", () => {
       });
     });
 
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      cancelable: true,
+    });
     await act(async () => {
-      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+      editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
     });
 
     editor.getEditorState().read(() => {
       expect($getNodeByKey(keys.directive)).toBeNull();
+      expect($getRoot().getTextContent()).toBe("beforeafter");
     });
   });
 

--- a/packages/react-lexical/src/plugins/DirectivePlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/DirectivePlugin.test.tsx
@@ -1,0 +1,375 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $createNodeSelection,
+  $createParagraphNode,
+  $createTextNode,
+  $getNodeByKey,
+  $getRoot,
+  $setSelection,
+  DELETE_CHARACTER_COMMAND,
+  KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
+  type LexicalEditor,
+  type NodeKey,
+} from "lexical";
+import { LexicalComposerInput } from "../LexicalComposerInput";
+import {
+  $createDirectiveNode,
+  type DirectiveNode,
+} from "../nodes/DirectiveNode";
+
+const setText = vi.fn<(text: string) => void>();
+const sendSpy = vi.fn<(options?: { steer?: boolean }) => void>();
+const cancelSpy = vi.fn<() => void>();
+
+const composerState = {
+  isEditing: true,
+  text: "",
+  type: "thread" as const,
+  isEmpty: true,
+  canCancel: false,
+  canSend: true,
+  dictation: undefined as undefined | { inputDisabled: boolean },
+};
+
+const threadState = {
+  isDisabled: false,
+  isRunning: false,
+};
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  const aui = {
+    composer: () => ({
+      setText,
+      getState: () => composerState,
+      cancel: cancelSpy,
+      send: sendSpy,
+    }),
+    thread: () => ({
+      getState: () => threadState,
+    }),
+    on: () => () => {},
+  };
+  type Selector<T> = (s: {
+    composer: typeof composerState;
+    thread: typeof threadState;
+  }) => T;
+  return {
+    ...actual,
+    useAui: () => aui,
+    useAuiState: <T,>(selector: Selector<T>) =>
+      selector({ composer: composerState, thread: threadState }),
+  };
+});
+
+type FixtureNodes = {
+  paragraph: ReturnType<typeof $createParagraphNode>;
+  before: ReturnType<typeof $createTextNode>;
+  directive: DirectiveNode;
+  after: ReturnType<typeof $createTextNode>;
+};
+
+type FixtureKeys = {
+  before: NodeKey;
+  directive: NodeKey;
+};
+
+function $createFixture(
+  select: (nodes: FixtureNodes) => void,
+  beforeText = "before",
+): FixtureKeys {
+  const paragraph = $createParagraphNode();
+  const before = $createTextNode(beforeText);
+  const directive = $createDirectiveNode({
+    id: "weather",
+    type: "tool",
+    label: "Weather",
+  });
+  const after = $createTextNode("after");
+
+  paragraph.append(before, directive, after);
+  $getRoot().clear();
+  $getRoot().append(paragraph);
+  select({ paragraph, before, directive, after });
+
+  return {
+    before: before.getKey(),
+    directive: directive.getKey(),
+  };
+}
+
+function ProbePlugin({
+  capture,
+}: {
+  capture: (editor: LexicalEditor) => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    capture(editor);
+  }, [capture, editor]);
+
+  return null;
+}
+
+function modifySelection(
+  this: Selection,
+  alter: string,
+  direction: string,
+): void {
+  if (this.rangeCount === 0 || alter !== "extend") return;
+
+  const range = this.getRangeAt(0).cloneRange();
+  if (direction === "backward") {
+    range.setStart(range.startContainer, range.startOffset - 1);
+  } else {
+    range.setEnd(range.endContainer, range.endOffset + 1);
+  }
+  this.removeAllRanges();
+  this.addRange(range);
+}
+
+describe("DirectivePlugin", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let editor: LexicalEditor;
+  let selectionModifyDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(async () => {
+    setText.mockReset();
+    sendSpy.mockReset();
+    cancelSpy.mockReset();
+    composerState.isEditing = true;
+    composerState.text = "";
+    composerState.isEmpty = true;
+    composerState.canSend = true;
+    composerState.dictation = undefined;
+    threadState.isDisabled = false;
+    threadState.isRunning = false;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    selectionModifyDescriptor = Object.getOwnPropertyDescriptor(
+      window.Selection.prototype,
+      "modify",
+    );
+    Object.defineProperty(window.Selection.prototype, "modify", {
+      configurable: true,
+      value: modifySelection,
+    });
+
+    await act(async () => {
+      root.render(
+        <LexicalComposerInput>
+          <ProbePlugin
+            capture={(capturedEditor) => {
+              editor = capturedEditor;
+            }}
+          />
+        </LexicalComposerInput>,
+      );
+    });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    if (selectionModifyDescriptor) {
+      Object.defineProperty(
+        window.Selection.prototype,
+        "modify",
+        selectionModifyDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(window.Selection.prototype, "modify");
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("deletes a directive forward from a text-node edge", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ before }) => {
+          before.select(
+            before.getTextContentSize(),
+            before.getTextContentSize(),
+          );
+        });
+      });
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Delete",
+      cancelable: true,
+    });
+    await act(async () => {
+      editor.dispatchCommand(KEY_DELETE_COMMAND, event);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+      expect($getRoot().getTextContent()).toBe("beforeafter");
+    });
+  });
+
+  it("deletes a directive forward from an element anchor", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ paragraph }) => {
+          paragraph.select(1, 1);
+        });
+      });
+    });
+
+    await act(async () => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, false);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("deletes a node-selected directive with forward Delete", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ directive }) => {
+          const selection = $createNodeSelection();
+          selection.add(directive.getKey());
+          $setSelection(selection);
+        });
+      });
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Delete",
+      cancelable: true,
+    });
+    await act(async () => {
+      editor.dispatchCommand(KEY_DELETE_COMMAND, event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("deletes a directive backward from a text-node edge", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ after }) => {
+          after.select(0, 0);
+        });
+      });
+    });
+
+    await act(async () => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("deletes a directive backward from an element anchor", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ paragraph }) => {
+          paragraph.select(2, 2);
+        });
+      });
+    });
+
+    await act(async () => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("deletes a node-selected directive with Backspace", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ directive }) => {
+          const selection = $createNodeSelection();
+          selection.add(directive.getKey());
+          $setSelection(selection);
+        });
+      });
+    });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      cancelable: true,
+    });
+    await act(async () => {
+      editor.dispatchCommand(KEY_BACKSPACE_COMMAND, event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("deletes a directive through the mobile backspace command path", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ after }) => {
+          after.select(0, 0);
+        });
+      });
+    });
+
+    await act(async () => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, true);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)).toBeNull();
+    });
+  });
+
+  it("falls through to plain-text forward deletion away from a directive", async () => {
+    let keys!: FixtureKeys;
+    await act(async () => {
+      editor.update(() => {
+        keys = $createFixture(({ before }) => {
+          before.select(1, 1);
+        }, "abcd");
+      });
+    });
+
+    await act(async () => {
+      editor.dispatchCommand(DELETE_CHARACTER_COMMAND, false);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($getNodeByKey(keys.directive)?.isAttached()).toBe(true);
+      expect($getNodeByKey(keys.before)?.getTextContent()).toBe("acd");
+    });
+  });
+});

--- a/packages/react-lexical/src/plugins/DirectivePlugin.tsx
+++ b/packages/react-lexical/src/plugins/DirectivePlugin.tsx
@@ -9,7 +9,9 @@ import {
   $isRangeSelection,
   $isTextNode,
   COMMAND_PRIORITY_LOW,
+  DELETE_CHARACTER_COMMAND,
   KEY_BACKSPACE_COMMAND,
+  KEY_DELETE_COMMAND,
   type TextNode,
 } from "lexical";
 import { mergeRegister } from "@lexical/utils";
@@ -38,6 +40,64 @@ type TriggerMatch = {
 };
 
 const WHITESPACE_RE = /\s/u;
+
+function $removeSelectedDirectiveNodes(): boolean {
+  const selection = $getSelection();
+  if (!$isNodeSelection(selection)) return false;
+
+  let handled = false;
+  for (const node of selection.getNodes()) {
+    if ($isDirectiveNode(node)) {
+      node.remove();
+      handled = true;
+    }
+  }
+  return handled;
+}
+
+function $removeAdjacentDirectiveNode(isBackward: boolean): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+
+  const anchor = selection.anchor;
+  const node = anchor.getNode();
+
+  if ($isTextNode(node)) {
+    const isAtEdge = isBackward
+      ? anchor.offset === 0
+      : anchor.offset === node.getTextContentSize();
+    if (!isAtEdge) return false;
+
+    const sibling = isBackward
+      ? node.getPreviousSibling()
+      : node.getNextSibling();
+    if ($isDirectiveNode(sibling)) {
+      sibling.remove();
+      return true;
+    }
+  }
+
+  if ($isElementNode(node)) {
+    const childIndex = isBackward ? anchor.offset - 1 : anchor.offset;
+    const child = childIndex >= 0 ? node.getChildAtIndex(childIndex) : null;
+    if ($isDirectiveNode(child)) {
+      child.remove();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function $removeSelectedDirectiveNodesFromKeyEvent(
+  event: KeyboardEvent | null,
+): boolean {
+  if (!$removeSelectedDirectiveNodes()) return false;
+
+  // Unprevented forward Delete reaches beforeinput deleteContentForward, which Lexical maps to DELETE_LINE_COMMAND.
+  event?.preventDefault();
+  return true;
+}
 
 export function findTriggerMatch(
   trigger: string,
@@ -128,50 +188,22 @@ export function DirectivePlugin({
       }),
 
       editor.registerCommand(
+        DELETE_CHARACTER_COMMAND,
+        (isBackward) =>
+          $removeSelectedDirectiveNodes() ||
+          $removeAdjacentDirectiveNode(isBackward),
+        COMMAND_PRIORITY_LOW,
+      ),
+
+      editor.registerCommand(
         KEY_BACKSPACE_COMMAND,
-        () => {
-          const selection = $getSelection();
+        $removeSelectedDirectiveNodesFromKeyEvent,
+        COMMAND_PRIORITY_LOW,
+      ),
 
-          if ($isNodeSelection(selection)) {
-            const nodes = selection.getNodes();
-            let handled = false;
-            for (const node of nodes) {
-              if ($isDirectiveNode(node)) {
-                node.remove();
-                handled = true;
-              }
-            }
-            return handled;
-          }
-
-          if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-            return false;
-          }
-
-          const anchor = selection.anchor;
-          const node = anchor.getNode();
-
-          if ($isTextNode(node) && anchor.offset === 0) {
-            const prev = node.getPreviousSibling();
-            if ($isDirectiveNode(prev)) {
-              prev.remove();
-              return true;
-            }
-          }
-
-          if ($isElementNode(node)) {
-            const childBefore =
-              anchor.offset > 0
-                ? node.getChildAtIndex(anchor.offset - 1)
-                : null;
-            if ($isDirectiveNode(childBefore)) {
-              childBefore.remove();
-              return true;
-            }
-          }
-
-          return false;
-        },
+      editor.registerCommand(
+        KEY_DELETE_COMMAND,
+        $removeSelectedDirectiveNodesFromKeyEvent,
         COMMAND_PRIORITY_LOW,
       ),
     );

--- a/packages/react-lexical/src/plugins/DirectivePlugin.tsx
+++ b/packages/react-lexical/src/plugins/DirectivePlugin.tsx
@@ -78,8 +78,9 @@ function $removeAdjacentDirectiveNode(isBackward: boolean): boolean {
   }
 
   if ($isElementNode(node)) {
-    const childIndex = isBackward ? anchor.offset - 1 : anchor.offset;
-    const child = childIndex >= 0 ? node.getChildAtIndex(childIndex) : null;
+    const child = node.getChildAtIndex(
+      isBackward ? anchor.offset - 1 : anchor.offset,
+    );
     if ($isDirectiveNode(child)) {
       child.remove();
       return true;


### PR DESCRIPTION
closes #4951

## summary

- forward Delete now removes a directive chip as one unit in all three positions backspace already handled: cursor at a text-node edge before the chip, element-anchored cursor at the chip index, and a node-selected chip
- deletion handling is unified on `DELETE_CHARACTER_COMMAND` with the direction payload, which also fixes a latent gap where mobile virtual keyboards (the beforeinput path dispatches `DELETE_CHARACTER_COMMAND` directly and bypasses `KEY_BACKSPACE_COMMAND`) could not delete chips with backspace either
- `KEY_BACKSPACE_COMMAND` and `KEY_DELETE_COMMAND` keep only the node-selection case, which the plain-text layer never converts to `DELETE_CHARACTER_COMMAND`; the handlers call `event.preventDefault()` because Lexical ignores `KEY_DELETE_COMMAND`'s return value and an unprevented forward Delete falls through to beforeinput `deleteContentForward`, which maps to `DELETE_LINE_COMMAND`
- adds the first test coverage for chip deletion: 8 jsdom tests covering both directions, the mobile command path, `defaultPrevented` on node-selection keys, and a negative case where plain-text default deletion proceeds untouched

## test plan

### already verified

- [x] `pnpm -C packages/react-lexical exec vitest run` -> 35 passed (27 pre-existing + 8 new)
- [x] `pnpm -C packages/react-lexical exec tsc --noEmit` -> clean
- [x] `pnpm exec turbo build --filter=@assistant-ui/react-lexical` -> 10/10 tasks successful
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean on all touched files

### reviewer should verify

- [ ] in the mentions demo, place the caret immediately before a chip and press Delete: the whole chip disappears in one keystroke and the following text is untouched; click a chip to node-select it and press Delete: same result

## notes

- `DirectiveNode.isIsolated()` stays true; Lexical's `deleteCharacter` deliberately no-ops on isolated decorators in both directions, so explicit command handling remains the right seam (flipping isolated would change the range-selection semantics chips rely on)
- word and line deletion (`DELETE_WORD_COMMAND`, `DELETE_LINE_COMMAND`) adjacent to chips keep default behavior and are left for a follow-up if reports surface

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

