### PR TITLE
fix(core): isolate thread runtime event listener errors

### DIFF
--- a/.changeset/tidy-thread-events-listen.md
+++ b/.changeset/tidy-thread-events-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate thread runtime event listener errors

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -182,7 +182,16 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
-    for (const callback of subscribers) callback(payload);
+    for (const callback of subscribers) {
+      try {
+        callback(payload);
+      } catch (error) {
+        console.error(
+          `[assistant-ui] Thread runtime "${event}" listener threw an error`,
+          error,
+        );
+      }
+    }
   }
 
   public subscribe(callback: () => void): Unsubscribe {

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -182,14 +182,26 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
+    const reportError = (error: unknown) => {
+      console.error(
+        `[assistant-ui] Thread runtime "${event}" listener threw an error`,
+        error,
+      );
+    };
+
     for (const callback of subscribers) {
       try {
-        callback(payload);
+        const result = callback(payload) as unknown;
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "then" in result &&
+          typeof result.then === "function"
+        ) {
+          void Promise.resolve(result).catch(reportError);
+        }
       } catch (error) {
-        console.error(
-          `[assistant-ui] Thread runtime "${event}" listener threw an error`,
-          error,
-        );
+        reportError(error);
       }
     }
   }

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocalRuntimeCore } from "./local-runtime-core";
 import type {
   ChatModelAdapter,
@@ -9,6 +9,10 @@ import type { AppendMessage } from "../../types/message";
 import type { LocalRuntimeOptionsBase } from "./local-runtime-options";
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const createThread = (
   adapter: ChatModelAdapter,
@@ -73,6 +77,35 @@ const createApprovalThread = (firstResult: ChatModelRunResult) => {
   });
   return { thread, runs };
 };
+
+describe("LocalThreadRuntimeCore events", () => {
+  it("isolates runEnd listener errors", async () => {
+    const listenerError = new Error("telemetry failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const laterListener = vi.fn();
+    const thread = createThread({
+      async run() {
+        return { content: [{ type: "text", text: "done" }] };
+      },
+    });
+
+    thread.unstable_on("runEnd", () => {
+      throw listenerError;
+    });
+    thread.unstable_on("runEnd", laterListener);
+
+    await expect(thread.append(userMessage("hello"))).resolves.toBeUndefined();
+
+    expect(laterListener).toHaveBeenCalledOnce();
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+    expect(consoleError).toHaveBeenCalledWith(
+      '[assistant-ui] Thread runtime "runEnd" listener threw an error',
+      listenerError,
+    );
+  });
+});
 
 describe("LocalThreadRuntimeCore human-in-the-loop tools", () => {
   it("pauses on requires-action while a listed tool call has no result", async () => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -105,6 +105,35 @@ describe("LocalThreadRuntimeCore events", () => {
       listenerError,
     );
   });
+
+  it("isolates async runEnd listener rejections", async () => {
+    const listenerError = new Error("async telemetry failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const laterListener = vi.fn();
+    const thread = createThread({
+      async run() {
+        return { content: [{ type: "text", text: "done" }] };
+      },
+    });
+
+    thread.unstable_on("runEnd", async () => {
+      throw listenerError;
+    });
+    thread.unstable_on("runEnd", laterListener);
+
+    await expect(thread.append(userMessage("hello"))).resolves.toBeUndefined();
+
+    expect(laterListener).toHaveBeenCalledOnce();
+    expect(thread.messages.at(-1)?.status?.type).toBe("complete");
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        '[assistant-ui] Thread runtime "runEnd" listener threw an error',
+        listenerError,
+      );
+    });
+  });
 });
 
 describe("LocalThreadRuntimeCore human-in-the-loop tools", () => {


### PR DESCRIPTION
## Summary

- isolate exceptions thrown or asynchronously rejected by individual thread runtime event listeners
- continue notifying later listeners without changing a successful runtime operation into a rejection
- add regression coverage and a patch changeset for `@assistant-ui/core`

## Why

A `runEnd` listener is observer code, commonly used for telemetry or cleanup. If one listener throws today, a successfully completed `append()` rejects and every listener registered after it is skipped, even though the assistant message is already complete. An async listener can similarly produce an unhandled rejection.

The dispatcher now catches each listener independently and reports synchronous throws and rejected Promise-like returns with the event name, matching the isolation behavior used by voice session listeners.

## Reproduction

Before this change, a completed run with a first `runEnd` listener that throws `telemetry failed` produced:

```json
{"rejected":"telemetry failed","laterListenerCalls":0,"finalStatus":{"type":"complete","reason":"unknown"}}
```

After this change, `append()` resolves, the later listener runs once, rejected async listeners are handled, and the completed message remains intact.

## Verification

- `pnpm exec vitest run src/runtimes/local/local-thread-runtime-core.test.ts` (27 tests)
- `pnpm --filter @assistant-ui/core test` (591 tests)
- `pnpm --filter @assistant-ui/core build`
- targeted `oxlint` and `oxfmt --check`
