### PR TITLE
fix(cloud-ai-sdk): preserve async tool callbacks

### DIFF
--- a/.changeset/calm-cloud-tool-callbacks.md
+++ b/.changeset/calm-cloud-tool-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: preserve async tool call callbacks

--- a/packages/cloud-ai-sdk/package.json
+++ b/packages/cloud-ai-sdk/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@ai-sdk/react": "^4.0.30",
     "@ai-sdk/react-v3": "npm:@ai-sdk/react@^3.0.211",
+    "@assistant-ui/react-ai-sdk": "workspace:*",
     "@assistant-ui/x-buildutils": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -21,6 +21,19 @@ const { persistMock, loadMessagesMock, MessagePersistenceMock } = vi.hoisted(
   },
 );
 
+const chatOptionsRef = vi.hoisted(() => ({
+  current: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@ai-sdk/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@ai-sdk/react")>()),
+  Chat: class {
+    constructor(options: Record<string, unknown>) {
+      chatOptionsRef.current = options;
+    }
+  },
+}));
+
 vi.mock("../chat/MessagePersistence", () => ({
   MessagePersistence: MessagePersistenceMock,
 }));
@@ -28,13 +41,14 @@ vi.mock("../chat/MessagePersistence", () => ({
 function createCore(overrides?: {
   onSyncError?: (...args: unknown[]) => void;
   generateTitle?: (...args: unknown[]) => void;
+  chatConfig?: Record<string, unknown>;
 }) {
   const generateTitle = overrides?.generateTitle ?? vi.fn();
   const onSyncError = overrides?.onSyncError;
 
   const refs = {
     threads: { generateTitle } as never,
-    chatConfig: {} as never,
+    chatConfig: (overrides?.chatConfig ?? {}) as never,
     callbacks: {} as never,
     onSyncError: onSyncError as ((error: Error) => void) | undefined,
   };
@@ -48,6 +62,24 @@ describe("CloudChatCore", () => {
     vi.clearAllMocks();
     persistMock.mockResolvedValue(undefined);
     loadMessagesMock.mockResolvedValue([]);
+    chatOptionsRef.current = null;
+  });
+
+  it("forwards async tool call completion to the AI SDK chat", () => {
+    const completion = Promise.resolve();
+    const onToolCall = vi.fn(() => completion);
+    const core = createCore({ chatConfig: { onToolCall } });
+
+    core.createChat("chat-1", {} as never);
+
+    const wrappedOnToolCall = chatOptionsRef.current?.onToolCall;
+    expect(wrappedOnToolCall).toBeTypeOf("function");
+    const result = (
+      wrappedOnToolCall as (options: unknown) => PromiseLike<void> | void
+    )({ toolCall: {} });
+
+    expect(onToolCall).toHaveBeenCalledWith({ toolCall: {} });
+    expect(result).toBe(completion);
   });
 
   it("generates a title once for a newly created thread after assistant output", async () => {

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -195,7 +195,7 @@ export class CloudChatCore {
         this.options.chatConfig.onData?.(data);
       },
       onToolCall: (toolCall) => {
-        this.options.chatConfig.onToolCall?.(toolCall);
+        return this.options.chatConfig.onToolCall?.(toolCall);
       },
       sendAutomaticallyWhen: (arg) =>
         this.options.chatConfig.sendAutomaticallyWhen?.(arg) ?? false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3465,6 +3465,9 @@ importers:
       '@ai-sdk/react-v3':
         specifier: npm:@ai-sdk/react@^3.0.211
         version: '@ai-sdk/react@3.0.232(react@19.2.7)(zod@4.4.3)'
+      '@assistant-ui/react-ai-sdk':
+        specifier: workspace:*
+        version: link:../react-ai-sdk
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils


### PR DESCRIPTION
## Summary

- return the configured `onToolCall` result from the Cloud chat wrapper
- keep asynchronous client-side tool handlers attached to the AI SDK lifecycle
- add a regression test for forwarding the handler Promise
- declare the existing cross-package format-adapter test dependency for clean CI builds

## Why

`CloudChatCore` invoked `onToolCall` without returning its result, converting an async handler into `undefined`. AI SDK supports and awaits `PromiseLike<void>` from this callback, so Cloud users running asynchronous client tools could continue stream processing before their handler completed, while rejected callback Promises were detached from AI SDK error handling.

For example, a tool handler that awaits a browser API or fetch before adding tool output now remains awaited as intended. Synchronous handlers keep the same behavior.

The Cloud package's existing format-consistency test imports the React AI SDK adapter source. Declaring that package as a dev dependency makes Turbo build its dependencies before the peer-v6 typecheck on clean runners; it does not change the published runtime dependencies.

## Testing

- `pnpm turbo test --filter="...[origin/main]"`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm exec oxlint packages/cloud-ai-sdk/src/core/CloudChatCore.ts packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts`
- changed-file formatting and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->