### PR TITLE
fix(core): preserve optimistic update order

### DIFF
--- a/.changeset/optimistic-update-order.md
+++ b/.changeset/optimistic-update-order.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve optimistic updates in invocation order

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2894,6 +2894,7 @@ type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TRe
 declare class OptimisticState<TState> extends BaseSubscribable {
   private readonly _pendingTransforms;
   private readonly _completedOptimistics;
+  private _nextTransformOrder;
   private _baseValue;
   private _cachedValue;
   constructor(initialState: TState);

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.test.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { OptimisticState } from "./optimistic-state";
+
+const deferred = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+};
+
+describe("OptimisticState", () => {
+  it("preserves invocation order when optimistic updates resolve in order", async () => {
+    const state = new OptimisticState({ title: "Untitled" });
+    const firstRequest = deferred();
+    const secondRequest = deferred();
+
+    const firstUpdate = state.optimisticUpdate({
+      execute: () => firstRequest.promise,
+      optimistic: (value) => ({ ...value, title: "Project Alpha" }),
+    });
+    const secondUpdate = state.optimisticUpdate({
+      execute: () => secondRequest.promise,
+      optimistic: (value) => ({ ...value, title: "Project Beta" }),
+    });
+
+    expect(state.value.title).toBe("Project Beta");
+
+    firstRequest.resolve();
+    await firstUpdate;
+    expect(state.value.title).toBe("Project Beta");
+
+    secondRequest.resolve();
+    await secondUpdate;
+
+    expect(state.value.title).toBe("Project Beta");
+  });
+
+  it("preserves invocation order when optimistic updates resolve out of order", async () => {
+    const state = new OptimisticState({ title: "Untitled" });
+    const firstRequest = deferred();
+    const secondRequest = deferred();
+
+    const firstUpdate = state.optimisticUpdate({
+      execute: () => firstRequest.promise,
+      optimistic: (value) => ({ ...value, title: "Project Alpha" }),
+    });
+    const secondUpdate = state.optimisticUpdate({
+      execute: () => secondRequest.promise,
+      optimistic: (value) => ({ ...value, title: "Project Beta" }),
+    });
+
+    secondRequest.resolve();
+    await secondUpdate;
+    expect(state.value.title).toBe("Project Beta");
+
+    firstRequest.resolve();
+    await firstUpdate;
+
+    expect(state.value.title).toBe("Project Beta");
+  });
+});

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
@@ -115,6 +115,8 @@ export class OptimisticState<TState> extends BaseSubscribable {
         transform.then,
       ]);
 
