### PR TITLE
fix(core): isolate voice session listener errors

### DIFF
--- a/.changeset/quiet-voice-listeners.md
+++ b/.changeset/quiet-voice-listeners.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate realtime voice session listener errors

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createVoiceSession, type VoiceSessionHelpers } from "./voice";
+
+const createTestSession = () => {
+  let helpers: VoiceSessionHelpers | undefined;
+  const session = createVoiceSession({}, async (sessionHelpers) => {
+    helpers = sessionHelpers;
+    return {
+      disconnect: vi.fn(),
+      mute: vi.fn(),
+      unmute: vi.fn(),
+    };
+  });
+
+  if (!helpers) throw new Error("Voice session setup did not start");
+  return { helpers, session };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("createVoiceSession", () => {
+  it("continues notifying listeners when one throws", () => {
+    const listenerError = new Error("listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { helpers, session } = createTestSession();
+
+    const transcriptListener = vi.fn();
+    session.onTranscript(() => {
+      throw listenerError;
+    });
+    session.onTranscript(transcriptListener);
+
+    const modeListener = vi.fn();
+    session.onModeChange(() => {
+      throw listenerError;
+    });
+    session.onModeChange(modeListener);
+
+    const volumeListener = vi.fn();
+    session.onVolumeChange(() => {
+      throw listenerError;
+    });
+    session.onVolumeChange(volumeListener);
+
+    const statusListener = vi.fn();
+    session.onStatusChange(() => {
+      throw listenerError;
+    });
+    session.onStatusChange(statusListener);
+
+    helpers.emitTranscript({ role: "assistant", text: "hello" });
+    helpers.emitMode("speaking");
+    helpers.emitVolume(0.5);
+    helpers.end("finished");
+
+    expect(transcriptListener).toHaveBeenCalledWith({
+      role: "assistant",
+      text: "hello",
+    });
+    expect(modeListener).toHaveBeenCalledWith("speaking");
+    expect(volumeListener).toHaveBeenCalledWith(0.5);
+    expect(statusListener).toHaveBeenCalledWith({
+      type: "ended",
+      reason: "finished",
+      error: undefined,
+    });
+    expect(helpers.isDisposed()).toBe(true);
+    expect(consoleError).toHaveBeenCalledTimes(4);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Voice session listener threw an error",
+      listenerError,
+    );
+  });
+});

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -57,6 +57,22 @@ export type VoiceSessionHelpers = {
   isDisposed: () => boolean;
 };
 
+const notifyListeners = <T>(
+  listeners: ReadonlySet<(value: T) => void>,
+  value: T,
+) => {
+  for (const listener of listeners) {
+    try {
+      listener(value);
+    } catch (error) {
+      console.error(
+        "[assistant-ui] Voice session listener threw an error",
+        error,
+      );
+    }
+  }
+};
+
 export function createVoiceSession(
   options: { abortSignal?: AbortSignal },
   setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>,
@@ -85,25 +101,25 @@ export function createVoiceSession(
     setStatus: (status) => {
       if (disposed) return;
       currentStatus = status;
-      for (const cb of statusCbs) cb(status);
+      notifyListeners(statusCbs, status);
     },
     end: (reason, error?) => {
       if (disposed) return;
       currentStatus = { type: "ended", reason, error };
-      for (const cb of statusCbs) cb(currentStatus);
+      notifyListeners(statusCbs, currentStatus);
       cleanup();
     },
     emitTranscript: (item) => {
       if (disposed) return;
-      for (const cb of transcriptCbs) cb(item);
+      notifyListeners(transcriptCbs, item);
     },
     emitMode: (mode) => {
       if (disposed) return;
-      for (const cb of modeCbs) cb(mode);
+      notifyListeners(modeCbs, mode);
     },
     emitVolume: (volume) => {
       if (disposed) return;
-      for (const cb of volumeCbs) cb(volume);
+      notifyListeners(volumeCbs, volume);
     },
     isDisposed: () => disposed,
   };


### PR DESCRIPTION
## Summary

- isolate realtime voice session subscriber failures
- continue delivering status, transcript, mode, and volume events to later subscribers
- add regression coverage and a patch changeset

## Why

While testing multiple realtime voice subscribers, I found that one callback throwing caused the event to escape `createVoiceSession()` and prevented every later subscriber from receiving it. For example, a failing analytics transcript listener could stop the captions listener from updating, and a failing status listener could prevent normal session cleanup.

The session currently invokes each callback directly in its `Set`, so JavaScript stops the loop at the first thrown error.

## Fix

Route voice-session notifications through a shared helper that catches and reports each subscriber error before continuing to the remaining listeners. This keeps faulty consumer callbacks isolated without changing successful callback delivery.

## Verification

- reproduced on `main`: the listener error escaped and the second listener was not called
- verified after the fix: no error escaped, the second listener was called, and the listener error was logged
- `@assistant-ui/core` focused test: 1 passed
- `@assistant-ui/core` full suite: 62 files, 581 tests passed
- `@assistant-ui/core` build
- oxlint and oxfmt checks on changed files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

