### PR TITLE
fix(core): keep composer attachment chips visible during upload

### DIFF
--- a/.changeset/composer-attachments-visible-during-upload.md
+++ b/.changeset/composer-attachments-visible-during-upload.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep composer attachment chips visible while their upload is in flight instead of clearing them before `send()` resolves

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -195,18 +195,17 @@ export abstract class BaseComposerRuntimeCore
           )
         : [];
 
-    const originalAttachments = this.attachments;
     const text = this.text;
     const quote = this._quote;
     this._quote = undefined;
-    this._emptyTextAndAttachments();
+    this._text = "";
+    this._notifySubscribers();
 
     let resolvedAttachments: Awaited<typeof attachments>;
     try {
       resolvedAttachments = await attachments;
     } catch (e) {
-      if (this.isEmpty && this._quote === undefined) {
-        this._attachments = originalAttachments;
+      if (!this.text.trim() && this._quote === undefined) {
         this._text = text;
         this._quote = quote;
         this._notifySubscribers();
@@ -225,6 +224,13 @@ export abstract class BaseComposerRuntimeCore
 
     const sendTask = this.handleSend(message, options);
     if (sendTask) void sendTask.catch(() => {});
+
+    if (resolvedAttachments.length > 0) {
+      const sentIds = new Set(resolvedAttachments.map((a) => a.id));
+      this._attachments = this._attachments.filter((a) => !sentIds.has(a.id));
+      this._notifySubscribers();
+    }
+
     this._notifyEventSubscribers("send", {});
   }
 

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { DefaultThreadComposerRuntimeCore } from "../runtime/base/default-thread-composer-runtime-core";
 import type { AttachmentAdapter } from "../adapters/attachment";
 import type { ThreadRuntimeCore } from "../runtime/interfaces/thread-runtime-core";
-import type { PendingAttachment } from "../types/attachment";
+import type {
+  CompleteAttachment,
+  PendingAttachment,
+} from "../types/attachment";
 
 const makeAdapter = (
   overrides: Partial<AttachmentAdapter> = {},
@@ -82,7 +85,7 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     await expect(sendPromise).rejects.toThrow("upload failed");
 
     expect(composer.text).toBe("new draft");
-    expect(composer.attachments).toHaveLength(0);
+    expect(composer.attachments).toHaveLength(1);
     expect(append).not.toHaveBeenCalled();
   });
 
@@ -107,7 +110,7 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     expect(composer.quote).toEqual({ text: "new quote", messageId: "m-2" });
     expect(composer.text).toBe("");
-    expect(composer.attachments).toHaveLength(0);
+    expect(composer.attachments).toHaveLength(1);
     expect(append).not.toHaveBeenCalled();
   });
 
@@ -221,5 +224,66 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     expect(appendCalls).toBe(1);
     expect(rejections).toEqual([]);
+  });
+
+  it("keeps attachment chips visible and clears text while an upload is in flight", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise<CompleteAttachment>((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+
+    expect(composer.text).toBe("");
+    expect(composer.attachments).toHaveLength(1);
+    expect(append).not.toHaveBeenCalled();
+
+    resolveSend();
+    await sendPromise;
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append.mock.calls[0]![0].attachments).toHaveLength(1);
+  });
+
+  it("preserves an attachment added while an upload is in flight", async () => {
+    let addCount = 0;
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+        id: `att-${++addCount}`,
+        type: "image",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      }),
+      send: (a) =>
+        new Promise<CompleteAttachment>((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    await composer.addAttachment(textFile());
+    const sendPromise = composer.send();
+    await composer.addAttachment(textFile());
+
+    resolveSend();
+    await sendPromise;
+
+    expect(composer.attachments).toHaveLength(1);
+    expect(composer.attachments[0]!.id).toBe("att-2");
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append.mock.calls[0]![0].attachments).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

- clear the composer text immediately on send, but keep the attachment chips visible until the upload resolves
- remove exactly the sent attachments (matched by id) after `handleSend`, so an attachment added during the upload window is preserved for the next message
- restore text/quote on upload failure guarded on the text alone; the chips are no longer cleared up front, so they remain for a retry
- add a patch changeset for `@assistant-ui/core`

## Why

Fixes #4796. `BaseComposerRuntimeCore.send()` called `_emptyTextAndAttachments()` synchronously, before `await`-ing the attachment upload. For the whole upload window (0.5-2s on a large file) the composer was empty and the message was not yet appended to the thread, so the message appeared to vanish.

Clearing the text immediately matches the expectation that the input empties on send; keeping the attachment chips through the upload fills the gap so the in-flight message stays visible until it lands in the thread.

## Behavior change

On a failed upload the attachment chips now remain in the composer (the user can retry without re-attaching) instead of being dropped. Two existing restore-on-failure tests are updated to assert this (attachments `0 -> 1`). A new regression test covers the chips staying visible mid-upload; it fails on `main` (`expected length 1, got 0`) and passes with this change.

## Verification

- `@assistant-ui/core`: `vitest run` — 62 files / 583 tests pass; new regression test verified to fail on `main` and pass here
- `tsc --noEmit` clean; `oxlint` + `oxfmt --check` clean on changed files
- reproduced on `main` and confirmed resolved with the change


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

