### PR TITLE
fix(react-google-adk): validate session api responses

### DIFF
--- a/.changeset/google-adk-session-responses.md
+++ b/.changeset/google-adk-session-responses.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: validate session API response shapes

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -62,6 +62,30 @@ describe("createAdkSessionAdapter - list", () => {
     expect(result.threads).toHaveLength(0);
   });
 
+  it("rejects a successful response that is not a session array", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { adapter } = createAdkSessionAdapter(baseOptions);
+
+    await expect(adapter.list()).rejects.toThrow(
+      "Invalid ADK session list response: expected an array of sessions.",
+    );
+  });
+
+  it("rejects session list entries without a valid id", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([{ id: "s1" }, {}]), { status: 200 }),
+    );
+
+    const { adapter } = createAdkSessionAdapter(baseOptions);
+
+    await expect(adapter.list()).rejects.toThrow(
+      'Invalid ADK session list response: session at index 1 must have a non-empty string "id".',
+    );
+  });
+
   it("throws when response is not ok", async () => {
     mockFetch.mockResolvedValueOnce(
       new Response("Server error", { status: 500 }),
@@ -137,6 +161,18 @@ describe("createAdkSessionAdapter - initialize", () => {
     const { adapter } = createAdkSessionAdapter(baseOptions);
     await expect(adapter.initialize("thread-1")).rejects.toThrow(
       "Failed to create session: 403",
+    );
+  });
+
+  it("rejects a successful response without a session id", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { adapter } = createAdkSessionAdapter(baseOptions);
+
+    await expect(adapter.initialize("thread-1")).rejects.toThrow(
+      'Invalid ADK session create response: expected an object with a non-empty string "id".',
     );
   });
 });
@@ -250,6 +286,18 @@ describe("createAdkSessionAdapter - fetch", () => {
       "Session not found: 404",
     );
   });
+
+  it("rejects a successful response without a session id", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { adapter } = createAdkSessionAdapter(baseOptions);
+
+    await expect(adapter.fetch("s1")).rejects.toThrow(
+      'Invalid ADK session fetch response: expected an object with a non-empty string "id".',
+    );
+  });
 });
 
 // ── load() ──
