### PR TITLE
fix(react-generative-ui): preserve Slack alert level types

### DIFF
--- a/.changeset/fix-preserve-slack-alert-level-liter-20260716105653.md
+++ b/.changeset/fix-preserve-slack-alert-level-liter-20260716105653.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: preserve Slack alert level literal types

--- a/packages/react-generative-ui/src/slack/constants.ts
+++ b/packages/react-generative-ui/src/slack/constants.ts
@@ -157,12 +157,7 @@ export function buildAlertBlock(
   text: string,
   tone: "info" | "success" | "warning" | "danger",
 ): SlackAlertBlock {
-  const level = {
-    info: "info",
-    success: "success",
-    warning: "warning",
-    danger: "error",
-  }[tone] as const;
+  const level = tone === "danger" ? "error" : tone;
   return { type: "alert", text: { type: "mrkdwn", text }, level };
 }
 


### PR DESCRIPTION
Closes #4992

## Root cause

TypeScript 6 rejects `as const` on an indexed expression and otherwise widens the Slack alert level to `string` when the docs app source-links `@assistant-ui/react-generative-ui/slack`.

## What changed

Use a direct conditional so `danger` maps to `error` and all other tones pass through while preserving the accepted literal union.

## Verification

- `pnpm --filter @assistant-ui/react-generative-ui test` (24 files, 527 tests)
- `pnpm --filter @assistant-ui/react-generative-ui build`
- `pnpm changeset status --since codex/mastra --verbose` (`@assistant-ui/react-generative-ui`: patch)
- cumulative current-main docs build (448 static pages)

Depends on #4994.