### PR TITLE
fix(core): refresh cloud history persistence on client change

### DIFF
--- a/.changeset/bright-clouds-refresh.md
+++ b/.changeset/bright-clouds-refresh.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: refresh Cloud history persistence when the Cloud client changes

--- a/.changeset/bright-clouds-refresh.md
+++ b/.changeset/bright-clouds-refresh.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"assistant-cloud": patch
 ---
 
 fix: refresh Cloud history persistence when the Cloud client changes

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -275,9 +275,10 @@ type CloudMessage = {
 };
 
 declare class CloudMessagePersistence {
-  private cloud;
   private idMapping;
+  private getCloud;
   constructor(cloud: AssistantCloud);
+  constructor(getCloud: () => AssistantCloud);
   append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;
   update(threadId: string, messageId: string, _format: string, content: ReadonlyJSONObject): Promise<void>;
   isPersisted(messageId: string): boolean;

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -14,8 +14,13 @@ import type { AssistantCloud } from "./AssistantCloud";
  */
 export class CloudMessagePersistence {
   private idMapping: Record<string, string | Promise<string>> = {};
+  private getCloud: () => AssistantCloud;
 
-  constructor(private cloud: AssistantCloud) {}
+  constructor(cloud: AssistantCloud);
+  constructor(getCloud: () => AssistantCloud);
+  constructor(cloud: AssistantCloud | (() => AssistantCloud)) {
+    this.getCloud = typeof cloud === "function" ? cloud : () => cloud;
+  }
 
   /**
    * Persist a message to the cloud.
@@ -33,12 +38,13 @@ export class CloudMessagePersistence {
     format: string,
     content: ReadonlyJSONObject,
   ): Promise<void> {
+    const cloud = this.getCloud();
     // Resolve parent's remote ID if it exists (may be a promise if concurrent)
     const resolvedParentId = parentId
       ? ((await this.idMapping[parentId]) ?? parentId)
       : null;
 
-    const task = this.cloud.threads.messages
+    const task = cloud.threads.messages
       .create(threadId, {
         parent_id: resolvedParentId,
         format,
@@ -70,6 +76,7 @@ export class CloudMessagePersistence {
     _format: string,
     content: ReadonlyJSONObject,
   ): Promise<void> {
+    const cloud = this.getCloud();
     const remoteId = await this.getRemoteId(messageId);
     if (!remoteId) {
       console.warn(
@@ -77,7 +84,7 @@ export class CloudMessagePersistence {
       );
       return;
     }
-    await this.cloud.threads.messages.update(threadId, remoteId, { content });
+    await cloud.threads.messages.update(threadId, remoteId, { content });
   }
 
   /**
@@ -108,7 +115,8 @@ export class CloudMessagePersistence {
    * @returns Array of cloud messages
    */
   async load(threadId: string, format?: string) {
-    const { messages } = await this.cloud.threads.messages.list(
+    const cloud = this.getCloud();
+    const { messages } = await cloud.threads.messages.list(
       threadId,
       format ? { format } : undefined,
     );

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -37,6 +37,33 @@ describe("CloudMessagePersistence", () => {
     expect(await persistence.getRemoteId("local-1")).toBe("remote-1");
   });
 
+  it("uses the current client without losing ID mappings", async () => {
+    const firstCloud = createMockCloud();
+    const secondCloud = createMockCloud();
+    let currentCloud = firstCloud;
+    persistence = new CloudMessagePersistence(() => currentCloud);
+    vi.mocked(firstCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-parent",
+    });
+    vi.mocked(secondCloud.threads.messages.create).mockResolvedValue({
+      message_id: "remote-child",
+    });
+
+    await persistence.append("thread-1", "parent", null, "aui/v0", {
+      text: "parent",
+    });
+    currentCloud = secondCloud;
+    await persistence.append("thread-1", "child", "parent", "aui/v0", {
+      text: "child",
+    });
+
+    expect(secondCloud.threads.messages.create).toHaveBeenCalledWith(
+      "thread-1",
+      expect.objectContaining({ parent_id: "remote-parent" }),
+    );
+    expect(await persistence.getRemoteId("child")).toBe("remote-child");
+  });
+
   it("resolves parent ID from a concurrent append", async () => {
     // Parent creation is delayed — the promise won't resolve immediately
     let resolveParent!: (v: { message_id: string }) => void;

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { AssistantCloud } from "assistant-cloud";
+import { describe, expect, it, vi } from "vitest";
+import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
+
+const mocks = vi.hoisted(() => {
+  const threadListItem = {
+    getState: () => ({ remoteId: "thread-1" }),
+  };
+
+  return {
+    assistantClient: {
+      threadListItem: () => threadListItem,
+    },
+    persistenceInstances: [] as Array<{
+      cloud: unknown;
+      load: ReturnType<typeof vi.fn>;
+    }>,
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.assistantClient,
+}));
+
+vi.mock("assistant-cloud", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("assistant-cloud")>()),
+  CloudMessagePersistence: class {
+    readonly load = vi.fn().mockResolvedValue([]);
+
+    constructor(readonly cloud: unknown) {
+      mocks.persistenceInstances.push(this);
+    }
+  },
+}));
+
+const makeCloud = () => ({}) as AssistantCloud;
+
+describe("useAssistantCloudThreadHistoryAdapter", () => {
+  it("refreshes formatted persistence when the Cloud client changes", async () => {
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+    const cloudRef = { current: firstCloud };
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const formatted = result.current.withFormat<
+      { id: string },
+      Record<string, unknown>
+    >({
+      format: "test",
+      encode: ({ message }) => message,
+      decode: ({ parent_id, content }) => ({
+        parentId: parent_id,
+        message: content as { id: string },
+      }),
+      getId: (message) => message.id,
+    });
+
+    await formatted.load();
+    await formatted.load();
+
+    expect(mocks.persistenceInstances).toHaveLength(1);
+    expect(mocks.persistenceInstances[0]?.cloud).toBe(firstCloud);
+    expect(mocks.persistenceInstances[0]?.load).toHaveBeenCalledTimes(2);
+
+    cloudRef.current = secondCloud;
+    await formatted.load();
+
+    expect(mocks.persistenceInstances).toHaveLength(2);
+    expect(mocks.persistenceInstances[1]?.cloud).toBe(secondCloud);
+    expect(mocks.persistenceInstances[1]?.load).toHaveBeenCalledTimes(1);
+    expect(mocks.persistenceInstances[1]?.load).toHaveBeenCalledWith(
+      "thread-1",
+      "test",
+    );
+  });
+});

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -14,10 +14,6 @@ const mocks = vi.hoisted(() => {
     assistantClient: {
       threadListItem: () => threadListItem,
     },
-    persistenceInstances: [] as Array<{
-      cloud: unknown;
-      load: ReturnType<typeof vi.fn>;
-    }>,
   };
 });
 
@@ -26,18 +22,14 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   useAui: () => mocks.assistantClient,
 }));
 
