### PR TITLE
fix(core): persist LocalRuntime runs paused for tool approval

### DIFF
--- a/.changeset/local-runtime-paused-approval-history.md
+++ b/.changeset/local-runtime-paused-approval-history.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix(core): persist LocalRuntime runs paused for tool approval

--- a/.changeset/local-runtime-paused-approval-history.md
+++ b/.changeset/local-runtime-paused-approval-history.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
 fix(core): persist LocalRuntime runs paused for tool approval

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2196,6 +2196,7 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   private abortController;
   private _queue;
   private _queueRunInFlight;
+  private _pausedPersistedIds;
   readonly isDisabled = false;
   readonly isSendDisabled = false;
   private _isLoading;
@@ -4093,6 +4094,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2196,6 +2196,8 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   private abortController;
   private _queue;
   private _queueRunInFlight;
+  private _historyWrites;
+  private _chainHistoryWrite;
   private _persistPausedMessage;
   readonly isDisabled = false;
   readonly isSendDisabled = false;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2197,6 +2197,7 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   private _queue;
   private _queueRunInFlight;
   private _pausedPersistedIds;
+  private _persistPartialPause;
   readonly isDisabled = false;
   readonly isSendDisabled = false;
   private _isLoading;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -2196,8 +2196,7 @@ declare class LocalThreadRuntimeCore extends BaseThreadRuntimeCore implements Th
   private abortController;
   private _queue;
   private _queueRunInFlight;
-  private _pausedPersistedIds;
-  private _persistPartialPause;
+  private _persistPausedMessage;
   readonly isDisabled = false;
   readonly isSendDisabled = false;
   private _isLoading;

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1352,6 +1352,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1084,6 +1084,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1478,6 +1478,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1317,6 +1317,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3260,6 +3260,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -2784,6 +2784,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4048,6 +4048,7 @@ type ThreadHistoryAdapter = {
   }>;
   resume?(options: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>): GenericThreadHistoryAdapter<TMessage>;
 };

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -65,6 +65,12 @@ export type ThreadHistoryAdapter = {
     options: ChatModelRunOptions,
   ): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
+  /**
+   * Rewrites an already appended message in place. Adapters that implement this
+   * let a runtime persist a run that is paused for tool approval and finalize
+   * the same message once the run resumes.
+   */
+  update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;
   /** Required when used with `useAISDKRuntime` / `useChatRuntime`. */
   withFormat?<TMessage, TStorageFormat extends Record<string, unknown>>(

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -68,7 +68,9 @@ export type ThreadHistoryAdapter = {
   /**
    * Rewrites a previously appended message in place, keyed by its message id.
    * Adapters that implement this let a runtime persist a run paused for tool
-   * approval and finalize the same message once the run resumes.
+   * approval and finalize the same message once the run resumes. An update may
+   * arrive for an id whose earlier write failed; treat it as an upsert keyed
+   * on the message id rather than assuming the entry exists.
    */
   update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;

--- a/packages/core/src/adapters/thread-history.ts
+++ b/packages/core/src/adapters/thread-history.ts
@@ -66,9 +66,9 @@ export type ThreadHistoryAdapter = {
   ): AsyncGenerator<ChatModelRunResult, void, unknown>;
   append(item: ExportedMessageRepositoryItem): Promise<void>;
   /**
-   * Rewrites an already appended message in place. Adapters that implement this
-   * let a runtime persist a run that is paused for tool approval and finalize
-   * the same message once the run resumes.
+   * Rewrites a previously appended message in place, keyed by its message id.
+   * Adapters that implement this let a runtime persist a run paused for tool
+   * approval and finalize the same message once the run resumes.
    */
   update?(item: ExportedMessageRepositoryItem): Promise<void>;
   delete?(items: ExportedMessageRepositoryItem[]): Promise<void>;

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { extractAuiV0 } from "./AssistantCloudThreadHistoryAdapter";
+
+const auiV0Message = (status: { type: string; reason?: string }) => ({
+  role: "assistant",
+  status,
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: "call-1",
+      toolName: "send_email",
+      args: {},
+      argsText: "{}",
+    },
+  ],
+  metadata: { steps: [{ usage: { inputTokens: 1, outputTokens: 2 } }] },
+});
+
+describe("extractAuiV0", () => {
+  it("returns null for a requires-action message so paused writes never report", () => {
+    expect(
+      extractAuiV0(
+        auiV0Message({ type: "requires-action", reason: "tool-calls" }),
+      ),
+    ).toBeNull();
+  });
+
+  it("reports a terminal message once with its usage", () => {
+    const result = extractAuiV0(auiV0Message({ type: "complete" }));
+    expect(result?.status).toBe("completed");
+    expect(result?.inputTokens).toBe(1);
+    expect(result?.outputTokens).toBe(2);
+  });
+});

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -102,6 +102,17 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     }
   }
 
