### PR TITLE
fix(cli): use semver for doctor version checks

### DIFF
--- a/.changeset/doctor-prerelease-ordering.md
+++ b/.changeset/doctor-prerelease-ordering.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: compare prerelease versions using SemVer rules in assistant-ui doctor

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
+import { compare, valid } from "semver";
 
 const ASSISTANT_UI_PACKAGE_NAMES = new Set([
   "assistant-stream",
@@ -254,40 +255,11 @@ async function fetchAllLatestVersions(
   return new Map(entries);
 }
 
-interface SemverParts {
-  major: number;
-  minor: number;
-  patch: number;
-  prerelease: string;
-}
-
-function parseSemver(v: string): SemverParts | null {
-  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([^+\s]+))?/.exec(v);
-  if (!m) return null;
-  return {
-    major: parseInt(m[1]!, 10),
-    minor: parseInt(m[2]!, 10),
-    patch: parseInt(m[3]!, 10),
-    prerelease: m[4] ?? "",
-  };
-}
-
 export function compareSemver(a: string, b: string): number {
-  const pa = parseSemver(a);
-  const pb = parseSemver(b);
-  if (!pa || !pb) return a.localeCompare(b);
-  if (pa.major !== pb.major) return pa.major - pb.major;
-  if (pa.minor !== pb.minor) return pa.minor - pb.minor;
-  if (pa.patch !== pb.patch) return pa.patch - pb.patch;
-
-  // Per SemVer §11: a version with a prerelease tag is *less than* the
-  // same x.y.z without one. We compare tags lexically for a stable
-  // ordering across prereleases — good enough for doctor's "is X older
-  // than the npm latest" check.
-  if (pa.prerelease === pb.prerelease) return 0;
-  if (!pa.prerelease) return 1;
-  if (!pb.prerelease) return -1;
-  return pa.prerelease.localeCompare(pb.prerelease);
+  const validA = valid(a);
+  const validB = valid(b);
+  if (!validA || !validB) return a.localeCompare(b);
+  return compare(validA, validB);
 }
 
 export interface OutdatedPackage {

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -38,6 +38,7 @@ describe("compareSemver", () => {
     expect(compareSemver("1.0.0-alpha", "1.0.0")).toBeLessThan(0);
     expect(compareSemver("1.0.0", "1.0.0-alpha")).toBeGreaterThan(0);
     expect(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.2")).toBeLessThan(0);
+    expect(compareSemver("1.0.0-beta.2", "1.0.0-beta.10")).toBeLessThan(0);
     expect(compareSemver("0.3.0-rc.1", "0.3.0")).toBeLessThan(0);
   });
 
@@ -280,6 +281,27 @@ describe("findOutdated", () => {
       ["@assistant-ui/core", "0.2.5"],
     ]);
     expect(findOutdated(installed, latest)).toEqual([]);
+  });
+
+  it("flags an older numeric prerelease", () => {
+    const installed: DiscoveredPackage[] = [
+      {
+        name: "@assistant-ui/react",
+        version: "1.0.0-beta.2",
+        installPath: "",
+      },
+    ];
+    const latest = new Map<string, string | null>([
+      ["@assistant-ui/react", "1.0.0-beta.10"],
+    ]);
+
+    expect(findOutdated(installed, latest)).toEqual([
+      {
+        name: "@assistant-ui/react",
+        current: "1.0.0-beta.2",
+        latest: "1.0.0-beta.10",
+      },
+    ]);
   });
 
   it("skips packages with no latest version (e.g. network failed)", () => {


### PR DESCRIPTION
## Summary

- replace the CLI doctor's hand-written prerelease comparison with the existing `semver` dependency
- preserve the lexical fallback for malformed version strings
- add regression coverage for numeric prerelease identifiers and outdated-package detection

## Why

While testing `assistant-ui doctor` with prerelease package versions, I found that an installed `1.0.0-beta.2` was treated as newer than the npm version `1.0.0-beta.10`. The current comparator uses lexical ordering for the prerelease tag, so `findOutdated()` can miss valid updates whenever numeric identifiers reach multiple digits.

SemVer requires numeric prerelease identifiers to be compared numerically, which the CLI's existing `semver` dependency already handles.

## Verification

- reproduced the bug with a focused test: the old comparator returned `1` and `findOutdated()` returned no update
- `pnpm --filter assistant-ui test`
- `pnpm --filter assistant-ui build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

