### PR TITLE
feat(assistant-stream-py): SSE idle heartbeat, enabled by default (15s)

### DIFF
--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -19,6 +19,10 @@ class AssistantStreamResponse(StreamingResponse):
         body = stream_encoder.encode_stream(stream)
         heartbeat_interval = resolve_heartbeat_interval(heartbeat)
         if heartbeat_interval is not None:
+            if stream_encoder.get_media_type() != "text/event-stream":
+                raise ValueError(
+                    "heartbeat is only supported for text/event-stream encoders"
+                )
             body = add_sse_heartbeat(body, heartbeat_interval)
         super().__init__(
             body,

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -1,9 +1,9 @@
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
-from assistant_stream.serialization.stream_encoder import (
-    StreamEncoder,
+from assistant_stream.serialization.heartbeat import (
     add_sse_heartbeat,
     resolve_heartbeat_interval,
 )
+from assistant_stream.serialization.stream_encoder import StreamEncoder
 from typing import AsyncGenerator, Union
 
 from starlette.responses import StreamingResponse

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -1,6 +1,10 @@
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
-from assistant_stream.serialization.stream_encoder import StreamEncoder
-from typing import AsyncGenerator
+from assistant_stream.serialization.stream_encoder import (
+    StreamEncoder,
+    add_sse_heartbeat,
+    resolve_heartbeat_interval,
+)
+from typing import AsyncGenerator, Union
 
 from starlette.responses import StreamingResponse
 
@@ -10,8 +14,13 @@ class AssistantStreamResponse(StreamingResponse):
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
         stream_encoder: StreamEncoder,
+        heartbeat: Union[float, int, bool, None] = None,
     ):
+        body = stream_encoder.encode_stream(stream)
+        heartbeat_interval = resolve_heartbeat_interval(heartbeat)
+        if heartbeat_interval is not None:
+            body = add_sse_heartbeat(body, heartbeat_interval)
         super().__init__(
-            stream_encoder.encode_stream(stream),
+            body,
             media_type=stream_encoder.get_media_type(),
         )

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -10,19 +10,26 @@ from starlette.responses import StreamingResponse
 
 
 class AssistantStreamResponse(StreamingResponse):
+    """
+    Streams an encoded assistant stream. For text/event-stream encoders, SSE
+    comment heartbeats are emitted while the stream is idle (15s interval by
+    default) to keep proxies from timing out the connection. Pass
+    `heartbeat=<seconds>` to change the interval, or `heartbeat=False` to
+    disable heartbeats.
+    """
+
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
         stream_encoder: StreamEncoder,
-        heartbeat: Union[float, int, bool, None] = None,
+        heartbeat: Union[float, int, bool, None] = True,
     ):
         body = stream_encoder.encode_stream(stream)
         heartbeat_interval = resolve_heartbeat_interval(heartbeat)
-        if heartbeat_interval is not None:
-            if stream_encoder.get_media_type() != "text/event-stream":
-                raise ValueError(
-                    "heartbeat is only supported for text/event-stream encoders"
-                )
+        if (
+            heartbeat_interval is not None
+            and stream_encoder.get_media_type() == "text/event-stream"
+        ):
             body = add_sse_heartbeat(body, heartbeat_interval)
         super().__init__(
             body,

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -1,10 +1,11 @@
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 from assistant_stream.serialization.heartbeat import (
+    HeartbeatOption,
     add_sse_heartbeat,
     resolve_heartbeat_interval,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator
 
 from starlette.responses import StreamingResponse
 
@@ -22,7 +23,7 @@ class AssistantStreamResponse(StreamingResponse):
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
         stream_encoder: StreamEncoder,
-        heartbeat: Union[float, int, bool, None] = True,
+        heartbeat: HeartbeatOption = True,
     ):
         heartbeat_interval = resolve_heartbeat_interval(heartbeat)
         body = stream_encoder.encode_stream(stream)

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -24,8 +24,8 @@ class AssistantStreamResponse(StreamingResponse):
         stream_encoder: StreamEncoder,
         heartbeat: Union[float, int, bool, None] = True,
     ):
-        body = stream_encoder.encode_stream(stream)
         heartbeat_interval = resolve_heartbeat_interval(heartbeat)