+  async update({ message }: ExportedMessageRepositoryItem) {
+    const remoteId = this.aui.threadListItem().getState().remoteId;
+    if (!remoteId) return;
+    await this._persistence.update(
+      remoteId,
+      message.id,
+      "aui/v0",
+      auiV0Encode(message),
+    );
+  }
+
   async delete() {
     throw new Error(
       "Assistant Cloud does not support deleting thread messages yet.",

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -380,9 +380,8 @@ function extractAuiV0<T>(content: T): TelemetryData | null {
   };
 
   if (msg.role !== "assistant") return null;
-  // A paused (requires-action) or mid-approval write isn't a finished run —
-  // reporting it would both mislabel it as "completed" (no map entry below)
-  // and double-count the same steps again when the terminal write reports.
+  // A paused (requires-action) write is not a finished run; reporting it would
+  // mislabel it "completed" and double-count steps once the terminal write reports.
   if (msg.status?.type === "requires-action") return null;
 
   const toolCalls = msg.content

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -380,6 +380,10 @@ function extractAuiV0<T>(content: T): TelemetryData | null {
   };
 
   if (msg.role !== "assistant") return null;
+  // A paused (requires-action) or mid-approval write isn't a finished run —
+  // reporting it would both mislabel it as "completed" (no map entry below)
+  // and double-count the same steps again when the terminal write reports.
+  if (msg.status?.type === "requires-action") return null;
 
   const toolCalls = msg.content
     ?.filter((p) => p.type === "tool-call" && p.toolName && p.toolCallId)

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -105,12 +105,12 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   async update({ message }: ExportedMessageRepositoryItem) {
     const remoteId = this.aui.threadListItem().getState().remoteId;
     if (!remoteId) return;
-    await this._persistence.update(
-      remoteId,
-      message.id,
-      "aui/v0",
-      auiV0Encode(message),
-    );
+    const encoded = auiV0Encode(message);
+    await this._persistence.update(remoteId, message.id, "aui/v0", encoded);
+
+    if (this.cloudRef.current.telemetry.enabled) {
+      this._maybeReportRun(remoteId, "aui/v0", encoded);
+    }
   }
 
   async delete() {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -102,7 +102,11 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
     }
   }
 
-  async update({ message }: ExportedMessageRepositoryItem) {
+  async update(item: ExportedMessageRepositoryItem) {
+    if (!this._persistence.isPersisted(item.message.id)) {
+      return this.append(item);
+    }
+    const { message } = item;
     const remoteId = this.aui.threadListItem().getState().remoteId;
     if (!remoteId) return;
     const encoded = auiV0Encode(message);
@@ -352,7 +356,7 @@ const AUI_STATUS_MAP: Record<string, TelemetryData["status"]> = {
   incomplete: "incomplete",
 };
 
-function extractAuiV0<T>(content: T): TelemetryData | null {
+export function extractAuiV0<T>(content: T): TelemetryData | null {
   const msg = content as {
     role?: string;
     status?: { type: string };

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -6,6 +6,7 @@ import type {
   SourceProviderMetadata,
   ThreadMessage,
   TextMessagePart,
+  ToolApprovalOption,
   Unstable_AudioMessagePart,
 } from "../../../types/message";
 import type { CompleteAttachment } from "../../../types/attachment";
@@ -17,6 +18,16 @@ import type {
   ReadonlyJSONValue,
 } from "assistant-stream/utils";
 import type { ExportedMessageRepositoryItem } from "../../../runtime/utils/message-repository";
+
+type AuiV0ToolApproval = {
+  readonly id: string;
+  readonly approved?: boolean;
+  readonly reason?: string;
+  readonly isAutomatic?: boolean;
+  readonly options?: readonly ToolApprovalOption[];
+  readonly optionId?: string;
+  readonly resolution?: "cancelled" | "expired";
+};
 
 type AuiV0MessagePart =
   | {
@@ -51,6 +62,7 @@ type AuiV0MessagePart =
       readonly args: ReadonlyJSONObject;
       readonly result?: ReadonlyJSONValue;
       readonly isError?: true;
+      readonly approval?: AuiV0ToolApproval;
     }
   | {
       readonly type: "tool-call";
@@ -59,6 +71,7 @@ type AuiV0MessagePart =
       readonly argsText: string;
       readonly result?: ReadonlyJSONValue;
       readonly isError?: true;
+      readonly approval?: AuiV0ToolApproval;
     }
   | {
       readonly type: "image";
@@ -216,6 +229,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               ? { result: part.result as ReadonlyJSONValue }
               : undefined),
             ...(part.isError ? { isError: true } : undefined),
+            ...(part.approval ? { approval: part.approval } : undefined),
           };
         }
 

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../runtime/utils/chat-model-adapter";
 import type { AppendMessage } from "../../types/message";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
+import type { ExportedMessageRepositoryItem } from "../../runtime/utils/message-repository";
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -14,6 +15,7 @@ const createThread = (
   adapter: ChatModelAdapter,
   options?: {
     suggestion?: LocalRuntimeOptionsBase["adapters"]["suggestion"];
+    history?: LocalRuntimeOptionsBase["adapters"]["history"];
   },
 ) => {
   const core = new LocalRuntimeCore(
@@ -22,6 +24,9 @@ const createThread = (
         chatModel: adapter,
         ...(options?.suggestion !== undefined && {
           suggestion: options.suggestion,
+        }),
+        ...(options?.history !== undefined && {
+          history: options.history,
         }),
       },
       unstable_humanToolNames: ["send_email"],
@@ -558,5 +563,176 @@ describe("LocalThreadRuntimeCore suggestions", () => {
     resolveSuggestions([{ prompt: "follow up" }]);
     await new Promise((r) => setTimeout(r, 0));
     expect(thread.suggestions).toEqual([{ prompt: "follow up" }]);
+  });
+});
+
+describe("LocalThreadRuntimeCore tool approval persistence", () => {
+  const createHistory = (options?: { update?: boolean }) => {
+    const appended: ExportedMessageRepositoryItem[] = [];
+    const updated: ExportedMessageRepositoryItem[] = [];
+    const history = {
+      async load() {
+        return { messages: [] };
+      },
+      async append(item: ExportedMessageRepositoryItem) {
+        appended.push(item);
+      },
+      ...(options?.update !== false && {
+        async update(item: ExportedMessageRepositoryItem) {
+          updated.push(item);
+        },
+      }),
+    };
+    return { history, appended, updated };
+  };
+
+  const createApprovalThreadWithHistory = (
+    history: LocalRuntimeOptionsBase["adapters"]["history"],
+  ) => {
+    const runs: ChatModelRunOptions[] = [];
+    return createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1)
+            return toolCallResult("send_email", { id: "a1" });
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+  };
+
+  it("persists a run paused for approval and rewrites it once the run finishes", async () => {
+    const { history, appended, updated } = createHistory();
+    const thread = createApprovalThreadWithHistory(history);
+
+    await thread.append(userMessage("send an email"));
+    await flush();
+
+    const assistant = appended.find((i) => i.message.role === "assistant");
+    expect(assistant?.message.status?.type).toBe("requires-action");
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+    expect(
+      appended.filter((i) => i.message.id === assistant?.message.id),
+    ).toHaveLength(1);
+    expect(updated.at(-1)?.message.id).toBe(assistant?.message.id);
+    expect(updated.at(-1)?.message.status?.type).toBe("complete");
+  });
+
+  it("keeps the append-only behavior for adapters without update", async () => {
+    const { history, appended } = createHistory({ update: false });
+    const thread = createApprovalThreadWithHistory(history);
+
+    await thread.append(userMessage("send an email"));
+    await flush();
+
+    expect(appended.some((i) => i.message.role === "assistant")).toBe(false);
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    const assistants = appended.filter((i) => i.message.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]?.message.status?.type).toBe("complete");
+  });
+
+  it("rewrites a restored paused message instead of appending a duplicate", async () => {
+    const { history, appended, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const paused: ExportedMessageRepositoryItem = {
+      parentId: null,
+      message: {
+        id: "restored",
+        role: "assistant",
+        content: [toolCallPart("send_email", { id: "a1" })],
+        status: { type: "requires-action", reason: "tool-calls" },
+        createdAt: new Date(),
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+        },
+      },
+    };
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      {
+        history: {
+          ...history,
+          async load() {
+            return { headId: "restored", messages: [paused] };
+          },
+        },
+      },
+    );
+
+    thread.__internal_load();
+    await flush();
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(appended).toHaveLength(0);
+    expect(updated.at(-1)?.message.id).toBe("restored");
+    expect(updated.at(-1)?.message.status?.type).toBe("complete");
+  });
+
+  it("still appends a restored paused message when the adapter cannot update", async () => {
+    const { history, appended } = createHistory({ update: false });
+    const paused: ExportedMessageRepositoryItem = {
+      parentId: null,
+      message: {
+        id: "restored",
+        role: "assistant",
+        content: [toolCallPart("send_email", { id: "a1" })],
+        status: { type: "requires-action", reason: "tool-calls" },
+        createdAt: new Date(),
+        metadata: {
+          unstable_state: null,
+          unstable_annotations: [],
+          unstable_data: [],
+          steps: [],
+          custom: {},
+        },
+      },
+    };
+    const thread = createThread(
+      {
+        async run() {
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      {
+        history: {
+          ...history,
+          async load() {
+            return { headId: "restored", messages: [paused] };
+          },
+        },
+      },
+    );
+
+    thread.__internal_load();
+    await flush();
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(appended).toHaveLength(1);
+    expect(appended[0]?.message.id).toBe("restored");
+    expect(appended[0]?.message.status?.type).toBe("complete");
   });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -946,4 +946,64 @@ describe("LocalThreadRuntimeCore tool approval persistence", () => {
     expect(updated).toHaveLength(1);
     expect(updated.at(-1)?.message.status?.type).toBe("incomplete");
   });
+
+  it("orders the terminal rewrite after an in-flight partial decision write", async () => {
+    const order: string[] = [];
+    let releasePartial!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releasePartial = resolve;
+    });
+    const history = {
+      async load() {
+        return { messages: [] };
+      },
+      async append() {},
+      async update(item: ExportedMessageRepositoryItem) {
+        const kind =
+          item.message.status?.type === "requires-action"
+            ? "partial"
+            : "terminal";
+        order.push(`${kind}:start`);
+        if (kind === "partial") await gate;
+        order.push(`${kind}:end`);
+      },
+    };
+    const runs: ChatModelRunOptions[] = [];
+    const twoPendingApprovals: ChatModelRunResult = {
+      content: [
+        { ...toolCallPart("send_email", { id: "a1" }), toolCallId: "call-1" },
+        { ...toolCallPart("send_email", { id: "a2" }), toolCallId: "call-2" },
+      ],
+      status: { type: "requires-action", reason: "tool-calls" },
+    };
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1) return twoPendingApprovals;
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("send two emails"));
+    await flush();
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    thread.respondToToolApproval({ approvalId: "a2", approved: true });
+    await flush();
+
+    expect(order).toEqual(["partial:start"]);
+
+    releasePartial();
+    await flush();
+
+    expect(order).toEqual([
+      "partial:start",
+      "partial:end",
+      "terminal:start",
+      "terminal:end",
+    ]);
+  });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -16,6 +16,7 @@ const createThread = (
   options?: {
     suggestion?: LocalRuntimeOptionsBase["adapters"]["suggestion"];
     history?: LocalRuntimeOptionsBase["adapters"]["history"];
+    maxSteps?: number;
   },
 ) => {
   const core = new LocalRuntimeCore(
@@ -30,6 +31,7 @@ const createThread = (
         }),
       },
       unstable_humanToolNames: ["send_email"],
+      ...(options?.maxSteps !== undefined && { maxSteps: options.maxSteps }),
     },
     undefined,
   );
