### PR TITLE
fix(tap): allow Node processes to exit

### DIFF
--- a/.changeset/calm-tap-schedulers.md
+++ b/.changeset/calm-tap-schedulers.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: allow Node.js processes to exit after importing the scheduler

--- a/packages/tap/src/__tests__/basic/scheduler.test.ts
+++ b/packages/tap/src/__tests__/basic/scheduler.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("UpdateScheduler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers setImmediate when available", async () => {
+    let scheduled: (() => void) | undefined;
+    const setImmediateMock = vi.fn((callback: () => void) => {
+      scheduled = callback;
+    });
+    const messageChannelMock = vi.fn();
+
+    vi.stubGlobal("setImmediate", setImmediateMock);
+    vi.stubGlobal("MessageChannel", messageChannelMock);
+
+    const { UpdateScheduler } = await import("../../core/scheduler");
+    const task = vi.fn();
+
+    new UpdateScheduler(task).markDirty();
+
+    expect(setImmediateMock).toHaveBeenCalledOnce();
+    expect(messageChannelMock).not.toHaveBeenCalled();
+    expect(task).not.toHaveBeenCalled();
+
+    scheduled?.();
+
+    expect(task).toHaveBeenCalledOnce();
+  });
+
+  it("uses MessageChannel when setImmediate is unavailable", async () => {
+    const port1 = {
+      onmessage: null as (() => void) | null,
+    };
+    const postMessage = vi.fn(() => port1.onmessage?.());
+
+    class MessageChannelMock {
+      readonly port1 = port1;
+      readonly port2 = { postMessage };
+    }
+
+    vi.stubGlobal("setImmediate", undefined);
+    vi.stubGlobal("MessageChannel", MessageChannelMock);
+
+    const { UpdateScheduler } = await import("../../core/scheduler");
+    const task = vi.fn();
+
+    new UpdateScheduler(task).markDirty();
+
+    expect(postMessage).toHaveBeenCalledOnce();
+    expect(task).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/tap/src/__tests__/basic/scheduler.test.ts
+++ b/packages/tap/src/__tests__/basic/scheduler.test.ts
@@ -9,31 +9,46 @@ describe("UpdateScheduler", () => {
     vi.unstubAllGlobals();
   });
 
-  it("prefers setImmediate when available", async () => {
-    let scheduled: (() => void) | undefined;
-    const setImmediateMock = vi.fn((callback: () => void) => {
-      scheduled = callback;
-    });
-    const messageChannelMock = vi.fn();
+  it("only refs Node MessageChannel ports while a flush is pending", async () => {
+    const receiver = {
+      onmessage: null as (() => void) | null,
+      ref: vi.fn(),
+      unref: vi.fn(),
+    };
+    const sender = {
+      postMessage: vi.fn(),
+      ref: vi.fn(),
+      unref: vi.fn(),
+    };
 
-    vi.stubGlobal("setImmediate", setImmediateMock);
-    vi.stubGlobal("MessageChannel", messageChannelMock);
+    class MessageChannelMock {
+      readonly port1 = receiver;
+      readonly port2 = sender;
+    }
+
+    vi.stubGlobal("MessageChannel", MessageChannelMock);
 
     const { UpdateScheduler } = await import("../../core/scheduler");
     const task = vi.fn();
 
+    expect(receiver.unref).toHaveBeenCalledOnce();
+    expect(sender.unref).toHaveBeenCalledOnce();
+
     new UpdateScheduler(task).markDirty();
 
-    expect(setImmediateMock).toHaveBeenCalledOnce();
-    expect(messageChannelMock).not.toHaveBeenCalled();
+    expect(receiver.ref).toHaveBeenCalledOnce();
+    expect(sender.ref).toHaveBeenCalledOnce();
+    expect(sender.postMessage).toHaveBeenCalledOnce();
     expect(task).not.toHaveBeenCalled();
 
-    scheduled?.();
+    receiver.onmessage?.();
 
     expect(task).toHaveBeenCalledOnce();
+    expect(receiver.unref).toHaveBeenCalledTimes(2);
+    expect(sender.unref).toHaveBeenCalledTimes(2);
   });
 
-  it("uses MessageChannel when setImmediate is unavailable", async () => {
+  it("supports browser MessageChannel ports without lifecycle methods", async () => {
     const port1 = {
       onmessage: null as (() => void) | null,
     };
@@ -44,7 +59,6 @@ describe("UpdateScheduler", () => {
       readonly port2 = { postMessage };
     }
 
-    vi.stubGlobal("setImmediate", undefined);
     vi.stubGlobal("MessageChannel", MessageChannelMock);
 
     const { UpdateScheduler } = await import("../../core/scheduler");

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -1,5 +1,10 @@
 type Task = () => void;
 
+type RefableMessagePort = MessagePort & {
+  ref?: () => void;
+  unref?: () => void;
+};
+
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
   isScheduled: boolean;
@@ -82,20 +87,30 @@ const flushScheduled = () => {
 
 // Schedule flushes as macrotasks so more state updates batch into one render.
 const scheduleMacrotask = (() => {
-  const setImmediate = (
-    globalThis as typeof globalThis & {
-      setImmediate?: (callback: () => void) => void;
-    }
-  ).setImmediate;
-
-  if (setImmediate) {
-    return () => setImmediate(flushScheduled);
-  }
-
   if (typeof MessageChannel !== "undefined") {
     const channel = new MessageChannel();
-    channel.port1.onmessage = flushScheduled;
-    return () => channel.port2.postMessage(null);
+    const receiver = channel.port1 as RefableMessagePort;
+    const sender = channel.port2 as RefableMessagePort;
+
+    const unref = () => {
+      receiver.unref?.();
+      sender.unref?.();
+    };
+
+    receiver.onmessage = () => {
+      try {
+        flushScheduled();
+      } finally {
+        unref();
+      }
+    };
+    unref();
+
+    return () => {
+      receiver.ref?.();
+      sender.ref?.();
+      sender.postMessage(null);
+    };
   }
   // Fallback for environments without MessageChannel
   return () => setTimeout(flushScheduled, 0);

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -80,9 +80,18 @@ const flushScheduled = () => {
   }
 };
 
-// Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
-// This allows more state updates to batch into a single re-render.
+// Schedule flushes as macrotasks so more state updates batch into one render.
 const scheduleMacrotask = (() => {
+  const setImmediate = (
+    globalThis as typeof globalThis & {
+      setImmediate?: (callback: () => void) => void;
+    }
+  ).setImmediate;
+
+  if (setImmediate) {
+    return () => setImmediate(flushScheduled);
+  }
+
   if (typeof MessageChannel !== "undefined") {
     const channel = new MessageChannel();
     channel.port1.onmessage = flushScheduled;


### PR DESCRIPTION
## Summary

- unref Node.js `MessageChannel` ports while the tap scheduler is idle
- temporarily ref the ports while a flush is pending, then unref them after settlement
- retain the existing `MessageChannel` scheduling behavior in browsers and Node.js
- cover both Node-style and browser-style ports and publish the fix as a patch

## Why

`@assistant-ui/tap` creates a module-level `MessageChannel` during import. In Node.js, its active `MessagePort` keeps short-lived scripts, CLIs, SSR workers, and test processes alive after their work is complete.

The ports now keep Node alive only while scheduler work is actually pending. This fixes process shutdown without changing the scheduler primitive or its macrotask ordering.

## Verification

- `@assistant-ui/tap` test suite: 449 tests passed
- downstream `@assistant-ui/react-mcp` scheduler-sensitive tests: 9 passed
- package TypeScript check
- package build
- lint and formatting checks
- built-package subprocess import exits normally
- scheduled subprocess flush runs before exiting