### PR TITLE
fix: formalize the AI SDK v7 line at 1.4

### DIFF
--- a/.changeset/ai-sdk-v7-line-at-1-4.md
+++ b/.changeset/ai-sdk-v7-line-at-1-4.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": minor
+---
+
+feat: formally open the AI SDK v7 line at 1.4. `1.3.41` shipped the v7 hard-dep switch as a patch inside the documented v6 line; from `1.4.0` the mapping is explicit: `^1.4` targets `ai@^7`, v6 users pin `1.3.40`, v5 users pin `1.1.21`.

--- a/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
@@ -720,7 +720,7 @@ Send a message in a fresh thread. Check the database:
 
 - The `threads` table has a new row with the current `userId`.
 - The `messages` table has at least two rows (user + assistant) for that thread.
-- `format` matches what `fmt.format` wrote (`"ai-sdk/v6"` for AI SDK v6) and `content` is the encoded `UIMessage` (a `role` plus `parts`), not a placeholder blob.
+- `format` matches what `fmt.format` wrote (`"ai-sdk/v6"`) and `content` is the encoded `UIMessage` (a `role` plus `parts`), not a placeholder blob. The format string names the stored `UIMessage` shape, not the installed AI SDK major; it stays `"ai-sdk/v6"` on AI SDK v7 and must never be renamed, or previously stored history stops matching.
 - Reload the page; the thread list and the messages survive.
 
 </Step>

--- a/apps/docs/content/docs/runtimes/ai-sdk/overview.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/overview.mdx
@@ -11,9 +11,9 @@ import { VercelIcon } from "@/components/icons/vercel";
 
 | AI SDK | Runtime package | Docs |
 | --- | --- | --- |
-| `ai@^7` + `@ai-sdk/react@^4` | `@assistant-ui/react-ai-sdk` (latest) | [v7 (current)](/docs/runtimes/ai-sdk/v7) |
-| `ai@^6` + `@ai-sdk/react@^3` | `@assistant-ui/react-ai-sdk@1.x` | [v6 (legacy)](/docs/runtimes/ai-sdk/v6-legacy) |
-| `ai@^5` + `@ai-sdk/react@^2` | `@assistant-ui/react-ai-sdk@0.x` | [v5 (legacy)](/docs/runtimes/ai-sdk/v5-legacy) |
+| `ai@^7` + `@ai-sdk/react@^4` | `@assistant-ui/react-ai-sdk@^1.4` (latest) | [v7 (current)](/docs/runtimes/ai-sdk/v7) |
+| `ai@^6` + `@ai-sdk/react@^3` | `@assistant-ui/react-ai-sdk@1.3.40` | [v6 (legacy)](/docs/runtimes/ai-sdk/v6-legacy) |
+| `ai@^5` + `@ai-sdk/react@^2` | `@assistant-ui/react-ai-sdk@1.1.21` | [v5 (legacy)](/docs/runtimes/ai-sdk/v5-legacy) |
 | `ai@^4` | `@assistant-ui/react-data-stream` | [v4 (legacy)](/docs/runtimes/ai-sdk/v4-legacy) |
 
 New projects should target v7. v6, v5, and v4 are documented for projects that have not migrated yet; all have known compatibility gaps and receive no new features.

