### PR TITLE
fix(ui): keyboard activation for radix attachment preview

### DIFF
--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -189,6 +189,17 @@ const AttachmentUI: FC = () => {
               )}
               role="button"
               tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  e.currentTarget.click();
+                } else if (e.key === " ") {
+                  e.preventDefault();
+                }
+              }}
+              onKeyUp={(e) => {
+                if (e.key === " ") e.currentTarget.click();
+              }}
               aria-label={`${typeLabel} attachment${
                 isError ? ", upload failed" : isUploading ? ", uploading" : ""
               }`}


### PR DESCRIPTION
## What

The Radix-flavor attachment tile (`attachment.radix.tsx`) could be focused but not activated with the keyboard: the trigger chain is `DialogTrigger asChild → TooltipTrigger asChild → <div role="button">`, and Radix's `DialogTrigger` only contributes an `onClick` — a `div` gets no native Enter/Space activation. Keyboard users could not open the image preview dialog. The Base flavor already handles this via `nativeButton={false}`.

## How

Adds the WAI-ARIA button keyboard pattern to the tile `div`:

- **Enter** activates on keydown. `preventDefault()` is required: without it the browser's default Enter activation runs after Radix moves focus into the dialog and fires a trusted click on the autofocused close button, so the dialog opened and immediately closed.
- **Space** activates on keyup, with keydown default-prevented so the page doesn't scroll (native button behavior).

`e.currentTarget.click()` triggers the slotted Radix `onClick`, so no Radix internals are touched. The tile intentionally stays a `div` (it contains block-level overlays).

## Verification

Smoke-tested in a real browser against the live `packages/ui` sources, both flavors: Enter opens, Escape closes, Space opens on keyup only without scrolling, mouse click and hover/focus tooltips unchanged, Base flavor unaffected.

No changeset: `@assistant-ui/ui` is private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

