### PR TITLE
fix(cli): scaffold voice and interactables examples via the registry

### DIFF
--- a/.changeset/cli-scaffold-registry-metadata.md
+++ b/.changeset/cli-scaffold-registry-metadata.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: install registry components when scaffolding the voice and interactables examples

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -166,7 +166,7 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     description: "Realtime voice with ElevenLabs",
     category: "example",
     path: "examples/with-elevenlabs-conversational",
-    hasLocalComponents: true,
+    hasLocalComponents: false,
   },
   {
     name: "with-elevenlabs-scribe",
@@ -182,7 +182,7 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     description: "Realtime voice with LiveKit",
     category: "example",
     path: "examples/with-livekit",
-    hasLocalComponents: true,
+    hasLocalComponents: false,
   },
   {
     name: "with-expo",
@@ -198,7 +198,7 @@ export const PROJECT_METADATA: ProjectMetadata[] = [
     description: "AI-driven interactive UI components",
     category: "example",
     path: "examples/with-interactables",
-    hasLocalComponents: true,
+    hasLocalComponents: false,
   },
   {
     name: "with-external-store",

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -301,12 +301,8 @@ describe("PROJECT_METADATA", () => {
   it("examples have correct hasLocalComponents values", () => {
     const examples = PROJECT_METADATA.filter((m) => m.category === "example");
     const withLocalComponents = examples.filter((e) => e.hasLocalComponents);
-    // These examples ship their own components (no shadcn)
     expect(withLocalComponents.map((e) => e.name)).toEqual([
-      "with-elevenlabs-conversational",
-      "with-livekit",
       "with-expo",
-      "with-interactables",
       "with-react-ink",
     ]);
   });

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -576,7 +576,7 @@ describe("transformProject — install behavior", () => {
 });
 
 describe("installShadcnRegistry behavior", () => {
-  it("reports the failure and preserves the scaffold when shadcn exits non-zero", async () => {
+  it("reports the failure when shadcn exits non-zero", async () => {
     // First spawn call is `pm install` (skipInstall: false); let it succeed.
     (spawn as Mock).mockImplementationOnce(() => {
       const ee = new EventEmitter();
@@ -606,7 +606,6 @@ describe("installShadcnRegistry behavior", () => {
       "shadcn@latest",
     );
     expect(result.registryInstallFailure?.retryCommand).not.toMatch(/--yes$/);
-    expect(fs.existsSync(path.join(testDir, "package.json"))).toBe(true);
   });
 
   it("reports no failure when shadcn succeeds", async () => {


### PR DESCRIPTION
closes #5018

## summary

- `with-elevenlabs-conversational`, `with-livekit`, and `with-interactables` were flagged `hasLocalComponents: true` in `PROJECT_METADATA`, but none of them ships a local `components/` directory; in the monorepo their `@/components/assistant-ui/*` imports resolve through tsconfig aliases into `packages/ui`, so scaffolds skipped the registry install and shipped unresolvable imports
- flip the three entries to `hasLocalComponents: false` so `create` scans the imports and installs `voice`, `markdown-text`, `tooltip-icon-button`, and `thread` from the registry like every other registry-backed example
- update the `PROJECT_METADATA` test to the corrected list and drop its falsified comment; rename the shadcn failure test and drop a lib-level assertion that could never fail there (follow-up promised in the #5013 review threads)

## test plan

### already verified

- [x] red-green: with only the source flip, `examples have correct hasLocalComponents values` fails on the old five-name list; green after the test update
- [x] `packages/cli` vitest run, 19 files, 242 tests, all passing
- [x] registry coverage probed on the deployed endpoint: `voice`, `thread`, `markdown-text`, `tooltip-icon-button` all resolve, and `voice` declares its `registryDependencies` (button, tooltip-icon-button)
- [x] end to end for all three examples: scaffolded with the local CLI (`--debug-source-root`), npm install plus registry install completed, components landed in `components/assistant-ui/`, and `next build` succeeded in each generated project

### reviewer should verify

- [ ] `pnpm --filter assistant-ui build`, then `node packages/cli/dist/index.js create demo -e with-livekit --use-npm --no-skills --debug-source-root .` and `npm run build` inside `demo`; the build passes and `components/assistant-ui/` contains voice, markdown-text, and tooltip-icon-button

## notes

- the example imports intentionally stay `@/components/assistant-ui/*`: deployed registry items install to `components/assistant-ui/*` (and their own contents import that shape), so both the monorepo aliases and the scaffolded layout resolve the unchanged imports
- deriving the gate from a `components/` directory check instead of metadata was considered and rejected for now: `with-react-ink` has no components directory and no component imports, and an empty scan would still install `utils` into a terminal app; tightening that gate can be its own change

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

