### PR TITLE
fix(core): mark a cancelled run incomplete when the adapter returns cleanly

### DIFF
--- a/.changeset/cancelled-run-status.md
+++ b/.changeset/cancelled-run-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: mark a cancelled local runtime run incomplete when the adapter returns without throwing

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -408,6 +408,74 @@ describe("LocalThreadRuntimeCore tool approvals", () => {
   });
 });
 
+describe("LocalThreadRuntimeCore cancellation", () => {
+  it("marks the message cancelled when a streaming adapter returns after abort", async () => {
+    let released!: () => void;
+    const streaming = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+
+    const thread = createThread({
+      async *run({ abortSignal }) {
+        yield { content: [{ type: "text", text: "partial" }] };
+        await streaming;
+        if (abortSignal.aborted) return;
+        yield { content: [{ type: "text", text: "partial answer" }] };
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("hi"));
+    await flush();
+
+    thread.cancelRun();
+    released();
+    await appendPromise;
+
+    expect(thread.messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("marks the message cancelled when a non-streaming adapter resolves after abort", async () => {
+    let released!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      released = resolve;
+    });
+
+    const thread = createThread({
+      async run() {
+        await pending;
+        return { content: [{ type: "text", text: "hello" }] };
+      },
+    });
+
+    const appendPromise = thread.append(userMessage("hi"));
+    await flush();
+
+    thread.cancelRun();
+    released();
+    await appendPromise;
+
+    expect(thread.messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("keeps a completed run complete", async () => {
+    const thread = createThread({
+      async *run() {
+        yield { content: [{ type: "text", text: "hello" }] };
+      },
+    });
+
+    await thread.append(userMessage("hi"));
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+  });
+});
+
 describe("LocalThreadRuntimeCore suggestions", () => {
   it("cancelRun aborts pending suggestion generation", async () => {
     const generate = vi.fn().mockImplementation(

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -537,7 +537,9 @@ export class LocalThreadRuntimeCore
 
       if (message.status.type === "running") {
         updateMessage({
-          status: { type: "complete", reason: "unknown" },
+          status: abortSignal.aborted
+            ? { type: "incomplete", reason: "cancelled" }
+            : { type: "complete", reason: "unknown" },
         });
       }
     } catch (e) {


### PR DESCRIPTION
### What breaks

Stopping a run in `LocalRuntime` can leave the assistant message marked `complete` instead of `incomplete` / `cancelled`. The partial answer then looks like a finished one: it is persisted to the history adapter as a completed message, reported to cloud telemetry with status `completed`, and any UI branching on the cancelled status never fires.

Repro with a streaming adapter:

```tsx
const adapter: ChatModelAdapter = {
  async *run({ abortSignal }) {
    for await (const chunk of myStream) {
      if (abortSignal.aborted) return; // cooperative stop
      yield { content: [{ type: "text", text }] };
    }
  },
};
```

Send a message, press stop mid-stream, and the message settles as `complete`.

### Root cause

`performRoundtrip` has two ways to notice a cancellation, and both need the adapter to cooperate in a specific way:

- the `abortSignal.aborted` check inside the `for await` loop, which is only reached if the generator yields *again* after the abort
- an `AbortError` propagating out of the adapter, caught below

An adapter that returns cleanly on abort hits neither, so `message.status` is still `running` when the loop ends and the run is finalized as `complete`. That is the shape the docs actually recommend for the surrounding SDK call: *"Swallow `AbortError` (it is the user cancelling)"* ([local-runtime best practices](https://www.assistant-ui.com/docs/runtimes/custom/local-runtime#best-practices)). The non-streaming branch had no abort check at all, so a promise resolving after the abort always overwrote the cancellation.

The shipped adapters are unaffected because they pass `abortSignal` straight to `fetch`, which throws.

### The fix

Finalize against the abort signal rather than assuming the adapter signalled the cancellation itself:

```ts
if (message.status.type === "running") {
  updateMessage({
    status: abortSignal.aborted
      ? { type: "incomplete", reason: "cancelled" }
      : { type: "complete", reason: "unknown" },
  });
}
```

An adapter that sets a terminal status explicitly is still respected, since the branch only runs while the status is `running`. The in-loop check is kept: it stops consuming the stream immediately instead of waiting for the generator to finish.

### Tests

Three cases in `local-thread-runtime-core.test.ts`: a streaming adapter that returns after the abort, a non-streaming adapter that resolves after the abort, and a normal run that must stay `complete`. The first two fail on `main` with `{ type: "complete", reason: "unknown" }`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

