### PR TITLE
fix(assistant-stream): prioritize backend tool results

### DIFF
--- a/.changeset/quiet-tools-respond.md
+++ b/.changeset/quiet-tools-respond.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"assistant-stream": patch
+---
+
+fix: prioritize backend tool results over stale argument parse errors

--- a/packages/assistant-stream/src/core/modules/tool-call.test.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.test.ts
@@ -3,6 +3,7 @@ import { createAssistantStreamController } from "./assistant-stream";
 import { ToolResponse } from "../tool/ToolResponse";
 import { toolResultStream } from "../tool/toolResultStream";
 import type { ToolCallReader } from "../tool/tool-types";
+import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 
 type Reader = ToolCallReader<Record<string, unknown>, unknown>;
 
@@ -30,7 +31,14 @@ describe("ToolCallStreamController", () => {
         async () => undefined,
       ),
     );
-    const drain = output.pipeTo(new WritableStream());
+    const chunks: AssistantStreamChunk[] = [];
+    const drain = output.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      }),
+    );
 
     const toolCall = controller.addToolCallPart({
       toolCallId: "tool-1",
@@ -49,5 +57,11 @@ describe("ToolCallStreamController", () => {
     expect(response.isError).toBe(false);
     expect(execute).not.toHaveBeenCalled();
     await drain;
+    const results = chunks.filter((chunk) => chunk.type === "result");
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      result: { source: "backend" },
+      isError: false,
+    });
   });
 });

--- a/packages/assistant-stream/src/core/modules/tool-call.test.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAssistantStreamController } from "./assistant-stream";
+import { ToolResponse } from "../tool/ToolResponse";
+import { toolResultStream } from "../tool/toolResultStream";
+import type { ToolCallReader } from "../tool/tool-types";
+
+type Reader = ToolCallReader<Record<string, unknown>, unknown>;
+
+describe("ToolCallStreamController", () => {
+  it("delivers a backend response before an args parse failure", async () => {
+    const [stream, controller] = createAssistantStreamController();
+    let resolveToolReader!: (reader: Reader) => void;
+    const toolReaderPromise = new Promise<Reader>((resolve) => {
+      resolveToolReader = resolve;
+    });
+    const streamCall = vi.fn((reader: Reader) => {
+      resolveToolReader(reader);
+    });
+    const execute = vi.fn();
+    const output = stream.pipeThrough(
+      toolResultStream(
+        {
+          weatherSearch: {
+            parameters: { type: "object", properties: {} },
+            execute,
+            streamCall,
+          },
+        },
+        new AbortController().signal,
+        async () => undefined,
+      ),
+    );
+    const drain = output.pipeTo(new WritableStream());
+
+    const toolCall = controller.addToolCallPart({
+      toolCallId: "tool-1",
+      toolName: "weatherSearch",
+    });
+    toolCall.argsText.append('{"query":"London","longitude":0');
+    const reader = await toolReaderPromise;
+    expect(await reader.args.get("query")).toBe("London");
+
+    toolCall.setResponse(new ToolResponse({ result: { source: "backend" } }));
+    toolCall.close();
+    controller.close();
+
+    const response = await reader.response.get();
+    expect(response.result).toEqual({ source: "backend" });
+    expect(response.isError).toBe(false);
+    expect(execute).not.toHaveBeenCalled();
+    await drain;
+  });
+});

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -65,9 +65,6 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _argsTextController!: TextStreamController;
 
   async setResponse(response: ToolResponseLike<ReadonlyJSONValue>) {
-    this._argsTextController.close();
-    await Promise.resolve(); // flush microtask queue
-    // TODO switch argsTextController to be something that doesn'#t require this
     this._controller.enqueue({
       type: "result",
       path: [],
@@ -83,6 +80,9 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
         ? { messages: response.messages }
         : {}),
     });
+    this._argsTextController.close();
+    await Promise.resolve(); // flush microtask queue
+    // TODO switch argsTextController to be something that doesn'#t require this
   }
 
   async close() {

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -51,6 +51,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
       string,
       ToolCallReaderImpl<ReadonlyJSONObject, ReadonlyJSONValue>
     >();
+    const toolCallIdsWithBackendResult = new Set<string>();
 
     super((readable) => {
       const transform = new TransformStream<
@@ -109,6 +110,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   modelContent: chunk.modelContent,
                 }),
               );
