### PR TITLE
fix(react-ai-sdk): skip rewriting unchanged history after each run

### DIFF
--- a/.changeset/skip-unchanged-history-rewrites.md
+++ b/.changeset/skip-unchanged-history-rewrites.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): skip rewriting unchanged messages after each run

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -501,10 +501,10 @@ describe("useExternalHistory persistence", () => {
   it("skips unchanged persisted messages on later runs", async () => {
     const { append, update, reportTelemetry, runCycle, flush } =
       createPersistenceHarness(true);
-    const completeStatus = {
+    const completeStatus: ThreadAssistantMessage["status"] = {
       type: "complete",
       reason: "stop",
-    } as ThreadAssistantMessage["status"];
+    };
     const old = createAssistantMessage(
       completeStatus,
       [{ id: "inner-old", parts: ["old"] }],
@@ -551,10 +551,10 @@ describe("useExternalHistory persistence", () => {
   it("absorbs agentic flickers without losing change detection", async () => {
     const { append, update, reportTelemetry, runCycle, flush, step } =
       createPersistenceHarness(true);
-    const completeStatus = {
+    const completeStatus: ThreadAssistantMessage["status"] = {
       type: "complete",
       reason: "stop",
-    } as ThreadAssistantMessage["status"];
+    };
     const old = createAssistantMessage(
       completeStatus,
       [{ id: "inner-old", parts: ["old"] }],
@@ -684,6 +684,51 @@ describe("useExternalHistory persistence", () => {
         message: { id: "inner-a", parts: ["changed"] },
       },
       "inner-a",
+    );
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("detects changes on non-assistant messages", async () => {
+    const { append, update, runCycle, flush } = createPersistenceHarness(true);
+    const makeUserMessage = (inner: InnerMessage): ThreadMessage => {
+      const message: ThreadMessage = {
+        id: "user-1",
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+        attachments: [],
+        createdAt: new Date(),
+        metadata: { custom: {} },
+      };
+      bindExternalStoreMessage(message, [inner]);
+      return message;
+    };
+    const assistant = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["answer"] }],
+    );
+
+    await runCycle([
+      makeUserMessage({ id: "inner-user", parts: ["hi"] }),
+      assistant,
+    ]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(2));
+
+    append.mockClear();
+    update.mockClear();
+
+    await runCycle([
+      makeUserMessage({ id: "inner-user", parts: ["hi", "attachment"] }),
+      assistant,
+    ]);
+    await flush();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      {
+        parentId: null,
+        message: { id: "inner-user", parts: ["hi", "attachment"] },
+      },
+      "inner-user",
     );
     expect(append).not.toHaveBeenCalled();
   });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -189,9 +189,10 @@ describe("useExternalHistory persistence", () => {
   const createAssistantMessage = (
     status: ThreadAssistantMessage["status"],
     innerMessages: InnerMessage[],
+    id = "assistant-a",
   ): ThreadMessage => {
     const message: ThreadAssistantMessage = {
-      id: "assistant-a",
+      id,
       role: "assistant",
       content: [],
       createdAt: new Date(),
@@ -284,7 +285,17 @@ describe("useExternalHistory persistence", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-    return { append, update, reportTelemetry, load, runCycle, flush };
+    const step = (partial: {
+      isRunning?: boolean;
+      messages?: ThreadMessage[];
+    }) =>
+      act(async () => {
+        if (partial.messages !== undefined) messages = partial.messages;
+        if (partial.isRunning !== undefined) isRunning = partial.isRunning;
+        listener?.();
+      });
+
+    return { append, update, reportTelemetry, load, runCycle, flush, step };
   };
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
@@ -485,5 +496,195 @@ describe("useExternalHistory persistence", () => {
       ],
       expect.any(Object),
     );
+  });
+
+  it("skips unchanged persisted messages on later runs", async () => {
+    const { append, update, reportTelemetry, runCycle, flush } =
+      createPersistenceHarness(true);
+    const completeStatus = {
+      type: "complete",
+      reason: "stop",
+    } as ThreadAssistantMessage["status"];
+    const old = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-old", parts: ["old"] }],
+      "old",
+    );
+    const active = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-active", parts: ["initial"] }],
+      "active",
+    );
+    const tail = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-tail", parts: ["tail"] }],
+      "tail",
+    );
+
+    await runCycle([old, active, tail]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(3));
+
+    append.mockClear();
+    update.mockClear();
+    reportTelemetry.mockClear();
+
+    const changedActive = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-active", parts: ["completed"] }],
+      "active",
+    );
+    await runCycle([old, changedActive, tail]);
+    await flush();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      {
+        parentId: "inner-old",
+        message: { id: "inner-active", parts: ["completed"] },
+      },
+      "inner-active",
+    );
+    expect(append).not.toHaveBeenCalled();
+    expect(reportTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("absorbs agentic flickers without losing change detection", async () => {
+    const { append, update, reportTelemetry, runCycle, flush, step } =
+      createPersistenceHarness(true);
+    const completeStatus = {
+      type: "complete",
+      reason: "stop",
+    } as ThreadAssistantMessage["status"];
+    const old = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-old", parts: ["old"] }],
+      "old",
+    );
+    const active = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-active", parts: ["initial"] }],
+      "active",
+    );
+    const tail = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-tail", parts: ["tail"] }],
+      "tail",
+    );
+
+    await runCycle([old, active, tail]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(3));
+
+    append.mockClear();
+    update.mockClear();
+    reportTelemetry.mockClear();
+
+    const changedActive = createAssistantMessage(
+      completeStatus,
+      [{ id: "inner-active", parts: ["completed"] }],
+      "active",
+    );
+    await step({ isRunning: true });
+    await step({ messages: [old, changedActive, tail] });
+    await step({ isRunning: false });
+    await step({ isRunning: true });
+    await step({ isRunning: false });
+    await flush();
+
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+    expect(update).toHaveBeenCalledWith(
+      {
+        parentId: "inner-old",
+        message: { id: "inner-active", parts: ["completed"] },
+      },
+      "inner-active",
+    );
+    expect(append).not.toHaveBeenCalled();
+    expect(reportTelemetry).not.toHaveBeenCalled();
+  });
+
+  it("persists idle-time changes on the next run stop", async () => {
+    const { append, update, reportTelemetry, runCycle, flush, step } =
+      createPersistenceHarness(true);
+    const initialActive = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["initial"] }],
+      "active",
+    );
+
+    await runCycle([initialActive]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    append.mockClear();
+    update.mockClear();
+    reportTelemetry.mockClear();
+
+    const changedActive = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["initial", "tool-result"] }],
+      "active",
+    );
+    await step({ messages: [changedActive] });
+
+    await runCycle([changedActive]);
+    await flush();
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith(
+      {
+        parentId: null,
+        message: { id: "inner-a", parts: ["initial", "tool-result"] },
+      },
+      "inner-a",
+    );
+    expect(append).not.toHaveBeenCalled();
+  });
+
+  it("retries a failed update on the next run", async () => {
+    const { append, update, reportTelemetry, runCycle, flush } =
+      createPersistenceHarness(true);
+    const initialActive = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["initial"] }],
+      "active",
+    );
+
+    await runCycle([initialActive]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    append.mockClear();
+    update.mockClear();
+    reportTelemetry.mockClear();
+    update.mockRejectedValueOnce(new Error("boom"));
+
+    const changedActive = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["changed"] }],
+      "active",
+    );
+    const changedMessages = [changedActive];
+
+    await runCycle(changedMessages);
+    await flush();
+    await runCycle(changedMessages);
+    await flush();
+
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenNthCalledWith(
+      1,
+      {
+        parentId: null,
+        message: { id: "inner-a", parts: ["changed"] },
+      },
+      "inner-a",
+    );
+    expect(update).toHaveBeenNthCalledWith(
+      2,
+      {
+        parentId: null,
+        message: { id: "inner-a", parts: ["changed"] },
+      },
+      "inner-a",
+    );
+    expect(append).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -217,7 +217,6 @@ export const useExternalHistory = <TMessage>(
 
         const changedRunMessageIds = new Set<string>();
         for (const message of latest.messages) {
-          if (message.role !== "assistant") continue;
           const externalMessages = getExternalStoreMessages<TMessage>(message);
           const previous = persistedExternalMessages.current.get(message.id);
           if (

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -49,6 +49,16 @@ const isAwaitingToolApproval = (message: ThreadMessage) =>
   message.status?.type === "requires-action" &&
   message.status.reason === "tool-calls";
 
+const snapshotExternalMessages = <TMessage>(
+  messages: readonly ThreadMessage[],
+) =>
+  new Map<string, TMessage[]>(
+    messages.map((message) => [
+      message.id,
+      [...getExternalStoreMessages<TMessage>(message)],
+    ]),
+  );
+
 export const useExternalHistory = <TMessage>(
   runtimeRef: RefObject<AssistantRuntime>,
   historyAdapter: ThreadHistoryAdapter | undefined,
@@ -69,6 +79,7 @@ export const useExternalHistory = <TMessage>(
   const historyIds = useRef(new Set<string>());
   const persistedInnerIds = useRef(new Set<string>());
   const deferredTelemetryIds = useRef(new Set<string>());
+  const persistedExternalMessages = useRef(new Map<string, TMessage[]>());
 
   const onSetMessagesRef = useRef(onSetMessages);
   useEffect(() => {
@@ -116,6 +127,10 @@ export const useExternalHistory = <TMessage>(
               deferredTelemetryIds.current.add(m.message.id);
             }
           }
+          persistedExternalMessages.current =
+            snapshotExternalMessages<TMessage>(
+              converted.messages.map((m) => m.message),
+            );
         }
       } catch (error) {
         console.error("Failed to load message history:", error);
@@ -150,13 +165,14 @@ export const useExternalHistory = <TMessage>(
     if (!formatAdapter) return;
 
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
-      const { isRunning } = runtimeRef.current.thread.getState();
+      const threadState = runtimeRef.current.thread.getState();
+      const { isRunning } = threadState;
       const wasRunning = wasRunningRef.current;
       wasRunningRef.current = isRunning;
 
       // Track step boundaries by content changes (more reliable than isRunning)
       if (runStartRef.current != null) {
-        const lastMsg = runtimeRef.current.thread.getState().messages.at(-1);
+        const lastMsg = threadState.messages.at(-1);
         if (lastMsg?.role === "assistant") {
           const currentToolCallCount = lastMsg.content.filter(
             (p) => p.type === "tool-call",
@@ -198,6 +214,20 @@ export const useExternalHistory = <TMessage>(
         // Re-read latest state — may have changed since the timeout was scheduled
         const latest = runtimeRef.current.thread.getState();
         if (latest.isRunning) return; // was just a flicker
+
+        const changedRunMessageIds = new Set<string>();
+        for (const message of latest.messages) {
+          if (message.role !== "assistant") continue;
+          const externalMessages = getExternalStoreMessages<TMessage>(message);
+          const previous = persistedExternalMessages.current.get(message.id);
+          if (
+            previous === undefined ||
+            previous.length !== externalMessages.length ||
+            externalMessages.some((item, index) => item !== previous[index])
+          ) {
+            changedRunMessageIds.add(message.id);
+          }
+        }
 
         // Derive durationMs from the last boundary (covers all steps)
         const boundaries = stepBoundariesRef.current;
@@ -243,6 +273,7 @@ export const useExternalHistory = <TMessage>(
 
         const { messages } = latest;
         let lastInnerMessageId: string | null = null;
+        const failedUpdateIds = new Set<string>();
 
         const getLastInnerId = (msgs: TMessage[]): string | null =>
           msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
@@ -276,23 +307,26 @@ export const useExternalHistory = <TMessage>(
           }
 
           if (historyIds.current.has(message.id)) {
-            const items = toBatchItems(innerMessages);
-            for (const item of items) {
-              const innerId = storageFormatAdapter.getId(item.message);
-              if (!persistedInnerIds.current.has(innerId)) {
-                await formatAdapter.append(item);
-                persistedInnerIds.current.add(innerId);
-              } else if (durationMs !== undefined) {
-                try {
-                  await formatAdapter.update?.(item, innerId);
-                } catch {
-                  // ignore update failures to avoid breaking the message processing loop
+            if (changedRunMessageIds.has(message.id)) {
+              const items = toBatchItems(innerMessages);
+              for (const item of items) {
+                const innerId = storageFormatAdapter.getId(item.message);
+                if (!persistedInnerIds.current.has(innerId)) {
+                  await formatAdapter.append(item);
+                  persistedInnerIds.current.add(innerId);
+                } else if (durationMs !== undefined) {
+                  try {
+                    await formatAdapter.update?.(item, innerId);
+                  } catch {
+                    // ignore update failures to avoid breaking the message processing loop
+                    failedUpdateIds.add(message.id);
+                  }
                 }
               }
-            }
-            if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
-              deferredTelemetryIds.current.delete(message.id);
-              formatAdapter.reportTelemetry?.(items, telemetryOptions);
+              if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
+                deferredTelemetryIds.current.delete(message.id);
+                formatAdapter.reportTelemetry?.(items, telemetryOptions);
+              }
             }
             lastInnerMessageId =
               getLastInnerId(innerMessages) ?? lastInnerMessageId;
@@ -317,6 +351,14 @@ export const useExternalHistory = <TMessage>(
             deferredTelemetryIds.current.add(message.id);
           }
         }
+
+        const nextSnapshot = snapshotExternalMessages<TMessage>(
+          latest.messages,
+        );
+        for (const id of failedUpdateIds) {
+          nextSnapshot.delete(id);
+        }
+        persistedExternalMessages.current = nextSnapshot;
       }, 0);
     });
 
@@ -355,6 +397,7 @@ export const useExternalHistory = <TMessage>(
 
       historyIds.current.delete(messageId);
       deferredTelemetryIds.current.delete(messageId);
+      persistedExternalMessages.current.delete(messageId);
       for (const item of itemsToDelete) {
         persistedInnerIds.current.delete(
           storageFormatAdapter.getId(item.message),

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -317,7 +317,7 @@ export const useExternalHistory = <TMessage>(
                   try {
                     await formatAdapter.update?.(item, innerId);
                   } catch {
-                    // ignore update failures to avoid breaking the message processing loop
+                    // A failed update drops the message from the refreshed baseline so it retries on the next run stop.
                     failedUpdateIds.add(message.id);
                   }
                 }


### PR DESCRIPTION
closes #5047

## summary

- `useExternalHistory` no longer rewrites every already-persisted message on every run stop; long threads previously produced one storage write per historical message per turn, including user messages
- the persist pass now diffs each assistant message's bound inner messages (by reference and length) against a snapshot taken at the last successful persist, and only changed messages enter the revisit branch's append/update/telemetry work
- baselining against the last persist rather than the run start means changes that land while the thread is idle (for example a client tool result added between runs) are still written at the next run stop, and a failed `update` drops its message from the refreshed baseline so it retries on the next run
- the baseline is seeded from loaded history so the first turn after a reload does not sweep the whole thread, and `deleteMessage` cleans its entry up alongside the existing id sets
- the change-detection idea originates from #5048; this lands it against the current persistence structure (post #5051) without that PR's telemetry double-report

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk exec vitest run src/ui/use-chat/useExternalHistory.test.ts` -> 16/16 green, including 4 new tests: unchanged messages are skipped, agentic flickers do not break detection, idle-time changes persist on the next run stop, and a failed update retries on the next run
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 166/166 green
- [x] `pnpm --filter @assistant-ui/react-ai-sdk build` -> green
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` clean on the changed files

### reviewer should verify

- [ ] with a custom `withFormat` history adapter that logs `append`/`update` calls: build a thread with 5 to 10 persisted messages, send one more message, and confirm the run stop produces writes only for the new user message and the new assistant message instead of one `update` per historical message

## notes

- reference-based change detection relies on AI SDK's immutable state updates; code that mutates inner messages in place (which also breaks React rendering) would no longer be repaired by the old full sweep
- two pre-existing edges in this area are tracked separately rather than folded in: overlapping persist passes on slow adapters can double-append (present since the revisit branch gained append capability), and the fresh-append branch does not consult `persistedInnerIds` in a contrived outer-id-change case; a follow-up issue covers serializing the persist pass and unifying the two branches
- supersedes #5048

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