@@ -835,5 +837,113 @@ describe("LocalThreadRuntimeCore tool approval persistence", () => {
     expect(persisted?.type === "tool-call" && persisted.result).toEqual({
       ok: true,
     });
+  });
+
+  it("persists a multi-step run once instead of writing intermediate steps", async () => {
+    const { history, appended, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1)
+            return {
+              content: [
+                { ...toolCallPart("lookup_weather"), result: { ok: true } },
+              ],
+              status: { type: "requires-action", reason: "tool-calls" },
+            };
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("what is the weather"));
+    await flush();
+
+    expect(runs).toHaveLength(2);
+    const assistants = appended.filter((i) => i.message.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]?.message.status?.type).toBe("complete");
+    expect(updated).toHaveLength(0);
+  });
+
+  it("rewrites the same entry when a resumed run pauses again", async () => {
+    const { history, appended, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1)
+            return toolCallResult("send_email", { id: "a1" });
+          if (runs.length === 2)
+            return {
+              content: [
+                {
+                  ...toolCallPart("send_email", { id: "a2" }),
+                  toolCallId: "call-2",
+                },
+              ],
+              status: { type: "requires-action", reason: "tool-calls" },
+            };
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("send two emails"));
+    await flush();
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(thread.messages.at(-1)?.status?.type).toBe("requires-action");
+
+    thread.respondToToolApproval({ approvalId: "a2", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(3);
+    const assistants = appended.filter((i) => i.message.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]?.message.status?.type).toBe("requires-action");
+    expect(updated).toHaveLength(2);
+    expect(
+      updated.every((i) => i.message.id === assistants[0]?.message.id),
+    ).toBe(true);
+    expect(updated.at(-1)?.message.status?.type).toBe("complete");
+  });
+
+  it("finalizes the history entry when a resumed run hits max steps", async () => {
+    const { history, appended, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          return {
+            content: [toolCallPart("send_email", { id: "a1" })],
+            status: { type: "requires-action", reason: "tool-calls" },
+            metadata: { steps: [{}] },
+          };
+        },
+      },
+      { history, maxSteps: 1 },
+    );
+
+    await thread.append(userMessage("send an email"));
+    await flush();
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    expect(thread.messages.at(-1)?.status?.type).toBe("incomplete");
+    const assistants = appended.filter((i) => i.message.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(updated).toHaveLength(1);
+    expect(updated.at(-1)?.message.status?.type).toBe("incomplete");
   });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -735,4 +735,105 @@ describe("LocalThreadRuntimeCore tool approval persistence", () => {
     expect(appended[0]?.message.id).toBe("restored");
     expect(appended[0]?.message.status?.type).toBe("complete");
   });
