### PR TITLE
fix(react-ink): tolerate transient part type mismatches

### DIFF
--- a/.changeset/part-selector-sentinels.md
+++ b/.changeset/part-selector-sentinels.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/react-ink": patch
+---
+
+Warn against throwing from part selectors and keep React Ink text rendering stable during transient part-type mismatches.

--- a/.changeset/part-selector-sentinels.md
+++ b/.changeset/part-selector-sentinels.md
@@ -3,4 +3,4 @@
 "@assistant-ui/react-ink": patch
 ---
 
-Warn against throwing from part selectors and keep React Ink text rendering stable during transient part-type mismatches.
+Warn against throwing from part selectors and keep React Ink part rendering stable during transient part-type mismatches.

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/primitives.mdx
@@ -469,8 +469,9 @@ const useMessagePart: { (): MessagePartState; <TSelected>(selector: (state: Mess
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx
@@ -489,8 +490,9 @@ See the [migration guide](https://assistant-ui.com/docs/migrations/v0-12).
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx
@@ -510,8 +512,9 @@ const useMessagePartFile: () => FileMessagePart & { readonly status: MessagePart
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx
@@ -531,8 +534,9 @@ const useMessagePartImage: () => ImageMessagePart & { readonly status: MessagePa
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx
@@ -560,8 +564,9 @@ const useMessagePartReasoning: () => ReasoningMessagePart & { readonly status: M
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx
@@ -581,8 +586,9 @@ const useMessagePartSource: () => ({ readonly type: "source"; readonly sourceTyp
 
 <Callout type="warn">
 <strong>Deprecated.</strong> Use [useAuiState](/docs/api-reference/hooks/state#useauistate) to select and narrow `s.part`.
-Return `null` for optional rendering, or throw inside the selector to
-preserve the old hook's strict behavior.
+Return `null` for optional rendering. Do not throw inside the selector:
+selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+part mismatch during thread switches can unmount the React root.
 </Callout>
 
 ```tsx

--- a/packages/react-ink/src/primitives/messagePart/MessagePartData.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartData.tsx
@@ -14,14 +14,11 @@ export namespace MessagePartPrimitiveData {
 export const MessagePartPrimitiveData = (
   props: MessagePartPrimitiveData.Props,
 ) => {
-  const partName = useAuiState((s) => {
-    if (s.part.type !== "data")
-      throw new Error(
-        "MessagePartPrimitive.Data can only be used inside data message parts.",
-      );
-    return s.part.name;
+  const label = useAuiState((s) => {
+    if (s.part.type !== "data") return "";
+    return `[data: ${s.part.name}]`;
   });
-  return <Text {...props}>[data: {partName}]</Text>;
+  return <Text {...props}>{label}</Text>;
 };
 
 MessagePartPrimitiveData.displayName = "MessagePartPrimitive.Data";

--- a/packages/react-ink/src/primitives/messagePart/MessagePartFile.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartFile.tsx
@@ -15,10 +15,7 @@ export const MessagePartPrimitiveFile = (
   props: MessagePartPrimitiveFile.Props,
 ) => {
   const label = useAuiState((s) => {
-    if (s.part.type !== "file")
-      throw new Error(
-        "MessagePartPrimitive.File can only be used inside file message parts.",
-      );
+    if (s.part.type !== "file") return "";
     const { filename, mimeType } = s.part;
     return filename ? `[file: ${filename} ${mimeType}]` : `[file: ${mimeType}]`;
   });

--- a/packages/react-ink/src/primitives/messagePart/MessagePartImage.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartImage.tsx
@@ -14,16 +14,11 @@ export namespace MessagePartPrimitiveImage {
 export const MessagePartPrimitiveImage = (
   props: MessagePartPrimitiveImage.Props,
 ) => {
-  const filename = useAuiState((s) => {
-    if (s.part.type !== "image")
-      throw new Error(
-        "MessagePartPrimitive.Image can only be used inside image message parts.",
-      );
-    return s.part.filename;
+  const label = useAuiState((s) => {
+    if (s.part.type !== "image") return "";
+    return s.part.filename ? `[image: ${s.part.filename}]` : "[image]";
   });
-  return (
-    <Text {...props}>{filename ? `[image: ${filename}]` : "[image]"}</Text>
-  );
+  return <Text {...props}>{label}</Text>;
 };
 
 MessagePartPrimitiveImage.displayName = "MessagePartPrimitive.Image";

--- a/packages/react-ink/src/primitives/messagePart/MessagePartReasoning.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartReasoning.tsx
@@ -15,10 +15,7 @@ export const MessagePartPrimitiveReasoning = (
   props: MessagePartPrimitiveReasoning.Props,
 ) => {
   const reasoning = useAuiState((s) => {
-    if (s.part.type !== "reasoning")
-      throw new Error(
-        "MessagePartPrimitive.Reasoning can only be used inside reasoning message parts.",
-      );
+    if (s.part.type !== "reasoning") return "";
     return s.part.text;
   });
   return <Text {...props}>{reasoning}</Text>;

--- a/packages/react-ink/src/primitives/messagePart/MessagePartSource.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartSource.tsx
@@ -28,10 +28,7 @@ export const MessagePartPrimitiveSource = (
   props: MessagePartPrimitiveSource.Props,
 ) => {
   const label = useAuiState((s) => {
-    if (s.part.type !== "source")
-      throw new Error(
-        "MessagePartPrimitive.Source can only be used inside source message parts.",
-      );
+    if (s.part.type !== "source") return "";
     return formatSource(s.part);
   });
   return <Text {...props}>{label}</Text>;

--- a/packages/react-ink/src/primitives/messagePart/MessagePartText.tsx
+++ b/packages/react-ink/src/primitives/messagePart/MessagePartText.tsx
@@ -15,10 +15,7 @@ export const MessagePartPrimitiveText = (
   props: MessagePartPrimitiveText.Props,
 ) => {
   const text = useAuiState((s) => {
-    if (s.part.type !== "text" && s.part.type !== "reasoning")
-      throw new Error(
-        "MessagePartPrimitive.Text can only be used inside text or reasoning message parts.",
-      );
+    if (s.part.type !== "text" && s.part.type !== "reasoning") return "";
     return s.part.text;
   });
   return <Text {...props}>{text}</Text>;

--- a/packages/react-ink/src/tests/MessagePartPrimitive.test.tsx
+++ b/packages/react-ink/src/tests/MessagePartPrimitive.test.tsx
@@ -32,26 +32,32 @@ describe("MessagePartPrimitive", () => {
     expect(frame).toBe("hello terminal");
   });
 
-  it("returns empty text during transient part-type mismatches", async () => {
-    let selectText: UseAuiStateSelector | undefined;
-    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) => {
-      selectText = selector;
-      return "";
-    });
+  it.each([
+    ["text", () => <MessagePartPrimitive.Text />],
+    ["image", () => <MessagePartPrimitive.Image />],
+    ["file", () => <MessagePartPrimitive.File />],
+    ["source", () => <MessagePartPrimitive.Source />],
+    ["reasoning", () => <MessagePartPrimitive.Reasoning />],
+    ["data", () => <MessagePartPrimitive.Data />],
+  ] as const)(
+    "returns empty %s output during transient part-type mismatches",
+    async (_name, renderPrimitive) => {
+      let selectPart: UseAuiStateSelector | undefined;
+      mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) => {
+        selectPart = selector;
+        return "";
+      });
 
-    await renderFrame(<MessagePartPrimitive.Text />);
+      await renderFrame(renderPrimitive());
 
-    expect(selectText).toBeDefined();
-    expect(
-      selectText!({
-        part: {
-          type: "image",
-          image: "data:image/png;base64,raw-image-bytes",
-          status: { type: "complete" },
-        },
-      } as never),
-    ).toBe("");
-  });
+      expect(selectPart).toBeDefined();
+      expect(
+        selectPart!({
+          part: { type: "tool-call" },
+        } as never),
+      ).toBe("");
+    },
+  );
 
   it("renders in-progress children only for running parts", async () => {
     mockPart(mockUseAuiState, {

--- a/packages/react-ink/src/tests/MessagePartPrimitive.test.tsx
+++ b/packages/react-ink/src/tests/MessagePartPrimitive.test.tsx
@@ -32,6 +32,27 @@ describe("MessagePartPrimitive", () => {
     expect(frame).toBe("hello terminal");
   });
 
+  it("returns empty text during transient part-type mismatches", async () => {
+    let selectText: UseAuiStateSelector | undefined;
+    mockUseAuiState.mockImplementation((selector: UseAuiStateSelector) => {
+      selectText = selector;
+      return "";
+    });
+
+    await renderFrame(<MessagePartPrimitive.Text />);
+
+    expect(selectText).toBeDefined();
+    expect(
+      selectText!({
+        part: {
+          type: "image",
+          image: "data:image/png;base64,raw-image-bytes",
+          status: { type: "complete" },
+        },
+      } as never),
+    ).toBe("");
+  });
+
   it("renders in-progress children only for running parts", async () => {
     mockPart(mockUseAuiState, {
       type: "text",

--- a/packages/react/src/primitives/messagePart/useMessagePartData.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartData.ts
@@ -5,8 +5,9 @@ import { useAuiState } from "@assistant-ui/store";
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx

--- a/packages/react/src/primitives/messagePart/useMessagePartFile.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartFile.ts
@@ -18,8 +18,9 @@ const EMPTY_FILE_PART: MessagePartState & FileMessagePart = Object.freeze({
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx

--- a/packages/react/src/primitives/messagePart/useMessagePartImage.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartImage.ts
@@ -17,8 +17,9 @@ const EMPTY_IMAGE_PART: MessagePartState & ImageMessagePart = Object.freeze({
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx

--- a/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartReasoning.ts
@@ -18,8 +18,9 @@ const EMPTY_REASONING_PART: MessagePartState & ReasoningMessagePart =
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx

--- a/packages/react/src/primitives/messagePart/useMessagePartSource.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartSource.ts
@@ -19,8 +19,9 @@ const EMPTY_SOURCE_PART: MessagePartState & SourceMessagePart = Object.freeze({
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx

--- a/packages/react/src/primitives/messagePart/useMessagePartText.ts
+++ b/packages/react/src/primitives/messagePart/useMessagePartText.ts
@@ -18,8 +18,9 @@ const EMPTY_TEXT_PART: MessagePartState & TextMessagePart = Object.freeze({
 
 /**
  * @deprecated Use {@link useAuiState} to select and narrow `s.part`.
- * Return `null` for optional rendering, or throw inside the selector to
- * preserve the old hook's strict behavior.
+ * Return `null` for optional rendering. Do not throw inside the selector:
+ * selectors run inside `useSyncExternalStore`'s `getSnapshot`, so a transient
+ * part mismatch during thread switches can unmount the React root.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Summary

- update the deprecated part-hook guidance to recommend returning `null` and explain why throwing from a `useAuiState` selector can unmount the React root during a thread switch
- apply the same documentation correction to `useMessagePartData`, which carried the identical stale guidance while already returning `null`
- make all six React Ink message-part primitives return an empty-string sentinel for transient type mismatches, matching the web hook behavior
- regenerate the API reference and add a patch changeset for `@assistant-ui/react` and `@assistant-ui/react-ink`
- follow-up commit `e040af0` applies the same selector guard to Image, File, Source, Reasoning, and Data after review identified the sibling mismatch path

Fixes #5131

## Validation

- focused `MessagePartPrimitive` regression passes (13 tests), including red-before-green mismatch coverage for text, image, file, source, reasoning, and data
- complete `@assistant-ui/react-ink` suite passes (21 files, 237 tests)
- `@assistant-ui/react-ink` typecheck and production build pass
- `@assistant-ui/react` production build passes (928 entries)
- API reference generation is idempotent; all six part-hook entries contain the corrected warning
- root lint and format checks pass with existing warnings elsewhere in the workspace
- the full `@assistant-ui/react` suite still reports two existing `messagePartSwitchRace` failures in the unchanged runtime path; the React changes in this PR are documentation-only
