### PR TITLE
fix(react-ai-sdk): avoid rewriting unchanged history

### DIFF
--- a/.changeset/quiet-runs-persist.md
+++ b/.changeset/quiet-runs-persist.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: avoid rewriting unchanged thread history after each run

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AssistantRuntime,
@@ -9,6 +9,7 @@ import type {
   ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
+import { bindExternalStoreMessage } from "@assistant-ui/core";
 
 vi.mock("@assistant-ui/store", () => ({
   useAui: () => ({
@@ -162,5 +163,134 @@ describe("toExportedMessageRepository", () => {
     expect(result.messages).toHaveLength(0);
     expect(result.headId).toBeNull();
     expect(() => new MessageRepository().import(result)).not.toThrow();
+  });
+});
+
+describe("useExternalHistory persistence", () => {
+  it("only updates persisted messages that participate in the active run", async () => {
+    type StoredMessage = { id: string; text: string };
+
+    const append = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reportTelemetry = vi.fn();
+    const formattedAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+      update,
+      reportTelemetry,
+    };
+    const historyAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue(formattedAdapter),
+    } as unknown as ThreadHistoryAdapter;
+
+    const makeMessage = (
+      id: string,
+      innerId: string,
+      text: string,
+    ): ThreadMessage => {
+      const message: ThreadMessage = {
+        id,
+        role: "assistant",
+        content: [{ type: "text", text }],
+        status: { type: "complete", reason: "stop" },
+        createdAt: new Date(),
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+        },
+      };
+      bindExternalStoreMessage(message, { id: innerId, text });
+      return message;
+    };
+
+    let messages = [
+      makeMessage("old", "inner-old", "old"),
+      makeMessage("active", "inner-active", "initial"),
+    ];
+    let isRunning = false;
+    let notify: (() => void) | undefined;
+    const thread = {
+      subscribe: vi.fn((listener: () => void) => {
+        notify = listener;
+        return () => {};
+      }),
+      getState: () => ({ isRunning, messages }),
+      import: vi.fn(),
+      export: vi.fn(),
+    } as unknown as AssistantRuntime["thread"];
+    const testRuntimeRef = {
+      current: { thread } as AssistantRuntime,
+    };
+    const testStorageFormat: MessageFormatAdapter<
+      StoredMessage,
+      Record<string, unknown>
+    > = {
+      format: "test",
+      encode: ({ message }) => message,
+      decode: (stored) => ({
+        parentId: stored.parent_id,
+        message: stored.content as StoredMessage,
+      }),
+      getId: (message) => message.id,
+    };
+
+    renderHook(() =>
+      useExternalHistory(
+        testRuntimeRef,
+        historyAdapter,
+        () => messages,
+        testStorageFormat,
+        () => {},
+      ),
+    );
+
+    const setRunning = (value: boolean) => {
+      act(() => {
+        isRunning = value;
+        notify?.();
+      });
+    };
+
+    setRunning(true);
+    setRunning(false);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(2));
+
+    append.mockClear();
+    update.mockClear();
+    reportTelemetry.mockClear();
+    messages = [
+      messages[0]!,
+      makeMessage("active", "inner-active", "completed"),
+    ];
+
+    setRunning(true);
+    setRunning(false);
+    setRunning(true);
+    setRunning(false);
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(append).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(
+      {
+        parentId: "inner-old",
+        message: { id: "inner-active", text: "completed" },
+      },
+      "inner-active",
+    );
+    expect(reportTelemetry).toHaveBeenCalledTimes(1);
+    expect(reportTelemetry).toHaveBeenCalledWith(
+      [
+        {
+          parentId: "inner-old",
+          message: { id: "inner-active", text: "completed" },
+        },
+      ],
+      expect.objectContaining({ durationMs: expect.any(Number) }),
+    );
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -167,7 +167,7 @@ describe("toExportedMessageRepository", () => {
 });
 
 describe("useExternalHistory persistence", () => {
-  it("only updates persisted messages that participate in the active run", async () => {
+  it("only updates persisted messages that change during the active run", async () => {
     type StoredMessage = { id: string; text: string };
 
     const append = vi.fn().mockResolvedValue(undefined);
@@ -211,6 +211,7 @@ describe("useExternalHistory persistence", () => {
     let messages = [
       makeMessage("old", "inner-old", "old"),
       makeMessage("active", "inner-active", "initial"),
+      makeMessage("tail", "inner-tail", "tail"),
     ];
     let isRunning = false;
     let notify: (() => void) | undefined;
@@ -258,17 +259,20 @@ describe("useExternalHistory persistence", () => {
 
     setRunning(true);
     setRunning(false);
-    await waitFor(() => expect(append).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(3));
 
     append.mockClear();
     update.mockClear();
     reportTelemetry.mockClear();
-    messages = [
-      messages[0]!,
-      makeMessage("active", "inner-active", "completed"),
-    ];
-
     setRunning(true);
+    act(() => {
+      messages = [
+        messages[0]!,
+        makeMessage("active", "inner-active", "completed"),
+        messages[2]!,
+      ];
+      notify?.();
+    });
     setRunning(false);
     setRunning(true);
     setRunning(false);

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -124,10 +124,21 @@ export const useExternalHistory = <TMessage>(
   const stepBoundariesRef = useRef<number[]>([]);
   const wasRunningRef = useRef(false);
   const toolCallCountRef = useRef(0);
-  const activeRunMessageIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!formatAdapter) return;
+
+    const snapshotExternalMessages = (messages: readonly ThreadMessage[]) =>
+      new Map<string, TMessage[]>(
+        messages.map((message) => [
+          message.id,
+          [...getExternalStoreMessages<TMessage>(message)],
+        ]),
+      );
+    let idleExternalMessages = snapshotExternalMessages(
+      runtimeRef.current.thread.getState().messages,
+    );
+    let runStartExternalMessages = idleExternalMessages;
 
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
       const threadState = runtimeRef.current.thread.getState();
@@ -139,14 +150,10 @@ export const useExternalHistory = <TMessage>(
         runStartRef.current = Date.now();
         stepBoundariesRef.current = [];
         toolCallCountRef.current = 0;
-        activeRunMessageIdsRef.current = new Set();
+        runStartExternalMessages = idleExternalMessages;
       }
 
       const lastMessage = threadState.messages.at(-1);
-      if (runStartRef.current != null && lastMessage?.role === "assistant") {
-        activeRunMessageIdsRef.current.add(lastMessage.id);
-      }
-
       // Track step boundaries by content changes (more reliable than isRunning)
       if (runStartRef.current != null) {
         if (lastMessage?.role === "assistant") {
@@ -170,7 +177,10 @@ export const useExternalHistory = <TMessage>(
       }
 
       // Only act on the true→false transition
-      if (!wasRunning) return;
+      if (!wasRunning) {
+        idleExternalMessages = snapshotExternalMessages(threadState.messages);
+        return;
+      }
 
       // Record step boundary offset (synchronous for accuracy)
       if (runStartRef.current != null) {
@@ -220,8 +230,20 @@ export const useExternalHistory = <TMessage>(
               }))
             : undefined;
 
-        const activeRunMessageIds = activeRunMessageIdsRef.current;
-        activeRunMessageIdsRef.current = new Set();
+        const changedRunMessageIds = new Set<string>();
+        for (const message of latest.messages) {
+          if (message.role !== "assistant") continue;
+          const externalMessages = getExternalStoreMessages<TMessage>(message);
+          const previous = runStartExternalMessages.get(message.id);
+          if (
+            previous === undefined ||
+            previous.length !== externalMessages.length ||
+            externalMessages.some((item, index) => item !== previous[index])
+          ) {
+            changedRunMessageIds.add(message.id);
+          }
+        }
+        idleExternalMessages = snapshotExternalMessages(latest.messages);
         runStartRef.current = null;
         stepBoundariesRef.current = [];
 
@@ -260,7 +282,7 @@ export const useExternalHistory = <TMessage>(
           }
 
           if (historyIds.current.has(message.id)) {
-            if (activeRunMessageIds.has(message.id)) {
+            if (changedRunMessageIds.has(message.id)) {
               const batchItems = toBatchItems(innerMessages);
               for (const item of batchItems) {
                 try {

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -124,20 +124,33 @@ export const useExternalHistory = <TMessage>(
   const stepBoundariesRef = useRef<number[]>([]);
   const wasRunningRef = useRef(false);
   const toolCallCountRef = useRef(0);
+  const activeRunMessageIdsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!formatAdapter) return;
 
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
-      const { isRunning } = runtimeRef.current.thread.getState();
+      const threadState = runtimeRef.current.thread.getState();
+      const { isRunning } = threadState;
       const wasRunning = wasRunningRef.current;
       wasRunningRef.current = isRunning;
 
+      if (isRunning && runStartRef.current == null) {
+        runStartRef.current = Date.now();
+        stepBoundariesRef.current = [];
+        toolCallCountRef.current = 0;
+        activeRunMessageIdsRef.current = new Set();
+      }
+
+      const lastMessage = threadState.messages.at(-1);
+      if (runStartRef.current != null && lastMessage?.role === "assistant") {
+        activeRunMessageIdsRef.current.add(lastMessage.id);
+      }
+
       // Track step boundaries by content changes (more reliable than isRunning)
       if (runStartRef.current != null) {
-        const lastMsg = runtimeRef.current.thread.getState().messages.at(-1);
-        if (lastMsg?.role === "assistant") {
-          const currentToolCallCount = lastMsg.content.filter(
+        if (lastMessage?.role === "assistant") {
+          const currentToolCallCount = lastMessage.content.filter(
             (p) => p.type === "tool-call",
           ).length;
           while (toolCallCountRef.current < currentToolCallCount) {
@@ -148,11 +161,6 @@ export const useExternalHistory = <TMessage>(
       }
 
       if (isRunning) {
-        if (runStartRef.current == null) {
-          runStartRef.current = Date.now();
-          stepBoundariesRef.current = [];
-          toolCallCountRef.current = 0;
-        }
         // Cancel any pending persist — isRunning went back to true
         if (persistTimerRef.current) {
           clearTimeout(persistTimerRef.current);
@@ -212,6 +220,8 @@ export const useExternalHistory = <TMessage>(
               }))
             : undefined;
 
+        const activeRunMessageIds = activeRunMessageIdsRef.current;
+        activeRunMessageIdsRef.current = new Set();
         runStartRef.current = null;
         stepBoundariesRef.current = [];
 
@@ -250,19 +260,19 @@ export const useExternalHistory = <TMessage>(
           }
 
           if (historyIds.current.has(message.id)) {
-            if (durationMs !== undefined) {
-              let parentId = lastInnerMessageId;
-              for (const innerMessage of innerMessages) {
+            if (activeRunMessageIds.has(message.id)) {
+              const batchItems = toBatchItems(innerMessages);
+              for (const item of batchItems) {
                 try {
                   await formatAdapter.update?.(
-                    { parentId, message: innerMessage },
-                    storageFormatAdapter.getId(innerMessage),
+                    item,
+                    storageFormatAdapter.getId(item.message),
                   );
                 } catch {
                   // ignore update failures to avoid breaking the message processing loop
                 }
-                parentId = storageFormatAdapter.getId(innerMessage);
               }
+              formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
             }
             lastInnerMessageId =
               getLastInnerId(innerMessages) ?? lastInnerMessageId;


### PR DESCRIPTION
## Summary

- track the assistant message IDs that participate in each active run
- update only those persisted messages when the run completes instead of rewriting the full thread history
- preserve parent linkage, telemetry reporting, agentic-step debounce behavior, and append behavior for new messages
- add a patch changeset for `@assistant-ui/react-ai-sdk`

## Root cause

The history persistence pass traversed every message to rebuild parent linkage, but it also called `update` for every already-persisted message whenever a run completed. Long threads therefore produced redundant storage writes after each response.

## Implementation

Run-scoped message IDs are collected while the runtime is active and snapshotted before asynchronous persistence begins. The persistence pass still walks the full repository to derive parent IDs, but existing messages are updated and reported for telemetry only when they participated in the completed run. The regression test also covers the `true → false → true → false` flicker used by agentic steps.

Fixes #5047

## Validation

- `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useExternalHistory.test.ts` — 7 tests passed
- `pnpm --filter @assistant-ui/react-ai-sdk test` — 157 tests passed
- `pnpm --filter @assistant-ui/react-ai-sdk build` — passed
- `pnpm lint` — passed (existing hook warnings remain elsewhere in the workspace)
- `pnpm test:types` — not clean on the current checkout due to unrelated workspace errors; the scoped direct check reaches an existing `generativeTools.test.ts:526` type error, while the package declaration build passes

## Risk

Behavior-changing, limited to persistence writes for messages already present in external history. New-message appends and history traversal are unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

