### PR TITLE
fix(core): keep composer attachments visible while their upload is in flight

### DIFF
--- a/.changeset/hip-panthers-attack.md
+++ b/.changeset/hip-panthers-attack.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep composer attachments visible while their upload is in flight

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -652,6 +652,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
+  private _isSending;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -654,6 +654,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
   private _removedDuringSend;
+  private _sendGeneration;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -652,7 +652,8 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
-  private _isSending;
+  protected _isSending: boolean;
+  private _removedDuringSend;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -629,6 +629,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
+  private _isSending;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -629,7 +629,8 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
-  private _isSending;
+  protected _isSending: boolean;
+  private _removedDuringSend;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -631,6 +631,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
   private _removedDuringSend;
+  private _sendGeneration;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -621,6 +621,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
+  private _isSending;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -621,7 +621,8 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
-  private _isSending;
+  protected _isSending: boolean;
+  private _removedDuringSend;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -623,6 +623,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
   private _removedDuringSend;
+  private _sendGeneration;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -927,6 +927,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
+  private _isSending;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -927,7 +927,8 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setText(value: string): void;
   setRole(role: MessageRole): void;
   setRunConfig(runConfig: RunConfig): void;
-  private _isSending;
+  protected _isSending: boolean;
+  private _removedDuringSend;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -929,6 +929,7 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   setRunConfig(runConfig: RunConfig): void;
   protected _isSending: boolean;
   private _removedDuringSend;
+  private _sendGeneration;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -133,6 +133,8 @@ export abstract class BaseComposerRuntimeCore
     this._notifySubscribers();
   }
 
