### PR TITLE
feat(react-pi): map settled and appended events

### DIFF
--- a/.changeset/calm-pi-events-settle.md
+++ b/.changeset/calm-pi-events-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+feat: map Pi settled and appended session events without snapshot refreshes

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1004,6 +1004,8 @@ type PiClientEventBody = {
   type: "agent_end";
   willRetry?: boolean;
 } | {
+  type: "agent_settled";
+} | {
   type: "turn_start";
   turnIndex: number;
 } | {
@@ -1045,6 +1047,9 @@ type PiClientEventBody = {
   type: "compaction_end";
   aborted: boolean;
   willRetry: boolean;
+} | {
+  type: "entry_appended";
+  entry: PiSessionEntry;
 } | {
   type: "auto_retry_start";
   attempt: number;
@@ -1276,6 +1281,55 @@ type PiSendMessageInput = {
 
 type PiSendOptions = {
   streamingBehavior?: "followUp" | "steer";
+};
+
+type PiSessionEntry = (PiSessionEntryBase & {
+  type: "message";
+  message: PiAgentMessage;
+}) | (PiSessionEntryBase & {
+  type: "thinking_level_change";
+  thinkingLevel: string;
+}) | (PiSessionEntryBase & {
+  type: "model_change";
+  provider: string;
+  modelId: string;
+}) | (PiSessionEntryBase & {
+  type: "compaction";
+  summary: string;
+  firstKeptEntryId: string;
+  tokensBefore: number;
+  details?: unknown;
+  fromHook?: boolean;
+}) | (PiSessionEntryBase & {
+  type: "branch_summary";
+  fromId: string;
+  summary: string;
+  details?: unknown;
+  fromHook?: boolean;
+}) | (PiSessionEntryBase & {
+  type: "custom";
+  customType: string;
+  data?: unknown;
+}) | (PiSessionEntryBase & {
+  type: "custom_message";
+  customType: string;
+  content: string | (PiTextContent | PiImageContent)[];
+  details?: unknown;
+  display: boolean;
+}) | (PiSessionEntryBase & {
+  type: "label";
+  targetId: string;
+  label: string | undefined;
+}) | (PiSessionEntryBase & {
+  type: "session_info";
+  name?: string;
+});
+
+type PiSessionEntryBase = {
+  type: string;
+  id: string;
+  parentId: string | null;
+  timestamp: string;
 };
 
 type PiSessionModel = NonNullable<Parameters<typeof createAgentSession>[0]>["model"];
@@ -2327,13 +2381,13 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
 }
 
 declare const isPiSteerQueueItemId: (id: string) => boolean;
 
 declare namespace entry_node_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
 }
 
 declare const openPiEventStream: (options: PiEventStreamOptions) => (() => void);

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1319,14 +1319,13 @@ type PiSessionEntry = (PiSessionEntryBase & {
 }) | (PiSessionEntryBase & {
   type: "label";
   targetId: string;
-  label: string | undefined;
+  label?: string | undefined;
 }) | (PiSessionEntryBase & {
   type: "session_info";
   name?: string;
-});
+}) | PiUnknownSessionEntry;
 
 type PiSessionEntryBase = {
-  type: string;
   id: string;
   parentId: string | null;
   timestamp: string;
@@ -1612,6 +1611,11 @@ type PiUnknownClientEventBody = {
   type: string;
   [key: string]: unknown;
 };
+
+interface PiUnknownSessionEntry extends PiSessionEntryBase {
+  type: string;
+  [key: string]: unknown;
+}
 
 declare class PiUnsupportedHostUiError extends Error {
   readonly method: string;
@@ -2381,13 +2385,13 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
 }
 
 declare const isPiSteerQueueItemId: (id: string) => boolean;
 
 declare namespace entry_node_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
+  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
 }
 
 declare const openPiEventStream: (options: PiEventStreamOptions) => (() => void);

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -868,6 +868,8 @@ type PiAgentMessage = PiKnownAgentMessage | PiUnknownAgentMessage;
 
 type PiAnyClientEvent = PiClientEvent | (PiUnknownClientEventBody & PiClientEventEnvelope);
 
