### PR TITLE
fix(react-pi): validate event stream content type

### DIFF
--- a/.changeset/react-pi-stream-content-type.md
+++ b/.changeset/react-pi-stream-content-type.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: validate event stream response content types

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -73,17 +73,28 @@ describe("createSseDecoder", () => {
 
 const encoder = new TextEncoder();
 
-/** A fresh SSE `Response` whose body streams `chunks` then closes. */
-const sseResponse = (chunks: string[]): Response =>
-  new Response(
+const streamResponse = (chunks: string[], contentType?: string): Response => {
+  const init: ResponseInit = { status: 200 };
+  if (contentType !== undefined) {
+    init.headers = { "content-type": contentType };
+  }
+
+  return new Response(
     new ReadableStream<Uint8Array>({
       start(controller) {
         for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
         controller.close();
       },
     }),
-    { status: 200, headers: { "content-type": "text/event-stream" } },
+    init,
   );
+};
+
+/** A fresh SSE `Response` whose body streams `chunks` then closes. */
+const sseResponse = (
+  chunks: string[],
+  contentType = "text/event-stream",
+): Response => streamResponse(chunks, contentType);
 
 const sseFrame = (event: PiAnyClientEvent): string =>
   `data: ${JSON.stringify(event)}\n\n`;
@@ -114,6 +125,96 @@ describe("openPiEventStream", () => {
 
     expect(events.map((e) => e.type)).toEqual(["agent_start", "agent_end"]);
     expect(events[0]).toMatchObject({ threadId: "t1", seq: 1 });
+  });
+
+  it("accepts parameterized event stream content types", async () => {
+    const fetchImpl = (async () =>
+      sseResponse(
+        [sseFrame({ type: "agent_start", threadId: "t1", seq: 1 })],
+        "Text/Event-Stream; charset=utf-8",
+      )) as unknown as typeof fetch;
+
+    const event = await new Promise<PiAnyClientEvent>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onEvent: (value) => {
+          close();
+          resolve(value);
+        },
+      });
+    });
+
+    expect(event).toMatchObject({ type: "agent_start", threadId: "t1" });
+  });
+
+  it.each([
+    ["HTML", "text/html; charset=utf-8", '"text/html; charset=utf-8"'],
+    ["JSON", "application/json", '"application/json"'],
+    ["a missing content type", undefined, "no Content-Type header"],
+  ])(
+    "reports %s responses through onError",
+    async (_label, contentType, received) => {
+      const fetchImpl = vi.fn(async () =>
+        streamResponse(["not an event stream"], contentType),
+      ) as unknown as typeof fetch;
+
+      const error = await new Promise<unknown>((resolve) => {
+        let close!: () => void;
+        close = openPiEventStream({
+          url: "/events",
+          fetchImpl,
+          reconnectDelay: () => Promise.resolve(),
+          onEvent: vi.fn(),
+          onError: (value) => {
+            close();
+            resolve(value);
+          },
+        });
+      });
+
+      expect(error).toEqual(
+        new Error(
+          `Expected Pi event stream Content-Type "text/event-stream", received ${received}`,
+        ),
+      );
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("reconnects after an invalid response content type", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return streamResponse(["<html>Please sign in</html>"], "text/html");
+      }
+      return sseResponse([
+        sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+      ]);
+    }) as unknown as typeof fetch;
+
+    const errors: unknown[] = [];
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.resolve(),
+        onError: (error) => errors.push(error),
+        onEvent: () => {
+          close();
+          resolve();
+        },
+      });
+    });
+
+    expect(calls).toBe(2);
+    expect(errors).toEqual([
+      new Error(
+        'Expected Pi event stream Content-Type "text/event-stream", received "text/html"',
+      ),
+    ]);
   });
 
   it("uses the controlled fetch stream even when native EventSource exists", async () => {
@@ -244,7 +345,7 @@ describe("openPiEventStream", () => {
       new Response(
         // A body that never enqueues — only an abort can end the read.
         new ReadableStream<Uint8Array>({ start() {} }),
-        { status: 200 },
+        { status: 200, headers: { "content-type": "text/event-stream" } },
       )) as unknown as typeof fetch;
 
     const close = openPiEventStream({

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -185,10 +185,19 @@ describe("openPiEventStream", () => {
 
   it("reconnects after an invalid response content type", async () => {
     let calls = 0;
+    const cancelBody = vi.fn();
     const fetchImpl = (async () => {
       calls += 1;
       if (calls === 1) {
-        return streamResponse(["<html>Please sign in</html>"], "text/html");
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode("<html>Please sign in</html>"));
+            },
+            cancel: cancelBody,
+          }),
+          { status: 200, headers: { "content-type": "text/html" } },
+        );
       }
       return sseResponse([
         sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
@@ -210,6 +219,7 @@ describe("openPiEventStream", () => {
     });
 
     expect(calls).toBe(2);
+    expect(cancelBody).toHaveBeenCalledOnce();
     expect(errors).toEqual([
       new Error(
         'Expected Pi event stream Content-Type "text/event-stream", received "text/html"',

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -135,6 +135,19 @@ export interface PiEventStreamOptions {
 const defaultReconnectDelay = () =>
   new Promise<void>((resolve) => setTimeout(resolve, 1000));
 
+const validateEventStreamContentType = (response: Response): void => {
+  const contentType = response.headers.get("Content-Type");
+  const mediaType = contentType?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType !== "text/event-stream") {
+    const received = contentType
+      ? `"${contentType}"`
+      : "no Content-Type header";
+    throw new Error(
+      `Expected Pi event stream Content-Type "text/event-stream", received ${received}`,
+    );
+  }
+};
+
 /**
  * Open a reconnecting SSE stream. Returns a synchronous unsubscribe that aborts
  * the in-flight request and stops reconnecting. Frames named `ping` and empty
@@ -167,6 +180,7 @@ export const openPiEventStream = (
         if (!response.ok || !response.body) {
           throw new Error(`Pi event stream failed: HTTP ${response.status}`);
         }
+        validateEventStreamContentType(response);
 
         const decoder = createSseDecoder();
         const reader = response.body.getReader();

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -142,6 +142,7 @@ const validateEventStreamContentType = (response: Response): void => {
     const received = contentType
       ? `"${contentType}"`
       : "no Content-Type header";
+    void response.body?.cancel().catch(() => undefined);
     throw new Error(
       `Expected Pi event stream Content-Type "text/event-stream", received ${received}`,
     );

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -220,7 +220,7 @@ describe("createPiHttpClient", () => {
             controller.close();
           },
         }),
-        { status: 200 },
+        { status: 200, headers: { "content-type": "text/event-stream" } },
       );
     }) as unknown as typeof fetch;
 


### PR DESCRIPTION
## Summary

- validate that successful React Pi stream responses use `text/event-stream`
- accept case-insensitive media types and parameters such as `charset=utf-8`
- report invalid response types through the existing `onError` callback and cancel rejected bodies before retrying

## Why

While testing a Pi endpoint behind an auth layer or proxy, a misrouted request can return an HTML sign-in page or JSON error with HTTP 200. Previously React Pi passed that body to the SSE parser, produced no events, and could keep reconnecting without explaining that the endpoint was not an event stream.

The client now reports the received `Content-Type`, while valid responses continue through the same parser and invalid responses retain the existing retry flow. Cancelling rejected bodies also prevents an open response from holding a connection while the next attempt starts.

## Verification

- `vitest run` in `packages/react-pi`: 10 files, 146 tests passed
- `aui-build` in `packages/react-pi`
- `oxlint` on changed TypeScript files
- `oxfmt` on changed files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->