+
+  it("persists a partial approval decision while another tool call is still pending", async () => {
+    const { history, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const twoPendingApprovals: ChatModelRunResult = {
+      content: [
+        { ...toolCallPart("send_email", { id: "a1" }), toolCallId: "call-1" },
+        { ...toolCallPart("send_email", { id: "a2" }), toolCallId: "call-2" },
+      ],
+      status: { type: "requires-action", reason: "tool-calls" },
+    };
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1) return twoPendingApprovals;
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("send two emails"));
+    await flush();
+
+    const assistant = thread.messages.at(-1)!;
+    expect(assistant.status?.type).toBe("requires-action");
+
+    thread.respondToToolApproval({ approvalId: "a1", approved: true });
+    await flush();
+
+    // The second approval is still pending, so the run must not resume yet —
+    // but the first decision has to survive a refresh in the meantime.
+    expect(runs).toHaveLength(1);
+    const persisted = updated
+      .at(-1)
+      ?.message.content.find(
+        (c) => c.type === "tool-call" && c.toolCallId === "call-1",
+      );
+    expect(
+      persisted?.type === "tool-call" && persisted.approval?.approved,
+    ).toBe(true);
+  });
+
+  it("persists a partial tool result while another human tool call is still pending", async () => {
+    const { history, updated } = createHistory();
+    const runs: ChatModelRunOptions[] = [];
+    const twoHumanTools: ChatModelRunResult = {
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "send_email",
+          args: {},
+          argsText: "{}",
+        },
+        {
+          type: "tool-call",
+          toolCallId: "call-2",
+          toolName: "send_email",
+          args: {},
+          argsText: "{}",
+        },
+      ],
+      status: { type: "requires-action", reason: "tool-calls" },
+    };
+    const thread = createThread(
+      {
+        async run(options) {
+          runs.push(options);
+          if (runs.length === 1) return twoHumanTools;
+          return { content: [{ type: "text", text: "done" }] };
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("send two emails"));
+    await flush();
+
+    const assistant = thread.messages.at(-1)!;
+
+    thread.addToolResult({
+      messageId: assistant.id,
+      toolName: "send_email",
+      toolCallId: "call-1",
+      result: { ok: true },
+      isError: false,
+    });
+    await flush();
+
+    expect(runs).toHaveLength(1);
+    const persisted = updated
+      .at(-1)
+      ?.message.content.find(
+        (c) => c.type === "tool-call" && c.toolCallId === "call-1",
+      );
+    expect(persisted?.type === "tool-call" && persisted.result).toEqual({
+      ok: true,
+    });
+  });
 });

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -68,6 +68,13 @@ export class LocalThreadRuntimeCore
   private _queue: MessageQueueController | null = null;
   private _queueRunInFlight = false;
 
