### PR TITLE
fix(react-ai-sdk): serialize history persistence

### DIFF
--- a/.changeset/serialize-ai-sdk-history-persistence.md
+++ b/.changeset/serialize-ai-sdk-history-persistence.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: serialize history persistence to prevent duplicate appends

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -305,6 +305,7 @@ describe("useExternalHistory persistence", () => {
       append,
       update,
       deleteItems,
+      formattedAdapter,
       deleteMessage: result.current.deleteMessage,
       reportTelemetry,
       load,
@@ -742,6 +743,22 @@ describe("useExternalHistory persistence", () => {
     } finally {
       releaseAppend();
     }
+  });
+
+  it("preserves the history adapter receiver during deletion", async () => {
+    const { deleteItems, formattedAdapter, deleteMessage, step } =
+      createPersistenceHarness(false);
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["first"] }],
+      "assistant-a",
+    );
+
+    await step({ messages: [message] });
+    await deleteMessage("assistant-a");
+
+    expect(deleteItems).toHaveBeenCalledOnce();
+    expect(deleteItems.mock.contexts[0]).toBe(formattedAdapter);
   });
 
   it("reports telemetry after retrying a failed append", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -706,6 +706,44 @@ describe("useExternalHistory persistence", () => {
     }
   });
 
+  it("uses the requested deletion snapshot after runtime state changes", async () => {
+    const { append, deleteItems, deleteMessage, runCycle, flush, step } =
+      createPersistenceHarness(false);
+    let releaseAppend!: () => void;
+    const pendingAppend = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    append.mockImplementationOnce(() => pendingAppend);
+
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["first"] }],
+      "assistant-a",
+    );
+
+    try {
+      await runCycle([message]);
+      await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+      const deletion = deleteMessage("assistant-a");
+      await step({ messages: [] });
+      await flush();
+      expect(deleteItems).not.toHaveBeenCalled();
+
+      releaseAppend();
+      await deletion;
+
+      expect(deleteItems).toHaveBeenCalledWith([
+        {
+          parentId: null,
+          message: { id: "inner-a", parts: ["first"] },
+        },
+      ]);
+    } finally {
+      releaseAppend();
+    }
+  });
+
   it("reports telemetry after retrying a failed append", async () => {
     const { append, reportTelemetry, runCycle, flush } =
       createPersistenceHarness(false);

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -225,6 +225,11 @@ describe("useExternalHistory persistence", () => {
         _localMessageId: string,
       ) => {},
     );
+    const deleteItems = vi.fn(
+      async (
+        _items: { parentId: string | null; message: InnerMessage }[],
+      ) => {},
+    );
     const reportTelemetry = vi.fn();
     const load = vi
       .fn()
@@ -232,6 +237,7 @@ describe("useExternalHistory persistence", () => {
     const formattedAdapter = {
       load,
       append,
+      delete: deleteItems,
       reportTelemetry,
       ...(supportsUpdate ? { update } : {}),
     };
@@ -258,7 +264,7 @@ describe("useExternalHistory persistence", () => {
       current: { thread } as AssistantRuntime,
     };
 
-    const { unmount } = renderHook(() =>
+    const { result, unmount } = renderHook(() =>
       useExternalHistory(
         persistenceRuntimeRef,
         historyAdapter,
@@ -298,6 +304,8 @@ describe("useExternalHistory persistence", () => {
     return {
       append,
       update,
+      deleteItems,
+      deleteMessage: result.current.deleteMessage,
       reportTelemetry,
       load,
       runCycle,
@@ -606,7 +614,7 @@ describe("useExternalHistory persistence", () => {
     }
   });
 
-  it("skips queued persistence passes after unmount", async () => {
+  it("finishes queued persistence passes after unmount", async () => {
     const { append, runCycle, flush, unmount } =
       createPersistenceHarness(false);
     let releaseFirstAppend!: () => void;
@@ -639,7 +647,63 @@ describe("useExternalHistory persistence", () => {
 
     expect(append.mock.calls.map(([item]) => item.message.id)).toEqual([
       "inner-a",
+      "inner-b",
     ]);
+  });
+
+  it("serializes deletion after pending persistence passes", async () => {
+    const { append, deleteItems, deleteMessage, runCycle, flush } =
+      createPersistenceHarness(false);
+    const events: string[] = [];
+    let releaseFirstAppend!: () => void;
+    const firstAppend = new Promise<void>((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    append.mockImplementation(async (item) => {
+      events.push(`append:${item.message.id}`);
+    });
+    append.mockImplementationOnce(async (item) => {
+      events.push(`append:${item.message.id}:start`);
+      await firstAppend;
+      events.push(`append:${item.message.id}:end`);
+    });
+    deleteItems.mockImplementation(async (items) => {
+      events.push(`delete:${items[0]?.message.id}`);
+    });
+
+    const firstMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["first"] }],
+      "assistant-a",
+    );
+    const secondMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-b", parts: ["second"] }],
+      "assistant-b",
+    );
+
+    try {
+      await runCycle([firstMessage]);
+      await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+      await runCycle([firstMessage, secondMessage]);
+      await flush();
+      const deletion = deleteMessage("assistant-a");
+      await flush();
+      expect(deleteItems).not.toHaveBeenCalled();
+
+      releaseFirstAppend();
+      await deletion;
+
+      expect(events).toEqual([
+        "append:inner-a:start",
+        "append:inner-a:end",
+        "append:inner-b",
+        "delete:inner-a",
+      ]);
+    } finally {
+      releaseFirstAppend();
+    }
   });
 
   it("reports telemetry after retrying a failed append", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -498,6 +498,56 @@ describe("useExternalHistory persistence", () => {
     );
   });
 
+  it("serializes overlapping persistence passes", async () => {
+    const { append, runCycle, flush } = createPersistenceHarness(true);
+    let releaseFirstAppend!: () => void;
+    const firstAppend = new Promise<void>((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    append.mockImplementationOnce(() => firstAppend);
+
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["answer"] }],
+    );
+
+    await runCycle([message]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    await runCycle([message]);
+    await flush();
+    const callsWhileFirstAppendWasPending = append.mock.calls.length;
+
+    releaseFirstAppend();
+    await flush();
+    await flush();
+
+    expect(callsWhileFirstAppendWasPending).toBe(1);
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reappend a stored inner message whose outer message was filtered", async () => {
+    const innerMessage = { id: "inner-a", parts: ["stored"] };
+    const { append, load, runCycle, flush } = createPersistenceHarness(false, {
+      loadMessages: {
+        messages: [{ parentId: null, message: innerMessage }],
+      },
+      toThreadMessages: () => [],
+    });
+
+    await waitFor(() => expect(load).toHaveBeenCalled());
+    await flush();
+
+    await runCycle([
+      createAssistantMessage({ type: "complete", reason: "stop" }, [
+        innerMessage,
+      ]),
+    ]);
+    await flush();
+
+    expect(append).not.toHaveBeenCalled();
+  });
+
   it("skips unchanged persisted messages on later runs", async () => {
     const { append, update, reportTelemetry, runCycle, flush } =
       createPersistenceHarness(true);

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -258,7 +258,7 @@ describe("useExternalHistory persistence", () => {
       current: { thread } as AssistantRuntime,
     };
 
-    renderHook(() =>
+    const { unmount } = renderHook(() =>
       useExternalHistory(
         persistenceRuntimeRef,
         historyAdapter,
@@ -295,7 +295,16 @@ describe("useExternalHistory persistence", () => {
         listener?.();
       });
 
-    return { append, update, reportTelemetry, load, runCycle, flush, step };
+    return {
+      append,
+      update,
+      reportTelemetry,
+      load,
+      runCycle,
+      flush,
+      step,
+      unmount,
+    };
   };
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
@@ -524,6 +533,142 @@ describe("useExternalHistory persistence", () => {
 
     expect(callsWhileFirstAppendWasPending).toBe(1);
     expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves telemetry timing for runs queued behind a pending append", async () => {
+    const { append, reportTelemetry, step, flush } =
+      createPersistenceHarness(false);
+    let releaseFirstAppend!: () => void;
+    const firstAppend = new Promise<void>((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    append.mockImplementationOnce(() => firstAppend);
+
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const firstMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["first"] }],
+      "assistant-a",
+    );
+    const secondMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-b", parts: ["second"] }],
+      "assistant-b",
+    );
+    const thirdMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-c", parts: ["third"] }],
+      "assistant-c",
+    );
+
+    try {
+      await step({ isRunning: true, messages: [firstMessage] });
+      now = 10;
+      await step({ isRunning: false });
+      await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+      now = 100;
+      await step({
+        isRunning: true,
+        messages: [firstMessage, secondMessage],
+      });
+      now = 110;
+      await step({ isRunning: false });
+      await flush();
+
+      now = 200;
+      await step({
+        isRunning: true,
+        messages: [firstMessage, secondMessage, thirdMessage],
+      });
+      now = 230;
+      await step({ isRunning: false });
+      await flush();
+
+      releaseFirstAppend();
+      await waitFor(() => expect(reportTelemetry).toHaveBeenCalledTimes(3));
+
+      const durations = Object.fromEntries(
+        reportTelemetry.mock.calls.map(([items, options]) => [
+          items[0]?.message.id,
+          options.durationMs,
+        ]),
+      );
+      expect(durations).toEqual({
+        "inner-a": 10,
+        "inner-b": 10,
+        "inner-c": 30,
+      });
+    } finally {
+      releaseFirstAppend();
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("skips queued persistence passes after unmount", async () => {
+    const { append, runCycle, flush, unmount } =
+      createPersistenceHarness(false);
+    let releaseFirstAppend!: () => void;
+    const firstAppend = new Promise<void>((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    append.mockImplementationOnce(() => firstAppend);
+
+    const firstMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["first"] }],
+      "assistant-a",
+    );
+    const secondMessage = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-b", parts: ["second"] }],
+      "assistant-b",
+    );
+
+    await runCycle([firstMessage]);
+    await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+
+    await runCycle([firstMessage, secondMessage]);
+    await flush();
+    unmount();
+
+    releaseFirstAppend();
+    await flush();
+    await flush();
+
+    expect(append.mock.calls.map(([item]) => item.message.id)).toEqual([
+      "inner-a",
+    ]);
+  });
+
+  it("reports telemetry after retrying a failed append", async () => {
+    const { append, reportTelemetry, runCycle, flush } =
+      createPersistenceHarness(false);
+    append.mockRejectedValueOnce(new Error("temporary storage failure"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [{ id: "inner-a", parts: ["answer"] }],
+    );
+
+    try {
+      await runCycle([message]);
+      await waitFor(() => expect(append).toHaveBeenCalledTimes(1));
+      await flush();
+      expect(reportTelemetry).not.toHaveBeenCalled();
+
+      await runCycle([message]);
+      await waitFor(() => expect(append).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(reportTelemetry).toHaveBeenCalledTimes(1));
+
+      expect(reportTelemetry).toHaveBeenCalledWith(
+        [{ parentId: null, message: { id: "inner-a", parts: ["answer"] } }],
+        expect.any(Object),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it("does not reappend a stored inner message whose outer message was filtered", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -157,6 +157,7 @@ export const useExternalHistory = <TMessage>(
 
   const runStartRef = useRef<number | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const persistInFlightRef = useRef<Promise<void>>(Promise.resolve());
   const stepBoundariesRef = useRef<number[]>([]);
   const wasRunningRef = useRef(false);
   const toolCallCountRef = useRef(0);
@@ -208,107 +209,117 @@ export const useExternalHistory = <TMessage>(
 
       // Debounce: wait one macrotask so agentic step flickers are absorbed
       if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
-      persistTimerRef.current = setTimeout(async () => {
+      persistTimerRef.current = setTimeout(() => {
         persistTimerRef.current = null;
+        persistInFlightRef.current = persistInFlightRef.current
+          .then(async () => {
+            // Re-read latest state — may have changed since the timeout was scheduled
+            const latest = runtimeRef.current.thread.getState();
+            if (latest.isRunning) return; // was just a flicker
 
-        // Re-read latest state — may have changed since the timeout was scheduled
-        const latest = runtimeRef.current.thread.getState();
-        if (latest.isRunning) return; // was just a flicker
-
-        const changedRunMessageIds = new Set<string>();
-        for (const message of latest.messages) {
-          const externalMessages = getExternalStoreMessages<TMessage>(message);
-          const previous = persistedExternalMessages.current.get(message.id);
-          if (
-            previous === undefined ||
-            previous.length !== externalMessages.length ||
-            externalMessages.some((item, index) => item !== previous[index])
-          ) {
-            changedRunMessageIds.add(message.id);
-          }
-        }
-
-        // Derive durationMs from the last boundary (covers all steps)
-        const boundaries = stepBoundariesRef.current;
-        const durationMs =
-          boundaries.length > 0 ? boundaries.at(-1) : undefined;
-
-        // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
-        if (boundaries.length === 1 && durationMs != null) {
-          const lastAssistant = latest.messages.findLast(
-            (m) => m.role === "assistant",
-          );
-          if (lastAssistant) {
-            const tcCount = lastAssistant.content.filter(
-              (p) => p.type === "tool-call",
-            ).length;
-            if (tcCount > 0) {
-              const totalSteps = tcCount + 1;
-              const stepDur = durationMs / totalSteps;
-              boundaries.length = 0;
-              for (let i = 0; i < totalSteps; i++) {
-                boundaries.push(Math.round((i + 1) * stepDur));
+            const changedRunMessageIds = new Set<string>();
+            for (const message of latest.messages) {
+              const externalMessages =
+                getExternalStoreMessages<TMessage>(message);
+              const previous = persistedExternalMessages.current.get(
+                message.id,
+              );
+              if (
+                previous === undefined ||
+                previous.length !== externalMessages.length ||
+                externalMessages.some((item, index) => item !== previous[index])
+              ) {
+                changedRunMessageIds.add(message.id);
               }
             }
-          }
-        }
 
-        // Build per-step timestamps when there are multiple steps
-        const stepTimestamps =
-          boundaries.length > 1
-            ? boundaries.map((endMs, i) => ({
-                start_ms: i === 0 ? 0 : boundaries[i - 1]!,
-                end_ms: endMs,
-              }))
-            : undefined;
+            // Derive durationMs from the last boundary (covers all steps)
+            const boundaries = stepBoundariesRef.current;
+            const durationMs =
+              boundaries.length > 0 ? boundaries.at(-1) : undefined;
 
-        runStartRef.current = null;
-        stepBoundariesRef.current = [];
+            // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
+            if (boundaries.length === 1 && durationMs != null) {
+              const lastAssistant = latest.messages.findLast(
+                (m) => m.role === "assistant",
+              );
+              if (lastAssistant) {
+                const tcCount = lastAssistant.content.filter(
+                  (p) => p.type === "tool-call",
+                ).length;
+                if (tcCount > 0) {
+                  const totalSteps = tcCount + 1;
+                  const stepDur = durationMs / totalSteps;
+                  boundaries.length = 0;
+                  for (let i = 0; i < totalSteps; i++) {
+                    boundaries.push(Math.round((i + 1) * stepDur));
+                  }
+                }
+              }
+            }
 
-        const telemetryOptions = {
-          ...(durationMs != null ? { durationMs } : undefined),
-          ...(stepTimestamps != null ? { stepTimestamps } : undefined),
-        };
+            // Build per-step timestamps when there are multiple steps
+            const stepTimestamps =
+              boundaries.length > 1
+                ? boundaries.map((endMs, i) => ({
+                    start_ms: i === 0 ? 0 : boundaries[i - 1]!,
+                    end_ms: endMs,
+                  }))
+                : undefined;
 
-        const { messages } = latest;
-        let lastInnerMessageId: string | null = null;
-        const failedUpdateIds = new Set<string>();
+            runStartRef.current = null;
+            stepBoundariesRef.current = [];
 
-        const getLastInnerId = (msgs: TMessage[]): string | null =>
-          msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
+            const telemetryOptions = {
+              ...(durationMs != null ? { durationMs } : undefined),
+              ...(stepTimestamps != null ? { stepTimestamps } : undefined),
+            };
 
-        const toBatchItems = (msgs: TMessage[]) =>
-          msgs.map((msg, idx) => ({
-            parentId:
-              idx === 0
-                ? lastInnerMessageId
-                : storageFormatAdapter.getId(msgs[idx - 1]!),
-            message: msg,
-          }));
+            const { messages } = latest;
+            let lastInnerMessageId: string | null = null;
+            const failedUpdateIds = new Set<string>();
 
-        for (const message of messages) {
-          const innerMessages = getExternalStoreMessages<TMessage>(message);
+            const getLastInnerId = (msgs: TMessage[]): string | null =>
+              msgs.length > 0 ? storageFormatAdapter.getId(msgs.at(-1)!) : null;
 
-          const isTerminal =
-            message.status === undefined ||
-            message.status.type === "complete" ||
-            message.status.type === "incomplete";
-          const isAwaitingToolCalls = isAwaitingToolApproval(message);
-          // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
-          const isReady =
-            isTerminal ||
-            (isAwaitingToolCalls && formatAdapter.update !== undefined);
+            const toBatchItems = (msgs: TMessage[]) =>
+              msgs.map((msg, idx) => ({
+                parentId:
+                  idx === 0
+                    ? lastInnerMessageId
+                    : storageFormatAdapter.getId(msgs[idx - 1]!),
+                message: msg,
+              }));
 
-          if (!isReady) {
-            lastInnerMessageId =
-              getLastInnerId(innerMessages) ?? lastInnerMessageId;
-            continue;
-          }
+            for (const message of messages) {
+              const innerMessages = getExternalStoreMessages<TMessage>(message);
 
-          if (historyIds.current.has(message.id)) {
-            if (changedRunMessageIds.has(message.id)) {
-              const items = toBatchItems(innerMessages);
-              for (const item of items) {
+              const isTerminal =
+                message.status === undefined ||
+                message.status.type === "complete" ||
+                message.status.type === "incomplete";
+              const isAwaitingToolCalls = isAwaitingToolApproval(message);
+              // A paused message's later content can only reach storage via update, so it is persisted early only when the adapter supports update.
+              const isReady =
+                isTerminal ||
+                (isAwaitingToolCalls && formatAdapter.update !== undefined);
+
+              if (!isReady) {
+                lastInnerMessageId =
+                  getLastInnerId(innerMessages) ?? lastInnerMessageId;
+                continue;
+              }
+
+              const isPersistedMessage = historyIds.current.has(message.id);
+              if (isPersistedMessage && !changedRunMessageIds.has(message.id)) {
+                lastInnerMessageId =
+                  getLastInnerId(innerMessages) ?? lastInnerMessageId;
+                continue;
+              }
+              if (!isPersistedMessage) historyIds.current.add(message.id);
+
+              const batchItems = toBatchItems(innerMessages);
+              for (const item of batchItems) {
                 const innerId = storageFormatAdapter.getId(item.message);
                 if (!persistedInnerIds.current.has(innerId)) {
                   await formatAdapter.append(item);
@@ -322,42 +333,36 @@ export const useExternalHistory = <TMessage>(
                   }
                 }
               }
-              if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
-                deferredTelemetryIds.current.delete(message.id);
-                formatAdapter.reportTelemetry?.(items, telemetryOptions);
+
+              lastInnerMessageId =
+                getLastInnerId(innerMessages) ?? lastInnerMessageId;
+
+              if (isPersistedMessage) {
+                if (
+                  deferredTelemetryIds.current.has(message.id) &&
+                  isTerminal
+                ) {
+                  deferredTelemetryIds.current.delete(message.id);
+                  formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+                }
+              } else if (isTerminal) {
+                formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
+              } else {
+                deferredTelemetryIds.current.add(message.id);
               }
             }
-            lastInnerMessageId =
-              getLastInnerId(innerMessages) ?? lastInnerMessageId;
-            continue;
-          }
-          historyIds.current.add(message.id);
 
-          const batchItems = toBatchItems(innerMessages);
-          for (const item of batchItems) {
-            await formatAdapter.append(item);
-            persistedInnerIds.current.add(
-              storageFormatAdapter.getId(item.message),
+            const nextSnapshot = snapshotExternalMessages<TMessage>(
+              latest.messages,
             );
-          }
-
-          lastInnerMessageId =
-            getLastInnerId(innerMessages) ?? lastInnerMessageId;
-
-          if (isTerminal) {
-            formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
-          } else {
-            deferredTelemetryIds.current.add(message.id);
-          }
-        }
-
-        const nextSnapshot = snapshotExternalMessages<TMessage>(
-          latest.messages,
-        );
-        for (const id of failedUpdateIds) {
-          nextSnapshot.delete(id);
-        }
-        persistedExternalMessages.current = nextSnapshot;
+            for (const id of failedUpdateIds) {
+              nextSnapshot.delete(id);
+            }
+            persistedExternalMessages.current = nextSnapshot;
+          })
+          .catch((error) => {
+            console.error("Failed to persist message history:", error);
+          });
       }, 0);
     });
 

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -165,7 +165,6 @@ export const useExternalHistory = <TMessage>(
   useEffect(() => {
     if (!formatAdapter) return;
 
-    let disposed = false;
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
       const threadState = runtimeRef.current.thread.getState();
       const { isRunning } = threadState;
@@ -259,8 +258,6 @@ export const useExternalHistory = <TMessage>(
 
         persistInFlightRef.current = persistInFlightRef.current
           .then(async () => {
-            if (disposed) return;
-
             const changedRunMessageIds = new Set<string>();
             for (const message of latest.messages) {
               const externalMessages =
@@ -363,7 +360,6 @@ export const useExternalHistory = <TMessage>(
     });
 
     return () => {
-      disposed = true;
       unsubscribe();
       if (persistTimerRef.current) {
         clearTimeout(persistTimerRef.current);
@@ -374,36 +370,42 @@ export const useExternalHistory = <TMessage>(
 
   const deleteMessage = useCallback(
     async (messageId: string) => {
-      if (!formatAdapter?.delete) return;
+      const deleteMessages = formatAdapter?.delete;
+      if (!deleteMessages) return;
 
-      const messages = runtimeRef.current.thread.getState().messages;
-      const messageIndex = messages.findIndex((m) => m.id === messageId);
-      if (messageIndex === -1) return;
+      const deletion = persistInFlightRef.current.then(async () => {
+        const messages = runtimeRef.current.thread.getState().messages;
+        const messageIndex = messages.findIndex((m) => m.id === messageId);
+        if (messageIndex === -1) return;
 
-      const previousInnerMessages = messages
-        .slice(0, messageIndex)
-        .flatMap(getExternalStoreMessages<TMessage>);
-      let parentId = previousInnerMessages.at(-1)
-        ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
-        : null;
-      const itemsToDelete = getExternalStoreMessages<TMessage>(
-        messages[messageIndex]!,
-      ).map((message) => {
-        const item = { parentId, message };
-        parentId = storageFormatAdapter.getId(message);
-        return item;
+        const previousInnerMessages = messages
+          .slice(0, messageIndex)
+          .flatMap(getExternalStoreMessages<TMessage>);
+        let parentId = previousInnerMessages.at(-1)
+          ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
+          : null;
+        const itemsToDelete = getExternalStoreMessages<TMessage>(
+          messages[messageIndex]!,
+        ).map((message) => {
+          const item = { parentId, message };
+          parentId = storageFormatAdapter.getId(message);
+          return item;
+        });
+
+        await deleteMessages(itemsToDelete);
+
+        historyIds.current.delete(messageId);
+        deferredTelemetryIds.current.delete(messageId);
+        persistedExternalMessages.current.delete(messageId);
+        for (const item of itemsToDelete) {
+          persistedInnerIds.current.delete(
+            storageFormatAdapter.getId(item.message),
+          );
+        }
       });
 
-      await formatAdapter.delete(itemsToDelete);
-
-      historyIds.current.delete(messageId);
-      deferredTelemetryIds.current.delete(messageId);
-      persistedExternalMessages.current.delete(messageId);
-      for (const item of itemsToDelete) {
-        persistedInnerIds.current.delete(
-          storageFormatAdapter.getId(item.message),
-        );
-      }
+      persistInFlightRef.current = deletion.catch(() => {});
+      await deletion;
     },
     [formatAdapter, runtimeRef, storageFormatAdapter],
   );

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -370,7 +370,7 @@ export const useExternalHistory = <TMessage>(
 
   const deleteMessage = useCallback(
     async (messageId: string) => {
-      const deleteMessages = formatAdapter?.delete;
+      const deleteMessages = formatAdapter?.delete?.bind(formatAdapter);
       if (!deleteMessages) return;
 
       const messages = runtimeRef.current.thread.getState().messages;

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -165,6 +165,7 @@ export const useExternalHistory = <TMessage>(
   useEffect(() => {
     if (!formatAdapter) return;
 
+    let disposed = false;
     const unsubscribe = runtimeRef.current.thread.subscribe(() => {
       const threadState = runtimeRef.current.thread.getState();
       const { isRunning } = threadState;
@@ -211,11 +212,54 @@ export const useExternalHistory = <TMessage>(
       if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
       persistTimerRef.current = setTimeout(() => {
         persistTimerRef.current = null;
+
+        const latest = runtimeRef.current.thread.getState();
+        if (latest.isRunning) return;
+
+        const boundaries = stepBoundariesRef.current;
+        const durationMs =
+          boundaries.length > 0 ? boundaries.at(-1) : undefined;
+
+        // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
+        if (boundaries.length === 1 && durationMs != null) {
+          const lastAssistant = latest.messages.findLast(
+            (m) => m.role === "assistant",
+          );
+          if (lastAssistant) {
+            const tcCount = lastAssistant.content.filter(
+              (p) => p.type === "tool-call",
+            ).length;
+            if (tcCount > 0) {
+              const totalSteps = tcCount + 1;
+              const stepDur = durationMs / totalSteps;
+              boundaries.length = 0;
+              for (let i = 0; i < totalSteps; i++) {
+                boundaries.push(Math.round((i + 1) * stepDur));
+              }
+            }
+          }
+        }
+
+        // Build per-step timestamps when there are multiple steps
+        const stepTimestamps =
+          boundaries.length > 1
+            ? boundaries.map((endMs, i) => ({
+                start_ms: i === 0 ? 0 : boundaries[i - 1]!,
+                end_ms: endMs,
+              }))
+            : undefined;
+
+        runStartRef.current = null;
+        stepBoundariesRef.current = [];
+
+        const telemetryOptions = {
+          ...(durationMs != null ? { durationMs } : undefined),
+          ...(stepTimestamps != null ? { stepTimestamps } : undefined),
+        };
+
         persistInFlightRef.current = persistInFlightRef.current
           .then(async () => {
-            // Re-read latest state — may have changed since the timeout was scheduled
-            const latest = runtimeRef.current.thread.getState();
-            if (latest.isRunning) return; // was just a flicker
+            if (disposed) return;
 
             const changedRunMessageIds = new Set<string>();
             for (const message of latest.messages) {
@@ -232,48 +276,6 @@ export const useExternalHistory = <TMessage>(
                 changedRunMessageIds.add(message.id);
               }
             }
-
-            // Derive durationMs from the last boundary (covers all steps)
-            const boundaries = stepBoundariesRef.current;
-            const durationMs =
-              boundaries.length > 0 ? boundaries.at(-1) : undefined;
-
-            // Fallback: if only 1 boundary but message has multiple steps, distribute evenly
-            if (boundaries.length === 1 && durationMs != null) {
-              const lastAssistant = latest.messages.findLast(
-                (m) => m.role === "assistant",
-              );
-              if (lastAssistant) {
-                const tcCount = lastAssistant.content.filter(
-                  (p) => p.type === "tool-call",
-                ).length;
-                if (tcCount > 0) {
-                  const totalSteps = tcCount + 1;
-                  const stepDur = durationMs / totalSteps;
-                  boundaries.length = 0;
-                  for (let i = 0; i < totalSteps; i++) {
-                    boundaries.push(Math.round((i + 1) * stepDur));
-                  }
-                }
-              }
-            }
-
-            // Build per-step timestamps when there are multiple steps
-            const stepTimestamps =
-              boundaries.length > 1
-                ? boundaries.map((endMs, i) => ({
-                    start_ms: i === 0 ? 0 : boundaries[i - 1]!,
-                    end_ms: endMs,
-                  }))
-                : undefined;
-
-            runStartRef.current = null;
-            stepBoundariesRef.current = [];
-
-            const telemetryOptions = {
-              ...(durationMs != null ? { durationMs } : undefined),
-              ...(stepTimestamps != null ? { stepTimestamps } : undefined),
-            };
 
             const { messages } = latest;
             let lastInnerMessageId: string | null = null;
@@ -316,7 +318,10 @@ export const useExternalHistory = <TMessage>(
                   getLastInnerId(innerMessages) ?? lastInnerMessageId;
                 continue;
               }
-              if (!isPersistedMessage) historyIds.current.add(message.id);
+              if (!isPersistedMessage) {
+                historyIds.current.add(message.id);
+                deferredTelemetryIds.current.add(message.id);
+              }
 
               const batchItems = toBatchItems(innerMessages);
               for (const item of batchItems) {
@@ -337,18 +342,9 @@ export const useExternalHistory = <TMessage>(
               lastInnerMessageId =
                 getLastInnerId(innerMessages) ?? lastInnerMessageId;
 
-              if (isPersistedMessage) {
-                if (
-                  deferredTelemetryIds.current.has(message.id) &&
-                  isTerminal
-                ) {
-                  deferredTelemetryIds.current.delete(message.id);
-                  formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
-                }
-              } else if (isTerminal) {
+              if (deferredTelemetryIds.current.has(message.id) && isTerminal) {
+                deferredTelemetryIds.current.delete(message.id);
                 formatAdapter.reportTelemetry?.(batchItems, telemetryOptions);
-              } else {
-                deferredTelemetryIds.current.add(message.id);
               }
             }
 
@@ -367,6 +363,7 @@ export const useExternalHistory = <TMessage>(
     });
 
     return () => {
+      disposed = true;
       unsubscribe();
       if (persistTimerRef.current) {
         clearTimeout(persistTimerRef.current);

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.ts
@@ -373,25 +373,25 @@ export const useExternalHistory = <TMessage>(
       const deleteMessages = formatAdapter?.delete;
       if (!deleteMessages) return;
 
+      const messages = runtimeRef.current.thread.getState().messages;
+      const messageIndex = messages.findIndex((m) => m.id === messageId);
+      if (messageIndex === -1) return;
+
+      const previousInnerMessages = messages
+        .slice(0, messageIndex)
+        .flatMap(getExternalStoreMessages<TMessage>);
+      let parentId = previousInnerMessages.at(-1)
+        ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
+        : null;
+      const itemsToDelete = getExternalStoreMessages<TMessage>(
+        messages[messageIndex]!,
+      ).map((message) => {
+        const item = { parentId, message };
+        parentId = storageFormatAdapter.getId(message);
+        return item;
+      });
+
       const deletion = persistInFlightRef.current.then(async () => {
-        const messages = runtimeRef.current.thread.getState().messages;
-        const messageIndex = messages.findIndex((m) => m.id === messageId);
-        if (messageIndex === -1) return;
-
-        const previousInnerMessages = messages
-          .slice(0, messageIndex)
-          .flatMap(getExternalStoreMessages<TMessage>);
-        let parentId = previousInnerMessages.at(-1)
-          ? storageFormatAdapter.getId(previousInnerMessages.at(-1)!)
-          : null;
-        const itemsToDelete = getExternalStoreMessages<TMessage>(
-          messages[messageIndex]!,
-        ).map((message) => {
-          const item = { parentId, message };
-          parentId = storageFormatAdapter.getId(message);
-          return item;
-        });
-
         await deleteMessages(itemsToDelete);
 
         historyIds.current.delete(messageId);


### PR DESCRIPTION
## Summary

- serialize AI SDK history persistence so later runs wait for the active append/update pass
- snapshot each completed run before enqueueing it, preserving separate duration and step telemetry
- serialize history deletions with persistence so deleted messages cannot be resurrected by pending writes
- let completed runs already in the queue finish across effect cleanup
- use one inner-message path for fresh and previously seen outer messages
- retain pending telemetry across transient append failures
- add regressions for overlapping appends, queued run timing, cleanup, deletion ordering, failed-append telemetry, and filtered outer messages

## Why

While testing history persistence with a deliberately slow adapter, a second run could finish while the first `append()` was still pending. Both passes could observe the same inner message before its persisted ID was recorded and append it twice.

Serializing writes closes that race. Capturing each completed run before it enters the queue preserves its own message and timing snapshot. The same queue now orders deletions after pending writes, ensuring the final storage operation remains the delete, while already-queued completed runs continue after effect cleanup instead of being lost.

A related load edge could reappend an already stored inner message when conversion filtered its original outer message. The unified per-inner-message path handles that case without changing normal serial persistence behavior.

## Testing

- confirmed the original two regressions fail against `main`
- confirmed each review regression fails against its preceding commit
- `pnpm exec turbo test --filter=@assistant-ui/react-ai-sdk --concurrency=4` (174 tests)
- `pnpm exec turbo build --filter=@assistant-ui/react-ai-sdk --concurrency=4`
- changed-file lint, formatting, and diff checks

Closes #5053