### PR TITLE
fix(core): handle failed composer appends

### DIFF
--- a/.changeset/quiet-composers-handle.md
+++ b/.changeset/quiet-composers-handle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: handle failed composer append tasks

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -651,7 +651,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   get queue(): readonly QueueItemState[];
   steerQueueItem(_queueItemId: string): void;
   removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
   private _safeEmitAttachmentAddError;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -628,7 +628,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   get queue(): readonly QueueItemState[];
   steerQueueItem(_queueItemId: string): void;
   removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
   private _safeEmitAttachmentAddError;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -620,7 +620,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   get queue(): readonly QueueItemState[];
   steerQueueItem(_queueItemId: string): void;
   removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
   private _safeEmitAttachmentAddError;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -926,7 +926,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   get queue(): readonly QueueItemState[];
   steerQueueItem(_queueItemId: string): void;
   removeQueueItem(_queueItemId: string): void;
-  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void;
+  protected abstract handleSend(message: Omit<AppendMessage, "parentId" | "sourceId">, options?: SendOptions): void | Promise<void>;
   protected abstract handleCancel(): void;
   addAttachment(fileOrAttachment: File | CreateAttachment): Promise<void>;
   private _safeEmitAttachmentAddError;

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -223,7 +223,8 @@ export abstract class BaseComposerRuntimeCore
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
 
-    this.handleSend(message, options);
+    const sendTask = this.handleSend(message, options);
+    if (sendTask) void sendTask.catch(() => {});
     this._notifyEventSubscribers("send", {});
   }
 
@@ -241,7 +242,7 @@ export abstract class BaseComposerRuntimeCore
   protected abstract handleSend(
     message: Omit<AppendMessage, "parentId" | "sourceId">,
     options?: SendOptions,
-  ): void;
+  ): void | Promise<void>;
   protected abstract handleCancel(): void;
 
   async addAttachment(fileOrAttachment: File | CreateAttachment) {

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -80,6 +80,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     message: Omit<AppendMessage, "parentId" | "sourceId">,
     options?: SendOptions,
   ) {
+    let appendTask: void | Promise<void> = undefined;
     const text = getThreadMessageText(message as AppendMessage);
     const attachmentsChanged = !attachmentsEqual(
       message.attachments ?? [],
@@ -114,7 +115,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
         message,
         composerMetadata,
       );
-      this.runtime.append({
+      appendTask = this.runtime.append({
         ...enriched,
         content,
         parentId: this._parentId,
@@ -124,6 +125,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     }
 
     this.handleCancel();
+    return appendTask;
   }
 
   public handleCancel() {

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -94,7 +94,7 @@ export class DefaultThreadComposerRuntimeCore
     );
     const enriched = this.enrichWithComposerMetadata(message, composerMetadata);
 
-    this.runtime.append({
+    return this.runtime.append({
       ...(enriched as AppendMessage),
       parentId: this.runtime.messages.at(-1)?.id ?? null,
       sourceId: null,

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -183,4 +183,43 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     resolveAppend();
     await sendTask;
   });
+
+  it("does not leak a rejected append task as an unhandled rejection", async () => {
+    // A vi.fn mock attaches settled-result handlers to returned promises,
+    // marking the rejection as handled; a plain function keeps it unobserved.
+    let appendCalls = 0;
+    const runtime = {
+      append: () => {
+        appendCalls += 1;
+        return Promise.reject(new Error("append failed"));
+      },
+      cancelRun: () => {},
+      subscribe: () => () => {},
+      capabilities: { cancel: false },
+      messages: [],
+      getModelContext: () => ({ unstable_composerMetadata: undefined }),
+    } as unknown as Omit<ThreadRuntimeCore, "composer">;
+    const composer = new DefaultThreadComposerRuntimeCore(runtime);
+
+    const rejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      composer.setText("hello");
+      await composer.send();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandledRejection);
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+    }
+
+    expect(appendCalls).toBe(1);
+    expect(rejections).toEqual([]);
+  });
 });

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -21,8 +21,7 @@ const makeAdapter = (
   ...overrides,
 });
 
