### PR TITLE
fix: clean up frame resources

### DIFF
--- a/.changeset/clean-frame-resources.md
+++ b/.changeset/clean-frame-resources.md
@@ -1,0 +1,5 @@
+---
+"safe-content-frame": patch
+---
+
+fix: clean up frame resources after disposal and load failures

--- a/packages/safe-content-frame/package.json
+++ b/packages/safe-content-frame/package.json
@@ -34,11 +34,14 @@
   "sideEffects": false,
   "scripts": {
     "build": "aui-build",
-    "dev": "vite demo"
+    "dev": "vite demo",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
-    "vite": "^8.1.4"
+    "jsdom": "^29.1.1",
+    "vite": "^8.1.4",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/safe-content-frame/src/index.test.ts
+++ b/packages/safe-content-frame/src/index.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SafeContentFrame } from "./index";
+
+class MockMessagePort {
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  readonly close = vi.fn();
+}
+
+class MockMessageChannel {
+  static instances: MockMessageChannel[] = [];
+
+  readonly port1 = new MockMessagePort();
+  readonly port2 = new MockMessagePort();
+
+  constructor() {
+    MockMessageChannel.instances.push(this);
+  }
+}
+
+describe("SafeContentFrame", () => {
+  let shadowRoot: ShadowRoot | undefined;
+
+  beforeEach(() => {
+    shadowRoot = undefined;
+    MockMessageChannel.instances = [];
+    vi.stubGlobal("MessageChannel", MockMessageChannel);
+    vi.stubGlobal("crypto", {
+      subtle: {
+        digest: vi.fn(async () => new Uint8Array(32).buffer),
+      },
+    });
+
+    const attachShadow = Element.prototype.attachShadow;
+    vi.spyOn(Element.prototype, "attachShadow").mockImplementation(function (
+      this: Element,
+      init: ShadowRootInit,
+    ) {
+      shadowRoot = attachShadow.call(this, init);
+      return shadowRoot;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    document.body.replaceChildren();
+  });
+
+  it("cleans up the shadow host and message channel on dispose", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", {
+      salt: "fixed",
+      useShadowDom: true,
+    });
+
+    const framePromise = renderer.renderHtml("<p>Hello</p>", container);
+    await vi.waitFor(() => {
+      expect(shadowRoot?.querySelector("iframe")).toBeTruthy();
+    });
+
+    const iframe = shadowRoot!.querySelector("iframe")!;
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+    iframe.dispatchEvent(new Event("load"));
+    const frame = await framePromise;
+
+    frame.dispose();
+    frame.dispose();
+
+    expect(container.childElementCount).toBe(0);
+    expect(MockMessageChannel.instances[0]!.port1.close).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up the mounted frame and message channel after a load error", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", {
+      salt: "fixed",
+      useShadowDom: true,
+    });
+
+    const framePromise = renderer.renderHtml("<p>Hello</p>", container);
+    await vi.waitFor(() => {
+      expect(shadowRoot?.querySelector("iframe")).toBeTruthy();
+    });
+
+    shadowRoot!.querySelector("iframe")!.dispatchEvent(new Event("error"));
+
+    await expect(framePromise).rejects.toThrow("Failed to load iframe");
+    expect(container.childElementCount).toBe(0);
+    expect(MockMessageChannel.instances[0]!.port1.close).toHaveBeenCalledOnce();
+    expect(MockMessageChannel.instances[0]!.port2.close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -136,16 +136,31 @@ export class SafeContentFrame {
     iframe.setAttribute("sandbox", this.getSandbox());
     iframe.style.cssText = "border:none;width:100%;height:100%";
 
+    let mountElement: HTMLElement = iframe;
     if (this.options.useShadowDom) {
       const host = document.createElement("div");
       host.attachShadow({ mode: "closed" }).appendChild(iframe);
       container.appendChild(host);
+      mountElement = host;
     } else {
       container.appendChild(iframe);
     }
 
     return new Promise((resolve, reject) => {
       const channel = new MessageChannel();
+      let channelTransferred = false;
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        iframe.onload = null;
+        iframe.onerror = null;
+        channel.port1.onmessage = null;
+        channel.port1.close();
+        if (!channelTransferred) channel.port2.close();
+        mountElement.remove();
+      };
+
       let onLoaded: () => void;
       const loaded = new Promise<void>((r) => {
         onLoaded = r;
@@ -160,19 +175,30 @@ export class SafeContentFrame {
       iframe.onload = () => {
         if (loadHandled) return;
         loadHandled = true;
-        iframe.contentWindow?.postMessage(
-          {
-            body: content.buffer.slice(
-              content.byteOffset,
-              content.byteOffset + content.byteLength,
-            ),
-            mimeType,
-            salt,
-            unsafeDocumentWrite: opts?.unsafeDocumentWrite,
-          },
-          iframeOrigin,
-          [channel.port2],
-        );
+        try {
+          const contentWindow = iframe.contentWindow;
+          if (!contentWindow) throw new Error("Failed to access iframe window");
+          contentWindow.postMessage(
+            {
+              body: content.buffer.slice(
+                content.byteOffset,
+                content.byteOffset + content.byteLength,
+              ),
+              mimeType,
+              salt,
+              unsafeDocumentWrite: opts?.unsafeDocumentWrite,
+            },
+            iframeOrigin,
+            [channel.port2],
+          );
+          channelTransferred = true;
+        } catch (error) {
+          cleanup();
+          reject(error);
+          return;
+        }
+        iframe.onload = null;
+        iframe.onerror = null;
         resolve({
           iframe,
           origin: iframeOrigin,
@@ -185,10 +211,13 @@ export class SafeContentFrame {
                 setTimeout(() => rej(new Error("Timeout")), ms),
               ),
             ]),
-          dispose: () => iframe.remove(),
+          dispose: cleanup,
         });
       };
-      iframe.onerror = () => reject(new Error("Failed to load iframe"));
+      iframe.onerror = () => {
+        cleanup();
+        reject(new Error("Failed to load iframe"));
+      };
       iframe.src = shimUrl;
     });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4591,9 +4591,15 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       vite:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/store:
     dependencies:


### PR DESCRIPTION
## Summary

- remove the actual mounted element when a frame is disposed, including the closed Shadow DOM host
- detach iframe handlers and close MessageChannel resources during disposal and load failures
- make cleanup idempotent and cover both lifecycle paths with regression tests

## Why

With `useShadowDom` enabled, `dispose()` removed only the iframe inside the closed shadow root, leaving an empty host element in the caller's container. A failed iframe load also rejected without removing its mount or closing either message port. Repeated previews or failed loads could therefore accumulate unused DOM nodes and channel resources.

The regression reproduces the old behavior as `container.childElementCount === 1` after both disposal and load failure; both paths now return it to `0`.

## Test plan

- `pnpm --filter safe-content-frame test`
- `pnpm --filter safe-content-frame build`
- `pnpm --filter safe-content-frame exec tsc --noEmit`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