+type PiAnySessionEntry = PiSessionEntry | PiUnknownSessionEntry;
+
 type PiAssistantContent = PiTextContent | PiThinkingContent | PiToolCall;
 
 interface PiAssistantMessage {
@@ -1049,7 +1051,7 @@ type PiClientEventBody = {
   willRetry: boolean;
 } | {
   type: "entry_appended";
-  entry: PiSessionEntry;
+  entry: PiAnySessionEntry;
 } | {
   type: "auto_retry_start";
   attempt: number;
@@ -1323,7 +1325,7 @@ type PiSessionEntry = (PiSessionEntryBase & {
 }) | (PiSessionEntryBase & {
   type: "session_info";
   name?: string;
-}) | PiUnknownSessionEntry;
+});
 
 type PiSessionEntryBase = {
   id: string;
@@ -2385,13 +2387,15 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
+  export { PiAgentMessage, PiAnyClientEvent, PiAnySessionEntry, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiEventStreamOptions, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiHttpClientOptions, PiImageContent, PiInputAttachment, PiInterruptAnswer, PiKnownAgentMessage, PiLoadState, PiModelInfo, ContentPart as PiProjectedContentPart, PiProjectionInput, PiQueueMode, PiQueuedMessage, PiRunStatus, PiRuntimeExtras, PiRuntimeOptions, PiRuntimeReadiness, PiSendMessageInput, PiSendOptions, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadController, PiThreadControllerLike, PiThreadMetadata, PiThreadSnapshot, PiThreadState, PiThreadStatus, PiToolCall, PiToolExecutionState, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUsage, PiUserContent, PiUserMessage, SplitHostUiRequests, SseFrame, createPiHttpClient, createPiThreadState, createSseDecoder, isKnownPiSessionEntry, isPiSteerQueueItemId, openPiEventStream, piQueueItemId, projectPiThreadMessages, projectPiThreadRepository, reducePiThreadState, responseForApproval, responseForInterrupt, responseForRequest, splitHostUiRequests, usePiHostUiRequests, usePiRuntime, usePiRuntimeExtras, usePiSession, usePiThreadState };
 }
+
+declare const isKnownPiSessionEntry: (entry: PiAnySessionEntry) => entry is PiSessionEntry;
 
 declare const isPiSteerQueueItemId: (id: string) => boolean;
 
 declare namespace entry_node_exports {
-  export { PiAgentMessage, PiAnyClientEvent, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor };
+  export { PiAgentMessage, PiAnyClientEvent, PiAnySessionEntry, PiAssistantContent, PiAssistantMessage, PiAssistantMessageDelta, PiBashExecutionMessage, PiBranchSummaryMessage, PiClient, PiClientEvent, PiClientEventBody, PiClientEventEnvelope, PiCompactionSummaryMessage, PiContextUsage, PiCustomMessage, PiHostUiRequest, PiHostUiRequestKind, PiHostUiResponse, PiImageContent, PiInputAttachment, PiKnownAgentMessage, PiModelInfo, PiNodeClientOptions, PiQueuedMessage, PiRuntimeReadiness, PiSendMessageInput, PiSessionEntry, PiStopReason, PiTextContent, PiThinkingContent, PiThinkingLevel, PiThreadMetadata, PiThreadSnapshot, PiThreadStatus, PiThreadSupervisor, PiThreadSupervisorOptions, PiToolCall, PiToolResultContent, PiToolResultMessage, PiTranscriptMessage, PiUnknownAgentMessage, PiUnknownClientEventBody, PiUnknownSessionEntry, PiUnsupportedHostUiError, PiUsage, PiUserContent, PiUserMessage, createPiNodeClient, getPiThreadSupervisor, isKnownPiSessionEntry };
 }
 
 declare const openPiEventStream: (options: PiEventStreamOptions) => (() => void);

--- a/packages/react-pi/src/node/mapping.test.ts
+++ b/packages/react-pi/src/node/mapping.test.ts
@@ -32,6 +32,27 @@ describe("mapSessionEvent", () => {
     ).toEqual({ type: "agent_end", willRetry: true });
   });
 
