### PR TITLE
fix: avoid false copy success without a clipboard handler

### DIFF
--- a/.changeset/action-bar-copy-feedback.md
+++ b/.changeset/action-bar-copy-feedback.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: avoid reporting copy success without a clipboard handler

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -768,9 +768,11 @@ import { ActionBarPrimitive } from "@assistant-ui/react-ink";
 Pressable that copies the message content. Pass a platform clipboard writer through `copyToClipboard`. Supports function-as-children for copy state feedback.
 
 ```tsx
+import clipboard from "clipboardy";
+
 <ActionBarPrimitive.Copy
   copiedDuration={3000}
-  copyToClipboard={copyToClipboard}
+  copyToClipboard={clipboard.write}
 >
   {({ isCopied }) => <Text>{isCopied ? "[Copied!]" : "[Copy]"}</Text>}
 </ActionBarPrimitive.Copy>
@@ -779,7 +781,7 @@ Pressable that copies the message content. Pass a platform clipboard writer thro
 | Prop | Type | Description |
 |------|------|-------------|
 | `copiedDuration` | `number` | Duration in ms to show "copied" state (default: 3000) |
-| `copyToClipboard` | `(text: string) => void` | Platform clipboard writer |
+| `copyToClipboard` | `(text: string) => void \| Promise<void>` | Platform clipboard writer |
 
 ### Edit
 

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -767,6 +767,8 @@ import { ActionBarPrimitive } from "@assistant-ui/react-ink";
 
 Pressable that copies the message content. Pass a platform clipboard writer through `copyToClipboard`. Supports function-as-children for copy state feedback.
 
+<InstallCommand npm={["clipboardy"]} />
+
 ```tsx
 import clipboard from "clipboardy";
 

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -765,10 +765,13 @@ import { ActionBarPrimitive } from "@assistant-ui/react-ink";
 
 ### Copy
 
-Pressable that copies the message content. Supports function-as-children for copy state feedback.
+Pressable that copies the message content. Pass a platform clipboard writer through `copyToClipboard`. Supports function-as-children for copy state feedback.
 
 ```tsx
-<ActionBarPrimitive.Copy copiedDuration={3000}>
+<ActionBarPrimitive.Copy
+  copiedDuration={3000}
+  copyToClipboard={copyToClipboard}
+>
   {({ isCopied }) => <Text>{isCopied ? "[Copied!]" : "[Copy]"}</Text>}
 </ActionBarPrimitive.Copy>
 ```
@@ -776,7 +779,7 @@ Pressable that copies the message content. Supports function-as-children for cop
 | Prop | Type | Description |
 |------|------|-------------|
 | `copiedDuration` | `number` | Duration in ms to show "copied" state (default: 3000) |
-| `copyToClipboard` | `(text: string) => void` | Custom clipboard function |
+| `copyToClipboard` | `(text: string) => void` | Platform clipboard writer |
 
 ### Edit
 

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -547,7 +547,8 @@ import { ActionBarPrimitive } from "@assistant-ui/react-native";
 import * as Clipboard from "expo-clipboard";
 
 const copyToClipboard = async (text: string) => {
-  await Clipboard.setStringAsync(text);
+  const didCopy = await Clipboard.setStringAsync(text);
+  if (!didCopy) throw new Error("Clipboard write failed");
 };
 
 <ActionBarPrimitive.Copy

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -541,10 +541,13 @@ import { ActionBarPrimitive } from "@assistant-ui/react-native";
 
 ### ActionBarPrimitive.Copy
 
-`Pressable` that copies the message content. Supports function-as-children for copy state feedback.
+`Pressable` that copies the message content. Pass a platform clipboard writer through `copyToClipboard`. Supports function-as-children for copy state feedback.
 
 ```tsx
-<ActionBarPrimitive.Copy copiedDuration={3000}>
+<ActionBarPrimitive.Copy
+  copiedDuration={3000}
+  copyToClipboard={copyToClipboard}
+>
   {({ isCopied }) => <Text>{isCopied ? "Copied!" : "Copy"}</Text>}
 </ActionBarPrimitive.Copy>
 ```
@@ -552,7 +555,7 @@ import { ActionBarPrimitive } from "@assistant-ui/react-native";
 | Prop | Type | Description |
 |------|------|-------------|
 | `copiedDuration` | `number` | Duration in ms to show "copied" state (default: 3000) |
