### PR TITLE
fix(react-pi): isolate shared streams by client

### DIFF
--- a/.changeset/quiet-pi-streams.md
+++ b/.changeset/quiet-pi-streams.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: isolate shared Pi event streams between client instances

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1766,12 +1766,6 @@ type SendOptions = {
   steer?: boolean;
 };
 
-type SharedStream = {
-  listeners: Set<(event: PiClientEvent) => void>;
-  close: () => void;
-  closeTimer: ReturnType<typeof setTimeout> | undefined;
-};
-
 type SourceMessagePart = {
   readonly type: "source";
   readonly sourceType: "url";
@@ -2369,10 +2363,6 @@ declare const createSseDecoder: () => {
 };
 
 declare const getPiThreadSupervisor: (options?: PiNodeClientOptions) => PiThreadSupervisor;
-
-declare global {
-  var __assistantUiPiHttpStreams: Map<string, SharedStream> | undefined;
-}
 
 declare global {
   interface Window {

--- a/packages/react-pi/src/client/httpClient.test.ts
+++ b/packages/react-pi/src/client/httpClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createPiHttpClient } from "./httpClient";
 import type {
   PiAnyClientEvent,
@@ -413,5 +413,50 @@ describe("createPiHttpClient", () => {
     unsubscribe();
 
     expect(calls[0]!.url).toBe("/api/pi/threads/t1/events?snapshot=false");
+  });
+
+  it("shares cookie-authenticated streams only within one client", async () => {
+    let browserIdentity = "user-a";
+    const openedAs: string[] = [];
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        openedAs.push(browserIdentity);
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              init?.signal?.addEventListener(
+                "abort",
+                () => controller.close(),
+                { once: true },
+              );
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          },
+        );
+      },
+    ) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const unsubscribers: (() => void)[] = [];
+    try {
+      const clientA = createPiHttpClient({ streamCloseDelayMs: 0 });
+      unsubscribers.push(clientA.subscribe("t1", () => {}));
+      unsubscribers.push(clientA.subscribe("t1", () => {}));
+
+      await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(1));
+
+      browserIdentity = "user-b";
+      const clientB = createPiHttpClient({ streamCloseDelayMs: 0 });
+      unsubscribers.push(clientB.subscribe("t1", () => {}));
+
+      await vi.waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(2));
+      expect(openedAs).toEqual(["user-a", "user-b"]);
+    } finally {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/react-pi/src/client/httpClient.ts
+++ b/packages/react-pi/src/client/httpClient.ts
@@ -45,16 +45,6 @@ type SharedStream = {
   closeTimer: ReturnType<typeof setTimeout> | undefined;
 };
 
-declare global {
-  // eslint-disable-next-line no-var
-  var __assistantUiPiHttpStreams: Map<string, SharedStream> | undefined;
-}
-
-const getDefaultBrowserStreams = () => {
-  globalThis.__assistantUiPiHttpStreams ??= new Map<string, SharedStream>();
-  return globalThis.__assistantUiPiHttpStreams;
-};
-
 export interface PiHttpClientOptions {
   /** Base path/URL of the route layer. Default: `/api/pi`. */
   baseUrl?: string;
@@ -336,10 +326,7 @@ export const createPiHttpClient = (
     `${base}/threads/${encodeURIComponent(threadId)}`;
 
   const jsonHeaders = { "content-type": "application/json", ...headers };
-  const streams =
-    fetchImpl === globalThis.fetch && headers === undefined
-      ? getDefaultBrowserStreams()
-      : new Map<string, SharedStream>();
+  const streams = new Map<string, SharedStream>();
 
   const send = (url: string, method: string, body?: unknown) =>
     fetchImpl(url, {


### PR DESCRIPTION
## Summary

- scope shared React Pi SSE connections to a single `createPiHttpClient()` instance
- keep connection deduplication for subscribers using the same client
- add a regression test for separate browser auth identities

## Why

The default browser transport cached streams globally by URL and thread. With cookie authentication, a client created after logout/login could therefore reuse an SSE connection opened by the previous user because the existing request keeps the cookies it connected with.

In the reproduced case, user A opened a thread stream, the browser identity changed to user B, and a second client subscribed to the same URL and thread. Only one network connection opened, so user B received user A's existing stream.

Each client now owns its stream cache. Subscribers within that client still share a connection, while a newly created client establishes its own authenticated stream.

## Testing

- `pnpm --filter @assistant-ui/react-pi exec vitest run src/client/httpClient.test.ts`
- `pnpm --filter @assistant-ui/react-pi test`
- `pnpm --filter @assistant-ui/react-pi build`
- `pnpm lint`
- `pnpm exec changeset status --since=origin/main`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

