### PR TITLE
fix(react-pi): widen pi-coding-agent peer range to include 0.79.x and  0.80.x

### DIFF
--- a/.changeset/react-pi-widen-pi-peer.md
+++ b/.changeset/react-pi-widen-pi-peer.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-pi": patch
 ---
 
-fix: widen pi-coding-agent peer range to include 0.79.x and 0.80.x
+fix: widen the pi-coding-agent peer to a >=0.78.0 floor so 0.79.x and 0.80.x installs stop warning

--- a/.changeset/react-pi-widen-pi-peer.md
+++ b/.changeset/react-pi-widen-pi-peer.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-pi": patch
 ---
 
-fix: widen the pi-coding-agent peer to a >=0.78.0 floor so 0.79.x and 0.80.x installs stop warning
+fix: widen the pi-coding-agent peer to >=0.78.0 <0.80.8, covering 0.79.x and 0.80.x up to the release that removed the AuthStorage API the node host still uses

--- a/.changeset/react-pi-widen-pi-peer.md
+++ b/.changeset/react-pi-widen-pi-peer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: widen pi-coding-agent peer range to include 0.79.x and 0.80.x

--- a/packages/react-pi/package.json
+++ b/packages/react-pi/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.11",
-    "@earendil-works/pi-coding-agent": "^0.78.0 || ^0.79.0 || ^0.80.0",
+    "@earendil-works/pi-coding-agent": ">=0.78.0",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-pi/package.json
+++ b/packages/react-pi/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.11",
-    "@earendil-works/pi-coding-agent": ">=0.78.0",
+    "@earendil-works/pi-coding-agent": ">=0.78.0 <0.80.8",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-pi/package.json
+++ b/packages/react-pi/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.11",
-    "@earendil-works/pi-coding-agent": "^0.78.0",
+    "@earendil-works/pi-coding-agent": "^0.78.0 || ^0.79.0 || ^0.80.0",
     "@types/react": "*",
     "react": "^18 || ^19"
   },

--- a/packages/react-pi/src/node/contextUsage.ts
+++ b/packages/react-pi/src/node/contextUsage.ts
@@ -5,7 +5,7 @@
  * this touches the Pi SDK at runtime (the token-estimation helpers), so it lives
  * in its own node-only module.
  *
- * The logic mirrors the SDK's `getContextUsage()` (pi `0.78`): trust the latest
+ * The logic mirrors the SDK's `getContextUsage()` (pi `0.78`–`0.80`): trust the latest
  * assistant `usage` (real API token counts), estimate only the messages after
  * it, and fall back to `{ tokens: null }` when a compaction boundary has no
  * trustworthy post-compaction usage yet. The one piece this re-implements is

--- a/packages/react-pi/src/node/mapping.ts
+++ b/packages/react-pi/src/node/mapping.ts
@@ -6,7 +6,7 @@
  * testable seam of the node host — exercised with hand-built fakes in
  * `mapping.test.ts`, no live `AgentSession` required.
  *
- * The mirror in `types` is structurally faithful to Pi `0.78` (verified
+ * The mirror in `types` is structurally faithful to Pi `0.78`–`0.80` (verified
  * against the real `.d.ts`), so most of the mapping is an identity cast at the
  * type boundary plus the few places the supervisor must enrich (turn index, live
  * run status, readiness).

--- a/packages/react-pi/src/types.ts
+++ b/packages/react-pi/src/types.ts
@@ -5,10 +5,11 @@
  * The Pi message/content/event shapes are mirrored here as plain serializable
  * types so they can travel over an arbitrary transport (HTTP/SSE, RPC
  * subprocess, Electron IPC). The shapes are kept structurally faithful to
- * Pi `0.78.0` so the node host (`./node`) can assign real Pi values into them
+ * Pi `0.78`–`0.80` so the node host (`./node`) can assign real Pi values into them
  * without conversion.
  *
- * Provenance (verified against `@earendil-works/pi-coding-agent@0.78.0`):
+ * Provenance (verified against `@earendil-works/pi-coding-agent` 0.78.0,
+ * 0.79.0, 0.79.10, and 0.80.7):
  * - content/message shapes: `@earendil-works/pi-ai/dist/types.d.ts`
  * - custom message roles:    `pi-coding-agent/dist/core/messages.d.ts`
  * - agent/session events:    `pi-agent-core/dist/types.d.ts` (`AgentEvent`),


### PR DESCRIPTION
## What

Widens the optional peer `@earendil-works/pi-coding-agent` from `^0.78.0` to `^0.78.0 || ^0.79.0 || ^0.80.0`, and updates the three source-header sentences stating the supported Pi span (`src/types.ts`, `src/node/mapping.ts`, `src/node/contextUsage.ts`) from `0.78` to `0.78`–`0.80`. Range widen only, no floor bump.

## Why

For 0.x versions a caret does not span minors, so `^0.78.0` means `>=0.78.0 <0.79.0` and excludes the 0.80.x line the package is built and tested against (devDependencies pin `^0.80.7`, npm latest is 0.80.10). Consumers of the `./node` entry who install current Pi get an unmet-peer warning on every install, and strict package managers can refuse the install.

## Impact

- `packages/react-pi/package.json`: peerDependencies range only; devDependencies unchanged.
- Three one-line comment updates in src headers. These files ship in the npm tarball, so the stated span should match the manifest claim.
- No lockfile diff, no runtime output change; patch changeset.

## Why the full 0.78–0.80 span is safe

The top of the range is continuously exercised (CI builds and tests against the 0.80.7 devDep); the bottom is the originally verified provenance target. The 0.79.x line was checked directly: the `.d.ts` surfaces the adapter mirrors were diffed across 0.78.0, 0.79.0, 0.79.10, and 0.80.7 — changes are purely additive (new optional fields, new event union members), with no consumed shape removed or renamed. `mapping.ts` drops unknown event variants through its `default:` arm, so additive upstream events are safe by construction.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

