### PR TITLE
fix(examples): rotate waterfall collapse chevron when span is collapsed

### DIFF
--- a/examples/waterfall/lib/waterfall-row.tsx
+++ b/examples/waterfall/lib/waterfall-row.tsx
@@ -25,7 +25,7 @@ export function WaterfallRow() {
           <SpanPrimitive.CollapseToggle className="text-muted-foreground hover:text-foreground flex shrink-0 items-center justify-center rounded p-0.5">
             <svg
               aria-hidden="true"
-              className="data-[collapsed=true]:[-rotate-90] size-3.5 transition-transform"
+              className="size-3.5 transition-transform group-data-[collapsed=true]:-rotate-90"
               viewBox="0 0 16 16"
               fill="currentColor"
             >


### PR DESCRIPTION
## What

Fixes the collapse chevron in the waterfall example staying static when a span is collapsed.

## Why

The svg used `data-[collapsed=true]:[-rotate-90]`, which is broken twice over: `[-rotate-90]` is invalid Tailwind (compiles to no CSS), and the `data-collapsed` attribute lives on the parent `SpanPrimitive.Root`/`CollapseToggle`, not on the svg itself, so the variant could never match.

## How

Changed the class to `group-data-[collapsed=true]:-rotate-90`, keyed off `SpanPrimitive.Root` which carries both the `group` class and `data-collapsed` — same pattern as the accordion/navigation-menu chevrons in `packages/ui`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

