### PR TITLE
fix(cloud): normalize response timestamps

### DIFF
--- a/.changeset/cloud-response-timestamps.md
+++ b/.changeset/cloud-response-timestamps.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: normalize thread and message response timestamps to Date objects

--- a/packages/cloud/src/AssistantCloudThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.ts
@@ -1,5 +1,6 @@
 import type { ReadonlyJSONObject } from "assistant-stream/utils";
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
+import { normalizeCloudTimestamp } from "./normalizeCloudTimestamp";
 
 export type CloudMessage = {
   id: string;
@@ -11,12 +12,21 @@ export type CloudMessage = {
   content: ReadonlyJSONObject;
 };
 
+type CloudMessageResponse = Omit<CloudMessage, "created_at" | "updated_at"> & {
+  created_at: string;
+  updated_at: string;
+};
+
 type AssistantCloudThreadMessageListQuery = {
   format?: string;
 };
 
 type AssistantCloudThreadMessageListResponse = {
   messages: CloudMessage[];
+};
+
+type AssistantCloudThreadMessageListAPIResponse = {
+  messages: CloudMessageResponse[];
 };
 
 type AssistantCloudThreadMessageCreateBody = {
@@ -33,6 +43,14 @@ type AssistantCloudThreadMessageUpdateBody = {
   content: ReadonlyJSONObject;
 };
 
+const normalizeCloudMessage = (
+  message: CloudMessageResponse,
+): CloudMessage => ({
+  ...message,
+  created_at: normalizeCloudTimestamp(message.created_at, "message.created_at"),
+  updated_at: normalizeCloudTimestamp(message.updated_at, "message.updated_at"),
+});
+
 export class AssistantCloudThreadMessages {
   constructor(private cloud: AssistantCloudAPI) {}
 
@@ -40,10 +58,15 @@ export class AssistantCloudThreadMessages {
     threadId: string,
     query?: AssistantCloudThreadMessageListQuery,
   ): Promise<AssistantCloudThreadMessageListResponse> {
-    return this.cloud.makeRequest(
+    const response = (await this.cloud.makeRequest(
       `/threads/${encodeURIComponent(threadId)}/messages`,
       { query },
-    );
+    )) as AssistantCloudThreadMessageListAPIResponse;
+
+    return {
+      ...response,
+      messages: response.messages.map(normalizeCloudMessage),
+    };
   }
 
   public async create(

--- a/packages/cloud/src/AssistantCloudThreads.test.ts
+++ b/packages/cloud/src/AssistantCloudThreads.test.ts
@@ -60,6 +60,18 @@ describe("AssistantCloudThreads response timestamps", () => {
     expect(result.created_at.toISOString()).toBe("2026-07-16T12:00:00.000Z");
   });
 
+  it("uses created_at when last_message_at is missing", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({
+      ...threadResponse,
+      last_message_at: null,
+    });
+
+    const result = await threads.get("thread-1");
+
+    expect(result.last_message_at).toEqual(result.created_at);
+  });
+
   it("normalizes message timestamps without changing content", async () => {
     const { threads, makeRequest } = createCloudThreads();
     makeRequest.mockResolvedValue({
@@ -90,6 +102,18 @@ describe("AssistantCloudThreads response timestamps", () => {
     makeRequest.mockResolvedValue({
       ...threadResponse,
       created_at: "not-a-timestamp",
+    });
+
+    await expect(threads.get("thread-1")).rejects.toThrow(
+      'Invalid Assistant Cloud response timestamp for "thread.created_at"',
+    );
+  });
+
+  it("rejects impossible calendar timestamps", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({
+      ...threadResponse,
+      created_at: "2026-02-30T12:00:00.000Z",
     });
 
     await expect(threads.get("thread-1")).rejects.toThrow(

--- a/packages/cloud/src/AssistantCloudThreads.test.ts
+++ b/packages/cloud/src/AssistantCloudThreads.test.ts
@@ -1,14 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
 import { AssistantCloudThreads } from "./AssistantCloudThreads";
+import { OriginalDate } from "./tests/setup";
 
 const mockedDate = globalThis.Date;
-const NativeDate = Object.getPrototypeOf(
-  (mockedDate as unknown as () => Date)(),
-).constructor as DateConstructor;
 
 beforeAll(() => {
-  globalThis.Date = NativeDate;
+  globalThis.Date = OriginalDate;
 });
 
 afterAll(() => {
@@ -42,9 +40,9 @@ describe("AssistantCloudThreads response timestamps", () => {
     const result = await threads.list();
 
     expect(result.threads[0]).toMatchObject({
-      last_message_at: new NativeDate("2026-07-16T12:30:00.000Z"),
-      created_at: new NativeDate("2026-07-16T12:00:00.000Z"),
-      updated_at: new NativeDate("2026-07-16T12:15:00.000Z"),
+      last_message_at: new OriginalDate("2026-07-16T12:30:00.000Z"),
+      created_at: new OriginalDate("2026-07-16T12:00:00.000Z"),
+      updated_at: new OriginalDate("2026-07-16T12:15:00.000Z"),
       metadata: { created_at: "leave-this-string-untouched" },
     });
     expect(threadResponse.created_at).toBe("2026-07-16T12:00:00.000Z");
@@ -56,7 +54,7 @@ describe("AssistantCloudThreads response timestamps", () => {
 
     const result = await threads.get("thread-1");
 
-    expect(result.created_at).toBeInstanceOf(NativeDate);
+    expect(result.created_at).toBeInstanceOf(OriginalDate);
     expect(result.created_at.toISOString()).toBe("2026-07-16T12:00:00.000Z");
   });
 
@@ -91,8 +89,8 @@ describe("AssistantCloudThreads response timestamps", () => {
     const result = await threads.messages.list("thread-1");
 
     expect(result.messages[0]).toMatchObject({
-      created_at: new NativeDate("2026-07-16T13:00:00.000Z"),
-      updated_at: new NativeDate("2026-07-16T13:05:00.000Z"),
+      created_at: new OriginalDate("2026-07-16T13:00:00.000Z"),
+      updated_at: new OriginalDate("2026-07-16T13:05:00.000Z"),
       content: { created_at: "leave-this-string-untouched" },
     });
   });

--- a/packages/cloud/src/AssistantCloudThreads.test.ts
+++ b/packages/cloud/src/AssistantCloudThreads.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { AssistantCloudAPI } from "./AssistantCloudAPI";
+import { AssistantCloudThreads } from "./AssistantCloudThreads";
+
+const mockedDate = globalThis.Date;
+const NativeDate = Object.getPrototypeOf(
+  (mockedDate as unknown as () => Date)(),
+).constructor as DateConstructor;
+
+beforeAll(() => {
+  globalThis.Date = NativeDate;
+});
+
+afterAll(() => {
+  globalThis.Date = mockedDate;
+});
+
+const createCloudThreads = () => {
+  const makeRequest = vi.fn();
+  const api = { makeRequest } as unknown as AssistantCloudAPI;
+  return { threads: new AssistantCloudThreads(api), makeRequest };
+};
+
+const threadResponse = {
+  title: "Support",
+  last_message_at: "2026-07-16T12:30:00.000Z",
+  metadata: { created_at: "leave-this-string-untouched" },
+  external_id: null,
+  id: "thread-1",
+  project_id: "project-1",
+  created_at: "2026-07-16T12:00:00.000Z",
+  updated_at: "2026-07-16T12:15:00.000Z",
+  workspace_id: "workspace-1",
+  is_archived: false,
+};
+
+describe("AssistantCloudThreads response timestamps", () => {
+  it("normalizes thread list timestamps without changing metadata", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({ threads: [threadResponse] });
+
+    const result = await threads.list();
+
+    expect(result.threads[0]).toMatchObject({
+      last_message_at: new NativeDate("2026-07-16T12:30:00.000Z"),
+      created_at: new NativeDate("2026-07-16T12:00:00.000Z"),
+      updated_at: new NativeDate("2026-07-16T12:15:00.000Z"),
+      metadata: { created_at: "leave-this-string-untouched" },
+    });
+    expect(threadResponse.created_at).toBe("2026-07-16T12:00:00.000Z");
+  });
+
+  it("normalizes timestamps when fetching one thread", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue(threadResponse);
+
+    const result = await threads.get("thread-1");
+
+    expect(result.created_at).toBeInstanceOf(NativeDate);
+    expect(result.created_at.toISOString()).toBe("2026-07-16T12:00:00.000Z");
+  });
+
+  it("normalizes message timestamps without changing content", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({
+      messages: [
+        {
+          id: "message-1",
+          parent_id: null,
+          height: 0,
+          created_at: "2026-07-16T13:00:00.000Z",
+          updated_at: "2026-07-16T13:05:00.000Z",
+          format: "aui/v0",
+          content: { created_at: "leave-this-string-untouched" },
+        },
+      ],
+    });
+
+    const result = await threads.messages.list("thread-1");
+
+    expect(result.messages[0]).toMatchObject({
+      created_at: new NativeDate("2026-07-16T13:00:00.000Z"),
+      updated_at: new NativeDate("2026-07-16T13:05:00.000Z"),
+      content: { created_at: "leave-this-string-untouched" },
+    });
+  });
+
+  it("rejects malformed response timestamps with field context", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({
+      ...threadResponse,
+      created_at: "not-a-timestamp",
+    });
+
+    await expect(threads.get("thread-1")).rejects.toThrow(
+      'Invalid Assistant Cloud response timestamp for "thread.created_at"',
+    );
+  });
+});

--- a/packages/cloud/src/AssistantCloudThreads.ts
+++ b/packages/cloud/src/AssistantCloudThreads.ts
@@ -1,5 +1,6 @@
 import type { AssistantCloudAPI } from "./AssistantCloudAPI";
 import { AssistantCloudThreadMessages } from "./AssistantCloudThreadMessages";
+import { normalizeCloudTimestamp } from "./normalizeCloudTimestamp";
 
 type AssistantCloudThreadsListQuery = {
   is_archived?: boolean;
@@ -20,8 +21,21 @@ type CloudThread = {
   is_archived: boolean;
 };
 
+type CloudThreadResponse = Omit<
+  CloudThread,
+  "last_message_at" | "created_at" | "updated_at"
+> & {
+  last_message_at: string;
+  created_at: string;
+  updated_at: string;
+};
+
 type AssistantCloudThreadsListResponse = {
   threads: CloudThread[];
+};
+
+type AssistantCloudThreadsListAPIResponse = {
+  threads: CloudThreadResponse[];
 };
 
 type AssistantCloudThreadsCreateBody = {
@@ -42,6 +56,16 @@ type AssistantCloudThreadsUpdateBody = {
   is_archived?: boolean | undefined;
 };
 
+const normalizeCloudThread = (thread: CloudThreadResponse): CloudThread => ({
+  ...thread,
+  last_message_at: normalizeCloudTimestamp(
+    thread.last_message_at,
+    "thread.last_message_at",
+  ),
+  created_at: normalizeCloudTimestamp(thread.created_at, "thread.created_at"),
+  updated_at: normalizeCloudTimestamp(thread.updated_at, "thread.updated_at"),
+});
+
 export class AssistantCloudThreads {
   public readonly messages: AssistantCloudThreadMessages;
 
@@ -52,11 +76,22 @@ export class AssistantCloudThreads {
   public async list(
     query?: AssistantCloudThreadsListQuery,
   ): Promise<AssistantCloudThreadsListResponse> {
-    return this.cloud.makeRequest("/threads", { query });
+    const response = (await this.cloud.makeRequest("/threads", {
+      query,
+    })) as AssistantCloudThreadsListAPIResponse;
+
+    return {
+      ...response,
+      threads: response.threads.map(normalizeCloudThread),
+    };
   }
 
   public async get(threadId: string): Promise<CloudThread> {
-    return this.cloud.makeRequest(`/threads/${encodeURIComponent(threadId)}`);
+    const thread = (await this.cloud.makeRequest(
+      `/threads/${encodeURIComponent(threadId)}`,
+    )) as CloudThreadResponse;
+
+    return normalizeCloudThread(thread);
   }
 
   public async create(

--- a/packages/cloud/src/AssistantCloudThreads.ts
+++ b/packages/cloud/src/AssistantCloudThreads.ts
@@ -25,7 +25,7 @@ type CloudThreadResponse = Omit<
   CloudThread,
   "last_message_at" | "created_at" | "updated_at"
 > & {
-  last_message_at: string;
+  last_message_at?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -56,15 +56,25 @@ type AssistantCloudThreadsUpdateBody = {
   is_archived?: boolean | undefined;
 };
 
-const normalizeCloudThread = (thread: CloudThreadResponse): CloudThread => ({
-  ...thread,
-  last_message_at: normalizeCloudTimestamp(
-    thread.last_message_at,
-    "thread.last_message_at",
-  ),
-  created_at: normalizeCloudTimestamp(thread.created_at, "thread.created_at"),
-  updated_at: normalizeCloudTimestamp(thread.updated_at, "thread.updated_at"),
-});
+const normalizeCloudThread = (thread: CloudThreadResponse): CloudThread => {
+  const createdAt = normalizeCloudTimestamp(
+    thread.created_at,
+    "thread.created_at",
+  );
+
+  return {
+    ...thread,
+    last_message_at:
+      thread.last_message_at == null
+        ? createdAt
+        : normalizeCloudTimestamp(
+            thread.last_message_at,
+            "thread.last_message_at",
+          ),
+    created_at: createdAt,
+    updated_at: normalizeCloudTimestamp(thread.updated_at, "thread.updated_at"),
+  };
+};
 
 export class AssistantCloudThreads {
   public readonly messages: AssistantCloudThreadMessages;

--- a/packages/cloud/src/normalizeCloudTimestamp.ts
+++ b/packages/cloud/src/normalizeCloudTimestamp.ts
@@ -1,21 +1,37 @@
+const calendarDatePattern = /^(\d{4})-(\d{2})-(\d{2})T/;
+
+const isLeapYear = (year: number) =>
+  year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+
+const daysInMonth = (year: number, month: number) =>
+  [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][
+    month - 1
+  ];
+
+const invalidTimestamp = (field: string) =>
+  new Error(`Invalid Assistant Cloud response timestamp for "${field}"`);
+
 export const normalizeCloudTimestamp = (
   value: unknown,
   field: string,
 ): Date => {
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
 
-  if (typeof value !== "string") {
-    throw new Error(
-      `Invalid Assistant Cloud response timestamp for "${field}"`,
-    );
+  if (typeof value !== "string") throw invalidTimestamp(field);
+
+  const match = calendarDatePattern.exec(value);
+  if (!match) throw invalidTimestamp(field);
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const maxDay = daysInMonth(year, month);
+  if (maxDay === undefined || day < 1 || day > maxDay) {
+    throw invalidTimestamp(field);
   }
 
   const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    throw new Error(
-      `Invalid Assistant Cloud response timestamp for "${field}"`,
-    );
-  }
+  if (Number.isNaN(date.getTime())) throw invalidTimestamp(field);
 
   return date;
 };

--- a/packages/cloud/src/normalizeCloudTimestamp.ts
+++ b/packages/cloud/src/normalizeCloudTimestamp.ts
@@ -1,0 +1,21 @@
+export const normalizeCloudTimestamp = (
+  value: unknown,
+  field: string,
+): Date => {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+
+  if (typeof value !== "string") {
+    throw new Error(
+      `Invalid Assistant Cloud response timestamp for "${field}"`,
+    );
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(
+      `Invalid Assistant Cloud response timestamp for "${field}"`,
+    );
+  }
+
+  return date;
+};

--- a/packages/cloud/src/tests/setup.ts
+++ b/packages/cloud/src/tests/setup.ts
@@ -3,7 +3,7 @@ import { vi } from "vitest";
 
 // Set up globalThis mocks if needed
 // Using a fixed date to avoid recursive calls
-const OriginalDate = globalThis.Date;
+export const OriginalDate = globalThis.Date;
 const fixedDate = new OriginalDate("2023-01-01");
 globalThis.Date = vi.fn(() => fixedDate) as any;
 globalThis.Date.now = vi.fn(() => fixedDate.getTime());


### PR DESCRIPTION
## Summary

- normalize Cloud thread timestamps returned by `threads.list()` and `threads.get()`
- normalize message timestamps returned by `threads.messages.list()`
- validate timestamp calendar values and report malformed fields with context
- use `created_at` as the activity-time fallback for legacy or empty threads without `last_message_at`

## Why

While exercising Cloud thread and message history, I noticed that the SDK declares fields such as `created_at`, `updated_at`, and `last_message_at` as `Date`, but ordinary JSON responses produce strings at runtime. Code that trusts the public type can therefore fail with errors such as `thread.created_at.getTime is not a function`.

Normalization happens at the endpoint boundaries instead of through a global JSON reviver, so timestamp-looking strings inside user-controlled metadata or message content keep their original values. The fallback for a missing `last_message_at` preserves the existing public `Date` contract while allowing empty or legacy threads to load.

## Testing

- `pnpm --filter assistant-cloud test`
- `pnpm --filter assistant-cloud build`
- `pnpm lint`