### PR TITLE
fix(docs): resolve generative ui workspace subpaths

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -19,6 +19,9 @@
       "@/*": ["./*"],
       "@assistant-ui/ui/*": ["../../packages/ui/src/*"],
       "fumadocs-mdx:collections/*": ["./.source/*"],
+      "@assistant-ui/react-generative-ui/*": [
+        "../../packages/react-generative-ui/src/*"
+      ],
       "@assistant-ui/*": ["../../packages/*/src"],
       "@assistant-ui/core/*": ["../../packages/core/src/*"],
       "@assistant-ui/react/*": ["../../packages/react/src/*"],


### PR DESCRIPTION
## Summary

- add a package-specific workspace alias for `@assistant-ui/react-generative-ui/*`
- resolve the exported `/slack`, `/ir`, and `/teams` entry points directly from their source files
- keep the existing broad `@assistant-ui/*` alias unchanged for package-root imports

## Why

The docs alias `@assistant-ui/* -> ../../packages/*/src` captures the package subpath as part of the wildcard. For example, `@assistant-ui/react-generative-ui/slack` was mapped to the nonexistent `packages/react-generative-ui/slack/src` path, which broke the docs build instead of resolving the package's exported `./slack` entry.

Closes #4991.

## Validation

- reproduced all three subpaths as unresolved before the change
- verified the package root and `/slack`, `/ir`, and `/teams` resolve to their expected source entry points after the change
- ran the type-doc and source-snapshot generators successfully
- `oxfmt --check apps/docs/tsconfig.json`
- `git diff --check`

The full local Next.js build was stopped before completion because the machine had less than 400 MB of disk space remaining; PR CI will provide the final production-build verification.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

