### PR TITLE
fix(react-langgraph): handle queued run failures

### DIFF
--- a/.changeset/calm-queues-settle.md
+++ b/.changeset/calm-queues-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: handle queued run failures without unhandled promise rejections

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -852,6 +852,53 @@ describe("useLangGraphRuntime", () => {
       );
     });
 
+    it("handles a queued run rejection", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {
+        if (streamMock.mock.calls.length === 1) {
+          await gate.promise;
+          return;
+        }
+        throw new Error("queued run failed");
+      });
+      const onUnhandledRejection = vi.fn();
+      process.on("unhandledRejection", onUnhandledRejection);
+
+      try {
+        const { result: runtimeResult } = renderHook(
+          () =>
+            useLangGraphRuntime({
+              stream: streamMock,
+              unstable_enableMessageQueue: true,
+            }),
+          {},
+        );
+        const wrapper = wrapperFactory(runtimeResult.current);
+        const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+        const send = async (text: string) => {
+          await act(async () => {
+            auiResult.current.composer().setText(text);
+            auiResult.current.composer().send();
+          });
+        };
+
+        await send("first");
+        await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+        await send("second");
+
+        await act(async () => {
+          gate.resolve();
+        });
+        await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(onUnhandledRejection).not.toHaveBeenCalled();
+      } finally {
+        process.off("unhandledRejection", onUnhandledRejection);
+      }
+    });
+
     it("does not expose the queue capability when the flag is off", async () => {
       const streamMock = vi.fn(async function* () {});
       const { result: runtimeResult } = renderHook(

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -393,7 +393,7 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   if (unstable_enableMessageQueue && !queueRef.current) {
     queueRef.current = createMessageQueue({
       run: (message) => {
-        void runUserMessageRef.current(message);
+        void runUserMessageRef.current(message).catch(() => {});
       },
     });
   } else if (!unstable_enableMessageQueue && queueRef.current) {


### PR DESCRIPTION
## Summary

- observe rejected LangGraph runs at the message queue's fire-and-forget boundary
- add a regression test covering a queued stream failure
- publish the fix as a patch for `@assistant-ui/react-langgraph`

## Why

With `unstable_enableMessageQueue` enabled, the queue driver started `runUserMessage()` with `void` and did not observe the returned promise. If a queued stream rejected, the run lifecycle settled but the rejection also escaped through the global `unhandledRejection` channel. In Node or strict test hosts, that can surface as an unrelated process-level failure.

The queue driver now attaches a terminal catch, matching the established fire-and-forget handling in the core local runtime without changing normal sends or stream state handling.

## Validation

- `pnpm --filter @assistant-ui/react-langgraph test` (190 tests)
- `pnpm --filter @assistant-ui/react-langgraph build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

