### PR TITLE
fix(core): preserve part scopes during thread switches

### DIFF
--- a/.changeset/tame-parts-switch.md
+++ b/.changeset/tame-parts-switch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep derived part scopes stable while removed parts unmount

--- a/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
+++ b/packages/core/src/react/primitives/chainOfThought/ChainOfThoughtParts.tsx
@@ -51,9 +51,7 @@ const ChainOfThoughtPrimitivePartsInner: FC<{
       Array.from({ length: partsLength }, (_, index) => (
         <ChainOfThoughtPartByIndexProvider key={index} index={index}>
           <RenderChildrenWithAccessor
-            getItemState={(aui) =>
-              aui.chainOfThought().part({ index }).getState()
-            }
+            getItemState={(aui) => aui.part().getState()}
           >
             {(getItem) =>
               children({

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -728,50 +728,63 @@ const EMPTY_RUNNING_TEXT_PART: Extract<EnrichedPartState, { type: "text" }> =
  * `<MessagePrimitive.GroupedParts>`. Returns whatever `children`
  * returns — callers decide how to handle a `null` return.
  */
-export const MessagePartChildren: FC<{
+type MessagePartChildrenProps = {
   index: number;
   children: (value: { part: EnrichedPartState }) => ReactNode;
-}> = ({ index, children }) => {
+};
+
+const MessagePartChildrenInner: FC<
+  Pick<MessagePartChildrenProps, "children">
+> = ({ children }) => {
   const aui = useAui();
   // Subscribed (not snapshotted like `tools`) so fallbacks registered
   // after the first render trigger a re-render and `hasUI` re-evaluates.
   const dataRenderers = useAuiState((s) => s.dataRenderers);
 
   return (
+    <RenderChildrenWithAccessor
+      getItemState={(client) => client.part().getState()}
+    >
+      {(getItem) =>
+        children({
+          get part() {
+            const state = getItem();
+            if (state.type === "tool-call") {
+              const toolsState = aui.tools().getState();
+              const hasUI = resolveToolRender(toolsState, state) !== null;
+              const partMethods = aui.part();
+              return {
+                ...state,
+                toolUI: hasUI ? <RegisteredToolUI /> : null,
+                addResult: partMethods.addToolResult,
+                resume: partMethods.resumeToolCall,
+                respondToApproval: partMethods.respondToToolApproval,
+              };
+            }
+            if (state.type === "data") {
+              const hasUI =
+                getDataRenderer(dataRenderers, state.name, undefined) !==
+                undefined;
+              return {
+                ...state,
+                dataRendererUI: hasUI ? <RegisteredDataRendererUI /> : null,
+              };
+            }
+            return state;
+          },
+        })
+      }
+    </RenderChildrenWithAccessor>
+  );
+};
+
+export const MessagePartChildren: FC<MessagePartChildrenProps> = ({
+  index,
+  children,
+}) => {
+  return (
     <PartByIndexProvider index={index}>
-      <RenderChildrenWithAccessor
-        getItemState={(aui) => aui.message().part({ index }).getState()}
-      >
-        {(getItem) =>
-          children({
-            get part() {
-              const state = getItem();
-              if (state.type === "tool-call") {
-                const toolsState = aui.tools().getState();
-                const hasUI = resolveToolRender(toolsState, state) !== null;
-                const partMethods = aui.message().part({ index });
-                return {
-                  ...state,
-                  toolUI: hasUI ? <RegisteredToolUI /> : null,
-                  addResult: partMethods.addToolResult,
-                  resume: partMethods.resumeToolCall,
-                  respondToApproval: partMethods.respondToToolApproval,
-                };
-              }
-              if (state.type === "data") {
-                const hasUI =
-                  getDataRenderer(dataRenderers, state.name, undefined) !==
-                  undefined;
-                return {
-                  ...state,
-                  dataRendererUI: hasUI ? <RegisteredDataRendererUI /> : null,
-                };
-              }
-              return state;
-            },
-          })
-        }
-      </RenderChildrenWithAccessor>
+      <MessagePartChildrenInner>{children}</MessagePartChildrenInner>
     </PartByIndexProvider>
   );
 };

--- a/packages/core/src/react/providers/ChainOfThoughtPartByIndexProvider.tsx
+++ b/packages/core/src/react/providers/ChainOfThoughtPartByIndexProvider.tsx
@@ -1,16 +1,33 @@
-import type { FC, PropsWithChildren } from "react";
+import { useMemo, type FC, type PropsWithChildren } from "react";
 import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+import type { PartMethods } from "../../store/scopes/part";
 
 export const ChainOfThoughtPartByIndexProvider: FC<
   PropsWithChildren<{
     index: number;
   }>
 > = ({ index, children }) => {
+  const lastPartRef = useMemo(
+    () => ({ index, current: null as PartMethods | null }),
+    [index],
+  );
   const aui = useAui({
     part: Derived({
       source: "chainOfThought",
       query: { type: "index", index },
-      get: (aui) => aui.chainOfThought().part({ index }),
+      get: (aui) => {
+        const chainOfThought = aui.chainOfThought();
+        if (
+          index >= chainOfThought.getState().parts.length &&
+          lastPartRef.current
+        ) {
+          return lastPartRef.current;
+        }
+
+        const part = chainOfThought.part({ index });
+        lastPartRef.current = part;
+        return part;
+      },
     }),
   });
 

--- a/packages/core/src/react/providers/PartByIndexProvider.tsx
+++ b/packages/core/src/react/providers/PartByIndexProvider.tsx
@@ -1,16 +1,30 @@
-import type { FC, PropsWithChildren } from "react";
+import { useMemo, type FC, type PropsWithChildren } from "react";
 import { useAui, AuiProvider, Derived } from "@assistant-ui/store";
+import type { PartMethods } from "../../store/scopes/part";
 
 export const PartByIndexProvider: FC<
   PropsWithChildren<{
     index: number;
   }>
 > = ({ index, children }) => {
+  const lastPartRef = useMemo(
+    () => ({ index, current: null as PartMethods | null }),
+    [index],
+  );
   const aui = useAui({
     part: Derived({
       source: "message",
       query: { type: "index", index },
-      get: (aui) => aui.message().part({ index }),
+      get: (aui) => {
+        const message = aui.message();
+        if (index >= message.getState().parts.length && lastPartRef.current) {
+          return lastPartRef.current;
+        }
+
+        const part = message.part({ index });
+        lastPartRef.current = part;
+        return part;
+      },
     }),
   });
 

--- a/packages/react/src/tests/messagePartSwitchRace.test.tsx
+++ b/packages/react/src/tests/messagePartSwitchRace.test.tsx
@@ -4,8 +4,8 @@ import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { flushSync } from "react-dom";
 import { useEffect, useState, type FC } from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { useAui } from "@assistant-ui/store";
-import { AssistantRuntimeProvider } from "../context";
+import { useAui, useAuiState } from "@assistant-ui/store";
+import { AssistantRuntimeProvider, PartByIndexProvider } from "../context";
 import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
 import type { ChatModelAdapter } from "../legacy-runtime/runtime-cores/local/ChatModelAdapter";
 import * as ThreadPrimitive from "../primitives/thread";
@@ -34,6 +34,13 @@ const toolMessages: readonly ThreadMessageLike[] = [
       { type: "tool-call", toolCallId: "tc-1", toolName: "search", args: {} },
       { type: "tool-call", toolCallId: "tc-2", toolName: "search", args: {} },
     ],
+  },
+];
+
+const shorterTextMessages: readonly ThreadMessageLike[] = [
+  {
+    role: "assistant",
+    content: [{ type: "text", text: "shorter" }],
   },
 ];
 
@@ -69,14 +76,31 @@ const Message: FC = () => (
   />
 );
 
-const App: FC = () => {
+const ChildrenMessage: FC = () => (
+  <MessagePrimitive.Parts>
+    {({ part }) => (part.type === "text" ? <TextLeaf /> : null)}
+  </MessagePrimitive.Parts>
+);
+
+const InvalidPartReader: FC = () => {
+  useAuiState((s) => s.part.type);
+  return null;
+};
+
+const InvalidPartMessage: FC = () => (
+  <PartByIndexProvider index={2}>
+    <InvalidPartReader />
+  </PartByIndexProvider>
+);
+
+const App: FC<{ MessageComponent?: FC }> = ({ MessageComponent = Message }) => {
   const runtime = useLocalRuntime(noOpAdapter, {
     initialMessages: textMessages,
   });
   harness.runtime = runtime;
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <ThreadPrimitive.Messages components={{ Message }} />
+      <ThreadPrimitive.Messages components={{ Message: MessageComponent }} />
     </AssistantRuntimeProvider>
   );
 };
@@ -101,5 +125,34 @@ describe("part hooks under a thread-switch race (#5118)", () => {
 
     await waitFor(() => expect(view.getAllByTestId("tool")).toHaveLength(2));
     expect(view.queryAllByTestId("text")).toHaveLength(0);
+  });
+
+  it.each([
+    ["components API", Message],
+    ["children API", ChildrenMessage],
+  ])(
+    "does not crash when the incoming message has fewer parts with the %s",
+    async (_label, MessageComponent) => {
+      let view!: ReturnType<typeof render>;
+      await act(async () => {
+        view = render(<App MessageComponent={MessageComponent} />);
+      });
+      await waitFor(() => expect(view.getAllByTestId("text")).toHaveLength(2));
+
+      await act(async () => {
+        harness.runtime!.thread.reset(shorterTextMessages);
+      });
+
+      await waitFor(() => expect(view.getAllByTestId("text")).toHaveLength(1));
+      expect(view.getByTestId("text").textContent).toBe("shorter");
+    },
+  );
+
+  it("still rejects an index that was never valid", async () => {
+    await expect(
+      act(async () => {
+        render(<App MessageComponent={InvalidPartMessage} />);
+      }),
+    ).rejects.toThrow("useClientLookup: Index 2 out of bounds (length: 2)");
   });
 });


### PR DESCRIPTION
## Summary

- keep the last valid derived part client available while an outgoing part subtree unmounts
- route message and chain-of-thought render-prop access through the scoped part client
- preserve the existing out-of-bounds error for indexes that were never valid

## Why

When switching from a message with multiple parts to one with fewer parts, a synchronous subscriber render can briefly rerender an outgoing leaf before React unmounts it. That leaf resolves its old index against the incoming message and throws `useClientLookup: Index 1 out of bounds (length: 1)`.

This is the derivation-layer follow-up to #5119 and covers the second crash flavor tracked in #5121.

Closes #5121.

## Verification

- reproduced the exact out-of-bounds failure on unmodified `main`
- added regression coverage for both component and children/render-prop APIs
- verified a never-valid index still throws
- `pnpm --filter @assistant-ui/core test` (587 tests)
- `pnpm --filter @assistant-ui/react test` (480 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm api-surface:check`
- changed-file oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