-const makeComposer = (adapter?: AttachmentAdapter) => {
-  const append = vi.fn();
+const makeComposer = (adapter?: AttachmentAdapter, append = vi.fn()) => {
   const runtime = {
     append,
     cancelRun: vi.fn(),
@@ -141,5 +140,47 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     expect(append.mock.calls[0]![0].content).toEqual([
       { type: "text", text: "hello" },
     ]);
+  });
+
+  it("observes asynchronous send tasks without waiting for them", async () => {
+    const sendTask = new Promise<void>(() => {});
+    const catchSpy = vi.spyOn(sendTask, "catch");
+    const { composer } = makeComposer();
+    vi.spyOn(composer, "handleSend").mockReturnValue(sendTask);
+
+    composer.setText("hello");
+    await expect(composer.send()).resolves.toBeUndefined();
+
+    expect(catchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("tracks the append task returned by the thread runtime", async () => {
+    let resolveAppend!: () => void;
+    const appendTask = new Promise<void>((resolve) => {
+      resolveAppend = resolve;
+    });
+    const { composer } = makeComposer(
+      undefined,
+      vi.fn(() => appendTask),
+    );
+
+    const sendTask = composer.handleSend({
+      createdAt: new Date(),
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      attachments: [],
+      runConfig: {},
+      metadata: { custom: {} },
+    });
+    let settled = false;
+    void sendTask.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    resolveAppend();
+    await sendTask;
   });
 });

--- a/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
@@ -4,11 +4,13 @@ import type { AppendMessage, ThreadMessage } from "../types/message";
 import type { CompleteAttachment } from "../types/attachment";
 import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
 
-const makeRuntime = (options?: {
-  messages?: ThreadMessage[];
-  composerMetadata?: Record<string, unknown>;
-}) => {
-  const append = vi.fn();
+const makeRuntime = (
+  options?: {
+    messages?: ThreadMessage[];
+    composerMetadata?: Record<string, unknown>;
+  },
+  append = vi.fn(),
+) => {
   const runtime = {
     append,
     composer: { runConfig: {} },
@@ -373,6 +375,42 @@ describe("DefaultEditComposerRuntimeCore", () => {
       composer.setText("changed");
       await composer.send();
       expect(endEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it("tracks the append task while exiting edit mode immediately", async () => {
+      let resolveAppend!: () => void;
+      const appendTask = new Promise<void>((resolve) => {
+        resolveAppend = resolve;
+      });
+      const { runtime } = makeRuntime(
+        undefined,
+        vi.fn(() => appendTask),
+      );
+      const endEdit = vi.fn();
+      const composer = new DefaultEditComposerRuntimeCore(runtime, endEdit, {
+        parentId: null,
+        message: makeUserMessage(),
+      });
+
+      const sendTask = composer.handleSend({
+        createdAt: new Date(),
+        role: "user",
+        content: [{ type: "text", text: "changed" }],
+        attachments: [],
+        runConfig: {},
+        metadata: { custom: {} },
+      });
+      let settled = false;
+      void sendTask.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+
+      expect(endEdit).toHaveBeenCalledTimes(1);
+      expect(settled).toBe(false);
+
+      resolveAppend();
+      await sendTask;
     });
 
     it("invokes endEditCallback on cancel", () => {


### PR DESCRIPTION
## Problem

While testing a failed model request locally, I found that composer sends can produce a global `unhandledrejection` after the draft has already cleared. Both default composer paths called `runtime.append()` without returning its asynchronous task, and `BaseComposerRuntimeCore.send()` ignored asynchronous `handleSend()` results.

Because the public composer send API is intentionally fire-and-forget, UI event handlers cannot catch that rejection themselves. Local runtimes already represent model failures in message status, so the additional global rejection is unexpected and can trigger application-level error handlers.

Closes #4980.

## Fix

- return the runtime append task from both thread and edit composers
- observe that task centrally in `BaseComposerRuntimeCore.send()`
- consume failures without awaiting the task, preserving immediate composer submission, queue behavior, and immediate edit-mode exit
- add regression coverage for the base, thread, and edit paths

PR #4801 overlaps these composer files for optimistic attachment sends; this bug is independently reproducible on `main`, and its task-observation behavior should be preserved when that PR is rebased.

## Verification

- standalone reproduction: changed from one unhandled rejection to zero while the composer still clears immediately
- `pnpm --filter @assistant-ui/core exec vitest run` (59 files, 576 tests)
- `pnpm --filter @assistant-ui/core exec tsc --noEmit`
- `pnpm lint` (passes with existing unrelated hook warnings)
- `pnpm --filter @assistant-ui/core build`
- `pnpm api-surface:check --filter @assistant-ui/core`
- full `pnpm build` under Node 24 built `@assistant-ui/core`, then the workspace run stopped on local `ENOSPC` while unrelated `react-o11y` and social-media outputs were being written


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

