### PR TITLE
refactor(react-ag-ui): share interrupt-response validation between submitInterruptResponses and steerAway

### DIFF
--- a/.changeset/ag-ui-shared-interrupt-validation.md
+++ b/.changeset/ag-ui-shared-interrupt-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+refactor: share interrupt-response validation between submitInterruptResponses and steerAway

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -425,38 +425,17 @@ export class AgUiThreadRuntimeCore {
       );
     }
 
-    const responsesById = new Map<string, AgUiResumeEntry>();
-    for (const entry of responses) {
-      if (!entry || typeof entry.interruptId !== "string") {
-        throw new Error(
-          "[agui] submitInterruptResponses: every entry must have an interruptId",
-        );
-      }
-      if (entry.status !== "resolved" && entry.status !== "cancelled") {
-        throw new Error(
-          `[agui] submitInterruptResponses: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
-        );
-      }
-      if (responsesById.has(entry.interruptId)) {
-        throw new Error(
-          `[agui] submitInterruptResponses: duplicate response for interrupt ${entry.interruptId}`,
-        );
-      }
-      responsesById.set(entry.interruptId, entry);
-    }
+    const responsesById = this.collectInterruptResponses(
+      "submitInterruptResponses",
+      pending.interrupts,
+      responses,
+    );
 
     const openIds = pending.interrupts.map((i) => i.id);
     const missing = openIds.filter((id) => !responsesById.has(id));
     if (missing.length > 0) {
       throw new Error(
         `[agui] submitInterruptResponses: missing responses for open interrupts: ${missing.join(", ")}`,
-      );
-    }
-    const known = new Set(openIds);
-    const unknownIds = [...responsesById.keys()].filter((id) => !known.has(id));
-    if (unknownIds.length > 0) {
-      throw new Error(
-        `[agui] submitInterruptResponses: unknown interrupt ids: ${unknownIds.join(", ")}`,
       );
     }
 
@@ -538,35 +517,51 @@ export class AgUiThreadRuntimeCore {
     interrupts: readonly AgUiInterrupt[],
     responses: readonly AgUiResumeEntry[] | undefined,
   ): AgUiResumeEntry[] {
-    const openIds = interrupts.map((interrupt) => interrupt.id);
-    const known = new Set(openIds);
+    const responsesById = this.collectInterruptResponses(
+      "steerAway",
+      interrupts,
+      responses ?? [],
+    );
+    return interrupts.map(
+      (interrupt) =>
+        responsesById.get(interrupt.id) ?? {
+          interruptId: interrupt.id,
+          status: "cancelled",
+        },
+    );
+  }
+
+  private collectInterruptResponses(
+    method: "submitInterruptResponses" | "steerAway",
+    interrupts: readonly AgUiInterrupt[],
+    responses: readonly AgUiResumeEntry[],
+  ): Map<string, AgUiResumeEntry> {
+    const known = new Set(interrupts.map((interrupt) => interrupt.id));
     const responsesById = new Map<string, AgUiResumeEntry>();
-    for (const entry of responses ?? []) {
+    for (const entry of responses) {
       if (!entry || typeof entry.interruptId !== "string") {
         throw new Error(
-          "[agui] steerAway: every response must have an interruptId",
+          `[agui] ${method}: every entry must have an interruptId`,
         );
       }
       if (entry.status !== "resolved" && entry.status !== "cancelled") {
         throw new Error(
-          `[agui] steerAway: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
+          `[agui] ${method}: invalid status "${entry.status}" for interrupt ${entry.interruptId}`,
         );
       }
       if (!known.has(entry.interruptId)) {
         throw new Error(
-          `[agui] steerAway: unknown interrupt id ${entry.interruptId}`,
+          `[agui] ${method}: unknown interrupt id ${entry.interruptId}`,
         );
       }
       if (responsesById.has(entry.interruptId)) {
         throw new Error(
-          `[agui] steerAway: duplicate response for interrupt ${entry.interruptId}`,
+          `[agui] ${method}: duplicate response for interrupt ${entry.interruptId}`,
         );
       }
       responsesById.set(entry.interruptId, entry);
     }
-    return openIds.map(
-      (id) => responsesById.get(id) ?? { interruptId: id, status: "cancelled" },
-    );
+    return responsesById;
   }
 
   private toAppendMessage(message: CreateAppendMessage): AppendMessage {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2224,6 +2224,35 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runCount).toBe(1);
   });
 
