### PR TITLE
fix(assistant-stream): isolate resumable stream hooks

### DIFF
--- a/.changeset/calm-stream-hooks.md
+++ b/.changeset/calm-stream-hooks.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: isolate resumable stream observability hook errors

--- a/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
+++ b/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
@@ -143,7 +143,7 @@ Per-tenant prefixes also make incident response cheaper. A `SCAN MATCH aui:app:t
 
 ## Observability hooks
 
-`ResumableStreamContextOptions` exposes lifecycle hooks for structured logging, metrics, and tracing. Each hook is invoked synchronously around the underlying store call; throwing inside a hook surfaces as a producer error.
+`ResumableStreamContextOptions` exposes lifecycle hooks for structured logging, metrics, and tracing. Hook exceptions and rejected promises are reported through `console.error` without affecting stream output or stored lifecycle status.
 
 ```ts title="/lib/resumable-context.ts"
 import { createResumableStreamContext } from "assistant-stream/resumable";
@@ -170,7 +170,7 @@ export const resumableContext = createResumableStreamContext({
 });
 ```
 
-Keep hook bodies cheap. They run on the producer's hot path and any latency they add becomes streaming latency seen by the client.
+Keep synchronous hook work cheap because invocation runs on the producer's hot path. Returned promises are observed for failures but are not awaited.
 
 ## Resource limits
 

--- a/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
+++ b/apps/docs/content/docs/guides/resumable-stream-deployment.mdx
@@ -170,7 +170,7 @@ export const resumableContext = createResumableStreamContext({
 });
 ```
 
-Keep synchronous hook work cheap because invocation runs on the producer's hot path. Returned promises are observed for failures but are not awaited.
+Keep synchronous hook work cheap. `onAcquire` runs on the `run()` request path for producers and consumers alike, while the remaining hooks run on the producer's streaming hot path. Returned promises are observed for failures but are not awaited.
 
 ## Resource limits
 

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -277,12 +277,15 @@ describe("createResumableStreamContext", () => {
   });
 
   it("continues acquisition when onAcquire throws", async () => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const hookError = new Error("acquire observer failed");
     const store = createInMemoryResumableStreamStore();
     const ctx = createResumableStreamContext({
       store,
       onAcquire: () => {
-        throw new Error("acquire observer failed");
+        throw hookError;
       },
     });
 
@@ -290,6 +293,10 @@ describe("createResumableStreamContext", () => {
 
     expect(await collect(stream)).toBe("hello");
     expect(await ctx.status("a")).toBe("done");
+    expect(consoleError).toHaveBeenCalledWith(
+      "resumable stream onAcquire hook failed:",
+      hookError,
+    );
   });
 
   it("continues streaming when onAppend throws", async () => {
@@ -308,6 +315,31 @@ describe("createResumableStreamContext", () => {
 
     expect(await collect(stream)).toBe("hello world");
     expect(await ctx.status("a")).toBe("done");
+  });
+
+  it("continues streaming when async onAppend rejects", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const hookError = new Error("async append observer failed");
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({
+      store,
+      onAppend: async () => {
+        throw hookError;
+      },
+    });
+
+    const stream = await ctx.run("a", () => makeStringStream(["hello"]));
+
+    expect(await collect(stream)).toBe("hello");
+    expect(await ctx.status("a")).toBe("done");
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "resumable stream onAppend hook failed:",
+        hookError,
+      );
+    });
   });
 
   it("keeps successful completion when onFinalize throws", async () => {

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createResumableStreamContext } from "./ResumableStreamContext";
 import { ResumableStreamError } from "./errors";
 import { createInMemoryResumableStreamStore } from "./stores/InMemoryResumableStreamStore";
@@ -7,6 +7,10 @@ const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 const bytes = (s: string): Uint8Array => enc.encode(s);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 async function collect(stream: ReadableStream<Uint8Array>): Promise<string> {
   const reader = stream.getReader();
@@ -270,5 +274,84 @@ describe("createResumableStreamContext", () => {
     expect(errors).toHaveLength(1);
     expect(errors[0]!.id).toBe("a");
     expect((errors[0]!.error as Error).message).toBe("boom");
+  });
+
+  it("continues acquisition when onAcquire throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({
+      store,
+      onAcquire: () => {
+        throw new Error("acquire observer failed");
+      },
+    });
+
+    const stream = await ctx.run("a", () => makeStringStream(["hello"]));
+
+    expect(await collect(stream)).toBe("hello");
+    expect(await ctx.status("a")).toBe("done");
+  });
+
+  it("continues streaming when onAppend throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({
+      store,
+      onAppend: () => {
+        throw new Error("append observer failed");
+      },
+    });
+
+    const stream = await ctx.run("a", () =>
+      makeStringStream(["hello ", "world"]),
+    );
+
+    expect(await collect(stream)).toBe("hello world");
+    expect(await ctx.status("a")).toBe("done");
+  });
+
+  it("keeps successful completion when onFinalize throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const onError = vi.fn();
+    const onFinalize = vi.fn(() => {
+      throw new Error("finalize observer failed");
+    });
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({ store, onError, onFinalize });
+
+    const stream = await ctx.run("a", () => makeStringStream(["hello"]));
+
+    expect(await collect(stream)).toBe("hello");
+    expect(await ctx.status("a")).toBe("done");
+    expect(onFinalize).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("finalizes producer errors when onError throws", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const tasks: Promise<unknown>[] = [];
+    const store = createInMemoryResumableStreamStore();
+    const ctx = createResumableStreamContext({
+      store,
+      waitUntil: (task) => tasks.push(task),
+      onError: () => {
+        throw new Error("error observer failed");
+      },
+    });
+    const producerError = new Error("producer failed");
+
+    const stream = await ctx.run(
+      "a",
+      () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(producerError);
+          },
+        }),
+    );
+    await Promise.allSettled(tasks);
+
+    expect(await ctx.status("a")).toBe("error");
+    await expect(collect(stream)).rejects.toThrow("producer failed");
   });
 });

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
@@ -1,4 +1,5 @@
 import { ResumableStreamError } from "./errors";
