### PR TITLE
fix(ui): keep radix TabsTrigger asChild inside the primitive

### DIFF
--- a/packages/ui/src/components/assistant-ui/tabs.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/tabs.radix.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   type ComponentProps,
 } from "react";
-import { Tabs as TabsPrimitive, Slot as SlotPrimitive } from "radix-ui";
+import { Tabs as TabsPrimitive } from "radix-ui";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
@@ -221,10 +221,9 @@ function TabsTrigger({
     context?.setHoveredValue(null);
   }, [context]);
 
-  const Comp = asChild ? SlotPrimitive.Root : TabsPrimitive.Trigger;
-
   return (
-    <Comp
+    <TabsPrimitive.Trigger
+      asChild={asChild}
       ref={ref}
       value={value}
       data-slot="tabs-trigger"

--- a/packages/ui/src/components/assistant-ui/tabs.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/tabs.radix.tsx
@@ -202,9 +202,7 @@ function TabsTrigger({
   value,
   asChild = false,
   ...props
-}: Omit<ComponentProps<typeof TabsPrimitive.Trigger>, "asChild"> & {
-  asChild?: boolean;
-}) {
+}: ComponentProps<typeof TabsPrimitive.Trigger>) {
   const context = useContext(TabsListContext);
   const ref = useRef<HTMLButtonElement>(null);
 


### PR DESCRIPTION
## What

In the Radix tabs flavor (`packages/ui/src/components/assistant-ui/tabs.radix.tsx`), `TabsTrigger` with `asChild` rendered a bare Radix `Slot` instead of `TabsPrimitive.Trigger`. The composed element (e.g. a link, as shown in the docs "As Link" sample) was never registered with Radix Tabs: no `role="tab"`, no `aria-selected`, no click/keyboard activation, no `data-state`, and the sliding indicator never followed it. The `value` prop also leaked onto the child as a DOM attribute.

## How

`TabsPrimitive.Trigger` natively supports `asChild`, so the fix forwards the prop to the primitive instead of swapping it out. Radix then merges `className`, `data-*`, ref, and handlers onto the child, so indicator registration and hover tracking keep working and `data-[state=active]` styling applies to composed links. The unused `Slot` import is removed. The Base UI flavor (`tabs.tsx`) uses the `render` prop and is unaffected.

## Verification

- `pnpm lint` and `packages/ui` typecheck pass; `pnpm -C apps/registry build` passes.
- Manual smoke on `/docs/ui/tabs` (Radix flavor, "As Link" sample): composed anchors render with `role="tab"`/`aria-selected`/`data-state`, click activates them, ArrowLeft/ArrowRight roving focus works, the active indicator tracks their exact offsets, and `value` no longer appears on the anchor. Non-`asChild` triggers on the same page behave unchanged.

No changeset: `@assistant-ui/ui` is private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

