### PR TITLE
fix(react-ai-sdk): close late mcp clients after timeout

### DIFF
--- a/.changeset/clean-mcp-timeout-clients.md
+++ b/.changeset/clean-mcp-timeout-clients.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: close MCP clients that resolve after a connection timeout

--- a/packages/react-ai-sdk/src/generativeTools.test.ts
+++ b/packages/react-ai-sdk/src/generativeTools.test.ts
@@ -372,6 +372,47 @@ describe("AISDKToolkit", () => {
     }
   });
 
+  it("closes an MCP client that resolves after its connection times out", async () => {
+    vi.useFakeTimers();
+    const close = vi.fn().mockResolvedValue(undefined);
+    let resolveClient!: (client: {
+      tools: typeof mocks.tools;
+      close: typeof close;
+    }) => void;
+    mocks.createMCPClient.mockReturnValue(
+      new Promise((resolve) => {
+        resolveClient = resolve;
+      }),
+    );
+
+    const toolkit = new AISDKToolkit({
+      toolkit: {
+        docs: {
+          type: "mcp",
+          server: {
+            type: "http",
+            url: "http://localhost:3001/mcp",
+            connectionTimeout: 10_000,
+          },
+        },
+      },
+    });
+
+    try {
+      const toolsPromise = toolkit.tools();
+      const expectedRejection = expect(toolsPromise).rejects.toThrow(
+        'MCP toolkit entry "docs" timed out while connecting after 10000ms.',
+      );
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expectedRejection;
+
+      resolveClient({ tools: mocks.tools, close });
+      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("times out MCP tool listing", async () => {
     vi.useFakeTimers();
     const close = vi.fn().mockResolvedValue(undefined);

--- a/packages/react-ai-sdk/src/generativeTools.ts
+++ b/packages/react-ai-sdk/src/generativeTools.ts
@@ -277,18 +277,19 @@ export class AISDKToolkit {
   ): Promise<MCPClient> {
     const existing = this.#mcpClients.get(name);
     if (existing) return existing;
+    const createPromise = createMCPClient(toMCPClientConfig(config));
     let next: Promise<MCPClient>;
-    next = withMcpConnectionTimeout(
-      createMCPClient(toMCPClientConfig(config)),
-      {
-        name,
-        config,
-        phase: "connecting",
-        startedAt,
-      },
-    ).catch((error) => {
+    next = withMcpConnectionTimeout(createPromise, {
+      name,
+      config,
+      phase: "connecting",
+      startedAt,
+    }).catch((error) => {
       if (this.#mcpClients.get(name) === next) {
         this.#mcpClients.delete(name);
+      }
+      if (error instanceof MCPConnectionTimeoutError) {
+        void createPromise.then((client) => client.close()).catch(() => {});
       }
       throw error;
     });


### PR DESCRIPTION
## Summary

- retain the underlying MCP client creation promise while applying the connection timeout
- close a client that resolves after the timeout has already rejected and evicted it
- add regression coverage for delayed client resolution

## Why

This is a follow-up to #4687. `connectionTimeout` rejects the outer race, but it cannot cancel `createMCPClient()`. If client creation finishes later, the result was previously discarded without calling `close()`. For stdio MCP servers, that can leave the transport and child process alive after the request has already failed.

The successful connection path and retry behavior are unchanged. Cleanup only attaches when an `MCPConnectionTimeoutError` wins the race, and late creation or close failures remain contained.

## Verification

- reproduced on `main`: after timing out and resolving the delayed client, `close()` was called 0 times
- regression test now confirms the late client is closed once
- `pnpm --filter @assistant-ui/react-ai-sdk test` (15 files, 168 tests)
- `pnpm build --filter=@assistant-ui/react-ai-sdk`
- `pnpm lint`
- `pnpm changeset status --since origin/main --verbose`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

