### PR TITLE
fix(cloud-ai-sdk): reset chat state on cloud change

### DIFF
--- a/.changeset/clean-cloud-switches.md
+++ b/.changeset/clean-cloud-switches.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: reset selected threads and cached chats when the Cloud client changes

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@ai-sdk/react": "^4.0.30",
     "@ai-sdk/react-v3": "npm:@ai-sdk/react@^3.0.211",
+    "@assistant-ui/react-ai-sdk": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.test.ts
@@ -6,6 +6,7 @@ import { useChatRegistry } from "./useChatRegistry";
 
 describe("useChatRegistry", () => {
   it("reuses the same chat for the same selected thread", () => {
+    const scope = {};
     const createChat = vi.fn().mockImplementation((chatKey: string) => ({
       id: chatKey,
       messages: [],
@@ -14,6 +15,7 @@ describe("useChatRegistry", () => {
     const { rerender } = renderHook(
       ({ threadId }) =>
         useChatRegistry({
+          scope,
           threadId,
           createChat: createChat as never,
         }),
@@ -29,6 +31,7 @@ describe("useChatRegistry", () => {
   });
 
   it("creates a fresh session key after leaving a selected thread", () => {
+    const scope = {};
     const createChat = vi.fn().mockImplementation((chatKey: string) => ({
       id: chatKey,
       messages: [],
@@ -37,6 +40,7 @@ describe("useChatRegistry", () => {
     const { rerender } = renderHook(
       ({ threadId }) =>
         useChatRegistry({
+          scope,
           threadId,
           createChat: createChat as never,
         }),
@@ -56,6 +60,7 @@ describe("useChatRegistry", () => {
   });
 
   it("creates a brand-new key immediately when leaving a thread that reused the previous new-chat key", () => {
+    const scope = {};
     const createChat = vi.fn().mockImplementation((chatKey: string) => ({
       id: chatKey,
       messages: [],
@@ -64,6 +69,7 @@ describe("useChatRegistry", () => {
     const { result, rerender } = renderHook(
       ({ threadId }) =>
         useChatRegistry({
+          scope,
           threadId,
           createChat: createChat as never,
         }),
@@ -82,5 +88,31 @@ describe("useChatRegistry", () => {
 
     rerender({ threadId: null });
     expect(result.current.activeChat.id).not.toBe(initialNewChatKey);
+  });
+
+  it("creates a new registry and chat when the scope changes", () => {
+    const createChat = vi
+      .fn()
+      .mockImplementation((chatKey: string) => ({ id: chatKey, messages: [] }));
+    const scopeA = {};
+    const scopeB = {};
+
+    const { result, rerender } = renderHook(
+      ({ scope }) =>
+        useChatRegistry({
+          scope,
+          threadId: "thread-1",
+          createChat: createChat as never,
+        }),
+      { initialProps: { scope: scopeA } },
+    );
+    const registryA = result.current.registry;
+    const chatA = result.current.activeChat;
+
+    rerender({ scope: scopeB });
+
+    expect(result.current.registry).not.toBe(registryA);
+    expect(result.current.activeChat).not.toBe(chatA);
+    expect(createChat).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/useChatRegistry.ts
@@ -11,38 +11,50 @@ function createSessionId(): string {
 }
 
 type UseChatRegistryOptions = {
+  scope: object;
   threadId: string | null;
   createChat: (chatKey: string, registry: ChatRegistry) => Chat<UIMessage>;
 };
 
+function createRegistry(
+  createChat: UseChatRegistryOptions["createChat"],
+): ChatRegistry {
+  let registry: ChatRegistry;
+  registry = new ChatRegistry((chatKey) => createChat(chatKey, registry));
+  return registry;
+}
+
 export function useChatRegistry({
+  scope,
   threadId,
   createChat,
 }: UseChatRegistryOptions): {
   registry: ChatRegistry;
   activeChat: Chat<UIMessage>;
 } {
-  // Ref ensures registry always delegates to the latest createChat,
-  // even if core is recreated (e.g. cloud identity change).
-  const createChatRef = useRef(createChat);
-  createChatRef.current = createChat;
-
   const registryRef = useRef<ChatRegistry | null>(null);
+  const freshSessionKey = useRef<string | null>(null);
+  const prevThreadId = useRef<string | null>(threadId);
+  const scopeRef = useRef(scope);
+
+  if (scopeRef.current !== scope) {
+    scopeRef.current = scope;
+    registryRef.current = null;
+    freshSessionKey.current = null;
+    prevThreadId.current = threadId;
+  }
+
   if (!registryRef.current) {
-    registryRef.current = new ChatRegistry((chatKey) =>
-      createChatRef.current(chatKey, registryRef.current!),
-    );
+    registryRef.current = createRegistry(createChat);
   }
   const registry = registryRef.current;
 
-  const freshSessionKey = useRef<string | null>(null);
   if (!freshSessionKey.current) {
     freshSessionKey.current = createSessionId();
   }
 
   // When the user navigates away from a thread (threadId goes null),
   // generate a fresh session key so the next new-chat gets its own Chat instance.
-  const prevThreadId = useRef<string | null>(threadId);
   if (threadId === null && prevThreadId.current !== null) {
     freshSessionKey.current = createSessionId();
   }

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.test.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.test.ts
@@ -165,4 +165,36 @@ describe("useCloudChat", () => {
     expect(lastCall).toBeDefined();
     expect(lastCall![0].chat).toBeDefined();
   });
+
+  it("replaces cached chats when the cloud changes", () => {
+    const createThreads = (cloud: typeof mockCloud) => ({
+      cloud,
+      threads: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn().mockResolvedValue(true),
+      get: vi.fn(),
+      create: vi.fn(),
+      delete: vi.fn(),
+      rename: vi.fn(),
+      archive: vi.fn(),
+      unarchive: vi.fn(),
+      threadId: "thread-1",
+      selectThread: vi.fn(),
+      generateTitle: vi.fn().mockResolvedValue(null),
+    });
+    const threadsA = createThreads({ ...mockCloud });
+    const threadsB = createThreads({ ...mockCloud });
+
+    const { rerender } = renderHook(
+      ({ threads }) => useCloudChat({ threads: threads as never }),
+      { initialProps: { threads: threadsA } },
+    );
+    const chatA = mockUseChat.mock.calls.at(-1)?.[0].chat;
+
+    rerender({ threads: threadsB });
+
+    const chatB = mockUseChat.mock.calls.at(-1)?.[0].chat;
+    expect(chatB).not.toBe(chatA);
+  });
 });

--- a/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
+++ b/packages/cloud-ai-sdk/src/chat/useCloudChat.ts
@@ -46,6 +46,7 @@ export function useCloudChat(
   });
 
   const { registry, activeChat } = useChatRegistry({
+    scope: threads.cloud,
     threadId: threads.threadId,
     createChat: (chatKey, reg) => core.createChat(chatKey, reg),
   });

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -149,8 +149,10 @@ describe("useThreads", () => {
     await waitFor(() => {
       expect(result.current.threads[0]?.id).toBe("thread-a");
     });
+    const selectThreadA = result.current.selectThread;
+    const refreshA = result.current.refresh;
     act(() => {
-      result.current.selectThread("thread-a");
+      selectThreadA("thread-a");
     });
 
     rerender({ cloud: cloudB });
@@ -159,6 +161,21 @@ describe("useThreads", () => {
     await waitFor(() => {
       expect(result.current.threads[0]?.id).toBe("thread-b");
     });
+    expect(result.current.threadId).toBeNull();
+
+    act(() => {
+      selectThreadA("late-thread-a");
+    });
+    expect(result.current.threadId).toBeNull();
+
+    let staleRefreshResult: boolean | undefined;
+    await act(async () => {
+      staleRefreshResult = await refreshA();
+    });
+    expect(staleRefreshResult).toBe(false);
+    expect(result.current.threads[0]?.id).toBe("thread-b");
+
+    rerender({ cloud: cloudA });
     expect(result.current.threadId).toBeNull();
   });
 

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -33,6 +33,20 @@ function createThreadListResponse(title: string, id = "thread-1") {
   };
 }
 
+function createCloud(id: string) {
+  return {
+    threads: {
+      list: vi.fn().mockResolvedValue(createThreadListResponse(id, id)),
+      get: vi.fn().mockImplementation(async (threadId: string) => {
+        return createThreadListResponse(threadId, threadId).threads[0]!;
+      }),
+      create: vi.fn(),
+      delete: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+}
+
 describe("useThreads", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -128,21 +142,11 @@ describe("useThreads", () => {
   });
 
   it("clears the selected thread when the cloud changes", async () => {
-    const createCloud = (id: string) =>
-      ({
-        threads: {
-          list: vi.fn().mockResolvedValue(createThreadListResponse(id, id)),
-          get: vi.fn(),
-          create: vi.fn(),
-          delete: vi.fn(),
-          update: vi.fn(),
-        },
-      }) as never;
     const cloudA = createCloud("thread-a");
     const cloudB = createCloud("thread-b");
 
     const { result, rerender } = renderHook(
-      ({ cloud }) => useThreads({ cloud }),
+      ({ cloud }) => useThreads({ cloud: cloud as never }),
       { initialProps: { cloud: cloudA } },
     );
 
@@ -150,7 +154,6 @@ describe("useThreads", () => {
       expect(result.current.threads[0]?.id).toBe("thread-a");
     });
     const selectThreadA = result.current.selectThread;
-    const refreshA = result.current.refresh;
     act(() => {
       selectThreadA("thread-a");
     });
@@ -168,15 +171,86 @@ describe("useThreads", () => {
     });
     expect(result.current.threadId).toBeNull();
 
-    let staleRefreshResult: boolean | undefined;
-    await act(async () => {
-      staleRefreshResult = await refreshA();
-    });
-    expect(staleRefreshResult).toBe(false);
-    expect(result.current.threads[0]?.id).toBe("thread-b");
-
     rerender({ cloud: cloudA });
     expect(result.current.threadId).toBeNull();
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-a");
+    });
+    expect(result.current.threadId).toBeNull();
+  });
+
+  it("ignores a refresh that resolves after the cloud changes", async () => {
+    const cloudA = createCloud("thread-a");
+    const cloudB = createCloud("thread-b");
+    const staleRefresh =
+      createDeferred<ReturnType<typeof createThreadListResponse>>();
+
+    const { result, rerender } = renderHook(
+      ({ cloud }) => useThreads({ cloud: cloud as never }),
+      { initialProps: { cloud: cloudA } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-a");
+    });
+    cloudA.threads.list.mockReturnValueOnce(staleRefresh.promise);
+
+    let refreshPromise!: Promise<boolean>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    expect(cloudA.threads.list).toHaveBeenCalledTimes(2);
+
+    rerender({ cloud: cloudB });
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-b");
+    });
+
+    await act(async () => {
+      staleRefresh.resolve(
+        createThreadListResponse("Stale A", "stale-thread-a"),
+      );
+      await refreshPromise;
+    });
+    expect(result.current.threads[0]?.id).toBe("thread-b");
+  });
+
+  it("ignores async mutations from an earlier use of the same cloud", async () => {
+    const cloudA = createCloud("thread-a");
+    const cloudB = createCloud("thread-b");
+    const staleCreate = createDeferred<{ thread_id: string }>();
+
+    const { result, rerender } = renderHook(
+      ({ cloud }) => useThreads({ cloud: cloud as never }),
+      { initialProps: { cloud: cloudA } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-a");
+    });
+    cloudA.threads.create.mockReturnValueOnce(staleCreate.promise);
+
+    let createPromise!: ReturnType<typeof result.current.create>;
+    act(() => {
+      createPromise = result.current.create();
+    });
+
+    rerender({ cloud: cloudB });
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-b");
+    });
+    rerender({ cloud: cloudA });
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-a");
+    });
+
+    await act(async () => {
+      staleCreate.resolve({ thread_id: "stale-thread-a" });
+      await createPromise;
+    });
+    expect(result.current.threads.map((thread) => thread.id)).toEqual([
+      "thread-a",
+    ]);
   });
 
   it("avoids unmounted state updates during async refresh", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -17,11 +17,11 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
-function createThreadListResponse(title: string) {
+function createThreadListResponse(title: string, id = "thread-1") {
   return {
     threads: [
       {
-        id: "thread-1",
+        id,
         title,
         is_archived: false,
         external_id: null,
@@ -125,6 +125,41 @@ describe("useThreads", () => {
       await firstRefresh;
     });
     expect(result.current.threads[0]?.title).toBe("Newest");
+  });
+
+  it("clears the selected thread when the cloud changes", async () => {
+    const createCloud = (id: string) =>
+      ({
+        threads: {
+          list: vi.fn().mockResolvedValue(createThreadListResponse(id, id)),
+          get: vi.fn(),
+          create: vi.fn(),
+          delete: vi.fn(),
+          update: vi.fn(),
+        },
+      }) as never;
+    const cloudA = createCloud("thread-a");
+    const cloudB = createCloud("thread-b");
+
+    const { result, rerender } = renderHook(
+      ({ cloud }) => useThreads({ cloud }),
+      { initialProps: { cloud: cloudA } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-a");
+    });
+    act(() => {
+      result.current.selectThread("thread-a");
+    });
+
+    rerender({ cloud: cloudB });
+
+    expect(result.current.threadId).toBeNull();
+    await waitFor(() => {
+      expect(result.current.threads[0]?.id).toBe("thread-b");
+    });
+    expect(result.current.threadId).toBeNull();
   });
 
   it("avoids unmounted state updates during async refresh", async () => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -46,6 +46,13 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     );
   }, [cloud]);
 
+  const activeCloudRef = useRef(cloud);
+  activeCloudRef.current = cloud;
+  const isCurrentCloud = useCallback(
+    () => activeCloudRef.current === cloud,
+    [cloud],
+  );
+
   const mountedRef = useRef(true);
   const refreshRequestRef = useRef(0);
   useEffect(() => {
@@ -75,8 +82,11 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   );
 
   const refresh = useCallback(async (): Promise<boolean> => {
+    if (!isCurrentCloud()) return false;
+
     const requestId = ++refreshRequestRef.current;
-    const isLatest = () => requestId === refreshRequestRef.current;
+    const isLatest = () =>
+      requestId === refreshRequestRef.current && isCurrentCloud();
     setIsLoading(true);
 
     try {
@@ -98,7 +108,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         setIsLoading(false);
       }
     }
-  }, [cloud, includeArchived, withAction]);
+  }, [cloud, includeArchived, isCurrentCloud, withAction]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -107,126 +117,156 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
 
   const get = useCallback(
     async (id: string): Promise<CloudThread | null> => {
-      return await withAction(async () => {
-        const thread = await cloud.threads.get(id);
-        return toCloudThread(thread);
-      }, null);
+      return await withAction(
+        async () => {
+          const thread = await cloud.threads.get(id);
+          return toCloudThread(thread);
+        },
+        null,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   const create = useCallback(
     async (opts?: { externalId?: string }): Promise<CloudThread | null> => {
-      return await withAction(async () => {
-        const response = await cloud.threads.create({
-          last_message_at: new Date(),
-          external_id: opts?.externalId,
-        });
-        const thread = await cloud.threads.get(response.thread_id);
-        const cloudThread = toCloudThread(thread);
+      return await withAction(
+        async () => {
+          const response = await cloud.threads.create({
+            last_message_at: new Date(),
+            external_id: opts?.externalId,
+          });
+          const thread = await cloud.threads.get(response.thread_id);
+          const cloudThread = toCloudThread(thread);
 
-        if (mountedRef.current) {
-          setThreads((prev) => [cloudThread, ...prev]);
-        }
+          if (mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) => [cloudThread, ...prev]);
+          }
 
-        return cloudThread;
-      }, null);
+          return cloudThread;
+        },
+        null,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   const deleteThread = useCallback(
     async (id: string): Promise<boolean> => {
-      return await withAction(async () => {
-        await cloud.threads.delete(id);
-        if (mountedRef.current) {
-          setThreads((prev) => prev.filter((t) => t.id !== id));
-        }
-        return true;
-      }, false);
+      return await withAction(
+        async () => {
+          await cloud.threads.delete(id);
+          if (mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) => prev.filter((t) => t.id !== id));
+          }
+          return true;
+        },
+        false,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   const rename = useCallback(
     async (id: string, title: string): Promise<boolean> => {
-      return await withAction(async () => {
-        await cloud.threads.update(id, { title });
-        if (mountedRef.current) {
-          setThreads((prev) =>
-            prev.map((t) => (t.id === id ? { ...t, title } : t)),
-          );
-        }
-        return true;
-      }, false);
+      return await withAction(
+        async () => {
+          await cloud.threads.update(id, { title });
+          if (mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) =>
+              prev.map((t) => (t.id === id ? { ...t, title } : t)),
+            );
+          }
+          return true;
+        },
+        false,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   const archive = useCallback(
     async (id: string): Promise<boolean> => {
-      return await withAction(async () => {
-        await cloud.threads.update(id, { is_archived: true });
+      return await withAction(
+        async () => {
+          await cloud.threads.update(id, { is_archived: true });
 
-        if (mountedRef.current) {
-          setThreads((prev) => {
-            if (includeArchived) {
-              return prev.map((t) =>
-                t.id === id ? { ...t, status: "archived" } : t,
-              );
-            }
-            return prev.filter((t) => t.id !== id);
-          });
-        }
+          if (mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) => {
+              if (includeArchived) {
+                return prev.map((t) =>
+                  t.id === id ? { ...t, status: "archived" } : t,
+                );
+              }
+              return prev.filter((t) => t.id !== id);
+            });
+          }
 
-        return true;
-      }, false);
+          return true;
+        },
+        false,
+        isCurrentCloud,
+      );
     },
-    [cloud, includeArchived, withAction],
+    [cloud, includeArchived, isCurrentCloud, withAction],
   );
 
   const unarchive = useCallback(
     async (id: string): Promise<boolean> => {
-      return await withAction(async () => {
-        await cloud.threads.update(id, { is_archived: false });
-        const thread = await cloud.threads.get(id);
-        const cloudThread = toCloudThread(thread);
+      return await withAction(
+        async () => {
+          await cloud.threads.update(id, { is_archived: false });
+          const thread = await cloud.threads.get(id);
+          const cloudThread = toCloudThread(thread);
 
-        if (mountedRef.current) {
-          setThreads((prev) => {
-            const filtered = prev.filter((t) => t.id !== id);
-            return [cloudThread, ...filtered];
-          });
-        }
+          if (mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) => {
+              const filtered = prev.filter((t) => t.id !== id);
+              return [cloudThread, ...filtered];
+            });
+          }
 
-        return true;
-      }, false);
+          return true;
+        },
+        false,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   const selectThread = useCallback(
     (id: string | null) => {
-      setSelection({ cloud, threadId: id });
+      setSelection((current) =>
+        current.cloud === cloud ? { cloud, threadId: id } : current,
+      );
     },
     [cloud],
   );
 
   const generateTitle = useCallback(
     async (tid: string): Promise<string | null> => {
-      return await withAction(async () => {
-        const title = await generateThreadTitle(cloud, tid);
+      return await withAction(
+        async () => {
+          const title = await generateThreadTitle(cloud, tid);
 
-        if (title && mountedRef.current) {
-          setThreads((prev) =>
-            prev.map((t) => (t.id === tid ? { ...t, title } : t)),
-          );
-        }
+          if (title && mountedRef.current && isCurrentCloud()) {
+            setThreads((prev) =>
+              prev.map((t) => (t.id === tid ? { ...t, title } : t)),
+            );
+          }
 
-        return title;
-      }, null);
+          return title;
+        },
+        null,
+        isCurrentCloud,
+      );
     },
-    [cloud, withAction],
+    [cloud, isCurrentCloud, withAction],
   );
 
   return {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -1,6 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import type {
   CloudThread,
   UseThreadsOptions,
@@ -49,10 +55,10 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     );
   }, [cloud]);
 
-  const activeScopeRef = useRef(scope);
-  useEffect(() => {
-    activeScopeRef.current = scope;
-  }, [scope]);
+  const activeScopeRef = useRef<typeof scope | null>(scope);
+  useLayoutEffect(() => {
+    activeScopeRef.current = scope.cloud === cloud ? scope : null;
+  }, [cloud, scope]);
   const isCurrentCloud = useCallback(
     () => scope.cloud === cloud && activeScopeRef.current === scope,
     [cloud, scope],

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -34,7 +34,17 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const [threads, setThreads] = useState<CloudThread[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
-  const [threadId, setThreadId] = useState<string | null>(null);
+  const [selection, setSelection] = useState(() => ({
+    cloud,
+    threadId: null as string | null,
+  }));
+  const threadId = selection.cloud === cloud ? selection.threadId : null;
+
+  useEffect(() => {
+    setSelection((current) =>
+      current.cloud === cloud ? current : { cloud, threadId: null },
+    );
+  }, [cloud]);
 
   const mountedRef = useRef(true);
   const refreshRequestRef = useRef(0);
@@ -195,9 +205,12 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     [cloud, withAction],
   );
 
-  const selectThread = useCallback((id: string | null) => {
-    setThreadId(id);
-  }, []);
+  const selectThread = useCallback(
+    (id: string | null) => {
+      setSelection({ cloud, threadId: id });
+    },
+    [cloud],
+  );
 
   const generateTitle = useCallback(
     async (tid: string): Promise<string | null> => {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -35,22 +35,27 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [selection, setSelection] = useState(() => ({
-    cloud,
+    scope: { cloud },
     threadId: null as string | null,
   }));
-  const threadId = selection.cloud === cloud ? selection.threadId : null;
+  const scope = selection.scope;
+  const threadId = scope.cloud === cloud ? selection.threadId : null;
 
   useEffect(() => {
     setSelection((current) =>
-      current.cloud === cloud ? current : { cloud, threadId: null },
+      current.scope.cloud === cloud
+        ? current
+        : { scope: { cloud }, threadId: null },
     );
   }, [cloud]);
 
-  const activeCloudRef = useRef(cloud);
-  activeCloudRef.current = cloud;
+  const activeScopeRef = useRef(scope);
+  useEffect(() => {
+    activeScopeRef.current = scope;
+  }, [scope]);
   const isCurrentCloud = useCallback(
-    () => activeCloudRef.current === cloud,
-    [cloud],
+    () => scope.cloud === cloud && activeScopeRef.current === scope,
+    [cloud, scope],
   );
 
   const mountedRef = useRef(true);
@@ -242,10 +247,12 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const selectThread = useCallback(
     (id: string | null) => {
       setSelection((current) =>
-        current.cloud === cloud ? { cloud, threadId: id } : current,
+        scope.cloud === cloud && current.scope === scope
+          ? { scope, threadId: id }
+          : current,
       );
     },
-    [cloud],
+    [cloud, scope],
   );
 
   const generateTitle = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3465,6 +3465,9 @@ importers:
       '@ai-sdk/react-v3':
         specifier: npm:@ai-sdk/react@^3.0.211
         version: '@ai-sdk/react@3.0.232(react@19.2.7)(zod@4.4.3)'
+      '@assistant-ui/react-ai-sdk':
+        specifier: workspace:*
+        version: link:../react-ai-sdk
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils


### PR DESCRIPTION
## Summary

- clear the selected thread when the `AssistantCloud` identity changes
- recreate the chat registry and fresh-session state for the new Cloud client
- ignore late thread actions from the previous Cloud client so they cannot overwrite the active client's state
- keep each registry's chat factory isolated so late work from the previous client cannot bind to the new registry

## Why

When an app switches from Cloud A to Cloud B without remounting, `useThreads()` refreshes B's thread list but previously retained A's selected `threadId`. `useChatRegistry()` also retained cached `Chat` instances, whose transport and persistence callbacks were created with Cloud A. A late operation from A could additionally overwrite B's thread state. That could load or persist through the previous account or workspace client after the UI had switched to B.

This is separate from, and complementary to, #5126, which updates the core Cloud history adapter rather than the `cloud-ai-sdk` hooks.

## Testing

- regression tests for selected thread and cached chat reset across Cloud A → B
- regression coverage for late A callbacks and A → B → A switching
- `pnpm turbo test --filter="...[origin/main]"`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