+        body = stream_encoder.encode_stream(stream)
         if (
             heartbeat_interval is not None
             and stream_encoder.get_media_type() == "text/event-stream"

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -2,9 +2,13 @@ from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
-from assistant_stream.serialization.stream_encoder import StreamEncoder
+from assistant_stream.serialization.stream_encoder import (
+    StreamEncoder,
+    add_sse_heartbeat,
+    resolve_heartbeat_interval,
+)
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any
+from typing import AsyncGenerator, Any, Optional, Union
 import json
 
 
@@ -21,7 +25,16 @@ class AssistantTransportEncoder(StreamEncoder):
     """
     AssistantTransportEncoder encodes AssistantStreamChunks into SSE format
     and emits [DONE] when the stream completes.
+
+    Pass `heartbeat=True` (15s) or `heartbeat=<seconds>` to emit SSE comment
+    lines while the stream is idle, keeping proxies from timing out the
+    connection. 0, False, and None disable heartbeats.
     """
+
+    def __init__(self, heartbeat: Union[float, int, bool, None] = None):
+        self._heartbeat_interval: Optional[float] = resolve_heartbeat_interval(
+            heartbeat
+        )
 
     def get_media_type(self) -> str:
         return "text/event-stream"
@@ -42,7 +55,7 @@ class AssistantTransportEncoder(StreamEncoder):
         components = snake_str.split("_")
         return components[0] + "".join(x.title() for x in components[1:])
 
-    async def encode_stream(
+    async def _encode_chunks(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]
     ) -> AsyncGenerator[str, None]:
         async for chunk in stream:
@@ -53,10 +66,19 @@ class AssistantTransportEncoder(StreamEncoder):
         # Emit [DONE] marker when stream completes
         yield "data: [DONE]\n\n"
 
+    def encode_stream(
+        self, stream: AsyncGenerator[AssistantStreamChunk, None]
+    ) -> AsyncGenerator[str, None]:
+        encoded = self._encode_chunks(stream)
+        if self._heartbeat_interval is not None:
+            return add_sse_heartbeat(encoded, self._heartbeat_interval)
+        return encoded
+
 
 class AssistantTransportResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
+        heartbeat: Union[float, int, bool, None] = None,
     ):
-        super().__init__(stream, AssistantTransportEncoder())
+        super().__init__(stream, AssistantTransportEncoder(heartbeat=heartbeat))

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -2,9 +2,10 @@ from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
+from assistant_stream.serialization.heartbeat import HeartbeatOption
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any, Union
+from typing import AsyncGenerator, Any
 import json
 
 
@@ -58,6 +59,6 @@ class AssistantTransportResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
-        heartbeat: Union[float, int, bool, None] = True,
+        heartbeat: HeartbeatOption = True,
     ):
         super().__init__(stream, AssistantTransportEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -2,13 +2,9 @@ from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
-from assistant_stream.serialization.stream_encoder import (
-    StreamEncoder,
-    add_sse_heartbeat,
-    resolve_heartbeat_interval,
-)
+from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any, Optional, Union
+from typing import AsyncGenerator, Any, Union
 import json
 
 
@@ -25,16 +21,7 @@ class AssistantTransportEncoder(StreamEncoder):
     """
     AssistantTransportEncoder encodes AssistantStreamChunks into SSE format
     and emits [DONE] when the stream completes.
-
-    Pass `heartbeat=True` (15s) or `heartbeat=<seconds>` to emit SSE comment
-    lines while the stream is idle, keeping proxies from timing out the
-    connection. 0, False, and None disable heartbeats.
     """
-
-    def __init__(self, heartbeat: Union[float, int, bool, None] = None):
-        self._heartbeat_interval: Optional[float] = resolve_heartbeat_interval(
-            heartbeat
-        )
 
     def get_media_type(self) -> str:
         return "text/event-stream"
@@ -55,7 +42,7 @@ class AssistantTransportEncoder(StreamEncoder):
         components = snake_str.split("_")
         return components[0] + "".join(x.title() for x in components[1:])
 
-    async def _encode_chunks(
+    async def encode_stream(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]
     ) -> AsyncGenerator[str, None]:
         async for chunk in stream:
@@ -66,19 +53,17 @@ class AssistantTransportEncoder(StreamEncoder):
         # Emit [DONE] marker when stream completes
         yield "data: [DONE]\n\n"
 
-    def encode_stream(
-        self, stream: AsyncGenerator[AssistantStreamChunk, None]
-    ) -> AsyncGenerator[str, None]:
-        encoded = self._encode_chunks(stream)
-        if self._heartbeat_interval is not None:
-            return add_sse_heartbeat(encoded, self._heartbeat_interval)
-        return encoded
-
 
 class AssistantTransportResponse(AssistantStreamResponse):
+    """
+    Pass `heartbeat=True` (15s) or `heartbeat=<seconds>` to emit SSE comment
+    lines while the stream is idle, keeping proxies from timing out the
+    connection. 0, False, and None disable heartbeats.
+    """
+
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
         heartbeat: Union[float, int, bool, None] = None,
     ):
