### PR TITLE
fix(cli): detect monorepos from workspace root

### DIFF
--- a/.changeset/warm-lions-jump.md
+++ b/.changeset/warm-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): detect monorepos from the workspace root

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -92,7 +92,7 @@ function getInstalledVersion(pkg: string, cwd: string): string | null {
 export function findWorkspaceRoot(cwd: string): string | null {
   let dir = cwd;
   const root = path.parse(dir).root;
-  while (dir !== root) {
+  while (true) {
     if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
     const pkgPath = path.join(dir, "package.json");
     if (fs.existsSync(pkgPath)) {
@@ -103,9 +103,9 @@ export function findWorkspaceRoot(cwd: string): string | null {
         // ignore
       }
     }
+    if (dir === root) return null;
     dir = path.dirname(dir);
   }
-  return null;
 }
 
 function readProjectDeps(

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -89,8 +89,8 @@ function getInstalledVersion(pkg: string, cwd: string): string | null {
   return null;
 }
 
-function findWorkspaceRoot(cwd: string): string | null {
-  let dir = path.dirname(cwd);
+export function findWorkspaceRoot(cwd: string): string | null {
+  let dir = cwd;
   const root = path.parse(dir).root;
   while (dir !== root) {
     if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { info, satisfiesRange } from "../../src/commands/info";
+import {
+  findWorkspaceRoot,
+  info,
+  satisfiesRange,
+} from "../../src/commands/info";
 
 function writePackage(
   root: string,
@@ -52,6 +56,59 @@ describe("satisfiesRange", () => {
       expect(satisfiesRange("19.2.0", range)).toBe(true);
     },
   );
+});
+
+describe("findWorkspaceRoot", () => {
+  it("detects a pnpm workspace from the workspace root", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-workspace-"));
+
+    try {
+      fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []");
+
+      expect(findWorkspaceRoot(root)).toBe(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("detects package.json workspaces from the workspace root", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-workspace-"));
+
+    try {
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ workspaces: ["apps/*"] }),
+      );
+
+      expect(findWorkspaceRoot(root)).toBe(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("finds the workspace root from a nested project", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-workspace-"));
+    const project = path.join(root, "apps", "chat");
+
+    try {
+      fs.mkdirSync(project, { recursive: true });
+      fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []");
+
+      expect(findWorkspaceRoot(project)).toBe(root);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null outside a workspace", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-project-"));
+
+    try {
+      expect(findWorkspaceRoot(root)).toBeNull();
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("info command", () => {

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs";
+import fs, { type PathLike } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -7,6 +7,19 @@ import {
   info,
   satisfiesRange,
 } from "../../src/commands/info";
+
+const existsSyncOverride = vi.hoisted(() =>
+  vi.fn<(candidate: PathLike) => boolean | undefined>(),
+);
+
+vi.mock("node:fs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...original,
+    existsSync: (candidate: PathLike) =>
+      existsSyncOverride(candidate) ?? original.existsSync(candidate),
+  };
+});
 
 function writePackage(
   root: string,
@@ -107,6 +120,20 @@ describe("findWorkspaceRoot", () => {
       expect(findWorkspaceRoot(root)).toBeNull();
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("checks the filesystem root for workspace markers", () => {
+    const root = path.parse(process.cwd()).root;
+    const workspaceFile = path.join(root, "pnpm-workspace.yaml");
+    existsSyncOverride.mockImplementation((candidate) =>
+      candidate === workspaceFile ? true : undefined,
+    );
+
+    try {
+      expect(findWorkspaceRoot(root)).toBe(root);
+    } finally {
+      existsSyncOverride.mockReset();
     }
   });
 });


### PR DESCRIPTION
## Summary

- check the current working directory before walking up to parent directories for workspace markers
- inspect the filesystem root as the final directory in the upward search
- cover pnpm and `package.json#workspaces` roots, nested projects, filesystem-root workspaces, and standalone projects
- add a patch changeset for the CLI

## Why

While running `assistant-ui info` from a nested app already detects its parent workspace, running the command directly at the workspace root skips that directory because `findWorkspaceRoot()` begins at `path.dirname(cwd)`. As a result, valid pnpm/npm/Yarn workspace roots can omit `Monorepo: yes` from diagnostic output.

Starting at `cwd` preserves the existing upward search while also checking the workspace root itself. The loop also checks the filesystem root once before stopping, which supports environments where a workspace is mounted directly there.

## Verification

- `pnpm --filter assistant-ui test -- test/commands/info.test.ts` (19 files, 235 tests)
- `pnpm --filter assistant-ui build`
- `pnpm lint`
- built CLI invocation from the repository root reports `Monorepo: yes`