### PR TITLE
fix(core): generate portable cloud attachment ids

### DIFF
--- a/.changeset/tidy-cloud-attachments.md
+++ b/.changeset/tidy-cloud-attachments.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: generate Cloud attachment IDs without requiring Web Crypto

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts
@@ -57,6 +57,22 @@ describe("CloudFileAttachmentAdapter", () => {
     ]);
   });
 
+  it("uploads when Web Crypto is unavailable", async () => {
+    vi.stubGlobal("crypto", undefined);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    const adapter = new CloudFileAttachmentAdapter(makeCloud());
+
+    const yields = await drain(adapter);
+
+    expect(yields).toHaveLength(2);
+    expect(yields[0]?.id).toBeTruthy();
+    expect(yields[1]?.id).toBe(yields[0]?.id);
+    expect(yields.at(-1)?.status).toEqual({
+      type: "requires-action",
+      reason: "composer-send",
+    });
+  });
+
   it("marks the attachment incomplete when the upload returns an HTTP error", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal(

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../../types/attachment";
 import type { ThreadUserMessagePart } from "../../../types/message";
 import type { AttachmentAdapter } from "../../../adapters/attachment";
+import { generateId } from "../../../utils/id";
 
 const guessAttachmentType = (
   contentType: string,
@@ -27,7 +28,7 @@ export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   }: {
     file: File;
   }): AsyncGenerator<PendingAttachment, void> {
-    const id = crypto.randomUUID();
+    const id = generateId();
     const type = guessAttachmentType(file.type);
     let attachment: PendingAttachment = {
       id,


### PR DESCRIPTION
## Summary

- replace the direct `crypto.randomUUID()` call in `CloudFileAttachmentAdapter` with core’s existing portable `generateId()` helper
- add a regression test that uploads an attachment with `globalThis.crypto` unavailable
- add a patch changeset for `@assistant-ui/core`

## Why

The Cloud attachment adapter creates a temporary local ID before it requests a presigned URL and uploads the file. Calling `crypto.randomUUID()` directly throws in environments where Web Crypto is unavailable, including some WebViews, older browser runtimes, and test environments, so the upload fails before it can begin.

This ID is only used to track the attachment as it moves from pending to ready; it is not an authentication token or security boundary. Reusing core’s existing portable `generateId()` helper therefore preserves the behavior in standard browsers while allowing the same upload flow to work without a global Web Crypto implementation.

## Testing

- `pnpm --filter @assistant-ui/core exec vitest run src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts`
- `pnpm turbo build --filter=@assistant-ui/core...`
- `pnpm exec oxlint packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