+  /**
+   * Ids of assistant messages already written to history while their run was
+   * paused for tool approval. A later run for the same message must rewrite that
+   * entry instead of appending a second copy of it.
+   */
+  private _pausedPersistedIds = new Set<string>();
+
   public readonly isDisabled = false;
   public readonly isSendDisabled = false;
 
@@ -200,6 +207,13 @@ export class LocalThreadRuntimeCore
       .then((repo) => {
         if (!repo) return;
         this.repository.import(repo);
+        if (this.adapters.history?.update) {
+          for (const { message } of repo.messages) {
+            if (message.status?.type === "requires-action") {
+              this._pausedPersistedIds.add(message.id);
+            }
+          }
+        }
         if (repo.messages.length > 0) {
           this.ensureInitialized();
         }
@@ -565,15 +579,27 @@ export class LocalThreadRuntimeCore
     } finally {
       this.abortController = null;
 
-      if (
+      const history = this._options.adapters.history;
+      const item = {
+        parentId,
+        message: message,
+        runConfig: this._lastRunConfig,
+      };
+      const isTerminal =
         message.status.type === "complete" ||
-        message.status.type === "incomplete"
-      ) {
-        await this._options.adapters.history?.append({
-          parentId,
-          message: message,
-          runConfig: this._lastRunConfig,
-        });
+        message.status.type === "incomplete";
+
+      if (this._pausedPersistedIds.has(message.id)) {
+        if (isTerminal) this._pausedPersistedIds.delete(message.id);
+        await history?.update?.(item);
+      } else if (isTerminal) {
+        await history?.append(item);
+      } else if (message.status.type === "requires-action" && history?.update) {
+        // Persisting the pause is only safe for adapters that can rewrite the
+        // entry later; an append-only adapter would strand a half-finished run
+        // in history with no way to finalize it once the approval resolves.
+        this._pausedPersistedIds.add(message.id);
+        await history.append(item);
       }
     }
     return message;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -68,6 +68,31 @@ export class LocalThreadRuntimeCore
   private _queue: MessageQueueController | null = null;
   private _queueRunInFlight = false;
 
+  private _historyWrites = new Map<string, Promise<void>>();
+
+  // Writes for one message id must land in issue order; an earlier paused
+  // snapshot arriving after the terminal write would resurrect the pause.
+  private _chainHistoryWrite(
+    id: string,
+    write: () => Promise<void>,
+  ): Promise<void> {
+    const next = (this._historyWrites.get(id) ?? Promise.resolve()).then(
+      write,
+      write,
+    );
+    const stored = next.then(
+      () => {},
+      () => {},
+    );
+    this._historyWrites.set(id, stored);
+    void stored.then(() => {
+      if (this._historyWrites.get(id) === stored) {
+        this._historyWrites.delete(id);
+      }
+    });
+    return next;
+  }
+
   // A decision recorded on a still-paused message must reach history before
   // the run resumes, or a refresh would restore the message without it.
   private _persistPausedMessage(
@@ -75,9 +100,11 @@ export class LocalThreadRuntimeCore
     message: ThreadAssistantMessage,
   ) {
     if (message.status?.type !== "requires-action") return;
-    this._options.adapters.history
-      ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
-      .catch(() => {});
+    const history = this._options.adapters.history;
+    if (!history?.update) return;
+    const update = history.update.bind(history);
+    const item = { parentId, message, runConfig: this._lastRunConfig };
+    this._chainHistoryWrite(message.id, () => update(item)).catch(() => {});
   }
 
   public readonly isDisabled = false;
@@ -600,10 +627,12 @@ export class LocalThreadRuntimeCore
       // Pauses are written only for adapters that can rewrite the entry later;
       // an append-only adapter would strand a half-finished run in history.
       if (isTerminal || (isPausing && history?.update)) {
-        if (alreadyPersisted && history?.update) {
-          await history.update(item);
-        } else {
-          await history?.append(item);
+        const write =
+          alreadyPersisted && history?.update
+            ? history.update.bind(history)
+            : history?.append.bind(history);
+        if (write) {
+          await this._chainHistoryWrite(message.id, () => write(item));
         }
       }
     }

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -75,6 +75,19 @@ export class LocalThreadRuntimeCore
    */
   private _pausedPersistedIds = new Set<string>();
 
+  // Other tool calls on the message may still be awaiting approval, so the run
+  // won't resume (and persist) yet — write this decision now, or a refresh
+  // before the rest resolve would restore the pre-decision message.
+  private _persistPartialPause(
+    parentId: string | null,
+    message: ThreadAssistantMessage,
+  ) {
+    if (!this._pausedPersistedIds.has(message.id)) return;
+    this._options.adapters.history
+      ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
+      .catch(() => {});
+  }
+
   public readonly isDisabled = false;
   public readonly isSendDisabled = false;
 
@@ -674,13 +687,8 @@ export class LocalThreadRuntimeCore
       shouldContinue(message, this._options.unstable_humanToolNames)
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
-    } else if (added && this._pausedPersistedIds.has(message.id)) {
-      // Other tool calls on this message are still awaiting approval, so the
-      // run won't resume (and persist) yet — write this decision now, or a
-      // refresh before the rest resolve would restore the pre-decision message.
-      this._options.adapters.history
-        ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
-        .catch(() => {});
+    } else if (added) {
+      this._persistPartialPause(parentId, message);
     }
   }
 