+  it("steerAway rejects entries without an interruptId or with an invalid status", async () => {
+    let runCount = 0;
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      runCount++;
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.steerAway("x", [{ status: "cancelled" } as any]),
+    ).rejects.toThrow("every entry must have an interruptId");
+    await expect(
+      core.steerAway("x", [{ interruptId: "int-1", status: "nope" } as any]),
+    ).rejects.toThrow(/invalid status "nope" for interrupt int-1/);
+    expect(runCount).toBe(1);
+  });
+
   it("steerAway cancels a pending client-side tool call and starts one fresh run", async () => {
     const runInputs: any[] = [];
     let runCount = 0;
@@ -3001,7 +3030,62 @@ describe("AGUIThreadRuntimeCore", () => {
         { interruptId: "int-1", status: "resolved" },
         { interruptId: "int-unknown", status: "resolved" },
       ]),
-    ).rejects.toThrow(/unknown interrupt ids: int-unknown/);
+    ).rejects.toThrow(/unknown interrupt id int-unknown/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unknown interrupt id even when open interrupts are unanswered", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-unknown", status: "resolved" },
+      ]),
+    ).rejects.toThrow(/unknown interrupt id int-unknown/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an unknown interrupt id when the same unknown id is submitted twice", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-unknown", status: "resolved" },
+        { interruptId: "int-unknown", status: "cancelled" },
+      ]),
+    ).rejects.toThrow(/unknown interrupt id int-unknown/);
     expect(runAgent).toHaveBeenCalledTimes(1);
   });
 
@@ -3058,6 +3142,36 @@ describe("AGUIThreadRuntimeCore", () => {
         { interruptId: "int-1", status: "cancelled" },
       ]),
     ).rejects.toThrow(/duplicate response/);
+    expect(runAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects resume entries without an interruptId or with an invalid status", async () => {
+    const runAgent = vi.fn(async (input: any, subscriber: any) => {
+      subscriber.onRunFinishedEvent?.({
+        event: {
+          type: "RUN_FINISHED",
+          runId: input.runId,
+          outcome: {
+            type: "interrupt",
+            interrupts: [{ id: "int-1", reason: "tool_call" }],
+          },
+        },
+      });
+      subscriber.onRunFinalized?.();
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const core = createCore(agent);
+    await core.append(createAppendMessage());
+
+    await expect(
+      core.submitInterruptResponses([{ status: "resolved" } as any]),
+    ).rejects.toThrow("every entry must have an interruptId");
+    await expect(
+      core.submitInterruptResponses([
+        { interruptId: "int-1", status: "nope" } as any,
+      ]),
+    ).rejects.toThrow(/invalid status "nope" for interrupt int-1/);
     expect(runAgent).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION

This PR  dedupes the interrupt-response validation in react-ag-ui so both interrupt entry points validate through one shared helper.

## What

`submitInterruptResponses` and `steerAway` each carried a near identical per-entry validation loop (interruptId presence, status validity, unknown id, duplicate), differing only in the error prefix. This extracts the loop into one private helper, `collectInterruptResponses`, on `AgUiThreadRuntimeCore`.

- Per-method error prefixes are preserved: `[agui] submitInterruptResponses:` vs `[agui] steerAway:`.
- Each caller keeps its own policy: submit still requires a response for every open interrupt and runs the expiry checks; steerAway still fills unanswered interrupts with `cancelled`.
- No public surface change; patch changeset for `@assistant-ui/react-ag-ui`.

## Why

The copies had already drifted in wording and check order, and any check added to one method silently misses the other. Sharing the loop keeps the two error surfaces consistent by construction.

## Impact

Accept/reject behavior is unchanged; only the error message selected under multiple simultaneous violations moves, plus two wording unifications:

| Input | Before | After |
| --- | --- | --- |
| submit: unknown id | `unknown interrupt ids: <ids>` | `unknown interrupt id <id>` (matches steerAway) |
| submit: unknown id + unanswered interrupts | missing-responses error | unknown-id error |
| submit: same unknown id twice | duplicate error | unknown-id error |
| steerAway: entry without interruptId | `every response must have an interruptId` | `every entry must have an interruptId` |

- One test regex updated (the plural unknown-ids pin); new tests pin the previously untested checks and the ordering change.
- react-ag-ui suite green (230 tests), full turbo build green.

## Rationale

The two methods' policies differ by design (submit is strict answer-everything, steerAway is cancel-what-I-skipped), so only the per-entry validation is shared and the policies stay at the call sites.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

