### PR TITLE
fix(docs): sandbox hosted artifact previews

### DIFF
--- a/apps/docs/components/examples/artifacts-view.tsx
+++ b/apps/docs/components/examples/artifacts-view.tsx
@@ -51,6 +51,7 @@ export const ArtifactsView = () => {
               <iframe
                 title="artifact-preview"
                 className="h-full w-full"
+                sandbox="allow-scripts"
                 srcDoc={artifact}
               />
             )}

--- a/apps/docs/components/examples/artifacts-view.tsx
+++ b/apps/docs/components/examples/artifacts-view.tsx
@@ -51,7 +51,7 @@ export const ArtifactsView = () => {
               <iframe
                 title="artifact-preview"
                 className="h-full w-full"
-                sandbox="allow-scripts"
+                sandbox="allow-scripts allow-forms"
                 srcDoc={artifact}
               />
             )}

--- a/apps/docs/content/examples/artifacts.mdx
+++ b/apps/docs/content/examples/artifacts.mdx
@@ -18,18 +18,18 @@ An open-source implementation of Claude Artifacts that allows users to generate 
 
 ## Features
 
-- **Real-time Preview**: Generated artifacts render instantly in a sandboxed iframe
+- **Real-time Preview**: Generated artifacts render instantly in an isolated sandboxed iframe
 - **Code Generation**: Creates complete HTML, CSS, and JavaScript applications
 - **Interactive Elements**: Artifacts can include buttons, forms, and animations
 - **Iteration Support**: Ask the AI to modify and improve generated artifacts
-- **Safe Execution**: Code runs in a sandboxed environment for security
+- **Safe Execution**: Code runs in a sandboxed iframe with scripts enabled but no access to the parent documentation page
 - **Export Options**: Download generated artifacts as standalone files
 
 ## How It Works
 
 1. **Request**: Ask the AI to create something (e.g., "Create a calculator app")
 2. **Generation**: The AI generates the necessary HTML, CSS, and JavaScript
-3. **Rendering**: Code is safely rendered in a preview panel
+3. **Rendering**: Code is safely rendered in an isolated preview panel
 4. **Iteration**: Request changes and see updates in real-time
 
 ## Use Cases


### PR DESCRIPTION
## Summary

- sandbox the hosted Artifacts preview with `allow-scripts` so generated JavaScript continues to run without inheriting the documentation page origin
- align the Artifacts page copy with the actual isolation guarantee

## Root cause

The hosted preview rendered untrusted `srcDoc` content in an iframe without a sandbox attribute. That gave generated artifact code the same origin as the documentation page despite the page claiming safe execution.

## Validation

- `pnpm exec oxfmt --check apps/docs/components/examples/artifacts-view.tsx apps/docs/content/examples/artifacts.mdx`
- `pnpm exec oxlint apps/docs/components/examples/artifacts-view.tsx`

Closes #5003

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

