### PR TITLE
fix(core): apply pending mute after voice setup

### DIFF
--- a/.changeset/quiet-voices-connect.md
+++ b/.changeset/quiet-voices-connect.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: apply pending mute state after voice session setup

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createVoiceSession, type VoiceSessionHelpers } from "./voice";
+import {
+  createVoiceSession,
+  type VoiceSessionControls,
+  type VoiceSessionHelpers,
+} from "./voice";
 
 const createTestSession = () => {
   let helpers: VoiceSessionHelpers | undefined;
@@ -16,11 +20,59 @@ const createTestSession = () => {
   return { helpers, session };
 };
 
+const createPendingTestSession = () => {
+  let resolveControls!: (controls: VoiceSessionControls) => void;
+  const controlsPromise = new Promise<VoiceSessionControls>((resolve) => {
+    resolveControls = resolve;
+  });
+  const controls = {
+    disconnect: vi.fn(),
+    mute: vi.fn(),
+    unmute: vi.fn(),
+  };
+  const session = createVoiceSession({}, () => controlsPromise);
+
+  return {
+    controls,
+    controlsPromise,
+    resolveControls: () => resolveControls(controls),
+    session,
+  };
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("createVoiceSession", () => {
+  it("applies mute requested while setup is pending", async () => {
+    const { controls, controlsPromise, resolveControls, session } =
+      createPendingTestSession();
+
+    session.mute();
+
+    expect(session.isMuted).toBe(true);
+    expect(controls.mute).not.toHaveBeenCalled();
+
+    resolveControls();
+    await controlsPromise;
+
+    expect(controls.mute).toHaveBeenCalledOnce();
+  });
+
+  it("does not apply stale mute after unmuting during setup", async () => {
+    const { controls, controlsPromise, resolveControls, session } =
+      createPendingTestSession();
+
+    session.mute();
+    session.unmute();
+    resolveControls();
+    await controlsPromise;
+
+    expect(session.isMuted).toBe(false);
+    expect(controls.mute).not.toHaveBeenCalled();
+  });
+
   it("continues notifying listeners when one throws", () => {
     const listenerError = new Error("listener failed");
     const consoleError = vi

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -171,7 +171,11 @@ export function createVoiceSession(
     try {
       if (disposed) return;
       controls = await setup(helpers);
-      if (disposed) controls.disconnect();
+      if (disposed) {
+        controls.disconnect();
+      } else if (isMuted) {
+        controls.mute();
+      }
     } catch (error) {
       helpers.end("error", error);
     }


### PR DESCRIPTION
## Summary

- apply a mute request made before asynchronous voice setup completes
- preserve a later unmute request as the latest user intent
- add focused regression coverage for both setup races

## Problem

While testing a delayed voice connection, calling `session.mute()` before `setup()` resolved produced `isMuted: true` but zero calls to the provider controls' `mute()` method. Once setup completed, the UI could therefore report a muted session while the underlying microphone remained unmuted.

The session now reconciles its current mute state immediately after controls become available. A mute followed by an unmute during setup remains unmuted.

## Verification

- reproduced before the fix: `{ uiIsMuted: true, underlyingMuteCalls: 0 }`
- verified after the fix: `{ uiIsMuted: true, underlyingMuteCalls: 1 }`
- `vitest run src/adapters/voice.test.ts` (3 tests)
- `aui-build` for `@assistant-ui/core`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