--- a/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
@@ -11,9 +11,9 @@ AI SDK v4 is a legacy version. New projects should use [AI SDK v7](/docs/runtime
 
 ## Why legacy
 
-Vercel ships AI SDK majors roughly yearly; v4 is two majors behind v6. The current `@assistant-ui/react-ai-sdk` package targets v6+ exclusively, so v4 users plug into [`@assistant-ui/react-data-stream`](/docs/runtimes/custom/data-stream) instead — the same data stream protocol that v4's `toDataStreamResponse()` emits.
+Vercel ships AI SDK majors roughly yearly; v4 is three majors behind v7. The current `@assistant-ui/react-ai-sdk` package targets the current AI SDK major (v7) exclusively, so v4 users plug into [`@assistant-ui/react-data-stream`](/docs/runtimes/custom/data-stream) instead — the same data stream protocol that v4's `toDataStreamResponse()` emits.
 
-This page is reference for existing v4 projects. Plan to migrate to v6 when feasible.
+This page is reference for existing v4 projects. Plan to migrate to v7 when feasible.
 
 ## Setup
 
@@ -95,9 +95,9 @@ When you are ready to upgrade:
 
 AI SDK provides codemods at [ai-sdk.dev/docs/migration-guides](https://ai-sdk.dev/docs/migration-guides) that handle the package-side rewrites.
 
-## Alternative: react-ai-sdk@0.1.10
+## Alternative: react-ai-sdk@0.10.16
 
-An older release line of `@assistant-ui/react-ai-sdk` (0.1.10) supported AI SDK v4 directly. It is no longer maintained and has no upgrade path; if you are starting a new v4 project, use `@assistant-ui/react-data-stream` instead.
+An older release line of `@assistant-ui/react-ai-sdk` supported AI SDK v4 directly; its last release was `0.10.16`. It is no longer maintained and has no upgrade path; if you are starting a new v4 project, use `@assistant-ui/react-data-stream` instead.
 
 ## Related
 

--- a/apps/docs/content/docs/runtimes/ai-sdk/v5-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v5-legacy.mdx
@@ -6,12 +6,12 @@ description: Reference for projects still on AI SDK v5. New projects should use 
 import { VercelIcon } from "@/components/icons/vercel";
 
 <Callout type="warn">
-AI SDK v5 is a legacy version. New projects should use [AI SDK v7](/docs/runtimes/ai-sdk/v7). v5 users stay on `@assistant-ui/react-ai-sdk@0.x`; the latest line targets v7+.
+AI SDK v5 is a legacy version. New projects should use [AI SDK v7](/docs/runtimes/ai-sdk/v7). v5 users pin `@assistant-ui/react-ai-sdk@1.1.21` (the last v5-compatible release); later releases target newer AI SDK majors.
 </Callout>
 
 ## Why legacy
 
-AI SDK v6 introduced major API changes: async `convertToModelMessages`, a new tool schema, and `toUIMessageStreamResponse()`. v5 still works but no longer receives new features in `@assistant-ui/react-ai-sdk`. Pinning to `@0.x` keeps you on the v5-compatible surface.
+AI SDK v6 introduced major API changes: async `convertToModelMessages`, a new tool schema, and `toUIMessageStreamResponse()`. v5 still works but no longer receives new features in `@assistant-ui/react-ai-sdk`. Pinning to `1.1.21` keeps you on the v5-compatible surface.
 
 This page is reference for existing v5 projects. Plan to migrate to v7 when feasible.
 
@@ -22,7 +22,7 @@ This page is reference for existing v5 projects. Plan to migrate to v7 when feas
 
 ### Install v5-compatible versions
 
-<InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-ai-sdk@0.x", "ai@^5", "@ai-sdk/openai@^1", "zod"]} />
+<InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-ai-sdk@1.1.21", "ai@^5", "@ai-sdk/openai@^1", "zod"]} />
 
 </Step>
 <Step>
@@ -98,7 +98,7 @@ const runtime = useVercelUseChatRuntime(chat);
 | Feature | v5 | v6 |
 | --- | --- | --- |
 | `ai` package | `ai@^5` | `ai@^6` |
-| `@assistant-ui/react-ai-sdk` | `@0.x` | `@latest` |
+| `@assistant-ui/react-ai-sdk` | `@1.1.21` | `@1.3.40` |
 | `@ai-sdk/openai` | `^1` | `^3` |
 | Message type | `Message` | `UIMessage` |
 | `convertToModelMessages` | Sync | Async (`await`) |

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
@@ -4,7 +4,7 @@ description: Reference for projects still on AI SDK v6. New projects should use 
 ---
 
 <Callout type="warn">
-AI SDK v6 is a legacy version. New projects should use [AI SDK v7](/docs/runtimes/ai-sdk/v7). v6 users stay on `@assistant-ui/react-ai-sdk@1.x`; the latest line targets v7+.
+AI SDK v6 is a legacy version. New projects should use [AI SDK v7](/docs/runtimes/ai-sdk/v7). v6 users pin `@assistant-ui/react-ai-sdk@1.3.40` (the last v6-compatible release); later releases target v7.
 </Callout>
 
 Requires `ai@^6` and `@ai-sdk/react@^3`. For other versions see the [overview](/docs/runtimes/ai-sdk/overview).

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
@@ -52,17 +52,17 @@ npm init -y
 <PlatformTabs>
 <Tab value="React">
 
-<InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-ai-sdk", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod"]} />
+<InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-ai-sdk@1.3.40", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod"]} />
 
 </Tab>
 <Tab value="React Native">
 
-<InstallCommand expo={["@assistant-ui/react-native", "@assistant-ui/react-ai-sdk", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod"]} />
+<InstallCommand expo={["@assistant-ui/react-native", "@assistant-ui/react-ai-sdk@1.3.40", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod"]} />
 
 </Tab>
 <Tab value="React Ink">
 
-<InstallCommand npm={["@assistant-ui/react-ink", "@assistant-ui/react-ai-sdk", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod", "ink", "react"]} />
+<InstallCommand npm={["@assistant-ui/react-ink", "@assistant-ui/react-ai-sdk@1.3.40", "ai@^6", "@ai-sdk/react@^3", "@ai-sdk/openai", "zod", "ink", "react"]} />
 
 </Tab>
 </PlatformTabs>


### PR DESCRIPTION
## what

- adds a minor changeset so the next release train publishes `@assistant-ui/react-ai-sdk@1.4.0`, formally opening the AI SDK v7 line at `^1.4`
- corrects the version mapping across the ai-sdk docs to exact pins: v6 pins `1.3.40`, v5 pins `1.1.21`, and the v4 page now names `0.10.16` (the real last v4-era release) instead of the never published `0.1.10`
- updates the v5 comparison table and the overview matrix accordingly, and states in the persistence guide that the `"ai-sdk/v6"` format string names the stored `UIMessage` shape, not the npm major, so it never renames on an SDK bump

## why

fixes #5069. `1.3.41` shipped the ai v7 hard-dep switch as a patch inside the line the docs call the v6 line (#4855 flipped that changeset from major to patch). anyone on `^1.3.x` or `~1.3.40` with `ai@^6` picks up a v7 adapter on a routine update and ends up with two `ai` majors in the tree; #4972 raised the same semver concern earlier. `1.3.41` cannot be retracted, but the line boundary becomes real going forward: v7 lives at `^1.4` and every older line has an exact documented pin.

## how

release mechanics only, no runtime code change: one changeset (minor, maintainer approved) plus five docs pages. a follow-up should deprecate `1.3.41` on npm with a pointer to `1.3.40` (v6) and `1.4.0` (v7); `~1.3.40` resolves to `1.3.41` regardless of this PR, so the deprecation warning is what makes that path loud.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

