### PR TITLE
fix(react-a2a): forward user attachments and file parts to the wire

### DIFF
--- a/.changeset/a2a-outbound-attachments.md
+++ b/.changeset/a2a-outbound-attachments.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: forward user attachments and file parts to the wire and derive real image MIME types

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1843,9 +1843,12 @@ declare function a2aPartsToContent(parts: A2APart[]): ThreadAssistantMessage["co
 
 declare function contentPartsToA2AParts(content: ReadonlyArray<{
   type: string;
-  text?: string;
-  image?: string;
-}>): A2APart[];
+  text?: string | undefined;
+  image?: string | undefined;
+  data?: string | undefined;
+  mimeType?: string | undefined;
+  filename?: string | undefined;
+}>, fallbackMimeType?: string): A2APart[];
 
 declare global {
   interface Window {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -690,3 +690,139 @@ describe("A2AThreadRuntimeCore", () => {
     });
   });
 });
+
+describe("outbound message conversion", () => {
+  function createCoreWithStream() {
+    const streamMessage = vi.fn().mockImplementation(async function* () {});
+    const core = new A2AThreadRuntimeCore({
+      client: createMockClient({ streamMessage }),
+      notifyUpdate: vi.fn() as unknown as () => void,
+    });
+    return { core, streamMessage };
+  }
+
+  it("forwards attachment content to the wire with the attachment MIME type", async () => {
+    const { core, streamMessage } = createCoreWithStream();
+
+    await core.append({
+      parentId: null,
+      role: "user",
+      content: [{ type: "text", text: "See attached" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "doc.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "https://files.com/doc.pdf",
+              mimeType: "",
+              filename: "doc.pdf",
+            },
+          ],
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    const sent = streamMessage.mock.calls[0]![0] as A2AMessage;
+    expect(sent.parts).toEqual([
+      { text: "See attached" },
+      {
+        url: "https://files.com/doc.pdf",
+        mediaType: "application/pdf",
+        filename: "doc.pdf",
+      },
+    ]);
+  });
+
+  it("forwards file parts in message content to the wire", async () => {
+    const { core, streamMessage } = createCoreWithStream();
+
+    await core.append({
+      parentId: null,
+      role: "user",
+      content: [
+        {
+          type: "file",
+          data: "data:text/csv;base64,ZmlsZQ==",
+          mimeType: "text/csv",
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    const sent = streamMessage.mock.calls[0]![0] as A2AMessage;
+    expect(sent.parts).toEqual([{ raw: "ZmlsZQ==", mediaType: "text/csv" }]);
+  });
+
+  it("does not throw for user messages missing attachments at runtime", async () => {
+    const { core, streamMessage } = createCoreWithStream();
+    const message = {
+      id: "u1",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Loaded" }],
+      status: { type: "complete", reason: "stop" },
+    } as unknown as ThreadMessage;
+
+    core.applyExternalMessages([message]);
+    await core.reload("u1");
+
+    const sent = streamMessage.mock.calls[0]![0] as A2AMessage;
+    expect(sent.parts).toEqual([{ text: "Loaded" }]);
+  });
+
+  it("forwards data URL image attachments as raw bytes", async () => {
+    const { core, streamMessage } = createCoreWithStream();
+
+    await core.append({
+      parentId: null,
+      role: "user",
+      content: [{ type: "text", text: "See image" }],
+      attachments: [
+        {
+          id: "att-2",
+          type: "image",
+          name: "a.png",
+          contentType: "image/png",
+          status: { type: "complete" },
+          content: [{ type: "image", image: "data:image/png;base64,aGVsbG8=" }],
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    const sent = streamMessage.mock.calls[0]![0] as A2AMessage;
+    expect(sent.parts).toEqual([
+      { text: "See image" },
+      { raw: "aGVsbG8=", mediaType: "image/png" },
+    ]);
+  });
+
+  it("does not throw for attachments missing content at runtime", async () => {
+    const { core, streamMessage } = createCoreWithStream();
+    const message = {
+      id: "u2",
+      role: "user",
+      createdAt: new Date(),
+      content: [{ type: "text", text: "Loaded" }],
+      attachments: [
+        {
+          id: "att-3",
+          type: "file",
+          name: "x.txt",
+          contentType: "text/plain",
+          status: { type: "complete" },
+        },
+      ],
+      status: { type: "complete", reason: "stop" },
+    } as unknown as ThreadMessage;
+
+    core.applyExternalMessages([message]);
+    await core.reload("u2");
+
+    const sent = streamMessage.mock.calls[0]![0] as A2AMessage;
+    expect(sent.parts).toEqual([{ text: "Loaded" }]);
+  });
+});

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -23,6 +23,7 @@ import type {
 } from "./types";
 import {
   a2aMessageToContent,
+  contentPartsToA2AParts,
   isTerminalTaskState,
   taskStateToMessageStatus,
 } from "./conversions";
@@ -484,12 +485,14 @@ export class A2AThreadRuntimeCore {
     const parts: A2APart[] = [];
 
     if (message.role === "user") {
-      for (const part of message.content) {
-        if (part.type === "text") {
-          parts.push({ text: part.text });
-        } else if (part.type === "image") {
-          parts.push({ url: part.image, mediaType: "image/*" });
-        }
+      parts.push(...contentPartsToA2AParts(message.content));
+      for (const attachment of message.attachments ?? []) {
+        parts.push(
+          ...contentPartsToA2AParts(
+            attachment.content ?? [],
+            attachment.contentType,
+          ),
+        );
       }
     }
 

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -245,17 +245,124 @@ describe("contentPartsToA2AParts", () => {
     expect(result).toEqual([{ text: "hi" }]);
   });
 
-  it("converts image parts", () => {
+  it("converts image URL parts without stamping a mediaType", () => {
     const result = contentPartsToA2AParts([
       { type: "image", image: "https://img.com/a.png" },
     ]);
+    expect(result).toEqual([{ url: "https://img.com/a.png" }]);
+  });
+
+  it("applies the fallback MIME type to image URL parts", () => {
+    const result = contentPartsToA2AParts(
+      [{ type: "image", image: "https://img.com/a.png" }],
+      "image/png",
+    );
     expect(result).toEqual([
-      { url: "https://img.com/a.png", mediaType: "image/*" },
+      { url: "https://img.com/a.png", mediaType: "image/png" },
+    ]);
+  });
+
+  it("applies the fallback MIME type and filename to image URL parts together", () => {
+    const result = contentPartsToA2AParts(
+      [{ type: "image", image: "https://img.com/a.png", filename: "a.png" }],
+      "image/png",
+    );
+    expect(result).toEqual([
+      {
+        url: "https://img.com/a.png",
+        mediaType: "image/png",
+        filename: "a.png",
+      },
+    ]);
+  });
+
+  it("passes non-base64 data URLs through as URLs for image parts", () => {
+    const result = contentPartsToA2AParts([
+      { type: "image", image: "data:text/plain,hello" },
+    ]);
+    expect(result).toEqual([{ url: "data:text/plain,hello" }]);
+  });
+
+  it("converts image data URLs to raw bytes with the embedded MIME type", () => {
+    const result = contentPartsToA2AParts([
+      { type: "image", image: "data:image/png;base64,aGVsbG8=" },
+    ]);
+    expect(result).toEqual([{ raw: "aGVsbG8=", mediaType: "image/png" }]);
+  });
+
+  it("propagates image filenames", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "image",
+        image: "data:image/png;base64,aGVsbG8=",
+        filename: "a.png",
+      },
+    ]);
+    expect(result).toEqual([
+      { raw: "aGVsbG8=", mediaType: "image/png", filename: "a.png" },
     ]);
   });
 
   it("skips image parts with no URL", () => {
     const result = contentPartsToA2AParts([{ type: "image" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("converts file parts with http URLs", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "https://files.com/doc.pdf",
+        mimeType: "application/pdf",
+        filename: "doc.pdf",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        url: "https://files.com/doc.pdf",
+        mediaType: "application/pdf",
+        filename: "doc.pdf",
+      },
+    ]);
+  });
+
+  it("converts file parts with data URLs to raw bytes", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "data:application/pdf;base64,ZmlsZQ==",
+        mimeType: "application/pdf",
+      },
+    ]);
+    expect(result).toEqual([{ raw: "ZmlsZQ==", mediaType: "application/pdf" }]);
+  });
+
+  it("converts file parts with raw base64 data", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: "ZmlsZQ==", mimeType: "text/csv" },
+    ]);
+    expect(result).toEqual([{ raw: "ZmlsZQ==", mediaType: "text/csv" }]);
+  });
+
+  it("falls back to the attachment MIME type when the file part MIME is empty", () => {
+    const result = contentPartsToA2AParts(
+      [{ type: "file", data: "ZmlsZQ==", mimeType: "" }],
+      "application/pdf",
+    );
+    expect(result).toEqual([{ raw: "ZmlsZQ==", mediaType: "application/pdf" }]);
+  });
+
+  it("omits mediaType when no MIME type is known", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: "ZmlsZQ==", mimeType: "" },
+    ]);
+    expect(result).toEqual([{ raw: "ZmlsZQ==" }]);
+  });
+
+  it("skips file parts with no data", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", mimeType: "application/pdf" },
+    ]);
     expect(result).toEqual([]);
   });
 

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -86,21 +86,72 @@ export function taskStateToMessageStatus(state: A2ATaskState): MessageStatus {
   }
 }
 
