### PR TITLE
fix(react-google-adk): validate artifact api responses

### DIFF
--- a/.changeset/tidy-adk-artifact-responses.md
+++ b/.changeset/tidy-adk-artifact-responses.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: validate Google ADK artifact API responses

--- a/packages/react-google-adk/src/AdkSessionAdapter.test.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.test.ts
@@ -415,6 +415,133 @@ describe("createAdkSessionAdapter - load", () => {
   });
 });
 
+describe("createAdkSessionAdapter - artifacts", () => {
+  it("lists names from current and legacy artifact responses", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(["report.pdf", { filename: "chart.png" }]), {
+        status: 200,
+      }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.list("s1")).resolves.toEqual([
+      "report.pdf",
+      "chart.png",
+    ]);
+    expect(mockFetch.mock.calls[0]![0]).toBe(`${expectedBaseUrl}/s1/artifacts`);
+  });
+
+  it("rejects an artifact list that is not an array", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.list("s1")).rejects.toThrow(
+      "Invalid ADK artifact list response: expected an array of artifact names.",
+    );
+  });
+
+  it("rejects malformed artifact list entries", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(["report.pdf", {}]), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.list("s1")).rejects.toThrow(
+      'Invalid ADK artifact list response: artifact at index 1 must be a non-empty string or an object with a non-empty string "filename".',
+    );
+  });
+
+  it.each([
+    ["text", { text: "artifact contents" }],
+    [
+      "inline data",
+      { inlineData: { mimeType: "image/png", data: "aGVsbG8=" } },
+    ],
+  ])("loads valid %s artifacts", async (_label, artifact) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(artifact), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.load("s1", "report.pdf")).resolves.toEqual(artifact);
+  });
+
+  it("rejects an artifact without supported content", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.load("s1", "report.pdf")).rejects.toThrow(
+      'Invalid ADK artifact load response: expected an object containing "text" or "inlineData".',
+    );
+  });
+
+  it.each([
+    [
+      "text",
+      { text: 42 },
+      'Invalid ADK artifact load response: "text" must be a string when present.',
+    ],
+    [
+      "inline data",
+      { inlineData: { mimeType: "image/png" } },
+      'Invalid ADK artifact load response: "inlineData" must contain string "mimeType" and "data" fields.',
+    ],
+  ])("rejects malformed %s artifact content", async (_label, value, error) => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(value), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.load("s1", "report.pdf")).rejects.toThrow(error);
+  });
+
+  it("lists artifact versions", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([0, 1, 2]), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.listVersions("s1", "report.pdf")).resolves.toEqual([
+      0, 1, 2,
+    ]);
+  });
+
+  it("rejects an artifact version list that is not an array", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.listVersions("s1", "report.pdf")).rejects.toThrow(
+      "Invalid ADK artifact versions response: expected an array of version numbers.",
+    );
+  });
+
+  it("rejects malformed artifact version entries", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify([0, "1"]), { status: 200 }),
+    );
+
+    const { artifacts } = createAdkSessionAdapter(baseOptions);
+
+    await expect(artifacts.listVersions("s1", "report.pdf")).rejects.toThrow(
+      "Invalid ADK artifact versions response: version at index 1 must be a non-negative integer.",
+    );
+  });
+});
+
 // ── URL construction ──
 
 describe("createAdkSessionAdapter - URL construction", () => {

--- a/packages/react-google-adk/src/AdkSessionAdapter.ts
+++ b/packages/react-google-adk/src/AdkSessionAdapter.ts
@@ -62,12 +62,13 @@ type AdkSessionResponse = {
   events?: unknown;
 };
 
-const isAdkSessionResponse = (value: unknown): value is AdkSessionResponse => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
-  const id = (value as Record<string, unknown>).id;
+const isAdkSessionResponse = (value: unknown): value is AdkSessionResponse => {
+  if (!isRecord(value)) return false;
+
+  const id = value.id;
   return typeof id === "string" && id.length > 0;
 };
 
@@ -97,6 +98,86 @@ const parseAdkSessionListResponse = (value: unknown): AdkSessionResponse[] => {
       );
     }
     return session;
+  });
+};
+
+const parseAdkArtifactListResponse = (value: unknown): string[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      "Invalid ADK artifact list response: expected an array of artifact names.",
+    );
+  }
+
+  return value.map((artifact, index) => {
+    if (typeof artifact === "string" && artifact.length > 0) {
+      return artifact;
+    }
+
+    if (isRecord(artifact)) {
+      const filename = artifact.filename;
+      if (typeof filename === "string" && filename.length > 0) {
+        return filename;
+      }
+    }
+
+    throw new Error(
+      `Invalid ADK artifact list response: artifact at index ${index} must be a non-empty string or an object with a non-empty string "filename".`,
+    );
+  });
+};
+
+const parseAdkArtifactResponse = (value: unknown): AdkArtifactData => {
+  if (!isRecord(value)) {
+    throw new Error(
+      'Invalid ADK artifact load response: expected an object containing "text" or "inlineData".',
+    );
+  }
+
+  const { text, inlineData } = value;
+  if (text === undefined && inlineData === undefined) {
+    throw new Error(
+      'Invalid ADK artifact load response: expected an object containing "text" or "inlineData".',
+    );
+  }
+
+  if (text !== undefined && typeof text !== "string") {
+    throw new Error(
+      'Invalid ADK artifact load response: "text" must be a string when present.',
+    );
+  }
+
+  if (
+    inlineData !== undefined &&
+    (!isRecord(inlineData) ||
+      typeof inlineData.mimeType !== "string" ||
+      typeof inlineData.data !== "string")
+  ) {
+    throw new Error(
+      'Invalid ADK artifact load response: "inlineData" must contain string "mimeType" and "data" fields.',
+    );
+  }
+
+  return value as AdkArtifactData;
+};
+
+const parseAdkArtifactVersionsResponse = (value: unknown): number[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(
+      "Invalid ADK artifact versions response: expected an array of version numbers.",
+    );
+  }
+
+  return value.map((version, index) => {
+    if (
+      typeof version !== "number" ||
+      !Number.isInteger(version) ||
+      version < 0
+    ) {
+      throw new Error(
+        `Invalid ADK artifact versions response: version at index ${index} must be a non-negative integer.`,
+      );
+    }
+    return version;
   });
 };
 
