### PR TITLE
docs(mastra): add current migration guide

### DIFF
--- a/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/meta.json
@@ -8,6 +8,7 @@
     "separate-server",
     "threads",
     "memory",
-    "workflows"
+    "workflows",
+    "migration"
   ]
 }

--- a/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
@@ -19,7 +19,13 @@ Both layouts must return an AI SDK UI message stream. Do not point the new runti
 
 Install the integration and Mastra client. Keep `@assistant-ui/react-ai-sdk`; `useMastraRuntime` builds on it.
 
-<InstallCommand npm={["@assistant-ui/react-mastra@latest", "@mastra/client-js@latest"]} />
+<InstallCommand
+  npm={[
+    "@assistant-ui/react-mastra@latest",
+    "@mastra/client-js@latest",
+    "@mastra/ai-sdk@latest",
+  ]}
+/>
 
 Replace a generic data-stream runtime:
 
@@ -45,7 +51,10 @@ const baseUrl = "http://localhost:4111";
 const client = new MastraClient({ baseUrl });
 const storageKey = "selected-mastra-thread";
 
-export function RuntimeProvider({ children }: PropsWithChildren) {
+export function RuntimeProvider({
+  children,
+  resourceId,
+}: PropsWithChildren<{ resourceId: string }>) {
   const [threadId, setThreadId] = useState<string | undefined>(() => {
     if (typeof window === "undefined") return undefined;
     return window.localStorage.getItem(storageKey) ?? undefined;
@@ -59,7 +68,7 @@ export function RuntimeProvider({ children }: PropsWithChildren) {
   const runtime = useMastraRuntime({
     client,
     agentId: "releaseAssistant",
-    resourceId: "authenticated-user-id",
+    resourceId,
     threadId,
     onThreadIdChange,
     transportOptions: {
@@ -75,7 +84,7 @@ export function RuntimeProvider({ children }: PropsWithChildren) {
 }
 ```
 
-`resourceId` identifies the authenticated account or tenant. `threadId` identifies one conversation and must be updated through `onThreadIdChange`. Authorize both values on the server; local storage is selection state, not an access-control boundary.
+Pass `resourceId` from the authenticated server session so every account or tenant has its own value. `threadId` identifies one conversation and must be updated through `onThreadIdChange`. Authorize both values on the server; local storage is selection state, not an access-control boundary.
 
 ## Keep existing UI adapters
 

--- a/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
@@ -1,0 +1,114 @@
+---
+title: Migrate to the Mastra runtime
+description: Replace a generic stream runtime with Mastra-backed threads, memory actions, and durable workflows.
+platforms: ["react"]
+---
+
+The dedicated `@assistant-ui/react-mastra` runtime adds Mastra-owned thread history and lifecycle APIs around the same AI SDK chat protocol. Migrate when the browser needs persisted thread navigation, semantic or working memory, or durable workflow controls. A chat-only application can keep using `useChatRuntime`.
+
+## Before you start
+
+Choose the server layout first:
+
+- [Full-stack](/docs/integrations/frameworks/mastra/full-stack) keeps Mastra and the frontend in one application.
+- [Separate server](/docs/integrations/frameworks/mastra/separate-server) exposes Mastra's client API and `chatRoute` from another service.
+
+Both layouts must return an AI SDK UI message stream. Do not point the new runtime at an older custom Mastra stream format.
+
+## Replace the runtime
+
+Install the integration and Mastra client. Keep `@assistant-ui/react-ai-sdk`; `useMastraRuntime` builds on it.
+
+<InstallCommand npm={["@assistant-ui/react-mastra@latest", "@mastra/client-js@latest"]} />
+
+Replace a generic data-stream runtime:
+
+```tsx title="Before"
+import { useDataStreamRuntime } from "@assistant-ui/react-data-stream";
+
+const runtime = useDataStreamRuntime({
+  api: "http://localhost:4111/chat/releaseAssistant",
+});
+```
+
+with a Mastra client, a stable resource identity, and the selected thread ID:
+
+```tsx title="After"
+"use client";
+
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useMastraRuntime } from "@assistant-ui/react-mastra";
+import { MastraClient } from "@mastra/client-js";
+import { type PropsWithChildren, useCallback, useState } from "react";
+
+const baseUrl = "http://localhost:4111";
+const client = new MastraClient({ baseUrl });
+const storageKey = "selected-mastra-thread";
+
+export function RuntimeProvider({ children }: PropsWithChildren) {
+  const [threadId, setThreadId] = useState<string | undefined>(() => {
+    if (typeof window === "undefined") return undefined;
+    return window.localStorage.getItem(storageKey) ?? undefined;
+  });
+  const onThreadIdChange = useCallback((nextId: string | undefined) => {
+    setThreadId(nextId);
+    if (nextId) window.localStorage.setItem(storageKey, nextId);
+    else window.localStorage.removeItem(storageKey);
+  }, []);
+
+  const runtime = useMastraRuntime({
+    client,
+    agentId: "releaseAssistant",
+    resourceId: "authenticated-user-id",
+    threadId,
+    onThreadIdChange,
+    transportOptions: {
+      api: `${baseUrl}/chat/releaseAssistant`,
+    },
+  });
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+`resourceId` identifies the authenticated account or tenant. `threadId` identifies one conversation and must be updated through `onThreadIdChange`. Authorize both values on the server; local storage is selection state, not an access-control boundary.
+
+## Keep existing UI adapters
+
+`UseMastraRuntimeOptions` includes the supported `useChatRuntime` options. Existing assistant-ui behavior stays on the standard runtime surface:
+
+| Existing behavior | Migration |
+| --- | --- |
+| Tool UIs | Keep `makeAssistantToolUI`, `useAssistantToolUI`, or the thread's tool fallback. Mastra tool parts arrive through the AI SDK stream. |
+| Attachments | Pass the existing `adapters.attachments` option to `useMastraRuntime`. |
+| Feedback | Pass the existing `adapters.feedback` option to `useMastraRuntime`. |
+| Speech synthesis | Pass the existing `adapters.speech` option to `useMastraRuntime`. |
+| Headers, credentials, or request body | Configure them in `transportOptions`, or pass a custom AI SDK `transport`. |
+
+Do not add Mastra-specific attachment, feedback, speech, or tool converters. The runtime forwards these options to `useChatRuntime`, and `@mastra/ai-sdk` owns server-stream conversion.
+
+## Add Mastra capabilities separately
+
+After chat and thread selection work, add only the capabilities your UI uses:
+
+- [Persisted threads](/docs/integrations/frameworks/mastra/threads) covers list, create, rename, archive, delete, and history restore.
+- [Semantic and working memory](/docs/integrations/frameworks/mastra/memory) adds `useMastraMemory` beside the runtime.
+- [Durable workflows](/docs/integrations/frameworks/mastra/workflows) adds `useMastraWorkflow` with reconnect, resume, and cancel.
+
+Memory and workflows are not nested configuration on `useMastraRuntime`. They use current `MastraClient` methods so each lifecycle remains independently testable and resumable.
+
+## Remove abandoned APIs
+
+The old integration proposal documented hooks for events, RAG, observability, automatic workflow configuration, and Mastra-specific adapter factories. Those APIs never shipped and are not part of this migration. Keep server-side RAG, tracing, evals, model routing, and agent tools in Mastra; expose only the resulting AI SDK message parts and the client actions the browser needs.
+
+## Verify the migration
+
+1. Send a message and confirm the response streams from the Mastra `chatRoute`.
+2. Create two threads and confirm their histories remain isolated after reload.
+3. Rename, archive, restore, and delete a thread from the assistant-ui thread list.
+4. If enabled, search memory or resume a suspended workflow after a full page reload.
+5. Confirm server authorization rejects a resource, thread, or workflow run owned by another user.

--- a/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/migration.mdx
@@ -24,6 +24,7 @@ Install the integration and Mastra client. Keep `@assistant-ui/react-ai-sdk`; `u
     "@assistant-ui/react-mastra@latest",
     "@mastra/client-js@latest",
     "@mastra/ai-sdk@latest",
+    "@mastra/core@latest",
   ]}
 />
 

--- a/apps/docs/content/docs/integrations/frameworks/mastra/overview.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/overview.mdx
@@ -21,6 +21,7 @@ For streaming chat only, keep using the standard [AI SDK runtime](/docs/runtimes
 | [Persisted threads](/docs/integrations/frameworks/mastra/threads) | Add Mastra-backed thread navigation and history to either deployment pattern. |
 | [Semantic and working memory](/docs/integrations/frameworks/mastra/memory) | Search semantic recall and manage persistent user context through Mastra's client. |
 | [Durable workflows](/docs/integrations/frameworks/mastra/workflows) | Render suspended workflow steps and resume persisted runs after reload. |
+| [Migration](/docs/integrations/frameworks/mastra/migration) | Move from `useDataStreamRuntime` or a chat-only AI SDK runtime to the dedicated Mastra runtime. |
 
 Both chat patterns use the AI SDK protocol. `useMastraRuntime` composes that chat runtime with Mastra's thread APIs; `useMastraMemory` and `useMastraWorkflow` use Mastra's supported client methods directly beside the chat runtime.
 
@@ -71,5 +72,11 @@ Workflow runs remain a separate lifecycle so a suspended approval can be rendere
     title="Semantic and working memory"
     description="Search recall and manage persistent user context."
     href="/docs/integrations/frameworks/mastra/memory"
+  />
+  <Card
+    icon={<MastraIcon width={20} height={20} />}
+    title="Migration guide"
+    description="Adopt the dedicated runtime without replacing working adapters."
+    href="/docs/integrations/frameworks/mastra/migration"
   />
 </Cards>


### PR DESCRIPTION
## Summary

Adds the migration guide promised by the original Mastra integration, rewritten against the current supported architecture:

- migrates `useDataStreamRuntime` to `useMastraRuntime` with explicit Mastra client, resource, and thread identity
- preserves existing tool UI, attachment, feedback, and speech adapters through `useChatRuntime` option passthrough
- links the owning thread, semantic/working memory, and durable workflow guides
- explicitly excludes the abandoned proposal's nonexistent event, RAG, observability, and automatic workflow APIs

Closes #5006
Parent: #4922
Stacked on #5002.

## Verification

- `pnpm -C apps/docs generate:api-reference --strict` (496 exports)
- `pnpm exec turbo build --filter=@assistant-ui/docs... --concurrency=4` (24 tasks, docs production build, 450 static pages)
- focused oxfmt and `git diff --check`

All verification used Node 24.11.1. This changes only the private docs app, so no changeset is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

