### PR TITLE
fix: flush unsupported title generation streams 

### DIFF
--- a/.changeset/unsupported-title-generation-streams.md
+++ b/.changeset/unsupported-title-generation-streams.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: complete unsupported title generation streams

--- a/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryThreadListAdapter } from "./in-memory";
+
+describe("InMemoryThreadListAdapter", () => {
+  it("closes its title stream when title generation is unsupported", async () => {
+    const adapter = new InMemoryThreadListAdapter();
+    const stream = await adapter.generateTitle();
+
+    await expect(stream.getReader().read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+});

--- a/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.ts
+++ b/packages/core/src/runtimes/remote-thread-list/adapter/in-memory.ts
@@ -38,7 +38,13 @@ export class InMemoryThreadListAdapter implements RemoteThreadListAdapter {
   }
 
   generateTitle(): Promise<AssistantStream> {
-    return Promise.resolve(new ReadableStream<AssistantStreamChunk>());
+    return Promise.resolve(
+      new ReadableStream<AssistantStreamChunk>({
+        start(controller) {
+          controller.close();
+        },
+      }),
+    );
   }
 
   fetch(threadId: string): Promise<RemoteThreadMetadata> {

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -210,10 +210,14 @@ describe("createAdkSessionAdapter - no-op methods", () => {
 // ── adapter.generateTitle ──
 
 describe("createAdkSessionAdapter - generateTitle", () => {
-  it("returns an empty ReadableStream", async () => {
+  it("closes its title stream when title generation is unsupported", async () => {
     const { adapter } = createAdkSessionAdapter(baseOptions);
-    const result = await adapter.generateTitle("s1", []);
-    expect(result).toBeInstanceOf(ReadableStream);
+    const stream = await adapter.generateTitle("s1", []);
+
+    await expect(stream.getReader().read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
   });
 });
 

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -159,7 +159,13 @@ export function createAdkSessionAdapter(
 
     generateTitle(): Promise<AssistantStream> {
       // Title generation not supported without assistant-cloud
-      return Promise.resolve(new ReadableStream<AssistantStreamChunk>());
+      return Promise.resolve(
+        new ReadableStream<AssistantStreamChunk>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+      );
     },
 
     async fetch(threadId: string): Promise<RemoteThreadMetadata> {


### PR DESCRIPTION
## Summary

- close the empty title streams returned by the in-memory and Google ADK adapters
- assert that unsupported title generation completes without emitting chunks
- add patch changesets for both affected packages

## Why

After the first run in a new remote thread, the runtime consumes the adapter title stream until that stream completes. The expected contracts are:

- a supported adapter emits title text and then closes
- an unsupported adapter emits no title chunks and closes immediately

The in-memory and Google ADK adapters currently return `new ReadableStream()` without enqueueing or closing it. They correctly produce no title, but the runtime consumer waits forever because it never receives the completion signal. Chat can continue, but the background title task remains pending and retains its runtime references.

Closing these no-op streams preserves the intended unsupported behavior while allowing the task to settle. This does not change title generation for supported adapters or attempt to fabricate titles where no title backend exists.

## Testing

- core: 57 test files, 538 tests
- react-google-adk: 9 test files, 186 tests
- TypeScript checks for both packages
- builds for both packages
- repository oxlint
- changed-file oxfmt check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

