### PR TITLE
fix(core): settle frame tool calls on dispose

### DIFF
--- a/.changeset/quiet-frames-settle.md
+++ b/.changeset/quiet-frames-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: reject pending AssistantFrame tool calls when the host is disposed

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -291,6 +291,7 @@ declare class AssistantFrameHost implements ModelContextProvider {
   private _requestCounter;
   private _iframeWindow;
   private _targetOrigin;
+  private _disposed;
   constructor(iframeWindow: Window, targetOrigin?: string);
   private handleMessage;
   private updateContext;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -454,6 +454,7 @@ declare class AssistantFrameHost implements ModelContextProvider {
   private _requestCounter;
   private _iframeWindow;
   private _targetOrigin;
+  private _disposed;
   constructor(iframeWindow: Window, targetOrigin?: string);
   private handleMessage;
   private updateContext;

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantFrameHost } from "./host";
+import { type FrameMessage, FRAME_MESSAGE_CHANNEL } from "./types";
+
+const executionContext = {
+  toolCallId: "tool-call",
+  abortSignal: new AbortController().signal,
+  human: async () => undefined,
+};
+
+const createHost = () => {
+  let handleMessage: ((event: MessageEvent) => void) | undefined;
+  const addEventListener = vi.fn(
+    (_type: string, listener: EventListenerOrEventListenerObject) => {
+      handleMessage = listener as (event: MessageEvent) => void;
+    },
+  );
+  const removeEventListener = vi.fn();
+  vi.stubGlobal("window", { addEventListener, removeEventListener });
+
+  const postMessage = vi.fn();
+  const iframeWindow = { postMessage } as unknown as Window;
+  const host = new AssistantFrameHost(iframeWindow);
+
+  const dispatchMessage = (message: FrameMessage) =>
+    handleMessage?.({
+      source: iframeWindow,
+      data: {
+        channel: FRAME_MESSAGE_CHANNEL,
+        message,
+      },
+    } as unknown as MessageEvent);
+
+  dispatchMessage({
+    type: "model-context-update",
+    context: {
+      tools: {
+        search: {
+          type: "frontend",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    },
+  });
+
+  const execute = host.getModelContext().tools?.search?.execute;
+  if (!execute) throw new Error("Expected the search tool to be available");
+
+  return { dispatchMessage, execute, host, postMessage };
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("AssistantFrameHost", () => {
+  it("resolves tool calls from frame results", async () => {
+    const { dispatchMessage, execute, host } = createHost();
+    const result = Promise.resolve(
+      execute({ query: "weather" }, executionContext),
+    );
+
+    dispatchMessage({
+      type: "tool-result",
+      id: "tool-0",
+      result: "sunny",
+    });
+
+    await expect(result).resolves.toBe("sunny");
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
+  it("rejects pending tool calls when disposed", async () => {
+    const { execute, host } = createHost();
+    const result = Promise.resolve(execute({}, executionContext));
+
+    host.dispose();
+
+    await expect(result).rejects.toThrow(
+      "AssistantFrameHost has been disposed",
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rejects tool calls made after disposal without posting a request", async () => {
+    const { execute, host, postMessage } = createHost();
+    host.dispose();
+
+    await expect(execute({}, executionContext)).rejects.toThrow(
+      "AssistantFrameHost has been disposed",
+    );
+    expect(postMessage).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -53,6 +53,7 @@ export class AssistantFrameHost implements ModelContextProvider {
   private _requestCounter = 0;
   private _iframeWindow: Window;
   private _targetOrigin: string;
+  private _disposed = false;
 
   constructor(iframeWindow: Window, targetOrigin: string = "*") {
     this._iframeWindow = iframeWindow;
@@ -130,6 +131,10 @@ export class AssistantFrameHost implements ModelContextProvider {
     timeout = 30000,
     timeoutMessage = "Request timed out",
   ): Promise<any> {
+    if (this._disposed) {
+      return Promise.reject(new Error("AssistantFrameHost has been disposed"));
+    }
+
     return new Promise((resolve, reject) => {
       this._pendingRequests.set(message.id, { resolve, reject });
 
@@ -188,8 +193,13 @@ export class AssistantFrameHost implements ModelContextProvider {
   }
 
   dispose() {
+    this._disposed = true;
     window.removeEventListener("message", this.handleMessage);
     this._subscribers.clear();
+    const error = new Error("AssistantFrameHost has been disposed");
+    for (const pending of this._pendingRequests.values()) {
+      pending.reject(error);
+    }
     this._pendingRequests.clear();
   }
 }


### PR DESCRIPTION
## Summary

- reject in-flight AssistantFrame tool requests when the host is disposed
- reject calls through stale tool handlers after disposal
- preserve successful result handling and clear request timers during disposal

## Why

When an AssistantFrame unmounts or navigates away during a tool call, `dispose()` currently clears the pending-request map without settling its promises. The timeout later sees no map entry either, so the tool promise remains pending forever and can leave the model run waiting indefinitely.

A minimal reproduction is:

```ts
const result = tool.execute(args, context);
host.dispose();
await result; // never settled before this change
```

Pending calls now reject with `AssistantFrameHost has been disposed`. Requests made through a stale tool reference after disposal reject immediately without posting to the frame.

## Testing

- `pnpm --filter @assistant-ui/core test -- src/model-context/frame/host.test.ts` (63 files, 584 tests)
- `pnpm --filter @assistant-ui/core exec tsc --noEmit`
- `pnpm --filter @assistant-ui/core... build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

