### PR TITLE
ci: fail claude-review when the run ends without posting the final review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -159,3 +159,20 @@ jobs:
           > **Fable's cybersecurity safeguard triggered — this review was served by Opus 4.8.** Ignore it and re-review with Fable locally.
 
           $(jq -r .body <<<"$COMMENT")"
+
+      # A run can also end cleanly without ever posting the final review,
+      # leaving the sticky comment stuck on its progress todos under a green
+      # check. The unchecked todos are written by the action's own progress
+      # tracking, so their presence in the last claude[bot] comment means the
+      # review never completed.
+      - name: Fail on unfinished review
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          COMMENT=$(gh api --paginate "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.user.login == "claude[bot]")' | jq -s 'last')
+          [ -n "$COMMENT" ] && [ "$COMMENT" != "null" ] || exit 0
+          jq -r .body <<<"$COMMENT" | grep -qE '^- \[ \]' || exit 0
+          echo "::error::Claude review ended without posting the final review (progress todos left unchecked)"
+          exit 1


### PR DESCRIPTION
Slimmed my claude-review hardening PR down to just the CI guard after @AVGVSTVS96's  prompt rewrite in #5035 superseded the synchronous-simplify half.

## What

Adds a `Fail on unfinished review` step to the claude-review job: after the run, if the last claude[bot] comment still contains unchecked progress todos (`- [ ]`), the job fails loudly instead of showing green.

## Why

Two recent runs ended cleanly with the sticky comment stuck on its progress spinner and no review ever posted, under a green check: #5025, and #5010 the day before, which was merged without ever receiving its review. The existing `Fail on Claude execution error` guard only catches `is_error: true` transcripts; a clean early exit without posting slips through. Dry-ran against real data: the guard flags #5025 and #5010 and passes the completed reviews on the last 23 merged PRs with zero false positives.

## Scope

An earlier version of this PR also made the simplify subagent run synchronously to remove the turn-end race that caused the stuck runs. #5035 retires the simplify pass entirely, which supersedes that half, so this PR is now the guard step only. It does not touch `REVIEW_PROMPT`, so it is conflict-free with #5035 and useful under either prompt.

Known limit: the guard only covers runs where the progress comment was created and left unfinished. A run that no-ops before creating any comment (which happens silently on every PR that modifies this workflow file, e.g. #5016/#4900/#4719) still shows green; that mode needs its own issue.