@@ -303,6 +351,30 @@ describe("createAdkSessionAdapter - load", () => {
     const result = await load("s1");
 
     expect(result.messages).toEqual([]);
+  });
+
+  it("rejects a successful response without a session id", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { load } = createAdkSessionAdapter(baseOptions);
+
+    await expect(load("s1")).rejects.toThrow(
+      'Invalid ADK session load response: expected an object with a non-empty string "id".',
+    );
+  });
+
+  it("rejects a session with a malformed events field", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: "s1", events: {} }), { status: 200 }),
+    );
+
+    const { load } = createAdkSessionAdapter(baseOptions);
+
+    await expect(load("s1")).rejects.toThrow(
+      'Invalid ADK session load response: expected "events" to be an array when present.',
+    );
   });
 
   it("throws when session fetch fails", async () => {

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -57,6 +57,49 @@ type AdkSessionAdapterResult = {
   };
 };
 
+type AdkSessionResponse = {
+  id: string;
+  events?: unknown;
+};
+
+const isAdkSessionResponse = (value: unknown): value is AdkSessionResponse => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const id = (value as Record<string, unknown>).id;
+  return typeof id === "string" && id.length > 0;
+};
+
+const parseAdkSessionResponse = (
+  value: unknown,
+  operation: "create" | "fetch" | "load",
+): AdkSessionResponse => {
+  if (!isAdkSessionResponse(value)) {
+    throw new Error(
+      `Invalid ADK session ${operation} response: expected an object with a non-empty string "id".`,
+    );
+  }
+  return value;
+};
+
+const parseAdkSessionListResponse = (value: unknown): AdkSessionResponse[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      "Invalid ADK session list response: expected an array of sessions.",
+    );
+  }
+
+  return value.map((session, index) => {
+    if (!isAdkSessionResponse(session)) {
+      throw new Error(
+        `Invalid ADK session list response: session at index ${index} must have a non-empty string "id".`,
+      );
+    }
+    return session;
+  });
+};
+
 /**
  * Creates a `RemoteThreadListAdapter` backed by ADK's session REST API,
  * plus a `load` function that reconstructs messages from session events.
@@ -96,12 +139,7 @@ export function createAdkSessionAdapter(
       if (!res.ok) {
         throw new Error(`Failed to list sessions: ${res.status}`);
       }
-      const data = (await res.json()) as Array<{
-        id: string;
-        app_name?: string;
-        user_id?: string;
-        last_update_time?: number;
-      }>;
+      const data = parseAdkSessionListResponse(await res.json());
 
       const threads: RemoteThreadMetadata[] = data.map((session) => ({
         status: "regular" as const,
@@ -125,7 +163,7 @@ export function createAdkSessionAdapter(
       if (!res.ok) {
         throw new Error(`Failed to create session: ${res.status}`);
       }
-      const session = (await res.json()) as { id: string };
+      const session = parseAdkSessionResponse(await res.json(), "create");
       return { remoteId: session.id, externalId: session.id };
     },
 
@@ -171,7 +209,7 @@ export function createAdkSessionAdapter(
       if (!res.ok) {
         throw new Error(`Session not found: ${res.status}`);
       }
-      const session = (await res.json()) as { id: string };
+      const session = parseAdkSessionResponse(await res.json(), "fetch");
       return {
         status: "regular",
         remoteId: session.id,
@@ -191,18 +229,23 @@ export function createAdkSessionAdapter(
     if (!res.ok) {
       throw new Error(`Failed to load session: ${res.status}`);
     }
-    const session = (await res.json()) as {
-      id: string;
-      events?: AdkEvent[];
-    };
+    const session = parseAdkSessionResponse(await res.json(), "load");
 
-    if (!session.events?.length) {
+    if (session.events !== undefined && !Array.isArray(session.events)) {
+      throw new Error(
+        'Invalid ADK session load response: expected "events" to be an array when present.',
+      );
+    }
+
+    const events = session.events as AdkEvent[] | undefined;
+
+    if (!events?.length) {
       return { messages: [] };
     }
 
     const accumulator = new AdkEventAccumulator();
     let messages: AdkMessage[] = [];
-    for (const event of session.events) {
+    for (const event of events) {
       messages = accumulator.processEvent(event);
     }
     return { messages };


### PR DESCRIPTION
## Why

While testing the Google ADK session adapter locally, I reproduced successful but malformed API responses such as:

```http
HTTP/1.1 200 OK
Content-Type: application/json

{}
```

The adapter previously trusted TypeScript casts at runtime. As a result:

- `list()` called `.map()` on `{}` and threw `TypeError: data.map is not a function`
- `initialize()` returned a thread with `remoteId: undefined`
- fetch/load paths could also accept unusable session metadata or malformed history

A `200` status only confirms HTTP success; an incompatible ADK server, misconfigured proxy, or malformed local mock can still return the wrong JSON shape.

## What changed

- validate that session list responses are arrays
- require a non-empty string session ID for list/create/fetch/load responses
- identify the malformed item index in list errors
- require `events` to be an array when present on load responses
- preserve existing behavior for valid responses
- add regression coverage and a patch changeset

## Verification

- `pnpm --filter @assistant-ui/react-google-adk test` (9 files, 200 tests)
- `pnpm exec turbo build --filter=@assistant-ui/react-google-adk...`
- `pnpm --filter @assistant-ui/react-google-adk exec tsc --noEmit`
- `pnpm lint`
- `pnpm changeset status --since origin/main`
- built-output smoke test confirming malformed `200 {}` responses now produce operation-specific errors while valid list/create responses retain their IDs


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

