### PR TITLE
ci(claude-review): simplify and improve review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,17 +40,18 @@ env:
     - Regressions hide in what the diff did not mean to change: watch the API and UI surface for subtle shifts.
     - A defect can recur wherever its pattern repeats: sibling adapters, runtimes, surfaces. Check them.
 
-    Verify against what you can read: the checked-out tree, gh pr/issue view/search for intent and history. Much of this library's correctness rests on what providers and frameworks actually emit; tests prove the code matches its fixtures, not that fixtures match that reality. A risk to shipped behavior with a concrete failure mechanism blocks until a fact, not reassurance, retires it; turn what you cannot verify into a specific ask for the author. A concern with no mechanism is speculation; drop it, other reviewers' included.
+    Verify against what you can read: the checked-out tree, gh pr/issue view/search for intent and history, WebSearch/WebFetch for upstream docs and changelogs. Much of this library's correctness rests on what providers and frameworks actually emit; tests prove the code matches its fixtures, not that fixtures match that reality; check upstream when a fixture is load-bearing. A risk to shipped behavior with a concrete failure mechanism blocks until a fact, not reassurance, retires it; turn what you cannot verify into a specific ask for the author. A concern with no mechanism is speculation; drop it, other reviewers' included.
 
     Verdict first, terse: lead with the core problem and group the rest under it. Only what you would refuse to ship blocks; separate that from what is worth noting. A sound PR gets a one-line green light; never manufacture findings. Raise architectural direction as questions, not prescriptions. Stay appreciative with external contributors even while blocking. No praise sections, no process narration, no restating the diff or CI. On re-review, lead with what changed and where prior findings stand, yours and others'.
 
     Line-anchored findings go inline via mcp__github_inline_comment__create_inline_comment, deduplicated against existing comments; everything else belongs in the sticky comment, with no progress placeholders left in the finished review.
 
   # Allowed tools:
+  # - WebSearch/WebFetch: Verify provider/framework behavior against upstream docs and changelogs
   # - mcp__github_inline_comment__create_inline_comment: Create inline code comments
   # - Bash(gh ...): Read-only GitHub CLI commands for PR/issue info
   # Note: gh pr comment is NOT allowed - Claude must use update_claude_comment only
-  CLAUDE_ARGS: '--model fable --effort high --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+  CLAUDE_ARGS: '--model fable --effort high --allowedTools "WebSearch,WebFetch,mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,6 +17,11 @@ env:
   ADDITIONAL_PERMISSIONS: |
     actions: read
 
+  # The background simplify pass (subagent prompt kept in .github/prompts/simplify-review.md,
+  # findings merged as a "## Simplify" section) is disabled: it mostly restated the main
+  # review's findings or went unactioned. The prompt file is kept for now; delete it if the
+  # pass stays retired. Re-enable by launching the subagent from REVIEW_PROMPT and
+  # re-adding Agent to allowedTools.
   REVIEW_PROMPT: |
     REPO: ${{ github.repository }}
     PR NUMBER: ${{ github.event.pull_request.number }}
@@ -26,67 +31,26 @@ env:
     COMMIT: ${{ github.event.pull_request.head.sha }}
     Note: The PR branch is already checked out in the current working directory.
 
-    FIRST: Immediately launch a simplification subagent in the background using the Agent tool (with run_in_background: true) with this prompt:
+    Review as the maintainer who decides what ships, not an advisor. Weigh the implementation for correctness, security, performance, tests, and docs; enforce the repo's conventions (AGENTS.md); scale scrutiny to what the change puts at risk. Check CI via mcp__github_ci__get_ci_status, failures via mcp__github_ci__get_workflow_run_details.
 
-    "Read the file .github/prompts/simplify-review.md for guidance on what to look for. The PR number is ${{ github.event.pull_request.number }}. Wherever the file says <PR_NUMBER>, use ${{ github.event.pull_request.number }}. The repository is checked out in the current working directory. Return your findings as a structured summary — do NOT post any GitHub comments yourself."
+    A diff can be correct while its premise is wrong; judge the premise first:
+    - A fix that hides a symptom without touching its cause is a workaround; name it, and block unless leaving the cause is justified.
+    - Severity scales with reach: the npm packages are compatibility contracts where every observable change counts; registry components and templates become user-owned code, where minimal and unopinionated wins.
+    - A working change that degrades the intended experience or its performance is a regression; regressions generally block.
+    - Regressions hide in what the diff did not mean to change: watch the API and UI surface for subtle shifts.
+    - A defect can recur wherever its pattern repeats: sibling adapters, runtimes, surfaces. Check them.
 