+  it("maps agent_settled and preserves appended session entries", () => {
+    const entry = {
+      type: "custom",
+      id: "entry-1",
+      parentId: null,
+      timestamp: "2026-07-18T00:00:00.000Z",
+      customType: "extension-state",
+      data: { enabled: true },
+    } as const satisfies Extract<
+      AgentSessionEvent,
+      { type: "entry_appended" }
+    >["entry"];
+
+    expect(
+      mapSessionEvent({ type: "agent_settled" }, { turnIndex: 0 }),
+    ).toEqual({ type: "agent_settled" });
+    expect(
+      mapSessionEvent({ type: "entry_appended", entry }, { turnIndex: 0 }),
+    ).toEqual({ type: "entry_appended", entry });
+  });
+
   it("stamps the supervisor-derived turnIndex on turn_start/turn_end", () => {
     expect(
       mapSessionEvent(ev({ type: "turn_start" }), { turnIndex: 2 }),

--- a/packages/react-pi/src/node/mapping.ts
+++ b/packages/react-pi/src/node/mapping.ts
@@ -24,6 +24,7 @@ import type {
   PiContextUsage,
   PiModelInfo,
   PiRuntimeReadiness,
+  PiSessionEntry,
   PiThinkingLevel,
   PiThreadMetadata,
   PiThreadStatus,
@@ -62,6 +63,9 @@ export const toPiMessages = (
   messages: readonly PiSdkMessage[],
 ): PiTranscriptMessage[] => messages.map(toPiMessage);
 
+const toPiSessionEntry = (entry: SessionEntry): PiSessionEntry =>
+  entry as unknown as PiSessionEntry;
+
 /** Last path segment, cross-platform, without pulling in `node:path`. */
 const baseName = (filePath: string): string => {
   const segments = filePath.split(/[\\/]/);
@@ -88,6 +92,8 @@ export const mapSessionEvent = (
       return { type: "agent_start" };
     case "agent_end":
       return { type: "agent_end", willRetry: event.willRetry };
+    case "agent_settled":
+      return { type: "agent_settled" };
     case "turn_start":
       return { type: "turn_start", turnIndex: ctx.turnIndex };
     case "turn_end":
@@ -138,6 +144,11 @@ export const mapSessionEvent = (
         aborted: event.aborted,
         willRetry: event.willRetry,
       };
+    case "entry_appended":
+      return {
+        type: "entry_appended",
+        entry: toPiSessionEntry(event.entry),
+      };
     case "session_info_changed":
       return event.name === undefined
         ? { type: "session_info_changed" }
@@ -155,8 +166,7 @@ export const mapSessionEvent = (
     default:
       // Forward-compat: a future Pi event type the union doesn't yet name. Pass
       // the bare type through so the controller's unknown-event fallback can
-      // full-refresh rather than silently dropping it. `event` is `never` here
-      // per the current closed union, hence the cast.
+      // full-refresh rather than silently dropping it.
       return {
         type: (event as { type: string }).type,
       } as unknown as PiClientEventBody;

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -406,7 +406,7 @@ describe("PiThreadController", () => {
     expect(controller.getState().messages).toHaveLength(1);
   });
 
-  it("does not refresh snapshots for settled or appended session events", async () => {
+  it("does not refresh snapshots for settled or custom entry events", async () => {
     const client = createFakeClient();
     const getThread = vi.spyOn(client, "getThread");
     const controller = new PiThreadController(client, THREAD);
@@ -434,6 +434,34 @@ describe("PiThreadController", () => {
     await Promise.resolve();
     expect(getThread).not.toHaveBeenCalled();
     expect(controller.getState().lastSeq).toBe(2);
+  });
+
+  it("refreshes snapshots for appended entry variants without companion events", async () => {
+    const client = createFakeClient();
+    const getThread = vi.spyOn(client, "getThread");
+    const controller = new PiThreadController(client, THREAD);
+    controller.connect();
+
+    client.emit(
+      ev(
+        {
+          type: "entry_appended",
+          entry: {
+            type: "model_change",
+            id: "entry-1",
+            parentId: null,
+            timestamp: "2026-07-18T00:00:00.000Z",
+            provider: "anthropic",
+            modelId: "claude-sonnet-4-5",
+          },
+        },
+        1,
+      ),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getThread).toHaveBeenCalledOnce();
   });
 
   it("shows an optimistic user message before send resolves", async () => {

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -406,6 +406,36 @@ describe("PiThreadController", () => {
     expect(controller.getState().messages).toHaveLength(1);
   });
 
+  it("does not refresh snapshots for settled or appended session events", async () => {
+    const client = createFakeClient();
+    const getThread = vi.spyOn(client, "getThread");
+    const controller = new PiThreadController(client, THREAD);
+    controller.connect();
+
+    client.emit(ev({ type: "agent_settled" }, 1));
+    client.emit(
+      ev(
+        {
+          type: "entry_appended",
+          entry: {
+            type: "custom",
+            id: "entry-1",
+            parentId: null,
+            timestamp: "2026-07-18T00:00:00.000Z",
+            customType: "extension-state",
+            data: { enabled: true },
+          },
+        },
+        2,
+      ),
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getThread).not.toHaveBeenCalled();
+    expect(controller.getState().lastSeq).toBe(2);
+  });
+
   it("shows an optimistic user message before send resolves", async () => {
     const client = createFakeClient();
     let resolveSend!: () => void;

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -464,6 +464,23 @@ describe("PiThreadController", () => {
     expect(getThread).toHaveBeenCalledOnce();
   });
 
+  it("refreshes when an older server omits the appended entry payload", async () => {
+    const client = createFakeClient();
+    const getThread = vi.spyOn(client, "getThread");
+    const controller = new PiThreadController(client, THREAD);
+    controller.connect();
+
+    client.emit({
+      type: "entry_appended",
+      threadId: THREAD,
+      seq: 1,
+    } as unknown as PiClientEvent);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getThread).toHaveBeenCalledOnce();
+  });
+
   it("shows an optimistic user message before send resolves", async () => {
     const client = createFakeClient();
     let resolveSend!: () => void;

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -127,6 +127,8 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
   "turn_start",
   "turn_end",
   "tool_execution_start",
+  "agent_settled",
+  "entry_appended",
 ]);
 
 /** Parse a `data:<mime>;base64,<data>` URL into Pi `ImageContent`. Non-data-URL

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -590,10 +590,12 @@ export class PiThreadController implements PiThreadControllerLike {
       }
     }
 
-    // Forward-compat fallback: the reducer tolerates unknown event types but
-    // can't act on them; reconcile from a fresh snapshot so nothing the
-    // reducer ignored leaves local state stale.
-    if (!KNOWN_EVENT_TYPES.has(event.type)) this.refreshInBackground();
+    // Pi 0.80.7 emits entry_appended only for custom extension entries. Keep
+    // snapshot reconciliation for other variants if Pi broadens that event.
+    const needsSnapshotRefresh =
+      !KNOWN_EVENT_TYPES.has(event.type) ||
+      (event.type === "entry_appended" && event.entry.type !== "custom");
+    if (needsSnapshotRefresh) this.refreshInBackground();
   }
 
   private setState(next: PiThreadState) {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -594,7 +594,7 @@ export class PiThreadController implements PiThreadControllerLike {
     // snapshot reconciliation for other variants if Pi broadens that event.
     const needsSnapshotRefresh =
       !KNOWN_EVENT_TYPES.has(event.type) ||
-      (event.type === "entry_appended" && event.entry.type !== "custom");
+      (event.type === "entry_appended" && event.entry?.type !== "custom");
     if (needsSnapshotRefresh) this.refreshInBackground();
   }
 

--- a/packages/react-pi/src/runtime/threadState.test.ts
+++ b/packages/react-pi/src/runtime/threadState.test.ts
@@ -334,6 +334,29 @@ describe("threadState", () => {
     expect(after.lastSeq).toBeGreaterThan(before.lastSeq);
   });
 
+  it("absorbs settled and appended events while advancing the sequence", () => {
+    const before = createPiThreadState("t1");
+    const after = apply(
+      before,
+      ev({ type: "agent_settled" }),
+      ev({
+        type: "entry_appended",
+        entry: {
+          type: "custom",
+          id: "entry-1",
+          parentId: null,
+          timestamp: "2026-07-18T00:00:00.000Z",
+          customType: "extension-state",
+          data: { enabled: true },
+        },
+      }),
+    );
+
+    expect(after.lastSeq).toBeGreaterThan(before.lastSeq);
+    expect(after.messages).toEqual(before.messages);
+    expect(after.metadata).toEqual(before.metadata);
+  });
+
   it("reconnect snapshot clears streaming pointer and tool buffers", () => {
     let s = apply(
       createPiThreadState("t1"),

--- a/packages/react-pi/src/runtime/threadState.ts
+++ b/packages/react-pi/src/runtime/threadState.ts
@@ -370,6 +370,10 @@ export const reducePiThreadState = (
         metadata: withMetadataStatus(state.metadata, "failed"),
       });
 
+    case "agent_settled":
+    case "entry_appended":
+      return stamped(state);
+
     default:
       // Forward-compatible: unknown event types are tolerated (seq bumped via
       // `stamped`), the controller decides whether to full-refresh.

--- a/packages/react-pi/src/types.test.ts
+++ b/packages/react-pi/src/types.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { isKnownPiSessionEntry } from "./types";
+import type {
+  PiAgentMessage,
+  PiAnySessionEntry,
+  PiSessionEntry,
+} from "./types";
+
+const baseEntry = {
+  id: "entry-1",
+  parentId: null,
+  timestamp: "2026-07-17T00:00:00.000Z",
+};
+
+describe("isKnownPiSessionEntry", () => {
+  it("distinguishes known entry types from future entry types", () => {
+    const known: PiAnySessionEntry = {
+      ...baseEntry,
+      type: "custom",
+      customType: "extension-state",
+    };
+    const unknown: PiAnySessionEntry = {
+      ...baseEntry,
+      type: "future_entry",
+    };
+
+    expect(isKnownPiSessionEntry(known)).toBe(true);
+    expect(isKnownPiSessionEntry(unknown)).toBe(false);
+  });
+
+  it("preserves payload narrowing for known entries", () => {
+    const assertKnownMessage = (entry: PiSessionEntry) => {
+      if (entry.type !== "message") return;
+      expectTypeOf(entry.message).toEqualTypeOf<PiAgentMessage>();
+    };
+    const assertAnyMessage = (entry: PiAnySessionEntry) => {
+      if (!isKnownPiSessionEntry(entry) || entry.type !== "message") return;
+      expectTypeOf(entry.message).toEqualTypeOf<PiAgentMessage>();
+    };
+    const message: PiAgentMessage = {
+      role: "user",
+      content: "Hello",
+      timestamp: 0,
+    };
+    const entry: PiSessionEntry = {
+      ...baseEntry,
+      type: "message",
+      message,
+    };
+
+    assertKnownMessage(entry);
+    assertAnyMessage(entry);
+  });
+});

--- a/packages/react-pi/src/types.ts
+++ b/packages/react-pi/src/types.ts
@@ -177,11 +177,15 @@ export type PiTranscriptMessage = PiAgentMessage;
 // ---------------------------------------------------------------------------
 
 type PiSessionEntryBase = {
-  type: string;
   id: string;
   parentId: string | null;
   timestamp: string;
 };
+
+export interface PiUnknownSessionEntry extends PiSessionEntryBase {
+  type: string;
+  [key: string]: unknown;
+}
 
 export type PiSessionEntry =
   | (PiSessionEntryBase & {
@@ -227,12 +231,13 @@ export type PiSessionEntry =
   | (PiSessionEntryBase & {
       type: "label";
       targetId: string;
-      label: string | undefined;
+      label?: string | undefined;
     })
   | (PiSessionEntryBase & {
       type: "session_info";
       name?: string;
-    });
+    })
+  | PiUnknownSessionEntry;
 
 // ---------------------------------------------------------------------------
 // Streaming delta — mirror of `AssistantMessageEvent` (the `contentIndex`

--- a/packages/react-pi/src/types.ts
+++ b/packages/react-pi/src/types.ts
@@ -182,11 +182,6 @@ type PiSessionEntryBase = {
   timestamp: string;
 };
 
-export interface PiUnknownSessionEntry extends PiSessionEntryBase {
-  type: string;
-  [key: string]: unknown;
-}
-
 export type PiSessionEntry =
   | (PiSessionEntryBase & {
       type: "message";
@@ -236,8 +231,34 @@ export type PiSessionEntry =
   | (PiSessionEntryBase & {
       type: "session_info";
       name?: string;
-    })
-  | PiUnknownSessionEntry;
+    });
+
+export interface PiUnknownSessionEntry extends PiSessionEntryBase {
+  type: string;
+  [key: string]: unknown;
+}
+
+export type PiAnySessionEntry = PiSessionEntry | PiUnknownSessionEntry;
+
+const KNOWN_PI_SESSION_ENTRY_TYPES = {
+  message: true,
+  thinking_level_change: true,
+  model_change: true,
+  compaction: true,
+  branch_summary: true,
+  custom: true,
+  custom_message: true,
+  label: true,
+  session_info: true,
+} satisfies Record<PiSessionEntry["type"], true>;
+
+export const isKnownPiSessionEntry = (
+  entry: PiAnySessionEntry,
+): entry is PiSessionEntry =>
+  Object.prototype.hasOwnProperty.call(
+    KNOWN_PI_SESSION_ENTRY_TYPES,
+    entry.type,
+  );
 
 // ---------------------------------------------------------------------------
 // Streaming delta — mirror of `AssistantMessageEvent` (the `contentIndex`
@@ -497,7 +518,7 @@ export type PiClientEventBody =
     }
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | { type: "compaction_end"; aborted: boolean; willRetry: boolean }
-  | { type: "entry_appended"; entry: PiSessionEntry }
+  | { type: "entry_appended"; entry: PiAnySessionEntry }
   | { type: "auto_retry_start"; attempt: number; delayMs: number }
   | { type: "auto_retry_end"; success: boolean }
   | { type: "session_info_changed"; name?: string }

--- a/packages/react-pi/src/types.ts
+++ b/packages/react-pi/src/types.ts
@@ -173,6 +173,68 @@ export type PiAgentMessage = PiKnownAgentMessage | PiUnknownAgentMessage;
 export type PiTranscriptMessage = PiAgentMessage;
 
 // ---------------------------------------------------------------------------
+// Session entries — mirror of Pi's persisted SessionEntry union.
+// ---------------------------------------------------------------------------
+
+type PiSessionEntryBase = {
+  type: string;
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+};
+
+export type PiSessionEntry =
+  | (PiSessionEntryBase & {
+      type: "message";
+      message: PiAgentMessage;
+    })
+  | (PiSessionEntryBase & {
+      type: "thinking_level_change";
+      thinkingLevel: string;
+    })
+  | (PiSessionEntryBase & {
+      type: "model_change";
+      provider: string;
+      modelId: string;
+    })
+  | (PiSessionEntryBase & {
+      type: "compaction";
+      summary: string;
+      firstKeptEntryId: string;
+      tokensBefore: number;
+      details?: unknown;
+      fromHook?: boolean;
+    })
+  | (PiSessionEntryBase & {
+      type: "branch_summary";
+      fromId: string;
+      summary: string;
+      details?: unknown;
+      fromHook?: boolean;
+    })
+  | (PiSessionEntryBase & {
+      type: "custom";
+      customType: string;
+      data?: unknown;
+    })
+  | (PiSessionEntryBase & {
+      type: "custom_message";
+      customType: string;
+      content: string | (PiTextContent | PiImageContent)[];
+      details?: unknown;
+      display: boolean;
+    })
+  | (PiSessionEntryBase & {
+      type: "label";
+      targetId: string;
+      label: string | undefined;
+    })
+  | (PiSessionEntryBase & {
+      type: "session_info";
+      name?: string;
+    });
+
+// ---------------------------------------------------------------------------
 // Streaming delta — mirror of `AssistantMessageEvent` (the `contentIndex`
 // structural discriminator). Every variant carries `partial`, the current
 // assistant message, so the projection can read `partial.content[contentIndex]`
@@ -395,6 +457,7 @@ export type PiClientEventBody =
   | { type: "snapshot"; snapshot: PiThreadSnapshot }
   | { type: "agent_start" }
   | { type: "agent_end"; willRetry?: boolean }
+  | { type: "agent_settled" }
   | { type: "turn_start"; turnIndex: number }
   | { type: "turn_end"; turnIndex: number }
   | { type: "message_start"; message: PiAgentMessage }
@@ -429,6 +492,7 @@ export type PiClientEventBody =
     }
   | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
   | { type: "compaction_end"; aborted: boolean; willRetry: boolean }
+  | { type: "entry_appended"; entry: PiSessionEntry }
   | { type: "auto_retry_start"; attempt: number; delayMs: number }
   | { type: "auto_retry_end"; success: boolean }
   | { type: "session_info_changed"; name?: string }


### PR DESCRIPTION
## Summary

- model Pi 0.80.x `agent_settled` and `entry_appended` events in the browser-safe event contract
- preserve the complete persisted session entry through the Node mapper with a forward-compatible fallback type
- avoid snapshot reconciliation for `agent_settled` and the custom entries Pi currently emits, while retaining reconciliation for unsupported future entry variants

## Why

Pi 0.80.x emits `entry_appended` when extensions persist custom session entries, but React Pi treated it and `agent_settled` as unknown events. That dropped the appended entry payload and scheduled unnecessary `getThread()` snapshot refreshes.

The unknown-event fallback remains unchanged. Non-custom `entry_appended` variants also retain snapshot reconciliation so a future Pi expansion cannot leave local state stale.

## Sequencing

This is the behavior follow-up to #5023. The implementation compiles against the Pi 0.80.7 development dependency already on `main`, but #5023 should merge first so the supported peer range and provenance update land before this behavior.

## Verification

- `pnpm --filter @assistant-ui/react-pi test` '(151 tests)'
- `pnpm --filter @assistant-ui/react-pi build` under Node 24
- full `pnpm api-surface` package build (40 packages)
- Node 24 filtered API-surface check
- targeted oxlint and oxfmt checks
- `git diff --check`

Closes #5024

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->