### PR TITLE
fix(react-google-adk): validate direct stream options

### DIFF
--- a/.changeset/google-adk-direct-options.md
+++ b/.changeset/google-adk-direct-options.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: reject incomplete direct stream options

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -231,6 +231,18 @@ describe("createAdkStream - proxy mode", () => {
 // ── Direct mode ──
 
 describe("createAdkStream - direct mode", () => {
+  it("rejects direct mode without a userId", () => {
+    expect(() =>
+      createAdkStream({
+        api: "http://localhost:8000",
+        appName: "my-app",
+      }),
+    ).toThrow(
+      'createAdkStream direct mode requires "userId" when "appName" is provided.',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("POSTs to /run_sse with ADK-native body", async () => {
     mockFetch.mockResolvedValueOnce(new Response(sseBody(""), { status: 200 }));
 

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -231,11 +231,15 @@ describe("createAdkStream - proxy mode", () => {
 // ── Direct mode ──
 
 describe("createAdkStream - direct mode", () => {
-  it("rejects direct mode without a userId", () => {
+  it.each([
+    ["missing", undefined],
+    ["empty", ""],
+  ])("rejects direct mode with a %s userId", (_label, userId) => {
     expect(() =>
       createAdkStream({
         api: "http://localhost:8000",
         appName: "my-app",
+        userId,
       }),
     ).toThrow(
       'createAdkStream direct mode requires "userId" when "appName" is provided.',

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -231,6 +231,17 @@ describe("createAdkStream - proxy mode", () => {
 // ── Direct mode ──
 
 describe("createAdkStream - direct mode", () => {
+  it("rejects direct mode with an empty appName", () => {
+    expect(() =>
+      createAdkStream({
+        api: "http://localhost:8000",
+        appName: "",
+        userId: "user-1",
+      }),
+    ).toThrow('createAdkStream direct mode requires a non-empty "appName".');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["missing", undefined],
     ["empty", ""],

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -61,7 +61,7 @@ export function createAdkStream(
   options: CreateAdkStreamOptions,
 ): AdkStreamCallback {
   const isDirect = options.appName != null;
-  if (isDirect && options.userId == null) {
+  if (isDirect && (options.userId == null || options.userId === "")) {
     throw new Error(
       'createAdkStream direct mode requires "userId" when "appName" is provided.',
     );

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -61,6 +61,11 @@ export function createAdkStream(
   options: CreateAdkStreamOptions,
 ): AdkStreamCallback {
   const isDirect = options.appName != null;
+  if (isDirect && options.userId == null) {
+    throw new Error(
+      'createAdkStream direct mode requires "userId" when "appName" is provided.',
+    );
+  }
 
   return async function* (messages, config) {
     const headers = await resolveHeaders(options.headers);

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -60,6 +60,12 @@ export type CreateAdkStreamOptions = {
 export function createAdkStream(
   options: CreateAdkStreamOptions,
 ): AdkStreamCallback {
+  if (options.appName === "") {
+    throw new Error(
+      'createAdkStream direct mode requires a non-empty "appName".',
+    );
+  }
+
   const isDirect = options.appName != null;
   if (isDirect && (options.userId == null || options.userId === "")) {
     throw new Error(


### PR DESCRIPTION
## Summary

- reject empty `appName` values and missing or empty `userId` values in direct stream configuration
- name the missing option before session initialization or network activity begins
- preserve existing proxy mode and valid direct-mode request behavior

## Why

`appName` currently enables direct mode by itself. A configuration such as:

```ts
createAdkStream({
  api: "http://localhost:8000",
  appName: "my-app",
});
```

therefore posts to `/run_sse`, but `JSON.stringify()` omits the undefined `userId`. The resulting ADK server error does not explain that the local stream configuration is incomplete, even though the API documentation says `userId` is required with `appName`. An empty `appName` similarly selected direct mode and sent an invalid application identifier.

`createAdkStream()` now rejects those configurations immediately with a focused error. Calls without `appName` remain in proxy mode, and calls with both direct-mode values follow the existing path unchanged.

## Verification

- reproduced the regression test failing before the guard
- `vitest run` in `packages/react-google-adk`: 9 files, 191 tests passed
- `aui-build` in `packages/react-google-adk`
- `oxlint` and `oxfmt` on the changed files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->