### PR TITLE
feat(eve): require eve 0.24

### DIFF
--- a/.changeset/eve-0-24.md
+++ b/.changeset/eve-0-24.md
@@ -2,4 +2,4 @@
 "@assistant-ui/eve": patch
 ---
 
-feat: support eve 0.23 and 0.24
+feat: require eve 0.24.3

--- a/.changeset/eve-0-24.md
+++ b/.changeset/eve-0-24.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+feat: support eve 0.23 and 0.24

--- a/api-surface/package.json
+++ b/api-surface/package.json
@@ -20,7 +20,7 @@
     "@standard-schema/spec": "^1.1.0",
     "ai": "^7.0.28",
     "denque": "^2.1.0",
-    "eve": "^0.22.6",
+    "eve": "^0.24.3",
     "ink": "^7.1.0",
     "ink-spinner": "^5.0.0",
     "lexical": "^0.46.0",

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -15,7 +15,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.22.6",
+    "eve": "^0.24.3",
     "lucide-react": "^1.24.0",
     "next": "^16.2.10",
     "react": "^19.2.7",

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
-    "eve": "^0.22.0",
+    "eve": "^0.22.0 || ^0.23.0 || ^0.24.0",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "eve": "^0.22.6",
+    "eve": "^0.24.3",
     "react": "^19.2.7",
     "vitest": "^4.1.10"
   },

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
-    "eve": "^0.22.0 || ^0.23.0 || ^0.24.0",
+    "eve": "^0.24.3",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       eve:
-        specifier: ^0.22.6
-        version: 0.22.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.24.3
+        version: 0.24.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       ink:
         specifier: ^7.1.0
         version: 7.1.0(@types/react@19.2.17)(react-devtools-core@6.1.5)(react@19.2.7)
@@ -1550,8 +1550,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.22.6
-        version: 0.22.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.24.3
+        version: 0.24.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -3565,8 +3565,8 @@ importers:
         specifier: ^19.2.17
         version: 19.2.17
       eve:
-        specifier: ^0.22.6
-        version: 0.22.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.24.3
+        version: 0.24.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -5176,8 +5176,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       eve:
-        specifier: ^0.22.6
-        version: 0.22.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.24.3
+        version: 0.24.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       lucide-react:
         specifier: ^1.24.0
         version: 1.24.0(react@19.2.7)
@@ -12183,13 +12183,13 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eve@0.22.6:
-    resolution: {integrity: sha512-LC3eGoWysnTxsTRaQomZkNcuOpGZqVuqA9i0qGzLFUKuj5le6bEpeHPe0wHYcOwI7RCyaMYZYpNPNkHRvaGVlg==}
+  eve@0.24.3:
+    resolution: {integrity: sha512-qdNUjF1tlEJHVEsmnuSBHkJToDo0VjXgiHX5KaWhbHxBfsHahPGVI+/ecW+DHvsLlzmw58/rk2ypQXdAkul4uA==}
     engines: {node: '>=24'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.0.0
-      ai: ^7.0.0
+      ai: ^7.0.26
       braintrust: ^3.0.0
       just-bash: ^3.0.0
       microsandbox: ^0.5.0
@@ -25291,7 +25291,7 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.22.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+  eve@0.24.3(@azure/identity@4.13.1)(@opentelemetry/api@1.9.0)(@upstash/redis@1.38.0)(ai@7.0.28(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       ai: 7.0.28(zod@4.4.3)
       nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))

--- a/templates/eve/package.json
+++ b/templates/eve/package.json
@@ -22,7 +22,7 @@
     "@assistant-ui/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "eve": "^0.22.6",
+    "eve": "^0.24.3",
     "lucide-react": "^1.24.0",
     "next": "^16.2.10",
     "react": "^19.2.7",


### PR DESCRIPTION
## what

moves the eve SDK line from 0.22 to 0.24 across the four manifests that pin it and requires it in `@assistant-ui/eve`'s peer range (`^0.24.3`). no source changes.

## why

eve 0.23.0 and 0.24.0 are breaking minors upstream, which is why this bump was held out of the #4887 dependency chore. the breaks live on the server/CLI/compiler side (root-only `agent` tool delegation, `isChannel` metadata narrowing, `ExperimentalWorkflow` to `experimental_workflow`): every file the adapter consumes through `eve/react` and `eve/client`, including the full transitive closure (`dist/src/react/**`, `client/**`, `protocol/**`, `runtime/input/**`), is byte identical between eve 0.22.6 and 0.24.3. the adapter therefore needs no code changes; the peer requirement moves forward with the tested line so an app's eve package (client and server runtime in one install) stays on a single, current version rather than mixing an old runtime with a new adapter.

## notes

- eve 0.24.3 raises its own `ai` peer floor from `^7.0.0` to `^7.0.26`; the repo satisfies it after #4887 (`ai ^7.0.28`), and consumers see that requirement from eve directly.
- ranges are written `^0.24.3`, not `^0.24.4`: 0.24.4 published inside the 24h `minimumReleaseAge` window and pnpm refuses it today; the caret picks it up once it ages.
- docs need no updates: the eve pages install `eve` unversioned and the code samples are version agnostic.
- verified: adapter tests green under eve 0.24.3, a single eve version in the lockfile, and full `pnpm build` plus `pnpm lint` green on the branch.
