### PR TITLE
fix(react-a2a): validate send message responses

### DIFF
--- a/.changeset/warm-a2a-responses.md
+++ b/.changeset/warm-a2a-responses.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: reject malformed successful A2A send message responses

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -442,6 +442,34 @@ describe("A2AClient", () => {
       expect((result as any).role).toBe("agent");
     });
 
+    it.each([
+      ["an empty object", {}],
+      ["a malformed task", { task: {} }],
+      ["a malformed message", { message: {} }],
+    ])("rejects %s returned with a successful status", async (_name, body) => {
+      fetchMock.mockResolvedValue(mockFetchResponse(body));
+
+      await expect(client.sendMessage(userMessage)).rejects.toThrow(
+        "Invalid A2A message:send response: expected a valid task or message payload.",
+      );
+    });
+
+    it.each([
+      ["task", { id: "t1", status: { state: "completed" } }],
+      [
+        "message",
+        {
+          messageId: "m2",
+          role: "agent",
+          parts: [{ text: "Hi" }],
+        },
+      ],
+    ])("accepts a direct %s response", async (_name, body) => {
+      fetchMock.mockResolvedValue(mockFetchResponse(body));
+
+      await expect(client.sendMessage(userMessage)).resolves.toEqual(body);
+    });
+
     it("normalizes 'content' array from v0.3 server response to internal 'parts'", async () => {
       fetchMock.mockResolvedValue(
         mockFetchResponse({

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -445,7 +445,21 @@ describe("A2AClient", () => {
     it.each([
       ["an empty object", {}],
       ["a malformed task", { task: {} }],
+      [
+        "a task with an unknown state",
+        { task: { id: "t1", status: { state: "typo" } } },
+      ],
       ["a malformed message", { message: {} }],
+      [
+        "a message with a malformed part",
+        {
+          message: {
+            messageId: "m2",
+            role: "agent",
+            parts: [null],
+          },
+        },
+      ],
     ])("rejects %s returned with a successful status", async (_name, body) => {
       fetchMock.mockResolvedValue(mockFetchResponse(body));
 

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -153,6 +153,41 @@ function discriminateStreamResponse(
   return null;
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isTask = (value: unknown): value is A2ATask =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  value.id.length > 0 &&
+  isRecord(value.status) &&
+  typeof value.status.state === "string" &&
+  value.status.state.length > 0;
+
+const isMessage = (value: unknown): value is A2AMessage =>
+  isRecord(value) &&
+  typeof value.messageId === "string" &&
+  value.messageId.length > 0 &&
+  typeof value.role === "string" &&
+  value.role.length > 0 &&
+  Array.isArray(value.parts);
+
+const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {
+  if (isRecord(value)) {
+    if (value.task != null) {
+      if (isTask(value.task)) return value.task;
+    } else if (value.message != null) {
+      if (isMessage(value.message)) return value.message;
+    } else if (isTask(value) || isMessage(value)) {
+      return value;
+    }
+  }
+
+  throw new Error(
+    "Invalid A2A message:send response: expected a valid task or message payload.",
+  );
+};
+
 function signalInit(signal?: AbortSignal): RequestInit {
   return signal ? { signal } : {};
 }
@@ -297,7 +332,7 @@ export class A2AClient {
     if (configuration) body.configuration = configuration;
     if (metadata) body.metadata = metadata;
 
-    const result = await this.fetchJSON<Record<string, unknown>>(
+    const result = await this.fetchJSON<unknown>(
       `${this.getBasePath()}/message:send`,
       {
         method: "POST",
@@ -306,11 +341,7 @@ export class A2AClient {
       },
     );
 
-    // Unwrap SendMessageResponse: {task: Task} | {message: Message}
-    if ("task" in result && result.task) return result.task as A2ATask;
-    if ("message" in result && result.message)
-      return result.message as A2AMessage;
-    return result as unknown as A2ATask | A2AMessage;
+    return parseSendMessageResponse(result);
   }
 
   async *streamMessage(

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -1,4 +1,5 @@
 import { SSEEventDecoder, type SSEEvent } from "assistant-stream/utils";
+import { isRecord } from "@assistant-ui/core/internal";
 import type {
   A2AAgentCard,
   A2AErrorInfo,
@@ -153,9 +154,6 @@ function discriminateStreamResponse(
   return null;
 }
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const isTask = (value: unknown): value is A2ATask =>
   isRecord(value) &&
   typeof value.id === "string" &&
@@ -174,13 +172,8 @@ const isMessage = (value: unknown): value is A2AMessage =>
 
 const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {
   if (isRecord(value)) {
-    if (value.task != null) {
-      if (isTask(value.task)) return value.task;
-    } else if (value.message != null) {
-      if (isMessage(value.message)) return value.message;
-    } else if (isTask(value) || isMessage(value)) {
-      return value;
-    }
+    const candidate = value.task ?? value.message ?? value;
+    if (isTask(candidate) || isMessage(candidate)) return candidate;
   }
 
   throw new Error(

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -154,17 +154,19 @@ function discriminateStreamResponse(
   return null;
 }
 
-const TASK_STATES: ReadonlySet<string> = new Set<A2ATaskState>([
-  "unspecified",
-  "submitted",
-  "working",
-  "completed",
-  "failed",
-  "canceled",
-  "input_required",
-  "rejected",
-  "auth_required",
-]);
+const TASK_STATES: ReadonlySet<string> = new Set(
+  Object.keys({
+    unspecified: true,
+    submitted: true,
+    working: true,
+    completed: true,
+    failed: true,
+    canceled: true,
+    input_required: true,
+    rejected: true,
+    auth_required: true,
+  } satisfies Record<A2ATaskState, true>),
+);
 
 const isTaskState = (value: unknown): value is A2ATaskState =>
   typeof value === "string" && TASK_STATES.has(value);

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -154,13 +154,27 @@ function discriminateStreamResponse(
   return null;
 }
 
+const TASK_STATES: ReadonlySet<string> = new Set<A2ATaskState>([
+  "unspecified",
+  "submitted",
+  "working",
+  "completed",
+  "failed",
+  "canceled",
+  "input_required",
+  "rejected",
+  "auth_required",
+]);
+
+const isTaskState = (value: unknown): value is A2ATaskState =>
+  typeof value === "string" && TASK_STATES.has(value);
+
 const isTask = (value: unknown): value is A2ATask =>
   isRecord(value) &&
   typeof value.id === "string" &&
   value.id.length > 0 &&
   isRecord(value.status) &&
-  typeof value.status.state === "string" &&
-  value.status.state.length > 0;
+  isTaskState(value.status.state);
 
 const isMessage = (value: unknown): value is A2AMessage =>
   isRecord(value) &&
@@ -168,7 +182,8 @@ const isMessage = (value: unknown): value is A2AMessage =>
   value.messageId.length > 0 &&
   typeof value.role === "string" &&
   value.role.length > 0 &&
-  Array.isArray(value.parts);
+  Array.isArray(value.parts) &&
+  value.parts.every(isRecord);
 
 const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {
   if (isRecord(value)) {


### PR DESCRIPTION
## Summary

- validate successful `message:send` responses before returning them from `A2AClient`
- reject empty or malformed payloads with a contextual error
- preserve wrapped responses, direct Task/Message compatibility, and existing key/enum normalization

## Why

The A2A v1 HTTP+JSON contract returns a `SendMessageResponse` containing either `{ task }` or `{ message }`:
https://github.com/a2aproject/A2A/blob/main/specification/a2a.proto

Today a successful response such as `200 {}` falls through to a TypeScript cast and is returned as though it were a Task or Message. The synchronous runtime cannot match either shape, so its assistant placeholder can remain running without an error.

Reproduction before this change:

```ts
fetchMock.mockResolvedValue(mockFetchResponse({}));

await client.sendMessage(userMessage); // resolves with {}
```

The client now checks the required Task fields (`id`, `status.state`) or Message fields (`messageId`, `role`, `parts`) after normalization. Invalid payloads throw:

```text
Invalid A2A message:send response: expected a valid task or message payload.
```

Direct Task and Message responses remain accepted for compatibility with the client's previous behavior.

## Testing

- reproduced the three new malformed-response cases failing against unmodified `main`
- `@assistant-ui/react-a2a`: 3 test files, 132 tests passing
- package TypeScript check
- `@assistant-ui/react-a2a` package build
- repository oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

