### PR TITLE
fix(assistant-stream): cancel polyfilled iterators on early exit

### DIFF
--- a/.changeset/tidy-streams-cancel.md
+++ b/.changeset/tidy-streams-cancel.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: cancel polyfilled async iterators when consumers stop early

--- a/packages/assistant-stream/src/utils/AsyncIterableStream.test.ts
+++ b/packages/assistant-stream/src/utils/AsyncIterableStream.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { asAsyncIterableStream } from "./AsyncIterableStream";
+
+const forcePolyfilledIterator = <T>(
+  stream: ReadableStream<T>,
+): AsyncIterable<T> & ReadableStream<T> => {
+  Object.defineProperty(stream, Symbol.asyncIterator, {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  });
+  return asAsyncIterableStream(stream);
+};
+
+describe("asAsyncIterableStream", () => {
+  it("cancels the source when iteration stops early", async () => {
+    const cancel = vi.fn();
+    const stream = forcePolyfilledIterator(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue("first");
+          controller.enqueue("second");
+        },
+        cancel,
+      }),
+    );
+
+    const values: string[] = [];
+    for await (const value of stream) {
+      values.push(value);
+      break;
+    }
+
+    expect(values).toEqual(["first"]);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("does not cancel a fully consumed source", async () => {
+    const cancel = vi.fn();
+    const stream = forcePolyfilledIterator(
+      new ReadableStream<string>({
+        start(controller) {
+          controller.enqueue("first");
+          controller.enqueue("second");
+          controller.close();
+        },
+        cancel,
+      }),
+    );
+
+    const values: string[] = [];
+    for await (const value of stream) {
+      values.push(value);
+    }
+
+    expect(values).toEqual(["first", "second"]);
+    expect(cancel).not.toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+  });
+});

--- a/packages/assistant-stream/src/utils/AsyncIterableStream.ts
+++ b/packages/assistant-stream/src/utils/AsyncIterableStream.ts
@@ -4,14 +4,29 @@ async function* streamGeneratorPolyfill<T>(
   this: ReadableStream<T>,
 ): AsyncGenerator<T, undefined, unknown> {
   const reader = this.getReader();
+  let shouldCancel = true;
   try {
     while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+      let result: ReadableStreamReadResult<T>;
+      try {
+        result = await reader.read();
+      } catch (error) {
+        shouldCancel = false;
+        throw error;
+      }
+      if (result.done) {
+        shouldCancel = false;
+        break;
+      }
+      const { value } = result;
       yield value;
     }
   } finally {
-    reader.releaseLock();
+    try {
+      if (shouldCancel) await reader.cancel();
+    } finally {
+      reader.releaseLock();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- cancel the underlying `ReadableStream` when the fallback async iterator is closed before reaching the end
- keep natural completion unchanged and always release the reader lock
- add regression coverage for both early exit and full consumption

## Why

`asAsyncIterableStream()` installs a fallback iterator in runtimes where `ReadableStream` does not provide `Symbol.asyncIterator`. When a consumer used `break` inside `for await`, the fallback released its reader lock but never cancelled the stream. A model or network response could therefore continue producing data after the consumer had stopped reading.

Cancelling on early iterator return matches native `ReadableStream` async-iteration behavior while leaving fully consumed streams untouched.

## Testing

- `pnpm --filter assistant-stream test`
- `pnpm --filter assistant-stream build`
- targeted oxlint and oxfmt checks
- direct fallback runtime probe (`cancelled=1`, `locked=false`)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