@@ -759,13 +767,8 @@ export class LocalThreadRuntimeCore
       shouldContinue(message, this._options.unstable_humanToolNames)
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
-    } else if (this._pausedPersistedIds.has(message.id)) {
-      // Other tool calls on this message are still awaiting approval, so the
-      // run won't resume (and persist) yet — write this decision now, or a
-      // refresh before the rest resolve would restore the pre-decision message.
-      this._options.adapters.history
-        ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
-        .catch(() => {});
+    } else {
+      this._persistPartialPause(parentId, message);
     }
   }
 }

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -590,16 +590,21 @@ export class LocalThreadRuntimeCore
         message.status.type === "incomplete";
 
       if (this._pausedPersistedIds.has(message.id)) {
-        if (isTerminal) this._pausedPersistedIds.delete(message.id);
+        // Only drop the id once the write actually lands — if update rejects,
+        // the id must stay so the next attempt retries via update, not append
+        // (which would duplicate the message).
         await history?.update?.(item);
+        if (isTerminal) this._pausedPersistedIds.delete(message.id);
       } else if (isTerminal) {
         await history?.append(item);
       } else if (message.status.type === "requires-action" && history?.update) {
         // Persisting the pause is only safe for adapters that can rewrite the
         // entry later; an append-only adapter would strand a half-finished run
         // in history with no way to finalize it once the approval resolves.
-        this._pausedPersistedIds.add(message.id);
+        // Mark it only once the append confirms, or a failed append would
+        // leave the id in the set with nothing in the store to update.
         await history.append(item);
+        this._pausedPersistedIds.add(message.id);
       }
     }
     return message;
@@ -669,6 +674,13 @@ export class LocalThreadRuntimeCore
       shouldContinue(message, this._options.unstable_humanToolNames)
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
+    } else if (added && this._pausedPersistedIds.has(message.id)) {
+      // Other tool calls on this message are still awaiting approval, so the
+      // run won't resume (and persist) yet — write this decision now, or a
+      // refresh before the rest resolve would restore the pre-decision message.
+      this._options.adapters.history
+        ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
+        .catch(() => {});
     }
   }
 
@@ -747,6 +759,13 @@ export class LocalThreadRuntimeCore
       shouldContinue(message, this._options.unstable_humanToolNames)
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
+    } else if (this._pausedPersistedIds.has(message.id)) {
+      // Other tool calls on this message are still awaiting approval, so the
+      // run won't resume (and persist) yet — write this decision now, or a
+      // refresh before the rest resolve would restore the pre-decision message.
+      this._options.adapters.history
+        ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
+        .catch(() => {});
     }
   }
 }

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -68,21 +68,13 @@ export class LocalThreadRuntimeCore
   private _queue: MessageQueueController | null = null;
   private _queueRunInFlight = false;
 
