### PR TITLE
feat(react-mcp): support `listResources()` pagination

### DIFF
--- a/.changeset/react-mcp-resource-pagination.md
+++ b/.changeset/react-mcp-resource-pagination.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+feat: support cursor pagination when listing MCP resources

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -124,7 +124,9 @@ type MCPServerMethods = {
   disconnect: () => Promise<void>;
   remove: () => Promise<void>;
   callTool: (name: string, args: unknown) => Promise<unknown>;
-  listResources: () => Promise<unknown>;
+  listResources: (params?: {
+    cursor?: string | undefined;
+  }) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
   completeAuth: (callbackUrl: string) => Promise<void>;
 };

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -316,15 +316,23 @@ await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
 await aui.mcp().server({ id }).connect();
 await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
 
-// Build a resource browser/preview UI for servers that expose resources.
-const { resources } = (await aui.mcp().server({ id }).listResources()) as {
+// Build a paginated resource browser/preview UI.
+type ResourcePage = {
   resources: Array<{ uri: string; name?: string }>;
+  nextCursor?: string;
 };
+
+const server = aui.mcp().server({ id });
+const firstPage = (await server.listResources()) as ResourcePage;
+const secondPage = firstPage.nextCursor
+  ? ((await server.listResources({
+      cursor: firstPage.nextCursor,
+    })) as ResourcePage)
+  : undefined;
+const resources = [...firstPage.resources, ...(secondPage?.resources ?? [])];
 const firstResource = resources[0];
 if (firstResource) {
-  const preview = await aui.mcp()
-    .server({ id })
-    .readResource(firstResource.uri);
+  const preview = await server.readResource(firstResource.uri);
 }
 ```
 

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -323,13 +323,17 @@ type ResourcePage = {
 };
 
 const server = aui.mcp().server({ id });
-const firstPage = (await server.listResources()) as ResourcePage;
-const secondPage = firstPage.nextCursor
-  ? ((await server.listResources({
-      cursor: firstPage.nextCursor,
-    })) as ResourcePage)
-  : undefined;
-const resources = [...firstPage.resources, ...(secondPage?.resources ?? [])];
+const resources: ResourcePage["resources"] = [];
+let nextCursor: string | undefined;
+
+do {
+  const page = (await (nextCursor === undefined
+    ? server.listResources()
+    : server.listResources({ cursor: nextCursor }))) as ResourcePage;
+  resources.push(...page.resources);
+  nextCursor = page.nextCursor;
+} while (nextCursor !== undefined);
+
 const firstResource = resources[0];
 if (firstResource) {
   const preview = await server.readResource(firstResource.uri);

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -73,7 +73,7 @@ export type MCPServerMethods = {
   remove: () => Promise<void>;
   callTool: (name: string, args: unknown) => Promise<unknown>;
   /** List resources exposed by the server. Returns the raw MCP `ListResourcesResult`. */
-  listResources: () => Promise<unknown>;
+  listResources: (params?: { cursor?: string | undefined }) => Promise<unknown>;
   /** Read a resource by URI. Returns the raw MCP `ReadResourceResult`. */
   readResource: (uri: string) => Promise<unknown>;
   /** OAuth only: pass full callback URL (e.g. window.location.href) */

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -329,6 +329,27 @@ describe("McpServerResource resource methods", () => {
     }
   });
 
+  it("forwards the resource pagination cursor", async () => {
+    const result = {
+      resources: [{ uri: "docs://page-two", name: "Page two" }],
+    };
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      mocks.clients[0].listResources.mockResolvedValueOnce(result);
+
+      await expect(
+        root.getValue().listResources({ cursor: "next-page" }),
+      ).resolves.toBe(result);
+      expect(mocks.clients[0].listResources).toHaveBeenCalledWith({
+        cursor: "next-page",
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("rejects listResources when the server is disconnected", async () => {
     const root = mount();
 

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -310,12 +310,12 @@ const useMcpServerResource = (
         arguments: args as Record<string, unknown> | undefined,
       });
     },
-    listResources: async () => {
+    listResources: async (params) => {
       const client = clientRef.current;
       if (!client) {
         throw new Error(`MCP server "${props.id}" is not connected`);
       }
-      return await client.listResources();
+      return await client.listResources(params);
     },
     readResource: async (uri) => {
       const client = clientRef.current;


### PR DESCRIPTION
## Summary

- allow `listResources()` to accept an optional MCP pagination cursor
- forward the cursor to the connected MCP client and cover it with a regression test
- document how a resource browser requests the next page

## Why

This is a follow-up to merged [PR #4699](https://github.com/assistant-ui/assistant-ui/pull/4699), which first exposed MCP resource listing and identified pagination as unfinished. A server can return `nextCursor`, but the zero-argument public method left resource browsers stuck on the first page because they could not send that cursor back.

After this change, callers can request the next page with:

```ts
type ResourcePage = {
  resources: Array<{ uri: string }>;
  nextCursor?: string;
};

const firstPage = (await server.listResources()) as ResourcePage;
const secondPage = firstPage.nextCursor
  ? await server.listResources({ cursor: firstPage.nextCursor })
  : undefined;
```

Existing `listResources()` calls continue to work unchanged.

## Validation

- `pnpm --filter @assistant-ui/react-mcp test` (22 tests)
- `pnpm --filter @assistant-ui/react-mcp build`
- filtered API surface generation and check for `@assistant-ui/react-mcp`
- `pnpm lint`
- `pnpm --filter @assistant-ui/docs build` (441 static pages)