### PR TITLE
fix(cloud-ai-sdk): correct README quickstart to render UIMessage parts

### DIFF
--- a/.changeset/cloud-ai-sdk-readme-quickstart.md
+++ b/.changeset/cloud-ai-sdk-readme-quickstart.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: README quickstart renders UIMessage parts and drops nonexistent threadId destructure

--- a/packages/cloud-ai-sdk/README.md
+++ b/packages/cloud-ai-sdk/README.md
@@ -18,11 +18,11 @@ npm install @assistant-ui/cloud-ai-sdk assistant-cloud ai @ai-sdk/react
 import { useCloudChat } from "@assistant-ui/cloud-ai-sdk";
 
 export function Chat() {
-  const { messages, sendMessage, threadId } = useCloudChat();
+  const { messages, sendMessage } = useCloudChat();
   return (
     <div>
       {messages.map((m) => (
-        <div key={m.id}>{m.content}</div>
+        <div key={m.id}>{m.parts.map((p) => p.type === "text" && p.text)}</div>
       ))}
       <button onClick={() => sendMessage({ text: "Hello" })}>Send</button>
     </div>


### PR DESCRIPTION
## What

Fixes the two broken lines in the `@assistant-ui/cloud-ai-sdk` README quickstart, the only usage example in the file:

- `<div key={m.id}>{m.content}</div>` becomes `<div key={m.id}>{m.parts.map((p) => p.type === "text" && p.text)}</div>`
- `const { messages, sendMessage, threadId } = useCloudChat()` drops `threadId`, which does not exist on the hook result

## Why

`useCloudChat` returns AI SDK `UIMessage` objects (`Chat<UIMessage>` throughout `src/chat/`, peer `ai ^6 || ^7`). Since AI SDK v5, `UIMessage` is parts based and has no `content` property, so anyone copy-pasting the quickstart renders empty divs. `UseCloudChatResult` is `UseChatHelpers<UIMessage> & { threads: UseThreadsResult }` (`src/types.ts:49`); `threadId` lives at `threads.threadId`, so the destructure is a compile error in a strict TypeScript project. This README ships in the npm tarball and is the first code a new user sees.

## Impact

- Docs only, no runtime or type surface change
- The parts idiom byte-matches what the canonical docs page already uses three times (`apps/docs/content/docs/cloud/ai-sdk.mdx:131,194,257`), so README and docs stay consistent
- Patch changeset included so the corrected README reaches npm (precedent: assistant-stream 0.3.16 shipped a patch for a README example fix, #4096)

## Rationale

The idiomatic alternative `parts.filter(...).map(...).join("")` would also work, but the docs page idiom wins on consistency: `false` renders as nothing in React, there is no key warning for an array of strings, and TypeScript narrows the `TextUIPart` union cleanly. Dropping `threadId` rather than switching to `threads` keeps the quickstart minimal; the paragraph below the example already points to `useThreads` for thread CRUD and selection.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

