### PR TITLE
fix(core): nested message runtime paths

### DIFF
--- a/.changeset/clean-message-runtime-paths.md
+++ b/.changeset/clean-message-runtime-paths.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix nested message runtime path references

--- a/packages/core/src/runtime/api/message-runtime.test.ts
+++ b/packages/core/src/runtime/api/message-runtime.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { CompleteAttachment } from "../../types/attachment";
+import type { ThreadRuntimeCoreBinding } from "./thread-runtime";
+import {
+  MessageRuntimeImpl,
+  type MessageState,
+  type MessageStateBinding,
+} from "./message-runtime";
+
+const messagePath = {
+  ref: "threads.main.messages[0]",
+  threadSelector: { type: "main" as const },
+  messageSelector: { type: "index" as const, index: 0 },
+};
+
+const attachment: CompleteAttachment = {
+  id: "attachment-1",
+  type: "file",
+  name: "notes.txt",
+  contentType: "text/plain",
+  content: [{ type: "text", text: "notes" }],
+  status: { type: "complete" },
+};
+
+const message: MessageState = {
+  id: "message-1",
+  role: "assistant",
+  createdAt: new Date(0),
+  content: [
+    { type: "text", text: "Hello" },
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "weather",
+      args: {},
+      argsText: "{}",
+    },
+  ],
+  attachments: [attachment],
+  status: { type: "complete", reason: "stop" },
+  metadata: {
+    unstable_state: null,
+    unstable_annotations: [],
+    unstable_data: [],
+    steps: [],
+    custom: {},
+  },
+  parentId: null,
+  index: 0,
+  isLast: true,
+  branchNumber: 1,
+  branchCount: 1,
+  speech: undefined,
+};
+
+const messageBinding: MessageStateBinding = {
+  path: messagePath,
+  getState: () => message,
+  subscribe: () => () => {},
+};
+
+const threadBinding = {
+  subscribe: () => () => {},
+} as unknown as ThreadRuntimeCoreBinding;
+
+describe("MessageRuntimeImpl paths", () => {
+  it("appends nested selectors to the message path", () => {
+    const runtime = new MessageRuntimeImpl(messageBinding, threadBinding);
+
+    expect(runtime.composer.path.ref).toBe("threads.main.messages[0].composer");
+    expect(runtime.getMessagePartByIndex(0).path.ref).toBe(
+      "threads.main.messages[0].content[0]",
+    );
+    expect(runtime.getMessagePartByToolCallId("call-1").path.ref).toBe(
+      'threads.main.messages[0].content[toolCallId="call-1"]',
+    );
+    expect(runtime.getAttachmentByIndex(0).path.ref).toBe(
+      "threads.main.messages[0].attachments[0]",
+    );
+  });
+});

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -142,7 +142,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
       new NestedSubscriptionSubject({
         path: {
           ...this.path,
-          ref: `${this.path.ref}${this.path.ref}.composer`,
+          ref: `${this.path.ref}.composer`,
           composerSource: "edit",
         },
         getState: this._getEditComposerRuntimeCore,
@@ -269,7 +269,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
       new ShallowMemoizeSubject({
         path: {
           ...this.path,
-          ref: `${this.path.ref}${this.path.ref}.content[${idx}]`,
+          ref: `${this.path.ref}.content[${idx}]`,
           messagePartSelector: { type: "index", index: idx },
         },
         getState: () => {
@@ -287,9 +287,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
       new ShallowMemoizeSubject({
         path: {
           ...this.path,
-          ref:
-            this.path.ref +
-            `${this.path.ref}.content[toolCallId=${JSON.stringify(toolCallId)}]`,
+          ref: `${this.path.ref}.content[toolCallId=${JSON.stringify(toolCallId)}]`,
           messagePartSelector: { type: "toolCallId", toolCallId },
         },
         getState: () => {
@@ -313,7 +311,7 @@ export class MessageRuntimeImpl implements MessageRuntime {
       new ShallowMemoizeSubject({
         path: {
           ...this.path,
-          ref: `${this.path.ref}${this.path.ref}.attachments[${idx}]`,
+          ref: `${this.path.ref}.attachments[${idx}]`,
           attachmentSource: "message",
           attachmentSelector: { type: "index", index: idx },
         },


### PR DESCRIPTION
## Summary

- correct nested `MessageRuntime` paths for edit composers, content parts, tool-call parts, and attachments
- add regression coverage for every affected nested runtime
- add a patch changeset for `@assistant-ui/core`

## Problem

Nested runtimes appended the parent message ref twice. For example, a content part under `threads.main.messages[0]` exposed:

```text
threads.main.messages[0]threads.main.messages[0].content[0]
```

instead of:

```text
threads.main.messages[0].content[0]
```

The state selectors were unchanged, but the public path metadata used for runtime introspection and debugging was malformed.

## Validation

- `pnpm --filter @assistant-ui/core exec vitest run src/runtime/api/message-runtime.test.ts`
- `pnpm --filter @assistant-ui/core test` (63 files, 582 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

