### PR TITLE
fix(core): accept json text attachments

### DIFF
--- a/.changeset/calm-lamps-smile.md
+++ b/.changeset/calm-lamps-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): accept application/json text attachments

--- a/.changeset/calm-lamps-smile.md
+++ b/.changeset/calm-lamps-smile.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix(core): accept application/json text attachments
+fix(core): accept application/json text attachments and parameterized MIME types

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -143,7 +143,7 @@ export function fileMatchesAccept(
     .map((type) => type.trim().toLowerCase());
 
   const fileExtension = `.${file.name.split(".").pop()!.toLowerCase()}`;
-  const fileMimeType = file.type.toLowerCase();
+  const fileMimeType = file.type.split(";", 1)[0]!.trim().toLowerCase();
 
   for (const type of allowedTypes) {
     if (type.startsWith(".") && type === fileExtension) {

--- a/packages/core/src/adapters/attachment.ts
+++ b/packages/core/src/adapters/attachment.ts
@@ -85,7 +85,7 @@ export const getFileDataURL = async (file: File): Promise<string> => {
 
 export class SimpleTextAttachmentAdapter implements AttachmentAdapter {
   public accept =
-    "text/plain,text/html,text/markdown,text/csv,text/xml,text/json,text/css";
+    "text/plain,text/html,text/markdown,text/csv,text/xml,text/json,application/json,text/css";
 
   public async add(state: { file: File }): Promise<PendingAttachment> {
     return {

--- a/packages/core/src/tests/attachment-adapters.test.ts
+++ b/packages/core/src/tests/attachment-adapters.test.ts
@@ -2,9 +2,21 @@ import { describe, expect, it } from "vitest";
 import type { PendingAttachment } from "../types/attachment";
 import {
   type AttachmentAdapter,
+  fileMatchesAccept,
   SimpleImageAttachmentAdapter,
   SimpleTextAttachmentAdapter,
 } from "../adapters/attachment";
+
+describe("fileMatchesAccept", () => {
+  it("matches MIME types with parameters", () => {
+    expect(
+      fileMatchesAccept(
+        { name: "data.json", type: "application/json; charset=utf-8" },
+        "application/json",
+      ),
+    ).toBe(true);
+  });
+});
 
 describe("SimpleTextAttachmentAdapter", () => {
   const makeFile = (contents: string, name = "notes.md") =>

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -128,6 +128,22 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("accepts JSON files with the application/json media type", async () => {
+    const composer = makeComposer(new SimpleTextAttachmentAdapter());
+
+    await expect(
+      composer.addAttachment(
+        new File(["{}"], "data.json", { type: "application/json" }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(composer.attachments[0]).toMatchObject({
+      type: "document",
+      name: "data.json",
+      contentType: "application/json",
+    });
+  });
+
   it("keeps different files with the same name as separate attachments", async () => {
     const composer = makeComposer(new SimpleTextAttachmentAdapter());
 


### PR DESCRIPTION
## Summary

- accept the standard `application/json` media type in `SimpleTextAttachmentAdapter`
- retain `text/json` for compatibility with existing environments
- compare MIME types without optional parameters during attachment validation
- add regressions at both the composer and MIME-matcher boundaries

## Why

JSON uses the registered `application/json` media type, but the built-in text attachment adapter only advertised `text/json`. A browser-style `new File([content], "data.json", { type: "application/json" })` therefore failed composer validation before the adapter could read it.

Programmatic file sources may also provide a valid parameterized value such as `application/json; charset=utf-8`. The matcher previously compared that full value literally. It now compares the MIME essence for validation while preserving the original `contentType` on the attachment.

This is additive: existing `text/json` files remain accepted, and unrelated file types remain rejected.

## Verification

- confirmed the composer regression fails before adding `application/json`
- `pnpm --filter @assistant-ui/core exec vitest run src/tests/attachment-adapters.test.ts src/tests/base-composer-runtime-core-addAttachment.test.ts` (2 files, 16 tests)
- `pnpm --filter @assistant-ui/core test` (57 files, 540 tests)
- `pnpm turbo build --filter=@assistant-ui/core`
- `pnpm lint`
- built-output check: exact JSON, parameterized JSON, and legacy `text/json` match; `application/pdf` remains rejected
