### PR TITLE
fix(react): preserve top anchor reserve between turns

### DIFF
--- a/.changeset/tidy-anchors-wait.md
+++ b/.changeset/tidy-anchors-wait.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: preserve the top-anchor reserve between turns

--- a/packages/react/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react/src/primitives/thread/ThreadViewport.tsx
@@ -111,16 +111,17 @@ const useTopAnchorTurn = (enabled: boolean) => {
     if (!enabled) return undefined;
     return getActiveTopAnchorTargetId(s.thread);
   });
-  const threadMessages = useAuiState((s) => s.thread.messages);
   const topAnchorTurn = useThreadViewport((s) => s.topAnchorTurn);
   const activeTurn = useMemo(() => {
     if (!activeAnchorId || !activeTargetId) return null;
     return { anchorId: activeAnchorId, targetId: activeTargetId };
   }, [activeAnchorId, activeTargetId]);
 
-  const topAnchorTurnIsValid = useMemo(
-    () => isTopAnchorTurnValid(topAnchorTurn, threadMessages),
-    [threadMessages, topAnchorTurn],
+  const topAnchorTurnIsValid = useAuiState(
+    (s) =>
+      enabled &&
+      !!topAnchorTurn &&
+      isTopAnchorTurnValid(topAnchorTurn, s.thread.messages),
   );
 
   useLayoutEffect(() => {

--- a/packages/react/src/primitives/thread/ThreadViewport.tsx
+++ b/packages/react/src/primitives/thread/ThreadViewport.tsx
@@ -23,6 +23,7 @@ import { useTopAnchorReserve } from "./topAnchor/useTopAnchorReserve";
 import {
   getActiveTopAnchorAnchorId,
   getActiveTopAnchorTargetId,
+  isTopAnchorTurnValid,
 } from "./topAnchor/topAnchorTurn";
 
 export namespace ThreadPrimitiveViewport {
@@ -110,10 +111,23 @@ const useTopAnchorTurn = (enabled: boolean) => {
     if (!enabled) return undefined;
     return getActiveTopAnchorTargetId(s.thread);
   });
+  const threadMessages = useAuiState((s) => s.thread.messages);
+  const topAnchorTurn = useThreadViewport((s) => s.topAnchorTurn);
   const activeTurn = useMemo(() => {
     if (!activeAnchorId || !activeTargetId) return null;
     return { anchorId: activeAnchorId, targetId: activeTargetId };
   }, [activeAnchorId, activeTargetId]);
+
+  const topAnchorTurnIsValid = useMemo(
+    () => isTopAnchorTurnValid(topAnchorTurn, threadMessages),
+    [threadMessages, topAnchorTurn],
+  );
+
+  useLayoutEffect(() => {
+    if (!topAnchorTurn || topAnchorTurnIsValid) return;
+
+    threadViewportStore.getState().setTopAnchorTurn(null);
+  }, [threadViewportStore, topAnchorTurn, topAnchorTurnIsValid]);
 
   useLayoutEffect(() => {
     if (!activeTurn) return;

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -122,6 +122,7 @@ describe("mountTopAnchorReserve", () => {
     ) as HTMLElement;
     const optimisticUserMessage = document.createElement("div");
     reserveHost.append(optimisticUserMessage);
+    const appendSpy = vi.spyOn(reserveHost, "append");
 
     setState({
       turnAnchor: "top",
@@ -134,6 +135,17 @@ describe("mountTopAnchorReserve", () => {
     expect(reserve.isConnected).toBe(true);
     expect(reserve.style.height).toBe("60px");
     expect(reserve.previousElementSibling).toBe(optimisticUserMessage);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: null, target: null },
+      targetConfig: null,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
 
     const nextAnchor = document.createElement("div");
     const nextTarget = document.createElement("div");

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -150,6 +150,45 @@ describe("mountTopAnchorReserve", () => {
     expect(reserve.isConnected).toBe(false);
   });
 
+  it("removes the reserve when only the registered anchor unmounts", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector(
+      "[data-aui-top-anchor-reserve]",
+    ) as HTMLElement;
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: null, target },
+      targetConfig: numericClamp,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.isConnected).toBe(false);
+    expect(reserve.style.height).toBe("0px");
+  });
+
   it("removes the reserve when the viewport is unavailable", () => {
     const viewport = document.createElement("div");
     const anchor = document.createElement("div");

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -43,6 +43,7 @@ const makeStore = (state: ReturnType<TopAnchorStore["getState"]>) => {
 };
 
 const numericClamp = { tallerThan: 160, visibleHeight: 96 };
+const activeTopAnchorTurn = { anchorId: "user-1", targetId: "assistant-1" };
 
 describe("mountTopAnchorReserve", () => {
   beforeEach(() => {
@@ -76,6 +77,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     mountTopAnchorReserve(store);
@@ -109,6 +111,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     const unmount = mountTopAnchorReserve(store);
@@ -124,6 +127,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor: null, target: null },
       targetConfig: null,
+      topAnchorTurn: activeTopAnchorTurn,
     });
     vi.runOnlyPendingTimers();
 
@@ -141,6 +145,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor: nextAnchor, target: nextTarget },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
     vi.runOnlyPendingTimers();
 
@@ -148,6 +153,47 @@ describe("mountTopAnchorReserve", () => {
 
     unmount();
     expect(reserve.isConnected).toBe(false);
+  });
+
+  it("removes the reserve when the active turn is no longer valid", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector(
+      "[data-aui-top-anchor-reserve]",
+    ) as HTMLElement;
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: null, target: null },
+      targetConfig: null,
+      topAnchorTurn: null,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.isConnected).toBe(false);
+    expect(reserve.style.height).toBe("0px");
   });
 
   it("removes the reserve when only the registered anchor unmounts", () => {
@@ -169,6 +215,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     mountTopAnchorReserve(store);
@@ -182,6 +229,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor: null, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
     vi.runOnlyPendingTimers();
 
@@ -208,6 +256,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     mountTopAnchorReserve(store);
@@ -221,6 +270,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport: null, anchor: null, target: null },
       targetConfig: null,
+      topAnchorTurn: null,
     });
     vi.runOnlyPendingTimers();
 
@@ -247,6 +297,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     mountTopAnchorReserve(store);
@@ -260,6 +311,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "bottom",
       element: { viewport, anchor: null, target: null },
       targetConfig: null,
+      topAnchorTurn: null,
     });
     vi.runOnlyPendingTimers();
 
@@ -285,6 +337,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
 
     mountTopAnchorReserve(store);
@@ -300,6 +353,7 @@ describe("mountTopAnchorReserve", () => {
       turnAnchor: "top",
       element: { viewport, anchor, target },
       targetConfig: numericClamp,
+      topAnchorTurn: activeTopAnchorTurn,
     });
     vi.runOnlyPendingTimers();
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.test.ts
@@ -90,6 +90,144 @@ describe("mountTopAnchorReserve", () => {
     expect(reserve.style.height).toBe("60px");
   });
 
+  it("preserves the reserve across a transient between-turns anchor gap", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+    });
+
+    const unmount = mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector(
+      "[data-aui-top-anchor-reserve]",
+    ) as HTMLElement;
+    const optimisticUserMessage = document.createElement("div");
+    reserveHost.append(optimisticUserMessage);
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: null, target: null },
+      targetConfig: null,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.isConnected).toBe(true);
+    expect(reserve.style.height).toBe("60px");
+    expect(reserve.previousElementSibling).toBe(optimisticUserMessage);
+
+    const nextAnchor = document.createElement("div");
+    const nextTarget = document.createElement("div");
+    reserveHost.append(nextTarget);
+    defineReadonlyNumber(nextAnchor, "offsetTop", 236);
+    defineReadonlyNumber(nextAnchor, "offsetHeight", 64);
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport, anchor: nextAnchor, target: nextTarget },
+      targetConfig: numericClamp,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.previousElementSibling).toBe(nextTarget);
+
+    unmount();
+    expect(reserve.isConnected).toBe(false);
+  });
+
+  it("removes the reserve when the viewport is unavailable", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector(
+      "[data-aui-top-anchor-reserve]",
+    ) as HTMLElement;
+
+    setState({
+      turnAnchor: "top",
+      element: { viewport: null, anchor: null, target: null },
+      targetConfig: null,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.isConnected).toBe(false);
+    expect(reserve.style.height).toBe("0px");
+  });
+
+  it("removes the reserve when top anchoring is disabled", () => {
+    const viewport = document.createElement("div");
+    const anchor = document.createElement("div");
+    const target = document.createElement("div");
+    const reserveHost = document.createElement("div");
+    reserveHost.append(target);
+    document.body.append(reserveHost);
+
+    defineReadonlyNumber(viewport, "offsetTop", 0);
+    defineReadonlyNumber(viewport, "clientHeight", 400);
+    defineReadonlyNumber(viewport, "scrollHeight", 560);
+    defineReadonlyNumber(anchor, "offsetTop", 220);
+    defineReadonlyNumber(anchor, "offsetHeight", 64);
+    viewport.scrollTo = vi.fn();
+
+    const { store, setState } = makeStore({
+      turnAnchor: "top",
+      element: { viewport, anchor, target },
+      targetConfig: numericClamp,
+    });
+
+    mountTopAnchorReserve(store);
+    vi.runOnlyPendingTimers();
+
+    const reserve = reserveHost.querySelector(
+      "[data-aui-top-anchor-reserve]",
+    ) as HTMLElement;
+
+    setState({
+      turnAnchor: "bottom",
+      element: { viewport, anchor: null, target: null },
+      targetConfig: null,
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(reserve.isConnected).toBe(false);
+    expect(reserve.style.height).toBe("0px");
+  });
+
   it("does not repeat the smooth top-anchor scroll for the same message", () => {
     const viewport = document.createElement("div");
     const anchor = document.createElement("div");

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -62,18 +62,18 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     const { viewport, anchor, target } = state.element;
     const clamp = state.targetConfig;
 
-    if (
-      state.turnAnchor !== "top" ||
-      !viewport ||
-      !anchor ||
-      !target ||
-      !clamp
-    ) {
+    if (state.turnAnchor !== "top" || !viewport) {
       observers.disconnect();
       if (reserve) {
         setReserveHeight(reserve, 0);
         reserve.remove();
       }
+      return;
+    }
+
+    if (!anchor || !target || !clamp) {
+      observers.disconnect();
+      if (reserve?.parentElement) reserve.parentElement.append(reserve);
       return;
     }
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -71,9 +71,18 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       return;
     }
 
-    if (!anchor || !target || !clamp) {
+    if (!anchor && !target && !clamp) {
       observers.disconnect();
       if (reserve?.parentElement) reserve.parentElement.append(reserve);
+      return;
+    }
+
+    if (!anchor || !target || !clamp) {
+      observers.disconnect();
+      if (reserve) {
+        setReserveHeight(reserve, 0);
+        reserve.remove();
+      }
       return;
     }
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -29,6 +29,10 @@ export type TopAnchorStore = {
       tallerThan: number;
       visibleHeight: number;
     } | null;
+    topAnchorTurn: {
+      readonly anchorId: string;
+      readonly targetId: string;
+    } | null;
   };
   subscribe(fn: () => void): () => void;
 };
@@ -71,7 +75,8 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
       return;
     }
 
-    if (!anchor && !target && !clamp) {
+    if (!anchor && !target && !clamp && state.topAnchorTurn) {
+      // ThreadViewport clears this state when either ID leaves the current branch.
       observers.disconnect();
       if (reserve?.parentElement) reserve.parentElement.append(reserve);
       return;

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -78,7 +78,12 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     if (!anchor && !target && !clamp && state.topAnchorTurn) {
       // ThreadViewport clears this state when either ID leaves the current branch.
       observers.disconnect();
-      if (reserve?.parentElement) reserve.parentElement.append(reserve);
+      if (
+        reserve?.parentElement &&
+        reserve.parentElement.lastElementChild !== reserve
+      ) {
+        reserve.parentElement.append(reserve);
+      }
       return;
     }
 

--- a/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
+++ b/packages/react/src/primitives/thread/topAnchor/mountTopAnchorReserve.ts
@@ -76,7 +76,9 @@ export const mountTopAnchorReserve = (store: TopAnchorStore) => {
     }
 
     if (!anchor && !target && !clamp && state.topAnchorTurn) {
-      // ThreadViewport clears this state when either ID leaves the current branch.
+      // ThreadViewport clears this state once the stored pair stops being the
+      // trailing turn (followed at most by pending user messages), so reaching
+      // here means the anchor gap is transient and the next run is imminent.
       observers.disconnect();
       if (
         reserve?.parentElement &&

--- a/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.test.ts
@@ -3,6 +3,7 @@ import {
   getActiveTopAnchorAnchorId,
   getActiveTopAnchorTargetId,
   getActiveTopAnchorTurn,
+  isTopAnchorTurnValid,
 } from "./topAnchorTurn";
 
 describe("topAnchorTurn", () => {
@@ -42,5 +43,31 @@ describe("topAnchorTurn", () => {
     ];
 
     expect(getActiveTopAnchorTurn({ isRunning: true, messages })).toBe(null);
+  });
+
+  it("keeps a completed turn valid while its messages remain in the branch", () => {
+    const turn = { anchorId: "user-2", targetId: "assistant-2" };
+
+    expect(
+      isTopAnchorTurnValid(turn, [
+        { id: "assistant-1" },
+        { id: "user-2" },
+        { id: "assistant-2" },
+      ]),
+    ).toBe(true);
+  });
+
+  it.each([
+    ["thread switch", [{ id: "other-user" }, { id: "other-assistant" }]],
+    ["new chat", []],
+    ["last-turn deletion", [{ id: "older-assistant" }]],
+    ["branch swap", [{ id: "branch-user" }, { id: "branch-assistant" }]],
+  ])("invalidates a stored turn after %s", (_transition, messages) => {
+    expect(
+      isTopAnchorTurnValid(
+        { anchorId: "user-2", targetId: "assistant-2" },
+        messages,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.test.ts
+++ b/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.test.ts
@@ -45,23 +45,65 @@ describe("topAnchorTurn", () => {
     expect(getActiveTopAnchorTurn({ isRunning: true, messages })).toBe(null);
   });
 
-  it("keeps a completed turn valid while its messages remain in the branch", () => {
+  it("keeps a completed turn valid while it remains the trailing turn", () => {
     const turn = { anchorId: "user-2", targetId: "assistant-2" };
 
     expect(
       isTopAnchorTurnValid(turn, [
-        { id: "assistant-1" },
-        { id: "user-2" },
-        { id: "assistant-2" },
+        { id: "assistant-1", role: "assistant" },
+        { id: "user-2", role: "user" },
+        { id: "assistant-2", role: "assistant" },
+      ]),
+    ).toBe(true);
+  });
+
+  it("keeps a turn valid across the between-turns gap with pending user messages", () => {
+    const turn = { anchorId: "user-2", targetId: "assistant-2" };
+
+    expect(
+      isTopAnchorTurnValid(turn, [
+        { id: "user-2", role: "user" },
+        { id: "assistant-2", role: "assistant" },
+        { id: "user-3", role: "user" },
+        { id: "user-4", role: "user" },
       ]),
     ).toBe(true);
   });
 
   it.each([
-    ["thread switch", [{ id: "other-user" }, { id: "other-assistant" }]],
+    [
+      "thread switch",
+      [
+        { id: "other-user", role: "user" },
+        { id: "other-assistant", role: "assistant" },
+      ],
+    ],
     ["new chat", []],
-    ["last-turn deletion", [{ id: "older-assistant" }]],
-    ["branch swap", [{ id: "branch-user" }, { id: "branch-assistant" }]],
+    ["last-turn deletion", [{ id: "older-assistant", role: "assistant" }]],
+    [
+      "branch swap",
+      [
+        { id: "branch-user", role: "user" },
+        { id: "branch-assistant", role: "assistant" },
+      ],
+    ],
+    [
+      "an externally synced completed turn",
+      [
+        { id: "user-2", role: "user" },
+        { id: "assistant-2", role: "assistant" },
+        { id: "user-3", role: "user" },
+        { id: "assistant-3", role: "assistant" },
+      ],
+    ],
+    [
+      "a resync separating the pair",
+      [
+        { id: "user-2", role: "user" },
+        { id: "inserted-assistant", role: "assistant" },
+        { id: "assistant-2", role: "assistant" },
+      ],
+    ],
   ])("invalidates a stored turn after %s", (_transition, messages) => {
     expect(
       isTopAnchorTurnValid(

--- a/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.ts
+++ b/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.ts
@@ -5,6 +5,23 @@ type TopAnchorTurnMessage = {
   readonly role: string;
 };
 
+export type TopAnchorTurn = {
+  readonly anchorId: string;
+  readonly targetId: string;
+};
+
+export const isTopAnchorTurnValid = (
+  turn: TopAnchorTurn | null,
+  messages: readonly Pick<TopAnchorTurnMessage, "id">[],
+) => {
+  if (!turn) return false;
+
+  return (
+    messages.some((message) => message.id === turn.anchorId) &&
+    messages.some((message) => message.id === turn.targetId)
+  );
+};
+
 export const getActiveTopAnchorTurn = ({
   isRunning,
   messages,

--- a/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.ts
+++ b/packages/react/src/primitives/thread/topAnchor/topAnchorTurn.ts
@@ -10,15 +10,27 @@ export type TopAnchorTurn = {
   readonly targetId: string;
 };
 
+/**
+ * A stored turn stays valid only while it is still the trailing turn: the
+ * anchor immediately precedes the target, and anything after the target is a
+ * pending user message awaiting the next run. An assistant message after the
+ * target means the turn was superseded (e.g. an external store synced in a
+ * turn completed elsewhere), so the reserve must be torn down, not preserved.
+ */
 export const isTopAnchorTurnValid = (
   turn: TopAnchorTurn | null,
-  messages: readonly Pick<TopAnchorTurnMessage, "id">[],
+  messages: readonly TopAnchorTurnMessage[],
 ) => {
   if (!turn) return false;
 
+  const targetIndex = messages.findIndex(
+    (message) => message.id === turn.targetId,
+  );
+  if (targetIndex < 1) return false;
+
   return (
-    messages.some((message) => message.id === turn.anchorId) &&
-    messages.some((message) => message.id === turn.targetId)
+    messages[targetIndex - 1]?.id === turn.anchorId &&
+    messages.slice(targetIndex + 1).every((message) => message.role === "user")
   );
 };
 


### PR DESCRIPTION
## Summary

* preserve the existing top-anchor reserve while an external runtime is between turns and the next anchor has not mounted yet
* clear sticky top-anchor state when its message IDs leave the current branch, then gate reserve preservation on that valid state
* move the preserved reserve after optimistic content, then let the next active target reposition and resize it
* keep cleanup when top anchoring is disabled, the viewport disappears, the active turn is invalid, or the reserve effect unmounts

Fixes assistant-ui/assistant-ui#5038.

## Validation

* added a current-main red regression that observed the reserve being disconnected during the between-turns gap
* reserve lifecycle and top-anchor state tests cover between-turn preservation, invalid cleanup, and thread switch, new chat, last-turn deletion, and branch swap transitions
* complete `@assistant-ui/react` suite passes (44 files, 466 tests)
* `@assistant-ui/react` production build passes (928 entries)
* root lint and format checks pass with existing warnings

Standalone package `tsc --noEmit` still reports the existing `ComposerRoot.test.tsx` `setMultiline` diagnostics on current main; this change does not touch that test.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)
