### PR TITLE
feat(assistant-stream): rename ObjectStream to GorpStream with deprecated aliases

### DIFF
--- a/.changeset/gorp-stream-rename.md
+++ b/.changeset/gorp-stream-rename.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+feat: rename ObjectStream to GorpStream (old names remain as deprecated aliases)

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -242,7 +242,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -300,6 +300,16 @@ type GeneratePresignedUploadUrlResponse = {
   publicUrl: string;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type MakeRequestOptions = {
   method?: "POST" | "PUT" | "DELETE" | undefined;
   headers?: Record<string, string> | undefined;
@@ -353,16 +363,6 @@ type MessageFormatAdapter<TMessage, TStorageFormat> = {
     message: TMessage;
   };
   getId(message: TMessage): string;
-};
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
 };
 
 type PartInit = {

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -191,7 +191,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamController = {
@@ -601,8 +601,8 @@ interface ConnectorConstructor {
   new (options: unknown): AbstractConnector;
 }
 
-type CreateObjectStreamOptions = {
-  execute: (controller: ObjectStreamController) => void | PromiseLike<void>;
+type CreateGorpStreamOptions = {
+  execute: (controller: GorpStreamController) => void | PromiseLike<void>;
   defaultValue?: ReadonlyJSONValue;
 };
 
@@ -736,6 +736,30 @@ type GenericUserMessage = {
   role: "user";
   content: (GenericTextPart | GenericFilePart)[];
 };
+
+type GorpStreamChunk = {
+  readonly snapshot: ReadonlyJSONValue;
+  readonly operations: readonly GorpStreamOperation[];
+};
+
+type GorpStreamController = {
+  readonly abortSignal: AbortSignal;
+  enqueue(operations: readonly GorpStreamOperation[]): void;
+};
+
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
+declare class GorpStreamResponse extends Response {
+  constructor(body: ReadableStream<GorpStreamChunk>);
+}
 
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
@@ -928,29 +952,11 @@ declare type NodeRole = "all" | "master" | "slave";
 
 type ObjectKey<T> = keyof T & (string | number);
 
-type ObjectStreamChunk = {
-  readonly snapshot: ReadonlyJSONValue;
-  readonly operations: readonly ObjectStreamOperation[];
-};
+type ObjectStreamChunk = GorpStreamChunk;
 
-type ObjectStreamController = {
-  readonly abortSignal: AbortSignal;
-  enqueue(operations: readonly ObjectStreamOperation[]): void;
-};
+declare const ObjectStreamResponse: typeof GorpStreamResponse;
 
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
-
-declare class ObjectStreamResponse extends Response {
-  constructor(body: ReadableStream<ObjectStreamChunk>);
-}
+type ObjectStreamResponse = GorpStreamResponse;
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
@@ -11916,17 +11922,25 @@ declare function createAssistantStreamController(): readonly [
 
 declare function createAssistantStreamResponse(callback: (controller: AssistantStreamController) => PromiseLike<void> | void): Response;
 
+declare const createGorpStream: (_param1: CreateGorpStreamOptions) => ReadableStream<GorpStreamChunk>;
+
 declare function createInMemoryResumableStreamStore(options?: InMemoryResumableStreamStoreOptions): ResumableStreamStore & {
   dispose: () => void;
 };
 
-declare const createInitialMessage: (_param1?: {
+declare const createInitialMessage: (_param2?: {
   unstable_state?: ReadonlyJSONValue;
 }) => AssistantMessage;
 
 declare function createIoredisResumableStreamStore(client: IoRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
 
-declare const createObjectStream: (_param2: CreateObjectStreamOptions) => ReadableStream<ObjectStreamChunk>;
+declare const createObjectStream: (_param3: {
+  execute: (controller: {
+    readonly abortSignal: AbortSignal;
+    enqueue(operations: readonly GorpStreamOperation[]): void;
+  }) => void | PromiseLike<void>;
+  defaultValue?: ReadonlyJSONValue;
+}) => ReadableStream<GorpStreamChunk>;
 
 declare function createRedisResumableStreamStore(client: NodeRedisLike, options?: RedisResumableStreamStoreOptions): ResumableStreamStore;
 
@@ -11936,7 +11950,9 @@ declare function createResumableStreamContext(options: ResumableStreamContextOpt
 
 declare function createResumeAssistantStreamResponse(options: CreateResumeAssistantStreamResponseOptions): Promise<Response>;
 
-declare const fromObjectStreamResponse: (response: Response) => ReadableStream<ObjectStreamChunk>;
+declare const fromGorpStreamResponse: (response: Response) => ReadableStream<GorpStreamChunk>;
+
+declare const fromObjectStreamResponse: (response: Response) => ReadableStream<GorpStreamChunk>;
 
 declare const getPartialJsonObjectFieldState: (obj: Record<string, unknown>, fieldPath: (string | number)[]) => FieldState;
 
@@ -11947,7 +11963,7 @@ declare namespace entry_resumable_exports {
 }
 
 declare namespace entry_root_exports {
-  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, AssistantTransportEncoder, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createObjectStream, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
+  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, AssistantTransportEncoder, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, GorpStreamChunk, GorpStreamResponse, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createGorpStream, createObjectStream, fromGorpStreamResponse, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
 }
 
 declare namespace entry_resumable_ioredis_exports {

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -246,7 +246,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -297,14 +297,7 @@ type GeneratePresignedUploadUrlResponse = {
   publicUrl: string;
 };
 
-type MakeRequestOptions = {
-  method?: "POST" | "PUT" | "DELETE" | undefined;
-  headers?: Record<string, string> | undefined;
-  query?: Record<string, string | number | boolean> | undefined;
-  body?: object | undefined;
-};
-
-type ObjectStreamOperation = {
+type GorpStreamOperation = {
   readonly type: "set";
   readonly path: readonly string[];
   readonly value: ReadonlyJSONValue;
@@ -312,6 +305,13 @@ type ObjectStreamOperation = {
   readonly type: "append-text";
   readonly path: readonly string[];
   readonly value: string;
+};
+
+type MakeRequestOptions = {
+  method?: "POST" | "PUT" | "DELETE" | undefined;
+  headers?: Record<string, string> | undefined;
+  query?: Record<string, string | number | boolean> | undefined;
+  body?: object | undefined;
 };
 
 type PartInit = {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -427,7 +427,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -1883,6 +1883,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type GroupByContext = {
   readonly toolUIs?: ToolsState["toolUIs"];
 };
@@ -2878,16 +2888,6 @@ declare const NoOpComposerClient: Resource<ClientOutput<"composer">, [
 ]>;
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -321,7 +321,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -829,6 +829,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
   description?: string | undefined;
@@ -1134,16 +1144,6 @@ type ModelContextProvider = {
 };
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -260,7 +260,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -673,6 +673,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HeadersValue = Record<string, string> | Headers;
 
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
@@ -998,16 +1008,6 @@ type ModelContextProvider = {
 };
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -636,7 +636,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -1129,6 +1129,16 @@ type GenerativeUISpec = {
   readonly root: GenerativeUINode | readonly GenerativeUINode[];
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
   description?: string | undefined;
@@ -1408,16 +1418,6 @@ type ModelContextProvider = {
 };
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnAdkAgentTransferCallback = (toAgent: string) => void | Promise<void>;
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -400,7 +400,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -1572,6 +1572,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
   description?: string | undefined;
@@ -2494,16 +2504,6 @@ type NotificationHandler<T extends NotificationEvent["type"] = NotificationEvent
 type OSCVariant = "osc777" | "osc9" | "osc99";
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -272,7 +272,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -751,6 +751,16 @@ type GenerativeUISpec = {
   readonly root: GenerativeUINode | readonly GenerativeUINode[];
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
   description?: string | undefined;
@@ -1122,16 +1132,6 @@ type ModelContextProvider = {
 };
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -276,7 +276,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -770,6 +770,16 @@ type GenerativeUISpec = {
   readonly root: GenerativeUINode | readonly GenerativeUINode[];
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type HumanTool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = ToolBase<TArgs, TResult> & {
   type: "human";
   description?: string | undefined;
@@ -1251,16 +1261,6 @@ type ModelContextProvider = {
 };
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnCustomEventCallback = (type: string, data: unknown) => void | Promise<void>;
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -398,7 +398,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -1399,6 +1399,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type GroupByContext = {
   readonly toolUIs?: ToolsState["toolUIs"];
 };
@@ -2167,16 +2177,6 @@ interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> =
 }
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -638,7 +638,7 @@ type AssistantStreamChunk = {
   readonly severity?: "critical" | "info" | "warning";
 } | {
   readonly type: "update-state";
-  readonly operations: ObjectStreamOperation[];
+  readonly operations: GorpStreamOperation[];
 });
 
 type AssistantStreamEncoder = ReadableWritablePair<Uint8Array<ArrayBuffer>, AssistantStreamChunk> & {
@@ -2236,6 +2236,16 @@ type GenericThreadHistoryAdapter<TMessage> = {
   }): void;
 };
 
+type GorpStreamOperation = {
+  readonly type: "set";
+  readonly path: readonly string[];
+  readonly value: ReadonlyJSONValue;
+} | {
+  readonly type: "append-text";
+  readonly path: readonly string[];
+  readonly value: string;
+};
+
 type GroupByContext = {
   readonly toolUIs?: ToolsState["toolUIs"];
 };
@@ -3150,16 +3160,6 @@ interface ModelContextRegistryToolHandle<TArgs extends Record<string, unknown> =
 }
 
 type ObjectKey<T> = keyof T & (string | number);
-
-type ObjectStreamOperation = {
-  readonly type: "set";
-  readonly path: readonly string[];
-  readonly value: ReadonlyJSONValue;
-} | {
-  readonly type: "append-text";
-  readonly path: readonly string[];
-  readonly value: string;
-};
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -1,5 +1,5 @@
 import type { ReadonlyJSONValue } from "../utils/json/json-value";
-import type { ObjectStreamOperation } from "./object/types";
+import type { GorpStreamOperation } from "./gorp/types";
 import type { ToolModelContentPart } from "./tool/tool-types";
 
 /**
@@ -138,6 +138,6 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
   | {
       /** Applies object-stream operations to state carried by this stream. */
       readonly type: "update-state";
-      readonly operations: ObjectStreamOperation[];
+      readonly operations: GorpStreamOperation[];
     }
 );

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -136,7 +136,7 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       readonly severity?: "critical" | "warning" | "info";
     }
   | {
-      /** Applies object-stream operations to state carried by this stream. */
+      /** Applies gorp-stream operations to state carried by this stream. */
       readonly type: "update-state";
       readonly operations: GorpStreamOperation[];
     }

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -13,7 +13,7 @@ import type {
   FilePart,
   DataPart,
 } from "../utils/types";
-import { ObjectStreamAccumulator } from "../object/ObjectStreamAccumulator";
+import { GorpStreamAccumulator } from "../gorp/GorpStreamAccumulator";
 import type { ReadonlyJSONValue } from "../../utils";
 import { TimingTracker } from "./TimingTracker";
 
@@ -388,7 +388,7 @@ const handleUpdateState = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { type: "update-state" },
 ): AssistantMessage => {
-  const acc = new ObjectStreamAccumulator(message.metadata.unstable_state);
+  const acc = new GorpStreamAccumulator(message.metadata.unstable_state);
   acc.append(chunk.operations);
 
   return {

--- a/packages/assistant-stream/src/core/gorp/GorpStream.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStream.test.ts
@@ -1,11 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createObjectStream } from "./createObjectStream";
-import {
-  ObjectStreamEncoder,
-  ObjectStreamDecoder,
-} from "./ObjectStreamResponse";
+import { createGorpStream } from "./createGorpStream";
+import { GorpStreamEncoder, GorpStreamDecoder } from "./GorpStreamResponse";
 import type { ReadonlyJSONValue } from "../../utils";
-import type { ObjectStreamChunk } from "./types";
+import type { GorpStreamChunk } from "./types";
 
 // Helper function to collect all chunks from a stream
 async function collectChunks<T>(stream: ReadableStream<T>): Promise<T[]> {
@@ -27,10 +24,10 @@ async function collectChunks<T>(stream: ReadableStream<T>): Promise<T[]> {
 
 // Helper function to encode and decode a stream
 async function encodeAndDecode(
-  stream: ReadableStream<ObjectStreamChunk>,
-): Promise<ReadableStream<ObjectStreamChunk>> {
+  stream: ReadableStream<GorpStreamChunk>,
+): Promise<ReadableStream<GorpStreamChunk>> {
   // Encode the stream to Uint8Array (simulating network transmission)
-  const encodedStream = stream.pipeThrough(new ObjectStreamEncoder());
+  const encodedStream = stream.pipeThrough(new GorpStreamEncoder());
 
   // Collect all encoded chunks
   const encodedChunks = await collectChunks(encodedStream);
@@ -45,18 +42,18 @@ async function encodeAndDecode(
     },
   });
 
-  // Decode the stream back to ObjectStreamChunk
-  return reconstructedStream.pipeThrough(new ObjectStreamDecoder());
+  // Decode the stream back to GorpStreamChunk
+  return reconstructedStream.pipeThrough(new GorpStreamDecoder());
 }
 
-describe("ObjectStream serialization and deserialization", () => {
+describe("GorpStream serialization and deserialization", () => {
   it("does not settle the stream after cancellation", async () => {
     let finishExecution!: () => void;
     let abortSignal!: AbortSignal;
     const execution = new Promise<void>((resolve) => {
       finishExecution = resolve;
     });
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         abortSignal = controller.abortSignal;
         return execution;
@@ -75,7 +72,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should discard an unterminated SSE event", async () => {
-    const operations: ObjectStreamChunk["operations"] = [
+    const operations: GorpStreamChunk["operations"] = [
       { type: "set", path: ["status"], value: "complete" },
     ];
     const stream = new ReadableStream<Uint8Array>({
@@ -88,7 +85,7 @@ describe("ObjectStream serialization and deserialization", () => {
     });
 
     const chunks = await collectChunks(
-      stream.pipeThrough(new ObjectStreamDecoder()),
+      stream.pipeThrough(new GorpStreamDecoder()),
     );
 
     expect(chunks).toEqual([]);
@@ -96,7 +93,7 @@ describe("ObjectStream serialization and deserialization", () => {
 
   it("should correctly serialize and deserialize simple objects", async () => {
     // Create an object stream with simple operations
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["name"], value: "John" },
@@ -120,7 +117,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle nested objects", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["user", "profile", "name"], value: "Jane" },
@@ -152,7 +149,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle arrays", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["items"], value: [] },
@@ -173,7 +170,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle mixed arrays and objects", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["users"], value: [] },
@@ -200,7 +197,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle append-text operations", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["message"], value: "Hello" },
@@ -221,7 +218,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle special characters and Unicode", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           {
@@ -253,7 +250,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle null and undefined values", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["nullValue"], value: null },
@@ -276,7 +273,7 @@ describe("ObjectStream serialization and deserialization", () => {
 
   it("should correctly handle large nested structures", async () => {
     // Create a deep nested structure
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["level1"], value: {} },
@@ -314,7 +311,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle operations in multiple enqueue calls", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         // First batch of operations
         controller.enqueue([
@@ -363,7 +360,7 @@ describe("ObjectStream serialization and deserialization", () => {
   });
 
   it("should correctly handle overwriting existing values", async () => {
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       execute: (controller) => {
         controller.enqueue([
           { type: "set", path: ["value"], value: "initial" },
@@ -395,7 +392,7 @@ describe("ObjectStream serialization and deserialization", () => {
       },
     };
 
-    const stream = createObjectStream({
+    const stream = createGorpStream({
       defaultValue: initialValue,
       execute: (controller) => {
         controller.enqueue([

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -1,7 +1,7 @@
 import type { ReadonlyJSONValue, ReadonlyJSONObject } from "../../utils";
-import type { ObjectStreamOperation } from "./types";
+import type { GorpStreamOperation } from "./types";
 
-export class ObjectStreamAccumulator {
+export class GorpStreamAccumulator {
   private _state: ReadonlyJSONValue;
 
   constructor(initialValue: ReadonlyJSONValue = null) {
@@ -12,24 +12,20 @@ export class ObjectStreamAccumulator {
     return this._state;
   }
 
-  append(ops: readonly ObjectStreamOperation[]) {
+  append(ops: readonly GorpStreamOperation[]) {
     this._state = ops.reduce(
-      (state, op) => ObjectStreamAccumulator.apply(state, op),
+      (state, op) => GorpStreamAccumulator.apply(state, op),
       this._state,
     );
   }
 
-  private static apply(state: ReadonlyJSONValue, op: ObjectStreamOperation) {
+  private static apply(state: ReadonlyJSONValue, op: GorpStreamOperation) {
     const type = op.type;
     switch (type) {
       case "set":
-        return ObjectStreamAccumulator.updatePath(
-          state,
-          op.path,
-          () => op.value,
-        );
+        return GorpStreamAccumulator.updatePath(state, op.path, () => op.value);
       case "append-text":
-        return ObjectStreamAccumulator.updatePath(state, op.path, (current) => {
+        return GorpStreamAccumulator.updatePath(state, op.path, (current) => {
           if (typeof current !== "string")
             throw new Error(`Expected string at path [${op.path.join(", ")}]`);
           return current + op.value;
@@ -65,7 +61,7 @@ export class ObjectStreamAccumulator {
         throw new Error(`Insert array index out of bounds`);
 
       const nextState = [...state];
-      nextState[idx] = ObjectStreamAccumulator.updatePath(
+      nextState[idx] = GorpStreamAccumulator.updatePath(
         nextState[idx],
         rest,
         updater,
@@ -75,7 +71,7 @@ export class ObjectStreamAccumulator {
     }
 
     const nextState = { ...(state as ReadonlyJSONObject) };
-    nextState[key] = ObjectStreamAccumulator.updatePath(
+    nextState[key] = GorpStreamAccumulator.updatePath(
       nextState[key],
       rest,
       updater,

--- a/packages/assistant-stream/src/core/gorp/GorpStreamResponse.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamResponse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fromObjectStreamResponse } from "./ObjectStreamResponse";
+import { fromGorpStreamResponse } from "./GorpStreamResponse";
 
 const createResponse = (contentType?: string) => {
   const headers = new Headers({
@@ -10,23 +10,23 @@ const createResponse = (contentType?: string) => {
   return new Response(new Uint8Array(), { headers });
 };
 
-describe("fromObjectStreamResponse", () => {
+describe("fromGorpStreamResponse", () => {
   it.each([
     "text/event-stream",
     "text/event-stream; charset=utf-8",
     "Text/Event-Stream; Charset=UTF-8",
   ])("accepts the event-stream content type %s", (contentType) => {
     expect(() =>
-      fromObjectStreamResponse(createResponse(contentType)),
+      fromGorpStreamResponse(createResponse(contentType)),
     ).not.toThrow();
   });
 
   it.each([undefined, "application/json", "text/event-streaming"])(
     "rejects the content type %s",
     (contentType) => {
-      expect(() =>
-        fromObjectStreamResponse(createResponse(contentType)),
-      ).toThrow("Response is not an event stream");
+      expect(() => fromGorpStreamResponse(createResponse(contentType))).toThrow(
+        "Response is not an event stream",
+      );
     },
   );
 });

--- a/packages/assistant-stream/src/core/gorp/GorpStreamResponse.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamResponse.ts
@@ -18,10 +18,6 @@ export class GorpStreamEncoder extends PipeableTransformStream<
             > {
               #isFirstChunk = true;
 
-              start() {
-                // Nothing needed here since we initialize in the field declaration
-              }
-
               transform(
                 chunk: GorpStreamChunk,
                 controller: TransformStreamDefaultController<

--- a/packages/assistant-stream/src/core/gorp/GorpStreamResponse.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamResponse.ts
@@ -1,10 +1,10 @@
 import { PipeableTransformStream } from "../utils/stream/PipeableTransformStream";
-import { ObjectStreamAccumulator } from "./ObjectStreamAccumulator";
+import { GorpStreamAccumulator } from "./GorpStreamAccumulator";
 import { SSEDecoder, SSEEncoder } from "../utils/stream/SSE";
-import type { ObjectStreamChunk, ObjectStreamOperation } from "./types";
+import type { GorpStreamChunk, GorpStreamOperation } from "./types";
 
-export class ObjectStreamEncoder extends PipeableTransformStream<
-  ObjectStreamChunk,
+export class GorpStreamEncoder extends PipeableTransformStream<
+  GorpStreamChunk,
   Uint8Array
 > {
   constructor() {
@@ -12,9 +12,9 @@ export class ObjectStreamEncoder extends PipeableTransformStream<
       readable
         .pipeThrough(
           (() => {
-            class ObjectStreamTransformer implements Transformer<
-              ObjectStreamChunk,
-              readonly ObjectStreamOperation[]
+            class GorpStreamTransformer implements Transformer<
+              GorpStreamChunk,
+              readonly GorpStreamOperation[]
             > {
               #isFirstChunk = true;
 
@@ -23,9 +23,9 @@ export class ObjectStreamEncoder extends PipeableTransformStream<
               }
 
               transform(
-                chunk: ObjectStreamChunk,
+                chunk: GorpStreamChunk,
                 controller: TransformStreamDefaultController<
-                  readonly ObjectStreamOperation[]
+                  readonly GorpStreamOperation[]
                 >,
               ) {
                 if (
@@ -45,7 +45,7 @@ export class ObjectStreamEncoder extends PipeableTransformStream<
                 this.#isFirstChunk = false;
               }
             }
-            return new TransformStream(new ObjectStreamTransformer());
+            return new TransformStream(new GorpStreamTransformer());
           })(),
         )
         .pipeThrough(new SSEEncoder()),
@@ -53,20 +53,17 @@ export class ObjectStreamEncoder extends PipeableTransformStream<
   }
 }
 
-export class ObjectStreamDecoder extends PipeableTransformStream<
+export class GorpStreamDecoder extends PipeableTransformStream<
   Uint8Array<ArrayBuffer>,
-  ObjectStreamChunk
+  GorpStreamChunk
 > {
   constructor() {
-    const accumulator = new ObjectStreamAccumulator();
+    const accumulator = new GorpStreamAccumulator();
     super((readable) =>
       readable
-        .pipeThrough(new SSEDecoder<readonly ObjectStreamOperation[]>())
+        .pipeThrough(new SSEDecoder<readonly GorpStreamOperation[]>())
         .pipeThrough(
-          new TransformStream<
-            readonly ObjectStreamOperation[],
-            ObjectStreamChunk
-          >({
+          new TransformStream<readonly GorpStreamOperation[], GorpStreamChunk>({
             transform(operations, controller) {
               accumulator.append(operations);
               controller.enqueue({
@@ -80,9 +77,9 @@ export class ObjectStreamDecoder extends PipeableTransformStream<
   }
 }
 
-export class ObjectStreamResponse extends Response {
-  constructor(body: ReadableStream<ObjectStreamChunk>) {
-    super(body.pipeThrough(new ObjectStreamEncoder()), {
+export class GorpStreamResponse extends Response {
+  constructor(body: ReadableStream<GorpStreamChunk>) {
+    super(body.pipeThrough(new GorpStreamEncoder()), {
       headers: new Headers({
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -93,9 +90,9 @@ export class ObjectStreamResponse extends Response {
   }
 }
 
-export const fromObjectStreamResponse = (
+export const fromGorpStreamResponse = (
   response: Response,
-): ReadableStream<ObjectStreamChunk> => {
+): ReadableStream<GorpStreamChunk> => {
   if (!response.ok)
     throw new Error(`Response failed, status ${response.status}`);
   if (!response.body) throw new Error("Response body is null");
@@ -110,5 +107,5 @@ export const fromObjectStreamResponse = (
   if (response.headers.get("Assistant-Stream-Format") !== "object-stream/v0") {
     throw new Error("Unsupported Assistant-Stream-Format header");
   }
-  return response.body.pipeThrough(new ObjectStreamDecoder());
+  return response.body.pipeThrough(new GorpStreamDecoder());
 };

--- a/packages/assistant-stream/src/core/gorp/createGorpStream.ts
+++ b/packages/assistant-stream/src/core/gorp/createGorpStream.ts
@@ -1,18 +1,18 @@
 import type { ReadonlyJSONValue } from "../../utils";
 import { withPromiseOrValue } from "../utils/withPromiseOrValue";
-import { ObjectStreamAccumulator } from "./ObjectStreamAccumulator";
-import type { ObjectStreamOperation, ObjectStreamChunk } from "./types";
+import { GorpStreamAccumulator } from "./GorpStreamAccumulator";
+import type { GorpStreamOperation, GorpStreamChunk } from "./types";
 
-type ObjectStreamController = {
+type GorpStreamController = {
   readonly abortSignal: AbortSignal;
 
-  enqueue(operations: readonly ObjectStreamOperation[]): void;
+  enqueue(operations: readonly GorpStreamOperation[]): void;
 };
 
-class ObjectStreamControllerImpl implements ObjectStreamController {
-  private _controller: ReadableStreamDefaultController<ObjectStreamChunk>;
+class GorpStreamControllerImpl implements GorpStreamController {
+  private _controller: ReadableStreamDefaultController<GorpStreamChunk>;
   private _abortController = new AbortController();
-  private _accumulator: ObjectStreamAccumulator;
+  private _accumulator: GorpStreamAccumulator;
   private _cancelled = false;
 
   get abortSignal() {
@@ -20,14 +20,14 @@ class ObjectStreamControllerImpl implements ObjectStreamController {
   }
 
   constructor(
-    controller: ReadableStreamDefaultController<ObjectStreamChunk>,
+    controller: ReadableStreamDefaultController<GorpStreamChunk>,
     defaultValue: ReadonlyJSONValue,
   ) {
     this._controller = controller;
-    this._accumulator = new ObjectStreamAccumulator(defaultValue);
+    this._accumulator = new GorpStreamAccumulator(defaultValue);
   }
 
-  enqueue(operations: readonly ObjectStreamOperation[]) {
+  enqueue(operations: readonly GorpStreamOperation[]) {
     if (this._cancelled) return;
 
     this._accumulator.append(operations);
@@ -55,10 +55,10 @@ class ObjectStreamControllerImpl implements ObjectStreamController {
 }
 
 const getStreamControllerPair = (defaultValue: ReadonlyJSONValue) => {
-  let controller!: ObjectStreamControllerImpl;
-  const stream = new ReadableStream<ObjectStreamChunk>({
+  let controller!: GorpStreamControllerImpl;
+  const stream = new ReadableStream<GorpStreamChunk>({
     start(c) {
-      controller = new ObjectStreamControllerImpl(c, defaultValue);
+      controller = new GorpStreamControllerImpl(c, defaultValue);
     },
     cancel(reason: unknown) {
       controller.__internalCancel(reason);
@@ -68,15 +68,15 @@ const getStreamControllerPair = (defaultValue: ReadonlyJSONValue) => {
   return [stream, controller] as const;
 };
 
-type CreateObjectStreamOptions = {
-  execute: (controller: ObjectStreamController) => void | PromiseLike<void>;
+type CreateGorpStreamOptions = {
+  execute: (controller: GorpStreamController) => void | PromiseLike<void>;
   defaultValue?: ReadonlyJSONValue;
 };
 
-export const createObjectStream = ({
+export const createGorpStream = ({
   execute,
   defaultValue = {},
-}: CreateObjectStreamOptions) => {
+}: CreateGorpStreamOptions) => {
   const [stream, controller] = getStreamControllerPair(defaultValue);
 
   withPromiseOrValue(

--- a/packages/assistant-stream/src/core/gorp/types.ts
+++ b/packages/assistant-stream/src/core/gorp/types.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyJSONValue } from "../../utils";
 
-export type ObjectStreamOperation =
+export type GorpStreamOperation =
   | {
       readonly type: "set";
       readonly path: readonly string[];
@@ -12,7 +12,7 @@ export type ObjectStreamOperation =
       readonly value: string;
     };
 
-export type ObjectStreamChunk = {
+export type GorpStreamChunk = {
   readonly snapshot: ReadonlyJSONValue;
-  readonly operations: readonly ObjectStreamOperation[];
+  readonly operations: readonly GorpStreamOperation[];
 };

--- a/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
@@ -2,7 +2,7 @@ import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "../../../utils/json/json-value";
-import type { ObjectStreamOperation } from "../../object/types";
+import type { GorpStreamOperation } from "../../gorp/types";
 
 export type DataStreamChunk = {
   [K in DataStreamStreamChunkType]: {
@@ -100,7 +100,7 @@ type DataStreamStreamChunkValue = {
   [DataStreamStreamChunkType.File]: { data: string; mimeType: string };
 
   // aui-extensions
-  [DataStreamStreamChunkType.AuiUpdateStateOperations]: ObjectStreamOperation[];
+  [DataStreamStreamChunkType.AuiUpdateStateOperations]: GorpStreamOperation[];
   [DataStreamStreamChunkType.AuiTextDelta]: {
     textDelta: string;
     parentId: string;

--- a/packages/assistant-stream/src/index.ts
+++ b/packages/assistant-stream/src/index.ts
@@ -62,12 +62,30 @@ export {
 export type { TextStreamController } from "./core/modules/text";
 export type { ToolCallStreamController } from "./core/modules/tool-call";
 
-export { createObjectStream } from "./core/object/createObjectStream";
+export { createGorpStream } from "./core/gorp/createGorpStream";
 export {
-  ObjectStreamResponse,
-  fromObjectStreamResponse,
-} from "./core/object/ObjectStreamResponse";
-export type { ObjectStreamChunk } from "./core/object/types";
+  GorpStreamResponse,
+  fromGorpStreamResponse,
+} from "./core/gorp/GorpStreamResponse";
+export type { GorpStreamChunk } from "./core/gorp/types";
+
+import { createGorpStream } from "./core/gorp/createGorpStream";
+import {
+  GorpStreamResponse,
+  fromGorpStreamResponse,
+} from "./core/gorp/GorpStreamResponse";
+import type { GorpStreamChunk } from "./core/gorp/types";
+
+/** @deprecated Use `createGorpStream` instead. */
+export const createObjectStream = createGorpStream;
+/** @deprecated Use `GorpStreamResponse` instead. */
+export const ObjectStreamResponse = GorpStreamResponse;
+/** @deprecated Use `GorpStreamResponse` instead. */
+export type ObjectStreamResponse = GorpStreamResponse;
+/** @deprecated Use `fromGorpStreamResponse` instead. */
+export const fromObjectStreamResponse = fromGorpStreamResponse;
+/** @deprecated Use `GorpStreamChunk` instead. */
+export type ObjectStreamChunk = GorpStreamChunk;
 
 export {
   toGenericMessages,

--- a/packages/assistant-stream/src/index.ts
+++ b/packages/assistant-stream/src/index.ts
@@ -62,19 +62,15 @@ export {
 export type { TextStreamController } from "./core/modules/text";
 export type { ToolCallStreamController } from "./core/modules/tool-call";
 
-export { createGorpStream } from "./core/gorp/createGorpStream";
-export {
-  GorpStreamResponse,
-  fromGorpStreamResponse,
-} from "./core/gorp/GorpStreamResponse";
-export type { GorpStreamChunk } from "./core/gorp/types";
-
 import { createGorpStream } from "./core/gorp/createGorpStream";
 import {
   GorpStreamResponse,
   fromGorpStreamResponse,
 } from "./core/gorp/GorpStreamResponse";
 import type { GorpStreamChunk } from "./core/gorp/types";
+
+export { createGorpStream, GorpStreamResponse, fromGorpStreamResponse };
+export type { GorpStreamChunk };
 
 /** @deprecated Use `createGorpStream` instead. */
 export const createObjectStream = createGorpStream;


### PR DESCRIPTION
## What

Renames the ObjectStream layer in `assistant-stream` to GorpStream. This is the first step of folding the gorp state-sync library (`packages/gorp`) into `assistant-stream`; GorpStream is the new canonical name for the object/state streaming layer.

## How

- `src/core/object/` is now `src/core/gorp/`, with files renamed to match the new symbols: `GorpStreamAccumulator`, `GorpStreamResponse` (incl. `GorpStreamEncoder`/`GorpStreamDecoder`), `createGorpStream`, and the `GorpStreamOperation`/`GorpStreamChunk` types. Colocated tests renamed accordingly.
- The public surface stays append-only: every previously exported name (`createObjectStream`, `ObjectStreamResponse`, `fromObjectStreamResponse`, `ObjectStreamChunk`) remains available as a deprecated alias in the package index, with `@deprecated` JSDoc pointing at the new name. `ObjectStreamResponse` keeps both its value and type meaning.
- The wire format is byte-identical: no protocol string changed (`"update-state"`, `"object-stream/v0"`, op types `"set"`/`"append-text"`, SSE framing all untouched), verified by the existing round-trip serialization tests.
- api-surface regenerated for `assistant-stream` and the packages that inline its types.
- Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

