### PR TITLE
feat(examples): demonstrate Mastra agents and tools

### DIFF
--- a/examples/with-mastra/README.md
+++ b/examples/with-mastra/README.md
@@ -3,6 +3,7 @@
 This example runs assistant-ui against a local Mastra server. It demonstrates:
 
 - AI SDK-compatible agent streaming
+- two selectable Mastra agents with distinct typed server tools
 - LibSQL-backed thread creation, switching, and message restoration
 - a durable workflow with two human approval checkpoints
 - workflow run restoration after a browser reload
@@ -21,3 +22,8 @@ by Git.
 The local example creates a persistent resource ID per browser. Production apps
 must derive that identity from an authenticated server session and authorize
 resource, thread, and workflow access on the server.
+
+The release assistant calls `draftReleaseBrief` before writing release copy.
+The risk analyst calls `assessRolloutRisk` before recommending release gates.
+Both stream through Mastra's dynamic `/chat/:agentId` route, and assistant-ui
+renders their tool parts through the canonical thread component.

--- a/examples/with-mastra/app/MyRuntimeProvider.tsx
+++ b/examples/with-mastra/app/MyRuntimeProvider.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 
@@ -17,10 +18,22 @@ export const mastraUrl =
 
 export const mastraClient = new MastraClient({ baseUrl: mastraUrl });
 
-const transportOptions = { api: `${mastraUrl}/chat` };
-const threadStorageKey = "assistant-ui-mastra-thread-id";
+export type MastraExampleAgentId = "releaseAssistant" | "riskAnalyst";
+
+const threadStorageKey = (agentId: MastraExampleAgentId) =>
+  `assistant-ui-mastra-thread-id:${agentId}`;
 const resourceStorageKey = "assistant-ui-mastra-resource-id";
 const ResourceIdContext = createContext<string | null>(null);
