### PR TITLE
fix(assistant-stream): clean up tool abort listeners

### DIFF
--- a/.changeset/clean-tool-abort-listeners.md
+++ b/.changeset/clean-tool-abort-listeners.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: clean up abort listeners after frontend tool execution settles

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -17,6 +17,56 @@ const createDelayedTool = (delay: number, result?: string): Tool => ({
 });
 
 describe("unstable_runPendingTools", () => {
+  it("removes the abort listener after tool execution settles", async () => {
+    const abortController = new AbortController();
+    const addEventListener = vi.spyOn(
+      abortController.signal,
+      "addEventListener",
+    );
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    );
+    const message: AssistantMessage = {
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "1",
+          toolName: "tool",
+          args: {},
+        } as ToolCallPart,
+      ],
+      content: [],
+      metadata: {
+        unstable_state: {},
+        unstable_data: [],
+        unstable_annotations: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    await unstable_runPendingTools(
+      message,
+      {
+        tool: {
+          parameters: { type: "object", properties: {} },
+          execute: async () => "done",
+        },
+      },
+      abortController.signal,
+      async () => {},
+    );
+
+    expect(addEventListener).toHaveBeenCalledOnce();
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      addEventListener.mock.calls[0]![1],
+    );
+  });
+
   describe("parallel execution", () => {
     it("should run tool calls in parallel", async () => {
       const tool1 = createDelayedTool(100, "Tool 1");

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -59,9 +59,10 @@ function getToolResponse(
 
     // Create abort promise that resolves after 2 microtasks
     // This gives tools that handle abort a chance to win the race
+    let onAbort!: () => void;
     const abortPromise = new Promise<ToolResponse<ReadonlyJSONValue>>(
       (resolve) => {
-        const onAbort = () => {
+        onAbort = () => {
           queueMicrotask(() => {
             queueMicrotask(() => {
               resolve(
@@ -116,7 +117,11 @@ function getToolResponse(
       return response;
     })();
 
-    return Promise.race([executePromise, abortPromise]);
+    try {
+      return await Promise.race([executePromise, abortPromise]);
+    } finally {
+      abortSignal.removeEventListener("abort", onAbort);
+    }
   };
 
   return getResult(tool.execute);


### PR DESCRIPTION
## Summary

- remove each frontend tool's abort listener after its execution race settles
- preserve the existing two-microtask cancellation grace period
- add regression coverage and a patch changeset for `assistant-stream`

## Why

`getToolResponse()` registered one listener on the run's shared `AbortSignal` for every frontend tool call, but successful or failed executions never removed it. In a reproduction with one assistant message containing 12 fast tool calls, all 12 tools completed while all 12 abort listeners remained attached.

This unnecessarily retains each listener and its closure until the signal aborts or the run is discarded, and tool-heavy runs can accumulate listener overhead or warnings.

## Fix

The execution/abort `Promise.race()` now removes the exact listener in `finally`, covering successful execution, execution failure, and cancellation without changing which result wins the race.

## Verification

- `assistant-stream` test suite: 330 passed, 20 skipped
- `assistant-stream` package build
- targeted oxlint and formatting checks
- manual 12-tool reproduction: remaining abort listeners changed from 12 to 0


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

