### PR TITLE
refactor(ui): align CommandDialog with upstream composition contract

### DIFF
--- a/packages/ui/src/components/ui/base/command.tsx
+++ b/packages/ui/src/components/ui/base/command.tsx
@@ -34,14 +34,14 @@ function CommandDialog({
   description = "Search for a command to run...",
   children,
   className,
-  showCloseButton = true,
+  showCloseButton = false,
   ...props
-}: React.ComponentProps<typeof Dialog> & {
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
   title?: string;
   description?: string;
   className?: string;
   showCloseButton?: boolean;
-  children?: React.ReactNode;
+  children: React.ReactNode;
 }) {
   return (
     <Dialog {...props}>
@@ -53,9 +53,7 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
+        {children}
       </DialogContent>
     </Dialog>
   );

--- a/packages/ui/src/components/ui/radix/command.tsx
+++ b/packages/ui/src/components/ui/radix/command.tsx
@@ -34,13 +34,14 @@ function CommandDialog({
   description = "Search for a command to run...",
   children,
   className,
-  showCloseButton = true,
+  showCloseButton = false,
   ...props
-}: React.ComponentProps<typeof Dialog> & {
+}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
   title?: string;
   description?: string;
   className?: string;
   showCloseButton?: boolean;
+  children: React.ReactNode;
 }) {
   return (
     <Dialog {...props}>
@@ -52,9 +53,7 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
+        {children}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## What

Realigns `CommandDialog` in the vendored command component (`packages/ui/src/components/ui/{base,radix}/command.tsx`) with shadcn upstream's current composition contract:

- `showCloseButton` default: `true` → `false`
- Removed the internal `<Command className="[&_[cmdk-…]]…">` auto-wrap; `children` now render directly inside `DialogContent`
- Props type: `Omit<React.ComponentProps<typeof Dialog>, "children"> & { …; children: React.ReactNode }` (children now required)

## Why

Registry items declare bare `"command"` registryDependencies, which the shadcn CLI resolves against the **official upstream registry** — not our vendored copies. Upstream changed `CommandDialog` to render children directly (canonical usage passes an explicit `<Command>` child). A user following current shadcn examples against our vendored file gets nested cmdk roots (`<Command>` inside the auto-wrapped `<Command>`).

**Behavior change** (old → new contract): callers must now pass an explicit `<Command>` child and opt into the close button. No in-repo consumer uses `CommandDialog` (only definitions + exports), and `templates/minimal` does not ship `command.tsx`, so nothing needed migration.

## Deliberately deferred drift

Only the `CommandDialog` contract is synced. Upstream's `InputGroup`-based `CommandInput` and the `CommandItem` checked-state indicator are **not** copied — upstream's version depends on `input-group`, which has no Base twin in this repo. Upstream's `cn-*` classes are also skipped (this repo doesn't use that class system); the existing `"overflow-hidden p-0"` is kept.

## Verification

- `grep CommandDialog` across packages/apps/templates/examples → only definitions/exports
- `pnpm sync-templates` ✓, `pnpm lint` ✓, `pnpm -C apps/registry build` ✓, `packages/ui` `tsc --noEmit` ✓
- `packages/ui` is private → no changeset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

