### PR TITLE
fix(react-hook-form): keep form context in sync

### DIFF
--- a/.changeset/fresh-form-context.md
+++ b/.changeset/fresh-form-context.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-hook-form": patch
+---
+
+fix: keep form values in model context up to date

--- a/packages/react-hook-form/package.json
+++ b/packages/react-hook-form/package.json
@@ -29,7 +29,9 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "aui-build"
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@assistant-ui/core": "^0.2.21",
@@ -48,9 +50,13 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^29.1.1",
     "react": "^19.2.7",
-    "react-hook-form": "^7.81.0"
+    "react-hook-form": "^7.81.0",
+    "vitest": "^4.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/react-hook-form/src/useAssistantForm.test.tsx
+++ b/packages/react-hook-form/src/useAssistantForm.test.tsx
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import type { ModelContext } from "@assistant-ui/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const register = vi.fn();
+  const setToolUI = vi.fn();
+
+  return {
+    register,
+    setToolUI,
+    aui: {
+      modelContext: () => ({ register }),
+      tools: () => ({ setToolUI }),
+    },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/store")>()),
+  useAui: () => mocks.aui,
+}));
+
+import { useAssistantForm } from "./useAssistantForm";
+
+let provider: { getModelContext: () => ModelContext };
+
+beforeEach(() => {
+  mocks.register.mockReset();
+  mocks.setToolUI.mockReset();
+  mocks.register.mockImplementation((value) => {
+    provider = value;
+    return () => {};
+  });
+});
+
+describe("useAssistantForm", () => {
+  it("exposes current form values to the model context", () => {
+    const { result } = renderHook(() =>
+      useAssistantForm<{ name: string }>({
+        defaultValues: { name: "" },
+      }),
+    );
+
+    expect(provider.getModelContext().system).toBe('Form State:\n{"name":""}');
+
+    act(() => {
+      result.current.setValue("name", "Ada");
+    });
+
+    expect(provider.getModelContext().system).toBe(
+      'Form State:\n{"name":"Ada"}',
+    );
+  });
+});

--- a/packages/react-hook-form/src/useAssistantForm.ts
+++ b/packages/react-hook-form/src/useAssistantForm.ts
@@ -82,8 +82,6 @@ export const useAssistantForm = <
   const aui = useAui();
   useEffect(() => {
     const value: ModelContext = {
-      system: `Form State:\n${JSON.stringify(getValues())}`,
-
       tools: {
         set_form_field: tool({
           ...formTools.set_form_field,
@@ -141,8 +139,12 @@ export const useAssistantForm = <
         }),
       },
     };
+
     return aui.modelContext().register({
-      getModelContext: () => value,
+      getModelContext: () => ({
+        ...value,
+        system: `Form State:\n${JSON.stringify(getValues())}`,
+      }),
     });
   }, [control, setValue, getValues, aui, reset, isSubmitting]);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4051,15 +4051,27 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
       react-hook-form:
         specifier: ^7.81.0
         version: 7.81.0(react@19.2.7)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/react-ink:
     dependencies:


### PR DESCRIPTION
## Summary

- read current React Hook Form values when assistant-ui requests model context
- keep the existing form tools registered without subscribing on every keystroke
- add regression coverage for values changed after the hook mounts

## Problem

While testing `useAssistantForm`, I found that the model context captured `getValues()` only once during effect registration. For example, a form mounted with `{ name: "" }` still sent that initial state to the model after `setValue("name", "Ada")` updated the form. This could make the assistant treat completed fields as empty or overwrite newer user input.

The regression test reproduces the old result as `Form State:\n{"name":""}` after the update. With this change, the same registered provider returns `Form State:\n{"name":"Ada"}`.

## Validation

- `pnpm --filter @assistant-ui/react-hook-form test`
- `pnpm --filter @assistant-ui/react-hook-form build`
- `pnpm --filter @assistant-ui/react-hook-form exec tsc --noEmit`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