+const httpUrlPattern = /^https?:\/\//i;
+
+function parseDataUrl(
+  value: string,
+): { mimeType: string; data: string } | null {
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.+)$/);
+  if (!match) return null;
+  return { mimeType: match[1]!, data: match[2]! };
+}
+
 export function contentPartsToA2AParts(
   content: ReadonlyArray<{
     type: string;
-    text?: string;
-    image?: string;
+    text?: string | undefined;
+    image?: string | undefined;
+    data?: string | undefined;
+    mimeType?: string | undefined;
+    filename?: string | undefined;
   }>,
+  fallbackMimeType?: string,
 ): A2APart[] {
   return content
     .map((part): A2APart | null => {
       switch (part.type) {
         case "text":
           return { text: part.text ?? "" };
-        case "image":
+        case "image": {
           if (!part.image) return null;
-          return { url: part.image, mediaType: "image/*" };
+          const parsed = parseDataUrl(part.image);
+          if (parsed) {
+            return {
+              raw: parsed.data,
+              mediaType: parsed.mimeType,
+              ...(part.filename && { filename: part.filename }),
+            };
+          }
+          return {
+            url: part.image,
+            ...(fallbackMimeType && { mediaType: fallbackMimeType }),
+            ...(part.filename && { filename: part.filename }),
+          };
+        }
+        case "file": {
+          if (!part.data) return null;
+          const declaredMimeType = part.mimeType || fallbackMimeType;
+          if (httpUrlPattern.test(part.data)) {
+            return {
+              url: part.data,
+              ...(declaredMimeType && { mediaType: declaredMimeType }),
+              ...(part.filename && { filename: part.filename }),
+            };
+          }
+          const parsed = parseDataUrl(part.data);
+          if (parsed) {
+            return {
+              raw: parsed.data,
+              mediaType: parsed.mimeType,
+              ...(part.filename && { filename: part.filename }),
+            };
+          }
+          return {
+            raw: part.data,
+            ...(declaredMimeType && { mediaType: declaredMimeType }),
+            ...(part.filename && { filename: part.filename }),
+          };
+        }
         default:
           return null;
       }


### PR DESCRIPTION
This PR fixes a silent data-loss bug in the A2A adapter where anything a user attached to a message just vanished before the request went out.

## What

- `threadMessageToA2AMessage` now converts `message.content` plus each attachment's content parts (with `attachment.contentType` as fallback MIME), delegating to the exported `contentPartsToA2AParts` instead of keeping a second hand-rolled copy.
- `contentPartsToA2AParts` gains `file` part handling (http URL, data URL, raw base64) and an optional trailing `fallbackMimeType` parameter.
- Image data URLs go out as `{raw, mediaType}` with the embedded MIME; plain URLs as `{url}` plus fallback MIME when known, no `mediaType` otherwise. The old `mediaType: "image/*"` is a match pattern, not a valid MIME type.
- `filename` propagated when present.

## Why

`UseA2ARuntimeOptions.adapters.attachments` advertises attachment support and core carries `attachments` onto the user ThreadMessage, but the converter read only `content` and handled only text and image, so attached files never reached the server. Both siblings already forward attachment content (adk's `attachments?.flatMap`, ag-ui's per-attachment conversion with `contentType` fallback); this mirrors them in a2a's flat part format.

The fallback matters concretely: `CloudFileAttachmentAdapter` emits image parts as plain http URLs with the real MIME only on `attachment.contentType`, and file parts that can carry `mimeType: ""`. MIME merging is truthy (`||`, matching ag-ui) so `mediaType: ""` is never emitted.

## Impact

- Attachments from any adapter (simple, cloud, composite) now reach the wire.
- Outbound images carry a valid MIME or none. The old `image/*` only round-tripped as an image by accident of the inbound `startsWith("image/")` check; an unknown-MIME URL image now renders inbound as a link, the spec-correct behavior. Extension sniffing was considered and rejected: no repo precedent, and ag-ui also omits MIME for undeclared URL sources.
- No public surface change: no new exports; input widening plus an optional trailing param, both backward compatible. Regenerated `api-surface` snapshot included, so that CI check is green without an autofix commit.

## Notes

- Defensive-converter rule throughout: missing `image`/`data` skips the part, non-canonical data URLs fall through to url/raw, and `message.attachments ?? []` guards history-loaded messages built via casts that lack the field at runtime despite the type saying required (covered by a test). Pure string handling, safe in Node, react-ink, and React Native.
- Delegating to `contentPartsToA2AParts` removes a duplicated mapping that had already drifted; behavior verified equivalent.
- Pre-existing, out of scope: `audio` attachment parts are still dropped; follow-up.
- Tests cover both converter directions plus the runtime wire path; new runtime tests appended at end of file to stay conflict-free with #4968.
- Patch changeset on `@assistant-ui/react-a2a`; full `turbo build` and repo lint pass locally.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

