### PR TITLE
feat(react): click blank composer space to focus the input

### DIFF
--- a/.changeset/composer-root-click-to-focus.md
+++ b/.changeset/composer-root-click-to-focus.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: focus composer input when clicking blank space in ComposerPrimitive.Root

--- a/packages/react/src/primitives/composer/ComposerRoot.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.test.tsx
@@ -1,12 +1,11 @@
-/**
- * @vitest-environment jsdom
- */
+/** @vitest-environment jsdom */
 import { act } from "react";
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import type { Root } from "react-dom/client";
 import type * as AssistantStore from "@assistant-ui/store";
 import type * as ComposerSendModule from "./ComposerSend";
+import { fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useComposerCompactContextOptional } from "./ComposerCompactContext";
 import type { ComposerCompactContextValue } from "./ComposerCompactContext";
@@ -58,7 +57,116 @@ const resetStoreState = () => {
   storeState.composer.text = "";
 };
 
-describe("ComposerPrimitiveRoot", () => {
+describe("ComposerPrimitiveRoot click-to-focus", () => {
+  beforeEach(() => {
+    resetStoreState();
+  });
+
+  it("focuses the textarea when primary-button mousedown starts on blank form space", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space">
+          <textarea data-testid="composer-input" />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+    const blankSpace = getByTestId("blank-space");
+    const textarea = getByTestId("composer-input");
+
+    fireEvent.mouseDown(blankSpace, { button: 0 });
+
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("does not move focus to the textarea when mousedown starts on an interactive child", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <button data-testid="interactive-child" type="button">
+          Action
+        </button>
+        <textarea data-testid="composer-input" />
+      </ComposerPrimitiveRoot>,
+    );
+    const button = getByTestId("interactive-child");
+    const textarea = getByTestId("composer-input");
+
+    fireEvent.mouseDown(button, { button: 0 });
+
+    expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("does not move focus to the textarea on non-primary mousedown", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space">
+          <textarea data-testid="composer-input" />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+    const blankSpace = getByTestId("blank-space");
+    const textarea = getByTestId("composer-input");
+
+    fireEvent.mouseDown(blankSpace, { button: 2 });
+
+    expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("focuses a contenteditable composer target when primary-button mousedown starts on blank form space", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space">
+          <div contentEditable data-testid="composer-input" tabIndex={0} />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+    const blankSpace = getByTestId("blank-space");
+    const composerInput = getByTestId("composer-input");
+
+    fireEvent.mouseDown(blankSpace, { button: 0 });
+
+    expect(document.activeElement).toBe(composerInput);
+  });
+
+  it("lets consumer onMouseDown prevent the default focus behavior", () => {
+    const onMouseDown = vi.fn((event: MouseEvent<HTMLFormElement>) => {
+      event.preventDefault();
+    });
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot onMouseDown={onMouseDown}>
+        <div data-testid="blank-space">
+          <textarea data-testid="composer-input" />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+    const blankSpace = getByTestId("blank-space");
+    const textarea = getByTestId("composer-input");
+
+    fireEvent.mouseDown(blankSpace, { button: 0 });
+
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("runs consumer onMouseDown and preserves default focus behavior when it does not prevent default", () => {
+    const onMouseDown = vi.fn();
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot onMouseDown={onMouseDown}>
+        <div data-testid="blank-space">
+          <textarea data-testid="composer-input" />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+    const blankSpace = getByTestId("blank-space");
+    const textarea = getByTestId("composer-input");
+
+    fireEvent.mouseDown(blankSpace, { button: 0 });
+
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(textarea);
+  });
+});
+
+describe("ComposerPrimitiveRoot compact mode", () => {
   let container: HTMLDivElement;
   let root: Root;
 

--- a/packages/react/src/primitives/composer/ComposerRoot.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.test.tsx
@@ -62,16 +62,22 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
     resetStoreState();
   });
 
-  it("focuses the textarea when primary-button mousedown starts on blank form space", () => {
+  const setupComposer = (props?: ComposerPrimitiveRoot.Props) => {
     const { getByTestId } = render(
-      <ComposerPrimitiveRoot>
+      <ComposerPrimitiveRoot {...props}>
         <div data-testid="blank-space">
           <textarea data-testid="composer-input" />
         </div>
       </ComposerPrimitiveRoot>,
     );
-    const blankSpace = getByTestId("blank-space");
-    const textarea = getByTestId("composer-input");
+    return {
+      blankSpace: getByTestId("blank-space"),
+      textarea: getByTestId("composer-input"),
+    };
+  };
+
+  it("focuses the textarea when primary-button mousedown starts on blank form space", () => {
+    const { blankSpace, textarea } = setupComposer();
 
     fireEvent.mouseDown(blankSpace, { button: 0 });
 
@@ -87,27 +93,55 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
         <textarea data-testid="composer-input" />
       </ComposerPrimitiveRoot>,
     );
-    const button = getByTestId("interactive-child");
-    const textarea = getByTestId("composer-input");
 
-    fireEvent.mouseDown(button, { button: 0 });
+    const notPrevented = fireEvent.mouseDown(getByTestId("interactive-child"), {
+      button: 0,
+    });
 
-    expect(document.activeElement).not.toBe(textarea);
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
+  });
+
+  it("does not steal focus from a role-based widget carrying a tabindex", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div role="slider" tabIndex={0} data-testid="widget" />
+        <textarea data-testid="composer-input" />
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("widget"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
+  });
+
+  it("does not steal focus from a roving-tabindex child with tabindex=-1", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <span tabIndex={-1} data-testid="roving-item">
+          Item
+        </span>
+        <textarea data-testid="composer-input" />
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("roving-item"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
   });
 
   it("does not move focus to the textarea on non-primary mousedown", () => {
-    const { getByTestId } = render(
-      <ComposerPrimitiveRoot>
-        <div data-testid="blank-space">
-          <textarea data-testid="composer-input" />
-        </div>
-      </ComposerPrimitiveRoot>,
-    );
-    const blankSpace = getByTestId("blank-space");
-    const textarea = getByTestId("composer-input");
+    const { blankSpace, textarea } = setupComposer();
 
-    fireEvent.mouseDown(blankSpace, { button: 2 });
+    const notPrevented = fireEvent.mouseDown(blankSpace, { button: 2 });
 
+    expect(notPrevented).toBe(true);
     expect(document.activeElement).not.toBe(textarea);
   });
 
@@ -119,27 +153,49 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
         </div>
       </ComposerPrimitiveRoot>,
     );
-    const blankSpace = getByTestId("blank-space");
-    const composerInput = getByTestId("composer-input");
 
-    fireEvent.mouseDown(blankSpace, { button: 0 });
+    fireEvent.mouseDown(getByTestId("blank-space"), { button: 0 });
 
-    expect(document.activeElement).toBe(composerInput);
+    expect(document.activeElement).toBe(getByTestId("composer-input"));
+  });
+
+  it("keeps the mousedown default when the form contains no composer input", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space" />
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("blank-space"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+  });
+
+  it("lets descendants keep native mousedown defaults via stopPropagation", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="selectable" onMouseDown={(e) => e.stopPropagation()}>
+          Selectable content
+        </div>
+        <textarea data-testid="composer-input" />
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("selectable"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
   });
 
   it("lets consumer onMouseDown prevent the default focus behavior", () => {
     const onMouseDown = vi.fn((event: MouseEvent<HTMLFormElement>) => {
       event.preventDefault();
     });
-    const { getByTestId } = render(
-      <ComposerPrimitiveRoot onMouseDown={onMouseDown}>
-        <div data-testid="blank-space">
-          <textarea data-testid="composer-input" />
-        </div>
-      </ComposerPrimitiveRoot>,
-    );
-    const blankSpace = getByTestId("blank-space");
-    const textarea = getByTestId("composer-input");
+    const { blankSpace, textarea } = setupComposer({ onMouseDown });
 
     fireEvent.mouseDown(blankSpace, { button: 0 });
 
@@ -149,15 +205,7 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
 
   it("runs consumer onMouseDown and preserves default focus behavior when it does not prevent default", () => {
     const onMouseDown = vi.fn();
-    const { getByTestId } = render(
-      <ComposerPrimitiveRoot onMouseDown={onMouseDown}>
-        <div data-testid="blank-space">
-          <textarea data-testid="composer-input" />
-        </div>
-      </ComposerPrimitiveRoot>,
-    );
-    const blankSpace = getByTestId("blank-space");
-    const textarea = getByTestId("composer-input");
+    const { blankSpace, textarea } = setupComposer({ onMouseDown });
 
     fireEvent.mouseDown(blankSpace, { button: 0 });
 

--- a/packages/react/src/primitives/composer/ComposerRoot.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.test.tsx
@@ -160,6 +160,22 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
     expect(document.activeElement).toBe(getByTestId("composer-input"));
   });
 
+  it("still focuses the textarea when the form is hosted inside a tabindex=-1 wrapper", () => {
+    const { getByTestId } = render(
+      <div tabIndex={-1}>
+        <ComposerPrimitiveRoot>
+          <div data-testid="blank-space">
+            <textarea data-testid="composer-input" />
+          </div>
+        </ComposerPrimitiveRoot>
+      </div>,
+    );
+
+    fireEvent.mouseDown(getByTestId("blank-space"), { button: 0 });
+
+    expect(document.activeElement).toBe(getByTestId("composer-input"));
+  });
+
   it("ignores mousedown on portaled descendants rendered outside the form's DOM", () => {
     const { getByTestId } = render(
       <ComposerPrimitiveRoot>

--- a/packages/react/src/primitives/composer/ComposerRoot.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.test.tsx
@@ -1,6 +1,7 @@
 /** @vitest-environment jsdom */
 import { act } from "react";
 import type { MouseEvent, ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { createRoot } from "react-dom/client";
 import type { Root } from "react-dom/client";
 import type * as AssistantStore from "@assistant-ui/store";
@@ -149,6 +150,54 @@ describe("ComposerPrimitiveRoot click-to-focus", () => {
     const { getByTestId } = render(
       <ComposerPrimitiveRoot>
         <div data-testid="blank-space">
+          <div contentEditable data-testid="composer-input" tabIndex={0} />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+
+    fireEvent.mouseDown(getByTestId("blank-space"), { button: 0 });
+
+    expect(document.activeElement).toBe(getByTestId("composer-input"));
+  });
+
+  it("ignores mousedown on portaled descendants rendered outside the form's DOM", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        {createPortal(<div data-testid="portal-blank" />, document.body)}
+        <textarea data-testid="composer-input" />
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("portal-blank"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
+  });
+
+  it("keeps the mousedown default when the only textarea is disabled", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space">
+          <textarea disabled data-testid="composer-input" />
+        </div>
+      </ComposerPrimitiveRoot>,
+    );
+
+    const notPrevented = fireEvent.mouseDown(getByTestId("blank-space"), {
+      button: 0,
+    });
+
+    expect(notPrevented).toBe(true);
+    expect(document.activeElement).not.toBe(getByTestId("composer-input"));
+  });
+
+  it("skips a disabled textarea and focuses the next composer input", () => {
+    const { getByTestId } = render(
+      <ComposerPrimitiveRoot>
+        <div data-testid="blank-space">
+          <textarea disabled data-testid="disabled-input" />
           <div contentEditable data-testid="composer-input" tabIndex={0} />
         </div>
       </ComposerPrimitiveRoot>,

--- a/packages/react/src/primitives/composer/ComposerRoot.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.tsx
@@ -110,7 +110,10 @@ export const ComposerPrimitiveRoot = forwardRef<
     // the React tree while their DOM nodes live outside the form.
     if (!(target instanceof Element) || !e.currentTarget.contains(target))
       return;
-    if (target.closest(INTERACTIVE_ELEMENT_SELECTOR)) return;
+    // Bound the ancestor walk to the form: hosts like AssistantModal render
+    // the composer inside a wrapper carrying tabindex="-1" (Radix FocusScope).
+    const interactive = target.closest(INTERACTIVE_ELEMENT_SELECTOR);
+    if (interactive && e.currentTarget.contains(interactive)) return;
     const input = e.currentTarget.querySelector<HTMLElement>(
       COMPOSER_INPUT_SELECTOR,
     );

--- a/packages/react/src/primitives/composer/ComposerRoot.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.tsx
@@ -8,6 +8,7 @@ import {
   type FormEvent,
   forwardRef,
   type ComponentPropsWithoutRef,
+  type MouseEvent,
   useMemo,
   useState,
 } from "react";
@@ -40,6 +41,14 @@ export namespace ComposerPrimitiveRoot {
  * is submitted (e.g., via Enter key or submit button). It automatically prevents the
  * default form submission and triggers the composer's send functionality.
  *
+ * Clicking blank space inside the form focuses the composer input (the first
+ * textarea or contenteditable element), so the whole composer surface acts as a
+ * click target. Interactive children (buttons, links, inputs, menu items) keep
+ * their own behavior. Because focusing happens on mousedown, text selection
+ * cannot start from non-interactive areas inside the form; consumers rendering
+ * selectable content there should opt out by calling `preventDefault()` in
+ * their own `onMouseDown` handler.
+ *
  * @example
  * ```tsx
  * <ComposerPrimitive.Root>
@@ -51,7 +60,7 @@ export namespace ComposerPrimitiveRoot {
 export const ComposerPrimitiveRoot = forwardRef<
   ComposerPrimitiveRoot.Element,
   ComposerPrimitiveRoot.Props
->(({ onSubmit, compact, ...rest }, forwardedRef) => {
+>(({ onSubmit, onMouseDown, compact, ...rest }, forwardedRef) => {
   const send = useComposerSend();
 
   const [multiline, setMultiline] = useState(false);
@@ -74,6 +83,22 @@ export const ComposerPrimitiveRoot = forwardRef<
     send();
   };
 
+  const handleMouseDown = (e: MouseEvent<HTMLFormElement>) => {
+    if (e.button !== 0) return;
+    if (
+      (e.target as HTMLElement).closest(
+        "button, a, input, textarea, select, label, [contenteditable]:not([contenteditable='false']), [role='button'], [role='menuitem'], [role='combobox'], [role='option']",
+      )
+    )
+      return;
+    const input = e.currentTarget.querySelector<HTMLElement>(
+      "textarea, [contenteditable]:not([contenteditable='false'])",
+    );
+    if (!input) return;
+    e.preventDefault();
+    input.focus();
+  };
+
   return (
     <ComposerCompactContext.Provider value={compact ? compactContext : null}>
       <Primitive.form
@@ -81,6 +106,7 @@ export const ComposerPrimitiveRoot = forwardRef<
         data-compact={isCompact ? "" : undefined}
         ref={forwardedRef}
         onSubmit={composeEventHandlers(onSubmit, handleSubmit)}
+        onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
       />
     </ComposerCompactContext.Provider>
   );

--- a/packages/react/src/primitives/composer/ComposerRoot.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.tsx
@@ -18,7 +18,7 @@ import { ComposerCompactContext } from "./ComposerCompactContext";
 const CONTENT_EDITABLE_SELECTOR =
   "[contenteditable]:not([contenteditable='false'])";
 
-const COMPOSER_INPUT_SELECTOR = `textarea, ${CONTENT_EDITABLE_SELECTOR}`;
+const COMPOSER_INPUT_SELECTOR = `textarea:not(:disabled), ${CONTENT_EDITABLE_SELECTOR}`;
 
 // Keeps tabindex="-1": roving-tabindex widgets click-focus items at -1.
 const INTERACTIVE_ELEMENT_SELECTOR = [
@@ -105,7 +105,12 @@ export const ComposerPrimitiveRoot = forwardRef<
 
   const handleMouseDown = (e: MouseEvent<HTMLFormElement>) => {
     if (e.button !== 0) return;
-    if ((e.target as Element).closest(INTERACTIVE_ELEMENT_SELECTOR)) return;
+    const target = e.target;
+    // Portaled descendants (e.g. a dialog overlay) propagate mousedown through
+    // the React tree while their DOM nodes live outside the form.
+    if (!(target instanceof Element) || !e.currentTarget.contains(target))
+      return;
+    if (target.closest(INTERACTIVE_ELEMENT_SELECTOR)) return;
     const input = e.currentTarget.querySelector<HTMLElement>(
       COMPOSER_INPUT_SELECTOR,
     );

--- a/packages/react/src/primitives/composer/ComposerRoot.tsx
+++ b/packages/react/src/primitives/composer/ComposerRoot.tsx
@@ -15,6 +15,29 @@ import {
 import { useComposerSend } from "./ComposerSend";
 import { ComposerCompactContext } from "./ComposerCompactContext";
 
+const CONTENT_EDITABLE_SELECTOR =
+  "[contenteditable]:not([contenteditable='false'])";
+
+const COMPOSER_INPUT_SELECTOR = `textarea, ${CONTENT_EDITABLE_SELECTOR}`;
+
+// Keeps tabindex="-1": roving-tabindex widgets click-focus items at -1.
+const INTERACTIVE_ELEMENT_SELECTOR = [
+  "a",
+  "audio[controls]",
+  "button",
+  "details",
+  "embed",
+  "iframe",
+  "input",
+  "label",
+  "select",
+  "summary",
+  "textarea",
+  "video[controls]",
+  CONTENT_EDITABLE_SELECTOR,
+  "[tabindex]",
+].join(", ");
+
 export namespace ComposerPrimitiveRoot {
   export type Element = ComponentRef<typeof Primitive.form>;
   /**
@@ -41,13 +64,10 @@ export namespace ComposerPrimitiveRoot {
  * is submitted (e.g., via Enter key or submit button). It automatically prevents the
  * default form submission and triggers the composer's send functionality.
  *
- * Clicking blank space inside the form focuses the composer input (the first
- * textarea or contenteditable element), so the whole composer surface acts as a
- * click target. Interactive children (buttons, links, inputs, menu items) keep
- * their own behavior. Because focusing happens on mousedown, text selection
- * cannot start from non-interactive areas inside the form; consumers rendering
- * selectable content there should opt out by calling `preventDefault()` in
- * their own `onMouseDown` handler.
+ * Clicking blank form space focuses the composer input (the first textarea or
+ * contenteditable inside the form). Text selection cannot start from blank
+ * areas; descendants that need native mousedown defaults can call
+ * `stopPropagation()` in their own `onMouseDown`.
  *
  * @example
  * ```tsx
@@ -85,14 +105,9 @@ export const ComposerPrimitiveRoot = forwardRef<
 
   const handleMouseDown = (e: MouseEvent<HTMLFormElement>) => {
     if (e.button !== 0) return;
-    if (
-      (e.target as HTMLElement).closest(
-        "button, a, input, textarea, select, label, [contenteditable]:not([contenteditable='false']), [role='button'], [role='menuitem'], [role='combobox'], [role='option']",
-      )
-    )
-      return;
+    if ((e.target as Element).closest(INTERACTIVE_ELEMENT_SELECTOR)) return;
     const input = e.currentTarget.querySelector<HTMLElement>(
-      "textarea, [contenteditable]:not([contenteditable='false'])",
+      COMPOSER_INPUT_SELECTOR,
     );
     if (!input) return;
     e.preventDefault();


### PR DESCRIPTION
Extracted from #4702 (@ephraimduncan) so the primitive behavior can land independently of the composer styling review.

`ComposerPrimitive.Root` focuses the composer input on primary-button mousedown over blank form space, making the whole composer surface a click target:

```ts
const handleMouseDown = (e: MouseEvent<HTMLFormElement>) => {
  if (e.button !== 0) return;
  if ((e.target as Element).closest(INTERACTIVE_ELEMENT_SELECTOR)) return;
  const input = e.currentTarget.querySelector<HTMLElement>(COMPOSER_INPUT_SELECTOR);
  if (!input) return;
  e.preventDefault();
  input.focus();
};
```

The guard is a conservative allowlist of focusables rather than an ARIA role list:

```ts
const INTERACTIVE_ELEMENT_SELECTOR = [
  "a", "audio[controls]", "button", "details", "embed", "iframe", "input",
  "label", "select", "summary", "textarea", "video[controls]",
  "[contenteditable]:not([contenteditable='false'])", "[tabindex]",
].join(", ");
```

- Keyboard-operable widgets must be focusable, so `[tabindex]` covers role-based widgets (slider, switch, tab, …) without enumerating roles; a role without a tabindex has no focus to steal and still receives its click.
- `[tabindex]` includes `-1` on purpose: roving-tabindex widgets (Radix toolbars/tabs/radios) click-focus items at -1.
- UA-only focusables (e.g. Chrome scroll containers) stay unguarded.

Focusing on mousedown means text selection can't start from blank areas. Descendants that need native mousedown defaults keep them:

```tsx
<div onMouseDown={(e) => e.stopPropagation()}>selectable content</div>
```

Verified in real Chrome (jsdom can't exercise native mousedown defaults): scrollbar drag on overflowing children, selection via the stopPropagation hatch, blank-space focus, no selection from blank space.

react-native/react-ink Roots untouched: mousedown focus is DOM-only.
