### PR TITLE
fix(react-pi): validate HTTP response payloads

### DIFF
--- a/.changeset/react-pi-http-response-validation.md
+++ b/.changeset/react-pi-http-response-validation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: validate JSON payloads returned by the Pi HTTP client

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -289,6 +289,21 @@ describe("createPiHttpClient", () => {
     ).resolves.toEqual(response);
   });
 
+  it("rejects tool results without a tool call id", async () => {
+    const { fn } = fakeFetch(() =>
+      json({
+        ...snapshot,
+        messages: [{ role: "toolResult", content: [] }],
+      }),
+    );
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  });
+
   it("rejects malformed known host UI request shapes", async () => {
     const { fn } = fakeFetch(() =>
       json({

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -195,6 +195,70 @@ describe("createPiHttpClient", () => {
     ).rejects.toThrow(/404.*session not found/s);
   });
 
+  it("rejects a malformed thread list response", async () => {
+    const { fn } = fakeFetch(() => json({}));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).listThreads(),
+    ).rejects.toThrow(
+      "Invalid Pi HTTP response while listing threads: expected an array of threads.",
+    );
+  });
+
+  it("identifies malformed thread metadata by index", async () => {
+    const { fn } = fakeFetch(() => json([{ id: "t1" }]));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).listThreads(),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a valid "status", and valid queued messages when present.',
+    );
+  });
+
+  it("rejects malformed thread snapshots", async () => {
+    const { fn } = fakeFetch(() => json({ metadata: snapshot.metadata }));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  });
+
+  it("rejects malformed queue and model responses", async () => {
+    const queueFetch = fakeFetch(() =>
+      json({ steering: [1], followUp: [] }),
+    ).fn;
+    const modelFetch = fakeFetch(() => json([{ provider: "anthropic" }])).fn;
+
+    await expect(
+      createPiHttpClient({ fetchImpl: queueFetch }).clearQueue("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while clearing a thread queue: expected an object with string arrays "steering" and "followUp".',
+    );
+    await expect(
+      createPiHttpClient({ fetchImpl: modelFetch }).getAvailableModels(),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while listing models: model at index 0 must have non-empty string "provider" and "modelId" fields.',
+    );
+  });
+
+  it("adds operation context to invalid JSON errors", async () => {
+    const { fn } = fakeFetch(
+      () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+    );
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).listThreads(),
+    ).rejects.toThrow(
+      "Invalid Pi HTTP response while listing threads: expected valid JSON.",
+    );
+  });
+
   it("honors a custom baseUrl", async () => {
     const { fn, calls } = fakeFetch(() => json([]));
     await createPiHttpClient({

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -211,12 +211,49 @@ describe("createPiHttpClient", () => {
     await expect(
       createPiHttpClient({ fetchImpl: fn }).listThreads(),
     ).rejects.toThrow(
-      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a valid "status", and valid queued messages when present.',
+      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a string "status", and structurally valid queued messages when present.',
     );
+  });
+
+  it("accepts unknown enum values from newer Pi servers", async () => {
+    const thread = {
+      id: "t1",
+      status: "paused",
+      queuedMessages: [{ id: "q1", mode: "priority", content: "later" }],
+    };
+    const listFetch = fakeFetch(() => json([thread])).fn;
+    const snapshotWithUnknownValues = {
+      metadata: thread,
+      messages: [{ role: "futureRole" }],
+      hostUiRequests: [{ id: "r1", kind: "form" }],
+    };
+    const snapshotFetch = fakeFetch(() => json(snapshotWithUnknownValues)).fn;
+
+    await expect(
+      createPiHttpClient({ fetchImpl: listFetch }).listThreads(),
+    ).resolves.toEqual([thread]);
+    await expect(
+      createPiHttpClient({ fetchImpl: snapshotFetch }).getThread("t1"),
+    ).resolves.toEqual(snapshotWithUnknownValues);
   });
 
   it("rejects malformed thread snapshots", async () => {
     const { fn } = fakeFetch(() => json({ metadata: snapshot.metadata }));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  });
+
+  it("rejects malformed known host UI request shapes", async () => {
+    const { fn } = fakeFetch(() =>
+      json({
+        ...snapshot,
+        hostUiRequests: [{ id: "r1", kind: "select", title: "Choose" }],
+      }),
+    );
 
     await expect(
       createPiHttpClient({ fetchImpl: fn }).getThread("t1"),

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -263,7 +263,7 @@ describe("createPiHttpClient", () => {
     const { fn } = fakeFetch(() =>
       json({
         ...snapshot,
-        messages: [{ role: "assistant", content: [] }],
+        messages: [{ role: "assistant" }],
       }),
     );
 
@@ -274,29 +274,12 @@ describe("createPiHttpClient", () => {
     );
   });
 
-  it("accepts complete known transcript messages", async () => {
+  it("accepts renderable messages with missing or null scalar metadata", async () => {
     const message = {
       role: "assistant",
       content: [{ type: "text", text: "Hello" }],
-      api: "messages",
-      provider: "anthropic",
-      model: "claude",
-      usage: {
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 2,
-        cost: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          total: 0,
-        },
-      },
-      stopReason: "stop",
-      timestamp: 1,
+      responseModel: null,
+      errorMessage: null,
     };
     const response = { ...snapshot, messages: [message] };
     const { fn } = fakeFetch(() => json(response));

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -263,7 +263,7 @@ describe("createPiHttpClient", () => {
     const { fn } = fakeFetch(() =>
       json({
         ...snapshot,
-        messages: [{ role: "assistant" }],
+        messages: [{ role: "assistant", content: [] }],
       }),
     );
 
@@ -272,6 +272,38 @@ describe("createPiHttpClient", () => {
     ).rejects.toThrow(
       'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
     );
+  });
+
+  it("accepts complete known transcript messages", async () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Hello" }],
+      api: "messages",
+      provider: "anthropic",
+      model: "claude",
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason: "stop",
+      timestamp: 1,
+    };
+    const response = { ...snapshot, messages: [message] };
+    const { fn } = fakeFetch(() => json(response));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).resolves.toEqual(response);
   });
 
   it("rejects malformed known host UI request shapes", async () => {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -211,7 +211,19 @@ describe("createPiHttpClient", () => {
     await expect(
       createPiHttpClient({ fetchImpl: fn }).listThreads(),
     ).rejects.toThrow(
-      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a string "status", and structurally valid queued messages when present.',
+      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a string "status", and correctly typed known fields.',
+    );
+  });
+
+  it("rejects malformed known thread metadata fields", async () => {
+    const { fn } = fakeFetch(() =>
+      json([{ id: "t1", status: "idle", archived: "yes" }]),
+    );
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).listThreads(),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while listing threads: thread at index 0 must have a non-empty string "id", a string "status", and correctly typed known fields.',
     );
   });
 
@@ -239,6 +251,21 @@ describe("createPiHttpClient", () => {
 
   it("rejects malformed thread snapshots", async () => {
     const { fn } = fakeFetch(() => json({ metadata: snapshot.metadata }));
+
+    await expect(
+      createPiHttpClient({ fetchImpl: fn }).getThread("t1"),
+    ).rejects.toThrow(
+      'Invalid Pi HTTP response while fetching a thread: expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  });
+
+  it("rejects malformed known transcript messages", async () => {
+    const { fn } = fakeFetch(() =>
+      json({
+        ...snapshot,
+        messages: [{ role: "assistant" }],
+      }),
+    );
 
     await expect(
       createPiHttpClient({ fetchImpl: fn }).getThread("t1"),

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -216,7 +216,9 @@ const isTranscriptMessage = (value: unknown): boolean => {
   }
   if (value.role === "toolResult") {
     return (
-      Array.isArray(value.content) && value.content.every(isUserContentPart)
+      typeof value.toolCallId === "string" &&
+      Array.isArray(value.content) &&
+      value.content.every(isUserContentPart)
     );
   }
   return true;

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -179,11 +179,7 @@ const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
 
 const isUserContentPart = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") {
-    return (
-      typeof value.text === "string" && isOptionalString(value.textSignature)
-    );
-  }
+  if (value.type === "text") return typeof value.text === "string";
   if (value.type === "image") {
     return typeof value.data === "string" && typeof value.mimeType === "string";
   }
@@ -196,105 +192,31 @@ const isUserContent = (value: unknown): boolean =>
 
 const isAssistantContentPart = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") {
-    return (
-      typeof value.text === "string" && isOptionalString(value.textSignature)
-    );
-  }
-  if (value.type === "thinking") {
-    return (
-      typeof value.thinking === "string" &&
-      isOptionalString(value.thinkingSignature) &&
-      isOptionalBoolean(value.redacted)
-    );
-  }
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "thinking") return typeof value.thinking === "string";
   if (value.type === "toolCall") {
     return (
       typeof value.id === "string" &&
       typeof value.name === "string" &&
-      isRecord(value.arguments) &&
-      isOptionalString(value.thoughtSignature)
+      (value.arguments == null || isRecord(value.arguments))
     );
   }
   return true;
 };
 
-const isUsage = (value: unknown): boolean =>
-  isRecord(value) &&
-  typeof value.input === "number" &&
-  typeof value.output === "number" &&
-  typeof value.cacheRead === "number" &&
-  typeof value.cacheWrite === "number" &&
-  typeof value.totalTokens === "number" &&
-  isRecord(value.cost) &&
-  typeof value.cost.input === "number" &&
-  typeof value.cost.output === "number" &&
-  typeof value.cost.cacheRead === "number" &&
-  typeof value.cost.cacheWrite === "number" &&
-  typeof value.cost.total === "number";
-
 const isTranscriptMessage = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.role !== "string") return false;
-  if (value.role === "user") {
-    return isUserContent(value.content) && typeof value.timestamp === "number";
-  }
+  if (value.role === "user" || value.role === "custom")
+    return isUserContent(value.content);
   if (value.role === "assistant") {
     return (
       Array.isArray(value.content) &&
-      value.content.every(isAssistantContentPart) &&
-      typeof value.api === "string" &&
-      typeof value.provider === "string" &&
-      typeof value.model === "string" &&
-      isOptionalString(value.responseModel) &&
-      isOptionalString(value.responseId) &&
-      isUsage(value.usage) &&
-      typeof value.stopReason === "string" &&
-      isOptionalString(value.errorMessage) &&
-      typeof value.timestamp === "number"
+      value.content.every(isAssistantContentPart)
     );
   }
   if (value.role === "toolResult") {
     return (
-      typeof value.toolCallId === "string" &&
-      typeof value.toolName === "string" &&
-      Array.isArray(value.content) &&
-      value.content.every(isUserContentPart) &&
-      typeof value.isError === "boolean" &&
-      typeof value.timestamp === "number"
-    );
-  }
-  if (value.role === "bashExecution") {
-    return (
-      typeof value.command === "string" &&
-      typeof value.output === "string" &&
-      (value.exitCode === undefined || typeof value.exitCode === "number") &&
-      typeof value.cancelled === "boolean" &&
-      typeof value.truncated === "boolean" &&
-      isOptionalString(value.fullOutputPath) &&
-      typeof value.timestamp === "number" &&
-      isOptionalBoolean(value.excludeFromContext)
-    );
-  }
-  if (value.role === "custom") {
-    return (
-      typeof value.customType === "string" &&
-      isUserContent(value.content) &&
-      typeof value.display === "boolean" &&
-      typeof value.timestamp === "number"
-    );
-  }
-  if (value.role === "branchSummary") {
-    return (
-      typeof value.summary === "string" &&
-      typeof value.fromId === "string" &&
-      typeof value.timestamp === "number"
-    );
-  }
-  if (value.role === "compactionSummary") {
-    return (
-      typeof value.summary === "string" &&
-      typeof value.tokensBefore === "number" &&
-      typeof value.timestamp === "number"
+      Array.isArray(value.content) && value.content.every(isUserContentPart)
     );
   }
   return true;

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -26,6 +26,7 @@
  *   POST   /threads/:id/host-ui     → 204                   (body: { response })
  *   GET    /threads/:id/events      → SSE of PiClientEvent (?snapshot=false skips initial snapshot)
  */
+import { isRecord } from "@assistant-ui/core/internal";
 import { openPiEventStream } from "./eventSource";
 import type {
   PiClient,
@@ -105,17 +106,11 @@ const readJson = async (
   }
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isThreadStatus = (value: unknown): value is PiThreadMetadata["status"] =>
-  value === "idle" || value === "running" || value === "failed";
-
 const isQueuedMessage = (value: unknown): boolean => {
   if (!isRecord(value)) return false;
   return (
     typeof value.id === "string" &&
-    (value.mode === "followUp" || value.mode === "steer") &&
+    typeof value.mode === "string" &&
     typeof value.content === "string"
   );
 };
@@ -125,7 +120,7 @@ const isThreadMetadata = (value: unknown): value is PiThreadMetadata => {
   return (
     typeof value.id === "string" &&
     value.id.length > 0 &&
-    isThreadStatus(value.status) &&
+    typeof value.status === "string" &&
     (value.queuedMessages === undefined ||
       (Array.isArray(value.queuedMessages) &&
         value.queuedMessages.every(isQueuedMessage)))
@@ -141,7 +136,7 @@ const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
     if (!isThreadMetadata(thread)) {
       throw invalidResponse(
         "listing threads",
-        `thread at index ${index} must have a non-empty string "id", a valid "status", and valid queued messages when present.`,
+        `thread at index ${index} must have a non-empty string "id", a string "status", and structurally valid queued messages when present.`,
       );
     }
   }
@@ -153,13 +148,24 @@ const isTranscriptMessage = (value: unknown): boolean =>
 
 const isHostUiRequest = (value: unknown): boolean => {
   if (!isRecord(value)) return false;
-  return (
-    typeof value.id === "string" &&
-    (value.kind === "confirm" ||
-      value.kind === "select" ||
-      value.kind === "input" ||
-      value.kind === "editor")
-  );
+  if (typeof value.id !== "string" || typeof value.kind !== "string") {
+    return false;
+  }
+
+  if (value.kind === "confirm") {
+    return typeof value.title === "string" && typeof value.message === "string";
+  }
+  if (value.kind === "select") {
+    return (
+      typeof value.title === "string" &&
+      Array.isArray(value.options) &&
+      value.options.every((option) => typeof option === "string")
+    );
+  }
+  if (value.kind === "input" || value.kind === "editor") {
+    return typeof value.title === "string";
+  }
+  return true;
 };
 
 const parseThreadSnapshotResponse = (

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -106,6 +106,15 @@ const readJson = async (
   }
 };
 
+const isOptionalString = (value: unknown): boolean =>
+  value === undefined || typeof value === "string";
+
+const isOptionalBoolean = (value: unknown): boolean =>
+  value === undefined || typeof value === "boolean";
+
+const isOptionalNumber = (value: unknown): boolean =>
+  value === undefined || typeof value === "number";
+
 const isQueuedMessage = (value: unknown): boolean => {
   if (!isRecord(value)) return false;
   return (
@@ -115,6 +124,20 @@ const isQueuedMessage = (value: unknown): boolean => {
   );
 };
 
+const isThreadConfig = (value: unknown): boolean =>
+  value === undefined ||
+  (isRecord(value) &&
+    isOptionalString(value.provider) &&
+    isOptionalString(value.modelId) &&
+    isOptionalString(value.thinkingLevel));
+
+const isContextUsage = (value: unknown): boolean =>
+  value === undefined ||
+  (isRecord(value) &&
+    (value.tokens === null || typeof value.tokens === "number") &&
+    typeof value.contextWindow === "number" &&
+    (value.percent === null || typeof value.percent === "number"));
+
 const isThreadMetadata = (value: unknown): value is PiThreadMetadata => {
   if (!isRecord(value)) return false;
   return (
@@ -123,7 +146,18 @@ const isThreadMetadata = (value: unknown): value is PiThreadMetadata => {
     typeof value.status === "string" &&
     (value.queuedMessages === undefined ||
       (Array.isArray(value.queuedMessages) &&
-        value.queuedMessages.every(isQueuedMessage)))
+        value.queuedMessages.every(isQueuedMessage))) &&
+    isOptionalString(value.title) &&
+    isOptionalString(value.workspacePath) &&
+    isOptionalBoolean(value.archived) &&
+    isOptionalString(value.runningRunId) &&
+    isThreadConfig(value.config) &&
+    isContextUsage(value.contextUsage) &&
+    isOptionalString(value.sessionFile) &&
+    isOptionalString(value.parentSessionPath) &&
+    isOptionalNumber(value.messageCount) &&
+    isOptionalString(value.createdAt) &&
+    isOptionalString(value.updatedAt)
   );
 };
 
@@ -136,19 +170,97 @@ const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
     if (!isThreadMetadata(thread)) {
       throw invalidResponse(
         "listing threads",
-        `thread at index ${index} must have a non-empty string "id", a string "status", and structurally valid queued messages when present.`,
+        `thread at index ${index} must have a non-empty string "id", a string "status", and correctly typed known fields.`,
       );
     }
   }
   return value;
 };
 
-const isTranscriptMessage = (value: unknown): boolean =>
-  isRecord(value) && typeof value.role === "string";
+const isUserContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "image") {
+    return typeof value.data === "string" && typeof value.mimeType === "string";
+  }
+  return true;
+};
+
+const isUserContent = (value: unknown): boolean =>
+  typeof value === "string" ||
+  (Array.isArray(value) && value.every(isUserContentPart));
+
+const isAssistantContentPart = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "thinking") return typeof value.thinking === "string";
+  if (value.type === "toolCall") {
+    return (
+      typeof value.id === "string" &&
+      typeof value.name === "string" &&
+      isRecord(value.arguments)
+    );
+  }
+  return true;
+};
+
+const isTranscriptMessage = (value: unknown): boolean => {
+  if (!isRecord(value) || typeof value.role !== "string") return false;
+  if (value.role === "user") return isUserContent(value.content);
+  if (value.role === "assistant") {
+    return (
+      Array.isArray(value.content) &&
+      value.content.every(isAssistantContentPart)
+    );
+  }
+  if (value.role === "toolResult") {
+    return (
+      typeof value.toolCallId === "string" &&
+      typeof value.toolName === "string" &&
+      Array.isArray(value.content) &&
+      value.content.every(isUserContentPart) &&
+      typeof value.isError === "boolean"
+    );
+  }
+  if (value.role === "bashExecution") {
+    return (
+      typeof value.command === "string" &&
+      typeof value.output === "string" &&
+      (value.exitCode === undefined || typeof value.exitCode === "number") &&
+      typeof value.cancelled === "boolean" &&
+      typeof value.truncated === "boolean"
+    );
+  }
+  if (value.role === "custom") {
+    return (
+      typeof value.customType === "string" &&
+      isUserContent(value.content) &&
+      typeof value.display === "boolean"
+    );
+  }
+  if (value.role === "branchSummary") {
+    return (
+      typeof value.summary === "string" && typeof value.fromId === "string"
+    );
+  }
+  if (value.role === "compactionSummary") {
+    return (
+      typeof value.summary === "string" &&
+      typeof value.tokensBefore === "number"
+    );
+  }
+  return true;
+};
 
 const isHostUiRequest = (value: unknown): boolean => {
   if (!isRecord(value)) return false;
   if (typeof value.id !== "string" || typeof value.kind !== "string") {
+    return false;
+  }
+  if (
+    !isOptionalString(value.toolCallId) ||
+    !isOptionalNumber(value.timeoutMs)
+  ) {
     return false;
   }
 
@@ -162,8 +274,13 @@ const isHostUiRequest = (value: unknown): boolean => {
       value.options.every((option) => typeof option === "string")
     );
   }
-  if (value.kind === "input" || value.kind === "editor") {
-    return typeof value.title === "string";
+  if (value.kind === "input") {
+    return (
+      typeof value.title === "string" && isOptionalString(value.placeholder)
+    );
+  }
+  if (value.kind === "editor") {
+    return typeof value.title === "string" && isOptionalString(value.prefill);
   }
   return true;
 };

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -179,7 +179,11 @@ const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
 
 const isUserContentPart = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
+  if (value.type === "text") {
+    return (
+      typeof value.text === "string" && isOptionalString(value.textSignature)
+    );
+  }
   if (value.type === "image") {
     return typeof value.data === "string" && typeof value.mimeType === "string";
   }
@@ -192,25 +196,61 @@ const isUserContent = (value: unknown): boolean =>
 
 const isAssistantContentPart = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.type !== "string") return false;
-  if (value.type === "text") return typeof value.text === "string";
-  if (value.type === "thinking") return typeof value.thinking === "string";
+  if (value.type === "text") {
+    return (
+      typeof value.text === "string" && isOptionalString(value.textSignature)
+    );
+  }
+  if (value.type === "thinking") {
+    return (
+      typeof value.thinking === "string" &&
+      isOptionalString(value.thinkingSignature) &&
+      isOptionalBoolean(value.redacted)
+    );
+  }
   if (value.type === "toolCall") {
     return (
       typeof value.id === "string" &&
       typeof value.name === "string" &&
-      isRecord(value.arguments)
+      isRecord(value.arguments) &&
+      isOptionalString(value.thoughtSignature)
     );
   }
   return true;
 };
 
+const isUsage = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.input === "number" &&
+  typeof value.output === "number" &&
+  typeof value.cacheRead === "number" &&
+  typeof value.cacheWrite === "number" &&
+  typeof value.totalTokens === "number" &&
+  isRecord(value.cost) &&
+  typeof value.cost.input === "number" &&
+  typeof value.cost.output === "number" &&
+  typeof value.cost.cacheRead === "number" &&
+  typeof value.cost.cacheWrite === "number" &&
+  typeof value.cost.total === "number";
+
 const isTranscriptMessage = (value: unknown): boolean => {
   if (!isRecord(value) || typeof value.role !== "string") return false;
-  if (value.role === "user") return isUserContent(value.content);
+  if (value.role === "user") {
+    return isUserContent(value.content) && typeof value.timestamp === "number";
+  }
   if (value.role === "assistant") {
     return (
       Array.isArray(value.content) &&
-      value.content.every(isAssistantContentPart)
+      value.content.every(isAssistantContentPart) &&
+      typeof value.api === "string" &&
+      typeof value.provider === "string" &&
+      typeof value.model === "string" &&
+      isOptionalString(value.responseModel) &&
+      isOptionalString(value.responseId) &&
+      isUsage(value.usage) &&
+      typeof value.stopReason === "string" &&
+      isOptionalString(value.errorMessage) &&
+      typeof value.timestamp === "number"
     );
   }
   if (value.role === "toolResult") {
@@ -219,7 +259,8 @@ const isTranscriptMessage = (value: unknown): boolean => {
       typeof value.toolName === "string" &&
       Array.isArray(value.content) &&
       value.content.every(isUserContentPart) &&
-      typeof value.isError === "boolean"
+      typeof value.isError === "boolean" &&
+      typeof value.timestamp === "number"
     );
   }
   if (value.role === "bashExecution") {
@@ -228,25 +269,32 @@ const isTranscriptMessage = (value: unknown): boolean => {
       typeof value.output === "string" &&
       (value.exitCode === undefined || typeof value.exitCode === "number") &&
       typeof value.cancelled === "boolean" &&
-      typeof value.truncated === "boolean"
+      typeof value.truncated === "boolean" &&
+      isOptionalString(value.fullOutputPath) &&
+      typeof value.timestamp === "number" &&
+      isOptionalBoolean(value.excludeFromContext)
     );
   }
   if (value.role === "custom") {
     return (
       typeof value.customType === "string" &&
       isUserContent(value.content) &&
-      typeof value.display === "boolean"
+      typeof value.display === "boolean" &&
+      typeof value.timestamp === "number"
     );
   }
   if (value.role === "branchSummary") {
     return (
-      typeof value.summary === "string" && typeof value.fromId === "string"
+      typeof value.summary === "string" &&
+      typeof value.fromId === "string" &&
+      typeof value.timestamp === "number"
     );
   }
   if (value.role === "compactionSummary") {
     return (
       typeof value.summary === "string" &&
-      typeof value.tokensBefore === "number"
+      typeof value.tokensBefore === "number" &&
+      typeof value.timestamp === "number"
     );
   }
   return true;

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -83,9 +83,145 @@ const assertOk = async (response: Response): Promise<void> => {
   );
 };
 
-const readJson = async <T>(response: Response): Promise<T> => {
+const invalidResponse = (
+  operation: string,
+  expectation: string,
+  cause?: unknown,
+): Error =>
+  new Error(
+    `Invalid Pi HTTP response while ${operation}: ${expectation}`,
+    cause === undefined ? undefined : { cause },
+  );
+
+const readJson = async (
+  response: Response,
+  operation: string,
+): Promise<unknown> => {
   await assertOk(response);
-  return (await response.json()) as T;
+  try {
+    return await response.json();
+  } catch (error) {
+    throw invalidResponse(operation, "expected valid JSON.", error);
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isThreadStatus = (value: unknown): value is PiThreadMetadata["status"] =>
+  value === "idle" || value === "running" || value === "failed";
+
+const isQueuedMessage = (value: unknown): boolean => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    (value.mode === "followUp" || value.mode === "steer") &&
+    typeof value.content === "string"
+  );
+};
+
+const isThreadMetadata = (value: unknown): value is PiThreadMetadata => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    value.id.length > 0 &&
+    isThreadStatus(value.status) &&
+    (value.queuedMessages === undefined ||
+      (Array.isArray(value.queuedMessages) &&
+        value.queuedMessages.every(isQueuedMessage)))
+  );
+};
+
+const parseThreadListResponse = (value: unknown): PiThreadMetadata[] => {
+  if (!Array.isArray(value)) {
+    throw invalidResponse("listing threads", "expected an array of threads.");
+  }
+
+  for (const [index, thread] of value.entries()) {
+    if (!isThreadMetadata(thread)) {
+      throw invalidResponse(
+        "listing threads",
+        `thread at index ${index} must have a non-empty string "id", a valid "status", and valid queued messages when present.`,
+      );
+    }
+  }
+  return value;
+};
+
+const isTranscriptMessage = (value: unknown): boolean =>
+  isRecord(value) && typeof value.role === "string";
+
+const isHostUiRequest = (value: unknown): boolean => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    (value.kind === "confirm" ||
+      value.kind === "select" ||
+      value.kind === "input" ||
+      value.kind === "editor")
+  );
+};
+
+const parseThreadSnapshotResponse = (
+  value: unknown,
+  operation: "creating a thread" | "fetching a thread",
+): PiThreadSnapshot => {
+  if (
+    !isRecord(value) ||
+    !isThreadMetadata(value.metadata) ||
+    !Array.isArray(value.messages) ||
+    !value.messages.every(isTranscriptMessage) ||
+    (value.hostUiRequests !== undefined &&
+      (!Array.isArray(value.hostUiRequests) ||
+        !value.hostUiRequests.every(isHostUiRequest)))
+  ) {
+    throw invalidResponse(
+      operation,
+      'expected a thread snapshot with valid "metadata", a "messages" array, and valid host UI requests when present.',
+    );
+  }
+  return value as PiThreadSnapshot;
+};
+
+const parseClearQueueResponse = (
+  value: unknown,
+): { steering: string[]; followUp: string[] } => {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.steering) ||
+    !value.steering.every((item) => typeof item === "string") ||
+    !Array.isArray(value.followUp) ||
+    !value.followUp.every((item) => typeof item === "string")
+  ) {
+    throw invalidResponse(
+      "clearing a thread queue",
+      'expected an object with string arrays "steering" and "followUp".',
+    );
+  }
+  return value as { steering: string[]; followUp: string[] };
+};
+
+const isModelInfo = (value: unknown): value is PiModelInfo =>
+  isRecord(value) &&
+  typeof value.provider === "string" &&
+  value.provider.length > 0 &&
+  typeof value.modelId === "string" &&
+  value.modelId.length > 0;
+
+const parseModelListResponse = (value: unknown): PiModelInfo[] => {
+  if (!Array.isArray(value)) {
+    throw invalidResponse("listing models", "expected an array of models.");
+  }
+
+  for (const [index, model] of value.entries()) {
+    if (!isModelInfo(model)) {
+      throw invalidResponse(
+        "listing models",
+        `model at index ${index} must have non-empty string "provider" and "modelId" fields.`,
+      );
+    }
+  }
+  return value;
 };
 
 export const createPiHttpClient = (
@@ -127,18 +263,31 @@ export const createPiHttpClient = (
         params.set("workspacePath", input.workspacePath);
       if (input?.includeArchived) params.set("includeArchived", "true");
       const query = params.toString();
-      return readJson<PiThreadMetadata[]>(
-        await send(`${base}/threads${query ? `?${query}` : ""}`, "GET"),
+      return parseThreadListResponse(
+        await readJson(
+          await send(`${base}/threads${query ? `?${query}` : ""}`, "GET"),
+          "listing threads",
+        ),
       );
     },
 
     createThread: async (input) =>
-      readJson<PiThreadSnapshot>(
-        await send(`${base}/threads`, "POST", input ?? {}),
+      parseThreadSnapshotResponse(
+        await readJson(
+          await send(`${base}/threads`, "POST", input ?? {}),
+          "creating a thread",
+        ),
+        "creating a thread",
       ),
 
     getThread: async (threadId) =>
-      readJson<PiThreadSnapshot>(await send(threadUrl(threadId), "GET")),
+      parseThreadSnapshotResponse(
+        await readJson(
+          await send(threadUrl(threadId), "GET"),
+          "fetching a thread",
+        ),
+        "fetching a thread",
+      ),
 
     sendMessage: async (threadId, input: PiSendMessageInput) => {
       await assertOk(
@@ -151,8 +300,11 @@ export const createPiHttpClient = (
     },
 
     clearQueue: async (threadId) =>
-      readJson<{ steering: string[]; followUp: string[] }>(
-        await send(`${threadUrl(threadId)}/queue/clear`, "POST"),
+      parseClearQueueResponse(
+        await readJson(
+          await send(`${threadUrl(threadId)}/queue/clear`, "POST"),
+          "clearing a thread queue",
+        ),
       ),
 
     getAvailableModels: async (input) => {
@@ -160,8 +312,11 @@ export const createPiHttpClient = (
       if (input?.workspacePath)
         params.set("workspacePath", input.workspacePath);
       const query = params.toString();
-      return readJson<PiModelInfo[]>(
-        await send(`${base}/models${query ? `?${query}` : ""}`, "GET"),
+      return parseModelListResponse(
+        await readJson(
+          await send(`${base}/models${query ? `?${query}` : ""}`, "GET"),
+          "listing models",
+        ),
       );
     },
 


### PR DESCRIPTION
## Summary

- validate thread lists and snapshots returned by the React Pi HTTP client
- validate queue-clear and model-list payloads before they enter runtime state
- add operation context when a successful response contains invalid JSON

## Why

While testing a Pi route that returned `200 {}`, `listThreads()` accepted the object as a thread array. The runtime then failed later at `threads.map(...)`, far from the actual response-contract problem.

This validates successful JSON responses at the HTTP boundary, so malformed payloads fail immediately with the operation that received them. The checks remain forward-compatible by allowing extra fields and unknown transcript roles.

## Validation

- `pnpm --filter @assistant-ui/react-pi test` (151 tests)
- `pnpm --filter @assistant-ui/react-pi... build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

