### PR TITLE
fix(core): settle stopped thread runtime starts

### DIFF
--- a/.changeset/calm-runtimes-settle.md
+++ b/.changeset/calm-runtimes-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: settle thread runtime starts when stopped before mounting

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
+
+describe("RemoteThreadListHookInstanceManager", () => {
+  it("rejects a pending start when the thread runtime is stopped", async () => {
+    const manager = new RemoteThreadListHookInstanceManager(() => {
+      throw new Error("Runtime hook should not render during this test");
+    }, {} as ThreadListRuntimeCore);
+
+    const startPromise = manager.startThreadRuntime("thread-1");
+    manager.stopThreadRuntime("thread-1");
+
+    await expect(startPromise).rejects.toThrow(
+      "Thread was deleted before runtime was started",
+    );
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -85,6 +85,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   public stopThreadRuntime(threadId: string) {
     this.instances.delete(threadId);
     this.useAliveThreadsKeysChanged.setState({}, true);
+    this._notifySubscribers();
   }
 
   public setRuntimeHook(newRuntimeHook: RemoteThreadListHook) {


### PR DESCRIPTION
## Summary

- notify pending runtime starters when a thread runtime is stopped
- cover the stop-before-mount path with a regression test
- add a patch changeset for `@assistant-ui/core`

## Why

`startThreadRuntime()` waits for the React runtime binder to mount. If the thread is deleted or detached before that happens, `stopThreadRuntime()` removes the instance but previously did not notify the manager's subscribers. The pending promise therefore never reached its existing rejection branch and could leave the calling thread operation waiting indefinitely.

The manager now notifies after removing the instance, so the pending start rejects with the existing `Thread was deleted before runtime was started` error.

## Verification

- reproduced on `main`: the regression test timed out after 5 seconds
- targeted regression test passes after the fix
- `pnpm --filter @assistant-ui/core test` (60 files, 578 tests)
- `pnpm lint`
- `pnpm build --filter @assistant-ui/core...`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

