### PR TITLE
docs(mcp-apps): document ag-ui tool result contract

### DIFF
--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -204,6 +204,59 @@ Your `mcp-apps/read-resource` handler reads the `ui://` resource as in the route
 
 The cleaner long-term fix is upstream: if `@ai-sdk/mcp`'s `getMCPAppToolMeta` also read `openai/outputTemplate`, then `callProviderMetadata.mcp.app` would populate automatically and this bridge would be unnecessary.
 
+## AG-UI integration
+
+With `@assistant-ui/react-ag-ui`, the backend associates an MCP App with a tool call through an `ACTIVITY_SNAPSHOT`. Include the tool call ID, the app's `ui://` resource URI, and the MCP server identity when routing across multiple servers:
+
+```json
+{
+  "type": "ACTIVITY_SNAPSHOT",
+  "activityType": "mcp-apps",
+  "content": {
+    "toolCallId": "call-1",
+    "resourceUri": "ui://maps/result.html",
+    "serverId": "maps",
+    "result": {
+      "content": [{ "type": "text", "text": "Map ready" }],
+      "structuredContent": { "center": [37.77, -122.42] },
+      "_meta": { "initialView": "street" },
+      "isError": false
+    }
+  }
+}
+```
+
+`serverId` is optional. If it is absent, the runtime accepts `serverHash` as a fallback. Older middleware may omit `toolCallId`, in which case the snapshot applies to the last resolved tool call; new integrations should include it so concurrent tool calls are correlated unambiguously.
+
+Send the normal `TOOL_CALL_RESULT` with a concise, model-visible summary:
+
+```json
+{
+  "type": "TOOL_CALL_RESULT",
+  "toolCallId": "call-1",
+  "content": "Map ready"
+}
+```
+
+The snapshot's `result` becomes the widget-visible `part.result`, while the `TOOL_CALL_RESULT.content` string is retained as `part.modelContent` for the model.
+
+Alternatively, AG-UI servers can place MCP host fields directly on `TOOL_CALL_RESULT`:
+
+```json
+{
+  "type": "TOOL_CALL_RESULT",
+  "toolCallId": "call-1",
+  "content": "Map ready",
+  "structuredContent": { "center": [37.77, -122.42] },
+  "_meta": { "initialView": "street" },
+  "isError": false
+}
+```
+
+In this form, the runtime assembles a `CallToolResult`-shaped `part.result` from `content`, `structuredContent`, `_meta`, and `isError`. An `ACTIVITY_SNAPSHOT` is still required to provide the app's `resourceUri` and optional server identity, but it does not need to repeat `result`.
+
+The visibility split follows the MCP Apps contract: `content` is model-visible; `structuredContent` and `_meta` are available only to the host and widget. When assistant-ui serializes history into a later AG-UI request, it sends the saved model-visible text and never includes `structuredContent` or `_meta`.
+
 ## Bridge protocol
 
 The bridge implements the MCP UI JSON-RPC protocol over `window.postMessage`, filtered by both `event.source === frame.iframe.contentWindow` AND `event.origin === frame.origin` — the cross-origin domain `SafeContentFrame` issues per render. Messages from any other origin or window are dropped silently.

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -226,7 +226,7 @@ With `@assistant-ui/react-ag-ui`, the backend associates an MCP App with a tool 
 }
 ```
 
-`serverId` is optional. If it is absent, the runtime accepts `serverHash` as a fallback. Older middleware may omit `toolCallId`, in which case the snapshot applies to the last resolved tool call; new integrations should include it so concurrent tool calls are correlated unambiguously.
+`serverId` is optional. If it is absent, the runtime accepts `serverHash` as a fallback. Older middleware may omit `toolCallId`, in which case the snapshot applies to the last resolved tool call; new integrations should include it so concurrent tool calls are correlated unambiguously. Emit the snapshot after the tool call's `TOOL_CALL_START`; a snapshot for a tool call ID the runtime has not seen is silently ignored.
 
 Send the normal `TOOL_CALL_RESULT` with a concise, model-visible summary:
 

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -238,7 +238,7 @@ Send the normal `TOOL_CALL_RESULT` with a concise, model-visible summary:
 }
 ```
 
-The snapshot's `result` becomes the widget-visible `part.result`, while the `TOOL_CALL_RESULT.content` string is retained as `part.modelContent` for the model.
+The snapshot's `result` becomes the widget-visible `part.result`, while the `TOOL_CALL_RESULT.content` string is retained for the model as `part.modelContent`, a text content-part array (`[{ "type": "text", "text": "Map ready" }]`).
 
 Alternatively, AG-UI servers can place MCP host fields directly on `TOOL_CALL_RESULT`:
 
@@ -253,7 +253,7 @@ Alternatively, AG-UI servers can place MCP host fields directly on `TOOL_CALL_RE
 }
 ```
 
-In this form, the runtime assembles a `CallToolResult`-shaped `part.result` from `content`, `structuredContent`, `_meta`, and `isError`. An `ACTIVITY_SNAPSHOT` is still required to provide the app's `resourceUri` and optional server identity, but it does not need to repeat `result`.
+In this form, the runtime assembles a `CallToolResult`-shaped `part.result` from `content`, `structuredContent`, `_meta`, and `isError`. At least one of `structuredContent` or `_meta` must be present; when both are absent the enriched path does not activate and the result falls back to the plain `content` string. An `ACTIVITY_SNAPSHOT` is still required to provide the app's `resourceUri` and optional server identity, but it does not need to repeat `result`.
 
 The visibility split follows the MCP Apps contract: `content` is model-visible; `structuredContent` and `_meta` are available only to the host and widget. When assistant-ui serializes history into a later AG-UI request, it sends the saved model-visible text and never includes `structuredContent` or `_meta`.
 


### PR DESCRIPTION
## Summary

- document the MCP Apps `ACTIVITY_SNAPSHOT` contract for AG-UI backends
- document enriched `TOOL_CALL_RESULT` fields and how they form the widget-visible result
- explain the model-visible versus host/widget-only data split

## Why

The MCP Apps guide covered the AI SDK integration but did not describe the AG-UI wire contract, leaving backend authors to infer the required event shapes from runtime code.

Closes #5101.

## Validation

- `fumadocs-mdx`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

