### PR TITLE
fix(core): isolate speech synthesis listener errors

### DIFF
--- a/.changeset/calm-speech-listeners.md
+++ b/.changeset/calm-speech-listeners.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate speech synthesis listener failures

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -7,6 +7,42 @@ afterEach(() => {
 });
 
 describe("WebSpeechSynthesisAdapter", () => {
+  it("isolates a late subscriber that throws after the utterance ended", async () => {
+    const listeners = new Map<string, EventListener>();
+    class MockSpeechSynthesisUtterance {
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      }
+    }
+    vi.stubGlobal("SpeechSynthesisUtterance", MockSpeechSynthesisUtterance);
+    vi.stubGlobal("window", {
+      speechSynthesis: {
+        speak: vi.fn(),
+        cancel: vi.fn(),
+      },
+    });
+    const listenerError = new Error("late listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const result = new WebSpeechSynthesisAdapter().speak("Hello");
+    listeners.get("end")!(new Event("end"));
+
+    const lateListener = vi.fn();
+    result.subscribe(() => {
+      throw listenerError;
+    });
+    result.subscribe(lateListener);
+    await Promise.resolve();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Speech synthesis listener threw an error",
+      listenerError,
+    );
+    expect(lateListener).toHaveBeenCalledOnce();
+  });
+
   it("continues notifying listeners when one throws", () => {
     const listeners = new Map<string, EventListener>();
     class MockSpeechSynthesisUtterance {

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSpeechSynthesisAdapter } from "./speech";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("WebSpeechSynthesisAdapter", () => {
+  it("continues notifying listeners when one throws", () => {
+    const listeners = new Map<string, EventListener>();
+    class MockSpeechSynthesisUtterance {
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      }
+    }
+    const speak = vi.fn();
+    vi.stubGlobal("SpeechSynthesisUtterance", MockSpeechSynthesisUtterance);
+    vi.stubGlobal("window", {
+      speechSynthesis: {
+        speak,
+        cancel: vi.fn(),
+      },
+    });
+    const listenerError = new Error("listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const result = new WebSpeechSynthesisAdapter().speak("Hello");
+    const laterListener = vi.fn();
+
+    result.subscribe(() => {
+      throw listenerError;
+    });
+    result.subscribe(laterListener);
+    listeners.get("end")?.({} as Event);
+
+    expect(speak).toHaveBeenCalledWith(
+      expect.any(MockSpeechSynthesisUtterance),
+    );
+    expect(laterListener).toHaveBeenCalledOnce();
+    expect(result.status).toEqual({
+      type: "ended",
+      reason: "finished",
+      error: undefined,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Speech synthesis listener threw an error",
+      listenerError,
+    );
+  });
+});

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -23,7 +23,7 @@ export type SpeechSynthesisAdapter = {
 };
 
 const notifySpeechSynthesisListeners = (
-  listeners: ReadonlySet<() => void>,
+  listeners: Iterable<() => void>,
 ): void => {
   for (const listener of listeners) {
     try {
@@ -97,7 +97,7 @@ export class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
         if (res.status.type === "ended") {
           let cancelled = false;
           queueMicrotask(() => {
-            if (!cancelled) callback();
+            if (!cancelled) notifySpeechSynthesisListeners([callback]);
           });
           return () => {
             cancelled = true;

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -22,6 +22,21 @@ export type SpeechSynthesisAdapter = {
   speak: (text: string) => SpeechSynthesisAdapter.Utterance;
 };
 
+const notifySpeechSynthesisListeners = (
+  listeners: ReadonlySet<() => void>,
+): void => {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.error(
+        "[assistant-ui] Speech synthesis listener threw an error",
+        error,
+      );
+    }
+  }
+};
+
 export namespace DictationAdapter {
   export type Status =
     | {
@@ -64,7 +79,7 @@ export class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
       if (res.status.type === "ended") return;
 
       res.status = { type: "ended", reason, error };
-      subscribers.forEach((handler) => handler());
+      notifySpeechSynthesisListeners(subscribers);
     };
 
     utterance.addEventListener("end", () => handleEnd("finished"));


### PR DESCRIPTION
## Summary
- isolate each Web Speech synthesis subscriber during completion notification
- continue notifying later subscribers when an earlier callback throws
- report subscriber failures consistently with realtime voice sessions

## Why
While testing multiple speech-synthesis subscribers, I found that one callback throwing exits the existing `Set.forEach` immediately. The utterance reaches its ended state, but later subscribers never receive the completion notification. This can leave UI consumers such as stop-speaking controls or status indicators stale because an unrelated subscriber failed first.

The realtime voice adapter already guards listeners individually. This applies the same behavior to Web Speech synthesis without changing successful callback behavior.

## Reproduction
Register two subscribers on one utterance, make the first throw, then dispatch the browser `end` event. Before this change, the exception escapes and the second subscriber is called zero times. After this change, the failure is logged and the second subscriber is notified once.

## Testing
- `pnpm --filter @assistant-ui/core test` (65 files, 590 tests)
- `pnpm --filter @assistant-ui/core build`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

