### PR TITLE
ci: split app and example builds into a separate job

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -131,10 +131,10 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR: Build packages changed compared to base branch
-            pnpm turbo build --filter="...[origin/${{ github.base_ref }}]"
+            pnpm turbo build --filter="...[origin/${{ github.base_ref }}]" --filter="!./apps/*" --filter="!./examples/*" --filter="!./templates/*"
           else
             # Push to main: Build packages changed in last commit
-            pnpm turbo build --filter="...[HEAD^1]"
+            pnpm turbo build --filter="...[HEAD^1]" --filter="!./apps/*" --filter="!./examples/*" --filter="!./templates/*"
           fi
 
       - name: Check API surface
@@ -149,6 +149,50 @@ jobs:
 
       - name: Test API surface generator
         run: pnpm run api-surface:test
+
+  build-apps:
+    name: Build Changed Apps
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # ratchet:pnpm/action-setup@v6.0.9
+
+      - name: Setup node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Cache turbo build setup
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # ratchet:actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-build-apps-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-build-apps-${{ github.ref }}-
+            ${{ runner.os }}-turbo-build-apps-
+            ${{ runner.os }}-turbo-build-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # apps/docs is excluded: the Vercel deployment check already builds it on every pull request.
+      - name: Build apps
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # PR: Build apps, examples, and templates affected by changes compared to base branch
+            pnpm turbo build --filter="...[origin/${{ github.base_ref }}]" --filter="!./packages/*" --filter="!./api-surface" --filter="!@assistant-ui/docs"
+          else
+            # Push to main: Build apps, examples, and templates affected by the last commit
+            pnpm turbo build --filter="...[HEAD^1]" --filter="!./packages/*" --filter="!./api-surface" --filter="!@assistant-ui/docs"
+          fi
 
   api-reference-drift:
     name: API Reference Drift


### PR DESCRIPTION
## summary

- the Build Changed Packages job routinely ran 6 to 10 minutes and the oxfmt 0.59 reformat PR hit the 10 minute timeout during the post-build .turbo cache upload after every build step had already succeeded; the cause is the `...[base]` filter selecting changed packages plus all dependents, and the repo topology (apps/docs depends on 16 workspace packages, 28 examples plus the registry depend on @assistant-ui/ui) turning any core-ish PR into a 30-plus Next.js build fleet on a 4 vCPU runner
- turbo cache cannot help there: the `dependsOn: ^build` hash chain guarantees exactly those dependents miss, so the fleet rebuilds on every PR that touches anything upstream of ui (measured: eve PR 1m11s, react-lexical PR 2m50s, react-generative-ui PRs 6m02s to 7m29s with 61 tasks and only 29 cached, dependency update PR 8m55s)
- this scopes the build job to packages only (excludes `./apps/*`, `./examples/*`, `./templates/*`), keeping the api-surface steps unchanged, and adds a parallel build-apps job covering examples, templates, and the registry with its own turbo cache key prefix (`turbo-build-apps-`, falling back to `turbo-build-` so first runs seed from existing main caches)
- apps/docs is excluded from build-apps because the Vercel deployment check already builds docs on every PR, including package-only ones; the packages gate (with api-surface) should now settle in about 2 minutes and the fleet builds run in parallel without docs as the long tail

## test plan

### already verified

- [x] `turbo build --dry=json` set algebra on a ui-upstream change: the packages job entry set drops from 33 to 2 (`react-generative-ui`, `ui`), the union of both jobs' entry sets equals the old selection minus docs, and build-apps still schedules prerequisite package builds itself (`ui#build` present in its task graph), so the two jobs are independent
- [x] workflow YAML parses (6 jobs) and actionlint reports only the pre-existing blacksmith runner label false positives that all jobs in this file share

### reviewer should verify

- [ ] on this PR both build jobs go green fast (the diff touches no package, so both filters select nothing)
- [ ] on the next package-touching PR, Build Changed Packages settles in about 2 minutes and Build Changed Apps runs the example fleet in parallel

## notes

- trade-off: docs-only PRs now rely on the Vercel check alone for compile gating; registry, examples, and templates keep a PR compile gate via build-apps (the registry workflow only deploys on pushes to main)
- if build-apps is still too slow on ui-upstream PRs, bumping just that job to an 8 vCPU runner is roughly cost neutral on per vCPU minute billing and halves its wall time

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

