### PR TITLE
feat(react-generative-ui): add the fromSlackBlocks inbound converter

### DIFF
--- a/.changeset/generative-ui-slack-inbound.md
+++ b/.changeset/generative-ui-slack-inbound.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+feat: add fromSlackBlocks to the ./slack subpath

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -231,6 +231,11 @@ type FileMessagePart = {
   readonly parentId?: string;
 };
 
+interface FromSlackBlocksResult {
+  readonly nodes: UIElement[];
+  readonly warnings: SlackConversionWarning[];
+}
+
 type FrontendTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "frontend";
   description?: string | undefined;
@@ -1256,6 +1261,8 @@ declare function defineGenerativeComponents(_library: GenerativeUILibrary): Gene
 
 declare const emptyActionRegistry: ActionRegistry;
 
+declare function fromSlackBlocks(blocks: unknown): FromSlackBlocksResult;
+
 declare function generativeUIToJSX(node: unknown, options?: GenerativeUIToJSXOptions): string;
 
 declare global {
@@ -1292,7 +1299,7 @@ declare function normalizeUINode(node: unknown, partialPath?: readonly string[] 
 declare function renderGenerativeUI(node: unknown, library: GenerativeUILibrary, context?: GenerativeUIRenderContext): ReactNode;
 
 declare namespace entry_slack_exports {
-  export { SlackActionElement, SlackActionsBlock, SlackAlertBlock, SlackAlertLevel, SlackBlock, SlackBlocksResult, SlackButtonElement, SlackCardBlock, SlackCarouselBlock, SlackCheckboxesElement, SlackContextBlock, SlackConversionWarning, SlackDataTableBlock, SlackDataTableCell, SlackDataTableRawNumberCell, SlackDataTableRawTextCell, SlackDatePickerElement, SlackDividerBlock, SlackHeaderBlock, SlackImageBlock, SlackInputBlock, SlackMarkdownBlock, SlackMrkdwnText, SlackOption, SlackPlainText, SlackPlainTextInputElement, SlackRadioButtonsElement, SlackSectionBlock, SlackStaticSelectElement, SlackTextObject, ToSlackBlocksOptions, decodeBlockAction, toSlackBlocks };
+  export { FromSlackBlocksResult, SlackActionElement, SlackActionsBlock, SlackAlertBlock, SlackAlertLevel, SlackBlock, SlackBlocksResult, SlackButtonElement, SlackCardBlock, SlackCarouselBlock, SlackCheckboxesElement, SlackContextBlock, SlackConversionWarning, SlackDataTableBlock, SlackDataTableCell, SlackDataTableRawNumberCell, SlackDataTableRawTextCell, SlackDatePickerElement, SlackDividerBlock, SlackHeaderBlock, SlackImageBlock, SlackInputBlock, SlackMarkdownBlock, SlackMrkdwnText, SlackOption, SlackPlainText, SlackPlainTextInputElement, SlackRadioButtonsElement, SlackSectionBlock, SlackStaticSelectElement, SlackTextObject, ToSlackBlocksOptions, decodeBlockAction, fromSlackBlocks, toSlackBlocks };
 }
 
 declare function toSlackBlocks(node: unknown, options?: ToSlackBlocksOptions): SlackBlocksResult;

--- a/apps/docs/content/docs/(reference)/api-reference/generative-ui/slack.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/generative-ui/slack.mdx
@@ -3,7 +3,7 @@ title: Slack Block Kit
 description: "Convert generative UI trees to Slack Block Kit payloads and decode block_actions interactions back into $action payloads."
 ---
 
-import { SlackBlocksResult, SlackConversionWarning, ToSlackBlocksOptions, decodeBlockAction, toSlackBlocks } from "@/generated/typeDocs";
+import { FromSlackBlocksResult, SlackBlocksResult, SlackConversionWarning, ToSlackBlocksOptions, decodeBlockAction, fromSlackBlocks, toSlackBlocks } from "@/generated/typeDocs";
 
 {/* AUTO-GENERATED PAGE by scripts/generate-api-reference.mts */}
 {/* Do not edit manually. */}
@@ -19,6 +19,39 @@ import { SlackBlocksResult, SlackConversionWarning, ToSlackBlocksOptions, decode
 Decodes one structural entry from a Slack `block_actions` payload.
 
 <ParametersTable {...decodeBlockAction} />
+
+### fromSlackBlocks
+
+Converts Slack Block Kit JSON back into a generative-ui IR tree, inverting
+[toSlackBlocks](/docs/api-reference/generative-ui/slack#toslackblocks). Accepts a blocks array or a `{ blocks }` wrapper;
+malformed input resolves to an empty node list plus a warning, and an
+unrecognized block or action element is skipped with a "dropped" warning.
+Every array read along the way (blocks, fields, options, elements, cards,
+rows, cells) is bounded to its site's cap before it is mapped over, so a
+hostile array (sparse or proxied with a fabricated `length`) is clamped
+with a "clamped" warning instead of stalling the event loop. Never throws.
+
+The Slack shape is lossier than the IR, so some information cannot be
+recovered: a context block's elements always decode as `Caption` (the
+original `Badge` vs `Caption` distinction does not survive the round trip),
+a button's `buttonStyle` is only recovered for the `primary`/`danger` Slack
+styles, a native alert block's `title` and `description` merge into a
+single `description` string, and a card's layout collapses to its `title`,
+a flat `children` list (image, then text, then caption, in that order),
+and `confirm`/`cancel` footer buttons. A section field's label and value
+are split on the first `*`+newline delimiter, so a label or value that
+itself contains that exact delimiter cannot be split back unambiguously.
+A data-table cell that Slack carries as `raw_text` always decodes as a
+string, even when its text is the stringified form of a boolean, since the
+Slack shape does not distinguish a boolean from ordinary text.
+
+<ParametersTable {...fromSlackBlocks} />
+
+### FromSlackBlocksResult
+
+The IR nodes and non-fatal warnings produced by converting Slack Block Kit JSON back into generative UI.
+
+<ParametersTable {...FromSlackBlocksResult} />
 
 ### SlackBlocksResult
 

--- a/apps/docs/content/docs/tools/generative-ui.mdx
+++ b/apps/docs/content/docs/tools/generative-ui.mdx
@@ -287,6 +287,8 @@ user's runtime selection (a picked option, a typed value) carried under
 decoded action to your handler stay the host app's responsibility; the
 converter only speaks JSON in and JSON out.
 
+The inverse direction is `fromSlackBlocks`: it maps a Block Kit payload back into vocabulary nodes, back-mapping each element's `action_id` to `$action.type` and reparsing serialized payload values. The round trip is faithful on the plain building blocks (text, images, facts, controls, tables, simple cards) and documented-lossy elsewhere: context elements all return as `Caption`, button styles beyond `primary` and `danger` are dropped, an alert's title and description come back as one description, and card layouts flatten to the fields the `card` block carries.
+
 A few conversion caveats worth knowing:
 
 - `Alert` has no message-surface equivalent upstream (Slack only supports it

--- a/apps/docs/scripts/generated-docs/classify.mts
+++ b/apps/docs/scripts/generated-docs/classify.mts
@@ -316,6 +316,8 @@ export const GENERATIVE_UI_PACKAGE_EXPORTS = new Map<
   ["AlertTone", { page: "tokens", role: "supporting-type" }],
 
   ["toSlackBlocks", { page: "slack", role: "primary" }],
+  ["fromSlackBlocks", { page: "slack", role: "primary" }],
+  ["FromSlackBlocksResult", { page: "slack", role: "primary" }],
   ["decodeBlockAction", { page: "slack", role: "primary" }],
   ["ToSlackBlocksOptions", { page: "slack", role: "primary" }],
   ["SlackBlocksResult", { page: "slack", role: "primary" }],

--- a/packages/react-generative-ui/src/slack.ts
+++ b/packages/react-generative-ui/src/slack.ts
@@ -1,6 +1,8 @@
 export { decodeBlockAction } from "./slack/decodeBlockAction";
+export { fromSlackBlocks } from "./slack/fromSlackBlocks";
 export { toSlackBlocks } from "./slack/toSlackBlocks";
 export type {
+  FromSlackBlocksResult,
   SlackActionElement,
   SlackActionsBlock,
   SlackAlertBlock,

--- a/packages/react-generative-ui/src/slack/constants.ts
+++ b/packages/react-generative-ui/src/slack/constants.ts
@@ -20,6 +20,13 @@ export const MESSAGE_BLOCK_CAP = 50;
 /** The block limit for a Slack modal. */
 export const MODAL_BLOCK_CAP = 100;
 
+/**
+ * The maximum number of top-level blocks accepted when parsing Slack Block
+ * Kit JSON back into generative UI, guarding against a hostile or malformed
+ * payload.
+ */
+export const INBOUND_BLOCK_CAP = 200;
+
 /** The character limit for header text. */
 export const HEADER_TEXT_CAP = 150;
 

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
@@ -1,0 +1,1063 @@
+import { describe, expect, it } from "vitest";
+import type { UIElement } from "../ir";
+import { INBOUND_BLOCK_CAP } from "./constants";
+import { fromSlackBlocks } from "./fromSlackBlocks";
+import { toSlackBlocks } from "./toSlackBlocks";
+import type { ToSlackBlocksOptions } from "./types";
+
+describe("fromSlackBlocks", () => {
+  describe("malformed input", () => {
+    it("returns empty nodes and a dropped warning for non-blocks input", () => {
+      const malformed: unknown[] = [
+        null,
+        undefined,
+        42,
+        "just text",
+        true,
+        {},
+        { blocks: "nope" },
+      ];
+      for (const input of malformed) {
+        const { nodes, warnings } = fromSlackBlocks(input);
+        expect(nodes).toEqual([]);
+        expect(warnings).toEqual([
+          {
+            code: "dropped",
+            component: "Root",
+            detail: "Input could not be converted.",
+          },
+        ]);
+      }
+    });
+
+    it("accepts a bare blocks array", () => {
+      const { nodes } = fromSlackBlocks([{ type: "divider" }]);
+      expect(nodes).toEqual([{ $type: "Divider" }]);
+    });
+
+    it("accepts a { blocks } wrapper", () => {
+      const { nodes } = fromSlackBlocks({ blocks: [{ type: "divider" }] });
+      expect(nodes).toEqual([{ $type: "Divider" }]);
+    });
+
+    it("never throws for degenerate block entries", () => {
+      const degenerate: unknown[] = [
+        null,
+        undefined,
+        42,
+        "x",
+        true,
+        [],
+        {},
+        () => {},
+      ];
+      expect(() => fromSlackBlocks(degenerate)).not.toThrow();
+      const { nodes, warnings } = fromSlackBlocks(degenerate);
+      expect(nodes).toEqual([]);
+      expect(warnings).toHaveLength(degenerate.length);
+    });
+  });
+
+  describe("bounded arrays", () => {
+    it("clamps a hostile proxied blocks array instead of hanging", () => {
+      const hostileArray = new Proxy([], {
+        get(target, prop) {
+          if (prop === "length") return 2 ** 31;
+          if (typeof prop === "string" && /^\d+$/.test(prop)) {
+            return { type: "divider" };
+          }
+          return Reflect.get(target, prop);
+        },
+        has(target, prop) {
+          if (prop === "length") return true;
+          if (typeof prop === "string" && /^\d+$/.test(prop)) return true;
+          return Reflect.has(target, prop);
+        },
+      });
+      const { nodes, warnings } = fromSlackBlocks(hostileArray);
+      expect(nodes).toHaveLength(INBOUND_BLOCK_CAP);
+      expect(warnings).toContainEqual({
+        code: "clamped",
+        component: "Root",
+        detail: `blocks were clamped to ${INBOUND_BLOCK_CAP} entries.`,
+      });
+    });
+  });
+
+  describe("unknown block types", () => {
+    it("skips an unrecognized block with a dropped warning", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        { type: "totally_made_up" },
+      ]);
+      expect(nodes).toEqual([]);
+      expect(warnings).toEqual([
+        {
+          code: "dropped",
+          component: "totally_made_up",
+          detail: "Unknown block type was dropped.",
+        },
+      ]);
+    });
+  });
+
+  describe("Header", () => {
+    it("inverts a header block", () => {
+      const { nodes } = fromSlackBlocks([
+        { type: "header", text: { type: "plain_text", text: "Title" } },
+      ]);
+      expect(nodes).toEqual([{ $type: "Header", text: "Title" }]);
+    });
+  });
+
+  describe("section", () => {
+    it("inverts section fields into one Fact per field", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "section",
+          fields: [
+            { type: "mrkdwn", text: "*Status*\nActive" },
+            { type: "mrkdwn", text: "*Owner*\nAda" },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        { $type: "Fact", label: "Status", value: "Active" },
+        { $type: "Fact", label: "Owner", value: "Ada" },
+      ]);
+      expect(warnings).toEqual([]);
+    });
+
+    it("falls back to a value-only Fact when a field does not match the label/value format", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "section",
+          fields: [{ type: "mrkdwn", text: "no format here" }],
+        },
+      ]);
+      expect(nodes).toEqual([
+        { $type: "Fact", label: "", value: "no format here" },
+      ]);
+      expect(warnings).toEqual([
+        {
+          code: "fallback",
+          component: "Fact",
+          detail:
+            "A section field that did not match the label/value format was kept as a value-only fact.",
+        },
+      ]);
+    });
+
+    it("inverts a section with mrkdwn text and a button accessory into a ListView of one ListViewItem", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Clickable" },
+          accessory: {
+            type: "button",
+            text: { type: "plain_text", text: "Open" },
+            action_id: "open_row",
+          },
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "ListView",
+          children: [
+            {
+              $type: "ListViewItem",
+              $action: { type: "open_row" },
+              children: { $type: "Text", value: "Clickable" },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("inverts a plain mrkdwn section into Text", () => {
+      const { nodes } = fromSlackBlocks([
+        { type: "section", text: { type: "mrkdwn", text: "Hello" } },
+      ]);
+      expect(nodes).toEqual([{ $type: "Text", value: "Hello" }]);
+    });
+  });
+
+  describe("context", () => {
+    it("inverts a single-element context into a Caption", () => {
+      const { nodes } = fromSlackBlocks([
+        { type: "context", elements: [{ type: "mrkdwn", text: "Fine print" }] },
+      ]);
+      expect(nodes).toEqual([{ $type: "Caption", value: "Fine print" }]);
+    });
+
+    it("inverts a multi-element context into a Row of Captions, collapsing the Badge/Caption distinction", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "context",
+          elements: [
+            { type: "mrkdwn", text: "New" },
+            { type: "mrkdwn", text: "since today" },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Row",
+          children: [
+            { $type: "Caption", value: "New" },
+            { $type: "Caption", value: "since today" },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("Image", () => {
+    it("inverts an image block", () => {
+      const { nodes } = fromSlackBlocks([
+        { type: "image", image_url: "https://x/y.png", alt_text: "A photo" },
+      ]);
+      expect(nodes).toEqual([
+        { $type: "Image", src: "https://x/y.png", alt: "A photo" },
+      ]);
+    });
+  });
+
+  describe("Divider", () => {
+    it("inverts a divider block", () => {
+      const { nodes } = fromSlackBlocks([{ type: "divider" }]);
+      expect(nodes).toEqual([{ $type: "Divider" }]);
+    });
+  });
+
+  describe("actions", () => {
+    it("inverts a button, mapping style to buttonStyle only for primary/danger and deriving $action from the object-only value payload", () => {
+      const { nodes: primary } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Buy" },
+              action_id: "buy",
+              value: JSON.stringify({ sku: "abc" }),
+              style: "primary",
+            },
+          ],
+        },
+      ]);
+      expect(primary).toEqual([
+        {
+          $type: "Button",
+          label: "Buy",
+          buttonStyle: "primary",
+          $action: { type: "buy", sku: "abc" },
+        },
+      ]);
+
+      const { nodes: danger } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Delete" },
+              action_id: "del",
+              style: "danger",
+            },
+          ],
+        },
+      ]);
+      expect((danger[0] as UIElement)["buttonStyle"]).toBe("danger");
+
+      const { nodes: plain } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Go" },
+              action_id: "go",
+            },
+          ],
+        },
+      ]);
+      expect(plain[0]).not.toHaveProperty("buttonStyle");
+      expect(plain[0]).toEqual({
+        $type: "Button",
+        label: "Go",
+        $action: { type: "go" },
+      });
+    });
+
+    it("inverts a static_select", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "static_select",
+              action_id: "pick",
+              options: [
+                { text: { type: "plain_text", text: "Alpha" }, value: "a" },
+                { text: { type: "plain_text", text: "Beta" }, value: "b" },
+              ],
+              placeholder: { type: "plain_text", text: "Pick one" },
+            },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Select",
+          options: [
+            { label: "Alpha", value: "a" },
+            { label: "Beta", value: "b" },
+          ],
+          placeholder: "Pick one",
+          $action: { type: "pick" },
+        },
+      ]);
+    });
+
+    it("inverts a datepicker, reading value from initial_date and omitting it when absent", () => {
+      const { nodes: withDate } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "datepicker",
+              action_id: "pick_date",
+              initial_date: "2026-07-15",
+            },
+          ],
+        },
+      ]);
+      expect(withDate).toEqual([
+        {
+          $type: "DatePicker",
+          value: "2026-07-15",
+          $action: { type: "pick_date" },
+        },
+      ]);
+
+      const { nodes: withoutDate } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [{ type: "datepicker", action_id: "pick_date" }],
+        },
+      ]);
+      expect(withoutDate[0]).not.toHaveProperty("value");
+    });
+
+    it("inverts checkboxes, reading label/name from the first option and defaultChecked from initial_options", () => {
+      const { nodes: checked } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "checkboxes",
+              action_id: "toggle",
+              options: [
+                { text: { type: "plain_text", text: "Agree" }, value: "agree" },
+              ],
+              initial_options: [
+                { text: { type: "plain_text", text: "Agree" }, value: "agree" },
+              ],
+            },
+          ],
+        },
+      ]);
+      expect(checked).toEqual([
+        {
+          $type: "Checkbox",
+          label: "Agree",
+          name: "agree",
+          defaultChecked: true,
+          $action: { type: "toggle" },
+        },
+      ]);
+
+      const { nodes: unchecked } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "checkboxes",
+              action_id: "toggle",
+              options: [
+                { text: { type: "plain_text", text: "Agree" }, value: "agree" },
+              ],
+            },
+          ],
+        },
+      ]);
+      expect(unchecked[0]).not.toHaveProperty("defaultChecked");
+    });
+
+    it("inverts radio_buttons, reading defaultValue from initial_option and omitting it when absent", () => {
+      const { nodes: withValue } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "radio_buttons",
+              action_id: "size",
+              options: [
+                { text: { type: "plain_text", text: "Small" }, value: "s" },
+                { text: { type: "plain_text", text: "Large" }, value: "l" },
+              ],
+              initial_option: {
+                text: { type: "plain_text", text: "Large" },
+                value: "l",
+              },
+            },
+          ],
+        },
+      ]);
+      expect(withValue).toEqual([
+        {
+          $type: "RadioGroup",
+          options: [
+            { label: "Small", value: "s" },
+            { label: "Large", value: "l" },
+          ],
+          defaultValue: "l",
+          $action: { type: "size" },
+        },
+      ]);
+
+      const { nodes: withoutValue } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "radio_buttons",
+              action_id: "size",
+              options: [
+                { text: { type: "plain_text", text: "Small" }, value: "s" },
+              ],
+            },
+          ],
+        },
+      ]);
+      expect(withoutValue[0]).not.toHaveProperty("defaultValue");
+    });
+
+    it("skips an unrecognized action element with a dropped warning, keeping the rest", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "actions",
+          elements: [
+            { type: "mystery_widget" },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Go" },
+              action_id: "go",
+            },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        { $type: "Button", label: "Go", $action: { type: "go" } },
+      ]);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "mystery_widget",
+        detail: "Unknown action element type was dropped.",
+      });
+    });
+  });
+
+  describe("Input", () => {
+    it("inverts an input block, passing multiline and placeholder through", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "input",
+          label: { type: "plain_text", text: "Notes" },
+          element: {
+            type: "plain_text_input",
+            action_id: "notes",
+            multiline: true,
+            placeholder: { type: "plain_text", text: "Type here" },
+          },
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Input",
+          label: "Notes",
+          placeholder: "Type here",
+          multiline: true,
+          $action: { type: "notes" },
+        },
+      ]);
+    });
+
+    it("omits multiline when not set", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "input",
+          label: { type: "plain_text", text: "Name" },
+          element: { type: "plain_text_input", action_id: "name" },
+        },
+      ]);
+      expect(nodes[0]).not.toHaveProperty("multiline");
+    });
+
+    it("drops an input block wrapping an unrecognized element", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "input",
+          label: { type: "plain_text", text: "Name" },
+          element: { type: "mystery" },
+        },
+      ]);
+      expect(nodes).toEqual([]);
+      expect(warnings).toContainEqual({
+        code: "dropped",
+        component: "Input",
+        detail: "Unknown input element type was dropped.",
+      });
+    });
+  });
+
+  describe("Markdown", () => {
+    it("inverts a markdown block", () => {
+      const { nodes } = fromSlackBlocks([
+        { type: "markdown", text: "# Title" },
+      ]);
+      expect(nodes).toEqual([{ $type: "Markdown", value: "# Title" }]);
+    });
+  });
+
+  describe("Card", () => {
+    it("inverts a clean card with hero image, body, subtext, and confirm/cancel actions", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "card",
+          hero_image: {
+            type: "image",
+            image_url: "https://x/y.png",
+            alt_text: "Package",
+          },
+          title: { type: "mrkdwn", text: "Order #42" },
+          body: { type: "mrkdwn", text: "Shipped" },
+          subtext: { type: "mrkdwn", text: "Updated just now" },
+          actions: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Ship" },
+              action_id: "ship",
+              style: "primary",
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Cancel" },
+              action_id: "cancel",
+            },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Card",
+          title: "Order #42",
+          children: [
+            { $type: "Image", src: "https://x/y.png", alt: "Package" },
+            { $type: "Text", value: "Shipped" },
+            { $type: "Caption", value: "Updated just now" },
+          ],
+          confirm: { label: "Ship", $action: { type: "ship" } },
+          cancel: { label: "Cancel", $action: { type: "cancel" } },
+        },
+      ]);
+      expect(warnings).toEqual([]);
+    });
+
+    it("appends card actions beyond confirm/cancel as Button children with a fallback warning", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "card",
+          title: { type: "mrkdwn", text: "Order" },
+          actions: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Yes" },
+              action_id: "yes",
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "No" },
+              action_id: "no",
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Maybe" },
+              action_id: "maybe",
+            },
+          ],
+        },
+      ]);
+      const card = nodes[0] as UIElement;
+      expect(card["children"]).toEqual([
+        { $type: "Button", label: "Maybe", $action: { type: "maybe" } },
+      ]);
+      expect(warnings).toContainEqual({
+        code: "fallback",
+        component: "Card",
+        detail:
+          "Card actions beyond confirm and cancel were appended as Button children.",
+      });
+    });
+
+    it("reconstructs a single non-primary button as cancel, not confirm", () => {
+      const { nodes, warnings } = fromSlackBlocks([
+        {
+          type: "card",
+          title: { type: "mrkdwn", text: "Order" },
+          actions: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Dismiss" },
+              action_id: "dismiss",
+            },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Card",
+          title: "Order",
+          cancel: { label: "Dismiss", $action: { type: "dismiss" } },
+        },
+      ]);
+      expect(nodes[0]).not.toHaveProperty("confirm");
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("Alert", () => {
+    it("maps alert level to tone, mapping error to danger and omitting tone for the default level", () => {
+      const cases: readonly [string, string | undefined][] = [
+        ["error", "danger"],
+        ["success", "success"],
+        ["warning", "warning"],
+        ["info", "info"],
+        ["default", undefined],
+      ];
+      for (const [level, tone] of cases) {
+        const { nodes } = fromSlackBlocks([
+          { type: "alert", text: { type: "mrkdwn", text: "x" }, level },
+        ]);
+        expect(nodes).toEqual([
+          {
+            $type: "Alert",
+            description: "x",
+            ...(tone !== undefined ? { tone } : {}),
+          },
+        ]);
+      }
+    });
+
+    it("keeps a joined title and description together in description, since the two cannot be separated", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "alert",
+          text: { type: "mrkdwn", text: "Heads up\nSomething happened." },
+          level: "info",
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Alert",
+          description: "Heads up\nSomething happened.",
+          tone: "info",
+        },
+      ]);
+    });
+  });
+
+  describe("Carousel", () => {
+    it("inverts a carousel's card elements", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "carousel",
+          elements: [
+            { type: "card", title: { type: "mrkdwn", text: "One" } },
+            { type: "card", title: { type: "mrkdwn", text: "Two" } },
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Carousel",
+          children: [
+            { $type: "Card", title: "One" },
+            { $type: "Card", title: "Two" },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("Table", () => {
+    it("inverts columns and typed rows", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "data_table",
+          caption: "Table",
+          rows: [
+            [
+              { type: "raw_text", text: "Name" },
+              { type: "raw_text", text: "Age" },
+            ],
+            [
+              { type: "raw_text", text: "Ada" },
+              { type: "raw_number", text: "36" },
+            ],
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        {
+          $type: "Table",
+          columns: [{ label: "Name" }, { label: "Age" }],
+          rows: [["Ada", 36]],
+        },
+      ]);
+    });
+
+    it("omits columns when every header cell is empty, inverting the rows-only synthesis", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "data_table",
+          caption: "Table",
+          rows: [
+            [
+              { type: "raw_text", text: "" },
+              { type: "raw_text", text: "" },
+            ],
+            [
+              { type: "raw_text", text: "Ada" },
+              { type: "raw_number", text: "36" },
+            ],
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([{ $type: "Table", rows: [["Ada", 36]] }]);
+    });
+
+    it("keeps a raw_number cell as its raw string when the text is not a finite number", () => {
+      const { nodes } = fromSlackBlocks([
+        {
+          type: "data_table",
+          caption: "Table",
+          rows: [
+            [{ type: "raw_text", text: "Name" }],
+            [{ type: "raw_number", text: "N/A" }],
+          ],
+        },
+      ]);
+      expect(nodes).toEqual([
+        { $type: "Table", columns: [{ label: "Name" }], rows: [["N/A"]] },
+      ]);
+    });
+  });
+
+  describe("round trip", () => {
+    const fixtures: readonly {
+      readonly name: string;
+      readonly tree: unknown;
+      readonly options?: ToSlackBlocksOptions;
+      readonly expected: readonly UIElement[];
+    }[] = [
+      {
+        name: "Header",
+        tree: { $type: "Header", text: "Title" },
+        expected: [{ $type: "Header", text: "Title" }],
+      },
+      {
+        name: "Text",
+        tree: { $type: "Text", value: "Hello" },
+        expected: [{ $type: "Text", value: "Hello" }],
+      },
+      {
+        name: "Caption",
+        tree: { $type: "Caption", value: "Fine print" },
+        expected: [{ $type: "Caption", value: "Fine print" }],
+      },
+      {
+        name: "Image",
+        tree: { $type: "Image", src: "https://x/y.png", alt: "A photo" },
+        expected: [{ $type: "Image", src: "https://x/y.png", alt: "A photo" }],
+      },
+      {
+        name: "Divider",
+        tree: { $type: "Divider" },
+        expected: [{ $type: "Divider" }],
+      },
+      {
+        name: "Markdown",
+        tree: { $type: "Markdown", value: "# Title" },
+        expected: [{ $type: "Markdown", value: "# Title" }],
+      },
+      {
+        name: "Button with payload",
+        tree: {
+          $type: "Button",
+          label: "Buy",
+          buttonStyle: "primary",
+          $action: { type: "buy", sku: "abc" },
+        },
+        expected: [
+          {
+            $type: "Button",
+            label: "Buy",
+            buttonStyle: "primary",
+            $action: { type: "buy", sku: "abc" },
+          },
+        ],
+      },
+      {
+        name: "Select",
+        tree: {
+          $type: "Select",
+          options: [
+            { label: "Alpha", value: "a" },
+            { label: "Beta", value: "b" },
+          ],
+          placeholder: "Pick one",
+          $action: { type: "pick" },
+        },
+        expected: [
+          {
+            $type: "Select",
+            options: [
+              { label: "Alpha", value: "a" },
+              { label: "Beta", value: "b" },
+            ],
+            placeholder: "Pick one",
+            $action: { type: "pick" },
+          },
+        ],
+      },
+      {
+        name: "DatePicker with initial date",
+        tree: {
+          $type: "DatePicker",
+          value: "2026-07-15",
+          $action: { type: "pick_date" },
+        },
+        expected: [
+          {
+            $type: "DatePicker",
+            value: "2026-07-15",
+            $action: { type: "pick_date" },
+          },
+        ],
+      },
+      {
+        name: "Checkbox with defaultChecked",
+        tree: {
+          $type: "Checkbox",
+          label: "Agree",
+          name: "agree",
+          defaultChecked: true,
+          $action: { type: "toggle" },
+        },
+        expected: [
+          {
+            $type: "Checkbox",
+            label: "Agree",
+            name: "agree",
+            defaultChecked: true,
+            $action: { type: "toggle" },
+          },
+        ],
+      },
+      {
+        name: "RadioGroup with defaultValue",
+        tree: {
+          $type: "RadioGroup",
+          options: [
+            { label: "Small", value: "s" },
+            { label: "Large", value: "l" },
+          ],
+          defaultValue: "l",
+          $action: { type: "size" },
+        },
+        expected: [
+          {
+            $type: "RadioGroup",
+            options: [
+              { label: "Small", value: "s" },
+              { label: "Large", value: "l" },
+            ],
+            defaultValue: "l",
+            $action: { type: "size" },
+          },
+        ],
+      },
+      {
+        name: "Input",
+        tree: {
+          $type: "Input",
+          label: "Notes",
+          placeholder: "Type here",
+          multiline: true,
+          $action: { type: "notes" },
+        },
+        expected: [
+          {
+            $type: "Input",
+            label: "Notes",
+            placeholder: "Type here",
+            multiline: true,
+            $action: { type: "notes" },
+          },
+        ],
+      },
+      {
+        name: "Fact pair",
+        tree: [
+          { $type: "Fact", label: "Status", value: "Active" },
+          { $type: "Fact", label: "Owner", value: "Ada" },
+        ],
+        expected: [
+          { $type: "Fact", label: "Status", value: "Active" },
+          { $type: "Fact", label: "Owner", value: "Ada" },
+        ],
+      },
+      {
+        name: "simple Card with title and body text",
+        tree: {
+          $type: "Card",
+          title: "Order #42",
+          children: [{ $type: "Text", value: "Shipped" }],
+        },
+        expected: [
+          {
+            $type: "Card",
+            title: "Order #42",
+            children: [{ $type: "Text", value: "Shipped" }],
+          },
+        ],
+      },
+      {
+        name: "Alert (modal surface, where the native alert block round-trips; the message-surface fallback is not invertible into an Alert)",
+        tree: {
+          $type: "Alert",
+          description: "Something happened.",
+          tone: "danger",
+        },
+        options: { surface: "modal" },
+        expected: [
+          {
+            $type: "Alert",
+            description: "Something happened.",
+            tone: "danger",
+          },
+        ],
+      },
+      {
+        name: "Carousel of two simple Cards",
+        tree: {
+          $type: "Carousel",
+          children: [
+            {
+              $type: "Card",
+              title: "One",
+              children: [{ $type: "Text", value: "First" }],
+            },
+            {
+              $type: "Card",
+              title: "Two",
+              children: [{ $type: "Text", value: "Second" }],
+            },
+          ],
+        },
+        expected: [
+          {
+            $type: "Carousel",
+            children: [
+              {
+                $type: "Card",
+                title: "One",
+                children: [{ $type: "Text", value: "First" }],
+              },
+              {
+                $type: "Card",
+                title: "Two",
+                children: [{ $type: "Text", value: "Second" }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "ListView of two actionable items",
+        tree: {
+          $type: "ListView",
+          children: [
+            {
+              $type: "ListViewItem",
+              $action: { type: "open_one" },
+              children: { $type: "Text", value: "Row one" },
+            },
+            {
+              $type: "ListViewItem",
+              $action: { type: "open_two" },
+              children: { $type: "Text", value: "Row two" },
+            },
+          ],
+        },
+        expected: [
+          {
+            $type: "ListView",
+            children: [
+              {
+                $type: "ListViewItem",
+                $action: { type: "open_one" },
+                children: { $type: "Text", value: "Row one" },
+              },
+              {
+                $type: "ListViewItem",
+                $action: { type: "open_two" },
+                children: { $type: "Text", value: "Row two" },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "Table with columns and mixed string/number rows",
+        tree: {
+          $type: "Table",
+          columns: [{ label: "Name" }, { label: "Age" }],
+          rows: [
+            ["Ada", 36],
+            ["Bob", 24],
+          ],
+        },
+        expected: [
+          {
+            $type: "Table",
+            columns: [{ label: "Name" }, { label: "Age" }],
+            rows: [
+              ["Ada", 36],
+              ["Bob", 24],
+            ],
+          },
+        ],
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      it(`round-trips ${fixture.name}`, () => {
+        const { blocks } = toSlackBlocks(fixture.tree, fixture.options);
+        const { nodes } = fromSlackBlocks(blocks);
+        expect(nodes).toEqual(fixture.expected);
+      });
+    }
+  });
+});

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
@@ -1061,3 +1061,59 @@ describe("fromSlackBlocks", () => {
     }
   });
 });
+
+describe("fromSlackBlocks checkbox and radio caps", () => {
+  it("marks defaultChecked only when the first option is initially selected", () => {
+    const base = {
+      type: "actions",
+      elements: [
+        {
+          type: "checkboxes",
+          action_id: "toggle",
+          options: [
+            { text: { type: "plain_text", text: "First" }, value: "first" },
+            { text: { type: "plain_text", text: "Second" }, value: "second" },
+          ],
+          initial_options: [
+            { text: { type: "plain_text", text: "Second" }, value: "second" },
+          ],
+        },
+      ],
+    };
+    const { nodes } = fromSlackBlocks([base]);
+    expect(nodes[0]).not.toHaveProperty("defaultChecked");
+
+    const checkedFirst = structuredClone(base);
+    checkedFirst.elements[0]!.initial_options = [
+      { text: { type: "plain_text", text: "First" }, value: "first" },
+    ];
+    const checked = fromSlackBlocks([checkedFirst]);
+    expect(checked.nodes[0]).toMatchObject({ defaultChecked: true });
+  });
+
+  it("clamps inbound radio options to the radio cap", () => {
+    const { nodes, warnings } = fromSlackBlocks([
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "radio_buttons",
+            action_id: "pick",
+            options: Array.from({ length: 30 }, (_, i) => ({
+              text: { type: "plain_text", text: `O${i}` },
+              value: `v${i}`,
+            })),
+          },
+        ],
+      },
+    ]);
+    const radio = nodes[0] as { options: unknown[] };
+    expect(radio.options).toHaveLength(10);
+    expect(
+      warnings.some(
+        (warning) =>
+          warning.component === "RadioGroup" && warning.code === "clamped",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.test.ts
@@ -1117,3 +1117,29 @@ describe("fromSlackBlocks checkbox and radio caps", () => {
     ).toBe(true);
   });
 });
+
+it("bounds hostile initial_options arrays when deriving defaultChecked", () => {
+  const hostile = new Proxy([], {
+    get(target, prop) {
+      if (prop === "length") return 2 ** 31;
+      if (prop === "slice") return Array.prototype.slice.bind(target);
+      return Reflect.get(target, prop);
+    },
+  });
+  const { nodes } = fromSlackBlocks([
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "checkboxes",
+          action_id: "toggle",
+          options: [
+            { text: { type: "plain_text", text: "First" }, value: "first" },
+          ],
+          initial_options: hostile,
+        },
+      ],
+    },
+  ]);
+  expect(nodes[0]).not.toHaveProperty("defaultChecked");
+});

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
@@ -8,6 +8,7 @@ import {
   DATA_TABLE_ROW_CAP,
   FACT_FIELD_CAP,
   INBOUND_BLOCK_CAP,
+  RADIO_OPTION_CAP,
   SELECT_OPTION_CAP,
 } from "./constants";
 import type { FromSlackBlocksResult, SlackConversionWarning } from "./types";
@@ -235,14 +236,16 @@ const checkboxFrom = (element: Record<string, unknown>): UIElement => {
   const initialOptions = Array.isArray(element["initial_options"])
     ? element["initial_options"]
     : [];
+  const firstValue =
+    isRecord(first) && typeof first["value"] === "string" ? first["value"] : "";
+  const firstChecked = initialOptions.some(
+    (option) => isRecord(option) && option["value"] === firstValue,
+  );
   return {
     $type: "Checkbox",
     label: isRecord(first) ? textOf(first["text"]) : "",
-    name:
-      isRecord(first) && typeof first["value"] === "string"
-        ? first["value"]
-        : "",
-    ...(initialOptions.length > 0 ? { defaultChecked: true } : {}),
+    name: firstValue,
+    ...(firstChecked ? { defaultChecked: true } : {}),
     $action: decodeAction(element["action_id"], element["value"]),
   };
 };
@@ -253,10 +256,10 @@ const radioGroupFrom = (
 ): UIElement => {
   const options = boundedArray(
     element["options"],
-    SELECT_OPTION_CAP,
+    RADIO_OPTION_CAP,
     warnings,
     "RadioGroup",
-    `options were clamped to ${SELECT_OPTION_CAP} entries.`,
+    `options were clamped to ${RADIO_OPTION_CAP} entries.`,
   );
   const initialOption = element["initial_option"];
   const initialValue =

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
@@ -1,0 +1,706 @@
+import type { Action, UIElement } from "../ir";
+import {
+  ACTIONS_ELEMENT_CAP,
+  CARD_ACTIONS_CAP,
+  CAROUSEL_CARD_CAP,
+  CONTEXT_ELEMENT_CAP,
+  DATA_TABLE_COLUMN_CAP,
+  DATA_TABLE_ROW_CAP,
+  FACT_FIELD_CAP,
+  INBOUND_BLOCK_CAP,
+  SELECT_OPTION_CAP,
+} from "./constants";
+import type { FromSlackBlocksResult, SlackConversionWarning } from "./types";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isDefined = <T>(value: T | undefined): value is T => value !== undefined;
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+const textOf = (value: unknown): string =>
+  isRecord(value) && typeof value["text"] === "string" ? value["text"] : "";
+
+const warn = (
+  warnings: SlackConversionWarning[],
+  code: SlackConversionWarning["code"],
+  component: string,
+  detail: string,
+) => {
+  warnings.push({ code, component, detail });
+};
+
+/**
+ * The shared bounded-iteration primitive: slices `value` to `cap` entries
+ * without ever reading past that many indices, so a hostile array (sparse or
+ * proxied with a fabricated `length`) cannot stall the event loop. `slice`
+ * itself performs the bounded read; only its own reported length is
+ * inspected to detect truncation.
+ */
+const clampArray = (
+  value: unknown,
+  cap: number,
+): { readonly items: unknown[]; readonly truncated: boolean } => {
+  if (!Array.isArray(value)) return { items: [], truncated: false };
+  return { items: value.slice(0, cap), truncated: value.length > cap };
+};
+
+const boundedArray = (
+  value: unknown,
+  cap: number,
+  warnings: SlackConversionWarning[],
+  component: string,
+  detail: string,
+): unknown[] => {
+  const { items, truncated } = clampArray(value, cap);
+  if (truncated) warn(warnings, "clamped", component, detail);
+  return items;
+};
+
+const parseValuePayload = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "string") return {};
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
+const decodeAction = (actionId: unknown, value: unknown): Action => ({
+  ...parseValuePayload(value),
+  type: typeof actionId === "string" ? actionId : "action",
+});
+
+const headerFrom = (block: Record<string, unknown>): UIElement => ({
+  $type: "Header",
+  text: textOf(block["text"]),
+});
+
+const imageFrom = (block: Record<string, unknown>): UIElement => ({
+  $type: "Image",
+  src: asString(block["image_url"]),
+  alt: asString(block["alt_text"]),
+});
+
+const markdownFrom = (block: Record<string, unknown>): UIElement => ({
+  $type: "Markdown",
+  value: asString(block["text"]),
+});
+
+const FACT_FIELD_PATTERN = /^\*([\s\S]*?)\*\n([\s\S]*)$/;
+
+const factFrom = (
+  field: unknown,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const text = textOf(field);
+  const match = FACT_FIELD_PATTERN.exec(text);
+  if (match) {
+    const [, label, value] = match;
+    return { $type: "Fact", label, value };
+  }
+  warn(
+    warnings,
+    "fallback",
+    "Fact",
+    "A section field that did not match the label/value format was kept as a value-only fact.",
+  );
+  return { $type: "Fact", label: "", value: text };
+};
+
+const listViewItemFrom = (
+  text: string,
+  button: Record<string, unknown>,
+): UIElement => ({
+  $type: "ListViewItem",
+  $action: decodeAction(button["action_id"], button["value"]),
+  children: { $type: "Text", value: text },
+});
+
+/**
+ * Recognizes a section block that stands for a `ListViewItem`: mrkdwn text
+ * paired with a button accessory, and no `fields` (a fields section is
+ * always a Facts section, never a list row).
+ */
+const listViewItemFromSection = (block: unknown): UIElement | undefined => {
+  if (!isRecord(block) || block["type"] !== "section") return undefined;
+  if (Array.isArray(block["fields"])) return undefined;
+  const accessory = block["accessory"];
+  if (!isRecord(accessory) || accessory["type"] !== "button") {
+    return undefined;
+  }
+  return listViewItemFrom(textOf(block["text"]), accessory);
+};
+
+const isDividerBlock = (block: unknown): boolean =>
+  isRecord(block) && block["type"] === "divider";
+
+const sectionFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement[] => {
+  const fields = block["fields"];
+  if (Array.isArray(fields)) {
+    return boundedArray(
+      fields,
+      FACT_FIELD_CAP,
+      warnings,
+      "Fact",
+      `fields were clamped to ${FACT_FIELD_CAP} entries.`,
+    ).map((field) => factFrom(field, warnings));
+  }
+  return [{ $type: "Text", value: textOf(block["text"]) }];
+};
+
+const captionFrom = (element: unknown): UIElement => ({
+  $type: "Caption",
+  value: textOf(element),
+});
+
+const contextFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const elements = boundedArray(
+    block["elements"],
+    CONTEXT_ELEMENT_CAP,
+    warnings,
+    "Row",
+    `elements were clamped to ${CONTEXT_ELEMENT_CAP} entries.`,
+  );
+  if (elements.length > 1) {
+    return { $type: "Row", children: elements.map(captionFrom) };
+  }
+  return {
+    $type: "Caption",
+    value: elements.length === 1 ? textOf(elements[0]) : "",
+  };
+};
+
+const optionFrom = (
+  option: unknown,
+): { label: string; value: string } | undefined => {
+  if (!isRecord(option) || typeof option["value"] !== "string") {
+    return undefined;
+  }
+  return { label: textOf(option["text"]), value: option["value"] };
+};
+
+const buttonFrom = (element: Record<string, unknown>): UIElement => {
+  const style = element["style"];
+  return {
+    $type: "Button",
+    label: textOf(element["text"]),
+    ...(style === "primary" || style === "danger"
+      ? { buttonStyle: style }
+      : {}),
+    $action: decodeAction(element["action_id"], element["value"]),
+  };
+};
+
+const selectFrom = (
+  element: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const options = boundedArray(
+    element["options"],
+    SELECT_OPTION_CAP,
+    warnings,
+    "Select",
+    `options were clamped to ${SELECT_OPTION_CAP} entries.`,
+  );
+  const placeholder = element["placeholder"];
+  return {
+    $type: "Select",
+    options: options.map(optionFrom).filter(isDefined),
+    ...(isRecord(placeholder) ? { placeholder: textOf(placeholder) } : {}),
+    $action: decodeAction(element["action_id"], element["value"]),
+  };
+};
+
+const datePickerFrom = (element: Record<string, unknown>): UIElement => ({
+  $type: "DatePicker",
+  ...(typeof element["initial_date"] === "string"
+    ? { value: element["initial_date"] }
+    : {}),
+  $action: decodeAction(element["action_id"], element["value"]),
+});
+
+const checkboxFrom = (element: Record<string, unknown>): UIElement => {
+  const options = Array.isArray(element["options"]) ? element["options"] : [];
+  const first = options[0];
+  const initialOptions = Array.isArray(element["initial_options"])
+    ? element["initial_options"]
+    : [];
+  return {
+    $type: "Checkbox",
+    label: isRecord(first) ? textOf(first["text"]) : "",
+    name:
+      isRecord(first) && typeof first["value"] === "string"
+        ? first["value"]
+        : "",
+    ...(initialOptions.length > 0 ? { defaultChecked: true } : {}),
+    $action: decodeAction(element["action_id"], element["value"]),
+  };
+};
+
+const radioGroupFrom = (
+  element: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const options = boundedArray(
+    element["options"],
+    SELECT_OPTION_CAP,
+    warnings,
+    "RadioGroup",
+    `options were clamped to ${SELECT_OPTION_CAP} entries.`,
+  );
+  const initialOption = element["initial_option"];
+  const initialValue =
+    isRecord(initialOption) && typeof initialOption["value"] === "string"
+      ? initialOption["value"]
+      : undefined;
+  return {
+    $type: "RadioGroup",
+    options: options.map(optionFrom).filter(isDefined),
+    ...(initialValue !== undefined ? { defaultValue: initialValue } : {}),
+    $action: decodeAction(element["action_id"], element["value"]),
+  };
+};
+
+const actionElementFrom = (
+  element: unknown,
+  warnings: SlackConversionWarning[],
+): UIElement | undefined => {
+  if (isRecord(element)) {
+    switch (element["type"]) {
+      case "button":
+        return buttonFrom(element);
+      case "static_select":
+        return selectFrom(element, warnings);
+      case "datepicker":
+        return datePickerFrom(element);
+      case "checkboxes":
+        return checkboxFrom(element);
+      case "radio_buttons":
+        return radioGroupFrom(element, warnings);
+    }
+  }
+  warn(
+    warnings,
+    "dropped",
+    isRecord(element) && typeof element["type"] === "string"
+      ? element["type"]
+      : "unknown",
+    "Unknown action element type was dropped.",
+  );
+  return undefined;
+};
+
+const actionsFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement[] => {
+  const elements = boundedArray(
+    block["elements"],
+    ACTIONS_ELEMENT_CAP,
+    warnings,
+    "Actions",
+    `elements were clamped to ${ACTIONS_ELEMENT_CAP} entries.`,
+  );
+  return elements
+    .map((element) => actionElementFrom(element, warnings))
+    .filter(isDefined);
+};
+
+const inputFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement[] => {
+  const element = block["element"];
+  if (!isRecord(element) || element["type"] !== "plain_text_input") {
+    warn(
+      warnings,
+      "dropped",
+      "Input",
+      "Unknown input element type was dropped.",
+    );
+    return [];
+  }
+  const placeholder = element["placeholder"];
+  return [
+    {
+      $type: "Input",
+      label: textOf(block["label"]),
+      ...(isRecord(placeholder) ? { placeholder: textOf(placeholder) } : {}),
+      ...(element["multiline"] === true ? { multiline: true } : {}),
+      $action: decodeAction(element["action_id"], undefined),
+    },
+  ];
+};
+
+type CardFooterButton = { readonly label: string; readonly $action: Action };
+
+const cardFooterButtonFrom = (button: unknown): CardFooterButton | undefined =>
+  isRecord(button)
+    ? {
+        label: textOf(button["text"]),
+        $action: decodeAction(button["action_id"], button["value"]),
+      }
+    : undefined;
+
+/**
+ * Assigns a card's footer actions by style rather than position: the
+ * primary-styled button is the confirm action and a non-primary button is
+ * cancel, since that is the pairing {@link toSlackBlocks} itself emits.
+ * Position is only a fallback for input that does not carry that pairing
+ * (zero or multiple primary-styled buttons among two or more actions).
+ */
+const assignCardFooterActions = (
+  actions: unknown[],
+  warnings: SlackConversionWarning[],
+): {
+  readonly confirm: CardFooterButton | undefined;
+  readonly cancel: CardFooterButton | undefined;
+  readonly leftover: unknown[];
+} => {
+  const isPrimaryButton = (action: unknown): boolean =>
+    isRecord(action) && action["style"] === "primary";
+  const primaryButtons = actions.filter(isPrimaryButton);
+
+  let confirmSource: unknown = undefined;
+  let cancelSource: unknown = undefined;
+  let leftover: unknown[] = [];
+
+  if (primaryButtons.length === 1) {
+    const [confirmButton] = primaryButtons;
+    const [cancelButton, ...rest] = actions.filter(
+      (action) => !isPrimaryButton(action),
+    );
+    confirmSource = confirmButton;
+    cancelSource = cancelButton;
+    leftover = rest;
+  } else if (primaryButtons.length === 0 && actions.length <= 1) {
+    const [onlyButton] = actions;
+    cancelSource = onlyButton;
+  } else if (actions.length > 0) {
+    const [first, second, ...rest] = actions;
+    confirmSource = first;
+    cancelSource = second;
+    leftover = rest;
+    warn(
+      warnings,
+      "fallback",
+      "Card",
+      "Confirm and cancel buttons could not be assigned by style and fell back to position.",
+    );
+  }
+
+  return {
+    confirm: cardFooterButtonFrom(confirmSource),
+    cancel: cardFooterButtonFrom(cancelSource),
+    leftover,
+  };
+};
+
+const cardFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const titleText = textOf(block["title"]);
+  const children: UIElement[] = [];
+  const heroImage = block["hero_image"];
+  if (isRecord(heroImage)) {
+    children.push({
+      $type: "Image",
+      src: asString(heroImage["image_url"]),
+      alt: asString(heroImage["alt_text"]),
+    });
+  }
+  const body = block["body"];
+  if (isRecord(body)) {
+    children.push({ $type: "Text", value: textOf(body) });
+  }
+  const subtext = block["subtext"];
+  if (isRecord(subtext)) {
+    children.push({ $type: "Caption", value: textOf(subtext) });
+  }
+  const actions = boundedArray(
+    block["actions"],
+    CARD_ACTIONS_CAP,
+    warnings,
+    "Card",
+    `actions were clamped to ${CARD_ACTIONS_CAP} entries.`,
+  );
+  const { confirm, cancel, leftover } = assignCardFooterActions(
+    actions,
+    warnings,
+  );
+  if (leftover.length > 0) {
+    for (const extra of leftover) {
+      if (isRecord(extra)) children.push(buttonFrom(extra));
+    }
+    warn(
+      warnings,
+      "fallback",
+      "Card",
+      "Card actions beyond confirm and cancel were appended as Button children.",
+    );
+  }
+  return {
+    $type: "Card",
+    ...(titleText ? { title: titleText } : {}),
+    ...(children.length > 0 ? { children } : {}),
+    ...(confirm !== undefined ? { confirm } : {}),
+    ...(cancel !== undefined ? { cancel } : {}),
+  };
+};
+
+const carouselFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const elements = boundedArray(
+    block["elements"],
+    CAROUSEL_CARD_CAP,
+    warnings,
+    "Carousel",
+    `cards were clamped to ${CAROUSEL_CARD_CAP} entries.`,
+  );
+  const cards = elements
+    .filter(isRecord)
+    .map((card) => cardFrom(card, warnings));
+  return { $type: "Carousel", children: cards };
+};
+
+const ALERT_LEVEL_TONES: Record<string, string> = {
+  error: "danger",
+  success: "success",
+  warning: "warning",
+  info: "info",
+};
+
+const alertFrom = (block: Record<string, unknown>): UIElement => {
+  const level = block["level"];
+  const tone = typeof level === "string" ? ALERT_LEVEL_TONES[level] : undefined;
+  return {
+    $type: "Alert",
+    description: textOf(block["text"]),
+    ...(tone !== undefined ? { tone } : {}),
+  };
+};
+
+const dataTableCellValue = (cell: unknown): string | number => {
+  if (!isRecord(cell)) return "";
+  const text = asString(cell["text"]);
+  if (cell["type"] === "raw_number") {
+    const parsed = Number(text);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return text;
+};
+
+const dataTableFrom = (
+  block: Record<string, unknown>,
+  warnings: SlackConversionWarning[],
+): UIElement => {
+  const { items: rows, truncated: rowsTruncated } = clampArray(
+    block["rows"],
+    DATA_TABLE_ROW_CAP + 1,
+  );
+  if (rowsTruncated) {
+    warn(
+      warnings,
+      "clamped",
+      "Table",
+      `rows were clamped to ${DATA_TABLE_ROW_CAP} entries.`,
+    );
+  }
+  const [headerRow, ...dataRows] = rows;
+  const { items: headerCells, truncated: headerTruncated } = clampArray(
+    headerRow,
+    DATA_TABLE_COLUMN_CAP,
+  );
+  let columnsTruncated = headerTruncated;
+  const normalizedRows = dataRows.map((row) => {
+    const { items: cells, truncated } = clampArray(row, DATA_TABLE_COLUMN_CAP);
+    if (truncated) columnsTruncated = true;
+    return cells;
+  });
+  if (columnsTruncated) {
+    warn(
+      warnings,
+      "clamped",
+      "Table",
+      `columns were clamped to ${DATA_TABLE_COLUMN_CAP} entries.`,
+    );
+  }
+  const headerAllEmpty = headerCells.every(
+    (cell) => !isRecord(cell) || asString(cell["text"]) === "",
+  );
+  const columns = headerCells.map((cell) => ({
+    label: isRecord(cell) ? asString(cell["text"]) : "",
+  }));
+  return {
+    $type: "Table",
+    ...(headerAllEmpty ? {} : { columns }),
+    rows: normalizedRows.map((row) => row.map(dataTableCellValue)),
+  };
+};
+
+function convertBlock(
+  block: unknown,
+  warnings: SlackConversionWarning[],
+): UIElement[] {
+  if (isRecord(block)) {
+    switch (block["type"]) {
+      case "header":
+        return [headerFrom(block)];
+      case "section":
+        return sectionFrom(block, warnings);
+      case "context":
+        return [contextFrom(block, warnings)];
+      case "image":
+        return [imageFrom(block)];
+      case "divider":
+        return [{ $type: "Divider" }];
+      case "actions":
+        return actionsFrom(block, warnings);
+      case "input":
+        return inputFrom(block, warnings);
+      case "markdown":
+        return [markdownFrom(block)];
+      case "card":
+        return [cardFrom(block, warnings)];
+      case "carousel":
+        return [carouselFrom(block, warnings)];
+      case "alert":
+        return [alertFrom(block)];
+      case "data_table":
+        return [dataTableFrom(block, warnings)];
+    }
+  }
+  warn(
+    warnings,
+    "dropped",
+    isRecord(block) && typeof block["type"] === "string"
+      ? block["type"]
+      : "unknown",
+    "Unknown block type was dropped.",
+  );
+  return [];
+}
+
+const extractBlockList = (input: unknown): unknown[] | undefined => {
+  if (Array.isArray(input)) return input;
+  if (isRecord(input) && Array.isArray(input["blocks"])) return input["blocks"];
+  return undefined;
+};
+
+/**
+ * Walks the (already bounded) block list, folding a run of one or more
+ * consecutive `ListViewItem`-shaped section blocks, optionally separated by
+ * single divider blocks, into one `ListView` container instead of emitting
+ * root-level `ListViewItem` nodes or the interleaved dividers. A divider that
+ * is not directly between two such items is left for {@link convertBlock} to
+ * decode as a literal `Divider`.
+ */
+function convertBlockList(
+  blocks: unknown[],
+  warnings: SlackConversionWarning[],
+): UIElement[] {
+  const nodes: UIElement[] = [];
+  let index = 0;
+  while (index < blocks.length) {
+    const firstItem = listViewItemFromSection(blocks[index]);
+    if (firstItem === undefined) {
+      nodes.push(...convertBlock(blocks[index], warnings));
+      index += 1;
+      continue;
+    }
+    const items: UIElement[] = [firstItem];
+    let cursor = index + 1;
+    while (true) {
+      if (isDividerBlock(blocks[cursor])) {
+        const candidate = listViewItemFromSection(blocks[cursor + 1]);
+        if (candidate === undefined) break;
+        items.push(candidate);
+        cursor += 2;
+        continue;
+      }
+      const candidate = listViewItemFromSection(blocks[cursor]);
+      if (candidate === undefined) break;
+      items.push(candidate);
+      cursor += 1;
+    }
+    nodes.push({ $type: "ListView", children: items });
+    index = cursor;
+  }
+  return nodes;
+}
+
+/**
+ * Converts Slack Block Kit JSON back into a generative-ui IR tree, inverting
+ * {@link toSlackBlocks}. Accepts a blocks array or a `{ blocks }` wrapper;
+ * malformed input resolves to an empty node list plus a warning, and an
+ * unrecognized block or action element is skipped with a "dropped" warning.
+ * Every array read along the way (blocks, fields, options, elements, cards,
+ * rows, cells) is bounded to its site's cap before it is mapped over, so a
+ * hostile array (sparse or proxied with a fabricated `length`) is clamped
+ * with a "clamped" warning instead of stalling the event loop. Never throws.
+ *
+ * The Slack shape is lossier than the IR, so some information cannot be
+ * recovered: a context block's elements always decode as `Caption` (the
+ * original `Badge` vs `Caption` distinction does not survive the round trip),
+ * a button's `buttonStyle` is only recovered for the `primary`/`danger` Slack
+ * styles, a native alert block's `title` and `description` merge into a
+ * single `description` string, and a card's layout collapses to its `title`,
+ * a flat `children` list (image, then text, then caption, in that order),
+ * and `confirm`/`cancel` footer buttons. A section field's label and value
+ * are split on the first `*`+newline delimiter, so a label or value that
+ * itself contains that exact delimiter cannot be split back unambiguously.
+ * A data-table cell that Slack carries as `raw_text` always decodes as a
+ * string, even when its text is the stringified form of a boolean, since the
+ * Slack shape does not distinguish a boolean from ordinary text.
+ */
+export function fromSlackBlocks(blocks: unknown): FromSlackBlocksResult {
+  const warnings: SlackConversionWarning[] = [];
+  try {
+    const list = extractBlockList(blocks);
+    if (list === undefined) {
+      return {
+        nodes: [],
+        warnings: [
+          {
+            code: "dropped",
+            component: "Root",
+            detail: "Input could not be converted.",
+          },
+        ],
+      };
+    }
+    const boundedList = boundedArray(
+      list,
+      INBOUND_BLOCK_CAP,
+      warnings,
+      "Root",
+      `blocks were clamped to ${INBOUND_BLOCK_CAP} entries.`,
+    );
+    const nodes = convertBlockList(boundedList, warnings);
+    return { nodes, warnings };
+  } catch {
+    return {
+      nodes: [],
+      warnings: [
+        {
+          code: "dropped",
+          component: "Root",
+          detail: "Input could not be converted.",
+        },
+      ],
+    };
+  }
+}

--- a/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/fromSlackBlocks.ts
@@ -238,9 +238,9 @@ const checkboxFrom = (element: Record<string, unknown>): UIElement => {
     : [];
   const firstValue =
     isRecord(first) && typeof first["value"] === "string" ? first["value"] : "";
-  const firstChecked = initialOptions.some(
-    (option) => isRecord(option) && option["value"] === firstValue,
-  );
+  const firstChecked = initialOptions
+    .slice(0, SELECT_OPTION_CAP)
+    .some((option) => isRecord(option) && option["value"] === firstValue);
   return {
     $type: "Checkbox",
     label: isRecord(first) ? textOf(first["text"]) : "",

--- a/packages/react-generative-ui/src/slack/toSlackBlocks.ts
+++ b/packages/react-generative-ui/src/slack/toSlackBlocks.ts
@@ -1167,9 +1167,8 @@ export function toSlackBlocks(
   options?: ToSlackBlocksOptions,
 ): SlackBlocksResult {
   const surface = options?.surface === "modal" ? "modal" : "message";
-  const blockCap = surface === "modal" ? MODAL_BLOCK_CAP : MESSAGE_BLOCK_CAP;
   const context: ConversionContext = {
-    blockCap,
+    blockCap: surface === "modal" ? MODAL_BLOCK_CAP : MESSAGE_BLOCK_CAP,
     surface,
     warnings: [],
     markdownCharacters: 0,
@@ -1179,10 +1178,10 @@ export function toSlackBlocks(
   try {
     const { root } = normalizeSpec(node as never);
     const converted = convertSequence(root, context, 0);
-    if (converted.length <= blockCap) {
+    if (converted.length <= context.blockCap) {
       return { blocks: converted, warnings: context.warnings };
     }
-    const kept = converted.slice(0, blockCap - 1);
+    const kept = converted.slice(0, context.blockCap - 1);
     const omitted = converted.length - kept.length;
     warn(
       context,

--- a/packages/react-generative-ui/src/slack/types.ts
+++ b/packages/react-generative-ui/src/slack/types.ts
@@ -1,3 +1,5 @@
+import type { UIElement } from "../ir";
+
 /** A Slack plain-text composition object. */
 export interface SlackPlainText {
   readonly type: "plain_text";
@@ -218,5 +220,11 @@ export interface SlackConversionWarning {
 /** The blocks and non-fatal warnings produced by Slack conversion. */
 export interface SlackBlocksResult {
   readonly blocks: SlackBlock[];
+  readonly warnings: SlackConversionWarning[];
+}
+
+/** The IR nodes and non-fatal warnings produced by converting Slack Block Kit JSON back into generative UI. */
+export interface FromSlackBlocksResult {
+  readonly nodes: UIElement[];
   readonly warnings: SlackConversionWarning[];
 }


### PR DESCRIPTION
## summary

- `fromSlackBlocks` completes the two-way Slack interop in the `./slack` subpath: a Block Kit payload maps back to vocabulary nodes with `action_id` back-mapped to `$action.type` and serialized button payloads reparsed under the same object-only rule `decodeBlockAction` uses; the converter is total (malformed input and unknown block types degrade to warnings, never throws) and every array walk is bounded with per-site caps so a hostile payload (sparse or proxied `length` near 2^32) cannot stall the event loop
- the inverse mappings are round-trip tested against what `toSlackBlocks` actually emits: 18 lossless-subset fixtures assert exact IR equality (including ListView container reconstruction from section+accessory runs, style-based card confirm/cancel assignment, RadioGroup `defaultValue`, and data_table header/row/`raw_number` handling), and the documented-lossy directions (context elements return as `Caption`s, alert title/description join, card layout flattening, table booleans as strings, the Fact delimiter ambiguity) are spelled out in the exported JSDoc
- ride-along cleanup: `toSlackBlocks`' block-cap enforcement now reads `ConversionContext.blockCap` instead of deriving the cap twice
- docs: the generative-ui guide gains the inbound paragraph and the generated api-reference Slack page picks up `fromSlackBlocks`/`FromSlackBlocksResult`

## test plan

### already verified

- [x] `vitest run` in packages/react-generative-ui -> 393/393 green, including the per-mapping inverse suite, the 18-fixture round-trip matrix, a hostile-length Proxy probe (completes with a clamped warning), and never-throws sweeps
- [x] `aui-build` in the package emits the subpath dists; root oxlint and oxfmt pass
- [x] a read-only adversarial review challenged every inverse mapping before this PR; all nine findings it raised (unbounded arrays, RadioGroup prop, positional card actions, ListView flattening, Fact fallback shape, NaN cells, two lossiness-doc gaps, fixture-matrix gaps) are fixed and pinned by tests

### reviewer should verify

- [ ] round-trip any gallery template: `fromSlackBlocks(toSlackBlocks(tree).blocks)` returns the documented IR (exact for the plain building blocks, degraded-with-warnings for web-only components)

## notes

- api-surface files for the new exports are expected to be regenerated by autofix.ci on the first CI cycle
- this closes the 6-PR generative-ui roadmap's core path (vocabulary, styled registry, gallery, live adoption, Slack outbound, Slack inbound)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

