### PR TITLE
fix(ui): route Base UI model-selector effort keys to cmdk

### DIFF
--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -587,21 +587,40 @@ function ModelSelectorEffort({
         "flex items-center justify-between gap-3 border-t px-3 py-2",
         className,
       )}
+      onKeyDownCapture={(e) => {
+        if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+        // Base UI's RadioGroup composite treats vertical arrows as roving-
+        // focus keys (orientation "both", not configurable), so intercept
+        // them in capture before it moves radio focus: the model list owns
+        // vertical navigation. Refocus cmdk's input and re-dispatch the key
+        // so the same press moves the list highlight, and Enter selects
+        // again (cmdk's Enter is inert while a radio has focus, so the
+        // highlight would otherwise move with no way to act).
+        e.preventDefault();
+        e.stopPropagation();
+        const input = e.currentTarget
+          .closest("[cmdk-root]")
+          ?.querySelector<HTMLInputElement>("[cmdk-input]");
+        input?.focus();
+        input?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: e.key, bubbles: true }),
+        );
+      }}
       onKeyDown={(e) => {
         onKeyDown?.(e);
         if (e.defaultPrevented) return;
-        // cmdk's Command root claims Home/End to jump the model list; stop
-        // them here so only the radiogroup reacts.
-        if (e.key === "Home" || e.key === "End") e.stopPropagation();
-        // Vertical arrows refocus cmdk's input before the event bubbles to
-        // the Command root: the same keypress then moves the list highlight,
-        // and Enter selects again (cmdk's Enter is inert while a radio has
-        // focus, so the highlight would otherwise move with no way to act).
-        if (e.key === "ArrowUp" || e.key === "ArrowDown") {
-          e.currentTarget
-            .closest("[cmdk-root]")
-            ?.querySelector<HTMLInputElement>("[cmdk-input]")
-            ?.focus();
+        // Base UI's radio composite ignores Home/End and cmdk's Command
+        // root would claim them to jump the model list; move radio focus
+        // here so only the radiogroup reacts.
+        if (e.key === "Home" || e.key === "End") {
+          e.preventDefault();
+          e.stopPropagation();
+          const radios = Array.from(
+            e.currentTarget.querySelectorAll<HTMLElement>(
+              '[role="radio"]:not([data-disabled])',
+            ),
+          );
+          (e.key === "Home" ? radios[0] : radios[radios.length - 1])?.focus();
         }
       }}
       {...props}

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -596,20 +596,19 @@ function ModelSelectorEffort({
         // focus (orientation "both", not configurable), so intercept them in
         // capture and hand the keypress to cmdk: the model list owns vertical
         // navigation, and cmdk's Enter is inert while a radio has focus.
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
         const input = e.currentTarget
           .closest("[cmdk-root]")
           ?.querySelector<HTMLInputElement>("[cmdk-input]");
         if (!input) return;
-        onKeyDown?.(e);
-        if (e.defaultPrevented) return;
         e.preventDefault();
         e.stopPropagation();
         input.focus();
-        input.dispatchEvent(
-          new KeyboardEvent("keydown", { key: e.key, bubbles: true }),
-        );
+        input.dispatchEvent(new KeyboardEvent("keydown", e.nativeEvent));
       }}
       onKeyDown={(e) => {
+        if (e.key === "ArrowUp" || e.key === "ArrowDown") return;
         onKeyDown?.(e);
         if (e.defaultPrevented) return;
         // Base UI's radio composite ignores Home/End and cmdk's Command

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -574,6 +574,7 @@ function ModelSelectorEffort({
   label = "Thinking",
   className,
   onKeyDown,
+  onKeyDownCapture,
   ...props
 }: ModelSelectorEffortProps) {
   const { efforts, effort, setEffort } = useModelSelectorEfforts();
@@ -588,21 +589,23 @@ function ModelSelectorEffort({
         className,
       )}
       onKeyDownCapture={(e) => {
+        onKeyDownCapture?.(e);
+        if (e.defaultPrevented) return;
         if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
-        // Base UI's RadioGroup composite treats vertical arrows as roving-
-        // focus keys (orientation "both", not configurable), so intercept
-        // them in capture before it moves radio focus: the model list owns
-        // vertical navigation. Refocus cmdk's input and re-dispatch the key
-        // so the same press moves the list highlight, and Enter selects
-        // again (cmdk's Enter is inert while a radio has focus, so the
-        // highlight would otherwise move with no way to act).
-        e.preventDefault();
-        e.stopPropagation();
+        // Base UI's RadioGroup composite claims vertical arrows for roving
+        // focus (orientation "both", not configurable), so intercept them in
+        // capture and hand the keypress to cmdk: the model list owns vertical
+        // navigation, and cmdk's Enter is inert while a radio has focus.
         const input = e.currentTarget
           .closest("[cmdk-root]")
           ?.querySelector<HTMLInputElement>("[cmdk-input]");
-        input?.focus();
-        input?.dispatchEvent(
+        if (!input) return;
+        onKeyDown?.(e);
+        if (e.defaultPrevented) return;
+        e.preventDefault();
+        e.stopPropagation();
+        input.focus();
+        input.dispatchEvent(
           new KeyboardEvent("keydown", { key: e.key, bubbles: true }),
         );
       }}


### PR DESCRIPTION
## What

Fixes keyboard routing in the Base UI flavor of `model-selector`'s reasoning-effort radio row:

- **ArrowUp/ArrowDown** with an effort radio focused previously changed the effort selection; they now move the model-list highlight (matching the Radix flavor).
- **Home/End** previously did nothing; they now jump to the first/last effort radio.

## Why

Base UI's `RadioGroup` renders its composite with the default `orientation="both"` and `enableHomeAndEndKeys: false`, and exposes no `orientation` prop. Vertical arrows are therefore consumed (`preventDefault`) by the radio composite during bubbling, before the wrapper's existing `onKeyDown` could refocus cmdk — so arrows changed the effort instead of navigating the list, and Home/End were dead. The Radix flavor avoids this via `orientation="horizontal"`, which Base UI cannot express.

## How

In `ModelSelectorEffort` (Base flavor only):

- A capture-phase `onKeyDownCapture` intercepts ArrowUp/ArrowDown before Base UI's composite sees them, focuses cmdk's input, and re-dispatches the key so the same press moves the list highlight (and Enter can then select).
- The bubble-phase `onKeyDown` keeps the caller passthrough and implements Home/End by focusing the first/last non-disabled radio.

The Radix flavor is untouched; exports and `data-slot`s are unchanged (registry parity build passes). `packages/ui` is private, so no changeset.

## Verification

Smoke-tested both flavors on the docs `model-selector` page: arrows move the list highlight without changing effort (focus lands on the cmdk input, Enter selects the highlighted model), Left/Right move radio focus, Home/End jump to first/last radio, Space still selects the focused radio. `tsc` on `packages/ui`, `pnpm lint`, and the registry build all pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

