### PR TITLE
fix(react-ag-ui): preserve MCP host fields in tool results

### DIFF
--- a/.changeset/fix-preserve-mcp-host-fields-in-ag-u-20260721133353.md
+++ b/.changeset/fix-preserve-mcp-host-fields-in-ag-u-20260721133353.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: preserve MCP Host fields in AG-UI tool results and restored history

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1363,8 +1363,16 @@ export class AgUiThreadRuntimeCore {
         matchedToolCall = true;
         return {
           ...part,
-          result: tryParseJSON(event.content ?? "") as ReadonlyJSONValue,
-          ...(event.role === "tool" ? { isError: false } : {}),
+          result: (event.mcpResult ??
+            tryParseJSON(event.content ?? "")) as ReadonlyJSONValue,
+          ...(event.mcpResult !== undefined
+            ? { modelContent: [{ type: "text" as const, text: event.content }] }
+            : {}),
+          ...(typeof event.mcpResult?.isError === "boolean"
+            ? { isError: event.mcpResult.isError }
+            : event.role === "tool"
+              ? { isError: false }
+              : {}),
           ...(event.messageId
             ? { unstable_toolMessageId: event.messageId }
             : {}),

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -13,6 +13,7 @@ import {
   type AgUiCustomMetadata,
 } from "./run-aggregator";
 import type { AgUiInterrupt } from "../types";
+import { parseMcpToolCallResult } from "../mcp-tool-result";
 
 export type { InputContent };
 
@@ -540,12 +541,18 @@ export function fromAgUiMessages(
     if (role === "tool") {
       const toolCallId = getToolCallId(rawMessage) ?? `tool-${generateId()}`;
       const toolMessageId = getString(rawMessage, "id");
+      const modelContent = extractText(rawMessage.content);
+      const mcpResult = parseMcpToolCallResult(rawMessage, modelContent);
+      const mcpModelContent = mcpResult
+        ? [{ type: "text" as const, text: modelContent }]
+        : undefined;
       const result =
-        rawMessage.result !== undefined
+        mcpResult ??
+        (rawMessage.result !== undefined
           ? rawMessage.result
           : typeof rawMessage.content === "string"
             ? parseJSONText(rawMessage.content)
-            : rawMessage.content;
+            : rawMessage.content);
       const isError =
         typeof rawMessage.error === "string" ||
         rawMessage.isError === true ||
@@ -581,6 +588,7 @@ export function fromAgUiMessages(
           const updatedPart: ToolCallPart = {
             ...(part as ToolCallPart),
             result,
+            ...(mcpModelContent ? { modelContent: mcpModelContent } : {}),
             ...(isError !== undefined ? { isError } : {}),
             ...(toolMessageId !== undefined
               ? { unstable_toolMessageId: toolMessageId }
@@ -615,6 +623,7 @@ export function fromAgUiMessages(
             args: {},
             argsText: "{}",
             result,
+            ...(mcpModelContent ? { modelContent: mcpModelContent } : {}),
             ...(isError !== undefined ? { isError } : {}),
             ...(toolMessageId !== undefined
               ? { unstable_toolMessageId: toolMessageId }
@@ -719,10 +728,9 @@ function convertAssistantMessage(
   for (const { id: toolCallId, part } of toolCalls) {
     if (part.result === undefined) continue;
 
-    const modelText = extractText(part.modelContent);
     const resultContent =
-      modelText.length > 0
-        ? modelText
+      part.modelContent !== undefined
+        ? extractText(part.modelContent)
         : typeof part.result === "string"
           ? part.result
           : JSON.stringify(part.result);

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -235,8 +235,13 @@ export class RunAggregator {
         this.finishToolCall(
           event.toolCallId,
           event.content ?? "",
-          event.role === "tool" ? false : undefined,
+          typeof event.mcpResult?.isError === "boolean"
+            ? event.mcpResult.isError
+            : event.role === "tool"
+              ? false
+              : undefined,
           event.messageId,
+          event.mcpResult,
         );
         this.emit();
         break;
@@ -442,6 +447,7 @@ export class RunAggregator {
     content: string,
     isError?: boolean,
     toolMessageId?: string,
+    mcpResult?: Record<string, unknown>,
   ) {
     if (!id) return;
     let entry = this.toolCalls.get(id);
@@ -464,7 +470,12 @@ export class RunAggregator {
     ) {
       this.partOrder.push({ kind: "tool-call", toolCallId: id });
     }
-    if (entry.snapshotResultApplied) {
+    if (mcpResult !== undefined && !entry.snapshotResultApplied) {
+      entry.result = mcpResult;
+      entry.modelContent = [{ type: "text", text: content }];
+      entry.snapshotResultApplied = true;
+      entry.isError = isError;
+    } else if (entry.snapshotResultApplied) {
       if (entry.modelContent === undefined) {
         entry.modelContent = [{ type: "text", text: content }];
       }

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -1,5 +1,6 @@
 import type { AgUiEvent, AgUiInterrupt, AgUiRunFinishedOutcome } from "./types";
 import type { Logger } from "./logger";
+import { parseMcpToolCallResult } from "./mcp-tool-result";
 
 export type ParseAgUiEventOptions = {
   logger?: Logger;
@@ -209,15 +210,17 @@ export const parseAgUiEvent = (
     case "TOOL_CALL_RESULT": {
       const toolCallId = getString("toolCallId");
       if (!toolCallId) return null;
+      const content = getString("content") ?? "";
       return withOptional(
         {
           type: "TOOL_CALL_RESULT" as const,
           toolCallId,
-          content: getString("content") ?? "",
+          content,
         },
         {
           messageId: getString("messageId"),
           role: payload.role === "tool" ? "tool" : undefined,
+          mcpResult: parseMcpToolCallResult(payload, content),
         },
       );
     }

--- a/packages/react-ag-ui/src/runtime/mcp-tool-result.ts
+++ b/packages/react-ag-ui/src/runtime/mcp-tool-result.ts
@@ -1,0 +1,26 @@
+import { isRecord } from "@assistant-ui/core/internal";
+
+export type McpToolCallResult = Record<string, unknown> & {
+  content: unknown[];
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+export const parseMcpToolCallResult = (
+  source: Record<string, unknown>,
+  modelContent: string,
+): McpToolCallResult | undefined => {
+  const structuredContent = isRecord(source.structuredContent)
+    ? source.structuredContent
+    : undefined;
+  const meta = isRecord(source._meta) ? source._meta : undefined;
+  if (!structuredContent && !meta) return undefined;
+
+  return {
+    content: modelContent ? [{ type: "text", text: modelContent }] : [],
+    ...(structuredContent ? { structuredContent } : {}),
+    ...(meta ? { _meta: meta } : {}),
+    ...(typeof source.isError === "boolean" ? { isError: source.isError } : {}),
+  };
+};

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -13,6 +13,7 @@ import type {
 import type { AbstractAgent } from "@ag-ui/client";
 import type { Logger } from "./logger";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
+import type { McpToolCallResult } from "./mcp-tool-result";
 
 /**
  * @experimental This API is still under active development and might change without notice.
@@ -162,6 +163,7 @@ export type AgUiEvent =
       toolCallId: string;
       content: string;
       role?: "tool";
+      mcpResult?: McpToolCallResult;
     }
   | {
       type: "ACTIVITY_SNAPSHOT";

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2744,8 +2744,11 @@ describe("AGUIThreadRuntimeCore", () => {
           type: "TOOL_CALL_RESULT",
           messageId: "tool-msg-1",
           toolCallId: "call-1",
-          content: '{"answer":"yes"}',
+          content: "yes",
           role: "tool",
+          structuredContent: { answer: "yes" },
+          _meta: { auditId: "audit-1" },
+          isError: true,
         },
       });
       subscriber.onTextMessageContentEvent?.({
@@ -2779,7 +2782,14 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(toolPart).toMatchObject({
       toolCallId: "call-1",
       toolName: "ask_question",
-      result: { answer: "yes" },
+      result: {
+        content: [{ type: "text", text: "yes" }],
+        structuredContent: { answer: "yes" },
+        _meta: { auditId: "audit-1" },
+        isError: true,
+      },
+      modelContent: [{ type: "text", text: "yes" }],
+      isError: true,
       unstable_toolMessageId: "tool-msg-1",
     });
     expect(second!.content.filter((p) => p.type === "tool-call")).toHaveLength(

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -106,7 +106,7 @@ describe("adapter conversions", () => {
     });
   });
 
-  it("uses modelContent text for completed tool messages", () => {
+  it("does not serialize Host-only data when modelContent is empty", () => {
     const result = toAgUiMessages([
       {
         id: "assistant-1",
@@ -125,7 +125,7 @@ describe("adapter conversions", () => {
               structuredContent: { ok: true },
               isError: false,
             },
-            modelContent: [{ type: "text", text: "joined text" }],
+            modelContent: [],
           },
         ],
       },
@@ -134,7 +134,7 @@ describe("adapter conversions", () => {
     expect(result[1]).toMatchObject({
       role: "tool",
       toolCallId: "call-42",
-      content: "joined text",
+      content: "",
     });
   });
 
@@ -164,7 +164,10 @@ describe("adapter conversions", () => {
         id: "msg-3",
         role: "tool",
         tool_call_id: "call-1",
-        content: '{"temperature":"22C"}',
+        content: [{ type: "text", text: "Map ready" }],
+        structuredContent: { temperature: "22C" },
+        _meta: { audience: "widget" },
+        isError: true,
       },
     ] as any);
 
@@ -178,7 +181,14 @@ describe("adapter conversions", () => {
       toolCallId: "call-1",
       toolName: "get_weather",
       argsText: '{"city":"Paris"}',
-      result: { temperature: "22C" },
+      result: {
+        content: [{ type: "text", text: "Map ready" }],
+        structuredContent: { temperature: "22C" },
+        _meta: { audience: "widget" },
+        isError: true,
+      },
+      modelContent: [{ type: "text", text: "Map ready" }],
+      isError: true,
     });
   });
 

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -161,14 +161,19 @@ describe("RunAggregator", () => {
     aggregator.handle({
       type: "TOOL_CALL_RESULT",
       toolCallId: "tool1",
-      content: '{"ok":true}',
+      content: "Map ready",
       role: "tool",
+      mcpResult: {
+        content: [{ type: "text", text: "Map ready" }],
+        structuredContent: { ok: true },
+        _meta: { audience: "widget" },
+        isError: true,
+      },
     } as AgUiEvent);
     aggregator.handle({
       type: "ACTIVITY_SNAPSHOT",
       activityType: "mcp-apps",
       content: {
-        result: { ok: true },
         resourceUri: "ui://srv/mcp-app.html",
         serverHash: "h",
         serverId: "s",
@@ -182,7 +187,16 @@ describe("RunAggregator", () => {
     expect((toolPart as any).mcp).toEqual({
       app: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },
     });
-    expect((toolPart as any).result).toEqual({ ok: true });
+    expect((toolPart as any).result).toEqual({
+      content: [{ type: "text", text: "Map ready" }],
+      structuredContent: { ok: true },
+      _meta: { audience: "widget" },
+      isError: true,
+    });
+    expect((toolPart as any).isError).toBe(true);
+    expect((toolPart as any).modelContent).toEqual([
+      { type: "text", text: "Map ready" },
+    ]);
   });
 
   it("uses the mcp app snapshot result while preserving the model-facing result", () => {
@@ -193,7 +207,7 @@ describe("RunAggregator", () => {
         { type: "image", data: "aGk=", mimeType: "image/png" },
       ],
       structuredContent: { ok: true },
-      isError: false,
+      isError: true,
     };
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -219,11 +233,22 @@ describe("RunAggregator", () => {
         toolInput: { city: "sf" },
       },
     } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "late result",
+      role: "tool",
+      mcpResult: {
+        content: [{ type: "text", text: "late result" }],
+        _meta: { stale: true },
+      },
+    } as AgUiEvent);
 
     const toolPart = results
       .at(-1)
       ?.content?.find((part) => part.type === "tool-call") as any;
     expect(toolPart.result).toEqual(result);
+    expect(toolPart.isError).toBe(true);
     expect(toolPart.modelContent).toEqual([{ type: "text", text: "ok" }]);
     expect(toolPart.mcp).toEqual({
       app: { resourceUri: "ui://srv/mcp-app.html", serverId: "s" },


### PR DESCRIPTION
## Summary

- preserve MCP `structuredContent` and `_meta` from AG-UI tool-result events
- keep the model-visible tool summary separate from the widget-visible result
- apply the same behavior to live runs, resumed runs, and restored history

## Root cause

The AG-UI parser reduced `TOOL_CALL_RESULT` to its model-visible `content` string before the run aggregator or history converter could inspect MCP host fields. `McpAppRenderer` therefore received only that string through `part.result`, even though its bridge already supports a full MCP result object.

This change assembles the MCP result at the AG-UI boundary, stores it in `part.result`, and keeps the short tool summary in `modelContent`. Converting messages back to AG-UI uses only `modelContent`, so host-only fields do not leak into model context. Server-owned history remains authoritative for widget-only fields; outbound client messages intentionally do not persist those fields.

Closes #5086.

## Validation

- `pnpm --filter @assistant-ui/react-ag-ui test` (226 tests passed)
- `pnpm turbo build --filter=@assistant-ui/react-ag-ui...` (8 tasks passed)
- focused oxlint and oxfmt checks
- `git diff --check`
- in-app browser reproduction using the real `McpAppRenderer` sandbox: the widget received `structuredContent` and `_meta`, outbound AG-UI content remained exactly `Map ready`, and the browser console had no warnings or errors
