### PR TITLE
fix(react-a2a): refresh runtime client on option changes

### DIFF
--- a/.changeset/tidy-clients-switch.md
+++ b/.changeset/tidy-clients-switch.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: refresh A2A runtime clients when connection options change

--- a/packages/react-a2a/package.json
+++ b/packages/react-a2a/package.json
@@ -49,8 +49,12 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
     "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "vitest": "^4.1.10"
   },
   "publishConfig": {

--- a/packages/react-a2a/src/useA2ARuntime.test.tsx
+++ b/packages/react-a2a/src/useA2ARuntime.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { A2AClient } from "./A2AClient";
+import { useA2ARuntime } from "./useA2ARuntime";
+
+const createMockClient = (waitForAbort = false) => {
+  let streamSignal: AbortSignal | undefined;
+  const getAgentCard = vi.fn().mockResolvedValue(undefined);
+  const streamMessage = vi.fn(
+    (
+      _message: unknown,
+      _configuration: unknown,
+      _metadata: unknown,
+      signal?: AbortSignal,
+    ): AsyncIterable<never> => {
+      streamSignal = signal;
+      return {
+        async *[Symbol.asyncIterator]() {
+          if (!waitForAbort || !signal) return;
+          await new Promise<void>((resolve) => {
+            if (signal.aborted) {
+              resolve();
+            } else {
+              signal.addEventListener("abort", () => resolve(), {
+                once: true,
+              });
+            }
+          });
+        },
+      };
+    },
+  );
+
+  return {
+    client: {
+      getAgentCard,
+      streamMessage,
+    } as unknown as A2AClient,
+    getAgentCard,
+    streamMessage,
+    get streamSignal() {
+      return streamSignal;
+    },
+  };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useA2ARuntime", () => {
+  it("switches provided clients and aborts the previous client run", async () => {
+    const first = createMockClient(true);
+    const second = createMockClient();
+    const { result, rerender } = renderHook(
+      ({ client }) => useA2ARuntime({ client }),
+      { initialProps: { client: first.client } },
+    );
+
+    await waitFor(() => expect(first.getAgentCard).toHaveBeenCalledOnce());
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(first.streamMessage).toHaveBeenCalledOnce());
+
+    rerender({ client: second.client });
+
+    await waitFor(() => expect(first.streamSignal?.aborted).toBe(true));
+    await waitFor(() => expect(second.getAgentCard).toHaveBeenCalledOnce());
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+      });
+    });
+
+    await waitFor(() => expect(second.streamMessage).toHaveBeenCalledOnce());
+    expect(first.streamMessage).toHaveBeenCalledOnce();
+  });
+
+  it("uses current headers without recreating the managed client", async () => {
+    const fetchMock = vi.fn(
+      async (input: string | URL | Request, _init?: RequestInit) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        if (url.endsWith("/.well-known/agent-card.json")) {
+          return new Response(
+            JSON.stringify({ capabilities: { streaming: true } }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          );
+        }
+        return new Response("", {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result, rerender } = renderHook(
+      ({ token }) =>
+        useA2ARuntime({
+          baseUrl: "https://agent.test",
+          headers: { Authorization: `Bearer ${token}` },
+          extensions: ["urn:example"],
+          fetchOptions: { credentials: "include" },
+        }),
+      { initialProps: { token: "first" } },
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+
+    rerender({ token: "second" });
+
+    act(() => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const streamRequest = fetchMock.mock.calls[1]!;
+    expect(streamRequest[1]?.headers).toMatchObject({
+      Authorization: "Bearer second",
+    });
+  });
+});

--- a/packages/react-a2a/src/useA2ARuntime.ts
+++ b/packages/react-a2a/src/useA2ARuntime.ts
@@ -12,10 +12,27 @@ import type {
   ExternalStoreAdapter,
   ThreadMessage,
 } from "@assistant-ui/core";
-import { A2AClient } from "./A2AClient";
+import { A2AClient, type A2AClientOptions } from "./A2AClient";
 import { A2AThreadRuntimeCore } from "./A2AThreadRuntimeCore";
 import { a2aExtras } from "./a2aExtras";
 import type { UseA2ARuntimeOptions } from "./types";
+
+type ManagedA2AClientOptions = Omit<A2AClientOptions, "headers">;
+
+const serializeManagedClientOptions = (
+  options: ManagedA2AClientOptions,
+): string => {
+  const fetchOptions = Object.fromEntries(
+    Object.entries(options.fetchOptions ?? {}).sort(([a], [b]) =>
+      a.localeCompare(b),
+    ),
+  );
+
+  return JSON.stringify({
+    ...options,
+    fetchOptions,
+  });
+};
 
 export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   const [_version, setVersion] = useState(0);
@@ -24,44 +41,46 @@ export function useA2ARuntime(options: UseA2ARuntimeOptions): AssistantRuntime {
   const historyAdapter = options.adapters?.history ?? runtimeAdapters?.history;
   const threadListAdapter = options.adapters?.threadList;
 
-  // Create or reuse client
-  const clientRef = useRef<A2AClient | null>(null);
-  if (!clientRef.current) {
-    if (options.client) {
-      clientRef.current = options.client;
-    } else if (options.baseUrl) {
-      clientRef.current = new A2AClient({
-        baseUrl: options.baseUrl,
-        basePath: options.basePath,
-        tenant: options.tenant,
-        headers: options.headers,
-        extensions: options.extensions,
-        fetchOptions: options.fetchOptions,
-      });
-    } else {
+  const headersRef = useRef(options.headers);
+  headersRef.current = options.headers;
+  const resolveHeaders = useCallback(() => {
+    const headers = headersRef.current;
+    return typeof headers === "function" ? headers() : (headers ?? {});
+  }, []);
+
+  const managedClientOptionsKey = options.client
+    ? null
+    : options.baseUrl
+      ? serializeManagedClientOptions({
+          baseUrl: options.baseUrl,
+          basePath: options.basePath,
+          tenant: options.tenant,
+          extensions: options.extensions,
+          fetchOptions: options.fetchOptions,
+        })
+      : null;
+
+  const client = useMemo(() => {
+    if (options.client) return options.client;
+    if (!managedClientOptionsKey) {
       throw new Error("useA2ARuntime requires either `client` or `baseUrl`");
     }
-  }
-  const client = clientRef.current;
 
-  // Create or reuse core
-  const coreRef = useRef<A2AThreadRuntimeCore | null>(null);
-  if (!coreRef.current) {
-    coreRef.current = new A2AThreadRuntimeCore({
-      client,
-      contextId: options.contextId,
-      configuration: options.configuration,
-      ...(options.onError && { onError: options.onError }),
-      ...(options.onCancel && { onCancel: options.onCancel }),
-      ...(options.onArtifactComplete && {
-        onArtifactComplete: options.onArtifactComplete,
-      }),
-      ...(historyAdapter && { history: historyAdapter }),
-      notifyUpdate,
+    return new A2AClient({
+      ...(JSON.parse(managedClientOptionsKey) as ManagedA2AClientOptions),
+      headers: resolveHeaders,
     });
-  }
+  }, [managedClientOptionsKey, options.client, resolveHeaders]);
 
-  const core = coreRef.current;
+  const core = useMemo(
+    () =>
+      new A2AThreadRuntimeCore({
+        client,
+        notifyUpdate,
+      }),
+    [client, notifyUpdate],
+  );
+
   core.updateOptions({
     client,
     contextId: options.contextId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3801,12 +3801,24 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.7
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- rebuild the managed A2A client when its connection options change
- create a fresh runtime core for a new client so the previous run is aborted and cannot update the replacement runtime
- resolve headers from the latest render for token refreshes without resetting the conversation unnecessarily

## Why

`useA2ARuntime` previously stored the first `A2AClient` in a ref and never replaced it. If an app switched from workspace A to workspace B, changed tenants, or supplied a new client after login, later messages could still be sent through workspace A and its old credentials.

Connection identity changes now replace the client and core, while header-only changes are read on each request. This keeps token refreshes lightweight while ensuring server, tenant, and explicit client switches stop using the previous connection.

## Testing

- `pnpm --filter @assistant-ui/react-a2a test` (136 tests)
- `pnpm --filter @assistant-ui/react-a2a... build`
- focused oxlint and oxfmt checks for the changed package files


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