-  /**
-   * Ids of assistant messages already written to history while their run was
-   * paused for tool approval. A later run for the same message must rewrite that
-   * entry instead of appending a second copy of it.
-   */
-  private _pausedPersistedIds = new Set<string>();
-
-  // Other tool calls on the message may still be awaiting approval, so the run
-  // won't resume (and persist) yet — write this decision now, or a refresh
-  // before the rest resolve would restore the pre-decision message.
-  private _persistPartialPause(
+  // A decision recorded on a still-paused message must reach history before
+  // the run resumes, or a refresh would restore the message without it.
+  private _persistPausedMessage(
     parentId: string | null,
     message: ThreadAssistantMessage,
   ) {
-    if (!this._pausedPersistedIds.has(message.id)) return;
+    if (message.status?.type !== "requires-action") return;
     this._options.adapters.history
       ?.update?.({ parentId, message, runConfig: this._lastRunConfig })
       .catch(() => {});
@@ -220,13 +212,6 @@ export class LocalThreadRuntimeCore
       .then((repo) => {
         if (!repo) return;
         this.repository.import(repo);
-        if (this.adapters.history?.update) {
-          for (const { message } of repo.messages) {
-            if (message.status?.type === "requires-action") {
-              this._pausedPersistedIds.add(message.id);
-            }
-          }
-        }
         if (repo.messages.length > 0) {
           this.ensureInitialized();
         }
@@ -378,6 +363,12 @@ export class LocalThreadRuntimeCore
   ): Promise<void> {
     this._notifyEventSubscribers("runStart", {});
 
+    // A run entered on a requires-action message resumes a pause an
+    // update-capable adapter already holds (written at pause time or loaded).
+    const alreadyPersisted =
+      message.status?.type === "requires-action" &&
+      this._options.adapters.history?.update !== undefined;
+
     try {
       // mark busy for runs not started through the queue (regenerate, resume)
       this._queue?.notifyBusy();
@@ -391,6 +382,7 @@ export class LocalThreadRuntimeCore
           parentId,
           message,
           runConfig,
+          alreadyPersisted,
           runCallback,
         );
         runCallback = undefined;
@@ -433,6 +425,7 @@ export class LocalThreadRuntimeCore
     parentId: string | null,
     message: ThreadAssistantMessage,
     runConfig: RunConfig | undefined,
+    alreadyPersisted: boolean,
     runCallback?: ChatModelAdapter["run"],
   ) {
     const messages = parentId ? this.repository.getMessages(parentId) : [];
@@ -498,17 +491,18 @@ export class LocalThreadRuntimeCore
 
     const maxSteps = this._options.maxSteps ?? 2;
 
-    const steps = message.metadata?.steps?.length ?? 0;
-    if (steps >= maxSteps) {
-      // reached max tool steps
-      updateMessage({
-        status: {
-          type: "incomplete",
-          reason: "tool-calls",
-        },
-      });
-      return message;
-    } else {
+    try {
+      const steps = message.metadata?.steps?.length ?? 0;
+      if (steps >= maxSteps) {
+        updateMessage({
+          status: {
+            type: "incomplete",
+            reason: "tool-calls",
+          },
+        });
+        return message;
+      }
+
       updateMessage({
         status: {
           type: "running",
@@ -518,9 +512,7 @@ export class LocalThreadRuntimeCore
       // Switch to the new message branch right after adding it for the first time
       this.repository.resetHead(message.id);
       this._notifySubscribers();
-    }
 
-    try {
       this._lastRunConfig = runConfig ?? {};
       // unstable_composerMetadata is composer-only (stamped onto the outgoing
       // message); never expose it to the chat-model adapter's run context.
@@ -595,29 +587,24 @@ export class LocalThreadRuntimeCore
       const history = this._options.adapters.history;
       const item = {
         parentId,
-        message: message,
+        message,
         runConfig: this._lastRunConfig,
       };
       const isTerminal =
         message.status.type === "complete" ||
         message.status.type === "incomplete";
+      const isPausing =
+        message.status.type === "requires-action" &&
+        !shouldContinue(message, this._options.unstable_humanToolNames);
 
-      if (this._pausedPersistedIds.has(message.id)) {
-        // Only drop the id once the write actually lands — if update rejects,
-        // the id must stay so the next attempt retries via update, not append
-        // (which would duplicate the message).
-        await history?.update?.(item);
-        if (isTerminal) this._pausedPersistedIds.delete(message.id);
-      } else if (isTerminal) {
-        await history?.append(item);
-      } else if (message.status.type === "requires-action" && history?.update) {
-        // Persisting the pause is only safe for adapters that can rewrite the
-        // entry later; an append-only adapter would strand a half-finished run
-        // in history with no way to finalize it once the approval resolves.
-        // Mark it only once the append confirms, or a failed append would
-        // leave the id in the set with nothing in the store to update.
-        await history.append(item);
-        this._pausedPersistedIds.add(message.id);
+      // Pauses are written only for adapters that can rewrite the entry later;
+      // an append-only adapter would strand a half-finished run in history.
+      if (isTerminal || (isPausing && history?.update)) {
+        if (alreadyPersisted && history?.update) {
+          await history.update(item);
+        } else {
+          await history?.append(item);
+        }
       }
     }
     return message;
@@ -688,7 +675,7 @@ export class LocalThreadRuntimeCore
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
     } else if (added) {
-      this._persistPartialPause(parentId, message);
+      this._persistPausedMessage(parentId, message);
     }
   }
 
@@ -768,7 +755,7 @@ export class LocalThreadRuntimeCore
     ) {
       this._runLoop(parentId, message, this._lastRunConfig).catch(() => {});
     } else {
-      this._persistPartialPause(parentId, message);
+      this._persistPausedMessage(parentId, message);
     }
   }
 }

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -53,6 +53,35 @@ describe("auiV0Encode", () => {
     ]);
   });
 
+  it("preserves a pending tool-call approval in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "send_email",
+          args: {},
+          argsText: "{}",
+          approval: { id: "a1" },
+        },
+      ],
+    });
+
+    const toolCall = encoded.content.find((p) => p.type === "tool-call");
+    expect(toolCall).toMatchObject({ approval: { id: "a1" } });
+  });
+
   it("preserves user attachments in the core cloud encoder", () => {
     const encoded = auiV0Encode({
       id: "m1",
@@ -129,6 +158,51 @@ describe("auiV0Encode", () => {
 });
 
 describe("auiV0Decode", () => {
+  it("round-trips a pending tool-call approval so a paused run stays resumable", () => {
+    const content = auiV0Encode({
+      id: "local",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "send_email",
+          args: {},
+          argsText: "{}",
+          approval: { id: "a1" },
+        },
+      ],
+    });
+
+    const decoded = auiV0Decode({
+      id: "cloud",
+      parent_id: null,
+      height: 0,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+      updated_at: new Date("2026-03-15T00:00:00.000Z"),
+      format: "aui/v0",
+      content: content as never,
+    });
+
+    if (decoded.message.role !== "assistant")
+      throw new Error("expected assistant");
+    const toolCall = decoded.message.content.find(
+      (p) => p.type === "tool-call",
+    );
+    expect(toolCall?.type === "tool-call" && toolCall.approval).toEqual({
+      id: "a1",
+    });
+  });
+
   it("restores user attachments from core cloud history", () => {
     const content = auiV0Encode({
       id: "local",

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -7,6 +7,7 @@ import type {
   SourceProviderMetadata,
   ThreadMessage,
   TextMessagePart,
+  ToolApprovalOption,
   Unstable_AudioMessagePart,
 } from "@assistant-ui/core";
 import { fromThreadMessageLike } from "../runtime-cores/external-store/ThreadMessageLike";
@@ -17,6 +18,16 @@ import type {
   ReadonlyJSONValue,
 } from "assistant-stream/utils";
 import type { ExportedMessageRepositoryItem } from "../runtime-cores/utils/MessageRepository";
+
+type AuiV0ToolApproval = {
+  readonly id: string;
+  readonly approved?: boolean;
+  readonly reason?: string;
+  readonly isAutomatic?: boolean;
+  readonly options?: readonly ToolApprovalOption[];
+  readonly optionId?: string;
+  readonly resolution?: "cancelled" | "expired";
+};
 
 type AuiV0MessagePart =
   | {
@@ -51,6 +62,7 @@ type AuiV0MessagePart =
       readonly args: ReadonlyJSONObject;
       readonly result?: ReadonlyJSONValue;
       readonly isError?: true;
+      readonly approval?: AuiV0ToolApproval;
     }
   | {
       readonly type: "tool-call";
@@ -59,6 +71,7 @@ type AuiV0MessagePart =
       readonly argsText: string;
       readonly result?: ReadonlyJSONValue;
       readonly isError?: true;
+      readonly approval?: AuiV0ToolApproval;
     }
   | {
       readonly type: "image";
@@ -216,6 +229,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
               ? { result: part.result as ReadonlyJSONValue }
               : undefined),
             ...(part.isError ? { isError: true } : undefined),
+            ...(part.approval ? { approval: part.approval } : undefined),
           };
         }
 


### PR DESCRIPTION
Closes #5054.

LocalRuntime only appends to history when a run reaches `complete` or `incomplete`, so a run that stops at `requires-action` for a tool approval is never written. Refresh the page mid-approval and the pending approval is gone.

As #5054 notes, the #5051 shape does not transplant: it finalizes through the formatted adapter's `update`, and the top-level `ThreadHistoryAdapter` has none. So this adds an optional `update(item)` there and implements it on the Assistant Cloud adapter on top of `CloudMessagePersistence.update`, paired with the cloud side's leaf-only message update endpoint.

the persistence protocol is stateless and keyed on the message id:

- each run loop writes history exactly once, at its end. a run entered on a `requires-action` message resumes a pause that an update-capable adapter already holds (written at pause time or restored via load), so it rewrites that entry through `update`; anything else appends. no persisted-id set, no load-time seeding, and restore needs no index.
- pauses are only written when the adapter implements `update`; append-only adapters keep the exact old behavior (terminal-only appends), so no half-finished run is stranded in history.
- a decision on one of several pending approvals is written immediately through `update`, so it survives a refresh while the rest are still pending.
- writes for one message id are serialized through a promise chain, so an in-flight partial write can never land after the terminal rewrite and resurrect the pause.
- the cloud adapter falls back to `append` when the message was never persisted (for example a failed pause write), and run telemetry skips `requires-action` content, so each run reports exactly once, from its terminal write.
- a run that ends by hitting `maxSteps` now persists its terminal `incomplete` state through the same path and clears the abort controller; previously that exit never wrote history, left the controller set (blocking later approval responses), and could leave a paused entry stale forever.

`aui/v0` encodes the tool-call `approval` field so a restored pause can actually be resumed, with encode and decode round-trip tests.

tests cover the paused append plus post-approval rewrite, append-only adapters keeping the old behavior, both restore paths, partial approval and partial tool-result persistence, multi-step runs writing once, a resumed run pausing again, write ordering, maxSteps finalization, and the telemetry guard. `pnpm -C packages/core test` is 599/599, build and lint green.

