### PR TITLE
fix(react-google-adk): normalize direct stream api urls

### DIFF
--- a/.changeset/google-adk-direct-api-url.md
+++ b/.changeset/google-adk-direct-api-url.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: normalize direct ADK stream API URLs

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -261,6 +261,30 @@ describe("createAdkStream - direct mode", () => {
     });
   });
 
+  it.each(["http://localhost:8000/", "http://localhost:8000//"])(
+    "normalizes trailing slashes in the api URL: %s",
+    async (api) => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(sseBody(""), { status: 200 }),
+      );
+
+      const stream = createAdkStream({
+        api,
+        appName: "my-app",
+        userId: "user-1",
+      });
+      const gen = await stream(
+        [{ id: "m1", type: "human", content: "Hello" }],
+        makeConfig(),
+      );
+      for await (const _ of gen) {
+        /* noop */
+      }
+
+      expect(mockFetch.mock.calls[0]![0]).toBe("http://localhost:8000/run_sse");
+    },
+  );
+
   it("calls config.initialize() to get the sessionId", async () => {
     const initialize = vi
       .fn()

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -1,5 +1,6 @@
 import { SSEEventDecoder } from "assistant-stream/utils";
 import { contentToParts } from "./contentToParts";
+import { trimTrailingSlashes } from "./trimTrailingSlashes";
 import type {
   AdkEvent,
   AdkEventPart,
@@ -69,7 +70,7 @@ export function createAdkStream(
 
     if (isDirect) {
       // Direct mode: POST to ADK server's /run_sse
-      url = `${options.api}/run_sse`;
+      url = `${trimTrailingSlashes(options.api)}/run_sse`;
       const { externalId } = await config.initialize();
       body = {
         appName: options.appName,

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -7,6 +7,7 @@ import type {
 } from "@assistant-ui/core";
 import { AdkEventAccumulator } from "./AdkEventAccumulator";
 import type { AdkEvent, AdkMessage } from "./types";
+import { trimTrailingSlashes } from "./trimTrailingSlashes";
 
 export type AdkSessionAdapterOptions = {
   /**
@@ -54,12 +55,6 @@ type AdkSessionAdapterResult = {
     ) => Promise<number[]>;
     delete: (sessionId: string, artifactName: string) => Promise<void>;
   };
-};
-
-const trimTrailingSlashes = (value: string) => {
-  let end = value.length;
-  while (end > 0 && value[end - 1] === "/") end -= 1;
-  return value.slice(0, end);
 };
 
 /**

--- a/packages/react-google-adk/src/trimTrailingSlashes.ts
+++ b/packages/react-google-adk/src/trimTrailingSlashes.ts
@@ -1,0 +1,5 @@
+export const trimTrailingSlashes = (value: string) => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") end -= 1;
+  return value.slice(0, end);
+};


### PR DESCRIPTION
## Summary

- normalize trailing slashes before direct Google ADK stream requests are sent to `/run_sse`
- reuse the URL normalization introduced for session endpoints in #4893
- cover API base URLs ending in one or multiple slashes

## Context

This is a follow-up to merged PR #4893. That PR normalized the session and artifact URLs built by `createAdkSessionAdapter`, but the separate direct-stream path in `createAdkStream` still constructed `${api}/run_sse` without normalization.

When configuring a direct ADK connection with `api: "http://localhost:8000/"`, chat requests were therefore sent to `http://localhost:8000//run_sse`. Strict routers and reverse proxies can treat that as a different path or return a redirect/404.

The shared helper now keeps session and direct-stream URL construction consistent. Proxy mode remains unchanged because its `api` option can intentionally be an exact application route such as `/api/adk/`.

## Verification

- `pnpm --filter @assistant-ui/react-google-adk test` (188 tests)
- `pnpm --filter @assistant-ui/react-google-adk build`
- `pnpm lint`
- `pnpm exec changeset status --since origin/main`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

