### PR TITLE
fix(react-a2a): validate agent card responses

### DIFF
--- a/.changeset/fair-a2a-cards.md
+++ b/.changeset/fair-a2a-cards.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: validate required fields in A2A agent card responses

--- a/.changeset/fair-a2a-cards.md
+++ b/.changeset/fair-a2a-cards.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-a2a": patch
 ---
 
-fix: validate required fields in A2A agent card responses
+fix: reject unrecognizable agent card responses and fill proto3-omitted fields

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -813,6 +813,42 @@ describe("A2AClient", () => {
       expect(card.supportedInterfaces).toHaveLength(1);
       expect(card.supportedInterfaces[0]!.protocolBinding).toBe("HTTP+JSON");
     });
+
+    it.each([
+      ["missing required fields", {}],
+      [
+        "an invalid supported interface",
+        {
+          name: "Test Agent",
+          description: "A test",
+          version: "1.0",
+          supportedInterfaces: [{}],
+          capabilities: {},
+          defaultInputModes: ["text"],
+          defaultOutputModes: ["text"],
+          skills: [],
+        },
+      ],
+      [
+        "an invalid skill",
+        {
+          name: "Test Agent",
+          description: "A test",
+          version: "1.0",
+          supportedInterfaces: [],
+          capabilities: {},
+          defaultInputModes: ["text"],
+          defaultOutputModes: ["text"],
+          skills: [{}],
+        },
+      ],
+    ])("rejects %s", async (_name, body) => {
+      fetchMock.mockResolvedValue(mockFetchResponse(body));
+
+      await expect(client.getAgentCard()).rejects.toThrow(
+        "Invalid A2A agent card response: expected a valid agent card payload.",
+      );
+    });
   });
 
   // --- SSE streaming ---
@@ -1292,6 +1328,14 @@ describe("A2AClient", () => {
 
       const [url] = fetchMock.mock.calls[0]!;
       expect(url).toBe("https://agent.test/extendedAgentCard");
+    });
+
+    it("rejects malformed cards returned with a successful status", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({}));
+
+      await expect(client.getExtendedAgentCard()).rejects.toThrow(
+        "Invalid A2A agent card response: expected a valid agent card payload.",
+      );
     });
   });
 });

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -815,39 +815,56 @@ describe("A2AClient", () => {
     });
 
     it.each([
-      ["missing required fields", {}],
-      [
-        "an invalid supported interface",
-        {
-          name: "Test Agent",
-          description: "A test",
-          version: "1.0",
-          supportedInterfaces: [{}],
-          capabilities: {},
-          defaultInputModes: ["text"],
-          defaultOutputModes: ["text"],
-          skills: [],
-        },
-      ],
-      [
-        "an invalid skill",
-        {
-          name: "Test Agent",
-          description: "A test",
-          version: "1.0",
-          supportedInterfaces: [],
-          capabilities: {},
-          defaultInputModes: ["text"],
-          defaultOutputModes: ["text"],
-          skills: [{}],
-        },
-      ],
+      ["an empty payload", {}],
+      ["a payload without a name", { version: "1.0", skills: [] }],
+      ["a non-object payload", "not a card"],
     ])("rejects %s", async (_name, body) => {
       fetchMock.mockResolvedValue(mockFetchResponse(body));
 
       await expect(client.getAgentCard()).rejects.toThrow(
         "Invalid A2A agent card response: expected a valid agent card payload.",
       );
+    });
+
+    it("fills defaults for fields omitted by proto3 JSON serialization", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({ name: "Test Agent" }));
+
+      const card = await client.getAgentCard();
+
+      expect(card).toMatchObject({
+        name: "Test Agent",
+        description: "",
+        version: "",
+        supportedInterfaces: [],
+        capabilities: {},
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        skills: [],
+      });
+    });
+
+    it("fills defaults inside interfaces and skills", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          name: "Test Agent",
+          supported_interfaces: [{ url: "https://agent.test/a2a" }],
+          skills: [{ id: "recipes", name: "Recipes" }],
+        }),
+      );
+
+      const card = await client.getAgentCard();
+
+      expect(card.supportedInterfaces[0]).toMatchObject({
+        url: "https://agent.test/a2a",
+        protocolBinding: "",
+        protocolVersion: "",
+      });
+      expect(card.skills[0]).toMatchObject({
+        id: "recipes",
+        name: "Recipes",
+        description: "",
+        tags: [],
+      });
     });
   });
 
