### PR TITLE
fix(core): resume the local runtime when a human tool result is falsy

### DIFF
--- a/.changeset/local-runtime-falsy-tool-result.md
+++ b/.changeset/local-runtime-falsy-tool-result.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: resume the local runtime when a human tool returns a falsy result

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -128,6 +128,34 @@ describe("LocalThreadRuntimeCore human-in-the-loop tools", () => {
       "text",
     ]);
   });
+
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+    ["null", null],
+  ])("resumes when the tool result is %s", async (_label, result) => {
+    const { thread, runs } = createApprovalThread(toolCallResult("send_email"));
+
+    await thread.append(userMessage("send an email"));
+    await flush();
+
+    thread.addToolResult({
+      messageId: thread.messages.at(-1)!.id,
+      toolCallId: "call-send_email",
+      toolName: "send_email",
+      result,
+      isError: false,
+    });
+    await flush();
+
+    expect(runs).toHaveLength(2);
+    const toolCall = runs[1]!
+      .unstable_getMessage()
+      .content.find((part) => part.type === "tool-call");
+    expect(toolCall?.result).toEqual(result);
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
 });
 
 describe("LocalThreadRuntimeCore tool approvals", () => {

--- a/packages/core/src/runtimes/local/should-continue.ts
+++ b/packages/core/src/runtimes/local/should-continue.ts
@@ -23,14 +23,17 @@ export const shouldContinue = (
   // TODO legacy behavior -- make specifying human tool names required
   if (humanToolNames === undefined) {
     return result.content.every(
-      (c) => c.type !== "tool-call" || !!c.result || c.approval !== undefined,
+      (c) =>
+        c.type !== "tool-call" ||
+        c.result !== undefined ||
+        c.approval !== undefined,
     );
   }
 
   return result.content.every(
     (c) =>
       c.type !== "tool-call" ||
-      !!c.result ||
+      c.result !== undefined ||
       c.approval !== undefined ||
       !humanToolNames.includes(c.toolName),
   );


### PR DESCRIPTION
A human-in-the-loop tool that resolves with a falsy value never resumes the run. With `unstable_humanToolNames: ["send_email"]`, the natural "user declined" path is `addToolResult({ result: false })` — and that leaves the thread parked in `requires-action` forever, with no error and no way out. Same for `0`, `""` and `null`, so any tool whose answer is a count, a plain string, or an explicit null hits it too.

`shouldContinue` gates the resume on `!!c.result`, so a present-but-falsy result is indistinguishable from a tool that has not answered yet, and `every()` never goes true. The check just above it in the same function already uses `c.result === undefined`, and every other result check in core (`ToolInvocationTracker`, `external-message-converter`) tests presence rather than truthiness — these two were the only truthy-checks left. It looks unintentional rather than deliberate: the callback predates human tool names and was carried over as-is, and the existing tests only ever pass `{ approved: true }` or a non-empty string, so falsy results were never exercised.

Switched both to `c.result !== undefined`. Nothing else changes — `undefined` still means unanswered, so the pause behavior for genuinely pending tools is identical.

Verified against a real `LocalRuntimeCore` rather than a stub: `false`/`0`/`""`/`null` each produce one run and a stuck `requires-action` on `main`, and two runs ending `complete` with the fix. The four new cases in `local-thread-runtime-core.test.ts` fail on `main` and pass here; the 18 existing tests in the file are untouched and still green.

One thing I left alone deliberately: `addToolResult` has the same truthiness shape in its `added` guard (`if (!c.result)`). I tried to build a failing case for it and could not — the run-loop status transition already blocks the extra resume, so it behaves identically either way. It seemed like speculative scope for a bug-fix PR, so I left it out; happy to fix it separately if you would rather it match.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

