### PR TITLE
fix(assistant-stream): prevent object stream settlement after cancellation

### DIFF
--- a/.changeset/quiet-streams-settle.md
+++ b/.changeset/quiet-streams-settle.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: guard object stream settlement after cancellation

--- a/packages/assistant-stream/src/core/object/ObjectStream.test.ts
+++ b/packages/assistant-stream/src/core/object/ObjectStream.test.ts
@@ -50,6 +50,30 @@ async function encodeAndDecode(
 }
 
 describe("ObjectStream serialization and deserialization", () => {
+  it("does not settle the stream after cancellation", async () => {
+    let finishExecution!: () => void;
+    let abortSignal!: AbortSignal;
+    const execution = new Promise<void>((resolve) => {
+      finishExecution = resolve;
+    });
+    const stream = createObjectStream({
+      execute: (controller) => {
+        abortSignal = controller.abortSignal;
+        return execution;
+      },
+    });
+    const reader = stream.getReader();
+
+    await reader.cancel("consumer stopped");
+
+    expect(abortSignal.aborted).toBe(true);
+    expect(abortSignal.reason).toBe("consumer stopped");
+
+    finishExecution();
+    await execution;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   it("should discard an unterminated SSE event", async () => {
     const operations: ObjectStreamChunk["operations"] = [
       { type: "set", path: ["status"], value: "complete" },

--- a/packages/assistant-stream/src/core/object/createObjectStream.ts
+++ b/packages/assistant-stream/src/core/object/createObjectStream.ts
@@ -13,6 +13,7 @@ class ObjectStreamControllerImpl implements ObjectStreamController {
   private _controller: ReadableStreamDefaultController<ObjectStreamChunk>;
   private _abortController = new AbortController();
   private _accumulator: ObjectStreamAccumulator;
+  private _cancelled = false;
 
   get abortSignal() {
     return this._abortController.signal;
@@ -27,6 +28,8 @@ class ObjectStreamControllerImpl implements ObjectStreamController {
   }
 
   enqueue(operations: readonly ObjectStreamOperation[]) {
+    if (this._cancelled) return;
+
     this._accumulator.append(operations);
 
     this._controller.enqueue({
@@ -36,14 +39,17 @@ class ObjectStreamControllerImpl implements ObjectStreamController {
   }
 
   __internalError(error: unknown) {
+    if (this._cancelled) return;
     this._controller.error(error);
   }
 
   __internalClose() {
+    if (this._cancelled) return;
     this._controller.close();
   }
 
   __internalCancel(reason?: unknown) {
+    this._cancelled = true;
     this._abortController.abort(reason);
   }
 }


### PR DESCRIPTION
## Summary

- mark an object stream controller as cancelled before aborting its producer signal
- ignore late enqueue, close, and error operations after consumer cancellation
- add a regression test and patch changeset for `assistant-stream`

## Why

I hit this while testing a pending `createObjectStream()` execution that outlived its consumer:

```ts
const stream = createObjectStream({
  execute: async () => {
    await pendingWork;
  },
});

const reader = stream.getReader();
await reader.cancel();
resolvePendingWork();
```

Cancellation closes the underlying `ReadableStream`, but it only aborted the signal exposed to `execute()`. If the async producer settled afterward, `createObjectStream()` still called `controller.close()`, which raised an unhandled `TypeError: Invalid state: Controller is already closed`. The same race can happen when a request is aborted, a component unmounts, or a consumer stops reading while model or database work is still pending.

The controller now records cancellation before dispatching the abort signal and treats subsequent producer operations as no-ops. Non-cancelled streams retain their existing behavior.

## Verification

- confirmed the regression test fails on the previous implementation with the unhandled controller error
- `pnpm --filter assistant-stream test`
- `pnpm --filter assistant-stream build`
- `pnpm --filter assistant-stream exec tsc --noEmit`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