@@ -1330,12 +1347,27 @@ describe("A2AClient", () => {
       expect(url).toBe("https://agent.test/extendedAgentCard");
     });
 
-    it("rejects malformed cards returned with a successful status", async () => {
-      fetchMock.mockResolvedValue(mockFetchResponse({}));
+    it.each([
+      ["an empty payload", {}],
+      ["a payload without a name", { version: "1.0" }],
+    ])("rejects %s", async (_name, body) => {
+      fetchMock.mockResolvedValue(mockFetchResponse(body));
 
       await expect(client.getExtendedAgentCard()).rejects.toThrow(
         "Invalid A2A agent card response: expected a valid agent card payload.",
       );
+    });
+
+    it("fills defaults for omitted fields", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({ name: "Extended Agent", skills: [{ id: "s" }] }),
+      );
+
+      const card = await client.getExtendedAgentCard();
+
+      expect(card.name).toBe("Extended Agent");
+      expect(card.supportedInterfaces).toEqual([]);
+      expect(card.skills[0]).toMatchObject({ id: "s", tags: [] });
     });
   });
 });

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -818,12 +818,36 @@ describe("A2AClient", () => {
       ["an empty payload", {}],
       ["a payload without a name", { version: "1.0", skills: [] }],
       ["a non-object payload", "not a card"],
+      [
+        "a wrong-typed supportedInterfaces",
+        { name: "Test Agent", supportedInterfaces: "invalid" },
+      ],
+      ["a wrong-typed skill entry", { name: "Test Agent", skills: ["nope"] }],
+      [
+        "a wrong-typed skill tags field",
+        { name: "Test Agent", skills: [{ id: "s", tags: "broken" }] },
+      ],
     ])("rejects %s", async (_name, body) => {
       fetchMock.mockResolvedValue(mockFetchResponse(body));
 
       await expect(client.getAgentCard()).rejects.toThrow(
         "Invalid A2A agent card response: expected a valid agent card payload.",
       );
+    });
+
+    it("treats explicit null fields as defaults", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          name: "Test Agent",
+          description: null,
+          skills: null,
+        }),
+      );
+
+      const card = await client.getAgentCard();
+
+      expect(card.description).toBe("");
+      expect(card.skills).toEqual([]);
     });
 
     it("fills defaults for fields omitted by proto3 JSON serialization", async () => {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -187,6 +187,43 @@ const isMessage = (value: unknown): value is A2AMessage =>
   Array.isArray(value.parts) &&
   value.parts.every(isRecord);
 
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isAgentInterface = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.url === "string" &&
+  typeof value.protocolBinding === "string" &&
+  typeof value.protocolVersion === "string";
+
+const isAgentSkill = (value: unknown): boolean =>
+  isRecord(value) &&
+  typeof value.id === "string" &&
+  typeof value.name === "string" &&
+  typeof value.description === "string" &&
+  isStringArray(value.tags);
+
+const isAgentCard = (value: unknown): value is A2AAgentCard =>
+  isRecord(value) &&
+  typeof value.name === "string" &&
+  typeof value.description === "string" &&
+  typeof value.version === "string" &&
+  Array.isArray(value.supportedInterfaces) &&
+  value.supportedInterfaces.every(isAgentInterface) &&
+  isRecord(value.capabilities) &&
+  isStringArray(value.defaultInputModes) &&
+  isStringArray(value.defaultOutputModes) &&
+  Array.isArray(value.skills) &&
+  value.skills.every(isAgentSkill);
+
+const parseAgentCardResponse = (value: unknown): A2AAgentCard => {
+  if (isAgentCard(value)) return value;
+
+  throw new Error(
+    "Invalid A2A agent card response: expected a valid agent card payload.",
+  );
+};
+
 const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {
   if (isRecord(value)) {
     const candidate = value.task ?? value.message ?? value;
@@ -318,14 +355,15 @@ export class A2AClient {
       await this.throwResponseError(response);
     }
     const json = await response.json();
-    return normalizeKeys(json) as A2AAgentCard;
+    return parseAgentCardResponse(normalizeKeys(json));
   }
 
   async getExtendedAgentCard(signal?: AbortSignal): Promise<A2AAgentCard> {
-    return this.fetchJSON<A2AAgentCard>(
+    const result = await this.fetchJSON<unknown>(
       `${this.getBasePath()}/extendedAgentCard`,
       signalInit(signal),
     );
+    return parseAgentCardResponse(result);
   }
 
   // --- Message ---

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -190,38 +190,53 @@ const isMessage = (value: unknown): value is A2AMessage =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
 
-const isAgentInterface = (value: unknown): boolean =>
-  isRecord(value) &&
-  typeof value.url === "string" &&
-  typeof value.protocolBinding === "string" &&
-  typeof value.protocolVersion === "string";
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
 
-const isAgentSkill = (value: unknown): boolean =>
-  isRecord(value) &&
-  typeof value.id === "string" &&
-  typeof value.name === "string" &&
-  typeof value.description === "string" &&
-  isStringArray(value.tags);
+const asStringArray = (value: unknown): string[] =>
+  isStringArray(value) ? value : [];
 
-const isAgentCard = (value: unknown): value is A2AAgentCard =>
-  isRecord(value) &&
-  typeof value.name === "string" &&
-  typeof value.description === "string" &&
-  typeof value.version === "string" &&
-  Array.isArray(value.supportedInterfaces) &&
-  value.supportedInterfaces.every(isAgentInterface) &&
-  isRecord(value.capabilities) &&
-  isStringArray(value.defaultInputModes) &&
-  isStringArray(value.defaultOutputModes) &&
-  Array.isArray(value.skills) &&
-  value.skills.every(isAgentSkill);
+const asRecordArray = (value: unknown): Record<string, unknown>[] =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
 
+// Proto3 JSON serialization omits default-valued fields, so a valid card may
+// arrive without its empty lists, strings, or capabilities. Fill defaults the
+// way AgentCard.fromJSON does instead of rejecting; only a missing name rejects.
 const parseAgentCardResponse = (value: unknown): A2AAgentCard => {
-  if (isAgentCard(value)) return value;
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    value.name.length === 0
+  ) {
+    throw new Error(
+      "Invalid A2A agent card response: expected a valid agent card payload.",
+    );
+  }
 
-  throw new Error(
-    "Invalid A2A agent card response: expected a valid agent card payload.",
-  );
+  return {
+    ...value,
+    name: value.name,
+    description: asString(value.description),
+    version: asString(value.version),
+    supportedInterfaces: asRecordArray(value.supportedInterfaces).map(
+      (entry) => ({
+        ...entry,
+        url: asString(entry.url),
+        protocolBinding: asString(entry.protocolBinding),
+        protocolVersion: asString(entry.protocolVersion),
+      }),
+    ),
+    capabilities: isRecord(value.capabilities) ? value.capabilities : {},
+    defaultInputModes: asStringArray(value.defaultInputModes),
+    defaultOutputModes: asStringArray(value.defaultOutputModes),
+    skills: asRecordArray(value.skills).map((entry) => ({
+      ...entry,
+      id: asString(entry.id),
+      name: asString(entry.name),
+      description: asString(entry.description),
+      tags: asStringArray(entry.tags),
+    })),
+  } as A2AAgentCard;
 };
 
 const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -190,51 +190,63 @@ const isMessage = (value: unknown): value is A2AMessage =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((item) => typeof item === "string");
 
-const asString = (value: unknown): string =>
-  typeof value === "string" ? value : "";
+const invalidAgentCard = (): never => {
+  throw new Error(
+    "Invalid A2A agent card response: expected a valid agent card payload.",
+  );
+};
 
-const asStringArray = (value: unknown): string[] =>
-  isStringArray(value) ? value : [];
+const parseCardString = (value: unknown): string =>
+  value == null ? "" : typeof value === "string" ? value : invalidAgentCard();
 
-const asRecordArray = (value: unknown): Record<string, unknown>[] =>
-  Array.isArray(value) ? value.filter(isRecord) : [];
+const parseCardStringArray = (value: unknown): string[] =>
+  value == null ? [] : isStringArray(value) ? value : invalidAgentCard();
 
-// Proto3 JSON serialization omits default-valued fields, so a valid card may
-// arrive without its empty lists, strings, or capabilities. Fill defaults the
-// way AgentCard.fromJSON does instead of rejecting; only a missing name rejects.
+const parseCardRecordArray = (value: unknown): Record<string, unknown>[] =>
+  value == null
+    ? []
+    : Array.isArray(value) && value.every(isRecord)
+      ? (value as Record<string, unknown>[])
+      : invalidAgentCard();
+
+const parseCardRecord = (value: unknown): Record<string, unknown> =>
+  value == null ? {} : isRecord(value) ? value : invalidAgentCard();
+
+// Proto3 JSON parsing treats omitted and null fields as defaults, so a valid
+// card may arrive without its empty lists, strings, or capabilities. Fill
+// those per the proto3 JSON mapping rules; a payload without a name or with a
+// present field of the wrong type rejects.
 const parseAgentCardResponse = (value: unknown): A2AAgentCard => {
   if (
     !isRecord(value) ||
     typeof value.name !== "string" ||
     value.name.length === 0
   ) {
-    throw new Error(
-      "Invalid A2A agent card response: expected a valid agent card payload.",
-    );
+    return invalidAgentCard();
   }
 
   return {
     ...value,
     name: value.name,
-    description: asString(value.description),
-    version: asString(value.version),
-    supportedInterfaces: asRecordArray(value.supportedInterfaces).map(
+    description: parseCardString(value.description),
+    version: parseCardString(value.version),
+    supportedInterfaces: parseCardRecordArray(value.supportedInterfaces).map(
       (entry) => ({
         ...entry,
-        url: asString(entry.url),
-        protocolBinding: asString(entry.protocolBinding),
-        protocolVersion: asString(entry.protocolVersion),
+        url: parseCardString(entry.url),
+        protocolBinding: parseCardString(entry.protocolBinding),
+        protocolVersion: parseCardString(entry.protocolVersion),
       }),
     ),
-    capabilities: isRecord(value.capabilities) ? value.capabilities : {},
-    defaultInputModes: asStringArray(value.defaultInputModes),
-    defaultOutputModes: asStringArray(value.defaultOutputModes),
-    skills: asRecordArray(value.skills).map((entry) => ({
+    capabilities: parseCardRecord(value.capabilities),
+    defaultInputModes: parseCardStringArray(value.defaultInputModes),
+    defaultOutputModes: parseCardStringArray(value.defaultOutputModes),
+    skills: parseCardRecordArray(value.skills).map((entry) => ({
       ...entry,
-      id: asString(entry.id),
-      name: asString(entry.name),
-      description: asString(entry.description),
-      tags: asStringArray(entry.tags),
+      id: parseCardString(entry.id),
+      name: parseCardString(entry.name),
+      description: parseCardString(entry.description),
+      tags: parseCardStringArray(entry.tags),
     })),
   } as A2AAgentCard;
 };


### PR DESCRIPTION
## Summary

- validate required fields in A2A agent card responses
- apply the same validation to standard and extended agent-card discovery
- preserve existing snake_case normalization for valid protocol responses
- add regression coverage for empty and malformed successful responses

## Why

While testing A2A discovery locally, I found that an endpoint returning HTTP 200 with `{}` was accepted as an `A2AAgentCard`. HTTP success only confirms that the request completed; it does not guarantee the payload contains the required agent-card fields.

That leaves properties such as `name`, `capabilities`, and `supportedInterfaces` typed as present while they are actually `undefined`, which can lead consumers to make capability decisions from invalid discovery data.

## Fix

Normalize incoming keys first, then validate the required top-level fields and the required fields of supported interfaces and skills. Invalid responses now reject with a contextual error instead of passing through as a typed agent card.

Valid cards, including snake_case responses, continue through the existing normalization path unchanged.

## Validation

- `pnpm test -- A2AClient.test.ts` (3 files, 138 tests)
- `pnpm exec oxlint packages/react-a2a/src/A2AClient.ts packages/react-a2a/src/A2AClient.test.ts`
- `pnpm exec oxfmt --check packages/react-a2a/src/A2AClient.ts packages/react-a2a/src/A2AClient.test.ts .changeset/fair-a2a-cards.md`
- `pnpm --filter @assistant-ui/react-a2a build`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

