### PR TITLE
fix(deps): deduplicate hast types

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@types/hast': 3.0.5
+
 importers:
 
   .:
@@ -4307,7 +4310,7 @@ importers:
         specifier: workspace:*
         version: link:../x-buildutils
       '@types/hast':
-        specifier: ^3.0.5
+        specifier: 3.0.5
         version: 3.0.5
       '@types/react':
         specifier: ^19.2.17
@@ -4547,7 +4550,7 @@ importers:
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/hast':
-        specifier: ^3.0.5
+        specifier: 3.0.5
         version: 3.0.5
       '@types/react':
         specifier: ^19.2.17
@@ -12742,7 +12745,7 @@ packages:
       '@oramacloud/client': 2.x.x
       '@tanstack/react-router': 1.x.x
       '@types/estree-jsx': '*'
-      '@types/hast': '*'
+      '@types/hast': 3.0.5
       '@types/mdast': '*'
       '@types/react': '*'
       algoliasearch: 5.x.x

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 
 linkWorkspacePackages: true
 preferWorkspacePackages: true
+overrides:
+  '@types/hast': 3.0.5
 publicHoistPattern:
   - '@types/*'
 


### PR DESCRIPTION
Closes #4997

## Root cause

The workspace resolves both `@types/hast 3.0.4` and `3.0.5`. Source-linked assistant-ui Markdown code and `react-markdown` then expose structurally incompatible HAST `Element` types under exact optional-property checking.

## What changed

Pin the workspace graph to `@types/hast 3.0.5` with a root pnpm override and normalize the lockfile so stale `3.0.4` snapshots cannot survive downstream dependency additions.

## Verification

- `pnpm why @types/hast -r` reports only `@types/hast@3.0.5`
- clean lockfile install on Node 24.11.1
- cumulative current-main docs build (448 static pages)
- `pnpm changeset status --since codex/mastra-slack-types --verbose` reports no release

This changes only workspace dependency resolution and does not modify a published package. Depends on #4995.