### PR TITLE
fix: preserve falsy runtime state

### DIFF
--- a/.changeset/falsy-runtime-state.md
+++ b/.changeset/falsy-runtime-state.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: preserve falsy runtime state values

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -99,4 +99,25 @@ describe("useExternalMessageConverter", () => {
       text: "HELLO",
     });
   });
+
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+  ])("preserves %s assistant state", (_label, state) => {
+    const callback: useExternalMessageConverter.Callback<TestMessage> = (
+      message,
+    ) => ({
+      role: message.role,
+      id: message.id,
+      content: [{ type: "text", text: message.text }],
+      ...(message.role === "assistant"
+        ? { metadata: { unstable_state: state } }
+        : undefined),
+    });
+
+    const { result } = renderConverter({ callback });
+
+    expect(result.current[1]?.metadata.unstable_state).toBe(state);
+  });
 });

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -170,7 +170,7 @@ const joinExternalMessages = (
 
             if (output.metadata) {
               assistantMessage.metadata ??= {};
-              if (output.metadata.unstable_state) {
+              if (output.metadata.unstable_state !== undefined) {
                 assistantMessage.metadata.unstable_state =
                   output.metadata.unstable_state;
               }

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -158,6 +158,25 @@ describe("LocalThreadRuntimeCore human-in-the-loop tools", () => {
   });
 });
 
+describe("LocalThreadRuntimeCore state", () => {
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+  ])("preserves %s model state", async (_label, state) => {
+    const thread = createThread({
+      async run() {
+        return { metadata: { unstable_state: state } };
+      },
+    });
+
+    await thread.append(userMessage("update state"));
+    await flush();
+
+    expect(thread.messages.at(-1)?.metadata.unstable_state).toBe(state);
+  });
+});
+
 describe("LocalThreadRuntimeCore tool approvals", () => {
   it("pauses the run while an approval is pending, even for unlisted tools", async () => {
     const { thread, runs } = createApprovalThread(

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -442,7 +442,7 @@ export class LocalThreadRuntimeCore
           ? {
               metadata: {
                 ...message.metadata,
-                ...(m.metadata.unstable_state
+                ...(m.metadata.unstable_state !== undefined
                   ? { unstable_state: m.metadata.unstable_state }
                   : undefined),
                 ...(annotations

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -1,0 +1,85 @@
+import type {
+  AssistantRuntime,
+  ChatModelAdapter,
+  ChatModelRunOptions,
+  ThreadAssistantMessage,
+} from "@assistant-ui/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const adapterRef = vi.hoisted(() => ({
+  current: undefined as ChatModelAdapter | undefined,
+}));
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/core/react")>()),
+  useLocalRuntime: (adapter: ChatModelAdapter) => {
+    adapterRef.current = adapter;
+    return {} as AssistantRuntime;
+  },
+}));
+
+import { useDataStreamRuntime } from "./useDataStreamRuntime";
+
+const CaptureRuntime = () => {
+  useDataStreamRuntime({ api: "/api/chat" });
+  return null;
+};
+
+const createMessage = (
+  state: ThreadAssistantMessage["metadata"]["unstable_state"],
+): ThreadAssistantMessage => ({
+  id: "assistant",
+  role: "assistant",
+  content: [],
+  status: { type: "running" },
+  createdAt: new Date(),
+  metadata: {
+    unstable_state: state,
+    unstable_annotations: [],
+    unstable_data: [],
+    steps: [],
+    custom: {},
+  },
+});
+
+const runWithState = async (
+  state: ThreadAssistantMessage["metadata"]["unstable_state"],
+) => {
+  const fetchMock = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(new Response("failed", { status: 500 }));
+  CaptureRuntime();
+
+  const message = createMessage(state);
+  const result = adapterRef.current!.run({
+    messages: [],
+    runConfig: {},
+    abortSignal: new AbortController().signal,
+    context: {},
+    unstable_getMessage: () => message,
+  } satisfies ChatModelRunOptions) as AsyncGenerator;
+
+  await expect(result.next()).rejects.toThrow("Status 500");
+
+  const request = fetchMock.mock.calls[0]?.[1];
+  return JSON.parse(request?.body as string) as Record<string, unknown>;
+};
+
+afterEach(() => {
+  adapterRef.current = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("useDataStreamRuntime request state", () => {
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+  ])("sends %s state", async (_label, state) => {
+    await expect(runWithState(state)).resolves.toMatchObject({ state });
+  });
+
+  it("omits null state", async () => {
+    await expect(runWithState(null)).resolves.not.toHaveProperty("state");
+  });
+});

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -118,7 +118,7 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
           ? { parentId: unstable_parentId }
           : {}),
         runConfig,
-        state: unstable_getMessage().metadata.unstable_state || undefined,
+        state: unstable_getMessage().metadata.unstable_state ?? undefined,
         ...context.callSettings,
         ...context.config,
         ...(bodyValue ?? {}),


### PR DESCRIPTION
## Summary

- preserve `false`, `0`, and empty-string runtime state in local runtime updates and external message conversion
- include those values in React data-stream requests while continuing to omit `null`
- add regression coverage for all three paths

## Why

Runtime state accepts JSON values, so boolean, numeric, and string sentinel states are valid. Truthiness checks treated these values as absent, which could silently reset converted messages to `null` or omit state from a backend request.

The core paths now check specifically for `undefined`. The data-stream request uses nullish coalescing so it preserves falsy values without changing the existing behavior that omits `null` from JSON requests.

## Verification

- reproduced all three falsy values being dropped before the fix
- `pnpm --filter @assistant-ui/core test` (587 tests)
- `pnpm --filter @assistant-ui/react-data-stream test` (12 tests)
- `pnpm lint`
- `pnpm --filter @assistant-ui/core --filter @assistant-ui/react-data-stream build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

