### PR TITLE
fix(assistant-stream): guard stream task settlement

### DIFF
--- a/.changeset/calm-stream-tasks-settle.md
+++ b/.changeset/calm-stream-tasks-settle.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: prevent assistant stream callback and cancellation failures from escaping as unhandled rejections

--- a/.changeset/calm-stream-tasks-settle.md
+++ b/.changeset/calm-stream-tasks-settle.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: prevent assistant stream callback and cancellation failures from escaping as unhandled rejections
+fix: prevent assistant stream task settlement from escaping as unhandled rejections

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   createAssistantStream,
   createAssistantStreamResponse,
@@ -89,6 +89,52 @@ describe("createAssistantStream task settlement", () => {
     });
 
     expect(unhandledRejections).toEqual([]);
+  });
+
+  it("reports callback failures after the controller is explicitly closed", async () => {
+    const error = new Error("cleanup failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const chunks = await collectChunks(
+        createAssistantStream((controller) => {
+          controller.close();
+          throw error;
+        }),
+      );
+
+      expect(chunks).toEqual([]);
+      expect(consoleError).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith(error);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("does not report callback failures caused after cancellation", async () => {
+    let failCallback!: (error: Error) => void;
+    const callbackPending = new Promise<void>((_, reject) => {
+      failCallback = reject;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        const reader = createAssistantStream(() => callbackPending).getReader();
+        await reader.cancel("consumer stopped");
+        failCallback(new Error("provider stopped"));
+        await callbackPending.catch(() => undefined);
+      });
+
+      expect(unhandledRejections).toEqual([]);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });
 

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -136,6 +136,41 @@ describe("createAssistantStream task settlement", () => {
       consoleError.mockRestore();
     }
   });
+
+  it("does not settle the outer stream again after a merged stream errors", async () => {
+    let finishCallback!: () => void;
+    const callbackPending = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+    const streamError = new Error("merged stream failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        const stream = createAssistantStream(async (controller) => {
+          controller.merge(
+            new ReadableStream({
+              start(streamController) {
+                streamController.error(streamError);
+              },
+            }),
+          );
+          await callbackPending;
+        });
+
+        await expect(collectChunks(stream)).rejects.toBe(streamError);
+        finishCallback();
+        await callbackPending;
+      });
+
+      expect(unhandledRejections).toEqual([]);
+      expect(consoleError).toHaveBeenCalledWith(streamError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
 });
 
 describe("AssistantStreamController withParentId", () => {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { createAssistantStreamResponse } from "./assistant-stream";
+import {
+  createAssistantStream,
+  createAssistantStreamResponse,
+} from "./assistant-stream";
 import { AssistantStream } from "../AssistantStream";
+import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import { DataStreamDecoder } from "../serialization/data-stream/DataStream";
 import { AssistantMessageAccumulator } from "../accumulators/assistant-message-accumulator";
 import type { AssistantMessage } from "../utils/types";
@@ -20,6 +24,73 @@ const accumulate = async (response: Response): Promise<AssistantMessage> => {
   );
   return last!;
 };
+
+const collectChunks = async (
+  stream: AssistantStream,
+): Promise<AssistantStreamChunk[]> => {
+  const chunks: AssistantStreamChunk[] = [];
+  await stream.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    }),
+  );
+  return chunks;
+};
+
+const captureUnhandledRejections = async (
+  callback: () => Promise<void>,
+): Promise<unknown[]> => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    await callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
+
+describe("createAssistantStream task settlement", () => {
+  it("emits callback failures without leaking an unhandled rejection", async () => {
+    let chunks: AssistantStreamChunk[] = [];
+    const unhandledRejections = await captureUnhandledRejections(async () => {
+      chunks = await collectChunks(
+        createAssistantStream(async () => {
+          throw new Error("provider failed");
+        }),
+      );
+    });
+
+    expect(chunks).toEqual([
+      {
+        type: "error",
+        path: [],
+        error: "Error: provider failed",
+      },
+    ]);
+    expect(unhandledRejections).toEqual([]);
+  });
+
+  it("does not settle the stream again after cancellation", async () => {
+    let finishCallback!: () => void;
+    const callbackPending = new Promise<void>((resolve) => {
+      finishCallback = resolve;
+    });
+
+    const unhandledRejections = await captureUnhandledRejections(async () => {
+      const reader = createAssistantStream(() => callbackPending).getReader();
+      await reader.cancel("consumer stopped");
+      finishCallback();
+      await callbackPending;
+    });
+
+    expect(unhandledRejections).toEqual([]);
+  });
+});
 
 describe("AssistantStreamController withParentId", () => {
   it("attaches parentId to text parts across a data-stream round trip", async () => {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -118,6 +118,10 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
     return this._state.merger.isSealed();
   }
 
+  get __internal_isCancelled() {
+    return this._state.merger.isCancelled();
+  }
+
   __internal_getReadable() {
     return this._state.merger.readable;
   }
@@ -303,6 +307,8 @@ export function createAssistantStream(
           path: [],
           error: String(e),
         });
+      } else if (!controller.__internal_isCancelled) {
+        console.error(e);
       }
     } finally {
       if (!controller.__internal_isClosed) {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -285,9 +285,8 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
  * {@link AssistantStreamController}.
  *
  * The callback may write synchronously or asynchronously. If it throws, an
- * `error` chunk is emitted before the error is rethrown; when the callback
- * settles, the stream is closed automatically unless the controller was
- * already closed.
+ * `error` chunk is emitted; when the callback settles, the stream is closed
+ * automatically unless the controller was already closed.
  */
 export function createAssistantStream(
   callback: (controller: AssistantStreamController) => PromiseLike<void> | void,
@@ -305,7 +304,6 @@ export function createAssistantStream(
           error: String(e),
         });
       }
-      throw e;
     } finally {
       if (!controller.__internal_isClosed) {
         controller.close();

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -115,7 +115,7 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 
   get __internal_isClosed() {
-    return this._state.merger.isSealed();
+    return this._state.merger.isSealed() || this._state.merger.isCancelled();
   }
 
   get __internal_isCancelled() {
@@ -288,9 +288,11 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
  * Creates an {@link AssistantStream} and writes to it with an
  * {@link AssistantStreamController}.
  *
- * The callback may write synchronously or asynchronously. If it throws, an
- * `error` chunk is emitted; when the callback settles, the stream is closed
- * automatically unless the controller was already closed.
+ * The callback may write synchronously or asynchronously. If it throws while
+ * the stream is open, an `error` chunk is emitted. Failures after an explicit
+ * close are logged, while failures after consumer cancellation are discarded.
+ * When the callback settles, the stream is closed automatically unless the
+ * controller was already closed.
  */
 export function createAssistantStream(
   callback: (controller: AssistantStreamController) => PromiseLike<void> | void,

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -115,7 +115,11 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 
   get __internal_isClosed() {
-    return this._state.merger.isSealed() || this._state.merger.isCancelled();
+    return (
+      this._state.merger.isSealed() ||
+      this._state.merger.isCancelled() ||
+      this._state.merger.isErrored()
+    );
   }
 
   get __internal_isCancelled() {

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -9,6 +9,7 @@ type MergeStreamItem = {
 export const createMergeStream = () => {
   const list: MergeStreamItem[] = [];
   let sealed = false;
+  let cancelled = false;
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
 
@@ -23,6 +24,8 @@ export const createMergeStream = () => {
         .read()
         .then(({ done, value }) => {
           item.promise = undefined;
+          if (cancelled) return;
+
           if (done) {
             list.splice(list.indexOf(item), 1);
             if (sealed && list.length === 0) {
@@ -36,6 +39,8 @@ export const createMergeStream = () => {
           currentPull = undefined;
         })
         .catch((e) => {
+          if (cancelled) return;
+
           console.error(e);
 
           list.forEach((item) => {
@@ -64,23 +69,32 @@ export const createMergeStream = () => {
       return currentPull.promise;
     },
     cancel() {
+      cancelled = true;
       list.forEach((item) => {
-        item.reader.cancel();
+        void item.reader.cancel().catch(() => undefined);
       });
       list.length = 0;
+      currentPull?.resolve();
+      currentPull = undefined;
     },
   });
 
   return {
     readable,
     isSealed() {
-      return sealed;
+      return sealed || cancelled;
     },
     seal() {
+      if (cancelled) return;
       sealed = true;
       if (list.length === 0) controller.close();
     },
     addStream(stream: ReadableStream<AssistantStreamChunk>) {
+      if (cancelled) {
+        void stream.cancel().catch(() => undefined);
+        return;
+      }
+
       if (sealed)
         throw new Error(
           "Cannot add streams after the run callback has settled.",

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -10,6 +10,7 @@ export const createMergeStream = () => {
   const list: MergeStreamItem[] = [];
   let sealed = false;
   let cancelled = false;
+  let errored = false;
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
 
@@ -31,7 +32,7 @@ export const createMergeStream = () => {
         .read()
         .then(({ done, value }) => {
           item.promise = undefined;
-          if (cancelled) return;
+          if (cancelled || errored) return;
 
           if (done) {
             list.splice(list.indexOf(item), 1);
@@ -46,8 +47,9 @@ export const createMergeStream = () => {
           currentPull = undefined;
         })
         .catch((e) => {
-          if (cancelled) return;
+          if (cancelled || errored) return;
 
+          errored = true;
           console.error(e);
           cancelAllReaders();
 
@@ -87,13 +89,16 @@ export const createMergeStream = () => {
     isCancelled() {
       return cancelled;
     },
+    isErrored() {
+      return errored;
+    },
     seal() {
-      if (cancelled) return;
+      if (cancelled || errored) return;
       sealed = true;
       if (list.length === 0) controller.close();
     },
     addStream(stream: ReadableStream<AssistantStreamChunk>) {
-      if (cancelled) {
+      if (cancelled || errored) {
         void stream.cancel().catch(() => undefined);
         return;
       }

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -13,6 +13,13 @@ export const createMergeStream = () => {
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
 
+  const cancelAllReaders = () => {
+    list.forEach((item) => {
+      void item.reader.cancel().catch(() => undefined);
+    });
+    list.length = 0;
+  };
+
   const handlePull = (item: MergeStreamItem) => {
     if (!item.promise) {
       // TODO for most streams, we can directly pipeTo to avoid the microTask queue
@@ -42,11 +49,7 @@ export const createMergeStream = () => {
           if (cancelled) return;
 
           console.error(e);
-
-          list.forEach((item) => {
-            item.reader.cancel();
-          });
-          list.length = 0;
+          cancelAllReaders();
 
           controller.error(e);
 
@@ -70,10 +73,7 @@ export const createMergeStream = () => {
     },
     cancel() {
       cancelled = true;
-      list.forEach((item) => {
-        void item.reader.cancel().catch(() => undefined);
-      });
-      list.length = 0;
+      cancelAllReaders();
       currentPull?.resolve();
       currentPull = undefined;
     },
@@ -83,6 +83,9 @@ export const createMergeStream = () => {
     readable,
     isSealed() {
       return sealed || cancelled;
+    },
+    isCancelled() {
+      return cancelled;
     },
     seal() {
       if (cancelled) return;

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -82,7 +82,7 @@ export const createMergeStream = () => {
   return {
     readable,
     isSealed() {
-      return sealed || cancelled;
+      return sealed;
     },
     isCancelled() {
       return cancelled;

--- a/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.test.ts
+++ b/packages/assistant-stream/src/resumable/createResumableAssistantStreamResponse.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   RESUMABLE_STREAM_ID_HEADER,
   createResumableAssistantStreamResponse,
@@ -140,25 +140,6 @@ describe("createResumableAssistantStreamResponse", () => {
   });
 
   describe("producer crash", () => {
-    let suppressed: unknown[];
-    let original: NodeJS.UnhandledRejectionListener[];
-    const swallow: NodeJS.UnhandledRejectionListener = (reason) => {
-      suppressed.push(reason);
-    };
-
-    beforeEach(() => {
-      suppressed = [];
-      original = process.listeners("unhandledRejection");
-      for (const l of original) process.off("unhandledRejection", l);
-      process.on("unhandledRejection", swallow);
-    });
-
-    afterEach(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-      process.off("unhandledRejection", swallow);
-      for (const l of original) process.on("unhandledRejection", l);
-    });
-
     it("synchronous callback throw is encoded into the body and finalizes the stream", async () => {
       const ctx = createResumableStreamContext({
         store: createInMemoryResumableStreamStore(),
@@ -184,11 +165,6 @@ describe("createResumableAssistantStreamResponse", () => {
       expect(replay).not.toBeNull();
       const replayBytes = await new Response(replay).arrayBuffer();
       expect(new Uint8Array(replayBytes)).toEqual(new Uint8Array(firstBytes));
-
-      while (suppressed.length === 0) {
-        await new Promise((r) => setTimeout(r, 5));
-      }
-      expect(suppressed.map((e) => (e as Error).message)).toContain("boom");
     });
   });
 


### PR DESCRIPTION
## Summary

- emit callback failures as assistant-stream error chunks without leaking an unhandled rejection
- treat consumer cancellation as a terminal merge-stream state so pending reads and late settlement cannot touch a cancelled controller
- preserve resumable error-chunk persistence and replay behavior

## Why

While testing custom stream producers, I hit two process-level failures: a callback error was delivered to the consumer as an error chunk but also escaped as an `unhandledRejection`, and cancelling a stream while its callback was pending later produced `Invalid state: Controller is already closed`. This can create duplicate error reporting or terminate a Node process after the stream has already handled the outcome.

The change keeps successful streams and their emitted chunks unchanged. After cancellation, remaining stream work is discarded because there is no longer a consumer.

## Testing

- added regressions that reproduce both failures on `main`
- `pnpm --filter assistant-stream test` (290 passed, 20 skipped)
- `pnpm --filter assistant-stream build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

