### PR TITLE
fix(docs): dual-flavor state selectors and accordion keyframes

### DIFF
--- a/apps/docs/lib/tool-trace.tsx
+++ b/apps/docs/lib/tool-trace.tsx
@@ -68,14 +68,14 @@ export function ToolTraceCard({
         <span className="text-muted-foreground/60 truncate text-xs">
           {description}
         </span>
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-trace:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-trace:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent
         className={cn(
           "relative overflow-hidden outline-none",
-          "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ease-out",
-          "data-[state=closed]:fill-mode-forwards data-[state=closed]:pointer-events-none",
-          "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
+          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out",
+          "data-closed:fill-mode-forwards data-closed:pointer-events-none",
+          "data-closed:duration-(--animation-duration) data-open:duration-(--animation-duration)",
         )}
       >
         <div className="my-1 ml-6 space-y-2">
@@ -162,14 +162,14 @@ export function ToolErrorCard({
           {signature}
         </span>
         <span className="text-destructive/70 truncate text-xs">{message}</span>
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]/tool-error:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-error:rotate-90" />
       </CollapsibleTrigger>
       <CollapsibleContent
         className={cn(
           "relative overflow-hidden outline-none",
-          "data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down ease-out",
-          "data-[state=closed]:fill-mode-forwards data-[state=closed]:pointer-events-none",
-          "data-[state=closed]:duration-(--animation-duration) data-[state=open]:duration-(--animation-duration)",
+          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out",
+          "data-closed:fill-mode-forwards data-closed:pointer-events-none",
+          "data-closed:duration-(--animation-duration) data-open:duration-(--animation-duration)",
         )}
       >
         <div className="my-1 ml-6 space-y-2">

--- a/apps/docs/lib/tool-trace.tsx
+++ b/apps/docs/lib/tool-trace.tsx
@@ -68,12 +68,12 @@ export function ToolTraceCard({
         <span className="text-muted-foreground/60 truncate text-xs">
           {description}
         </span>
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-trace:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-trace:rotate-90 motion-reduce:transition-none" />
       </CollapsibleTrigger>
       <CollapsibleContent
         className={cn(
           "relative overflow-hidden outline-none",
-          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out",
+          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out motion-reduce:animate-none",
           "data-closed:fill-mode-forwards data-closed:pointer-events-none",
           "data-closed:duration-(--animation-duration) data-open:duration-(--animation-duration)",
         )}
@@ -162,12 +162,12 @@ export function ToolErrorCard({
           {signature}
         </span>
         <span className="text-destructive/70 truncate text-xs">{message}</span>
-        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-error:rotate-90" />
+        <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-open/tool-error:rotate-90 motion-reduce:transition-none" />
       </CollapsibleTrigger>
       <CollapsibleContent
         className={cn(
           "relative overflow-hidden outline-none",
-          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out",
+          "data-closed:animate-collapsible-up data-open:animate-collapsible-down ease-out motion-reduce:animate-none",
           "data-closed:fill-mode-forwards data-closed:pointer-events-none",
           "data-closed:duration-(--animation-duration) data-open:duration-(--animation-duration)",
         )}

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -35,6 +35,28 @@
       height: 0;
     }
   }
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-accordion-content-height,
+        var(--accordion-panel-height, auto)
+      );
+    }
+  }
+  @keyframes accordion-up {
+    from {
+      height: var(
+        --radix-accordion-content-height,
+        var(--accordion-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
 }
 
 @plugin "tailwind-scrollbar";


### PR DESCRIPTION
## What

Two dual-flavor CSS gaps in the docs app broke open/close animations for Base UI components (the docs default flavor):

1. `apps/docs/lib/tool-trace.tsx` styled its Collapsible — which resolves to the Base UI flavor via the docs tsconfig (`@/components/ui/*` maps base-first) — exclusively with Radix `data-[state=...]` selectors. Base UI emits `data-open`/`data-closed` presence attributes instead, so the assistant's tool trace cards had no expand/collapse animation, no `fill-mode`/`pointer-events` handling while closed, and the chevron never rotated.
2. No docs stylesheet defined `accordion-down/up` keyframes, so the `animate-accordion-*` utilities fell through to tw-animate-css@1.4.0, whose keyframes read `--radix-accordion-content-height` (then bits/reka/kb/ngp) — Base UI's `--accordion-panel-height` is not in the chain. The Base-flavor accordion samples on `/docs/ui/accordion` snapped open/closed while the Radix flavor animated.

## How

- Converted both tool-trace collapsible blocks to the flavor-neutral vocabulary the kit already uses (the `data-open`/`data-closed` custom variants defined in `apps/docs/styles/globals.css`; exemplar: `packages/ui/src/components/assistant-ui/reasoning.tsx`). The chevron uses `group-data-open/...` alone: the group class sits on the Collapsible root, where Base UI emits `data-open` and Radix's `data-state="open"` is covered by the custom variant's other branch, so no `group-data-panel-open` twin is needed.
- Added dual-source `accordion-down/up` keyframes to the docs `@theme inline` block, mirroring the CSS the registry already injects for consumers (`apps/registry/src/registry.ts`). Keyframes defined there take precedence over the tw-animate-css definitions for the `animate-accordion-*` utilities — the same mechanism the existing collapsible keyframes in that block rely on.

Templates and the registry app render no accordions, so no other stylesheet needed the block.

## Verification

- Browser-tested against the docs dev server:
  - Base accordion runs `accordion-down` with `--accordion-panel-height` resolving (height interpolates instead of snapping); Radix flavor still animates via `--radix-accordion-content-height`.
  - Tool-trace panel gets `collapsible-up/down`, `fill-mode: forwards`, `pointer-events: none`, and the 0.2s duration under both `data-open`/`data-closed` and `data-state` vocabularies; chevron settles at 90° for both.
  - Reasoning collapse behavior unchanged (shared-keyframe regression check).
- `tsc --noEmit` clean for `apps/docs`; `pnpm lint` clean.

No changeset: only the private docs app is touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

