### PR TITLE
docs: fix ai sdk overview link

### DIFF
--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -3,7 +3,7 @@ title: AI SDK v7
 description: Integrate Vercel AI SDK v7 with assistant-ui for streaming chat.
 ---
 
-Current-version integration. Requires `ai@^7` and `@ai-sdk/react@^4`. For older versions see the [overview](/docs/runtimes/ai-sdk).
+Current-version integration. Requires `ai@^7` and `@ai-sdk/react@^4`. For older versions see the [overview](/docs/runtimes/ai-sdk/overview).
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

Fix the AI SDK v7 page’s overview link to point to `/docs/runtimes/ai-sdk/overview`.

## Why

The previous `/docs/runtimes/ai-sdk` target has no page, so users looking for older AI SDK integration guides were sent to a missing route.

## Verification

- confirmed `apps/docs/content/docs/runtimes/ai-sdk/overview.mdx` exists
- confirmed the AI SDK v6 guide already uses the corrected route
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/4996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

