### PR TITLE
fix(react-ink): remount windowed Static scrollback on thread switch

### DIFF
--- a/.changeset/ink-static-thread-remount.md
+++ b/.changeset/ink-static-thread-remount.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ink": patch
+---
+
+fix: remount windowed Static scrollback on thread switch

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.test.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.test.tsx
@@ -1,12 +1,13 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useLayoutEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render } from "ink-testing-library";
 import { Text } from "ink";
 
 const hoisted = vi.hoisted(() => ({
-  state: { messagesLength: 0 },
+  state: { messagesLength: 0, mainThreadId: "t-default" },
   capturedIndices: [] as number[],
   staticItemCounts: [] as number[],
+  emittedStaticItems: [] as unknown[],
   tailItemCounts: [] as number[],
 }));
 
@@ -14,6 +15,7 @@ vi.mock("ink", async (importOriginal) => {
   const actual = await importOriginal<typeof import("ink")>();
   return {
     ...actual,
+    // Mirrors Ink's real emit-once cursor so remount/shrink semantics match.
     Static: <T,>({
       items,
       children,
@@ -21,8 +23,14 @@ vi.mock("ink", async (importOriginal) => {
       items: readonly T[];
       children: (item: T, index: number) => ReactNode;
     }) => {
+      const [index, setIndex] = useState(0);
+      const newItems = items.slice(index);
+      useLayoutEffect(() => {
+        setIndex(items.length);
+      }, [items.length]);
       hoisted.staticItemCounts.push(items.length);
-      return <>{items.map((item, i) => children(item, i))}</>;
+      hoisted.emittedStaticItems.push(...newItems);
+      return <>{newItems.map((item, i) => children(item, index + i))}</>;
     },
   };
 });
@@ -34,6 +42,7 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
     useAuiState: (selector: (s: unknown) => unknown) => {
       const state = {
         thread: { messages: { length: hoisted.state.messagesLength } },
+        threads: { mainThreadId: hoisted.state.mainThreadId },
         message: {
           role: "user" as const,
           composer: { isEditing: false },
@@ -72,8 +81,10 @@ import { ThreadPrimitive } from "../../index";
 
 beforeEach(() => {
   hoisted.state.messagesLength = 0;
+  hoisted.state.mainThreadId = "t-default";
   hoisted.capturedIndices = [];
   hoisted.staticItemCounts = [];
+  hoisted.emittedStaticItems = [];
   hoisted.tailItemCounts = [];
 });
 
@@ -203,6 +214,53 @@ describe("ThreadPrimitive.Messages", () => {
     );
 
     expect(hoisted.capturedIndices).toEqual([0, 1, 2, 3]);
+  });
+
+  it("re-emits the new thread's Static prefix on thread switch", () => {
+    hoisted.state.messagesLength = 20;
+    hoisted.state.mainThreadId = "thread-a";
+    const stableRender = () => <Text>m</Text>;
+
+    const instance = render(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {stableRender}
+      </ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.emittedStaticItems).toEqual(
+      Array.from({ length: 13 }, (_, i) => i),
+    );
+
+    hoisted.state.mainThreadId = "thread-b";
+    instance.rerender(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {stableRender}
+      </ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.emittedStaticItems.slice(13)).toEqual(
+      Array.from({ length: 13 }, (_, i) => i),
+    );
+  });
+
+  it("emits only newly graduated Static rows when the same thread grows", () => {
+    hoisted.state.messagesLength = 20;
+    const stableRender = () => <Text>m</Text>;
+
+    const instance = render(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {stableRender}
+      </ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.emittedStaticItems).toEqual(
+      Array.from({ length: 13 }, (_, i) => i),
+    );
+
+    hoisted.state.messagesLength = 22;
+    instance.rerender(
+      <ThreadPrimitive.Messages windowSize={3} windowOverscan={4}>
+        {stableRender}
+      </ThreadPrimitive.Messages>,
+    );
+    expect(hoisted.emittedStaticItems.slice(13)).toEqual([13, 14]);
   });
 
   it("does not re-render messages when an inline components literal is passed", () => {

--- a/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
+++ b/packages/react-ink/src/primitives/thread/ThreadMessages.tsx
@@ -129,6 +129,8 @@ const ThreadMessagesInner: FC<{
   windowOverscan?: number | undefined;
 }> = ({ children, windowSize, windowOverscan = 4 }) => {
   const messagesLength = useAuiState((s) => s.thread.messages.length);
+  // Subscribed, not just read: a switch to a thread with an equal message count would otherwise never re-render this component, and the Static key would never apply.
+  const mainThreadId = useAuiState((s) => s.threads.mainThreadId);
 
   const tailStart =
     windowSize !== undefined
@@ -158,7 +160,7 @@ const ThreadMessagesInner: FC<{
 
   return (
     <>
-      <Static items={prefixIndices}>
+      <Static key={mainThreadId} items={prefixIndices}>
         {(index) => <MemoMessage key={index} index={index} render={children} />}
       </Static>
       {tail}


### PR DESCRIPTION
## What

With `windowSize` set, `ThreadPrimitive.Messages` feeds older rows into Ink's `<Static>`, which keeps an internal emit cursor and never repaints. The region carried no thread identity, so on a thread switch the new thread's early rows (below `tailStart`) were never rendered at all. This keys `<Static>` by `s.threads.mainThreadId` so a switch remounts it and re-emits the new thread's prefix.

## Why

Thread switching and windowing are both first-class react-ink features, and combining them silently dropped messages. The old thread's rows staying in scrollback is a terminal limitation; the new thread's rows never printing is data loss.

## Impact

- Windowed apps now print the full history of the thread they switch to; within a thread, emission stays incremental (key is stable, graduated rows emit once).
- No new public surface, append-only safe. Patch changeset for `@assistant-ui/react-ink`.
- Full `turbo run build` green (86/86), react-ink suite green (233 tests), lint clean.

## Rationale

Verified against Ink 7.1.0 source: `Static` holds its cursor in `useState(0)` and slices `items` from it, so a key change resets the cursor and prints the new prefix exactly once. The `mainThreadId` read is deliberately a subscription (an equal-message-count switch would otherwise never re-render the component); a code comment guards it. Only `<Static>` is keyed, since the live tail already self-updates via per-index subscriptions.

- Tests: the `Static` mock now mirrors Ink's real cursor logic instead of rendering everything each pass. New thread-switch test fails without the fix (zero rows emitted); new growth test proves no duplicate re-emission.
- Known limitation, deferred to the planned docs caveat PR: external-store runtimes without `adapter.threadId` have a constant thread id, so the remount cannot fire there.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