@@ -259,8 +340,7 @@ export function createAdkSessionAdapter(
       const headers = await getHeaders();
       const res = await fetch(artifactBaseUrl(sessionId), { headers });
       if (!res.ok) throw new Error(`Failed to list artifacts: ${res.status}`);
-      const data = (await res.json()) as Array<{ filename: string }>;
-      return data.map((a) => a.filename);
+      return parseAdkArtifactListResponse(await res.json());
     },
 
     async load(sessionId, artifactName, version?) {
@@ -269,7 +349,7 @@ export function createAdkSessionAdapter(
       if (version != null) url += `/versions/${version}`;
       const res = await fetch(url, { headers });
       if (!res.ok) throw new Error(`Failed to load artifact: ${res.status}`);
-      return (await res.json()) as AdkArtifactData;
+      return parseAdkArtifactResponse(await res.json());
     },
 
     async listVersions(sessionId, artifactName) {
@@ -279,7 +359,7 @@ export function createAdkSessionAdapter(
       if (!res.ok) {
         throw new Error(`Failed to list artifact versions: ${res.status}`);
       }
-      return (await res.json()) as number[];
+      return parseAdkArtifactVersionsResponse(await res.json());
     },
 
     async delete(sessionId, artifactName) {


### PR DESCRIPTION
## Summary

- accept current Google ADK artifact-name responses as `string[]` while preserving the existing `{ filename: string }[]` shape
- validate artifact lists, loaded artifact content, and version lists before exposing them to callers
- report operation-specific errors for malformed successful responses
- add a patch changeset for `@assistant-ui/react-google-adk`

## Problem

The artifact helpers trusted successful JSON responses through TypeScript casts. A `200 {}` response made `artifacts.list()` fail with the low-context `data.map is not a function`, while malformed artifact content and version lists passed through unchanged.

There was also a compatibility bug: the current [Google ADK API server returns artifact names as `list[str]`](https://github.com/google/adk-python/blob/main/src/google/adk/cli/api_server.py#L1449-L1458), but the adapter treated every entry as `{ filename: string }`. Valid string entries therefore became `undefined`.

The parser now accepts both supported name shapes and rejects invalid data at the response boundary. Artifact bodies must contain valid `text` or `inlineData`, and versions must be non-negative integers.

## Validation

- reproduced 8 failing cases against unchanged `main`, including the raw `.map` error and valid string names becoming `undefined`
- `pnpm --filter @assistant-ui/react-google-adk exec vitest run src/AdkSessionAdapter.test.ts` (43 tests)
- `pnpm --filter @assistant-ui/react-google-adk test` (9 files, 211 tests)
- `pnpm --filter @assistant-ui/react-google-adk build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