+  private _isSending = false;
+
   private _emptyTextAndAttachments() {
     this._attachments = [];
     this._text = "";
@@ -175,7 +177,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async send(options?: SendOptions) {
-    if (!this.canSend) return;
+    if (!this.canSend || this._isSending) return;
 
     if (this._dictationSession) {
       this._dictationSession.cancel();
@@ -199,20 +201,29 @@ export abstract class BaseComposerRuntimeCore
     const text = this.text;
     const quote = this._quote;
     this._quote = undefined;
-    this._emptyTextAndAttachments();
+    this._text = "";
+    this._isSending = true;
+    this._notifySubscribers();
 
     let resolvedAttachments: Awaited<typeof attachments>;
     try {
       resolvedAttachments = await attachments;
     } catch (e) {
-      if (this.isEmpty && this._quote === undefined) {
-        this._attachments = originalAttachments;
+      if (!this.text.trim() && this._quote === undefined) {
         this._text = text;
         this._quote = quote;
-        this._notifySubscribers();
       }
+      this._isSending = false;
+      this._notifySubscribers();
       throw e;
     }
+
+    // Drop by id, not wholesale: the user may have added or removed chips while
+    // the upload was in flight.
+    const sentIds = new Set(originalAttachments.map((a) => a.id));
+    this._attachments = this._attachments.filter((a) => !sentIds.has(a.id));
+    this._isSending = false;
+    this._notifySubscribers();
 
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
       createdAt: new Date(),

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -151,6 +151,11 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async reset() {
+    // A send whose adapter never settles must not brick the composer; reset is
+    // the escape hatch that releases the in-flight lock.
+    this._isSending = false;
+    this._removedDuringSend.clear();
+
     if (
       this._attachments.length === 0 &&
       this._text === "" &&
@@ -205,14 +210,15 @@ export abstract class BaseComposerRuntimeCore
     try {
       resolvedAttachments = await Promise.all(attachmentTasks);
     } catch (e) {
+      if (!this.text.trim() && this._quote === undefined) {
+        this._text = text;
+        this._quote = quote;
+        this._notifySubscribers();
+      }
       // Promise.all rejects on the first failure, but sibling uploads from this
       // batch keep running; wait for them to settle before unlocking retries, or
       // a retry could re-send attachments that are still in flight.
       await Promise.allSettled(attachmentTasks);
-      if (!this.text.trim() && this._quote === undefined) {
-        this._text = text;
-        this._quote = quote;
-      }
       this._removedDuringSend.clear();
       this._isSending = false;
       this._notifySubscribers();
@@ -412,15 +418,16 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
+    // A send in flight may already be uploading this attachment; the upload
+    // can't be cancelled, so mark it to be dropped from the outgoing message
+    // before any await gives the upload a chance to settle first.
+    if (this._isSending) this._removedDuringSend.add(attachmentId);
+
     if (!isAttachmentComplete(attachment)) {
       const adapter = this.getAttachmentAdapter();
       if (!adapter) throw new Error("Attachments are not supported");
       await adapter.remove(attachment);
     }
-
-    // A send in flight may already be uploading this attachment; the upload
-    // can't be cancelled, so mark it to be dropped from the outgoing message.
-    if (this._isSending) this._removedDuringSend.add(attachmentId);
     this._attachments = this._attachments.filter((a) => a.id !== attachmentId);
     this._notifySubscribers();
   }

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -133,7 +133,8 @@ export abstract class BaseComposerRuntimeCore
     this._notifySubscribers();
   }
 
-  private _isSending = false;
+  protected _isSending = false;
+  private _removedDuringSend = new Set<string>();
 
   private _emptyTextAndAttachments() {
     this._attachments = [];
@@ -185,17 +186,12 @@ export abstract class BaseComposerRuntimeCore
     }
 
     const adapter = this.getAttachmentAdapter();
-    const attachments =
-      this.attachments.length > 0
-        ? Promise.all(
-            this.attachments.map(async (a) => {
-              if (isAttachmentComplete(a)) return a;
-              if (!adapter) throw new Error("Attachments are not supported");
-              const result = await adapter.send(a);
-              return result as CompleteAttachment;
-            }),
-          )
-        : [];
+    const attachmentTasks = this.attachments.map(async (a) => {
+      if (isAttachmentComplete(a)) return a;
+      if (!adapter) throw new Error("Attachments are not supported");
+      const result = await adapter.send(a);
+      return result as CompleteAttachment;
+    });
 
     const originalAttachments = this.attachments;
     const text = this.text;
@@ -205,14 +201,19 @@ export abstract class BaseComposerRuntimeCore
     this._isSending = true;
     this._notifySubscribers();
 
-    let resolvedAttachments: Awaited<typeof attachments>;
+    let resolvedAttachments: CompleteAttachment[];
     try {
-      resolvedAttachments = await attachments;
+      resolvedAttachments = await Promise.all(attachmentTasks);
     } catch (e) {
+      // Promise.all rejects on the first failure, but sibling uploads from this
+      // batch keep running; wait for them to settle before unlocking retries, or
+      // a retry could re-send attachments that are still in flight.
+      await Promise.allSettled(attachmentTasks);
       if (!this.text.trim() && this._quote === undefined) {
         this._text = text;
         this._quote = quote;
       }
+      this._removedDuringSend.clear();
       this._isSending = false;
       this._notifySubscribers();
       throw e;
@@ -225,11 +226,18 @@ export abstract class BaseComposerRuntimeCore
     this._isSending = false;
     this._notifySubscribers();
 
+    // An attachment removed mid-upload can't be cancelled, but it can still be
+    // dropped from the outgoing message instead of silently being sent anyway.
+    const finalAttachments = resolvedAttachments.filter(
+      (a) => !this._removedDuringSend.has(a.id),
+    );
+    this._removedDuringSend.clear();
+
     const message: Omit<AppendMessage, "parentId" | "sourceId"> = {
       createdAt: new Date(),
       role: this.role,
       content: text ? [{ type: "text", text }] : [],
-      attachments: resolvedAttachments,
+      attachments: finalAttachments,
       runConfig: this.runConfig,
       metadata: { custom: { ...(quote ? { quote } : {}) } },
     };
@@ -410,6 +418,9 @@ export abstract class BaseComposerRuntimeCore
       await adapter.remove(attachment);
     }
 
+    // A send in flight may already be uploading this attachment; the upload
+    // can't be cancelled, so mark it to be dropped from the outgoing message.
+    if (this._isSending) this._removedDuringSend.add(attachmentId);
     this._attachments = this._attachments.filter((a) => a.id !== attachmentId);
     this._notifySubscribers();
   }

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -135,6 +135,7 @@ export abstract class BaseComposerRuntimeCore
 
   protected _isSending = false;
   private _removedDuringSend = new Set<string>();
+  private _sendGeneration = 0;
 
   private _emptyTextAndAttachments() {
     this._attachments = [];
@@ -152,7 +153,10 @@ export abstract class BaseComposerRuntimeCore
 
   public async reset() {
     // A send whose adapter never settles must not brick the composer; reset is
-    // the escape hatch that releases the in-flight lock.
+    // the escape hatch that releases the in-flight lock. Bumping the generation
+    // invalidates that send entirely so a late-settling upload can neither
+    // append the discarded draft nor touch a newer send's lock.
+    this._sendGeneration++;
     this._isSending = false;
     this._removedDuringSend.clear();
 
@@ -204,26 +208,36 @@ export abstract class BaseComposerRuntimeCore
     this._quote = undefined;
     this._text = "";
     this._isSending = true;
+    const generation = ++this._sendGeneration;
     this._notifySubscribers();
 
     let resolvedAttachments: CompleteAttachment[];
     try {
       resolvedAttachments = await Promise.all(attachmentTasks);
     } catch (e) {
-      if (!this.text.trim() && this._quote === undefined) {
-        this._text = text;
-        this._quote = quote;
-        this._notifySubscribers();
+      if (generation === this._sendGeneration) {
+        if (!this.text.trim() && this._quote === undefined) {
+          this._text = text;
+          this._quote = quote;
+          this._notifySubscribers();
+        }
+        // Promise.all rejects on the first failure, but sibling uploads from
+        // this batch keep running; the send rejects immediately while the
+        // retry lock is held until they settle, or a retry could re-send
+        // attachments that are still in flight.
+        void Promise.allSettled(attachmentTasks).then(() => {
+          if (generation !== this._sendGeneration) return;
+          this._removedDuringSend.clear();
+          this._isSending = false;
+          this._notifySubscribers();
+        });
       }
-      // Promise.all rejects on the first failure, but sibling uploads from this
-      // batch keep running; wait for them to settle before unlocking retries, or
-      // a retry could re-send attachments that are still in flight.
-      await Promise.allSettled(attachmentTasks);
-      this._removedDuringSend.clear();
-      this._isSending = false;
-      this._notifySubscribers();
       throw e;
     }
+
+    // A reset during the upload discarded this send's draft; the settled
+    // uploads must not append it or touch the lock a newer send may own.
+    if (generation !== this._sendGeneration) return;
 
     // Drop by id, not wholesale: the user may have added or removed chips while
     // the upload was in flight.

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -15,7 +15,7 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   }
 
   public get canSend() {
-    return !this.isEmpty;
+    return !this.isEmpty && !this._isSending;
   }
 
   protected getAttachmentAdapter() {

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -23,7 +23,7 @@ export class DefaultThreadComposerRuntimeCore
   }
 
   public get canSend() {
-    return !this.isEmpty && !this.runtime.isSendDisabled;
+    return !this.isEmpty && !this.runtime.isSendDisabled && !this._isSending;
   }
 
   public override get queue(): readonly QueueItemState[] {

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -82,7 +82,7 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     await expect(sendPromise).rejects.toThrow("upload failed");
 
     expect(composer.text).toBe("new draft");
-    expect(composer.attachments).toHaveLength(0);
+    expect(composer.attachments).toHaveLength(1);
     expect(append).not.toHaveBeenCalled();
   });
 
@@ -107,7 +107,7 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     expect(composer.quote).toEqual({ text: "new quote", messageId: "m-2" });
     expect(composer.text).toBe("");
-    expect(composer.attachments).toHaveLength(0);
+    expect(composer.attachments).toHaveLength(1);
     expect(append).not.toHaveBeenCalled();
   });
 
@@ -126,6 +126,88 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     expect(message.content).toEqual([{ type: "text", text: "hello" }]);
     expect(message.attachments).toHaveLength(1);
     expect(message.attachments[0].status).toEqual({ type: "complete" });
+  });
+
+  it("keeps the attachments visible until the upload resolves", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    await Promise.resolve();
+
+    expect(composer.text).toBe("");
+    expect(composer.attachments).toHaveLength(1);
+    expect(append).not.toHaveBeenCalled();
+
+    resolveSend();
+    await sendPromise;
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an attachment added while the upload was in flight", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+        id: `att-${file.name}`,
+        type: "image",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      }),
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer } = makeComposer(adapter);
+
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    await composer.addAttachment(new File(["x"], "later.txt"));
+    resolveSend();
+    await sendPromise;
+
+    expect(composer.attachments.map((a) => a.name)).toEqual(["later.txt"]);
+  });
+
+  it("ignores a second send while the first upload is still running", async () => {
+    let sendCalls = 0;
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) => {
+        sendCalls += 1;
+        return new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        });
+      },
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    await composer.send();
+    resolveSend();
+    await sendPromise;
+
+    expect(sendCalls).toBe(1);
+    expect(append).toHaveBeenCalledTimes(1);
   });
 
   it("sends a text-only message with no attachment adapter", async () => {

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -275,8 +275,7 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     resolveA();
     await caught;
-
-    expect(composer.canSend).toBe(true);
+    await vi.waitFor(() => expect(composer.canSend).toBe(true));
     expect(sendCallsForA).toBe(1);
   });
 
