### PR TITLE
feat(examples): demonstrate Mastra agents and tools

### DIFF
--- a/examples/with-mastra/README.md
+++ b/examples/with-mastra/README.md
@@ -3,6 +3,7 @@
 This example runs assistant-ui against a local Mastra server. It demonstrates:
 
 - AI SDK-compatible agent streaming
+- two selectable Mastra agents with distinct typed server tools
 - LibSQL-backed thread creation, switching, and message restoration
 - a durable workflow with two human approval checkpoints
 - workflow run restoration after a browser reload
@@ -16,3 +17,8 @@ pnpm --filter with-mastra dev
 The command starts Next.js on `http://localhost:3000` and a Mastra Hono server
 on `http://localhost:4111`. Local environment and `mastra.db*` files are ignored
 by Git.
+
+The release assistant calls `draftReleaseBrief` before writing release copy.
+The risk analyst calls `assessRolloutRisk` before recommending release gates.
+Both stream through Mastra's dynamic `/chat/:agentId` route, and assistant-ui
+renders their tool parts through the canonical thread component.

--- a/examples/with-mastra/app/MyRuntimeProvider.tsx
+++ b/examples/with-mastra/app/MyRuntimeProvider.tsx
@@ -3,17 +3,21 @@
 import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import { useMastraRuntime } from "@assistant-ui/react-mastra";
 import { MastraClient } from "@mastra/client-js";
-import { type PropsWithChildren, useCallback, useState } from "react";
+import { type PropsWithChildren, useCallback, useMemo, useState } from "react";
 
 export const mastraUrl =
   process.env.NEXT_PUBLIC_MASTRA_URL ?? "http://localhost:4111";
 
 export const mastraClient = new MastraClient({ baseUrl: mastraUrl });
 
-const transportOptions = { api: `${mastraUrl}/chat` };
 const threadStorageKey = "assistant-ui-mastra-thread-id";
 
