### PR TITLE
fix(react-ai-sdk): persist pending tool approvals

### DIFF
--- a/.changeset/quiet-tools-wait.md
+++ b/.changeset/quiet-tools-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+Persist assistant messages while tool calls await approval.

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type {
   AssistantRuntime,
@@ -9,6 +9,7 @@ import type {
   ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
+import { bindExternalStoreMessage } from "@assistant-ui/core";
 
 vi.mock("@assistant-ui/store", () => ({
   useAui: () => ({
@@ -162,5 +163,87 @@ describe("toExportedMessageRepository", () => {
     expect(result.messages).toHaveLength(0);
     expect(result.headId).toBeNull();
     expect(() => new MessageRepository().import(result)).not.toThrow();
+  });
+});
+
+describe("useExternalHistory persistence", () => {
+  it("persists assistant messages waiting for tool approval", async () => {
+    const append = vi.fn().mockResolvedValue(undefined);
+    const formattedAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+    };
+    const historyAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue(formattedAdapter),
+    } as unknown as ThreadHistoryAdapter;
+
+    const message: ThreadMessage = {
+      id: "approval-message",
+      role: "assistant",
+      content: [{ type: "text", text: "Approve the tool call" }],
+      status: { type: "requires-action", reason: "tool-calls" },
+      createdAt: new Date(),
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    bindExternalStoreMessage(message, { id: "inner-approval-message" });
+
+    let isRunning = false;
+    let notify: (() => void) | undefined;
+    const thread = {
+      subscribe: vi.fn((listener: () => void) => {
+        notify = listener;
+        return () => {};
+      }),
+      getState: () => ({ isRunning, messages: [message] }),
+      import: vi.fn(),
+      export: vi.fn(),
+    } as unknown as AssistantRuntime["thread"];
+    const testRuntimeRef = {
+      current: { thread } as AssistantRuntime,
+    };
+    const storageAdapter: MessageFormatAdapter<
+      { id: string },
+      Record<string, unknown>
+    > = {
+      format: "test",
+      encode: ({ message }) => message,
+      decode: (stored) => ({
+        parentId: stored.parent_id,
+        message: stored.content as { id: string },
+      }),
+      getId: (storedMessage) => storedMessage.id,
+    };
+
+    renderHook(() =>
+      useExternalHistory(
+        testRuntimeRef,
+        historyAdapter,
+        () => [message],
+        storageAdapter,
+        () => {},
+      ),
+    );
+
+    act(() => {
+      isRunning = true;
+      notify?.();
+      isRunning = false;
+      notify?.();
+    });
+
+    await waitFor(() =>
+      expect(append).toHaveBeenCalledWith({
+        parentId: null,
+        message: { id: "inner-approval-message" },
+      }),
+    );
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -240,6 +240,8 @@ export const useExternalHistory = <TMessage>(
 
           const isReady =
             message.status === undefined ||
+            (message.status.type === "requires-action" &&
+              message.status.reason === "tool-calls") ||
             message.status.type === "complete" ||
             message.status.type === "incomplete";
 


### PR DESCRIPTION
## Summary

- persist assistant messages when a run pauses for tool-call approval
- keep other interrupted message statuses on their existing persistence path
- add a regression test and patch changeset for `@assistant-ui/react-ai-sdk`

Fixes #5046

## Root cause

`useExternalHistory` appends messages when a run stops, but its readiness check only accepted messages without a status or with a terminal `complete`/`incomplete` status. Tool calls waiting for approval use `requires-action/tool-calls`, so the persistence pass skipped the assistant message and a reload lost the pending approval state.

This change admits that specific stable approval state into the existing append flow. It does not change the history adapter schema, stored message format, parent mapping, or public API.

## Validation

- `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useExternalHistory.test.ts` (7 tests)
- `pnpm --filter @assistant-ui/react-ai-sdk test` (157 tests)
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- `pnpm lint` (existing warnings remain elsewhere in the workspace)
- `git diff --check`

The new regression was the only failing focused test against the unchanged readiness predicate because `append` was never called, then passed with this change. A direct package `tsc --noEmit` still reaches the existing `src/generativeTools.test.ts:526` `TS2769`; the package declaration build passes and the affected files produce no diagnostics.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

