### PR TITLE
fix(react-mcp): validate persisted connection timeouts

### DIFF
--- a/.changeset/gentle-carpets-wait.md
+++ b/.changeset/gentle-carpets-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: ignore custom MCP servers with malformed persisted connection timeouts

--- a/.changeset/gentle-carpets-wait.md
+++ b/.changeset/gentle-carpets-wait.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-mcp": patch
 ---
 
-fix: ignore custom MCP servers with malformed persisted connection timeouts
+fix: ignore malformed persisted MCP connection timeout values

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -33,15 +33,32 @@ describe("normalizeCustomServerRecords", () => {
         { ...validRecord, name: 123 },
         { ...validRecord, url: null },
         { ...validRecord, createdAt: Number.NaN },
-        { ...validRecord, connectionTimeout: "10000" },
-        { ...validRecord, connectionTimeout: null },
-        { ...validRecord, connectionTimeout: -1 },
-        { ...validRecord, connectionTimeout: Number.NaN },
-        { ...validRecord, connectionTimeout: Number.POSITIVE_INFINITY },
         { ...validRecord, auth: { type: "bearer", token: "" } },
         { ...validRecord, auth: { type: "bearer", token: 123 } },
       ]),
     ).toEqual([validRecord]);
+  });
+
+  it("strips malformed connection timeouts without dropping servers", () => {
+    expect(
+      normalizeCustomServerRecords([
+        { ...validRecord, id: "string-timeout", connectionTimeout: "10000" },
+        { ...validRecord, id: "null-timeout", connectionTimeout: null },
+        { ...validRecord, id: "negative-timeout", connectionTimeout: -1 },
+        { ...validRecord, id: "nan-timeout", connectionTimeout: Number.NaN },
+        {
+          ...validRecord,
+          id: "infinite-timeout",
+          connectionTimeout: Number.POSITIVE_INFINITY,
+        },
+      ]),
+    ).toEqual([
+      { ...validRecord, id: "string-timeout" },
+      { ...validRecord, id: "null-timeout" },
+      { ...validRecord, id: "negative-timeout" },
+      { ...validRecord, id: "nan-timeout" },
+      { ...validRecord, id: "infinite-timeout" },
+    ]);
   });
 
   it("accepts finite non-negative connection timeouts", () => {
@@ -183,7 +200,7 @@ const loadStorage = (storage: Storage) =>
   }).getValue();
 
 describe("McpLocalStorage custom servers", () => {
-  it("filters malformed connection timeouts when loading", async () => {
+  it("strips malformed connection timeouts when loading", async () => {
     const storage = createStorage();
     storage.setItem(
       "test-mcp:custom-servers",
@@ -199,6 +216,7 @@ describe("McpLocalStorage custom servers", () => {
 
     await expect(loadStorage(storage).loadCustomServers()).resolves.toEqual([
       validRecord,
+      { ...validRecord, id: "bad-timeout" },
     ]);
   });
 });

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.test.ts
@@ -33,10 +33,27 @@ describe("normalizeCustomServerRecords", () => {
         { ...validRecord, name: 123 },
         { ...validRecord, url: null },
         { ...validRecord, createdAt: Number.NaN },
+        { ...validRecord, connectionTimeout: "10000" },
+        { ...validRecord, connectionTimeout: null },
+        { ...validRecord, connectionTimeout: -1 },
+        { ...validRecord, connectionTimeout: Number.NaN },
+        { ...validRecord, connectionTimeout: Number.POSITIVE_INFINITY },
         { ...validRecord, auth: { type: "bearer", token: "" } },
         { ...validRecord, auth: { type: "bearer", token: 123 } },
       ]),
     ).toEqual([validRecord]);
+  });
+
+  it("accepts finite non-negative connection timeouts", () => {
+    expect(
+      normalizeCustomServerRecords([
+        { ...validRecord, connectionTimeout: 0 },
+        { ...validRecord, connectionTimeout: 10_000 },
+      ]),
+    ).toEqual([
+      { ...validRecord, connectionTimeout: 0 },
+      { ...validRecord, connectionTimeout: 10_000 },
+    ]);
   });
 
   it("accepts persisted bearer and oauth auth configs", () => {
@@ -164,6 +181,27 @@ const loadStorage = (storage: Storage) =>
       }),
     );
   }).getValue();
+
+describe("McpLocalStorage custom servers", () => {
+  it("filters malformed connection timeouts when loading", async () => {
+    const storage = createStorage();
+    storage.setItem(
+      "test-mcp:custom-servers",
+      JSON.stringify([
+        validRecord,
+        {
+          ...validRecord,
+          id: "bad-timeout",
+          connectionTimeout: "immediately",
+        },
+      ]),
+    );
+
+    await expect(loadStorage(storage).loadCustomServers()).resolves.toEqual([
+      validRecord,
+    ]);
+  });
+});
 
 describe("McpLocalStorage auth state", () => {
   it("normalizes loaded auth state from localStorage", async () => {

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -98,11 +98,25 @@ const isCustomServerRecord = (
   );
 };
 
+const normalizeCustomServerRecord = (
+  value: unknown,
+): MCPCustomServerRecord | null => {
+  if (isCustomServerRecord(value)) return value;
+  if (!isRecord(value)) return null;
+
+  const record = { ...value };
+  delete record.connectionTimeout;
+  return isCustomServerRecord(record) ? record : null;
+};
+
 export const normalizeCustomServerRecords = (
   value: unknown,
 ): MCPCustomServerRecord[] => {
   if (!Array.isArray(value)) return [];
-  return value.filter(isCustomServerRecord);
+  return value.flatMap((item) => {
+    const record = normalizeCustomServerRecord(item);
+    return record === null ? [] : [record];
+  });
 };
 
 const normalizeOAuthTokens = (

--- a/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
+++ b/packages/react-mcp/src/resources/storage/McpLocalStorage.ts
@@ -45,6 +45,12 @@ const isOptionalStringArray = (value: unknown): value is string[] | undefined =>
   value === undefined ||
   (Array.isArray(value) && value.every((item) => typeof item === "string"));
 
+const isOptionalConnectionTimeout = (
+  value: unknown,
+): value is number | undefined =>
+  value === undefined ||
+  (typeof value === "number" && Number.isFinite(value) && value >= 0);
+
 const isValidServerId = (id: string): boolean => {
   try {
     assertValidServerId(id);
@@ -87,7 +93,8 @@ const isCustomServerRecord = (
     isNonEmptyString(value.name) &&
     isNonEmptyString(value.url) &&
     Number.isFinite(value.createdAt) &&
-    isMCPAuthConfig(value.auth)
+    isMCPAuthConfig(value.auth) &&
+    isOptionalConnectionTimeout(value.connectionTimeout)
   );
 };
 


### PR DESCRIPTION
## Summary

- validate persisted custom MCP server `connectionTimeout` values
- accept omitted and finite non-negative timeout values, including `0`
- remove only a malformed optional timeout while preserving the otherwise-valid server record

## Why

Custom MCP server configuration is restored from local storage at runtime. If a stale, corrupt, or manually edited record contains a timeout such as `"10000"`, `null`, or a negative value, the existing validator accepts it and the runtime can time out immediately or behave unpredictably after reload.

The normalizer now strips that malformed optional value so the server remains configured and falls back to the manager-level timeout. This does not introduce a new option or change valid timeout behavior; malformed required server fields continue to discard the record as before.

## Verification

- `pnpm --filter @assistant-ui/react-mcp test` (4 files, 25 tests)
- `pnpm --filter @assistant-ui/react-mcp build`
- targeted oxlint and oxfmt checks
- `git diff --check`