### PR TITLE
fix(examples): sandbox the with-artifacts preview iframe

### DIFF
--- a/examples/with-artifacts/app/page.tsx
+++ b/examples/with-artifacts/app/page.tsx
@@ -76,6 +76,7 @@ function ArtifactsView() {
             <iframe
               className="h-full w-full"
               title="Artifact Preview"
+              sandbox="allow-scripts allow-forms"
               srcDoc={code}
             />
           </div>


### PR DESCRIPTION
## summary

- add `sandbox="allow-scripts allow-forms"` to the artifact preview iframe in `examples/with-artifacts/app/page.tsx`, the sibling of the hosted docs preview fixed in #5020
- model-generated `srcDoc` content previously ran same origin with the example app; with the sandbox it runs in an opaque origin (scripts enabled, no access to the host page, cookies, or storage)
- `allow-forms` matches #5020: the example's suggestion prompts generate landing pages where a form submit would otherwise be silently blocked

## test plan

### already verified

- [x] `oxlint` and `oxfmt --check` clean on the changed file
- [x] attribute shape and placement mirror the merged #5020 fix; the component has no parent-iframe coupling that sandboxing could break

### reviewer should verify

- [ ] run the with-artifacts example, generate an artifact, and confirm the preview still renders and scripts execute

## notes

- #4936 (open) touches the same file for the work panel pattern and will need a trivial rebase after this lands
- no changeset; examples are private packages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

