### PR TITLE
fix(react-ai-sdk): persist history for pending tool approvals

### DIFF
--- a/.changeset/history-pending-approval-persistence.md
+++ b/.changeset/history-pending-approval-persistence.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): persist pending tool approvals and append post-approval continuations

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -267,7 +267,12 @@ describe("useExternalHistory persistence", () => {
       });
     };
 
-    return { append, update, reportTelemetry, runCycle };
+    const flush = () =>
+      act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+    return { append, update, reportTelemetry, runCycle, flush };
   };
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
@@ -291,7 +296,7 @@ describe("useExternalHistory persistence", () => {
   });
 
   it("keeps paused messages unpersisted when the adapter lacks update", async () => {
-    const { append, runCycle } = createPersistenceHarness(false);
+    const { append, runCycle, flush } = createPersistenceHarness(false);
     const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
 
     await runCycle([
@@ -301,9 +306,7 @@ describe("useExternalHistory persistence", () => {
       ),
     ]);
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await flush();
     expect(append).not.toHaveBeenCalled();
 
     await runCycle([
@@ -388,7 +391,7 @@ describe("useExternalHistory persistence", () => {
   });
 
   it("defers run telemetry until the paused message completes", async () => {
-    const { reportTelemetry, runCycle } = createPersistenceHarness(true);
+    const { reportTelemetry, runCycle, flush } = createPersistenceHarness(true);
     const pendingInnerMessage = { id: "inner-a", parts: ["pending"] };
     const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
     const continuationInnerMessage = { id: "inner-b", parts: ["answer"] };
@@ -399,9 +402,7 @@ describe("useExternalHistory persistence", () => {
         [pendingInnerMessage],
       ),
     ]);
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await flush();
     expect(reportTelemetry).not.toHaveBeenCalled();
 
     await runCycle([
@@ -410,9 +411,7 @@ describe("useExternalHistory persistence", () => {
         continuationInnerMessage,
       ]),
     ]);
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+    await flush();
 
     expect(reportTelemetry).toHaveBeenCalledTimes(1);
     expect(reportTelemetry).toHaveBeenCalledWith(

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -215,9 +215,11 @@ describe("useExternalHistory persistence", () => {
         _localMessageId: string,
       ) => {},
     );
+    const reportTelemetry = vi.fn();
     const formattedAdapter = {
       load: vi.fn().mockResolvedValue({ messages: [] }),
       append,
+      reportTelemetry,
       ...(supportsUpdate ? { update } : {}),
     };
     const historyAdapter: ThreadHistoryAdapter = {
@@ -265,7 +267,7 @@ describe("useExternalHistory persistence", () => {
       });
     };
 
-    return { append, update, getState, runCycle };
+    return { append, update, reportTelemetry, runCycle };
   };
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
@@ -289,7 +291,7 @@ describe("useExternalHistory persistence", () => {
   });
 
   it("keeps paused messages unpersisted when the adapter lacks update", async () => {
-    const { append, getState, runCycle } = createPersistenceHarness(false);
+    const { append, runCycle } = createPersistenceHarness(false);
     const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
 
     await runCycle([
@@ -299,10 +301,10 @@ describe("useExternalHistory persistence", () => {
       ),
     ]);
 
-    await waitFor(() => {
-      expect(getState).toHaveBeenCalledTimes(4);
-      expect(append).not.toHaveBeenCalled();
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
+    expect(append).not.toHaveBeenCalled();
 
     await runCycle([
       createAssistantMessage({ type: "complete", reason: "stop" }, [
@@ -382,6 +384,43 @@ describe("useExternalHistory persistence", () => {
     expect(update).toHaveBeenCalledWith(
       { parentId: null, message: finalInnerMessage },
       "inner-a",
+    );
+  });
+
+  it("defers run telemetry until the paused message completes", async () => {
+    const { reportTelemetry, runCycle } = createPersistenceHarness(true);
+    const pendingInnerMessage = { id: "inner-a", parts: ["pending"] };
+    const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
+    const continuationInnerMessage = { id: "inner-b", parts: ["answer"] };
+
+    await runCycle([
+      createAssistantMessage(
+        { type: "requires-action", reason: "tool-calls" },
+        [pendingInnerMessage],
+      ),
+    ]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(reportTelemetry).not.toHaveBeenCalled();
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        finalInnerMessage,
+        continuationInnerMessage,
+      ]),
+    ]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(reportTelemetry).toHaveBeenCalledTimes(1);
+    expect(reportTelemetry).toHaveBeenCalledWith(
+      [
+        { parentId: null, message: finalInnerMessage },
+        { parentId: "inner-a", message: continuationInnerMessage },
+      ],
+      expect.any(Object),
     );
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -14,7 +14,10 @@ import type {
 
 vi.mock("@assistant-ui/store", () => ({
   useAui: () => ({
-    threadListItem: Object.assign(() => null, { source: undefined }),
+    threadListItem: Object.assign(
+      () => ({ getState: () => ({ remoteId: "remote-1" }) }),
+      { source: {} },
+    ),
   }),
 }));
 
@@ -205,7 +208,13 @@ describe("useExternalHistory persistence", () => {
     return message;
   };
 
-  const createPersistenceHarness = (supportsUpdate: boolean) => {
+  const createPersistenceHarness = (
+    supportsUpdate: boolean,
+    options?: {
+      loadMessages?: MessageFormatRepository<InnerMessage>;
+      toThreadMessages?: (messages: InnerMessage[]) => ThreadMessage[];
+    },
+  ) => {
     const append = vi.fn(
       async (_item: { parentId: string | null; message: InnerMessage }) => {},
     );
@@ -216,8 +225,11 @@ describe("useExternalHistory persistence", () => {
       ) => {},
     );
     const reportTelemetry = vi.fn();
+    const load = vi
+      .fn()
+      .mockResolvedValue(options?.loadMessages ?? { messages: [] });
     const formattedAdapter = {
-      load: vi.fn().mockResolvedValue({ messages: [] }),
+      load,
       append,
       reportTelemetry,
       ...(supportsUpdate ? { update } : {}),
@@ -249,7 +261,7 @@ describe("useExternalHistory persistence", () => {
       useExternalHistory(
         persistenceRuntimeRef,
         historyAdapter,
-        () => [],
+        options?.toThreadMessages ?? (() => []),
         persistenceStorageFormat,
         () => {},
       ),
@@ -272,7 +284,7 @@ describe("useExternalHistory persistence", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-    return { append, update, reportTelemetry, runCycle, flush };
+    return { append, update, reportTelemetry, load, runCycle, flush };
   };
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
@@ -413,6 +425,58 @@ describe("useExternalHistory persistence", () => {
     ]);
     await flush();
 
+    expect(reportTelemetry).toHaveBeenCalledTimes(1);
+    expect(reportTelemetry).toHaveBeenCalledWith(
+      [
+        { parentId: null, message: finalInnerMessage },
+        { parentId: "inner-a", message: continuationInnerMessage },
+      ],
+      expect.any(Object),
+    );
+  });
+
+  it("restores deferred telemetry for reloaded paused messages", async () => {
+    const { append, update, reportTelemetry, load, runCycle, flush } =
+      createPersistenceHarness(true, {
+        loadMessages: {
+          messages: [
+            {
+              parentId: null,
+              message: { id: "inner-a", parts: ["pending"] },
+            },
+          ],
+        },
+        toThreadMessages: (msgs) => [
+          createAssistantMessage(
+            { type: "requires-action", reason: "tool-calls" },
+            msgs,
+          ),
+        ],
+      });
+
+    await waitFor(() => expect(load).toHaveBeenCalled());
+    await flush();
+
+    const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
+    const continuationInnerMessage = { id: "inner-b", parts: ["answer"] };
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        finalInnerMessage,
+        continuationInnerMessage,
+      ]),
+    ]);
+    await flush();
+
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append).toHaveBeenCalledWith({
+      parentId: "inner-a",
+      message: continuationInnerMessage,
+    });
+    expect(update).toHaveBeenCalledWith(
+      { parentId: null, message: finalInnerMessage },
+      "inner-a",
+    );
     expect(reportTelemetry).toHaveBeenCalledTimes(1);
     expect(reportTelemetry).toHaveBeenCalledWith(
       [

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { bindExternalStoreMessage } from "@assistant-ui/core";
 import type {
   AssistantRuntime,
   MessageFormatAdapter,
   MessageFormatRepository,
+  ThreadAssistantMessage,
   ThreadHistoryAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
@@ -162,5 +164,224 @@ describe("toExportedMessageRepository", () => {
     expect(result.messages).toHaveLength(0);
     expect(result.headId).toBeNull();
     expect(() => new MessageRepository().import(result)).not.toThrow();
+  });
+});
+
+describe("useExternalHistory persistence", () => {
+  type InnerMessage = { id: string; parts: string[] };
+
+  const persistenceStorageFormat: MessageFormatAdapter<
+    InnerMessage,
+    Record<string, unknown>
+  > = {
+    format: "test",
+    encode: (item) => ({ data: item.message }),
+    decode: (stored) => ({
+      parentId: stored.parent_id,
+      message: stored.content as unknown as InnerMessage,
+    }),
+    getId: (message) => message.id,
+  };
+
+  const createAssistantMessage = (
+    status: ThreadAssistantMessage["status"],
+    innerMessages: InnerMessage[],
+  ): ThreadMessage => {
+    const message: ThreadAssistantMessage = {
+      id: "assistant-a",
+      role: "assistant",
+      content: [],
+      createdAt: new Date(),
+      status,
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    bindExternalStoreMessage(message, innerMessages);
+    return message;
+  };
+
+  const createPersistenceHarness = (supportsUpdate: boolean) => {
+    const append = vi.fn(
+      async (_item: { parentId: string | null; message: InnerMessage }) => {},
+    );
+    const update = vi.fn(
+      async (
+        _item: { parentId: string | null; message: InnerMessage },
+        _localMessageId: string,
+      ) => {},
+    );
+    const formattedAdapter = {
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append,
+      ...(supportsUpdate ? { update } : {}),
+    };
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn(),
+      append: vi.fn(),
+      withFormat: vi.fn().mockReturnValue(formattedAdapter),
+    };
+
+    let listener: (() => void) | undefined;
+    let isRunning = false;
+    let messages: ThreadMessage[] = [];
+    const getState = vi.fn(() => ({ isRunning, messages }));
+    const thread = {
+      subscribe: (nextListener: () => void) => {
+        listener = nextListener;
+        return () => {};
+      },
+      getState,
+      import: vi.fn(),
+      export: vi.fn(() => ({ headId: null, messages: [] })),
+    } as unknown as AssistantRuntime["thread"];
+    const persistenceRuntimeRef = {
+      current: { thread } as AssistantRuntime,
+    };
+
+    renderHook(() =>
+      useExternalHistory(
+        persistenceRuntimeRef,
+        historyAdapter,
+        () => [],
+        persistenceStorageFormat,
+        () => {},
+      ),
+    );
+
+    const runCycle = async (nextMessages: ThreadMessage[]) => {
+      await act(async () => {
+        messages = nextMessages;
+        isRunning = true;
+        listener?.();
+      });
+      await act(async () => {
+        isRunning = false;
+        listener?.();
+      });
+    };
+
+    return { append, update, getState, runCycle };
+  };
+
+  it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
+    const { append, runCycle } = createPersistenceHarness(true);
+    const innerMessage = { id: "inner-a", parts: ["pending"] };
+
+    await runCycle([
+      createAssistantMessage(
+        { type: "requires-action", reason: "tool-calls" },
+        [innerMessage],
+      ),
+    ]);
+
+    await waitFor(() =>
+      expect(append).toHaveBeenCalledWith({
+        parentId: null,
+        message: innerMessage,
+      }),
+    );
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps paused messages unpersisted when the adapter lacks update", async () => {
+    const { append, getState, runCycle } = createPersistenceHarness(false);
+    const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
+
+    await runCycle([
+      createAssistantMessage(
+        { type: "requires-action", reason: "tool-calls" },
+        [{ id: "inner-a", parts: ["pending"] }],
+      ),
+    ]);
+
+    await waitFor(() => {
+      expect(getState).toHaveBeenCalledTimes(4);
+      expect(append).not.toHaveBeenCalled();
+    });
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        finalInnerMessage,
+      ]),
+    ]);
+
+    await waitFor(() =>
+      expect(append).toHaveBeenCalledWith({
+        parentId: null,
+        message: finalInnerMessage,
+      }),
+    );
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates the previously persisted message when its run completes", async () => {
+    const { append, update, runCycle } = createPersistenceHarness(true);
+    const pendingInnerMessage = { id: "inner-a", parts: ["pending"] };
+    const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
+
+    await runCycle([
+      createAssistantMessage(
+        { type: "requires-action", reason: "tool-calls" },
+        [pendingInnerMessage],
+      ),
+    ]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        finalInnerMessage,
+      ]),
+    ]);
+
+    await waitFor(() =>
+      expect(update).toHaveBeenCalledWith(
+        { parentId: null, message: finalInnerMessage },
+        "inner-a",
+      ),
+    );
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends continuation inner messages after approval", async () => {
+    const { append, update, runCycle } = createPersistenceHarness(true);
+    const pendingInnerMessage = { id: "inner-a", parts: ["pending"] };
+    const finalInnerMessage = { id: "inner-a", parts: ["pending", "final"] };
+    const continuationInnerMessage = { id: "inner-b", parts: ["answer"] };
+
+    await runCycle([
+      createAssistantMessage(
+        { type: "requires-action", reason: "tool-calls" },
+        [pendingInnerMessage],
+      ),
+    ]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        finalInnerMessage,
+        continuationInnerMessage,
+      ]),
+    ]);
+
+    await waitFor(() =>
+      expect(append).toHaveBeenCalledWith({
+        parentId: "inner-a",
+        message: continuationInnerMessage,
+      }),
+    );
+    expect(append.mock.calls.map(([item]) => item.message.id)).toEqual([
+      "inner-a",
+      "inner-b",
+    ]);
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      { parentId: null, message: finalInnerMessage },
+      "inner-a",
+    );
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -64,6 +64,7 @@ export const useExternalHistory = <TMessage>(
 
   const historyIds = useRef(new Set<string>());
   const persistedInnerIds = useRef(new Set<string>());
+  const deferredTelemetryIds = useRef(new Set<string>());
 
   const onSetMessagesRef = useRef(onSetMessages);
   useEffect(() => {
@@ -250,14 +251,17 @@ export const useExternalHistory = <TMessage>(
         for (const message of messages) {
           const innerMessages = getExternalStoreMessages<TMessage>(message);
 
-          const isReady =
+          const isTerminal =
             message.status === undefined ||
             message.status.type === "complete" ||
-            message.status.type === "incomplete" ||
-            // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
-            (message.status.type === "requires-action" &&
-              message.status.reason === "tool-calls" &&
-              formatAdapter.update !== undefined);
+            message.status.type === "incomplete";
+          const isAwaitingToolCalls =
+            message.status?.type === "requires-action" &&
+            message.status.reason === "tool-calls";
+          // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
+          const isReady =
+            isTerminal ||
+            (isAwaitingToolCalls && formatAdapter.update !== undefined);
 
           if (!isReady) {
             lastInnerMessageId =
@@ -266,23 +270,23 @@ export const useExternalHistory = <TMessage>(
           }
 
           if (historyIds.current.has(message.id)) {
-            let parentId = lastInnerMessageId;
-            for (const innerMessage of innerMessages) {
-              const innerMessageId = storageFormatAdapter.getId(innerMessage);
-              if (!persistedInnerIds.current.has(innerMessageId)) {
-                await formatAdapter.append({ parentId, message: innerMessage });
-                persistedInnerIds.current.add(innerMessageId);
+            const items = toBatchItems(innerMessages);
+            for (const item of items) {
+              const innerId = storageFormatAdapter.getId(item.message);
+              if (!persistedInnerIds.current.has(innerId)) {
+                await formatAdapter.append(item);
+                persistedInnerIds.current.add(innerId);
               } else if (durationMs !== undefined) {
                 try {
-                  await formatAdapter.update?.(
-                    { parentId, message: innerMessage },
-                    innerMessageId,
-                  );
+                  await formatAdapter.update?.(item, innerId);
                 } catch {
                   // ignore update failures to avoid breaking the message processing loop
                 }
               }
-              parentId = innerMessageId;
+            }
+            if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
+              deferredTelemetryIds.current.delete(message.id);
+              formatAdapter.reportTelemetry?.(items, telemetryOptions);
             }
             lastInnerMessageId =
               getLastInnerId(innerMessages) ?? lastInnerMessageId;
@@ -301,7 +305,11 @@ export const useExternalHistory = <TMessage>(
           lastInnerMessageId =
             getLastInnerId(innerMessages) ?? lastInnerMessageId;
 
-          formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+          if (isTerminal) {
+            formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+          } else {
+            deferredTelemetryIds.current.add(message.id);
+          }
         }
       }, 0);
     });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -45,6 +45,10 @@ export const toExportedMessageRepository = <TMessage>(
   };
 };
 
+const isAwaitingToolApproval = (message: ThreadMessage) =>
+  message.status?.type === "requires-action" &&
+  message.status.reason === "tool-calls";
+
 export const useExternalHistory = <TMessage>(
   runtimeRef: RefObject<AssistantRuntime>,
   historyAdapter: ThreadHistoryAdapter | undefined,
@@ -105,15 +109,10 @@ export const useExternalHistory = <TMessage>(
             messages.flatMap(getExternalStoreMessages<TMessage>),
           );
 
-          historyIds.current = new Set(
-            converted.messages.map((m) => m.message.id),
-          );
-
+          historyIds.current = new Set();
           for (const m of converted.messages) {
-            if (
-              m.message.status?.type === "requires-action" &&
-              m.message.status.reason === "tool-calls"
-            ) {
+            historyIds.current.add(m.message.id);
+            if (isAwaitingToolApproval(m.message)) {
               deferredTelemetryIds.current.add(m.message.id);
             }
           }
@@ -264,9 +263,7 @@ export const useExternalHistory = <TMessage>(
             message.status === undefined ||
             message.status.type === "complete" ||
             message.status.type === "incomplete";
-          const isAwaitingToolCalls =
-            message.status?.type === "requires-action" &&
-            message.status.reason === "tool-calls";
+          const isAwaitingToolCalls = isAwaitingToolApproval(message);
           // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
           const isReady =
             isTerminal ||

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -63,6 +63,7 @@ export const useExternalHistory = <TMessage>(
   const [isLoading, setIsLoading] = useState(false);
 
   const historyIds = useRef(new Set<string>());
+  const persistedInnerIds = useRef(new Set<string>());
 
   const onSetMessagesRef = useRef(onSetMessages);
   useEffect(() => {
@@ -87,6 +88,11 @@ export const useExternalHistory = <TMessage>(
       try {
         const repo = await formatAdapter.load();
         if (repo && repo.messages.length > 0) {
+          for (const m of repo.messages) {
+            persistedInnerIds.current.add(
+              storageFormatAdapter.getId(m.message),
+            );
+          }
           const converted = toExportedMessageRepository(toThreadMessages, repo);
           runtimeRef.current.thread.import(converted);
 
@@ -117,7 +123,13 @@ export const useExternalHistory = <TMessage>(
     }
 
     loadHistory();
-  }, [formatAdapter, toThreadMessages, runtimeRef, optionalThreadListItem]);
+  }, [
+    formatAdapter,
+    toThreadMessages,
+    runtimeRef,
+    optionalThreadListItem,
+    storageFormatAdapter,
+  ]);
 
   const runStartRef = useRef<number | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -241,7 +253,11 @@ export const useExternalHistory = <TMessage>(
           const isReady =
             message.status === undefined ||
             message.status.type === "complete" ||
-            message.status.type === "incomplete";
+            message.status.type === "incomplete" ||
+            // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
+            (message.status.type === "requires-action" &&
+              message.status.reason === "tool-calls" &&
+              formatAdapter.update !== undefined);
 
           if (!isReady) {
             lastInnerMessageId =
@@ -250,19 +266,23 @@ export const useExternalHistory = <TMessage>(
           }
 
           if (historyIds.current.has(message.id)) {
-            if (durationMs !== undefined) {
-              let parentId = lastInnerMessageId;
-              for (const innerMessage of innerMessages) {
+            let parentId = lastInnerMessageId;
+            for (const innerMessage of innerMessages) {
+              const innerMessageId = storageFormatAdapter.getId(innerMessage);
+              if (!persistedInnerIds.current.has(innerMessageId)) {
+                await formatAdapter.append({ parentId, message: innerMessage });
+                persistedInnerIds.current.add(innerMessageId);
+              } else if (durationMs !== undefined) {
                 try {
                   await formatAdapter.update?.(
                     { parentId, message: innerMessage },
-                    storageFormatAdapter.getId(innerMessage),
+                    innerMessageId,
                   );
                 } catch {
                   // ignore update failures to avoid breaking the message processing loop
                 }
-                parentId = storageFormatAdapter.getId(innerMessage);
               }
+              parentId = innerMessageId;
             }
             lastInnerMessageId =
               getLastInnerId(innerMessages) ?? lastInnerMessageId;
@@ -273,6 +293,9 @@ export const useExternalHistory = <TMessage>(
           const batchItems = toBatchItems(innerMessages);
           for (const item of batchItems) {
             await formatAdapter.append(item);
+            persistedInnerIds.current.add(
+              storageFormatAdapter.getId(item.message),
+            );
           }
 
           lastInnerMessageId =
@@ -317,6 +340,11 @@ export const useExternalHistory = <TMessage>(
       await formatAdapter.delete(itemsToDelete);
 
       historyIds.current.delete(messageId);
+      for (const item of itemsToDelete) {
+        persistedInnerIds.current.delete(
+          storageFormatAdapter.getId(item.message),
+        );
+      }
     },
     [formatAdapter, runtimeRef, storageFormatAdapter],
   );

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -108,6 +108,15 @@ export const useExternalHistory = <TMessage>(
           historyIds.current = new Set(
             converted.messages.map((m) => m.message.id),
           );
+
+          for (const m of converted.messages) {
+            if (
+              m.message.status?.type === "requires-action" &&
+              m.message.status.reason === "tool-calls"
+            ) {
+              deferredTelemetryIds.current.add(m.message.id);
+            }
+          }
         }
       } catch (error) {
         console.error("Failed to load message history:", error);
@@ -348,6 +357,7 @@ export const useExternalHistory = <TMessage>(
       await formatAdapter.delete(itemsToDelete);
 
       historyIds.current.delete(messageId);
+      deferredTelemetryIds.current.delete(messageId);
       for (const item of itemsToDelete) {
         persistedInnerIds.current.delete(
           storageFormatAdapter.getId(item.message),


### PR DESCRIPTION
closes #5046
closes #5050

## summary

- assistant messages paused for tool call approval (`requires-action/tool-calls`) are now persisted by `useExternalHistory`, so a page refresh no longer loses the pending approval state
- the paused message is persisted early only when the formatted history adapter supports `update`; adapters that only implement `load` and `append` keep the previous behavior (skip while paused, full append once complete) instead of gaining silent data loss on the post-approval run
- the hook now tracks persisted inner message ids across load, append, and delete; when a run stop revisits an already persisted outer message it appends inner messages that are not yet in storage (post-approval continuations, with correct parent chaining) and updates the ones that are
- the naive alternative (only widening the readiness guard) leaves the post-approval tool output and final answer unrecoverable for load plus append adapters and drops new-id continuations even on Assistant Cloud; the full failure analysis is in #5050

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useExternalHistory.test.ts` -> 10/10 green, including 4 new tests covering the paused append, the no-update adapter keeping old behavior, the post-approval update, and the continuation append with parent chaining
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 160/160 green
- [x] `pnpm --filter @assistant-ui/react-ai-sdk build` -> green
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` clean on the changed files

### reviewer should verify

- [ ] with `useChatRuntime`, a cloud history adapter, and a `needsApproval: true` tool: refresh mid-approval, confirm the approval prompt is restored; approve, let the run finish, reload again, and confirm the tool output and final answer are present in the restored thread

## notes

- LocalRuntime has the same persistence gap but its top-level `ThreadHistoryAdapter` has no `update` method, so this shape does not transplant; tracked as a follow-up in #5050 along with the `CloudMessagePersistence.update` silent skip and the missing `update` documentation for DIY adapters
- supersedes the approach attempted in #5049

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

