### PR TITLE
fix(cli): resolve symlinked workspace paths

### DIFF
--- a/.changeset/fresh-spoons-link.md
+++ b/.changeset/fresh-spoons-link.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix(cli): discover workspace packages from symlinked working directories

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
 import { compare, valid } from "semver";
-import { findWorkspaceRoot, resolveProjectPath } from "../lib/utils/workspace";
+import { findWorkspaceRoot, resolveRealPath } from "../lib/utils/workspace";
 
 const ASSISTANT_UI_PACKAGE_NAMES = new Set([
   "assistant-stream",
@@ -40,7 +40,7 @@ function processPackageDir(
   results: DiscoveredPackage[],
   visited: ProcessedDir,
 ): void {
-  const real = resolveProjectPath(pkgDir);
+  const real = resolveRealPath(pkgDir);
   if (visited.set.has(real)) return;
   visited.set.add(real);
 
@@ -184,7 +184,7 @@ function walkPnpmStore(
 export function discoverInstalledPackages(cwd: string): DiscoveredPackage[] {
   const results: DiscoveredPackage[] = [];
   const visited: ProcessedDir = { set: new Set() };
-  let dir = resolveProjectPath(cwd);
+  let dir = resolveRealPath(cwd);
   const scanRoot = findWorkspaceRoot(dir) ?? dir;
 
   while (true) {
@@ -373,7 +373,7 @@ export const doctor = new Command()
   )
   .option("--no-network", "Skip the npm registry check for latest versions.")
   .action(async (opts: { cwd: string; network: boolean }) => {
-    const cwd = resolveProjectPath(opts.cwd);
+    const cwd = resolveRealPath(opts.cwd);
     const packageJsonPath = path.join(cwd, "package.json");
 
     if (!fs.existsSync(packageJsonPath)) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
 import { compare, valid } from "semver";
-import { findWorkspaceRoot } from "../lib/utils/workspace";
+import { findWorkspaceRoot, resolveProjectPath } from "../lib/utils/workspace";
 
 const ASSISTANT_UI_PACKAGE_NAMES = new Set([
   "assistant-stream",
@@ -190,7 +190,7 @@ function walkPnpmStore(
 export function discoverInstalledPackages(cwd: string): DiscoveredPackage[] {
   const results: DiscoveredPackage[] = [];
   const visited: ProcessedDir = { set: new Set() };
-  let dir = path.resolve(cwd);
+  let dir = resolveProjectPath(cwd);
   const scanRoot = findWorkspaceRoot(dir) ?? dir;
 
   while (true) {
@@ -379,7 +379,7 @@ export const doctor = new Command()
   )
   .option("--no-network", "Skip the npm registry check for latest versions.")
   .action(async (opts: { cwd: string; network: boolean }) => {
-    const cwd = path.resolve(opts.cwd);
+    const cwd = resolveProjectPath(opts.cwd);
     const packageJsonPath = path.join(cwd, "package.json");
 
     if (!fs.existsSync(packageJsonPath)) {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -40,13 +40,7 @@ function processPackageDir(
   results: DiscoveredPackage[],
   visited: ProcessedDir,
 ): void {
-  const real = (() => {
-    try {
-      return fs.realpathSync(pkgDir);
-    } catch {
-      return pkgDir;
-    }
-  })();
+  const real = resolveProjectPath(pkgDir);
   if (visited.set.has(real)) return;
   visited.set.add(real);
 

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
 import { satisfies } from "semver";
-import { findWorkspaceRoot } from "../lib/utils/workspace";
+import { findWorkspaceRoot, resolveProjectPath } from "../lib/utils/workspace";
 
 export { findWorkspaceRoot };
 
@@ -416,7 +416,7 @@ export const info = new Command()
     process.cwd(),
   )
   .action(async (opts) => {
-    const cwd = path.resolve(opts.cwd);
+    const cwd = resolveProjectPath(opts.cwd);
     const packageJsonPath = path.join(cwd, "package.json");
 
     if (!fs.existsSync(packageJsonPath)) {

--- a/packages/cli/src/commands/info.ts
+++ b/packages/cli/src/commands/info.ts
@@ -6,7 +6,7 @@ import { spawnSync } from "node:child_process";
 import chalk from "chalk";
 import { detect } from "detect-package-manager";
 import { satisfies } from "semver";
-import { findWorkspaceRoot, resolveProjectPath } from "../lib/utils/workspace";
+import { findWorkspaceRoot, resolveRealPath } from "../lib/utils/workspace";
 
 export { findWorkspaceRoot };
 
@@ -416,7 +416,7 @@ export const info = new Command()
     process.cwd(),
   )
   .action(async (opts) => {
-    const cwd = resolveProjectPath(opts.cwd);
+    const cwd = resolveRealPath(opts.cwd);
     const packageJsonPath = path.join(cwd, "package.json");
 
     if (!fs.existsSync(packageJsonPath)) {

--- a/packages/cli/src/lib/utils/workspace.ts
+++ b/packages/cli/src/lib/utils/workspace.ts
@@ -1,8 +1,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-export function resolveProjectPath(cwd: string): string {
-  const resolved = path.resolve(cwd);
+export function resolveRealPath(inputPath: string): string {
+  const resolved = path.resolve(inputPath);
 
   try {
     return fs.realpathSync(resolved);

--- a/packages/cli/src/lib/utils/workspace.ts
+++ b/packages/cli/src/lib/utils/workspace.ts
@@ -1,6 +1,16 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+export function resolveProjectPath(cwd: string): string {
+  const resolved = path.resolve(cwd);
+
+  try {
+    return fs.realpathSync(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
 export function findWorkspaceRoot(cwd: string): string | null {
   let dir = path.resolve(cwd);
   const root = path.parse(dir).root;

--- a/packages/cli/test/commands/doctor.test.ts
+++ b/packages/cli/test/commands/doctor.test.ts
@@ -154,9 +154,15 @@ describe("doctor — workspace package discovery", () => {
     );
     const root = path.join(fixture, "workspace");
     const app = path.join(root, "packages", "app");
+    const linkedApp = path.join(fixture, "linked-app");
 
     try {
       fs.mkdirSync(app, { recursive: true });
+      fs.symlinkSync(
+        app,
+        linkedApp,
+        process.platform === "win32" ? "junction" : "dir",
+      );
       fs.writeFileSync(
         path.join(root, "package.json"),
         JSON.stringify({
@@ -183,18 +189,22 @@ describe("doctor — workspace package discovery", () => {
         installPath: "node_modules/@assistant-ui/core",
       });
 
-      expect(discoverInstalledPackages(app)).toEqual([
+      const realRoot = fs.realpathSync(root);
+      const expected = [
         {
           name: "@assistant-ui/react",
           version: "0.14.5",
           installPath: path.join(
-            root,
+            realRoot,
             "node_modules",
             "@assistant-ui",
             "react",
           ),
         },
-      ]);
+      ];
+
+      expect(discoverInstalledPackages(app)).toEqual(expected);
+      expect(discoverInstalledPackages(linkedApp)).toEqual(expected);
     } finally {
       fs.rmSync(fixture, { recursive: true, force: true });
     }

--- a/packages/cli/test/commands/info.test.ts
+++ b/packages/cli/test/commands/info.test.ts
@@ -139,6 +139,46 @@ describe("findWorkspaceRoot", () => {
 });
 
 describe("info command", () => {
+  it("finds hoisted packages from a symlinked workspace project", async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-link-"));
+    const root = path.join(fixture, "workspace");
+    const app = path.join(root, "packages", "app");
+    const linkedApp = path.join(fixture, "linked-app");
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ private: true, workspaces: ["packages/*"] }),
+      );
+      fs.writeFileSync(
+        path.join(app, "package.json"),
+        JSON.stringify({
+          name: "app",
+          dependencies: { "@assistant-ui/react": "0.14.5" },
+        }),
+      );
+      writePackage(root, "@assistant-ui/react", { version: "0.14.5" });
+      fs.symlinkSync(
+        app,
+        linkedApp,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      await info.parseAsync(["node", "info", "--cwd", linkedApp], {
+        from: "node",
+      });
+
+      const output = consoleLog.mock.calls.flat().join("\n");
+      expect(output).toContain("Monorepo:         yes");
+      expect(output).toContain("@assistant-ui/react");
+    } finally {
+      consoleLog.mockRestore();
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
   it("includes declared assistant-ui integrations and their peer warnings", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "aui-info-"));
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});


### PR DESCRIPTION
## Summary

- canonicalize CLI working directories before workspace and package discovery
- make `doctor` scan the real workspace ancestry when `--cwd` is a symlink
- make `info` report the real workspace and its root-hoisted packages through the same symlinked path

## Why

This is a follow-up to #5041. Its workspace-hoisting fix works for a direct path such as `packages/app`, but the review identified a remaining edge case when that app is reached through a symlink outside the workspace:

```sh
ln -s /repo/packages/app /tmp/app
assistant-ui doctor --cwd /tmp/app
```

I reproduced the merged behavior: the direct app path found the root-hoisted `@assistant-ui/react`, while the symlinked path returned no packages because traversal followed `/tmp` instead of the symlink target under `/repo`.

The selected path is now canonicalized with `realpath` before Doctor scanning and Info collection. Missing or inaccessible paths retain their resolved input so the commands keep their existing user-facing package.json error handling.

The existing `findWorkspaceRoot` re-export from `info.ts` remains intact because it predates #5041 and the CLI package surface is append-only.

## Validation

- regression test fails on merged `main` with `expected []` for the symlinked app
- coverage verifies direct and symlinked Doctor discovery return the same hoisted package
- coverage verifies Info reports `Monorepo: yes` and `@assistant-ui/react` from a symlinked app
- `pnpm --filter assistant-ui test` (245 tests)
- `pnpm --filter assistant-ui build`
- `pnpm lint`
- built CLI smoke test for both `doctor --cwd <symlink> --no-network` and `info --cwd <symlink>`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