-| `copyToClipboard` | `(text: string) => void` | Custom clipboard function |
+| `copyToClipboard` | `(text: string) => void` | Platform clipboard writer |
 
 ### ActionBarPrimitive.Edit
 

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -544,6 +544,12 @@ import { ActionBarPrimitive } from "@assistant-ui/react-native";
 `Pressable` that copies the message content. Pass a platform clipboard writer through `copyToClipboard`. Supports function-as-children for copy state feedback.
 
 ```tsx
+import * as Clipboard from "expo-clipboard";
+
+const copyToClipboard = async (text: string) => {
+  await Clipboard.setStringAsync(text);
+};
+
 <ActionBarPrimitive.Copy
   copiedDuration={3000}
   copyToClipboard={copyToClipboard}
@@ -555,7 +561,7 @@ import { ActionBarPrimitive } from "@assistant-ui/react-native";
 | Prop | Type | Description |
 |------|------|-------------|
 | `copiedDuration` | `number` | Duration in ms to show "copied" state (default: 3000) |
-| `copyToClipboard` | `(text: string) => void` | Platform clipboard writer |
+| `copyToClipboard` | `(text: string) => void \| Promise<void>` | Platform clipboard writer |
 
 ### ActionBarPrimitive.Edit
 

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
@@ -47,11 +47,12 @@ afterEach(() => {
 
 describe("useActionBarCopy", () => {
   it("does not report copy success without a clipboard handler", async () => {
-    const { copy } = useActionBarCopy();
+    const { copy, disabled } = useActionBarCopy();
 
     copy();
     await Promise.resolve();
 
+    expect(disabled).toBe(true);
     expect(mocks.setIsCopied).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const setIsCopied = vi.fn();
+
+  return {
+    setIsCopied,
+    state: {
+      message: {
+        role: "assistant",
+        status: { type: "complete", reason: "stop" },
+        parts: [{ type: "text", text: "Hello" }],
+        isCopied: false,
+      },
+      composer: {
+        isEditing: false,
+        text: "",
+      },
+    },
+    aui: {
+      message: () => ({
+        getCopyText: () => "Hello",
+        setIsCopied,
+      }),
+    },
+  };
+});
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useCallback: ((callback: unknown) =>
+    callback) as typeof import("react").useCallback,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+  useAuiState: ((selector: (state: typeof mocks.state) => unknown) =>
+    selector(mocks.state)) as typeof import("@assistant-ui/store").useAuiState,
+}));
+
+import { useActionBarCopy } from "./useActionBarCopy";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useActionBarCopy", () => {
+  it("does not report copy success without a clipboard handler", async () => {
+    const { copy } = useActionBarCopy();
+
+    copy();
+    await Promise.resolve();
+
+    expect(mocks.setIsCopied).not.toHaveBeenCalled();
+  });
+
+  it("reports copy success after the clipboard handler resolves", async () => {
+    const copyToClipboard = vi.fn();
+    const { copy } = useActionBarCopy({ copyToClipboard });
+
+    copy();
+    await Promise.resolve();
+
+    expect(copyToClipboard).toHaveBeenCalledWith("Hello");
+    expect(mocks.setIsCopied).toHaveBeenCalledWith(true);
+  });
+
+  it("does not report copy success when the clipboard handler rejects", async () => {
+    const copyToClipboard = vi.fn().mockRejectedValue(new Error("denied"));
+    const { copy } = useActionBarCopy({ copyToClipboard });
+
+    copy();
+    await Promise.resolve();
+
+    expect(mocks.setIsCopied).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -39,5 +39,5 @@ export const useActionBarCopy = ({
     );
   }, [aui, isEditing, composerValue, copiedDuration, copyToClipboard]);
 
-  return { copy, disabled, isCopied };
+  return { copy, disabled: disabled || !copyToClipboard, isCopied };
 };

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -23,13 +23,14 @@ export const useActionBarCopy = ({
   const composerValue = useAuiState((s) => s.composer.text);
 
   const copy = useCallback(() => {
+    if (!copyToClipboard) return;
+
     const valueToCopy = isEditing ? composerValue : aui.message().getCopyText();
     if (!valueToCopy) return;
 
-    const write = copyToClipboard ?? (() => {});
     // The rejection handler swallows clipboard write failures (permission denied,
     // API unavailable) so they don't surface as unhandled promise rejections.
-    Promise.resolve(write(valueToCopy)).then(
+    Promise.resolve(copyToClipboard(valueToCopy)).then(
       () => {
         aui.message().setIsCopied(true);
         setTimeout(() => aui.message().setIsCopied(false), copiedDuration);


### PR DESCRIPTION
## What changed

- return without setting `isCopied` when no `copyToClipboard` handler is available
- preserve success feedback after a real clipboard write and suppress feedback after rejected writes
- document the platform clipboard writer required by React Native and Ink

## Why

React Native and Ink do not provide a default clipboard implementation. Their official primitive examples omitted `copyToClipboard`, so pressing Copy ran a successful no-op and displayed `Copied!` even though nothing reached the clipboard.

## Verification

- reproduced the bug with a regression test that failed before the source change
- `pnpm --filter @assistant-ui/core test` (584 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm --filter @assistant-ui/docs build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