+              toolCallIdsWithBackendResult.add(toolCallId);
               break;
             }
             case "tool-call-args-text-finish": {
@@ -122,6 +124,11 @@ export class ToolExecutionStream extends PipeableTransformStream<
               // Args fully streamed: close the reader so awaited absent fields
               // resolve. Awaited so the close settles before the writer is reused.
               await streamController.finishArgsText();
+
+              // A backend result is authoritative. Closing the args stream still
+              // emits this finish chunk, but must not parse stale/incomplete args,
+              // execute the frontend tool, or enqueue a second result.
+              if (toolCallIdsWithBackendResult.has(toolCallId)) break;
 
               let isExecuting = false;
               const promise = withPromiseOrValue(
@@ -206,10 +213,13 @@ export class ToolExecutionStream extends PipeableTransformStream<
                 toolCallPromise.then(() => {
                   toolCallPromises.delete(toolCallId);
                   toolCallControllers.delete(toolCallId);
+                  toolCallIdsWithBackendResult.delete(toolCallId);
 
                   controller.enqueue(chunk);
                 });
               } else {
+                toolCallControllers.delete(toolCallId);
+                toolCallIdsWithBackendResult.delete(toolCallId);
                 controller.enqueue(chunk);
               }
             }

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -53,9 +53,10 @@ existing `streamCall` keeps its original args view.
 
 ### A.5. First resolution (`result` becomes defined)
 The tracker calls `setResponse` on the active controller and closes it.
-`reader.response.get()` resolves. If the tool also had a frontend
-`execute`, the executor is short-circuited via `_skipExecuteStreamIds`.
-Single fire.
+The backend result is emitted before the args stream closes, so a stale
+args parse failure cannot replace it. `reader.response.get()` resolves.
+If the tool also had a frontend `execute`, the executor is short-circuited
+via `_skipExecuteStreamIds`. Single fire.
 
 ### A.6. Previously-resolved tool's `result` is replaced
 Silently ignored — `entry.hasResult` short-circuits both the
@@ -166,22 +167,6 @@ snapshot is processed against the fresh pipeline. Repeated failures
 keep the tracker dead with a visible error to avoid restart loops.
 
 ## Known limitations
