### PR TITLE
fix(cli): parse scaffold tsconfig as jsonc

### DIFF
--- a/.changeset/cli-tsconfig-jsonc.md
+++ b/.changeset/cli-tsconfig-jsonc.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: accept JSONC syntax when transforming scaffold tsconfig files

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "giget": "^3.3.0",
     "glob": "^13.0.6",
     "jscodeshift": "^17.3.0",
+    "jsonc-parser": "^3.3.1",
     "semver": "^7.8.5"
   },
   "devDependencies": {

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -3,6 +3,11 @@ import * as path from "node:path";
 import { downloadTemplate } from "giget";
 import { sync as globSync } from "glob";
 import { detect } from "detect-package-manager";
+import {
+  parse as parseJsonc,
+  printParseErrorCode,
+  type ParseError,
+} from "jsonc-parser";
 import { logger } from "./utils/logger";
 import { runSpawn, SpawnExitError } from "./run-spawn";
 
@@ -281,6 +286,18 @@ function transformPackageJson(projectDir: string): void {
   fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 }
 
+function parseTsConfig(content: string): any {
+  const errors: ParseError[] = [];
+  const tsconfig = parseJsonc(content, errors, { allowTrailingComma: true });
+  const error = errors[0];
+  if (error) {
+    throw new SyntaxError(
+      `Invalid tsconfig.json: ${printParseErrorCode(error.error)} at offset ${error.offset}`,
+    );
+  }
+  return tsconfig;
+}
+
 function transformTsConfig(projectDir: string): void {
   const tsconfigPath = path.join(projectDir, "tsconfig.json");
 
@@ -289,7 +306,7 @@ function transformTsConfig(projectDir: string): void {
   }
 
   const content = fs.readFileSync(tsconfigPath, "utf-8");
-  const tsconfig = JSON.parse(content);
+  const tsconfig = parseTsConfig(content);
 
   // Remove workspace paths
   if (tsconfig.compilerOptions?.paths) {

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -276,6 +276,42 @@ describe("transformProject — hasLocalComponents: false", () => {
 
   // tsconfig tests
   describe("tsconfig transforms", () => {
+    it("accepts comments and trailing commas", async () => {
+      writeFile(
+        "tsconfig.json",
+        `{
+  // Paths inherited from the monorepo scaffold
+  "compilerOptions": {
+    "paths": {
+      "@/components/ui/*": ["../../packages/ui/src/components/ui/*"],
+      "@/*": ["./*"],
+    },
+  },
+}`,
+      );
+
+      await run();
+
+      const tsconfig = readJSON("tsconfig.json");
+      expect(
+        tsconfig.compilerOptions.paths["@/components/ui/*"],
+      ).toBeUndefined();
+      expect(tsconfig.compilerOptions.paths["@/*"]).toEqual(["./*"]);
+    });
+
+    it("rejects malformed JSONC", async () => {
+      writeFile(
+        "tsconfig.json",
+        `{
+  "compilerOptions": {
+    "strict": true,,
+  },
+}`,
+      );
+
+      await expect(run()).rejects.toThrow("Invalid tsconfig.json");
+    });
+
     it("removes workspace paths", async () => {
       writeJSON("tsconfig.json", {
         compilerOptions: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3402,6 +3402,9 @@ importers:
       jscodeshift:
         specifier: ^17.3.0
         version: 17.3.0
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       semver:
         specifier: ^7.8.5
         version: 7.8.5


### PR DESCRIPTION
## Summary

- parse scaffold `tsconfig.json` files with `jsonc-parser`
- support TypeScript-compatible comments and trailing commas during project transformation
- keep malformed JSONC failures explicit instead of accepting a partial parse

## Why

While testing project scaffolding with a normal commented `tsconfig.json`, the CLI failed in `transformTsConfig()` because it used `JSON.parse()`. TypeScript treats `tsconfig.json` as JSONC, so `//` comments, block comments, and trailing commas are valid configuration syntax.

This change accepts that standard syntax before applying the existing workspace alias and `extends` transformations. The transformed file continues to be normalized as JSON, matching the CLI's existing output behavior.

## Verification

- reproduced the original `SyntaxError` with a commented config containing trailing commas
- added tests for valid JSONC and malformed JSONC
- manually ran the built transformer against a JSONC fixture
- `pnpm --filter assistant-ui test`
- `pnpm --filter assistant-ui build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