+      // `then` can replace state with a stale snapshot, so replay every
+      // completed effect; otherwise replay only newer overlapping effects.
       for (const completed of this._completedOptimistics) {
         if (transform.then || completed.order > pendingTransform.order) {
           this._baseValue = completed.optimistic(this._baseValue);

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
@@ -116,7 +116,7 @@ export class OptimisticState<TState> extends BaseSubscribable {
       ]);
 
       for (const completed of this._completedOptimistics) {
-        if (completed.order > pendingTransform.order) {
+        if (transform.then || completed.order > pendingTransform.order) {
           this._baseValue = completed.optimistic(this._baseValue);
         }
       }

--- a/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
+++ b/packages/core/src/runtimes/remote-thread-list/optimistic-state.ts
@@ -14,7 +14,13 @@ type Transform<TState, TResult> = {
 };
 
 type PendingTransform<TState, TResult> = Transform<TState, TResult> & {
+  order: number;
   task: Promise<TResult>;
+};
+
+type CompletedOptimistic<TState> = {
+  order: number;
+  optimistic: (state: TState) => TState;
 };
 
 const pipeTransforms = <TState, TExtra>(
@@ -32,14 +38,16 @@ export class OptimisticState<TState> extends BaseSubscribable {
     [];
 
   /**
-   * `optimistic` callbacks from transforms that have already resolved.
-   * Re-applied after every `then` callback so that a wholesale state
-   * replacement (e.g. list()) cannot erase earlier completed effects
-   * (e.g. delete). Cleared when no pending transforms remain.
+   * Completed optimistic callbacks remain active while any transform is
+   * pending, so later state replacements cannot erase them. Invocation order
+   * determines which overlapping optimistic update wins.
    *
    * Correctness requirement: `optimistic` callbacks must be idempotent.
    */
-  private readonly _completedOptimistics: Array<(state: TState) => TState> = [];
+  private readonly _completedOptimistics: Array<CompletedOptimistic<TState>> =
+    [];
+
+  private _nextTransformOrder = 0;
 
   private _baseValue: TState;
   private _cachedValue: TState;
@@ -51,12 +59,25 @@ export class OptimisticState<TState> extends BaseSubscribable {
   }
 
   private _updateState(): void {
-    this._cachedValue = this._pendingTransforms.reduce((state, transform) => {
-      return pipeTransforms(state, transform.task, [
-        transform.loading,
-        transform.optimistic,
-      ]);
-    }, this._baseValue);
+    const activeTransforms = [
+      ...this._pendingTransforms.map((transform) => ({
+        order: transform.order,
+        apply: (state: TState) =>
+          pipeTransforms(state, transform.task, [
+            transform.loading,
+            transform.optimistic,
+          ]),
+      })),
+      ...this._completedOptimistics.map(({ order, optimistic }) => ({
+        order,
+        apply: optimistic,
+      })),
+    ].sort((a, b) => a.order - b.order);
+
+    this._cachedValue = activeTransforms.reduce(
+      (state, transform) => transform.apply(state),
+      this._baseValue,
+    );
 
     this._notifySubscribers();
   }
@@ -77,8 +98,13 @@ export class OptimisticState<TState> extends BaseSubscribable {
   public async optimisticUpdate<TResult>(
     transform: Transform<TState, TResult>,
   ): Promise<TResult> {
+    const order = this._nextTransformOrder++;
     const task = transform.execute();
-    const pendingTransform = { ...transform, task };
+    const pendingTransform = {
+      ...transform,
+      order,
+      task,
+    };
     try {
       this._pendingTransforms.push(pendingTransform);
       this._updateState();
@@ -89,14 +115,18 @@ export class OptimisticState<TState> extends BaseSubscribable {
         transform.then,
       ]);
 
-      // Re-apply previously completed optimistic callbacks so that a
-      // then() that does wholesale replacement cannot erase their effects.
-      for (const fn of this._completedOptimistics) {
-        this._baseValue = fn(this._baseValue);
+      for (const completed of this._completedOptimistics) {
+        if (completed.order > pendingTransform.order) {
+          this._baseValue = completed.optimistic(this._baseValue);
+        }
       }
 
       if (transform.optimistic) {
-        this._completedOptimistics.push(transform.optimistic);
+        this._completedOptimistics.push({
+          order: pendingTransform.order,
+          optimistic: transform.optimistic,
+        });
+        this._completedOptimistics.sort((a, b) => a.order - b.order);
       }
 
       return result;

--- a/packages/core/src/tests/OptimisticState-list-race.test.ts
+++ b/packages/core/src/tests/OptimisticState-list-race.test.ts
@@ -79,6 +79,39 @@ const applyListResult = (
 };
 
 describe("list + delete race condition", () => {
+  it("stale list() does not re-add a thread deleted before list started", async () => {
+    const state = new OptimisticState<RemoteThreadState>(
+      applyListResult(EMPTY_STATE, {
+        threads: [{ remoteId: "thread-A", status: "regular", title: "A" }],
+      }),
+    );
+    const deleteDeferred = deferred<void>();
+    const listDeferred = deferred<ListResult>();
+
+    const deletePromise = state.optimisticUpdate({
+      execute: () => deleteDeferred.promise,
+      optimistic: (s) => updateStatusReducer(s, "thread-A", "deleted"),
+    });
+    const listPromise = state.optimisticUpdate({
+      execute: () => listDeferred.promise,
+      loading: (s) => ({ ...s, isLoading: true }),
+      then: applyListResult,
+    });
+
+    deleteDeferred.resolve();
+    await deletePromise;
+
+    listDeferred.resolve({
+      threads: [{ remoteId: "thread-A", status: "regular", title: "A" }],
+    });
+    await listPromise;
+
+    expect(state.value.threadIds).not.toContain("thread-A");
+    expect(
+      state.value.threadData[createThreadMappingId("thread-A")],
+    ).toBeUndefined();
+  });
+
   it("stale list() does not re-add a thread deleted while list was in flight", async () => {
     const state = new OptimisticState<RemoteThreadState>(EMPTY_STATE);
 


### PR DESCRIPTION
## Summary

- preserve overlapping optimistic updates in invocation order rather than request completion order
- keep completed optimistic effects active in the correct order while another request is pending
- retain completed mutations when a stale list response reconciles thread state
- add regression coverage for request completion and list/mutation ordering

## Bug

While exercising rapid consecutive thread renames, I reproduced this sequence:

1. Rename `Untitled` to `Project Alpha`.
2. Before that request settles, rename it again to `Project Beta`.
3. Let the `Alpha` request resolve, followed by the `Beta` request.

The final local title incorrectly became `Project Alpha`. Completed optimistic callbacks were stored and replayed in request completion order, so the older `Alpha` callback was reapplied after the newer `Beta` update settled. The final UI state therefore depended on network timing instead of the order of the user actions.

## Fix

Each optimistic transform now receives a monotonic invocation order before its request starts. Pending and completed optimistic effects are applied in that order. Optimistic-only updates replay already-completed effects that were invoked after them, while `then`-based reconciliation continues to replay every completed mutation so a stale `list()` response cannot erase a delete or archive regardless of which operation started first.

## Verification

- confirmed the new regression test fails on `main` with `Expected: Project Beta`, `Received: Project Alpha`
- `pnpm --filter @assistant-ui/core test` (58 files, 541 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm exec changeset status --since origin/main`
