### PR TITLE
docs: fix stale langchain links

### DIFF
--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -6,7 +6,7 @@ description: Integrate cloud persistence and thread management with LangGraph Cl
 
 ## Overview
 
-This guide shows how to integrate Assistant Cloud with [LangGraph Cloud](https://docs.langchain.com/langsmith/deploy-to-cloud) using assistant-ui's runtime system and pre-built UI components.
+This guide shows how to integrate Assistant Cloud with [LangGraph Cloud](https://docs.langchain.com/langsmith/deploy-to-cloud-overview) using assistant-ui's runtime system and pre-built UI components.
 
 ## Prerequisites
 

--- a/apps/docs/content/docs/cloud/langgraph.mdx
+++ b/apps/docs/content/docs/cloud/langgraph.mdx
@@ -6,7 +6,7 @@ description: Integrate cloud persistence and thread management with LangGraph Cl
 
 ## Overview
 
-This guide shows how to integrate Assistant Cloud with [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/) using assistant-ui's runtime system and pre-built UI components.
+This guide shows how to integrate Assistant Cloud with [LangGraph Cloud](https://docs.langchain.com/langsmith/deploy-to-cloud) using assistant-ui's runtime system and pre-built UI components.
 
 ## Prerequisites
 

--- a/apps/docs/content/docs/integrations/observability/langsmith.mdx
+++ b/apps/docs/content/docs/integrations/observability/langsmith.mdx
@@ -35,7 +35,7 @@ LANGSMITH_API_KEY=lsv2_pt_...
 LANGSMITH_PROJECT=assistant-ui
 ```
 
-`LANGSMITH_PROJECT` controls which project receives traces; the default project applies if you omit it. See LangSmith's [environment variable reference](https://docs.langchain.com/langsmith/trace-without-env-vars) for the full list.
+`LANGSMITH_PROJECT` controls which project receives traces; the default project applies if you omit it. See LangSmith's [project configuration guide](https://docs.langchain.com/langsmith/log-traces-to-project) for details.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/integrations/observability/langsmith.mdx
+++ b/apps/docs/content/docs/integrations/observability/langsmith.mdx
@@ -35,7 +35,7 @@ LANGSMITH_API_KEY=lsv2_pt_...
 LANGSMITH_PROJECT=assistant-ui
 ```
 
-`LANGSMITH_PROJECT` controls which project receives traces; the default project applies if you omit it. See LangSmith's [environment variable reference](https://docs.langchain.com/langsmith/how_to_environment_variables) for the full list.
+`LANGSMITH_PROJECT` controls which project receives traces; the default project applies if you omit it. See LangSmith's [environment variable reference](https://docs.langchain.com/langsmith/trace-without-env-vars) for the full list.
 
 </Step>
 <Step>

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -5,7 +5,7 @@ description: Use LangChain's useStream hook with a React chat UI through assista
 
 import { LangGraphIcon } from "@/components/icons/langgraph";
 
-`@assistant-ui/react-langchain` wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph-sdk/react-stream) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
+`@assistant-ui/react-langchain` wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph/streaming) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
 
 ## When to use it
 
@@ -32,7 +32,7 @@ Shared adapters (attachments, speech, feedback) work the same way described in [
 
 ## Requirements
 
-- A LangGraph Cloud API server (locally via [LangGraph Studio](https://github.com/langchain-ai/langgraph-studio) or hosted via [LangSmith](https://www.langchain.com/langsmith)).
+- A LangGraph Cloud API server (locally via [LangGraph Studio](https://docs.langchain.com/langsmith/quick-start-studio) or hosted via [LangSmith](https://www.langchain.com/langsmith)).
 - The graph state must include a `messages` key with LangChain-alike messages, or pass a custom `messagesKey`.
 
 ## Quickstart

--- a/apps/docs/content/docs/runtimes/langchain.mdx
+++ b/apps/docs/content/docs/runtimes/langchain.mdx
@@ -5,7 +5,7 @@ description: Use LangChain's useStream hook with a React chat UI through assista
 
 import { LangGraphIcon } from "@/components/icons/langgraph";
 
-`@assistant-ui/react-langchain` wraps [`useStream`](https://docs.langchain.com/oss/javascript/langgraph/streaming) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
+`@assistant-ui/react-langchain` wraps [`useStream`](https://reference.langchain.com/javascript/langchain-react/use-stream) from `@langchain/react` and exposes it as an assistant-ui runtime. It targets the same backend as [`@assistant-ui/react-langgraph`](/docs/runtimes/langgraph/overview) (LangGraph Cloud) but at a higher level, delegating stream plumbing to the upstream hook.
 
 ## When to use it
 

--- a/apps/docs/content/docs/runtimes/langgraph/overview.mdx
+++ b/apps/docs/content/docs/runtimes/langgraph/overview.mdx
@@ -13,7 +13,7 @@ description: Build a chat UI for LangGraph agents in React with assistant-ui —
 
 Pick the LangGraph runtime when:
 
-- You have (or want) a LangGraph Cloud server, locally via [LangGraph Studio](https://github.com/langchain-ai/langgraph-studio) or hosted via [LangSmith](https://www.langchain.com/langsmith).
+- You have (or want) a LangGraph Cloud server, locally via [LangGraph Studio](https://docs.langchain.com/langsmith/quick-start-studio) or hosted via [LangSmith](https://www.langchain.com/langsmith).
 - Your graph state has a `messages` key with LangChain-alike messages.
 - You want generative UI (`ui_message`), per-message metadata, subgraph events, or checkpoint-based message editing.
 


### PR DESCRIPTION
## Summary

- replace the retired LangGraph Cloud and JavaScript streaming documentation URLs
- point both LangGraph Studio references to the current Studio quickstart
- update the LangSmith environment-variable reference

## Why

LangChain reorganized its documentation, leaving five external link occurrences across four assistant-ui pages pointing to 404 destinations. This keeps those links useful without expanding the surrounding docs.

## Verification

- confirmed all four unique replacement URLs return HTTP 200
- `pnpm lint`
- `TMPDIR=/tmp pnpm --filter @assistant-ui/docs build`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