-vi.mock("assistant-cloud", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("assistant-cloud")>()),
-  CloudMessagePersistence: class {
-    readonly load = vi.fn().mockResolvedValue([]);
-
-    constructor(readonly cloud: unknown) {
-      mocks.persistenceInstances.push(this);
-    }
-  },
-}));
-
-const makeCloud = () => ({}) as AssistantCloud;
+const makeCloud = () =>
+  ({
+    threads: {
+      messages: {
+        list: vi.fn().mockResolvedValue({ messages: [] }),
+      },
+    },
+  }) as unknown as AssistantCloud;
 
 describe("useAssistantCloudThreadHistoryAdapter", () => {
   it("refreshes formatted persistence when the Cloud client changes", async () => {
@@ -63,19 +55,15 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     await formatted.load();
     await formatted.load();
 
-    expect(mocks.persistenceInstances).toHaveLength(1);
-    expect(mocks.persistenceInstances[0]?.cloud).toBe(firstCloud);
-    expect(mocks.persistenceInstances[0]?.load).toHaveBeenCalledTimes(2);
+    expect(firstCloud.threads.messages.list).toHaveBeenCalledTimes(2);
 
     cloudRef.current = secondCloud;
     await formatted.load();
 
-    expect(mocks.persistenceInstances).toHaveLength(2);
-    expect(mocks.persistenceInstances[1]?.cloud).toBe(secondCloud);
-    expect(mocks.persistenceInstances[1]?.load).toHaveBeenCalledTimes(1);
-    expect(mocks.persistenceInstances[1]?.load).toHaveBeenCalledWith(
-      "thread-1",
-      "test",
-    );
+    expect(firstCloud.threads.messages.list).toHaveBeenCalledTimes(2);
+    expect(secondCloud.threads.messages.list).toHaveBeenCalledOnce();
+    expect(secondCloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
+      format: "test",
+    });
   });
 });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -16,14 +16,9 @@ import { auiV0Decode, auiV0Encode } from "./auiV0";
 import { type AssistantClient, useAui } from "@assistant-ui/store";
 import type { ThreadListItemMethods } from "../../../store/scopes/thread-list-item";
 
