### PR TITLE
fix(cli): include assistant-ui version in info

### DIFF
--- a/.changeset/cli-info-version.md
+++ b/.changeset/cli-info-version.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: include the running CLI version in info output

--- a/apps/docs/content/docs/(docs)/cli.mdx
+++ b/apps/docs/content/docs/(docs)/cli.mdx
@@ -356,6 +356,7 @@ npx assistant-ui@latest info
 ```
 
 This command collects and prints:
+- The running `assistant-ui` CLI version
 - OS, Node.js version, package manager, and framework
 - All installed `@assistant-ui/*` and `assistant-*` package versions
 - Key ecosystem dependency versions (React, Next.js, AI SDK, etc.)
@@ -365,6 +366,7 @@ This command collects and prints:
 
 ```
 Environment:
+  assistant-ui CLI: 0.0.106
   OS:               macOS 15.3 (arm64)
   Node.js:          v22.14.0
   Package Manager:  pnpm 10.32.1

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -197,6 +197,19 @@ function getOsInfo(): string {
   }
 }
 
+function getCliVersion(): string {
+  try {
+    const packageJson = JSON.parse(
+      fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { version?: unknown };
+    return typeof packageJson.version === "string"
+      ? packageJson.version
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
 async function getPackageManagerInfo(
   cwd: string,
 ): Promise<{ name: string; version: string }> {
@@ -230,6 +243,7 @@ interface PackageInfo {
 }
 
 interface InfoData {
+  cliVersion: string;
   os: string;
   node: string;
   pm: { name: string; version: string };
@@ -317,6 +331,7 @@ async function collectInfo(
   const warnings = collectWarnings(packages, cwd, projectPkg);
 
   return {
+    cliVersion: getCliVersion(),
     os: getOsInfo(),
     node: process.version,
     pm,
@@ -344,6 +359,7 @@ function renderPlain(data: InfoData): string[] {
   const lines: string[] = [];
 
   lines.push("Environment:");
+  lines.push(`  assistant-ui CLI: ${data.cliVersion}`);
   lines.push(`  OS:               ${data.os}`);
   lines.push(`  Node.js:          ${data.node}`);
   lines.push(`  Package Manager:  ${data.pm.name} ${data.pm.version}`);
@@ -370,6 +386,7 @@ function renderColored(data: InfoData): string[] {
   const lines: string[] = [];
 
   lines.push(chalk.bold("Environment:"));
+  lines.push(`  assistant-ui CLI: ${data.cliVersion}`);
   lines.push(`  OS:               ${data.os}`);
   lines.push(`  Node.js:          ${data.node}`);
   lines.push(`  Package Manager:  ${data.pm.name} ${data.pm.version}`);

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -142,6 +142,9 @@ describe("info command", () => {
   it("includes declared assistant-ui integrations and their peer warnings", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-"));
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const cliPackageJson = JSON.parse(
+      fs.readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
 
     try {
       fs.writeFileSync(
@@ -173,6 +176,7 @@ describe("info command", () => {
       });
 
       const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain(`assistant-ui CLI: ${cliPackageJson.version}`);
       expect(output).toContain("@assistant-ui/react-mcp");
       expect(output).toContain("@assistant-ui/react-generative-ui");
       expect(output).toContain("assistant-stream");


### PR DESCRIPTION
## Summary

- include the running `assistant-ui` CLI version in `assistant-ui info` output and its copyable report
- resolve the version from the CLI package metadata, so `npx` and global installs report the executable that produced the diagnostics
- add test coverage, CLI docs, and a patch changeset

## Why

`assistant-ui info` reports project packages and environment details, but currently omits the CLI version itself. When someone reports a CLI-specific failure, maintainers cannot tell whether the report came from an older global or `npx` installation. Including the executing CLI version makes those reports directly actionable.

## Verification

- `pnpm --filter assistant-ui test` (238 tests)
- `pnpm --filter assistant-ui build`
- `pnpm --filter @assistant-ui/agent-launcher build`
- `pnpm --filter assistant-ui exec tsc --noEmit`
- `pnpm lint`
- ran the built CLI and confirmed `assistant-ui CLI: 0.0.106` appears in both terminal and copyable output
- docs type generation and source snapshot generation pass; the final local Next.js compile was blocked by the host disk reaching `ENOSPC` while writing `.next/trace`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