+import { withPromiseOrValue } from "../core/utils/withPromiseOrValue";
 import type {
   ResumableStreamRole,
   ResumableStreamStatus,
@@ -48,14 +49,13 @@ const invokeObservabilityHook = <TArgs extends unknown[]>(
   ...args: TArgs
 ): void => {
   if (!hook) return;
-  try {
-    hook(...args);
-  } catch (error) {
-    console.error(
-      `[assistant-ui] Resumable stream ${name} hook threw an error`,
-      error,
-    );
-  }
+  void withPromiseOrValue(
+    () => hook(...args),
+    () => {},
+    (error) => {
+      console.error(`resumable stream ${name} hook failed:`, error);
+    },
+  );
 };
 
 export function createResumableStreamContext(

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
@@ -42,6 +42,22 @@ export interface ResumableStreamContext {
   delete(streamId: string): Promise<void>;
 }
 
+const invokeObservabilityHook = <TArgs extends unknown[]>(
+  name: string,
+  hook: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+): void => {
+  if (!hook) return;
+  try {
+    hook(...args);
+  } catch (error) {
+    console.error(
+      `[assistant-ui] Resumable stream ${name} hook threw an error`,
+      error,
+    );
+  }
+};
+
 export function createResumableStreamContext(
   options: ResumableStreamContextOptions,
 ): ResumableStreamContext {
@@ -53,7 +69,7 @@ export function createResumableStreamContext(
   return {
     async run(streamId, makeStream) {
       const role = await store.acquire(streamId, acquireOptions);
-      onAcquire?.(streamId, role);
+      invokeObservabilityHook("onAcquire", onAcquire, streamId, role);
       if (role === "producer") {
         startProducerTask(store, streamId, makeStream, {
           waitUntil,
@@ -119,13 +135,18 @@ function startProducerTask(
         const { done, value } = await reader.read();
         if (done) break;
         await store.append(streamId, value);
-        onAppend?.(streamId, value.byteLength);
+        invokeObservabilityHook(
+          "onAppend",
+          onAppend,
+          streamId,
+          value.byteLength,
+        );
       }
       await store.finalize(streamId, "done");
-      onFinalize?.(streamId, "done");
+      invokeObservabilityHook("onFinalize", onFinalize, streamId, "done");
     } catch (err) {
       cancelled = true;
-      onError?.(streamId, err);
+      invokeObservabilityHook("onError", onError, streamId, err);
       const message = err instanceof Error ? err.message : String(err);
       try {
         await reader?.cancel(err);
@@ -134,7 +155,13 @@ function startProducerTask(
       }
       try {
         await store.finalize(streamId, "error", message);
-        onFinalize?.(streamId, "error", message);
+        invokeObservabilityHook(
+          "onFinalize",
+          onFinalize,
+          streamId,
+          "error",
+          message,
+        );
       } catch (finalizeErr) {
         console.error("resumable stream finalize failed:", finalizeErr);
       }


### PR DESCRIPTION
## Summary

- isolate `onAcquire`, `onAppend`, `onFinalize`, and `onError` exceptions from resumable stream control flow
- report observer failures with the failing hook name
- cover successful and failed producer lifecycles with regression tests

## Why

The resumable stream callbacks are documented as observability hooks, but their exceptions currently change stream behavior. A throwing `onAppend` turns a healthy producer into an error result, while a throwing `onAcquire` leaves an acquired stream stuck in `streaming` without starting its producer. A throwing `onError` can also prevent the original producer failure from being finalized.

This keeps observer failures visible without allowing them to replace producer output or stored lifecycle state.

## Verification

- `pnpm --filter assistant-stream test` (330 passed, 20 skipped)
- `pnpm --filter assistant-stream build`
- `pnpm lint`
- built-package smoke test: healthy output remained readable, status finished as `done`, and both observer failures were reported

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