-type CloudPersistenceEntry = {
-  cloud: AssistantCloud;
-  persistence: CloudMessagePersistence;
-};
-
 const globalPersistence = new WeakMap<
   ThreadListItemMethods,
-  CloudPersistenceEntry
+  CloudMessagePersistence
 >();
 
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
@@ -34,42 +29,33 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
 
   private get _persistence(): CloudMessagePersistence {
     const key = this.aui.threadListItem();
-    const cloud = this.cloudRef.current;
-    let entry = globalPersistence.get(key);
-    if (!entry || entry.cloud !== cloud) {
-      entry = {
-        cloud,
-        persistence: new CloudMessagePersistence(cloud),
-      };
-      globalPersistence.set(key, entry);
+    if (!globalPersistence.has(key)) {
+      globalPersistence.set(
+        key,
+        new CloudMessagePersistence(() => this.cloudRef.current),
+      );
     }
-    return entry.persistence;
+    return globalPersistence.get(key)!;
   }
 
   withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
   ): GenericThreadHistoryAdapter<TMessage> {
     const adapter = this;
-    let persistence = adapter._persistence;
-    let formatted = createFormattedPersistence(persistence, formatAdapter);
-    const getFormatted = () => {
-      const nextPersistence = adapter._persistence;
-      if (nextPersistence !== persistence) {
-        persistence = nextPersistence;
-        formatted = createFormattedPersistence(persistence, formatAdapter);
-      }
-      return formatted;
-    };
+    const formatted = createFormattedPersistence(
+      this._persistence,
+      formatAdapter,
+    );
     return {
       // Note: callers must also call reportTelemetry() for run tracking
       async append(item: MessageFormatItem<TMessage>) {
         const { remoteId } = await adapter.aui.threadListItem().initialize();
-        await getFormatted().append(remoteId, item);
+        await formatted.append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
         const remoteId = adapter.aui.threadListItem().getState().remoteId;
         if (!remoteId) return;
-        await getFormatted().update?.(remoteId, item, localMessageId);
+        await formatted.update?.(remoteId, item, localMessageId);
       },
       async delete() {
         throw new Error(
@@ -95,7 +81,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       async load(): Promise<MessageFormatRepository<TMessage>> {
         const remoteId = adapter.aui.threadListItem().getState().remoteId;
         if (!remoteId) return { messages: [] };
-        return getFormatted().load(remoteId);
+        return formatted.load(remoteId);
       },
     };
   }

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -16,9 +16,14 @@ import { auiV0Decode, auiV0Encode } from "./auiV0";
 import { type AssistantClient, useAui } from "@assistant-ui/store";
 import type { ThreadListItemMethods } from "../../../store/scopes/thread-list-item";
 
+type CloudPersistenceEntry = {
+  cloud: AssistantCloud;
+  persistence: CloudMessagePersistence;
+};
+
 const globalPersistence = new WeakMap<
   ThreadListItemMethods,
-  CloudMessagePersistence
+  CloudPersistenceEntry
 >();
 
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
@@ -29,33 +34,42 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
 
   private get _persistence(): CloudMessagePersistence {
     const key = this.aui.threadListItem();
-    if (!globalPersistence.has(key)) {
-      globalPersistence.set(
-        key,
-        new CloudMessagePersistence(this.cloudRef.current),
-      );
+    const cloud = this.cloudRef.current;
+    let entry = globalPersistence.get(key);
+    if (!entry || entry.cloud !== cloud) {
+      entry = {
+        cloud,
+        persistence: new CloudMessagePersistence(cloud),
+      };
+      globalPersistence.set(key, entry);
     }
-    return globalPersistence.get(key)!;
+    return entry.persistence;
   }
 
   withFormat<TMessage, TStorageFormat extends Record<string, unknown>>(
     formatAdapter: MessageFormatAdapter<TMessage, TStorageFormat>,
   ): GenericThreadHistoryAdapter<TMessage> {
     const adapter = this;
-    const formatted = createFormattedPersistence(
-      this._persistence,
-      formatAdapter,
-    );
+    let persistence = adapter._persistence;
+    let formatted = createFormattedPersistence(persistence, formatAdapter);
+    const getFormatted = () => {
+      const nextPersistence = adapter._persistence;
+      if (nextPersistence !== persistence) {
+        persistence = nextPersistence;
+        formatted = createFormattedPersistence(persistence, formatAdapter);
+      }
+      return formatted;
+    };
     return {
       // Note: callers must also call reportTelemetry() for run tracking
       async append(item: MessageFormatItem<TMessage>) {
         const { remoteId } = await adapter.aui.threadListItem().initialize();
-        await formatted.append(remoteId, item);
+        await getFormatted().append(remoteId, item);
       },
       async update(item: MessageFormatItem<TMessage>, localMessageId: string) {
         const remoteId = adapter.aui.threadListItem().getState().remoteId;
         if (!remoteId) return;
-        await formatted.update?.(remoteId, item, localMessageId);
+        await getFormatted().update?.(remoteId, item, localMessageId);
       },
       async delete() {
         throw new Error(
@@ -81,7 +95,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
       async load(): Promise<MessageFormatRepository<TMessage>> {
         const remoteId = adapter.aui.threadListItem().getState().remoteId;
         if (!remoteId) return { messages: [] };
-        return formatted.load(remoteId);
+        return getFormatted().load(remoteId);
       },
     };
   }


### PR DESCRIPTION
## Summary

- allow `CloudMessagePersistence` to receive a current-client getter while preserving the existing constructor
- make the core Cloud history adapter use that getter so login or workspace client changes are reflected without a remount
- preserve local-to-remote message ID mappings across client changes
- add regression coverage for the core adapter and parent chaining across two Cloud clients

## Why

While testing a login or workspace client switch without a full app remount, the history adapter could keep the first `AssistantCloud` instance cached. Subsequent history loads or writes could then continue through the old authenticated client.

The persistence object must remain stable because it owns the local-to-remote message ID mapping used for parent chaining, updates, and deduplication. The fix therefore keeps one persistence per thread item and resolves the current Cloud client at the start of each operation. Existing callers that construct `CloudMessagePersistence` with a fixed client continue to work unchanged.

## Verification

- reproduced the old behavior: after swapping the ref, the third formatted history load still called client A
- verified the fix routes that load to client B
- verified a parent mapped through client A is used as the remote parent when its child is written through client B
- `assistant-cloud`: 5 test files passed, 42 tests passed, 2 skipped
- `@assistant-ui/core`: 65 test files passed, 588 tests passed
- both published packages build successfully
- changed files pass oxlint and oxfmt