### PR TITLE
fix(core): generate unique attachment ids

### DIFF
--- a/.changeset/unique-attachment-ids.md
+++ b/.changeset/unique-attachment-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: generate unique IDs for built-in file attachments

--- a/packages/core/src/adapters/attachment.test.ts
+++ b/packages/core/src/adapters/attachment.test.ts
@@ -78,6 +78,20 @@ describe("getFileDataURL", () => {
 });
 
 describe("SimpleImageAttachmentAdapter", () => {
+  it("assigns unique IDs to files with the same name", async () => {
+    const adapter = new SimpleImageAttachmentAdapter();
+    const first = await adapter.add({
+      file: new File(["first"], "image.png", { type: "image/png" }),
+    });
+    const second = await adapter.add({
+      file: new File(["second"], "image.png", { type: "image/png" }),
+    });
+
+    expect(first.id).not.toBe(second.id);
+    expect(first.name).toBe("image.png");
+    expect(second.name).toBe("image.png");
+  });
+
   it("sends an image as a data URL", async () => {
     globalThis.FileReader = undefined as unknown as typeof FileReader;
 

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -20,7 +20,7 @@ export class SimpleImageAttachmentAdapter implements AttachmentAdapter {
 
   public async add(state: { file: File }): Promise<PendingAttachment> {
     return {
-      id: state.file.name,
+      id: generateId(),
       type: "image",
       name: state.file.name,
       contentType: state.file.type,
@@ -89,7 +89,7 @@ export class SimpleTextAttachmentAdapter implements AttachmentAdapter {
 
   public async add(state: { file: File }): Promise<PendingAttachment> {
     return {
-      id: state.file.name,
+      id: generateId(),
       type: "document",
       name: state.file.name,
       contentType: state.file.type,

--- a/packages/core/src/tests/attachment-adapters.test.ts
+++ b/packages/core/src/tests/attachment-adapters.test.ts
@@ -16,7 +16,7 @@ describe("SimpleTextAttachmentAdapter", () => {
     })) as PendingAttachment;
 
     expect(pending).toMatchObject({
-      id: "notes.md",
+      id: expect.any(String),
       type: "document",
       name: "notes.md",
       contentType: "text/markdown",
@@ -61,7 +61,7 @@ describe("SimpleImageAttachmentAdapter", () => {
     })) as PendingAttachment;
 
     expect(pending).toMatchObject({
-      id: "pixel.png",
+      id: expect.any(String),
       type: "image",
       name: "pixel.png",
       contentType: "image/png",

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
-import type { AttachmentAdapter } from "../adapters/attachment";
+import {
+  SimpleTextAttachmentAdapter,
+  type AttachmentAdapter,
+} from "../adapters/attachment";
 import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
 import type { PendingAttachment } from "../types/attachment";
 
@@ -123,6 +126,24 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
 
     expect(onAdd).toHaveBeenCalledTimes(1);
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("keeps different files with the same name as separate attachments", async () => {
+    const composer = makeComposer(new SimpleTextAttachmentAdapter());
+
+    await composer.addAttachment(
+      new File(["first"], "notes.txt", { type: "text/plain" }),
+    );
+    await composer.addAttachment(
+      new File(["second"], "notes.txt", { type: "text/plain" }),
+    );
+
+    expect(composer.attachments).toHaveLength(2);
+    expect(composer.attachments[0]!.id).not.toBe(composer.attachments[1]!.id);
+    expect(composer.attachments.map((attachment) => attachment.name)).toEqual([
+      "notes.txt",
+      "notes.txt",
+    ]);
   });
 
   it("does not let subscriber errors mask the original throw", async () => {


### PR DESCRIPTION
## Summary

- assign generated IDs to files added through the built-in image and text attachment adapters
- keep the original filename as display metadata
- add regression coverage for same-named files in the composer

## Why

The built-in adapters used `File.name` as the attachment ID. The composer upserts attachments by ID, so selecting `client-a/notes.txt` followed by a different `client-b/notes.txt` caused the second file to replace the first. This is easy to encounter with common names such as `notes.txt`, `image.png`, or `report.pdf`.

Using the existing `generateId()` utility gives each selected file its own identity while preserving the filename users see.

## Testing

- `pnpm --filter @assistant-ui/core test` (56 files, 537 tests)
- `pnpm --filter @assistant-ui/core exec tsc --noEmit`
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

