### PR TITLE
fix(react-langgraph): preserve streamed bedrock tool args

### DIFF
--- a/.changeset/tidy-maps-smile.md
+++ b/.changeset/tidy-maps-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: preserve streamed Bedrock tool call arguments

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -155,6 +155,61 @@ describe("convertLangChainMessages metadata", () => {
     });
   });
 
+  it("keeps Bedrock tool args prefix-monotonic when the first chunk has no args", () => {
+    const firstResult = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        {
+          id: "tool-1",
+          name: "fetch_page_content",
+          args: {},
+          index: 0,
+        },
+      ],
+      tool_call_chunks: [
+        {
+          id: "tool-1",
+          index: 0,
+          name: "fetch_page_content",
+        },
+      ],
+    });
+
+    const nextResult = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        {
+          id: "tool-1",
+          name: "fetch_page_content",
+          args: {},
+          index: 0,
+        },
+      ],
+      tool_call_chunks: [
+        {
+          id: "tool-1",
+          index: 0,
+          name: "fetch_page_content",
+          args: '{"url":',
+        },
+      ],
+    });
+
+    const firstToolCallPart = firstResult.content.find(
+      (part) => part.type === "tool-call",
+    );
+    const nextToolCallPart = nextResult.content.find(
+      (part) => part.type === "tool-call",
+    );
+
+    expect(firstToolCallPart).toMatchObject({ argsText: "" });
+    expect(nextToolCallPart).toMatchObject({ argsText: '{"url":' });
+  });
+
   it("keeps key order from partial_json when final snapshot falls back to args", () => {
     const metadata = {
       toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -210,6 +210,38 @@ describe("convertLangChainMessages metadata", () => {
     expect(nextToolCallPart).toMatchObject({ argsText: '{"url":' });
   });
 
+  it("serializes completed tool args when an argless chunk remains", () => {
+    const result = convertLangChainMessages({
+      type: "ai",
+      id: "ai-1",
+      content: "",
+      tool_calls: [
+        {
+          id: "tool-1",
+          name: "fetch_page_content",
+          args: { url: "https://example.com" },
+          index: 0,
+        },
+      ],
+      tool_call_chunks: [
+        {
+          id: "tool-1",
+          index: 0,
+          name: "fetch_page_content",
+        },
+      ],
+    });
+
+    const toolCallPart = result.content.find(
+      (part) => part.type === "tool-call",
+    );
+
+    expect(toolCallPart).toMatchObject({
+      args: { url: "https://example.com" },
+      argsText: '{"url":"https://example.com"}',
+    });
+  });
+
   it("keeps key order from partial_json when final snapshot falls back to args", () => {
     const metadata = {
       toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -62,7 +62,8 @@ const resolveToolCallArgs = ({
   const providedArgsText =
     chunk.partial_json ??
     matchingToolCallChunk?.args ??
-    matchingToolCallChunk?.args_json;
+    matchingToolCallChunk?.args_json ??
+    (matchingToolCallChunk ? "" : undefined);
   const argsText =
     providedArgsText ??
     stableStringifyToolArgs(toolArgsKeyOrderCache, cacheKey, chunk.args);

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -63,7 +63,9 @@ const resolveToolCallArgs = ({
     chunk.partial_json ??
     matchingToolCallChunk?.args ??
     matchingToolCallChunk?.args_json ??
-    (matchingToolCallChunk ? "" : undefined);
+    (matchingToolCallChunk && Object.keys(chunk.args).length === 0
+      ? ""
+      : undefined);
   const argsText =
     providedArgsText ??
     stableStringifyToolArgs(toolArgsKeyOrderCache, cacheKey, chunk.args);

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -59,12 +59,15 @@ const resolveToolCallArgs = ({
   toolCallId: string;
 }): Pick<ToolCallMessagePart, "args" | "argsText"> => {
   const cacheKey = getToolArgsCacheKey(messageId, "tool", toolCallId);
+  const streamedArgsText =
+    matchingToolCallChunk?.args ?? matchingToolCallChunk?.args_json;
   const isStreamingArglessChunk =
-    matchingToolCallChunk !== undefined && Object.keys(chunk.args).length === 0;
+    matchingToolCallChunk !== undefined &&
+    streamedArgsText === undefined &&
+    Object.keys(chunk.args).length === 0;
   const providedArgsText =
     chunk.partial_json ??
-    matchingToolCallChunk?.args ??
-    matchingToolCallChunk?.args_json ??
+    streamedArgsText ??
     (isStreamingArglessChunk ? "" : undefined);
   const argsText =
     providedArgsText ??

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -59,13 +59,13 @@ const resolveToolCallArgs = ({
   toolCallId: string;
 }): Pick<ToolCallMessagePart, "args" | "argsText"> => {
   const cacheKey = getToolArgsCacheKey(messageId, "tool", toolCallId);
+  const isStreamingArglessChunk =
+    matchingToolCallChunk !== undefined && Object.keys(chunk.args).length === 0;
   const providedArgsText =
     chunk.partial_json ??
     matchingToolCallChunk?.args ??
     matchingToolCallChunk?.args_json ??
-    (matchingToolCallChunk && Object.keys(chunk.args).length === 0
-      ? ""
-      : undefined);
+    (isStreamingArglessChunk ? "" : undefined);
   const argsText =
     providedArgsText ??
     stableStringifyToolArgs(toolArgsKeyOrderCache, cacheKey, chunk.args);


### PR DESCRIPTION
## Summary

- treat an argless matching `tool_call_chunk` as an empty streaming prefix
- preserve the existing stringify fallback for completed or reloaded messages without chunks
- add a regression test covering the Bedrock first-frame shape and following partial args

## Why

Bedrock can start a tool call with a chunk that has an ID and name but no argument text. The converter previously turned the parsed empty object into `"{}"`. Later argument prefixes such as `{"url":` are not extensions of `"{}"`, so the invocation tracker rejected them and the frontend tool executed with empty arguments.

## Testing

- reproduced on current `main`: the regression test received `argsText: "{}"` instead of `""`
- `@assistant-ui/react-langgraph`: 182 tests passed
- `@assistant-ui/react-langgraph` build passed
- repository lint and format checks passed (existing unrelated warnings only)

Closes #5074

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

