### PR TITLE
fix(cli): discover hoisted packages in doctor

### DIFF
--- a/.changeset/tender-dragons-listen.md
+++ b/.changeset/tender-dragons-listen.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): discover assistant-ui packages hoisted above the doctor working directory

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
 import { compare, valid } from "semver";
+import { findWorkspaceRoot } from "../lib/utils/workspace";
 
 const ASSISTANT_UI_PACKAGE_NAMES = new Set([
   "assistant-stream",
@@ -183,14 +184,23 @@ function walkPnpmStore(
 }
 
 // Discover every installation of an assistant-ui-family package reachable
-// from `cwd`. Recurses into nested node_modules so transitive copies
-// (the real source of duplicate-version bugs) are not missed, and scans the
-// pnpm `.pnpm` virtual store, which the hoisted walk cannot reach.
+// from `cwd`. Node resolves packages through ancestor node_modules directories,
+// so inspect each level to include workspace-hoisted installs. Nested installs
+// and pnpm virtual stores are scanned to catch duplicate transitive copies.
 export function discoverInstalledPackages(cwd: string): DiscoveredPackage[] {
   const results: DiscoveredPackage[] = [];
   const visited: ProcessedDir = { set: new Set() };
-  walkNodeModulesAt(cwd, results, visited);
-  walkPnpmStore(cwd, results, visited);
+  let dir = path.resolve(cwd);
+  const scanRoot = findWorkspaceRoot(dir) ?? dir;
+
+  while (true) {
+    walkNodeModulesAt(dir, results, visited);
+    walkPnpmStore(dir, results, visited);
+
+    if (dir === scanRoot) break;
+    dir = path.dirname(dir);
+  }
+
   return results;
 }
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -6,6 +6,9 @@ import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
 import { satisfies } from "semver";
+import { findWorkspaceRoot } from "../lib/utils/workspace";
+
+export { findWorkspaceRoot };
 
 const ASSISTANT_UI_PACKAGES = [
   // Distribution
@@ -87,25 +90,6 @@ function getInstalledVersion(pkg: string, cwd: string): string | null {
     // ignore
   }
   return null;
-}
-
-export function findWorkspaceRoot(cwd: string): string | null {
-  let dir = cwd;
-  const root = path.parse(dir).root;
-  while (true) {
-    if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
-    const pkgPath = path.join(dir, "package.json");
-    if (fs.existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-        if (pkg.workspaces) return dir;
-      } catch {
-        // ignore
-      }
-    }
-    if (dir === root) return null;
-    dir = path.dirname(dir);
-  }
 }
 
 function readProjectDeps(

--- a/packages/cli/src/lib/utils/workspace.ts
+++ b/packages/cli/src/lib/utils/workspace.ts
@@ -1,0 +1,24 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export function findWorkspaceRoot(cwd: string): string | null {
+  let dir = path.resolve(cwd);
+  const root = path.parse(dir).root;
+
+  while (true) {
+    if (fs.existsSync(path.join(dir, "pnpm-workspace.yaml"))) return dir;
+
+    const pkgPath = path.join(dir, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+        if (pkg.workspaces) return dir;
+      } catch {
+        // Malformed package manifests are not workspace markers.
+      }
+    }
+
+    if (dir === root) return null;
+    dir = path.dirname(dir);
+  }
+}

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -147,6 +147,60 @@ describe("doctor — package discovery", () => {
   });
 });
 
+describe("doctor — workspace package discovery", () => {
+  it("finds packages hoisted above the selected workspace package", () => {
+    const fixture = fs.mkdtempSync(
+      path.join(os.tmpdir(), "aui-doctor-workspace-"),
+    );
+    const root = path.join(fixture, "workspace");
+    const app = path.join(root, "packages", "app");
+
+    try {
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({
+          name: "workspace",
+          private: true,
+          workspaces: ["packages/*"],
+        }),
+      );
+      fs.writeFileSync(
+        path.join(app, "package.json"),
+        JSON.stringify({
+          name: "app",
+          dependencies: { "@assistant-ui/react": "0.14.5" },
+        }),
+      );
+      writePackage(root, {
+        name: "@assistant-ui/react",
+        version: "0.14.5",
+        installPath: "node_modules/@assistant-ui/react",
+      });
+      writePackage(fixture, {
+        name: "@assistant-ui/core",
+        version: "0.2.0",
+        installPath: "node_modules/@assistant-ui/core",
+      });
+
+      expect(discoverInstalledPackages(app)).toEqual([
+        {
+          name: "@assistant-ui/react",
+          version: "0.14.5",
+          installPath: path.join(
+            root,
+            "node_modules",
+            "@assistant-ui",
+            "react",
+          ),
+        },
+      ]);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("doctor — pnpm store discovery", () => {
   let root: string;
 


### PR DESCRIPTION
## Summary

- discover assistant-ui installations from the selected `--cwd` through its workspace root
- share workspace-root detection between `info` and `doctor`
- keep scans inside the workspace and deduplicate physical package paths as before

## Why

In a monorepo, package managers can install `@assistant-ui/react` in the root `node_modules` while the consuming app lives under `packages/app`. Running `assistant-ui doctor` at the root finds the package, but `assistant-ui doctor --cwd packages/app` previously scanned only the app-level `node_modules` and incorrectly reported that no assistant-ui packages were installed. That also prevented Doctor from checking those packages for duplicate or outdated versions.

The lookup now follows ancestor `node_modules` directories through the detected workspace root, matching the layout available to the app without scanning unrelated parent projects.

## Validation

- reproduced the regression with a workspace app and a root-hoisted `@assistant-ui/react` installation; the new test returned `[]` before the fix
- added coverage that packages above the workspace boundary are ignored
- `pnpm --filter assistant-ui test` (244 tests)
- `pnpm --filter assistant-ui build`
- `pnpm lint`
- ran the built CLI against the hoisted fixture with `doctor --cwd packages/app --no-network`; it found the installation and reported no duplicates


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

