### PR TITLE
fix(assistant-stream): guard gorp accumulator path navigation

### DIFF
--- a/.changeset/gorp-ops-own-property-guard.md
+++ b/.changeset/gorp-ops-own-property-guard.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: guard gorp accumulator path navigation against inherited keys and prototype-polluting path segments

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { GorpStreamAccumulator } from "./GorpStreamAccumulator";
+
+describe("GorpStreamAccumulator", () => {
+  it("rejects unsafe path segments", () => {
+    for (const path of [
+      ["__proto__", "polluted"],
+      ["constructor", "prototype", "polluted"],
+      ["a", "__proto__"],
+    ]) {
+      const acc = new GorpStreamAccumulator({});
+      expect(() => acc.append([{ type: "set", path, value: true }])).toThrow(
+        /Unsafe gorp path segment/,
+      );
+    }
+    expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+  });
+
+  it("treats inherited keys as absent when navigating", () => {
+    const acc = new GorpStreamAccumulator({});
+    acc.append([{ type: "set", path: ["toString", "x"], value: 1 }]);
+    expect(acc.state).toEqual({ toString: { x: 1 } });
+
+    const append = new GorpStreamAccumulator({});
+    expect(() =>
+      append.append([{ type: "append-text", path: ["toString"], value: "!" }]),
+    ).toThrow("Expected string at path [toString]");
+  });
+});

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.test.ts
@@ -21,9 +21,8 @@ describe("GorpStreamAccumulator", () => {
     acc.append([{ type: "set", path: ["toString", "x"], value: 1 }]);
     expect(acc.state).toEqual({ toString: { x: 1 } });
 
-    const append = new GorpStreamAccumulator({});
-    expect(() =>
-      append.append([{ type: "append-text", path: ["toString"], value: "!" }]),
-    ).toThrow("Expected string at path [toString]");
+    const append = new GorpStreamAccumulator({ toString: "hi" });
+    append.append([{ type: "append-text", path: ["toString"], value: "!" }]);
+    expect(append.state).toEqual({ toString: "hi!" });
   });
 });

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyJSONValue, ReadonlyJSONObject } from "../../utils";
+import { assertSafePathSegment } from "./changeTree";
 import type { GorpStreamOperation } from "./types";
 
 export class GorpStreamAccumulator {
@@ -53,6 +54,7 @@ export class GorpStreamAccumulator {
     }
 
     const [key, ...rest] = path as [string, ...(readonly string[])];
+    assertSafePathSegment(key);
     if (Array.isArray(state)) {
       const idx = Number(key);
       if (Number.isNaN(idx))
@@ -72,7 +74,7 @@ export class GorpStreamAccumulator {
 
     const nextState = { ...(state as ReadonlyJSONObject) };
     nextState[key] = GorpStreamAccumulator.updatePath(
-      nextState[key],
+      Object.hasOwn(nextState, key) ? nextState[key] : undefined,
       rest,
       updater,
     );

--- a/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
+++ b/packages/assistant-stream/src/core/gorp/GorpStreamAccumulator.ts
@@ -64,7 +64,7 @@ export class GorpStreamAccumulator {
 
       const nextState = [...state];
       nextState[idx] = GorpStreamAccumulator.updatePath(
-        nextState[idx],
+        Object.hasOwn(nextState, idx) ? nextState[idx] : undefined,
         rest,
         updater,
       );


### PR DESCRIPTION
`GorpStreamAccumulator.updatePath` navigated wire-supplied op paths with bare bracket reads (`nextState[key]`), so inherited keys resolved to `Object.prototype` members instead of being treated as missing, and a `__proto__` path segment write mutated the resulting state object's prototype (e.g. a `set` at `["__proto__", "x"]` made `x` visible on the replicated state via its prototype chain). `changeTree.ts` already guards against both; the accumulator — which consumes ops straight off the SSE wire via `GorpStreamResponse` and `update-state` chunks — did not.

- Resolve children with `Object.hasOwn`, so inherited keys behave as absent.
- Reject `__proto__` / `constructor` / `prototype` path segments via the existing `assertSafePathSegment`, matching the changeTree convention.
- Add tests covering unsafe-segment rejection and inherited-key navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

