### PR TITLE
feat(ui): scroll follow-up suggestion pills with edge fades

### DIFF
--- a/apps/docs/components/docs/samples/follow-up-suggestions.tsx
+++ b/apps/docs/components/docs/samples/follow-up-suggestions.tsx
@@ -3,9 +3,11 @@
 import type { FC, PropsWithChildren } from "react";
 import {
   AssistantRuntimeProvider,
+  ComposerPrimitive,
   useExternalStoreRuntime,
   type ThreadMessageLike,
 } from "@assistant-ui/react";
+import { ArrowUpIcon } from "lucide-react";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { SampleFrame } from "@/components/docs/samples/sample-frame";
 
@@ -24,7 +26,7 @@ const userMessage: DemoMessage = {
 const assistantMessage: DemoMessage = {
   id: "assistant-1",
   role: "assistant",
-  text: "Start by mapping the first-run path, then add a few suggested prompts that help users discover the highest-value workflows.",
+  text: "Start by mapping the first-run path, then add a few suggested prompts that help users discover the highest-value workflows. Keep the empty state focused on one clear action.",
 };
 
 const messages = [
@@ -33,15 +35,12 @@ const messages = [
 ] satisfies readonly DemoMessage[];
 
 const suggestions = [
-  {
-    prompt: "Draft three onboarding prompts",
-  },
-  {
-    prompt: "Turn this into a checklist",
-  },
-  {
-    prompt: "Show me a better empty state",
-  },
+  { prompt: "Draft three onboarding prompts" },
+  { prompt: "Turn this into a checklist" },
+  { prompt: "Write copy for the welcome screen" },
+  { prompt: "Show me a better empty state" },
+  { prompt: "Which metrics show onboarding is working?" },
+  { prompt: "Compare a guided tour vs. suggested prompts" },
 ];
 
 const convertMessage = (message: DemoMessage): ThreadMessageLike => ({
@@ -67,21 +66,39 @@ const FollowUpSuggestionsRuntimeProvider: FC<PropsWithChildren> = ({
   );
 };
 
+const SampleComposer = () => (
+  <ComposerPrimitive.Root className="border-border bg-background dark:border-muted-foreground/15 relative flex w-full flex-col rounded-3xl border shadow-[0_9px_9px_0px_rgba(0,0,0,0.01),0_2px_5px_0px_rgba(0,0,0,0.06)]">
+    <ComposerPrimitive.Input
+      placeholder="Reply..."
+      className="field-sizing-content min-h-10 w-full resize-none bg-transparent px-5 pt-3.5 pb-2.5 text-sm leading-relaxed focus:outline-none"
+      rows={1}
+    />
+    <div className="flex items-center justify-end px-3 pb-3">
+      <ComposerPrimitive.Send className="bg-primary text-primary-foreground flex size-8 shrink-0 items-center justify-center rounded-full transition-opacity disabled:opacity-30">
+        <ArrowUpIcon className="size-4" />
+      </ComposerPrimitive.Send>
+    </div>
+  </ComposerPrimitive.Root>
+);
+
 export const FollowUpSuggestionsSample = () => {
   return (
-    <SampleFrame className="bg-muted/40 flex h-auto min-h-72 items-center justify-center p-6">
+    <SampleFrame className="bg-muted/40 flex h-auto items-center justify-center p-6">
       <FollowUpSuggestionsRuntimeProvider>
-        <div className="bg-background w-full max-w-2xl rounded-xl border p-4 shadow-sm">
+        <div className="bg-background flex w-full max-w-2xl flex-col rounded-xl border p-4 shadow-sm">
           <div className="flex justify-end">
-            <div className="bg-primary text-primary-foreground max-w-[80%] rounded-2xl px-3.5 py-2 text-sm">
+            <div className="bg-muted max-w-[80%] rounded-2xl px-3.5 py-2 text-sm">
               {userMessage.text}
             </div>
           </div>
           <div className="mt-4 max-w-[85%] text-sm leading-relaxed">
             {assistantMessage.text}
           </div>
-          <div className="mt-4">
+          <div className="mt-5">
             <ThreadFollowupSuggestions />
+          </div>
+          <div className="mt-3">
+            <SampleComposer />
           </div>
         </div>
       </FollowUpSuggestionsRuntimeProvider>

--- a/apps/docs/content/docs/ui/follow-up-suggestions.mdx
+++ b/apps/docs/content/docs/ui/follow-up-suggestions.mdx
@@ -74,6 +74,8 @@ const ThreadViewportFooter = () => {
 
 The component only renders when the thread is not empty, not currently running, and has at least one suggestion. Each suggestion uses `ThreadPrimitive.Suggestion`, replaces the composer text with the prompt, and sends it immediately.
 
+Suggestions stay on a single line. When they overflow, the row scrolls horizontally without a scrollbar, and each edge with clipped content fades out — so no fade shows at the start edge until you scroll.
+
 ## Related Components
 
 - [Thread](/docs/ui/thread) - Complete chat interface with message list and composer

--- a/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
+++ b/packages/ui/src/components/assistant-ui/follow-up-suggestions.tsx
@@ -1,23 +1,58 @@
 "use client";
 
 import { AuiIf, useAuiState, ThreadPrimitive } from "@assistant-ui/react";
-import type { FC } from "react";
+import { useCallback, useEffect, useRef, useState, type FC } from "react";
 
-export const ThreadFollowupSuggestions: FC = () => {
+const FollowupSuggestionsRow: FC = () => {
   const suggestions = useAuiState((s) => s.thread.suggestions);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rtlRef = useRef<boolean | null>(null);
+  const [fades, setFades] = useState({ left: false, right: false });
+
+  const updateFades = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const maxScroll = el.scrollWidth - el.clientWidth;
+    // scrollLeft runs 0..-max in RTL; normalize to hidden width per physical edge.
+    const fromStart = Math.abs(el.scrollLeft);
+    // getComputedStyle forces a style recalc per scroll event; direction is stable, read it once.
+    const rtl = (rtlRef.current ??= getComputedStyle(el).direction === "rtl");
+    const [left, right] = rtl
+      ? [maxScroll - fromStart, fromStart]
+      : [fromStart, maxScroll - fromStart];
+    setFades((prev) => {
+      const next = { left: left > 1, right: right > 1 };
+      return prev.left === next.left && prev.right === next.right ? prev : next;
+    });
+  }, []);
+
+  useEffect(() => {
+    updateFades();
+    const el = scrollRef.current;
+    if (!el?.firstElementChild) return undefined;
+    const observer = new ResizeObserver(updateFades);
+    observer.observe(el);
+    observer.observe(el.firstElementChild);
+    return () => observer.disconnect();
+  }, [updateFades]);
+
+  const maskImage = `linear-gradient(to right, ${
+    fades.left ? "transparent, black 2rem" : "black"
+  }, ${fades.right ? "black calc(100% - 2rem), transparent" : "black"})`;
+
   return (
-    <AuiIf
-      condition={(s) =>
-        !s.thread.isEmpty &&
-        !s.thread.isRunning &&
-        s.thread.suggestions.length > 0
-      }
+    <div
+      ref={scrollRef}
+      onScroll={updateFades}
+      // overflow-x clips both axes; py-1/-my-1 gives focus rings vertical room without changing outer height.
+      className="aui-thread-followup-suggestions -my-1 w-full overflow-x-auto py-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      style={{ maskImage, WebkitMaskImage: maskImage }}
     >
-      <div className="aui-thread-followup-suggestions flex min-h-8 items-center justify-center gap-2">
+      <div className="mx-auto flex min-h-8 w-max items-center gap-2 px-0.5">
         {suggestions.map((suggestion, idx) => (
           <ThreadPrimitive.Suggestion
             key={idx}
-            className="aui-thread-followup-suggestion bg-background hover:bg-muted/80 rounded-full border px-3 py-1 text-sm transition-colors ease-in"
+            className="aui-thread-followup-suggestion bg-background hover:bg-muted/80 rounded-full border px-3 py-1 text-sm whitespace-nowrap transition-colors ease-in"
             prompt={suggestion.prompt}
             method="replace"
             autoSend
@@ -26,6 +61,18 @@ export const ThreadFollowupSuggestions: FC = () => {
           </ThreadPrimitive.Suggestion>
         ))}
       </div>
-    </AuiIf>
+    </div>
   );
 };
+
+export const ThreadFollowupSuggestions: FC = () => (
+  <AuiIf
+    condition={(s) =>
+      !s.thread.isEmpty &&
+      !s.thread.isRunning &&
+      s.thread.suggestions.length > 0
+    }
+  >
+    <FollowupSuggestionsRow />
+  </AuiIf>
+);


### PR DESCRIPTION
## Summary

`ThreadFollowupSuggestions` previously wrapped pill text onto multiple lines when suggestions overflowed. This matches it to the welcome suggestions pill treatment:

- Pills stay on a single line (`whitespace-nowrap`), centered while they fit.
- On overflow the row scrolls horizontally with no scrollbar.
- A mask fade appears only on an edge with clipped content: at the start position there is no fade on the leading edge; mid-scroll both edges fade; at the end only the trailing edge's fade disappears.
- Fade edges are computed from scroll position (RTL-aware) and kept in sync via a `ResizeObserver`, so container resizes and suggestion changes update the mask.

## Docs

- Expanded the follow-up suggestions sample: composer added below the pills, user bubble matched to the canonical `bg-muted` thread style, and enough suggestions to overflow so the scroll + fade behavior is visible on the page.
- Behavior section documents the single-line scroll and fade rules.
- Callout and Related Components now cross-link the Welcome Suggestions component page.

## Screenshots

| Scroll start (no leading fade) | Mid-scroll (both edges fade) | End (no trailing fade) |
| --- | --- | --- |
| ![scroll start](https://gist.githubusercontent.com/AVGVSTVS96/1cd516498433eed2b31ba55a1be9c6e3/raw/followup-scroll-start.png) | ![mid scroll](https://gist.githubusercontent.com/AVGVSTVS96/1cd516498433eed2b31ba55a1be9c6e3/raw/followup-scroll-mid.png) | ![scroll end](https://gist.githubusercontent.com/AVGVSTVS96/1cd516498433eed2b31ba55a1be9c6e3/raw/followup-scroll-end.png) |

## Test plan

- `tsc --noEmit` clean in `packages/ui` and `apps/docs`; oxlint/oxfmt clean.
- Verified in the docs dev server: mask is trailing-edge-only at scroll start, both edges mid-scroll, leading-edge-only at the end.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.3zlkaBCjP-E1Ihs1WNTw6FbRSZAxYdK1v5Ot_E9qxdLpy3BpnJEz2-Pw6r4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->