### PR TITLE
fix(core): handle failed local history loads

### DIFF
--- a/.changeset/quiet-local-history-loads.md
+++ b/.changeset/quiet-local-history-loads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: handle failed local history loads

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatModelAdapter } from "../../runtime/utils/chat-model-adapter";
+import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
+import { useLocalRuntime } from "./useLocalRuntime";
+
+const chatModel: ChatModelAdapter = {
+  run: async () => ({ content: [] }),
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useLocalRuntime", () => {
+  it("handles rejected history loads", async () => {
+    const error = new Error("history unavailable");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const history = {
+      load: vi.fn().mockRejectedValue(error),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const App = () => {
+      const runtime = useLocalRuntime(chatModel, { adapters: { history } });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <div />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const renderApp = () => (
+      <StrictMode>
+        <App />
+      </StrictMode>
+    );
+    const { rerender } = render(renderApp());
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] local thread history load failed:",
+        error,
+      );
+    });
+
+    rerender(renderApp());
+    expect(history.load).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/react/runtimes/useLocalRuntime.ts
+++ b/packages/core/src/react/runtimes/useLocalRuntime.ts
@@ -35,6 +35,7 @@ const useLocalThreadRuntime = (
   const [runtime] = useState(() => new LocalRuntimeCore(opt, initialMessages));
 
   const threadIdRef = useRef<string | undefined>(undefined);
+  const historyLoadPromiseRef = useRef<Promise<void> | undefined>(undefined);
   threadIdRef.current = useAuiState((s) => s.threadListItem.remoteId);
 
   useEffect(() => {
@@ -51,8 +52,19 @@ const useLocalThreadRuntime = (
 
   useEffect(() => {
     runtime.threads.getMainThreadRuntimeCore().__internal_setOptions(opt);
-    runtime.threads.getMainThreadRuntimeCore().__internal_load();
   });
+
+  useEffect(() => {
+    const loadPromise = runtime.threads
+      .getMainThreadRuntimeCore()
+      .__internal_load();
+    if (historyLoadPromiseRef.current === loadPromise) return;
+
+    historyLoadPromiseRef.current = loadPromise;
+    void loadPromise.catch((error: unknown) => {
+      console.error("[assistant-ui] local thread history load failed:", error);
+    });
+  }, [runtime]);
 
   useEffect(() => {
     if (!modelContext) return undefined;


### PR DESCRIPTION
## Summary

- consume rejected local history load promises instead of leaking an unhandled rejection
- keep option updates independent from the one-time history load
- report a contextual error once, including under React Strict Mode

## Why

While testing a local runtime with a temporarily unavailable history adapter, `history.load()` rejected with `history unavailable`. The runtime cleared its loading state, but `useLocalRuntime()` ignored the returned promise, so the rejection escaped to the application's global `unhandledRejection` handler.

This keeps the internal promise behavior intact for explicit callers while ensuring the React hook owns the asynchronous task it starts.

## Testing

- `pnpm --filter @assistant-ui/core test` (64 files, 586 tests)
- `pnpm --filter @assistant-ui/core exec tsc --noEmit`
- `pnpm exec oxlint packages/core/src/react/runtimes/useLocalRuntime.ts packages/core/src/react/runtimes/useLocalRuntime.test.tsx`
- `pnpm exec turbo build --filter=@assistant-ui/core...`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