-        super().__init__(stream, AssistantTransportEncoder(heartbeat=heartbeat))
+        super().__init__(stream, AssistantTransportEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -4,7 +4,7 @@ from assistant_stream.serialization.assistant_stream_response import (
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any
+from typing import AsyncGenerator, Any, Union
 import json
 
 
@@ -58,5 +58,6 @@ class AssistantTransportResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
+        heartbeat: Union[float, int, bool, None] = True,
     ):
-        super().__init__(stream, AssistantTransportEncoder())
+        super().__init__(stream, AssistantTransportEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -4,7 +4,7 @@ from assistant_stream.serialization.assistant_stream_response import (
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any, Union
+from typing import AsyncGenerator, Any
 import json
 
 
@@ -55,15 +55,8 @@ class AssistantTransportEncoder(StreamEncoder):
 
 
 class AssistantTransportResponse(AssistantStreamResponse):
-    """
-    Pass `heartbeat=True` (15s) or `heartbeat=<seconds>` to emit SSE comment
-    lines while the stream is idle, keeping proxies from timing out the
-    connection. 0, False, and None disable heartbeats.
-    """
-
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
-        heartbeat: Union[float, int, bool, None] = None,
     ):
-        super().__init__(stream, AssistantTransportEncoder(), heartbeat=heartbeat)
+        super().__init__(stream, AssistantTransportEncoder())

--- a/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
@@ -1,0 +1,59 @@
+import asyncio
+import math
+from typing import AsyncGenerator, Optional, Union
+
+DEFAULT_HEARTBEAT_INTERVAL = 15.0
+
+SSE_HEARTBEAT_LINE = ": heartbeat\n\n"
+
+
+def resolve_heartbeat_interval(
+    heartbeat: Union[float, int, bool, None],
+) -> Optional[float]:
+    """
+    Normalize a heartbeat option to an interval in seconds.
+
+    True enables the default interval; a positive number is used as-is;
+    0, False, and None disable heartbeats.
+    """
+    if heartbeat is True:
+        return DEFAULT_HEARTBEAT_INTERVAL
+    if not heartbeat:
+        return None
+    interval = float(heartbeat)
+    if not math.isfinite(interval) or interval <= 0:
+        raise ValueError(f"heartbeat interval must be a positive finite number, got {heartbeat!r}")
+    return interval
+
+
+async def add_sse_heartbeat(
+    stream: AsyncGenerator[str, None],
+    interval: float,
+) -> AsyncGenerator[str, None]:
+    """
+    Yield SSE comment heartbeats whenever the encoded stream is idle for
+    `interval` seconds. Any real chunk resets the timer.
+    """
+    task: Optional[asyncio.Task] = None
+    try:
+        while True:
+            if task is None:
+                task = asyncio.create_task(stream.__anext__())
+            done, _ = await asyncio.wait({task}, timeout=interval)
+            if not done:
+                yield SSE_HEARTBEAT_LINE
+                continue
+            try:
+                item = task.result()
+            except StopAsyncIteration:
+                task = None
+                return
+            task = None
+            yield item
+    finally:
+        if task is not None and not task.done():
+            task.cancel()
+            await asyncio.wait({task})
+            if not task.cancelled():
+                task.exception()
+        await stream.aclose()

--- a/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
@@ -51,7 +51,7 @@ async def add_sse_heartbeat(
             task = None
             yield item
     finally:
-        if task is not None and not task.done():
+        if task is not None:
             task.cancel()
             await asyncio.wait({task})
             if not task.cancelled():

--- a/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
@@ -6,9 +6,11 @@ DEFAULT_HEARTBEAT_INTERVAL = 15.0
 
 SSE_HEARTBEAT_LINE = ": heartbeat\n\n"
 
+HeartbeatOption = Union[float, int, bool, None]
+
 
 def resolve_heartbeat_interval(
-    heartbeat: Union[float, int, bool, None],
+    heartbeat: HeartbeatOption,
 ) -> Optional[float]:
     """
     Normalize a heartbeat option to an interval in seconds.
@@ -55,5 +57,5 @@ async def add_sse_heartbeat(
             task.cancel()
             await asyncio.wait({task})
             if not task.cancelled():
-                task.exception()
+                task.exception()  # retrieve the outcome so asyncio does not log "Task exception was never retrieved"
         await stream.aclose()

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -3,10 +3,11 @@ import json
 import time
 import string
 import random
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
+from assistant_stream.serialization.heartbeat import HeartbeatOption
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 
 
@@ -75,7 +76,7 @@ class OpenAIStreamResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
-        heartbeat: Union[float, int, bool, None] = True,
+        heartbeat: HeartbeatOption = True,
     ):
         """
         Initializes the response with the OpenAI SSE encoder.

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -3,7 +3,7 @@ import json
 import time
 import string
 import random
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
@@ -75,9 +75,8 @@ class OpenAIStreamResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
-        heartbeat: Union[float, int, bool, None] = None,
     ):
         """
         Initializes the response with the OpenAI SSE encoder.
         """
-        super().__init__(stream, OpenAIStreamEncoder(), heartbeat=heartbeat)
+        super().__init__(stream, OpenAIStreamEncoder())

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -3,7 +3,7 @@ import json
 import time
 import string
 import random
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Union
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
@@ -75,8 +75,9 @@ class OpenAIStreamResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
+        heartbeat: Union[float, int, bool, None] = True,
     ):
         """
         Initializes the response with the OpenAI SSE encoder.
         """
-        super().__init__(stream, OpenAIStreamEncoder())
+        super().__init__(stream, OpenAIStreamEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -3,7 +3,7 @@ import json
 import time
 import string
 import random
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Union
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
@@ -75,8 +75,9 @@ class OpenAIStreamResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
+        heartbeat: Union[float, int, bool, None] = None,
     ):
         """
         Initializes the response with the OpenAI SSE encoder.
         """
-        super().__init__(stream, OpenAIStreamEncoder())
+        super().__init__(stream, OpenAIStreamEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import math
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Optional, Union
@@ -56,10 +57,8 @@ async def add_sse_heartbeat(
     finally:
         if task is not None and not task.done():
             task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
                 await task
-            except (asyncio.CancelledError, StopAsyncIteration):
-                pass
         await stream.aclose()
 
 

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,62 +1,6 @@
-import asyncio
-import math
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator, Optional, Union
+from typing import AsyncGenerator
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
-
-DEFAULT_HEARTBEAT_INTERVAL = 15.0
-
-SSE_HEARTBEAT_LINE = ": heartbeat\n\n"
-
-
-def resolve_heartbeat_interval(
-    heartbeat: Union[float, int, bool, None],
-) -> Optional[float]:
-    """
-    Normalize a heartbeat option to an interval in seconds.
-
-    True enables the default interval; a positive number is used as-is;
-    0, False, and None disable heartbeats.
-    """
-    if heartbeat is True:
-        return DEFAULT_HEARTBEAT_INTERVAL
-    if not heartbeat:
-        return None
-    interval = float(heartbeat)
-    if not math.isfinite(interval) or interval <= 0:
-        raise ValueError(f"heartbeat interval must be a positive finite number, got {heartbeat!r}")
-    return interval
-
-
-async def add_sse_heartbeat(
-    stream: AsyncGenerator[str, None],
-    interval: float,
-) -> AsyncGenerator[str, None]:
-    """
-    Yield SSE comment heartbeats whenever the encoded stream is idle for
-    `interval` seconds. Any real chunk resets the timer.
-    """
-    task: Optional[asyncio.Task] = None
-    try:
-        while True:
-            if task is None:
-                task = asyncio.create_task(stream.__anext__())
-            done, _ = await asyncio.wait({task}, timeout=interval)
-            if not done:
-                yield SSE_HEARTBEAT_LINE
-                continue
-            try:
-                item = task.result()
-            except StopAsyncIteration:
-                task = None
-                return
-            task = None
-            yield item
-    finally:
-        if task is not None and not task.done():
-            task.cancel()
-            await asyncio.wait({task})
-        await stream.aclose()
 
 
 class StreamEncoder(ABC):

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -36,12 +36,11 @@ async def add_sse_heartbeat(
     Yield SSE comment heartbeats whenever the encoded stream is idle for
     `interval` seconds. Any real chunk resets the timer.
     """
-    iterator = stream.__aiter__()
     task: Optional[asyncio.Task] = None
     try:
         while True:
             if task is None:
-                task = asyncio.ensure_future(iterator.__anext__())
+                task = asyncio.create_task(stream.__anext__())
             done, _ = await asyncio.wait({task}, timeout=interval)
             if not done:
                 yield SSE_HEARTBEAT_LINE

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Optional, Union
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
@@ -21,7 +22,10 @@ def resolve_heartbeat_interval(
         return DEFAULT_HEARTBEAT_INTERVAL
     if not heartbeat:
         return None
-    return float(heartbeat)
+    interval = float(heartbeat)
+    if not math.isfinite(interval) or interval <= 0:
+        raise ValueError(f"heartbeat interval must be a positive finite number, got {heartbeat!r}")
+    return interval
 
 
 async def add_sse_heartbeat(

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,6 +1,57 @@
+import asyncio
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional, Union
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
+
+DEFAULT_HEARTBEAT_INTERVAL = 15.0
+
+SSE_HEARTBEAT_LINE = ": heartbeat\n\n"
+
+
+def resolve_heartbeat_interval(
+    heartbeat: Union[float, int, bool, None],
+) -> Optional[float]:
+    """
+    Normalize a heartbeat option to an interval in seconds.
+
+    True enables the default interval; a positive number is used as-is;
+    0, False, and None disable heartbeats.
+    """
+    if heartbeat is True:
+        return DEFAULT_HEARTBEAT_INTERVAL
+    if not heartbeat:
+        return None
+    return float(heartbeat)
+
+
+async def add_sse_heartbeat(
+    stream: AsyncGenerator[str, None],
+    interval: float,
+) -> AsyncGenerator[str, None]:
+    """
+    Yield SSE comment heartbeats whenever the encoded stream is idle for
+    `interval` seconds. Any real chunk resets the timer.
+    """
+    iterator = stream.__aiter__()
+    task: Optional[asyncio.Task] = None
+    try:
+        while True:
+            if task is None:
+                task = asyncio.ensure_future(iterator.__anext__())
+            done, _ = await asyncio.wait({task}, timeout=interval)
+            if not done:
+                yield SSE_HEARTBEAT_LINE
+                continue
+            try:
+                item = task.result()
+            except StopAsyncIteration:
+                task = None
+                return
+            task = None
+            yield item
+    finally:
+        if task is not None:
+            task.cancel()
 
 
 class StreamEncoder(ABC):

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -54,8 +54,13 @@ async def add_sse_heartbeat(
             task = None
             yield item
     finally:
-        if task is not None:
+        if task is not None and not task.done():
             task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, StopAsyncIteration):
+                pass
+        await stream.aclose()
 
 
 class StreamEncoder(ABC):

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import math
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Optional, Union
@@ -57,8 +56,7 @@ async def add_sse_heartbeat(
     finally:
         if task is not None and not task.done():
             task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
-                await task
+            await asyncio.wait({task})
         await stream.aclose()
 
 

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -4,14 +4,13 @@ import json
 import pytest
 
 from assistant_stream.assistant_stream_chunk import TextDeltaChunk
-from assistant_stream.serialization.assistant_transport import (
-    AssistantTransportResponse,
-)
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
+from assistant_stream.serialization.assistant_transport import (
+    AssistantTransportEncoder,
+)
 from assistant_stream.serialization.data_stream import DataStreamEncoder
-from assistant_stream.serialization.openai_stream import OpenAIStreamResponse
 from assistant_stream.serialization.stream_encoder import (
     DEFAULT_HEARTBEAT_INTERVAL,
     SSE_HEARTBEAT_LINE,
@@ -21,29 +20,15 @@ from assistant_stream.serialization.stream_encoder import (
 
 
 def test_resolve_heartbeat_interval():
+    assert resolve_heartbeat_interval(True) == DEFAULT_HEARTBEAT_INTERVAL
     assert resolve_heartbeat_interval(None) is None
     assert resolve_heartbeat_interval(False) is None
     assert resolve_heartbeat_interval(0) is None
-    assert resolve_heartbeat_interval(True) == DEFAULT_HEARTBEAT_INTERVAL
     assert resolve_heartbeat_interval(5) == 5.0
     assert resolve_heartbeat_interval(0.5) == 0.5
     for invalid in (-1, -0.5, float("inf"), float("nan")):
         with pytest.raises(ValueError):
             resolve_heartbeat_interval(invalid)
-
-
-@pytest.mark.anyio
-async def test_heartbeat_disabled_by_default():
-    async def stream():
-        yield TextDeltaChunk(text_delta="hello")
-        await asyncio.sleep(0.15)
-        yield TextDeltaChunk(text_delta="world")
-
-    response = AssistantTransportResponse(stream())
-    lines = [line async for line in response.body_iterator]
-
-    assert all(not line.startswith(":") for line in lines)
-    assert lines[-1] == "data: [DONE]\n\n"
 
 
 @pytest.mark.anyio
@@ -53,7 +38,9 @@ async def test_heartbeat_emitted_when_idle():
         await asyncio.sleep(0.18)
         yield TextDeltaChunk(text_delta="world")
 
-    response = AssistantTransportResponse(stream(), heartbeat=0.05)
+    response = AssistantStreamResponse(
+        stream(), AssistantTransportEncoder(), heartbeat=0.05
+    )
     lines = [line async for line in response.body_iterator]
 
     heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
@@ -66,41 +53,32 @@ async def test_heartbeat_emitted_when_idle():
 
 
 @pytest.mark.anyio
-async def test_heartbeat_emitted_when_idle_openai():
+async def test_heartbeat_false_disables():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.15)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = AssistantStreamResponse(
+        stream(), AssistantTransportEncoder(), heartbeat=False
+    )
+    lines = [line async for line in response.body_iterator]
+
+    assert all(not line.startswith(":") for line in lines)
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_non_sse_response_unaffected():
     async def stream():
         yield TextDeltaChunk(text_delta="hello")
         await asyncio.sleep(0.18)
         yield TextDeltaChunk(text_delta="world")
 
-    response = OpenAIStreamResponse(stream(), heartbeat=0.05)
+    response = AssistantStreamResponse(stream(), DataStreamEncoder(), heartbeat=0.05)
     lines = [line async for line in response.body_iterator]
 
-    heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
-    assert len(heartbeats) >= 2
-    assert lines[-1] == "data: [DONE]\n\n"
-
-
-@pytest.mark.anyio
-async def test_heartbeat_rejected_for_non_sse_encoder():
-    async def stream():
-        yield TextDeltaChunk(text_delta="hello")
-
-    with pytest.raises(ValueError, match="text/event-stream"):
-        AssistantStreamResponse(stream(), DataStreamEncoder(), heartbeat=0.05)
-
-
-@pytest.mark.anyio
-async def test_no_heartbeat_when_chunks_are_frequent():
-    async def stream():
-        for i in range(5):
-            await asyncio.sleep(0.01)
-            yield TextDeltaChunk(text_delta=str(i))
-
-    response = AssistantTransportResponse(stream(), heartbeat=0.5)
-    lines = [line async for line in response.body_iterator]
-
-    assert all(line.startswith("data: ") for line in lines)
-    assert lines[-1] == "data: [DONE]\n\n"
+    assert SSE_HEARTBEAT_LINE not in lines
 
 
 @pytest.mark.anyio
@@ -110,7 +88,9 @@ async def test_real_chunk_resets_heartbeat_timer():
             await asyncio.sleep(0.05)
             yield TextDeltaChunk(text_delta=str(i))
 
-    response = AssistantTransportResponse(stream(), heartbeat=0.5)
+    response = AssistantStreamResponse(
+        stream(), AssistantTransportEncoder(), heartbeat=0.5
+    )
     lines = [line async for line in response.body_iterator]
 
     assert SSE_HEARTBEAT_LINE not in lines
@@ -118,12 +98,10 @@ async def test_real_chunk_resets_heartbeat_timer():
 
 @pytest.mark.anyio
 async def test_add_sse_heartbeat_cancels_pending_read_on_close():
-    started = asyncio.Event()
     cancelled = asyncio.Event()
 
     async def stream():
         yield "data: 1\n\n"
-        started.set()
         try:
             await asyncio.sleep(10)
         except asyncio.CancelledError:

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -20,6 +20,9 @@ def test_resolve_heartbeat_interval():
     assert resolve_heartbeat_interval(True) == DEFAULT_HEARTBEAT_INTERVAL
     assert resolve_heartbeat_interval(5) == 5.0
     assert resolve_heartbeat_interval(0.5) == 0.5
+    for invalid in (-1, -0.5, float("inf"), float("nan")):
+        with pytest.raises(ValueError):
+            resolve_heartbeat_interval(invalid)
 
 
 @pytest.mark.anyio

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -1,0 +1,107 @@
+import asyncio
+import json
+
+import pytest
+
+from assistant_stream.assistant_stream_chunk import TextDeltaChunk
+from assistant_stream.serialization.assistant_transport import AssistantTransportEncoder
+from assistant_stream.serialization.stream_encoder import (
+    DEFAULT_HEARTBEAT_INTERVAL,
+    SSE_HEARTBEAT_LINE,
+    add_sse_heartbeat,
+    resolve_heartbeat_interval,
+)
+
+
+def test_resolve_heartbeat_interval():
+    assert resolve_heartbeat_interval(None) is None
+    assert resolve_heartbeat_interval(False) is None
+    assert resolve_heartbeat_interval(0) is None
+    assert resolve_heartbeat_interval(True) == DEFAULT_HEARTBEAT_INTERVAL
+    assert resolve_heartbeat_interval(5) == 5.0
+    assert resolve_heartbeat_interval(0.5) == 0.5
+
+
+@pytest.mark.anyio
+async def test_heartbeat_disabled_by_default():
+    encoder = AssistantTransportEncoder()
+
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.15)
+        yield TextDeltaChunk(text_delta="world")
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert all(not line.startswith(":") for line in lines)
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_emitted_when_idle():
+    encoder = AssistantTransportEncoder(heartbeat=0.05)
+
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
+    assert len(heartbeats) >= 2
+
+    data_lines = [line for line in lines if line.startswith("data: ")]
+    assert data_lines[-1] == "data: [DONE]\n\n"
+    payloads = [json.loads(line[6:-2]) for line in data_lines[:-1]]
+    assert [p["textDelta"] for p in payloads] == ["hello", "world"]
+
+
+@pytest.mark.anyio
+async def test_no_heartbeat_when_chunks_are_frequent():
+    encoder = AssistantTransportEncoder(heartbeat=0.2)
+
+    async def stream():
+        for i in range(5):
+            await asyncio.sleep(0.01)
+            yield TextDeltaChunk(text_delta=str(i))
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert all(line.startswith("data: ") for line in lines)
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_real_chunk_resets_heartbeat_timer():
+    encoder = AssistantTransportEncoder(heartbeat=0.1)
+
+    async def stream():
+        for i in range(3):
+            await asyncio.sleep(0.07)
+            yield TextDeltaChunk(text_delta=str(i))
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert SSE_HEARTBEAT_LINE not in lines
+
+
+@pytest.mark.anyio
+async def test_add_sse_heartbeat_cancels_pending_read_on_close():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def stream():
+        yield "data: 1\n\n"
+        started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    gen = add_sse_heartbeat(stream(), 0.05)
+    assert await gen.__anext__() == "data: 1\n\n"
+    assert await gen.__anext__() == SSE_HEARTBEAT_LINE
+    await gen.aclose()
+    await asyncio.wait_for(cancelled.wait(), timeout=1)

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -11,7 +11,7 @@ from assistant_stream.serialization.assistant_transport import (
     AssistantTransportEncoder,
 )
 from assistant_stream.serialization.data_stream import DataStreamEncoder
-from assistant_stream.serialization.stream_encoder import (
+from assistant_stream.serialization.heartbeat import (
     DEFAULT_HEARTBEAT_INTERVAL,
     SSE_HEARTBEAT_LINE,
     add_sse_heartbeat,

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -7,6 +7,10 @@ from assistant_stream.assistant_stream_chunk import TextDeltaChunk
 from assistant_stream.serialization.assistant_transport import (
     AssistantTransportResponse,
 )
+from assistant_stream.serialization.assistant_stream_response import (
+    AssistantStreamResponse,
+)
+from assistant_stream.serialization.data_stream import DataStreamEncoder
 from assistant_stream.serialization.openai_stream import OpenAIStreamResponse
 from assistant_stream.serialization.stream_encoder import (
     DEFAULT_HEARTBEAT_INTERVAL,
@@ -74,6 +78,15 @@ async def test_heartbeat_emitted_when_idle_openai():
     heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
     assert len(heartbeats) >= 2
     assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_rejected_for_non_sse_encoder():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+
+    with pytest.raises(ValueError, match="text/event-stream"):
+        AssistantStreamResponse(stream(), DataStreamEncoder(), heartbeat=0.05)
 
 
 @pytest.mark.anyio

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -9,6 +9,7 @@ from assistant_stream.serialization.assistant_stream_response import (
 )
 from assistant_stream.serialization.assistant_transport import (
     AssistantTransportEncoder,
+    AssistantTransportResponse,
 )
 from assistant_stream.serialization.data_stream import DataStreamEncoder
 from assistant_stream.serialization.heartbeat import (
@@ -62,6 +63,20 @@ async def test_heartbeat_false_disables():
     response = AssistantStreamResponse(
         stream(), AssistantTransportEncoder(), heartbeat=False
     )
+    lines = [line async for line in response.body_iterator]
+
+    assert all(not line.startswith(":") for line in lines)
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_subclass_forwards_heartbeat_kwarg():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.15)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = AssistantTransportResponse(stream(), heartbeat=False)
     lines = [line async for line in response.body_iterator]
 
     assert all(not line.startswith(":") for line in lines)

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -36,7 +36,7 @@ def test_resolve_heartbeat_interval():
 async def test_heartbeat_emitted_when_idle():
     async def stream():
         yield TextDeltaChunk(text_delta="hello")
-        await asyncio.sleep(0.18)
+        await asyncio.sleep(0.55)
         yield TextDeltaChunk(text_delta="world")
 
     response = AssistantStreamResponse(

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -4,7 +4,10 @@ import json
 import pytest
 
 from assistant_stream.assistant_stream_chunk import TextDeltaChunk
-from assistant_stream.serialization.assistant_transport import AssistantTransportEncoder
+from assistant_stream.serialization.assistant_transport import (
+    AssistantTransportResponse,
+)
+from assistant_stream.serialization.openai_stream import OpenAIStreamResponse
 from assistant_stream.serialization.stream_encoder import (
     DEFAULT_HEARTBEAT_INTERVAL,
     SSE_HEARTBEAT_LINE,
@@ -27,14 +30,13 @@ def test_resolve_heartbeat_interval():
 
 @pytest.mark.anyio
 async def test_heartbeat_disabled_by_default():
-    encoder = AssistantTransportEncoder()
-
     async def stream():
         yield TextDeltaChunk(text_delta="hello")
         await asyncio.sleep(0.15)
         yield TextDeltaChunk(text_delta="world")
 
-    lines = [line async for line in encoder.encode_stream(stream())]
+    response = AssistantTransportResponse(stream())
+    lines = [line async for line in response.body_iterator]
 
     assert all(not line.startswith(":") for line in lines)
     assert lines[-1] == "data: [DONE]\n\n"
@@ -42,14 +44,13 @@ async def test_heartbeat_disabled_by_default():
 
 @pytest.mark.anyio
 async def test_heartbeat_emitted_when_idle():
-    encoder = AssistantTransportEncoder(heartbeat=0.05)
-
     async def stream():
         yield TextDeltaChunk(text_delta="hello")
         await asyncio.sleep(0.18)
         yield TextDeltaChunk(text_delta="world")
 
-    lines = [line async for line in encoder.encode_stream(stream())]
+    response = AssistantTransportResponse(stream(), heartbeat=0.05)
+    lines = [line async for line in response.body_iterator]
 
     heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
     assert len(heartbeats) >= 2
@@ -61,15 +62,29 @@ async def test_heartbeat_emitted_when_idle():
 
 
 @pytest.mark.anyio
-async def test_no_heartbeat_when_chunks_are_frequent():
-    encoder = AssistantTransportEncoder(heartbeat=0.2)
+async def test_heartbeat_emitted_when_idle_openai():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
 
+    response = OpenAIStreamResponse(stream(), heartbeat=0.05)
+    lines = [line async for line in response.body_iterator]
+
+    heartbeats = [line for line in lines if line == SSE_HEARTBEAT_LINE]
+    assert len(heartbeats) >= 2
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_no_heartbeat_when_chunks_are_frequent():
     async def stream():
         for i in range(5):
             await asyncio.sleep(0.01)
             yield TextDeltaChunk(text_delta=str(i))
 
-    lines = [line async for line in encoder.encode_stream(stream())]
+    response = AssistantTransportResponse(stream(), heartbeat=0.5)
+    lines = [line async for line in response.body_iterator]
 
     assert all(line.startswith("data: ") for line in lines)
     assert lines[-1] == "data: [DONE]\n\n"
@@ -77,14 +92,13 @@ async def test_no_heartbeat_when_chunks_are_frequent():
 
 @pytest.mark.anyio
 async def test_real_chunk_resets_heartbeat_timer():
-    encoder = AssistantTransportEncoder(heartbeat=0.1)
-
     async def stream():
         for i in range(3):
-            await asyncio.sleep(0.07)
+            await asyncio.sleep(0.05)
             yield TextDeltaChunk(text_delta=str(i))
 
-    lines = [line async for line in encoder.encode_stream(stream())]
+    response = AssistantTransportResponse(stream(), heartbeat=0.5)
+    lines = [line async for line in response.body_iterator]
 
     assert SSE_HEARTBEAT_LINE not in lines
 
@@ -107,4 +121,21 @@ async def test_add_sse_heartbeat_cancels_pending_read_on_close():
     assert await gen.__anext__() == "data: 1\n\n"
     assert await gen.__anext__() == SSE_HEARTBEAT_LINE
     await gen.aclose()
-    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert cancelled.is_set()
+
+
+@pytest.mark.anyio
+async def test_add_sse_heartbeat_closes_upstream_when_no_read_pending():
+    closed = asyncio.Event()
+
+    async def stream():
+        try:
+            yield "data: 1\n\n"
+            yield "data: 2\n\n"
+        finally:
+            closed.set()
+
+    gen = add_sse_heartbeat(stream(), 10)
+    assert await gen.__anext__() == "data: 1\n\n"
+    await gen.aclose()
+    assert closed.is_set()


### PR DESCRIPTION
## What

SSE responses now emit `: heartbeat` comment lines whenever the stream is idle for 15 seconds, enabled by default. This keeps proxies and load balancers from timing out long-running streams (e.g. slow tool calls) between chunks.

## How

The feature lives entirely in `stream_encoder.py` plus a few lines in `AssistantStreamResponse`:

- `add_sse_heartbeat(stream, interval)` wraps an encoded SSE stream and yields a comment line whenever no chunk arrives within the interval; any real chunk resets the timer. On close it cancels and awaits the pending read and closes the upstream generator deterministically.
- `resolve_heartbeat_interval(heartbeat)` normalizes the option: `True` (the default) is 15s, a positive number is used as-is, and `False`/`0`/`None` disable heartbeats. Negative or non-finite values raise `ValueError`.
- `AssistantStreamResponse.__init__` accepts `heartbeat: Union[float, int, bool, None] = True` and applies the wrapper only when the encoder's media type is `text/event-stream`, so non-SSE responses (e.g. `DataStreamResponse`) are unaffected.

Encoders are untouched: `encode_stream` remains a plain async generator, and `AssistantTransportResponse` / `OpenAIStreamResponse` inherit the behavior with no signature changes.

To customize, construct the response through `AssistantStreamResponse` with the desired `heartbeat` value.

SSE comments are part of the SSE spec and ignored by `EventSource` and the assistant-transport client, so no client changes are needed.