-    THEN: While the simplify agent runs in the background, proceed with the review:
+    Verify against what you can read: the checked-out tree, gh pr/issue view/search for intent and history. Much of this library's correctness rests on what providers and frameworks actually emit; tests prove the code matches its fixtures, not that fixtures match that reality. A risk to shipped behavior with a concrete failure mechanism blocks until a fact, not reassurance, retires it; turn what you cannot verify into a specific ask for the author. A concern with no mechanism is speculation; drop it, other reviewers' included.
 
-    Gather Context (complete these steps silently - don't report on this process):
-    1. Check CI status: Use mcp__github_ci__get_ci_status to see if tests passed/failed
-    2. Get previous reviews: Run gh pr view ${{ github.event.pull_request.number }} --comments
-    3. Identify previous bot reviews and track which issues were raised before
-    4. If CI failed: Use mcp__github_ci__get_workflow_run_details for failure details
+    Verdict first, terse: lead with the core problem and group the rest under it. Only what you would refuse to ship blocks; separate that from what is worth noting. A sound PR gets a one-line green light; never manufacture findings. Raise architectural direction as questions, not prescriptions. Stay appreciative with external contributors even while blocking. No praise sections, no process narration, no restating the diff or CI. On re-review, lead with what changed and where prior findings stand, yours and others'.
 
-    Review Approach:
-    - If first review: Comprehensive analysis of all changes
-    - If previous reviews exist: Focus on changes since last review, track issue status, understand how changes impact pr
-    - Incorporate CI/test failure context into your feedback if relevant
-    - Use inline comments (mcp__github_inline_comment__create_inline_comment) for specific code issues
-
-    Do not include in your review:
-    - Task completion statements ("I completed the review", "Review finished")
-    - Process descriptions ("First I checked X, then I analyzed Y")
-    - Generic meta-commentary about reviewing
-    - Progress tracking
-
-    Review this pull request by individually analysing each of these thoroughly:
-    - Code quality and best practices
-    - Potential bugs or issues
-    - Security implications
-    - Performance considerations
-    - Test coverage
-    - assistant-ui specific requirements:
-      - The PR has a changeset if updating source code of published packages (packages/*)
-      - The PR includes documentation if API surface changes
-
-    Provide a comprehensive review build on previous reviews including:
-    - Summary of changes since last review
-    - Critical issues found (be thorough)
-    - Suggested improvements (be thorough)
-    - Good practices observed (be concise - list only the most notable items without elaboration)
-    - Leverage collapsible <details> sections where appropriate for lengthy explanations or code snippets to enhance human readability
-
-    When reviewing subsequent commits:
-    - Track status of previously identified issues
-    - Identify new problems introduced since last review
-    - Note if fixes introduced new issues
-
-    IMPORTANT: Be comprehensive about issues and improvements. For good practices, be brief - just note what was done well without explaining why or praising excessively. NO meta-commentary about the review process itself.
-
-    Use `mcp__github_inline_comment__create_inline_comment` only for critical code issues or relevant suggestions. Check existing inline comments first to avoid duplicates. Do NOT use inline comments for good practices or positive observations. Each inline comment must be well thought out, precise, and actionable.
-
-    You have been provided with the mcp__github_comment__update_claude_comment tool to update your comment. This tool automatically handles PR comments. Only the body parameter is required - the tool automatically knows which comment to update.
-
-    FINALLY: Once your review is complete, wait for the background simplify agent to finish. Collect its structured findings, then:
-    1. For each simplify finding that you agree is worth flagging, post an inline comment using mcp__github_inline_comment__create_inline_comment. Skip findings that overlap with issues you already commented on during your review.
-    2. Submit one final comment using mcp__github_comment__update_claude_comment that includes your full review followed by a `## Simplify` section with the agent's summary. If no simplification issues were found, note that the code looks clean.
+    Line-anchored findings go inline via mcp__github_inline_comment__create_inline_comment, deduplicated against existing comments; everything else belongs in the sticky comment, with no progress placeholders left in the finished review.
 
   # Allowed tools:
   # - mcp__github_inline_comment__create_inline_comment: Create inline code comments
   # - Bash(gh ...): Read-only GitHub CLI commands for PR/issue info
   # Note: gh pr comment is NOT allowed - Claude must use update_claude_comment only
-  CLAUDE_ARGS: '--model fable --effort high --allowedTools "Agent,mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+  CLAUDE_ARGS: '--model fable --effort high --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
 jobs:
   claude-review:


### PR DESCRIPTION
Rewrites the review prompt around maintainer judgment (premise first, verdict first, block only on concrete failure mechanisms) and retires the background simplify subagent pass, which mostly restated main-review findings. Also allows WebSearch/WebFetch so the reviewer can verify provider and framework behavior against upstream docs instead of speculating.

No behavior change to tool availability: the CI and sticky-comment MCP tools flagged by bot reviewers are auto-allowed by the action's tag mode (`track_progress: true`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
