### PR TITLE
fix: warn on unmapped cloud updates and document the update contract

### DIFF
--- a/.changeset/cloud-update-unmapped-warning.md
+++ b/.changeset/cloud-update-unmapped-warning.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix(assistant-cloud): warn when an update targets a message without a remote id

--- a/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
@@ -592,6 +592,32 @@ The top-level `load`/`append` on the history adapter are required by the type bu
 </Step>
 <Step>
 
+### Support in-place updates (optional)
+
+The optional `update(item, localMessageId)` method on the object returned from `withFormat` lets the runtime rewrite an already-persisted message in place. It receives the same `{ parentId, message }` item shape as `append`, plus the id of the row to rewrite.
+
+The runtime calls `update` after a run for persisted messages whose content changed, to finalize assistant messages persisted early while waiting for tool call approval, and to refresh run timing metadata.
+
+`update` is opt-in. When it is absent, messages paused for tool approval are not persisted until the run reaches a terminal status, so a page refresh during the pause loses the pending approval state. Implementing `update` enables early persistence.
+
+```tsx title="runtime/thread-adapter.tsx"
+async update(item, localMessageId) {
+  const { remoteId } = await aui.threadListItem().initialize();
+  await fetch(`${API_URL}/threads/${remoteId}/messages/${localMessageId}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      format: fmt.format,
+      content: fmt.encode(item),
+    }),
+  });
+},
+```
+
+The backend needs a matching update route keyed by message id, mirroring the append route from the earlier step.
+
+</Step>
+<Step>
+
 ### Mount the runtime
 
 Wrap the app in a `useRemoteThreadListRuntime` that delegates per-thread runtime to `useChatRuntime`:
@@ -705,6 +731,7 @@ Send a message in a fresh thread. Check the database:
 - **First-message race.** `append` may fire before the thread row exists. The `unstable_Provider` example above always awaits `aui.threadListItem().initialize()` before writing; do the same in any custom implementation.
 - **Reload after async auth.** If `auth()` resolves after the initial `list()` call, threads won't appear until the user refreshes. Call `aui.threads().reload()` from a `useEffect` watching the session. Pattern is documented in [threads](/docs/runtimes/concepts/threads#reloading-after-async-authentication).
 - **Format string.** The `format` column is *not* a free-text label; it identifies the on-disk shape so multiple runtimes can coexist. Don't strip it. Don't make assumptions about its value (`useChatRuntime` is responsible for setting and decoding it).
+- **Pending approvals need `update`.** Tool call approvals persist across reloads only when the formatted adapter implements `update`; omitting it keeps the pre-approval snapshot out of storage by design.
 - **`unstable_Provider` synchronous-children rule.** The Provider must render `children` on first commit; do not gate them behind suspense, loading state, or `useEffect`. Load data inside an always-rendered child.
 
 ## Related

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -71,7 +71,12 @@ export class CloudMessagePersistence {
     content: ReadonlyJSONObject,
   ): Promise<void> {
     const remoteId = await this.getRemoteId(messageId);
-    if (!remoteId) return; // not persisted yet, skip
+    if (!remoteId) {
+      console.warn(
+        `Skipping update for message ${messageId}: no remote id is mapped.`,
+      );
+      return;
+    }
     await this.cloud.threads.messages.update(threadId, remoteId, { content });
   }
 

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -121,6 +121,19 @@ describe("CloudMessagePersistence", () => {
     );
   });
 
+  it("warns and skips update when no remote id is mapped", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await persistence.update("thread-1", "unmapped-1", "aui/v0", {
+      text: "x",
+    });
+
+    expect(cloud.threads.messages.update).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      "Skipping update for message unmapped-1: no remote id is mapped.",
+    );
+  });
+
   it("cleans up ID mapping on append failure", async () => {
     vi.mocked(cloud.threads.messages.create).mockRejectedValue(
       new Error("network error"),


### PR DESCRIPTION
closes #5055

## summary

- `CloudMessagePersistence.update` no longer silently returns when the local message id has no remote mapping; it warns with the id so a skipped rewrite is distinguishable from a successful one
- the custom persistence guide gains a `Support in-place updates (optional)` step documenting the `update(item, localMessageId)` contract on the `withFormat` return: the item shape, the three call sites (changed persisted messages after a run, finalizing assistant messages persisted early while awaiting tool approval, run timing refreshes), the opt-in semantics when `update` is absent, and a PATCH example matching the page's existing fetch style, plus a `## Notes` bullet stating that pending approvals only survive reloads when `update` is implemented
- the runtime's only path into `CloudMessagePersistence.update` goes through the formatted adapter, and since #5052 only changed and already-mapped messages are updated, so the new warning fires on genuine anomalies rather than routine flows

## test plan

### already verified

- [x] `pnpm --filter assistant-cloud test` -> 40 passed, 2 skipped
- [x] `pnpm --filter assistant-cloud build` -> green
- [x] `pnpm -C apps/docs exec fumadocs-mdx` -> content compiles
- [x] `pnpm exec oxfmt --check packages/cloud/src/CloudMessagePersistence.ts` -> clean

### reviewer should verify

- [ ] open `/docs/integrations/persistence/custom-adapter` in the docs dev server and confirm the new step renders correctly between the adapter implementation and Mount the runtime, with intact Steps numbering

## notes

- #5055 also floats upsert semantics as an alternative to the warning; that needs create-on-missing support in the cloud API, so this PR lands the observability half and the docs half

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