-
-### Result delivery after args regression (A.2 + A.5 in the same snapshot)
-When a snapshot has both a regressed `argsText` *and* a backend result
-on the same tool call, `activeController.setResponse(result)` closes
-`argsText` before enqueueing the result chunk. The args-text-finish
-chunk reaches `ToolExecutionStream` first, attempts to parse the
-(stale) accumulated argsText, fails, and emits a parse-error result
-that beats the backend result to the reader's response promise.
-
-The tracker's `entry.hasResult` short-circuit *does* suppress both
-result chunks at the `onResult` callback level (no double-fire), but
-the reader's `response.get()` already resolved with the parse error.
-
-Fixable upstream in `ToolCallStreamControllerImpl.setResponse` by
-enqueueing the result chunk before closing argsText. Tracked separately;
-out of scope for the tracker layer.
 
 ### Host callback throws
 `onResult` and `onStatusesChange` are invoked through wrappers that

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -152,63 +152,6 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
-  it("delivers a backend result before a stale args parse failure after divergence", async () => {
-    const execute = vi.fn(async () => ({ source: "client" }));
-    let streamedQuery: Promise<unknown> | undefined;
-    const streamCall = vi.fn((reader) => {
-      streamedQuery = reader.args.get("query");
-    });
-    const getTools = () => ({
-      weatherSearch: {
-        parameters: { type: "object", properties: {} },
-        execute,
-        streamCall,
-      } satisfies Tool,
-    });
-    const onResult = vi.fn();
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    try {
-      const tracker = new ToolInvocationTracker(getTools, {
-        onResult,
-        onStatusesChange: () => {},
-      });
-      tracker.setState(createState([]));
-      tracker.setState(
-        createState([
-          createAssistantMessage('{"query":"London","longitude":0', {
-            query: "London",
-            longitude: 0,
-          }),
-        ]),
-      );
-
-      await waitFor(() => {
-        expect(streamCall).toHaveBeenCalledTimes(1);
-      });
-      expect(await streamedQuery).toBe("London");
-
-      tracker.setState(
-        createState([
-          createAssistantMessage(
-            '{"query":"Paris"}',
-            { query: "Paris" },
-            { result: { source: "backend" } },
-          ),
-        ]),
-      );
-
-      const [reader] = streamCall.mock.calls[0]!;
-      const response = await reader.response.get();
-      expect(response.result).toEqual({ source: "backend" });
-      expect(response.isError).toBe(false);
-      expect(execute).not.toHaveBeenCalled();
-      expect(onResult).not.toHaveBeenCalled();
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
   it("clears executing status under the logical toolCallId when reset() lands while execute is pending", async () => {
     // Tests the F.1 lifecycle: reset() aborts in-flight execute() invocations
     // and clears their executing status. The status key is the logical
@@ -1005,7 +948,8 @@ describe("ToolInvocationTracker", () => {
     // result replacement) and verifying streamCall fires exactly once.
     //
     // The pathological mid-stream regression case (A.2) is covered by
-    // the dedicated regression test above.
+    // the assistant-stream ordering regression test in
+    // packages/assistant-stream/src/core/modules/tool-call.test.ts.
     const streamCall = vi.fn();
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const getTools = () => ({

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -152,6 +152,63 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
+  it("delivers a backend result before a stale args parse failure after divergence", async () => {
+    const execute = vi.fn(async () => ({ source: "client" }));
+    let streamedQuery: Promise<unknown> | undefined;
+    const streamCall = vi.fn((reader) => {
+      streamedQuery = reader.args.get("query");
+    });
+    const getTools = () => ({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute,
+        streamCall,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const tracker = new ToolInvocationTracker(getTools, {
+        onResult,
+        onStatusesChange: () => {},
+      });
+      tracker.setState(createState([]));
+      tracker.setState(
+        createState([
+          createAssistantMessage('{"query":"London","longitude":0', {
+            query: "London",
+            longitude: 0,
+          }),
+        ]),
+      );
+
+      await waitFor(() => {
+        expect(streamCall).toHaveBeenCalledTimes(1);
+      });
+      expect(await streamedQuery).toBe("London");
+
+      tracker.setState(
+        createState([
+          createAssistantMessage(
+            '{"query":"Paris"}',
+            { query: "Paris" },
+            { result: { source: "backend" } },
+          ),
+        ]),
+      );
+
+      const [reader] = streamCall.mock.calls[0]!;
+      const response = await reader.response.get();
+      expect(response.result).toEqual({ source: "backend" });
+      expect(response.isError).toBe(false);
+      expect(execute).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it("clears executing status under the logical toolCallId when reset() lands while execute is pending", async () => {
     // Tests the F.1 lifecycle: reset() aborts in-flight execute() invocations
     // and clears their executing status. The status key is the logical
@@ -948,12 +1005,7 @@ describe("ToolInvocationTracker", () => {
     // result replacement) and verifying streamCall fires exactly once.
     //
     // The pathological mid-stream regression case (A.2) is covered by
-    // the dedicated regression test above. Mixing A.2 with a backend
-    // result in the same snapshot exposes a separate issue inside
-    // assistant-stream's `ToolCallStreamController.setResponse` ordering
-    // (parse-failure result reaches the reader before the backend
-    // result); that's tracked separately and out of scope for the
-    // tracker-level contract.
+    // the dedicated regression test above.
     const streamCall = vi.fn();
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const getTools = () => ({


### PR DESCRIPTION
## Summary

- emit backend tool responses before closing the argument text stream
- prevent a stale argument parse failure from winning the response race after `argsText` divergence
- add an assistant-stream regression test for the response ordering and update the documented tracker edge case

## Root cause

When a live snapshot contained both divergent `argsText` and a backend result, `ToolCallStreamControllerImpl.setResponse` closed the args stream first. That emitted `tool-call-args-text-finish`, so `ToolExecutionStream` parsed the stale incomplete prefix and resolved the reader with `Function parameter parsing failed` before the backend result chunk arrived.

Enqueueing the backend result before closing `argsText` preserves the authoritative response while retaining the existing close/flush behavior.

## Verification

- Regression red/green in `assistant-stream`:
  - old ordering: the focused test fails with `Function parameter parsing failed`
  - new ordering: the focused test receives `{ source: "backend" }`
- `assistant-stream`: 327 passed, 20 skipped
- `@assistant-ui/core`: 585 passed
- `aui-build` passed for both packages
- changed-file `oxlint`: 0 warnings, 0 errors
- changed-file `oxfmt --check`: passed
- `changeset status --since origin/main`: passed

The ordering regression lives in `assistant-stream` so Turbo tests do not depend on `@assistant-ui/core` resolving a concurrently built workspace package.

Closes #5102