-export function MyRuntimeProvider({ children }: PropsWithChildren) {
+export type MastraExampleAgentId = "releaseAssistant" | "riskAnalyst";
+
+export function MyRuntimeProvider({
+  agentId,
+  children,
+}: PropsWithChildren<{ agentId: MastraExampleAgentId }>) {
   const [threadId, setThreadId] = useState<string | undefined>(() => {
     if (typeof window === "undefined") return undefined;
     return window.localStorage.getItem(threadStorageKey) ?? undefined;
@@ -29,10 +33,14 @@ export function MyRuntimeProvider({ children }: PropsWithChildren) {
     },
     [],
   );
+  const transportOptions = useMemo(
+    () => ({ api: `${mastraUrl}/chat/${agentId}` }),
+    [agentId],
+  );
 
   const runtime = useMastraRuntime({
     client: mastraClient,
-    agentId: "releaseAssistant",
+    agentId,
     resourceId: "assistant-ui-mastra-example",
     threadId,
     onThreadIdChange: handleThreadIdChange,

--- a/examples/with-mastra/app/globals.css
+++ b/examples/with-mastra/app/globals.css
@@ -204,9 +204,44 @@
   min-height: 4.5rem;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 1rem;
   border-bottom: 1px solid var(--border);
   padding: 0.8rem 1.1rem;
+}
+
+.agent-selector {
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 0.2rem;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  background: var(--muted);
+  padding: 0.2rem;
+}
+
+.agent-selector button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 0.3rem;
+  background: transparent;
+  padding: 0.35rem 0.5rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.agent-selector button[aria-selected="true"] {
+  background: var(--background);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px rgb(23 25 24 / 10%);
+}
+
+.agent-selector button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 1px;
 }
 
 .eyebrow {
@@ -505,5 +540,20 @@
 
   .capability-list {
     display: none;
+  }
+
+  .chat-stage__header {
+    align-items: flex-start;
+  }
+
+  .agent-selector {
+    width: 100%;
+    order: 3;
+  }
+
+  .agent-selector button {
+    min-width: 0;
+    flex: 1;
+    justify-content: center;
   }
 }

--- a/examples/with-mastra/app/page.tsx
+++ b/examples/with-mastra/app/page.tsx
@@ -4,25 +4,73 @@ import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { Thread } from "@/components/assistant-ui/thread";
 import { WorkflowPanel } from "@/components/workflow-panel";
 import { AuiProvider, Suggestions, useAui } from "@assistant-ui/react";
-import { DatabaseIcon, GitBranchIcon, SparklesIcon } from "lucide-react";
-import { MyRuntimeProvider } from "./MyRuntimeProvider";
+import {
+  DatabaseIcon,
+  FileTextIcon,
+  GitBranchIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  WrenchIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  type MastraExampleAgentId,
+  MyRuntimeProvider,
+} from "./MyRuntimeProvider";
 
-function ChatSurface() {
-  const aui = useAui({
-    suggestions: Suggestions([
+const agents = {
+  releaseAssistant: {
+    name: "Release Assistant",
+    eyebrow: "Release communications",
+    icon: FileTextIcon,
+    suggestions: [
       {
         title: "Draft release notes",
-        label: "from a short change summary",
+        label: "with the release brief tool",
         prompt:
-          "Draft concise release notes for a new Mastra integration with persistent threads and workflow approvals.",
+          "Use the draft release brief tool for a new Mastra integration aimed at developers, then write concise release notes.",
       },
       {
-        title: "Review rollout risk",
-        label: "for a framework adapter",
+        title: "Write an announcement",
+        label: "for persisted threads",
         prompt:
-          "Give me a practical rollout checklist for a new framework adapter package.",
+          "Use the draft release brief tool to structure an end-user announcement for persisted conversation threads.",
       },
-    ]),
+    ],
+  },
+  riskAnalyst: {
+    name: "Risk Analyst",
+    eyebrow: "Rollout assurance",
+    icon: ShieldCheckIcon,
+    suggestions: [
+      {
+        title: "Assess rollout risk",
+        label: "for a persistence change",
+        prompt:
+          "Use the rollout risk tool to assess a persistence migration with no tested rollback path.",
+      },
+      {
+        title: "Define release gates",
+        label: "for a reversible UI change",
+        prompt:
+          "Use the rollout risk tool to define release gates for a UI-only change with a tested rollback.",
+      },
+    ],
+  },
+} as const;
+
+const agentStorageKey = "assistant-ui-mastra-agent-id";
+const agentIds: readonly MastraExampleAgentId[] = [
+  "releaseAssistant",
+  "riskAnalyst",
+];
+
+const isAgentId = (value: string | null): value is MastraExampleAgentId =>
+  value === "releaseAssistant" || value === "riskAnalyst";
+
+function ChatSurface({ agentId }: { agentId: MastraExampleAgentId }) {
+  const aui = useAui({
+    suggestions: Suggestions([...agents[agentId].suggestions]),
   });
 
   return (
@@ -32,7 +80,44 @@ function ChatSurface() {
   );
 }
 
-function Workbench() {
+function AgentSelector({
+  agentId,
+  onAgentChange,
+}: {
+  agentId: MastraExampleAgentId;
+  onAgentChange: (agentId: MastraExampleAgentId) => void;
+}) {
+  return (
+    <div className="agent-selector" role="tablist" aria-label="Mastra agent">
+      {agentIds.map((id) => {
+        const agent = agents[id];
+        const Icon = agent.icon;
+        return (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={agentId === id}
+            onClick={() => onAgentChange(id)}
+          >
+            <Icon className="size-3.5" />
+            {agent.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Workbench({
+  agentId,
+  onAgentChange,
+}: {
+  agentId: MastraExampleAgentId;
+  onAgentChange: (agentId: MastraExampleAgentId) => void;
+}) {
+  const agent = agents[agentId];
+
   return (
     <main className="workbench">
       <aside className="thread-rail" aria-label="Mastra memory threads">
@@ -59,9 +144,10 @@ function Workbench() {
       <section className="chat-stage" aria-label="Release assistant chat">
         <header className="chat-stage__header">
           <div>
-            <p className="eyebrow">Release operations</p>
-            <h1>Release Assistant</h1>
+            <p className="eyebrow">{agent.eyebrow}</p>
+            <h1>{agent.name}</h1>
           </div>
+          <AgentSelector agentId={agentId} onAgentChange={onAgentChange} />
           <div className="capability-list" aria-label="Enabled features">
             <span>
               <SparklesIcon className="size-3.5" /> AI SDK stream
@@ -69,10 +155,13 @@ function Workbench() {
             <span>
               <GitBranchIcon className="size-3.5" /> Mastra memory
             </span>
+            <span>
+              <WrenchIcon className="size-3.5" /> Typed tools
+            </span>
           </div>
         </header>
         <div className="chat-stage__body">
-          <ChatSurface />
+          <ChatSurface agentId={agentId} />
         </div>
       </section>
 
@@ -82,9 +171,20 @@ function Workbench() {
 }
 
 export default function Home() {
+  const [agentId, setAgentId] =
+    useState<MastraExampleAgentId>("releaseAssistant");
+  useEffect(() => {
+    const stored = window.localStorage.getItem(agentStorageKey);
+    if (isAgentId(stored)) setAgentId(stored);
+  }, []);
+  const handleAgentChange = useCallback((nextAgentId: MastraExampleAgentId) => {
+    setAgentId(nextAgentId);
+    window.localStorage.setItem(agentStorageKey, nextAgentId);
+  }, []);
+
   return (
-    <MyRuntimeProvider>
-      <Workbench />
+    <MyRuntimeProvider agentId={agentId}>
+      <Workbench agentId={agentId} onAgentChange={handleAgentChange} />
     </MyRuntimeProvider>
   );
 }

--- a/examples/with-mastra/src/mastra/index.ts
+++ b/examples/with-mastra/src/mastra/index.ts
@@ -3,6 +3,7 @@ import { Agent } from "@mastra/core/agent";
 import { Mastra } from "@mastra/core/mastra";
 import { LibSQLStore } from "@mastra/libsql";
 import { Memory } from "@mastra/memory";
+import { assessRolloutRisk, draftReleaseBrief } from "./tools/release-tools.js";
 import { releaseReviewWorkflow } from "./workflows/release-review.js";
 
 const storage = new LibSQLStore({
@@ -22,21 +23,34 @@ const releaseAssistant = new Agent({
   name: "Release Assistant",
   model: "openai/gpt-4o-mini",
   memory,
+  tools: { draftReleaseBrief },
   instructions: `You are a concise release operations assistant.
 Help users turn product changes into clear release notes, risk checks, and rollout plans.
+Call draftReleaseBrief before writing release notes or a release announcement.
 Use the conversation history when the user refers to earlier details.
 Prefer short headings and concrete next actions.`,
 });
 
+const riskAnalyst = new Agent({
+  id: "risk-analyst",
+  name: "Risk Analyst",
+  model: "openai/gpt-4o-mini",
+  memory,
+  tools: { assessRolloutRisk },
+  instructions: `You are a skeptical but practical release risk analyst.
+Call assessRolloutRisk before recommending whether a rollout should proceed.
+Ask for missing persistence or rollback details instead of inventing them.
+Summarize the tool result as concrete release gates.`,
+});
+
 export const mastra = new Mastra({
   storage,
-  agents: { releaseAssistant },
+  agents: { releaseAssistant, riskAnalyst },
   workflows: { releaseReviewWorkflow },
   server: {
     apiRoutes: [
       chatRoute({
-        path: "/chat",
-        agent: "releaseAssistant",
+        path: "/chat/:agentId",
         version: "v6",
       }),
     ],

--- a/examples/with-mastra/src/mastra/tools/release-tools.ts
+++ b/examples/with-mastra/src/mastra/tools/release-tools.ts
@@ -1,0 +1,56 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const draftReleaseBrief = createTool({
+  id: "draft-release-brief",
+  description:
+    "Turn a product change into a structured release brief before drafting release notes.",
+  inputSchema: z.object({
+    change: z.string().describe("The product or engineering change to release"),
+    audience: z
+      .enum(["developers", "operators", "end-users"])
+      .describe("The primary audience for the release"),
+  }),
+  outputSchema: z.object({
+    headline: z.string(),
+    audience: z.string(),
+    sections: z.array(z.string()),
+  }),
+  execute: async ({ change, audience }) => ({
+    headline: change.trim().replace(/[.!?]+$/, ""),
+    audience,
+    sections: ["What changed", "Why it matters", "Upgrade notes"],
+  }),
+});
+
+export const assessRolloutRisk = createTool({
+  id: "assess-rollout-risk",
+  description:
+    "Classify rollout risk and return the checks required before deployment.",
+  inputSchema: z.object({
+    change: z.string().describe("The change being evaluated"),
+    touchesPersistence: z
+      .boolean()
+      .describe("Whether the change reads or writes persistent state"),
+    hasRollback: z
+      .boolean()
+      .describe("Whether a tested rollback path is available"),
+  }),
+  outputSchema: z.object({
+    level: z.enum(["low", "medium", "high"]),
+    checks: z.array(z.string()),
+  }),
+  execute: async ({ touchesPersistence, hasRollback }) => {
+    const level: "low" | "medium" | "high" = touchesPersistence
+      ? hasRollback
+        ? "medium"
+        : "high"
+      : hasRollback
+        ? "low"
+        : "medium";
+    const checks = ["canary deployment", "error-rate alert", "owner sign-off"];
+    if (touchesPersistence) checks.push("backup and restore verification");
+    if (!hasRollback) checks.push("forward-fix runbook");
+    return { level, checks };
+  },
+});


### PR DESCRIPTION
## Summary

Completes the original Mastra example's multi-agent and tool-calling promise with current supported primitives:

- registers release and risk agents with one typed Mastra `createTool` each
- exposes both through the official dynamic `chatRoute` AI SDK endpoint
- adds an accessible agent selector with agent-specific identity and suggestions
- persists the selected agent and keeps the existing Mastra thread/runtime path
- renders streamed tool parts through the canonical assistant-ui thread component

Closes #5005
Parent: #4922
Stacked on #4935.

## Verification

- focused oxlint, oxfmt, and `git diff --check`
- `pnpm --filter with-mastra build` (Next.js client and Mastra server)
- live OpenAI request to `/chat/releaseAssistant`: streamed `draftReleaseBrief` input, structured output, and final text
- live OpenAI request to `/chat/riskAnalyst`: streamed `assessRolloutRisk`, returned `high`, and rendered release gates in the stream

All verification used Node 24.11.1 and current Mastra 1.51.0 / client 1.32.0 / AI SDK adapter 1.6.2. The example is private, so no changeset is required.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

