### PR TITLE
fix(tw-shimmer): correct background shimmer speed in firefox

### DIFF
--- a/.changeset/tough-pans-shimmer.md
+++ b/.changeset/tough-pans-shimmer.md
@@ -1,0 +1,5 @@
+---
+"tw-shimmer": patch
+---
+
+fix background shimmer animation speed in Firefox

--- a/packages/tw-shimmer/src/index.css
+++ b/packages/tw-shimmer/src/index.css
@@ -116,6 +116,12 @@
   --_bg: transparent;
   --_fg: var(--shimmer-color, oklch(from currentColor 0 c h / 0.06));
 
+  @-moz-document url-prefix() {
+    & {
+      --_duration: var(--shimmer-duration, calc(1500000 / var(--_speed)));
+    }
+  }
+
   @variant dark {
     --_fg: var(--shimmer-color, oklch(from currentColor 0 c h / 0.3));
   }

--- a/packages/tw-shimmer/src/index.css
+++ b/packages/tw-shimmer/src/index.css
@@ -70,7 +70,7 @@
   }
 
   @-moz-document url-prefix() {
-    & {
+    &:not(.shimmer-bg) {
       --_duration: var(--shimmer-duration, calc(375000 / var(--_speed)));
     }
   }

--- a/packages/tw-shimmer/src/index.css
+++ b/packages/tw-shimmer/src/index.css
@@ -117,7 +117,7 @@
   --_fg: var(--shimmer-color, oklch(from currentColor 0 c h / 0.06));
 
   @-moz-document url-prefix() {
-    & {
+    &.shimmer {
       --_duration: var(--shimmer-duration, calc(1500000 / var(--_speed)));
     }
   }


### PR DESCRIPTION
closes #4965,
## Summary

- add a Firefox-specific duration fallback for background shimmers
- keep the existing text shimmer fallback and explicit duration overrides unchanged
- add a patch changeset for `tw-shimmer`

## Why

While testing the Background Shimmer demo from #4965, I reproduced a `0.395s` animation cycle in Firefox versus `1.486s` in Chromium. The shared Firefox fallback was calibrated for text shimmer at its default speed of `200`; `shimmer-bg` defaults to `1000`, so reusing that calculation makes the background shimmer race across skeletons.

The background-specific fallback brings the same demo to `1.520s` in Firefox without changing non-Firefox calculations.

## Verification

- `pnpm lint`
- manually loaded `/tw-shimmer` in Firefox 144 and Chromium 143
- verified default background duration: Firefox `1.520s`, Chromium `1.486s`
- verified `shimmer-speed` still scales at `500` and `2000`
- verified an explicit `2750ms` duration remains `2.770s` in both browsers
- verified text shimmer duration is unchanged

Fixes #4965

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