+
+const readThreadIds = () => {
+  if (typeof window === "undefined") return {};
+  return Object.fromEntries(
+    (["releaseAssistant", "riskAnalyst"] as const).flatMap((agentId) => {
+      const threadId = window.localStorage.getItem(threadStorageKey(agentId));
+      return threadId ? [[agentId, threadId]] : [];
+    }),
+  ) as Partial<Record<MastraExampleAgentId, string>>;
+};
 
 export const useMastraResourceId = () => {
   const resourceId = useContext(ResourceIdContext);
@@ -32,42 +45,53 @@ export const useMastraResourceId = () => {
   return resourceId;
 };
 
-function MastraRuntimeProvider({
+function AgentRuntimeProvider({
+  agentId,
   children,
   resourceId,
-}: PropsWithChildren<{ resourceId: string }>) {
-  const [threadId, setThreadId] = useState<string | undefined>(() => {
-    return window.localStorage.getItem(threadStorageKey) ?? undefined;
-  });
+}: PropsWithChildren<{
+  agentId: MastraExampleAgentId;
+  resourceId: string;
+}>) {
+  const [threadIds, setThreadIds] =
+    useState<Partial<Record<MastraExampleAgentId, string>>>(readThreadIds);
+  const threadId = threadIds[agentId];
   const handleThreadIdChange = useCallback(
     (nextThreadId: string | undefined) => {
-      setThreadId(nextThreadId);
+      setThreadIds((current) => ({ ...current, [agentId]: nextThreadId }));
       if (nextThreadId) {
-        window.localStorage.setItem(threadStorageKey, nextThreadId);
+        window.localStorage.setItem(threadStorageKey(agentId), nextThreadId);
       } else {
-        window.localStorage.removeItem(threadStorageKey);
+        window.localStorage.removeItem(threadStorageKey(agentId));
       }
     },
-    [],
+    [agentId],
+  );
+  const transportOptions = useMemo(
+    () => ({ api: `${mastraUrl}/chat/${agentId}` }),
+    [agentId],
   );
 
   const runtime = useMastraRuntime({
     client: mastraClient,
-    agentId: "releaseAssistant",
-    resourceId,
+    agentId,
+    resourceId: `${resourceId}:${agentId}`,
     threadId,
     onThreadIdChange: handleThreadIdChange,
     transportOptions,
   });
 
   return (
-    <AssistantRuntimeProvider runtime={runtime}>
+    <AssistantRuntimeProvider key={agentId} runtime={runtime}>
       {children}
     </AssistantRuntimeProvider>
   );
 }
 
-export function MyRuntimeProvider({ children }: PropsWithChildren) {
+export function MyRuntimeProvider({
+  agentId,
+  children,
+}: PropsWithChildren<{ agentId: MastraExampleAgentId }>) {
   const [resourceId, setResourceId] = useState<string>();
   useEffect(() => {
     const stored = window.localStorage.getItem(resourceStorageKey);
@@ -80,9 +104,9 @@ export function MyRuntimeProvider({ children }: PropsWithChildren) {
 
   return (
     <ResourceIdContext.Provider value={resourceId}>
-      <MastraRuntimeProvider resourceId={resourceId}>
+      <AgentRuntimeProvider agentId={agentId} resourceId={resourceId}>
         {children}
-      </MastraRuntimeProvider>
+      </AgentRuntimeProvider>
     </ResourceIdContext.Provider>
   );
 }

--- a/examples/with-mastra/app/MyRuntimeProvider.tsx
+++ b/examples/with-mastra/app/MyRuntimeProvider.tsx
@@ -18,7 +18,11 @@ export const mastraUrl =
 
 export const mastraClient = new MastraClient({ baseUrl: mastraUrl });
 
-export type MastraExampleAgentId = "releaseAssistant" | "riskAnalyst";
+export const mastraExampleAgentIds = [
+  "releaseAssistant",
+  "riskAnalyst",
+] as const;
+export type MastraExampleAgentId = (typeof mastraExampleAgentIds)[number];
 
 const threadStorageKey = (agentId: MastraExampleAgentId) =>
   `assistant-ui-mastra-thread-id:${agentId}`;
@@ -28,7 +32,7 @@ const ResourceIdContext = createContext<string | null>(null);
 const readThreadIds = () => {
   if (typeof window === "undefined") return {};
   return Object.fromEntries(
-    (["releaseAssistant", "riskAnalyst"] as const).flatMap((agentId) => {
+    mastraExampleAgentIds.flatMap((agentId) => {
       const threadId = window.localStorage.getItem(threadStorageKey(agentId));
       return threadId ? [[agentId, threadId]] : [];
     }),

--- a/examples/with-mastra/app/globals.css
+++ b/examples/with-mastra/app/globals.css
@@ -204,9 +204,44 @@
   min-height: 4.5rem;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
   border-bottom: 1px solid var(--border);
   padding: 0.8rem 1.1rem;
+}
+
+.agent-selector {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 0.2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: var(--muted);
+  padding: 0.2rem;
+}
+
+.agent-selector button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 0.3rem;
+  background: transparent;
+  padding: 0.35rem 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.agent-selector button[aria-selected="true"] {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px rgb(23 25 24 / 10%);
+}
+
+.agent-selector button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
 }
 
 .eyebrow {
@@ -519,5 +554,20 @@
 
   .capability-list {
     display: none;
+  }
+
+  .chat-stage__header {
+    align-items: flex-start;
+  }
+
+  .agent-selector {
+    width: 100%;
+    order: 3;
+  }
+
+  .agent-selector button {
+    min-width: 0;
+    flex: 1;
+    justify-content: center;
   }
 }

--- a/examples/with-mastra/app/globals.css
+++ b/examples/with-mastra/app/globals.css
@@ -233,7 +233,7 @@
   cursor: pointer;
 }
 
-.agent-selector button[aria-selected="true"] {
+.agent-selector button[aria-pressed="true"] {
   background: var(--background);
   color: var(--foreground);
   box-shadow: 0 1px 2px rgb(23 25 24 / 10%);

--- a/examples/with-mastra/app/page.tsx
+++ b/examples/with-mastra/app/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
+  mastraExampleAgentIds,
   type MastraExampleAgentId,
   MyRuntimeProvider,
 } from "./MyRuntimeProvider";
@@ -60,13 +61,10 @@ const agents = {
 } as const;
 
 const agentStorageKey = "assistant-ui-mastra-agent-id";
-const agentIds: readonly MastraExampleAgentId[] = [
-  "releaseAssistant",
-  "riskAnalyst",
-];
 
 const isAgentId = (value: string | null): value is MastraExampleAgentId =>
-  value === "releaseAssistant" || value === "riskAnalyst";
+  value !== null &&
+  (mastraExampleAgentIds as readonly string[]).includes(value);
 
 function ChatSurface({ agentId }: { agentId: MastraExampleAgentId }) {
   const aui = useAui({
@@ -88,16 +86,15 @@ function AgentSelector({
   onAgentChange: (agentId: MastraExampleAgentId) => void;
 }) {
   return (
-    <div className="agent-selector" role="tablist" aria-label="Mastra agent">
-      {agentIds.map((id) => {
+    <div className="agent-selector" role="group" aria-label="Select agent">
+      {mastraExampleAgentIds.map((id) => {
         const agent = agents[id];
         const Icon = agent.icon;
         return (
           <button
             key={id}
             type="button"
-            role="tab"
-            aria-selected={agentId === id}
+            aria-pressed={agentId === id}
             onClick={() => onAgentChange(id)}
           >
             <Icon className="size-3.5" />

--- a/examples/with-mastra/app/page.tsx
+++ b/examples/with-mastra/app/page.tsx
@@ -4,25 +4,73 @@ import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { Thread } from "@/components/assistant-ui/thread";
 import { WorkflowPanel } from "@/components/workflow-panel";
 import { AuiProvider, Suggestions, useAui } from "@assistant-ui/react";
-import { DatabaseIcon, GitBranchIcon, SparklesIcon } from "lucide-react";
-import { MyRuntimeProvider } from "./MyRuntimeProvider";
+import {
+  DatabaseIcon,
+  FileTextIcon,
+  GitBranchIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  WrenchIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  type MastraExampleAgentId,
+  MyRuntimeProvider,
+} from "./MyRuntimeProvider";
 
-function ChatSurface() {
-  const aui = useAui({
-    suggestions: Suggestions([
+const agents = {
+  releaseAssistant: {
+    name: "Release Assistant",
+    eyebrow: "Release communications",
+    icon: FileTextIcon,
+    suggestions: [
       {
         title: "Draft release notes",
-        label: "from a short change summary",
+        label: "with the release brief tool",
         prompt:
-          "Draft concise release notes for a new Mastra integration with persistent threads and workflow approvals.",
+          "Use the draft release brief tool for a new Mastra integration aimed at developers, then write concise release notes.",
       },
       {
-        title: "Review rollout risk",
-        label: "for a framework adapter",
+        title: "Write an announcement",
+        label: "for persisted threads",
         prompt:
-          "Give me a practical rollout checklist for a new framework adapter package.",
+          "Use the draft release brief tool to structure an end-user announcement for persisted conversation threads.",
       },
-    ]),
+    ],
+  },
+  riskAnalyst: {
+    name: "Risk Analyst",
+    eyebrow: "Rollout assurance",
+    icon: ShieldCheckIcon,
+    suggestions: [
+      {
+        title: "Assess rollout risk",
+        label: "for a persistence change",
+        prompt:
+          "Use the rollout risk tool to assess a persistence migration with no tested rollback path.",
+      },
+      {
+        title: "Define release gates",
+        label: "for a reversible UI change",
+        prompt:
+          "Use the rollout risk tool to define release gates for a UI-only change with a tested rollback.",
+      },
+    ],
+  },
+} as const;
+
+const agentStorageKey = "assistant-ui-mastra-agent-id";
+const agentIds: readonly MastraExampleAgentId[] = [
+  "releaseAssistant",
+  "riskAnalyst",
+];
+
+const isAgentId = (value: string | null): value is MastraExampleAgentId =>
+  value === "releaseAssistant" || value === "riskAnalyst";
+
+function ChatSurface({ agentId }: { agentId: MastraExampleAgentId }) {
+  const aui = useAui({
+    suggestions: Suggestions([...agents[agentId].suggestions]),
   });
 
   return (
@@ -32,7 +80,44 @@ function ChatSurface() {
   );
 }
 
-function Workbench() {
+function AgentSelector({
+  agentId,
+  onAgentChange,
+}: {
+  agentId: MastraExampleAgentId;
+  onAgentChange: (agentId: MastraExampleAgentId) => void;
+}) {
+  return (
+    <div className="agent-selector" role="tablist" aria-label="Mastra agent">
+      {agentIds.map((id) => {
+        const agent = agents[id];
+        const Icon = agent.icon;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={agentId === id}
+            onClick={() => onAgentChange(id)}
+          >
+            <Icon className="size-3.5" />
+            {agent.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Workbench({
+  agentId,
+  onAgentChange,
+}: {
+  agentId: MastraExampleAgentId;
+  onAgentChange: (agentId: MastraExampleAgentId) => void;
+}) {
+  const agent = agents[agentId];
+
   return (
     <main className="workbench">
       <aside className="thread-rail" aria-label="Mastra memory threads">
@@ -56,12 +141,13 @@ function Workbench() {
         </div>
       </aside>
 
-      <section className="chat-stage" aria-label="Release assistant chat">
+      <section className="chat-stage" aria-label={`${agent.name} chat`}>
         <header className="chat-stage__header">
           <div>
-            <p className="eyebrow">Release operations</p>
-            <h1>Release Assistant</h1>
+            <p className="eyebrow">{agent.eyebrow}</p>
+            <h1>{agent.name}</h1>
           </div>
+          <AgentSelector agentId={agentId} onAgentChange={onAgentChange} />
           <div className="capability-list" aria-label="Enabled features">
             <span>
               <SparklesIcon className="size-3.5" /> AI SDK stream
@@ -69,10 +155,13 @@ function Workbench() {
             <span>
               <GitBranchIcon className="size-3.5" /> Mastra memory
             </span>
+            <span>
+              <WrenchIcon className="size-3.5" /> Typed tools
+            </span>
           </div>
         </header>
         <div className="chat-stage__body">
-          <ChatSurface />
+          <ChatSurface agentId={agentId} />
         </div>
       </section>
 
@@ -82,9 +171,20 @@ function Workbench() {
 }
 
 export default function Home() {
+  const [agentId, setAgentId] =
+    useState<MastraExampleAgentId>("releaseAssistant");
+  useEffect(() => {
+    const stored = window.localStorage.getItem(agentStorageKey);
+    if (isAgentId(stored)) setAgentId(stored);
+  }, []);
+  const handleAgentChange = useCallback((nextAgentId: MastraExampleAgentId) => {
+    setAgentId(nextAgentId);
+    window.localStorage.setItem(agentStorageKey, nextAgentId);
+  }, []);
+
   return (
-    <MyRuntimeProvider>
-      <Workbench />
+    <MyRuntimeProvider agentId={agentId}>
+      <Workbench agentId={agentId} onAgentChange={handleAgentChange} />
     </MyRuntimeProvider>
   );
 }

--- a/examples/with-mastra/package.json
+++ b/examples/with-mastra/package.json
@@ -8,6 +8,7 @@
     "build": "pnpm build:web && pnpm build:server",
     "build:web": "next build",
     "build:server": "tsc6 -p tsconfig.server.json",
+    "test": "vitest run",
     "start": "concurrently -k -n web,mastra \"next start\" \"node dist/server.js\""
   },
   "dependencies": {
@@ -47,6 +48,7 @@
     "tailwindcss": "^4.3.2",
     "tw-animate-css": "^1.4.0",
     "tsx": "^4.23.1",
-    "typescript": "npm:@typescript/typescript6@^6.0.2"
+    "typescript": "npm:@typescript/typescript6@^6.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/examples/with-mastra/src/mastra/index.ts
+++ b/examples/with-mastra/src/mastra/index.ts
@@ -3,6 +3,7 @@ import { Agent } from "@mastra/core/agent";
 import { Mastra } from "@mastra/core/mastra";
 import { LibSQLStore } from "@mastra/libsql";
 import { Memory } from "@mastra/memory";
+import { assessRolloutRisk, draftReleaseBrief } from "./tools/release-tools.js";
 import { releaseReviewWorkflow } from "./workflows/release-review.js";
 
 const storage = new LibSQLStore({
@@ -22,21 +23,34 @@ const releaseAssistant = new Agent({
   name: "Release Assistant",
   model: "openai/gpt-4o-mini",
   memory,
+  tools: { draftReleaseBrief },
   instructions: `You are a concise release operations assistant.
 Help users turn product changes into clear release notes, risk checks, and rollout plans.
+Call draftReleaseBrief before writing release notes or a release announcement.
 Use the conversation history when the user refers to earlier details.
 Prefer short headings and concrete next actions.`,
 });
 
+const riskAnalyst = new Agent({
+  id: "risk-analyst",
+  name: "Risk Analyst",
+  model: "openai/gpt-4o-mini",
+  memory,
+  tools: { assessRolloutRisk },
+  instructions: `You are a skeptical but practical release risk analyst.
+Call assessRolloutRisk before recommending whether a rollout should proceed.
+Ask for missing persistence or rollback details instead of inventing them.
+Summarize the tool result as concrete release gates.`,
+});
+
 export const mastra = new Mastra({
   storage,
-  agents: { releaseAssistant },
+  agents: { releaseAssistant, riskAnalyst },
   workflows: { releaseReviewWorkflow },
   server: {
     apiRoutes: [
       chatRoute({
-        path: "/chat",
-        agent: "releaseAssistant",
+        path: "/chat/:agentId",
         version: "v6",
       }),
     ],

--- a/examples/with-mastra/src/mastra/tools/release-tools.test.ts
+++ b/examples/with-mastra/src/mastra/tools/release-tools.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { assessRolloutRisk, draftReleaseBrief } from "./release-tools";
+
+describe("release tools", () => {
+  it("builds a release brief from validated tool input", async () => {
+    const result = await draftReleaseBrief.execute!(
+      {
+        change: "Persist Mastra threads.",
+        audience: "developers",
+      },
+      undefined as never,
+    );
+
+    expect(result).toEqual({
+      headline: "Persist Mastra threads",
+      audience: "developers",
+      sections: ["What changed", "Why it matters", "Upgrade notes"],
+    });
+  });
+
+  it("uses persistence and rollback inputs to classify risk", async () => {
+    await expect(
+      assessRolloutRisk.execute!(
+        {
+          change: "Migrate stored messages",
+          touchesPersistence: true,
+          hasRollback: false,
+        },
+        undefined as never,
+      ),
+    ).resolves.toEqual({
+      level: "high",
+      checks: [
+        "canary deployment",
+        "error-rate alert",
+        "owner sign-off",
+        "backup and restore verification",
+        "forward-fix runbook",
+      ],
+    });
+  });
+});

--- a/examples/with-mastra/src/mastra/tools/release-tools.test.ts
+++ b/examples/with-mastra/src/mastra/tools/release-tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { assessRolloutRisk, draftReleaseBrief } from "./release-tools";
+import { assessRolloutRisk, draftReleaseBrief } from "./release-tools.js";
 
 describe("release tools", () => {
   it("builds a release brief from validated tool input", async () => {

--- a/examples/with-mastra/src/mastra/tools/release-tools.ts
+++ b/examples/with-mastra/src/mastra/tools/release-tools.ts
@@ -1,0 +1,56 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const draftReleaseBrief = createTool({
+  id: "draft-release-brief",
+  description:
+    "Turn a product change into a structured release brief before drafting release notes.",
+  inputSchema: z.object({
+    change: z.string().describe("The product or engineering change to release"),
+    audience: z
+      .enum(["developers", "operators", "end-users"])
+      .describe("The primary audience for the release"),
+  }),
+  outputSchema: z.object({
+    headline: z.string(),
+    audience: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async ({ change, audience }) => ({
+    headline: change.trim().replace(/[.!?]+$/, ""),
+    audience,
+    sections: ["What changed", "Why it matters", "Upgrade notes"],
+  }),
+});
+
+export const assessRolloutRisk = createTool({
+  id: "assess-rollout-risk",
+  description:
+    "Classify rollout risk and return the checks required before deployment.",
+  inputSchema: z.object({
+    change: z.string().describe("The change being evaluated"),
+    touchesPersistence: z
+      .boolean()
+      .describe("Whether the change reads or writes persistent state"),
+    hasRollback: z
+      .boolean()
+      .describe("Whether a tested rollback path is available"),
+  }),
+  outputSchema: z.object({
+    level: z.enum(["low", "medium", "high"]),
+    checks: z.array(z.string()),
+  }),
+  execute: async ({ touchesPersistence, hasRollback }) => {
+    const level: "low" | "medium" | "high" = touchesPersistence
+      ? hasRollback
+        ? "medium"
+        : "high"
+      : hasRollback
+        ? "low"
+        : "medium";
+    const checks = ["canary deployment", "error-rate alert", "owner sign-off"];
+    if (touchesPersistence) checks.push("backup and restore verification");
+    if (!hasRollback) checks.push("forward-fix runbook");
+    return { level, checks };
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2576,6 +2576,9 @@ importers:
       typescript:
         specifier: npm:@typescript/typescript6@^6.0.2
         version: '@typescript/typescript6@6.0.2'
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   examples/with-mcp:
     dependencies:


### PR DESCRIPTION
Closes #5005
Parent: #4922
Stacked on: #4935

## What changed

- add a release assistant and risk analyst with distinct typed Mastra server tools
- expose both through the supported dynamic `chatRoute`
- add an accessible agent selector with agent-specific identity and suggestions
- keep resource IDs and selected thread IDs isolated per agent
- render streamed tool calls through assistant-ui's canonical thread component
- document reproducible prompts for both tool paths

## Why

The rebuilt integration needs executable proof that assistant-ui can switch between Mastra agents and render real server-side tool calls without adding adapter-specific runtime or tool plumbing.

## Verification

- `pnpm exec turbo build --filter=with-mastra... --concurrency=4` on Node 24 (18 tasks; Next.js and Mastra server builds pass)
- focused `oxlint`, `oxfmt`, and `git diff --check`
- live provider-backed request to `/chat/releaseAssistant`: `draftReleaseBrief` tool input, structured output, and final streamed text
- live provider-backed request to `/chat/riskAnalyst`: `assessRolloutRisk` tool input, structured output, and final streamed text

No changeset is required because `with-mastra` is a private example package.
