### PR TITLE
fix(react-lexical): delegate Tab to composer input plugins

### DIFF
--- a/.changeset/lexical-plugin-tab-delegation.md
+++ b/.changeset/lexical-plugin-tab-delegation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: delegate Tab key events to composer input plugins

--- a/packages/react-lexical/src/LexicalComposerInput.test.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.test.tsx
@@ -11,6 +11,9 @@ import { LexicalComposerInput } from "./LexicalComposerInput";
 const setText = vi.fn<(text: string) => void>();
 const sendSpy = vi.fn<(options?: { steer?: boolean }) => void>();
 const cancelSpy = vi.fn<() => void>();
+const pluginHandleKeyDown = vi.fn<(event: KeyboardEvent) => boolean>();
+const setCursorPosition = vi.fn<(position: number) => void>();
+const registerInput = vi.fn(() => () => {});
 
 const composerState = {
   isEditing: true,
@@ -55,6 +58,25 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
   };
 });
 
+vi.mock("@assistant-ui/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/react")>();
+  return {
+    ...actual,
+    INTERNAL: {
+      ...actual.INTERNAL,
+      useComposerInputPluginRegistryOptional: () => ({
+        getPlugins: () => [
+          {
+            handleKeyDown: pluginHandleKeyDown,
+            setCursorPosition,
+          },
+        ],
+        registerInput,
+      }),
+    },
+  };
+});
+
 describe("LexicalComposerInput", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -63,6 +85,10 @@ describe("LexicalComposerInput", () => {
     setText.mockReset();
     sendSpy.mockReset();
     cancelSpy.mockReset();
+    pluginHandleKeyDown.mockReset();
+    pluginHandleKeyDown.mockReturnValue(false);
+    setCursorPosition.mockReset();
+    registerInput.mockClear();
     composerState.isEditing = true;
     composerState.text = "";
     composerState.isEmpty = true;
@@ -134,5 +160,27 @@ describe("LexicalComposerInput", () => {
     });
 
     expect(container.querySelector(".aui-lexical-input")).not.toBeNull();
+  });
+
+  it("delegates Tab to composer input plugins", async () => {
+    await act(async () => {
+      root.render(<LexicalComposerInput />);
+    });
+
+    const input = container.querySelector(".aui-lexical-input");
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input!.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    expect(pluginHandleKeyDown).toHaveBeenCalledOnce();
+    expect(pluginHandleKeyDown.mock.calls[0]![0].key).toBe("Tab");
   });
 });

--- a/packages/react-lexical/src/LexicalComposerInput.tsx
+++ b/packages/react-lexical/src/LexicalComposerInput.tsx
@@ -26,6 +26,7 @@ import {
   KEY_BACKSPACE_COMMAND,
   KEY_ENTER_COMMAND,
   KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
 } from "lexical";
 import { mergeRegister } from "@lexical/utils";
 import { useAui, useAuiState } from "@assistant-ui/store";
@@ -154,6 +155,15 @@ function KeyboardPlugin({
 
       editor.registerCommand(
         KEY_BACKSPACE_COMMAND,
+        (event) => {
+          if (event && delegateToPlugins(event)) return true;
+          return false;
+        },
+        COMMAND_PRIORITY_HIGH,
+      ),
+
+      editor.registerCommand(
+        KEY_TAB_COMMAND,
         (event) => {
           if (event && delegateToPlugins(event)) return true;
           return false;


### PR DESCRIPTION
## Summary

- forward Lexical Tab commands through the composer input plugin registry
- preserve native Tab behavior when no plugin consumes the event
- add focused regression coverage and a patch changeset

This brings LexicalComposerInput in line with ComposerPrimitive.Input and fixes Tab handling for plugin-driven surfaces such as trigger popovers and welcome suggestions.

## Testing

- pnpm -C packages/react-lexical test (36 tests)
- tsc -p packages/react-lexical/tsconfig.json --noEmit
- oxlint on changed TypeScript files
- oxfmt --check on changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