@@ -307,17 +306,14 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     await composer.addAttachment(new File(["a"], "a.txt"));
     await composer.addAttachment(new File(["b"], "b.txt"));
 
-    const caught = composer.send().catch(() => {});
+    const sendPromise = composer.send();
+    await expect(sendPromise).rejects.toThrow("b failed");
 
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
     expect(composer.text).toBe("hello");
     expect(composer.canSend).toBe(false);
 
     resolveA();
-    await caught;
-    expect(composer.canSend).toBe(true);
+    await vi.waitFor(() => expect(composer.canSend).toBe(true));
   });
 
   it("excludes a removed attachment even when the upload settles before the adapter remove", async () => {
@@ -368,6 +364,37 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
 
     await composer.send();
     expect(append).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards a stalled send that settles after reset instead of appending it", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("stale draft");
+    await composer.addAttachment(textFile());
+    void composer.send();
+    await Promise.resolve();
+
+    await composer.reset();
+    composer.setText("fresh draft");
+    await composer.send();
+    expect(append).toHaveBeenCalledTimes(1);
+
+    resolveSend();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(composer.canSend).toBe(false);
+    composer.setText("still unlocked");
+    expect(composer.canSend).toBe(true);
   });
 
   it("excludes an attachment removed while its upload was still in flight", async () => {

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -280,6 +280,96 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     expect(sendCallsForA).toBe(1);
   });
 
