### PR TITLE
fix(cli): consistent base default for style-less registry resolution

### DIFF
--- a/.changeset/cli-registry-styleless-base-default.md
+++ b/.changeset/cli-registry-styleless-base-default.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: align undefined-style registry defaults with the base default and correct the shipped skill's registry commands

--- a/packages/cli/plugin/skills/assistant-ui/SKILL.md
+++ b/packages/cli/plugin/skills/assistant-ui/SKILL.md
@@ -24,20 +24,39 @@ This initializes shadcn and installs the default assistant-ui chat components.
 Install components via the shadcn registry:
 
 ```bash
-npx shadcn@latest add "https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json"
+npx shadcn@latest add "https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json"
 ```
+
+For Radix-styled projects (`components.json` style not starting with `base-`), use `https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json` instead.
 
 Available component presets:
 
 | Preset | Registry URL |
 |--------|-------------|
-| AI SDK Quick Start | `https://r.assistant-ui.com/chat/b/ai-sdk-quick-start/json` |
+| AI SDK Quick Start | `https://r.assistant-ui.com/base/chat/b/ai-sdk-quick-start/json` |
 
-You can also add individual assistant-ui shadcn components:
+You can also add individual assistant-ui components with the assistant-ui CLI, which picks the right flavor from `components.json`:
 
 ```bash
-npx shadcn@latest add assistant-ui/thread
-npx shadcn@latest add assistant-ui/markdown-text
+npx assistant-ui add thread
+npx assistant-ui add markdown-text
+```
+
+To use the shadcn CLI directly instead, add the assistant-ui registry to `components.json`:
+
+```json
+{
+  "registries": {
+    "@assistant-ui": "https://r.assistant-ui.com/styles/{style}/{name}.json"
+  }
+}
+```
+
+Then add components with the namespaced form:
+
+```bash
+npx shadcn@latest add @assistant-ui/thread
+npx shadcn@latest add @assistant-ui/markdown-text
 ```
 
 ## Step 3: Runtime Setup

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -67,7 +67,7 @@ export const add = new Command()
     // Check if project is initialized
     if (!hasConfig(opts.cwd)) {
       logger.warn(
-        "It looks like you haven't initialized your project yet. Run 'assistant-ui init' first.",
+        "It looks like you haven't initialized your project yet — defaulting to Base UI flavored components. Run 'assistant-ui init' first for a configured setup.",
       );
       logger.break();
     }

--- a/packages/cli/src/lib/utils/registry.test.ts
+++ b/packages/cli/src/lib/utils/registry.test.ts
@@ -94,9 +94,15 @@ describe("resolveRegistryItemUrl", () => {
     );
   });
 
-  it("uses the plain URL without a style", () => {
+  it("uses the base URL without a style", () => {
     expect(resolveRegistryItemUrl("thread")).toBe(
-      "https://r.assistant-ui.com/thread.json",
+      "https://r.assistant-ui.com/base/thread.json",
+    );
+  });
+
+  it("uses the base URL for an explicit undefined style", () => {
+    expect(resolveRegistryItemUrl("thread", undefined)).toBe(
+      "https://r.assistant-ui.com/base/thread.json",
     );
   });
 

--- a/packages/cli/src/lib/utils/registry.ts
+++ b/packages/cli/src/lib/utils/registry.ts
@@ -31,7 +31,11 @@ export function resolveRegistryItemUrl(
   component: string,
   style?: string,
 ): string {
-  const registryUrl = style?.startsWith("base-")
+  if (style === undefined) {
+    return `${REGISTRY_BASE_URL}/base/${encodeURIComponent(component)}.json`;
+  }
+
+  const registryUrl = style.startsWith("base-")
     ? `${REGISTRY_BASE_URL}/styles/${encodeURIComponent(style)}`
     : REGISTRY_BASE_URL;
 

--- a/packages/cli/test/commands/add.test.ts
+++ b/packages/cli/test/commands/add.test.ts
@@ -33,7 +33,7 @@ describe("createAddComponentsPlan", () => {
         "--yes",
         "shadcn@latest",
         "add",
-        "https://r.assistant-ui.com/thread.json",
+        "https://r.assistant-ui.com/base/thread.json",
         "--yes",
         "--cwd",
         "/repo",
@@ -56,8 +56,8 @@ describe("createAddComponentsPlan", () => {
         "dlx",
         "shadcn@latest",
         "add",
-        "https://r.assistant-ui.com/thread.json",
-        "https://r.assistant-ui.com/markdown-text.json",
+        "https://r.assistant-ui.com/base/thread.json",
+        "https://r.assistant-ui.com/base/markdown-text.json",
         "--overwrite",
         "--cwd",
         "/repo",
@@ -75,7 +75,11 @@ describe("createAddComponentsPlan", () => {
       }),
     ).toEqual({
       command: "bunx",
-      args: ["shadcn@latest", "add", "https://r.assistant-ui.com/thread.json"],
+      args: [
+        "shadcn@latest",
+        "add",
+        "https://r.assistant-ui.com/base/thread.json",
+      ],
     });
   });
 


### PR DESCRIPTION
## What

Two shipped CLI surfaces contradicted the registry's flavor routing (Radix at `r.assistant-ui.com/{name}.json`, Base UI at `r.assistant-ui.com/base/{name}.json`):

1. **Inconsistent style-less defaults**: `resolveQuickStartRegistryUrl(undefined)` resolved to the **Base** tree while `resolveRegistryItemUrl(name, undefined)` resolved to the plain **Radix** URL. Since `add` warns-and-proceeds when no `components.json` exists, an uninitialized project got a Base quick-start but Radix individual components — a mixed-flavor project.
2. **Broken shipped skill guidance**: the published agent skill (`packages/cli/plugin/skills/assistant-ui/SKILL.md`, shipped in the npm package) hardcoded the Radix-only quick-start URL and instructed `npx shadcn@latest add assistant-ui/thread` — an unnamespaced ref the shadcn CLI resolves against the *official* shadcn registry (`styles/{style}/assistant-ui/thread.json`), which 404s.

## How

- `resolveRegistryItemUrl` now treats `undefined` style the same as the quick-start resolver: default to the Base tree. Base is the product default (all templates declare `base-nova`; `shadcn init --defaults` resolves a Base preset). Every **defined** non-`base-` style keeps resolving to the plain Radix URL, so the documented legacy Radix fallback is unchanged for configured projects.
- The `add` warning now states which flavor will be installed when no config is found.
- SKILL.md quick-start URLs point at `/base/chat/b/ai-sdk-quick-start/json` (with the Radix alternative noted), and the invalid unnamespaced commands are replaced by `npx assistant-ui add <name>` (flavor-aware) plus the namespaced `@assistant-ui/<name>` form with the `registries` config it requires — matching the installation docs.
- Updated the tests that codified the old contradictory default (`registry.test.ts`, `test/commands/add.test.ts`).

No behavior change for projects with a defined non-`base-` style.

## Verification

- `pnpm -C packages/cli test`: 239/239 pass
- `tsc --noEmit` in `packages/cli` and `pnpm lint`: clean
- Registry server contract confirmed: `apps/registry/vercel.json` rewrites `/styles/base-*/…` → `/base/…`, and `build-registry.ts` emits `dist/base/{name}.json`, so the new style-less target exists.

Includes a patch changeset for `assistant-ui`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

