### PR TITLE
fix(core): detect removed keys in shallow memoized state

### DIFF
--- a/.changeset/fresh-states-notify.md
+++ b/.changeset/fresh-states-notify.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: detect removed keys in shallow memoized state

--- a/packages/core/src/subscribable/subscribable.test.ts
+++ b/packages/core/src/subscribable/subscribable.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SubscribableWithState } from "./subscribable";
+import { ShallowMemoizeSubject } from "./subscribable";
+
+type TestState = {
+  status: string;
+  error?: string;
+};
+
+const createBinding = (initialState: TestState) => {
+  let state = initialState;
+  const subscribers = new Set<() => void>();
+
+  const binding: SubscribableWithState<TestState, null> = {
+    path: null,
+    getState: () => state,
+    subscribe: (callback) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+  };
+
+  return {
+    binding,
+    update(nextState: TestState) {
+      state = nextState;
+      for (const callback of subscribers) callback();
+    },
+  };
+};
+
+describe("ShallowMemoizeSubject", () => {
+  it("notifies subscribers when a state key is removed", () => {
+    const source = createBinding({
+      status: "running",
+      error: "Connection failed",
+    });
+    const subject = new ShallowMemoizeSubject(source.binding);
+    const subscriber = vi.fn();
+    subject.subscribe(subscriber);
+
+    source.update({ status: "running" });
+
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(subject.getState()).toEqual({ status: "running" });
+  });
+
+  it("does not notify subscribers for a shallow-equal state", () => {
+    const source = createBinding({ status: "running" });
+    const subject = new ShallowMemoizeSubject(source.binding);
+    const subscriber = vi.fn();
+    subject.subscribe(subscriber);
+
+    source.update({ status: "running" });
+
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -39,7 +39,10 @@ function shallowEqual<T extends object>(
   if (objA === undefined) return false;
   if (objB === undefined) return false;
 
-  for (const key of Object.keys(objA)) {
+  const keysA = Object.keys(objA);
+  if (keysA.length !== Object.keys(objB).length) return false;
+
+  for (const key of keysA) {
     const valueA = objA[key as keyof T];
     const valueB = objB[key as keyof T];
     if (!Object.is(valueA, valueB)) return false;


### PR DESCRIPTION
## Summary

- compare shallow-memoized state key counts before comparing values
- notify subscribers and replace the cached snapshot when a property is removed
- preserve memoization for genuinely shallow-equal states
- add a patch changeset for `@assistant-ui/core`

## Why

`ShallowMemoizeSubject` compared only keys present in the new state. For example, transitioning from `{ status: "running", error: "Connection failed" }` to `{ status: "running" }` checked only `status`, treated the objects as equal, retained the previous snapshot, and skipped subscriber notifications.

Checking the enumerable key counts first makes property removal a state change while keeping equal-shape, equal-value objects memoized.

## Verification

- reproduced on `main`: the removed-key regression received zero notifications and retained stale state
- targeted regression and shallow-equal control tests pass
- `pnpm --filter @assistant-ui/core test` (61 files, 580 tests)
- `pnpm lint`
- `pnpm build --filter @assistant-ui/core...`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

