### PR TITLE
fix(cli): sanitize scaffold tsconfigs and surface shadcn install failures

### DIFF
--- a/.changeset/create-scaffold-sanitation.md
+++ b/.changeset/create-scaffold-sanitation.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: sanitize tsconfig for every create scaffold and surface registry install failures

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -12,6 +12,7 @@ import {
   resolvePackageManagerForCwd,
   scaffoldProject,
   transformProject,
+  type TransformResult,
 } from "../lib/create-project";
 import { runSpawn, SpawnExitError } from "../lib/run-spawn";
 import {
@@ -609,6 +610,7 @@ export const create = new Command()
           ? `Copying project from local source: ${localSourceRoot}`
           : "Downloading project...",
       );
+      let transformResult: TransformResult;
       try {
         const source = localSourceRoot
           ? { kind: "local" as const, rootDir: localSourceRoot }
@@ -632,7 +634,7 @@ export const create = new Command()
         }
 
         // 5. Run transform pipeline
-        await transformProject(absoluteProjectDir, {
+        transformResult = await transformProject(absoluteProjectDir, {
           hasLocalComponents: project.hasLocalComponents,
           skipInstall: opts.skipInstall,
           packageManager: pm,
@@ -684,6 +686,15 @@ export const create = new Command()
       }
 
       process.removeListener("exit", cleanupOnExit);
+
+      if (transformResult.registryInstallFailure) {
+        logger.break();
+        logger.error("Project created with missing components.");
+        logger.info("Retry the component install with:");
+        logger.info(`  cd ${resolvedProjectDirectory}`);
+        logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
+        process.exit(1);
+      }
 
       logger.break();
       logger.success("Project created successfully!");

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -659,6 +659,16 @@ export const create = new Command()
         throw err;
       }
 
+      if (transformResult.registryInstallFailure) {
+        process.removeListener("exit", cleanupOnExit);
+        logger.break();
+        logger.error("Project created with missing components.");
+        logger.info("Retry the component install with:");
+        logger.info(`  cd ${resolvedProjectDirectory}`);
+        logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
+        process.exit(1);
+      }
+
       // 6. Apply preset if provided
       if (scaffoldSelector.preset) {
         const presetUrl = resolvePresetUrl(scaffoldSelector.preset);
@@ -686,15 +696,6 @@ export const create = new Command()
       }
 
       process.removeListener("exit", cleanupOnExit);
-
-      if (transformResult.registryInstallFailure) {
-        logger.break();
-        logger.error("Project created with missing components.");
-        logger.info("Retry the component install with:");
-        logger.info(`  cd ${resolvedProjectDirectory}`);
-        logger.info(`  ${transformResult.registryInstallFailure.retryCommand}`);
-        process.exit(1);
-      }
 
       logger.break();
       logger.success("Project created successfully!");

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -337,9 +337,7 @@ function transformTsConfig(projectDir: string): void {
         targets.some(
           (target) =>
             typeof target === "string" &&
-            (target.includes("packages/ui/") ||
-              target.includes("../../packages/") ||
-              target.startsWith("../..")),
+            (target.includes("packages/ui/") || target.startsWith("../")),
         );
       if (workspaceKeys.has(key) || targetsWorkspace) {
         delete tsconfig.compilerOptions.paths[key];

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -476,18 +476,16 @@ async function installShadcnRegistry(
   const [cmd, dlxArgs] = dlxCommand(pm);
   // For npm, dlxArgs may already include `--yes` for npx auto-install.
   // The trailing `--yes` is for shadcn's own confirmation prompt.
-  const addArgs = [...dlxArgs, "shadcn@latest", "add", ...components, "--yes"];
+  const retryArgs = [...dlxArgs, "shadcn@latest", "add", ...components];
+  const addArgs = [...retryArgs, "--yes"];
 
   try {
     await runSpawn(cmd, addArgs, projectDir);
     return undefined;
   } catch (error) {
     if (error instanceof SpawnExitError) {
-      const retryCommand = `${cmd} ${addArgs.slice(0, -1).join(" ")}`;
-      logger.warn(
-        `shadcn exited with code ${error.code}. Run the following to retry:\n  ${retryCommand}`,
-      );
-      return { retryCommand };
+      logger.warn(`shadcn exited with code ${error.code}.`);
+      return { retryCommand: `${cmd} ${retryArgs.join(" ")}` };
     }
 
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -210,22 +210,25 @@ export async function resolvePackageManagerForCwd(
   }
 }
 
+export interface TransformResult {
+  registryInstallFailure?: { retryCommand: string };
+}
+
 export async function transformProject(
   projectDir: string,
   opts: TransformOptions,
-): Promise<void> {
+): Promise<TransformResult> {
   logger.step("Transforming package.json...");
   transformPackageJson(projectDir);
+
+  logger.step("Transforming project files...");
+  transformTsConfig(projectDir);
+  transformCssFiles(projectDir);
 
   let assistantUI: string[] | undefined;
   let shadcnUI: string[] | undefined;
 
   if (!opts.hasLocalComponents) {
-    logger.step("Transforming project files...");
-
-    transformTsConfig(projectDir);
-    transformCssFiles(projectDir);
-
     const components = scanRequiredComponents(projectDir);
     assistantUI = components.assistantUI;
     shadcnUI = components.shadcnUI;
@@ -249,8 +252,15 @@ export async function transformProject(
     const auiComponents = assistantUI.map((c) => `@assistant-ui/${c}`);
     const components = [...allShadcn, ...auiComponents];
     logger.step(`Installing components: ${components.join(", ")}...`);
-    await installShadcnRegistry(projectDir, components, "components", pm);
+    const failure = await installShadcnRegistry(
+      projectDir,
+      components,
+      "components",
+      pm,
+    );
+    if (failure) return { registryInstallFailure: failure };
   }
+  return {};
 }
 
 function transformPackageJson(projectDir: string): void {
@@ -326,7 +336,10 @@ function transformTsConfig(projectDir: string): void {
         Array.isArray(targets) &&
         targets.some(
           (target) =>
-            typeof target === "string" && target.includes("packages/ui/"),
+            typeof target === "string" &&
+            (target.includes("packages/ui/") ||
+              target.includes("../../packages/") ||
+              target.startsWith("../..")),
         );
       if (workspaceKeys.has(key) || targetsWorkspace) {
         delete tsconfig.compilerOptions.paths[key];
@@ -461,7 +474,7 @@ async function installShadcnRegistry(
   components: string[],
   label: string,
   pm: PackageManagerName,
-): Promise<void> {
+): Promise<{ retryCommand: string } | undefined> {
   const [cmd, dlxArgs] = dlxCommand(pm);
   // For npm, dlxArgs may already include `--yes` for npx auto-install.
   // The trailing `--yes` is for shadcn's own confirmation prompt.
@@ -469,12 +482,14 @@ async function installShadcnRegistry(
 
   try {
     await runSpawn(cmd, addArgs, projectDir);
+    return undefined;
   } catch (error) {
     if (error instanceof SpawnExitError) {
+      const retryCommand = `${cmd} ${addArgs.slice(0, -1).join(" ")}`;
       logger.warn(
-        `shadcn exited with code ${error.code}. Run the following to retry:\n  ${cmd} ${addArgs.slice(0, -1).join(" ")}`,
+        `shadcn exited with code ${error.code}. Run the following to retry:\n  ${retryCommand}`,
       );
-      return;
+      return { retryCommand };
     }
 
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -260,6 +260,60 @@ describe("transformProject — hasLocalComponents: true", () => {
     expect(pkg.devDependencies.typescript).toBe("^5.0.0");
     expect(pkg.name).toBe(path.basename(testDir));
   });
+
+  it("sanitizes tsconfig and css files", async () => {
+    writeJSON("package.json", { name: "test", dependencies: {} });
+    writeJSON("tsconfig.json", {
+      extends: "@assistant-ui/x-buildutils/ts/base",
+      compilerOptions: {
+        paths: {
+          "@/*": ["./*"],
+          "@/components/assistant-ui/*": [
+            "../../packages/ui/src/components/assistant-ui/*",
+          ],
+          "@assistant-ui/*": ["../../packages/*/src"],
+        },
+      },
+    });
+    writeFile(
+      "app/globals.css",
+      '@source "../../packages/ui/src";\nbody { margin: 0; }\n',
+    );
+
+    await transformProject(testDir, {
+      ...defaultOpts,
+      hasLocalComponents: true,
+    });
+
+    const tsconfig = readJSON("tsconfig.json");
+    expect(tsconfig.extends).toBeUndefined();
+    expect(tsconfig.compilerOptions.target).toBe("ESNext");
+    const paths = tsconfig.compilerOptions.paths;
+    expect(paths["@/components/assistant-ui/*"]).toBeUndefined();
+    expect(paths["@assistant-ui/*"]).toBeUndefined();
+    expect(paths["@/*"]).toEqual(["./*"]);
+    expect(readFile("app/globals.css")).not.toContain("packages/ui/src");
+  });
+
+  it("does not install registry components", async () => {
+    writeJSON("package.json", { name: "test", dependencies: {} });
+    writeFile(
+      "app/page.tsx",
+      'import { Button } from "@/components/ui/button";\n',
+    );
+
+    await transformProject(testDir, {
+      ...defaultOpts,
+      skipInstall: false,
+      hasLocalComponents: true,
+    });
+
+    const shadcnCalls = (spawn as Mock).mock.calls.filter(
+      ([cmd, args]: [string, string[]]) =>
+        cmd === TEST_DLX_CMD && args.includes("shadcn@latest"),
+    );
+    expect(shadcnCalls).toHaveLength(0);
+  });
 });
 
 describe("transformProject — hasLocalComponents: false", () => {
@@ -341,6 +395,29 @@ describe("transformProject — hasLocalComponents: false", () => {
       expect(paths["@/hooks/*"]).toBeUndefined();
       expect(paths["@/lib/utils"]).toBeUndefined();
       expect(paths["@assistant-ui/ui/*"]).toBeUndefined();
+      expect(paths["@/*"]).toEqual(["./*"]);
+    });
+
+    it("removes monorepo-escaping path targets", async () => {
+      writeJSON("tsconfig.json", {
+        compilerOptions: {
+          paths: {
+            "@/*": ["./*"],
+            "@assistant-ui/*": ["../../packages/*/src"],
+            "@assistant-ui/core/*": ["../../packages/core/src/*"],
+            "assistant-stream": ["../../packages/assistant-stream/src"],
+            "assistant-stream/*": ["../../packages/assistant-stream/src/*"],
+          },
+        },
+      });
+
+      await run();
+
+      const paths = readJSON("tsconfig.json").compilerOptions.paths;
+      expect(paths["@assistant-ui/*"]).toBeUndefined();
+      expect(paths["@assistant-ui/core/*"]).toBeUndefined();
+      expect(paths["assistant-stream"]).toBeUndefined();
+      expect(paths["assistant-stream/*"]).toBeUndefined();
       expect(paths["@/*"]).toEqual(["./*"]);
     });
 
@@ -497,7 +574,7 @@ describe("transformProject — install behavior", () => {
 });
 
 describe("installShadcnRegistry behavior", () => {
-  it("resolves with a warning when shadcn exits non-zero", async () => {
+  it("reports the failure and preserves the scaffold when shadcn exits non-zero", async () => {
     // First spawn call is `pm install` (skipInstall: false); let it succeed.
     (spawn as Mock).mockImplementationOnce(() => {
       const ee = new EventEmitter();
@@ -517,11 +594,32 @@ describe("installShadcnRegistry behavior", () => {
       'import { Button } from "@/components/ui/button";\n',
     );
 
-    // Should NOT throw — warn-and-continue behavior
-    await transformProject(testDir, {
+    const result = await transformProject(testDir, {
       ...defaultOpts,
       skipInstall: false,
       hasLocalComponents: false,
     });
+
+    expect(result.registryInstallFailure?.retryCommand).toContain(
+      "shadcn@latest",
+    );
+    expect(result.registryInstallFailure?.retryCommand).not.toMatch(/--yes$/);
+    expect(fs.existsSync(path.join(testDir, "package.json"))).toBe(true);
+  });
+
+  it("reports no failure when shadcn succeeds", async () => {
+    writeJSON("package.json", { name: "test", dependencies: {} });
+    writeFile(
+      "app/page.tsx",
+      'import { Button } from "@/components/ui/button";\n',
+    );
+
+    const result = await transformProject(testDir, {
+      ...defaultOpts,
+      skipInstall: false,
+      hasLocalComponents: false,
+    });
+
+    expect(result.registryInstallFailure).toBeUndefined();
   });
 });

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -405,6 +405,7 @@ describe("transformProject — hasLocalComponents: false", () => {
             "@/*": ["./*"],
             "@assistant-ui/*": ["../../packages/*/src"],
             "@assistant-ui/core/*": ["../../packages/core/src/*"],
+            "@shared/*": ["../shared/*"],
             "assistant-stream": ["../../packages/assistant-stream/src"],
             "assistant-stream/*": ["../../packages/assistant-stream/src/*"],
           },
@@ -416,6 +417,7 @@ describe("transformProject — hasLocalComponents: false", () => {
       const paths = readJSON("tsconfig.json").compilerOptions.paths;
       expect(paths["@assistant-ui/*"]).toBeUndefined();
       expect(paths["@assistant-ui/core/*"]).toBeUndefined();
+      expect(paths["@shared/*"]).toBeUndefined();
       expect(paths["assistant-stream"]).toBeUndefined();
       expect(paths["assistant-stream/*"]).toBeUndefined();
       expect(paths["@/*"]).toEqual(["./*"]);


### PR DESCRIPTION
## What

`npx assistant-ui create` shipped broken scaffolds:

- tsconfig sanitation was skipped for examples flagged `hasLocalComponents`, leaving a dangling `extends "@assistant-ui/x-buildutils/ts/base"` and `../../packages/...` path aliases that don't exist outside the monorepo.
- Even when it ran, the alias filter only stripped `packages/ui/` targets, so aliases like `"@assistant-ui/*": ["../../packages/*/src"]` survived and shadowed the installed npm packages.
- A failed `shadcn add` was swallowed and the CLI still printed "Project created successfully!".

## How

- Run tsconfig/CSS sanitation for every scaffold; only component scanning/registry install stays gated on `hasLocalComponents`.
- Strip any path target escaping the project root, not just `packages/ui/`.
- `installShadcnRegistry` returns a structured result; `create` now prints the retry command, exits nonzero, and keeps the scaffold on disk instead of reporting success.

## Verification

- New unit tests cover local-component sanitation, monorepo-escaping alias stripping, and the failure result.
- E2E: scaffolded `with-elevenlabs-conversational` has a standalone tsconfig; a simulated `shadcn add` failure exits 1 without the success banner and preserves the scaffold.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