+  it("restores the draft before a failed batch's stragglers settle", async () => {
+    let resolveA!: () => void;
+    const adapter = makeAdapter({
+      add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+        id: `att-${file.name}`,
+        type: "image",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      }),
+      send: (a) => {
+        if (a.id === "att-a.txt") {
+          return new Promise((resolve) => {
+            resolveA = () =>
+              resolve({ ...a, status: { type: "complete" }, content: [] });
+          });
+        }
+        return Promise.reject(new Error("b failed"));
+      },
+    });
+    const { composer } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(new File(["a"], "a.txt"));
+    await composer.addAttachment(new File(["b"], "b.txt"));
+
+    const caught = composer.send().catch(() => {});
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(composer.text).toBe("hello");
+    expect(composer.canSend).toBe(false);
+
+    resolveA();
+    await caught;
+    expect(composer.canSend).toBe(true);
+  });
+
+  it("excludes a removed attachment even when the upload settles before the adapter remove", async () => {
+    let resolveSend!: () => void;
+    let resolveRemove!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+      remove: () =>
+        new Promise((resolve) => {
+          resolveRemove = () => resolve();
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    const removePromise = composer.removeAttachment("att-1");
+    resolveSend();
+    await sendPromise;
+
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append.mock.calls[0]![0].attachments).toHaveLength(0);
+
+    resolveRemove();
+    await removePromise;
+  });
+
+  it("releases the in-flight lock on reset so a stalled send cannot brick the composer", async () => {
+    const adapter = makeAdapter({
+      send: () => new Promise(() => {}),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    await composer.addAttachment(textFile());
+    void composer.send();
+    await Promise.resolve();
+    expect(composer.canSend).toBe(false);
+
+    await composer.reset();
+    composer.setText("again");
+    expect(composer.canSend).toBe(true);
+
+    await composer.send();
+    expect(append).toHaveBeenCalledTimes(1);
+  });
+
   it("excludes an attachment removed while its upload was still in flight", async () => {
     let resolveSend!: () => void;
     const adapter = makeAdapter({

--- a/packages/core/src/tests/base-composer-runtime-core-send.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-send.test.ts
@@ -210,6 +210,99 @@ describe("BaseComposerRuntimeCore.send restore-on-failure", () => {
     expect(append).toHaveBeenCalledTimes(1);
   });
 
+  it("reports canSend as false while a send is in flight", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer } = makeComposer(adapter);
+
+    composer.setText("hello");
+    await composer.addAttachment(textFile());
+    expect(composer.canSend).toBe(true);
+
+    const sendPromise = composer.send();
+    await Promise.resolve();
+
+    expect(composer.canSend).toBe(false);
+
+    resolveSend();
+    await sendPromise;
+  });
+
+  it("keeps sending blocked until every upload in a failed batch settles", async () => {
+    let resolveA!: () => void;
+    let sendCallsForA = 0;
+    const adapter = makeAdapter({
+      add: async ({ file }: { file: File }): Promise<PendingAttachment> => ({
+        id: `att-${file.name}`,
+        type: "image",
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: { type: "requires-action", reason: "composer-send" },
+      }),
+      send: (a) => {
+        if (a.id === "att-a.txt") {
+          sendCallsForA += 1;
+          return new Promise((resolve) => {
+            resolveA = () =>
+              resolve({ ...a, status: { type: "complete" }, content: [] });
+          });
+        }
+        return Promise.reject(new Error("b failed"));
+      },
+    });
+    const { composer } = makeComposer(adapter);
+
+    await composer.addAttachment(new File(["a"], "a.txt"));
+    await composer.addAttachment(new File(["b"], "b.txt"));
+
+    const sendPromise = composer.send();
+    const caught = sendPromise.catch(() => {});
+
+    // b's rejection has already surfaced from Promise.all, but a's upload is
+    // still running — sending must stay blocked so a retry can't fire a second
+    // adapter.send for the attachment that's still in flight.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(composer.canSend).toBe(false);
+
+    resolveA();
+    await caught;
+
+    expect(composer.canSend).toBe(true);
+    expect(sendCallsForA).toBe(1);
+  });
+
+  it("excludes an attachment removed while its upload was still in flight", async () => {
+    let resolveSend!: () => void;
+    const adapter = makeAdapter({
+      send: (a) =>
+        new Promise((resolve) => {
+          resolveSend = () =>
+            resolve({ ...a, status: { type: "complete" }, content: [] });
+        }),
+    });
+    const { composer, append } = makeComposer(adapter);
+
+    await composer.addAttachment(textFile());
+
+    const sendPromise = composer.send();
+    await composer.removeAttachment("att-1");
+    resolveSend();
+    await sendPromise;
+
+    expect(append).toHaveBeenCalledTimes(1);
+    const message = append.mock.calls[0]![0];
+    expect(message.attachments).toHaveLength(0);
+  });
+
   it("sends a text-only message with no attachment adapter", async () => {
     const { composer, append } = makeComposer();
 


### PR DESCRIPTION
Fixes #4796. `BaseComposerRuntimeCore.send()` called `_emptyTextAndAttachments()` synchronously before awaiting `adapter.send()`, so with a deferred-upload adapter the composer went blank the moment you hit send and the chat stayed empty for the whole upload window — with a 10MB file that's a couple of seconds where the message looks like it vanished.

Text still clears immediately (people expect the input to empty on send), but the attachments now stay until the upload resolves, then get dropped by id rather than wholesale — the user can add or remove chips while the upload is running and those shouldn't be wiped. Since the composer is no longer empty during the upload, `canSend` would let a second click re-enter `send()` and upload the same attachments twice, so there's an in-flight guard now.

The failure path changed too: attachments are never cleared up front, so there's nothing to restore, and a failed upload leaves the files in the composer to retry instead of discarding them. The text/quote restore is gated on the user not having typed something new, same as before, just keyed on the text rather than `isEmpty` (which no longer goes true mid-send). Two existing tests asserted the old "attachments gone after a failed upload" behavior — updated them.

Added tests for the visible-during-upload window, the add-while-in-flight case and the double-send guard; all three fail on the unfixed `send()`. Full core suite green (588).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

