### PR TITLE
fix(react-opencode): import useEffectEvent from use-effect-event ponyfill

### DIFF
--- a/.changeset/opencode-useeffectevent-ponyfill.md
+++ b/.changeset/opencode-useeffectevent-ponyfill.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: import useEffectEvent from the use-effect-event ponyfill instead of react

--- a/packages/react-opencode/package.json
+++ b/packages/react-opencode/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@assistant-ui/core": "^0.2.21",
     "@assistant-ui/store": "^0.2.20",
-    "@opencode-ai/sdk": "^1.18.1"
+    "@opencode-ai/sdk": "^1.18.1",
+    "use-effect-event": "^2.0.3"
   },
   "peerDependencies": {
     "@assistant-ui/react": "^0.14.14",

--- a/packages/react-opencode/src/useOpenCodeRuntime.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeRuntime.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+
+const { ponyfillCalls } = vi.hoisted(() => ({
+  ponyfillCalls: { count: 0 },
+}));
+
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useEffectEvent: undefined,
+}));
+
+vi.mock("use-effect-event", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("use-effect-event")>();
+  return {
+    ...mod,
+    useEffectEvent: ((fn: never) => {
+      ponyfillCalls.count += 1;
+      return mod.useEffectEvent(fn);
+    }) as typeof mod.useEffectEvent,
+  };
+});
+
+import { useOpenCodeRuntime } from "./useOpenCodeRuntime";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const stubClient = {
+  experimental: {
+    session: {
+      list: () => Promise.resolve({ data: [] }),
+    },
+  },
+} as unknown as ReturnType<typeof createOpencodeClient>;
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+});
+
+describe("useOpenCodeRuntime", () => {
+  it("mounts on React versions without a native useEffectEvent", async () => {
+    const App = () => {
+      const runtime = useOpenCodeRuntime({ client: stubClient });
+      return createElement(AssistantRuntimeProvider, { runtime });
+    };
+    const container = document.createElement("div");
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(createElement(App));
+    });
+    expect(ponyfillCalls.count).toBeGreaterThan(0);
+  });
+});

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -13,7 +13,10 @@ import type {
   ThreadMessage,
 } from "@assistant-ui/react";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
-import { useEffect, useEffectEvent, useMemo } from "react";
+import { useEffect, useMemo } from "react";
+// Ponyfill: React only ships `useEffectEvent` from 19.2, but the peer range
+// allows React 18.
+import { useEffectEvent } from "use-effect-event";
 import type {
   OpenCodeRuntimeOptions,
   OpenCodeThreadControllerLike,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4453,6 +4453,9 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.18.1
         version: 1.18.1
+      use-effect-event:
+        specifier: ^2.0.3
+        version: 2.0.3(react@19.2.7)
     devDependencies:
       '@assistant-ui/react':
         specifier: workspace:*


### PR DESCRIPTION
Closes #5138

## What

Swap the `useEffectEvent` import in `useOpenCodeRuntime.ts` from `"react"` to the `use-effect-event` ponyfill, exactly as react-pi does.

## Why

React only ships `useEffectEvent` from 19.2, but the package peers on `react: "^18 || ^19"`. On React 18.x, 19.0, or 19.1 the named import resolves to `undefined` and the runtime throws a TypeError on first render (#5138).

## Impact

- No public surface change; call-site semantics identical on React 19.2+.
- `use-effect-event@^2.0.3` added to `dependencies` (runtime import in the published dist), matching react-pi.
- New colocated test mounts the runtime with React's `useEffectEvent` stripped: it reproduces the exact crash on the old import and passes with the swap; a ponyfill spy guards against a vacuous pass.
- Patch changeset.

The alternative, tightening the peer range to `>=19.2`, would be a breaking range narrowing; the ponyfill matches the already-merged react-pi fix.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

