### PR TITLE
fix(react-mcp): close connections completed after unmount

### DIFF
--- a/.changeset/close-react-mcp-unmounted-connections.md
+++ b/.changeset/close-react-mcp-unmounted-connections.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: close pending MCP connections when their resource is disposed

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -1,4 +1,6 @@
 import { createTapRoot, useResource } from "@assistant-ui/tap";
+import type { ClientOutput } from "@assistant-ui/store";
+import { useEffect } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MCPAuthConfig } from "../mcp-scope";
 import type { MCPStorage } from "./storage/types";
@@ -109,15 +111,18 @@ const resetMocks = () => {
   mocks.StreamableHTTPClientTransport.mockClear();
 };
 
-const mount = (props?: {
-  auth?: MCPAuthConfig | undefined;
-  connectionTimeout?: number | undefined;
-}) => {
+const mount = (
+  props?: {
+    auth?: MCPAuthConfig | undefined;
+    connectionTimeout?: number | undefined;
+  },
+  onMount?: (server: ClientOutput<"mcpServer">) => void,
+) => {
   const connectionTimeout =
     props && "connectionTimeout" in props ? props.connectionTimeout : 10_000;
 
   return createTapRoot(function Root() {
-    return useResource(
+    const server = useResource(
       McpServerResource({
         id: "docs",
         kind: "connector",
@@ -131,6 +136,10 @@ const mount = (props?: {
         onRemove: vi.fn(async () => {}),
       }),
     );
+    useEffect(() => {
+      onMount?.(server);
+    }, [onMount, server]);
+    return server;
   });
 };
 
@@ -326,6 +335,28 @@ describe("McpServerResource connection lifecycle", () => {
 
 describe("McpServerResource completeAuth", () => {
   beforeEach(resetMocks);
+
+  it("completes auth across the StrictMode effect replay", async () => {
+    let completeAuth: Promise<void> | undefined;
+    let started = false;
+    const root = mount({ auth: { type: "oauth" } }, (server) => {
+      if (started) return;
+      started = true;
+      completeAuth = server.completeAuth(
+        "https://example.com/callback?code=abc",
+      );
+    });
+
+    try {
+      await expect(completeAuth).resolves.toBeUndefined();
+      await flushMacrotask();
+
+      expect(mocks.transports[0].finishAuth).toHaveBeenCalledTimes(1);
+      expect(root.getValue().getState().connectionState).toBe("connected");
+    } finally {
+      root.unmount();
+    }
+  });
 
   it("rejects when the callback URL has no authorization code", async () => {
     const root = mount();

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -424,11 +424,14 @@ describe("McpServerResource completeAuth", () => {
 
       root.unmount();
       didUnmount = true;
-      rejectFinishAuth(new Error("Connection closed"));
+      const finishAuthError = new Error("Connection closed");
+      rejectFinishAuth(finishAuthError);
 
-      await expect(completeAuth).rejects.toThrow(
-        'MCP server "docs" authorization was interrupted before completion.',
-      );
+      await expect(completeAuth).rejects.toMatchObject({
+        message:
+          'MCP server "docs" authorization was interrupted before completion.',
+        cause: finishAuthError,
+      });
     } finally {
       if (!didUnmount) root.unmount();
     }

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -402,6 +402,37 @@ describe("McpServerResource completeAuth", () => {
       if (!didUnmount) root.unmount();
     }
   });
+
+  it("normalizes late auth failures after unmount", async () => {
+    let rejectFinishAuth!: (error: Error) => void;
+    mocks.finishAuthResults.push(
+      () =>
+        new Promise<void>((_, reject) => {
+          rejectFinishAuth = reject;
+        }),
+    );
+    const root = mount({ auth: { type: "oauth" } });
+    let didUnmount = false;
+
+    try {
+      const completeAuth = root
+        .getValue()
+        .completeAuth("https://example.com/callback?code=abc");
+      await waitFor(
+        () => mocks.transports[0]?.finishAuth.mock.calls.length === 1,
+      );
+
+      root.unmount();
+      didUnmount = true;
+      rejectFinishAuth(new Error("Connection closed"));
+
+      await expect(completeAuth).rejects.toThrow(
+        'MCP server "docs" authorization was interrupted before completion.',
+      );
+    } finally {
+      if (!didUnmount) root.unmount();
+    }
+  });
 });
 
 describe("McpServerResource resource methods", () => {

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -138,7 +138,7 @@ const mount = (
     );
     useEffect(() => {
       onMount?.(server);
-    }, [onMount, server]);
+    }, [server]);
     return server;
   });
 };

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
     }>
   > = [];
   const finishAuthResults: Array<() => Promise<void>> = [];
+  const closeResults: Array<() => Promise<void>> = [];
 
   const Client = vi.fn().mockImplementation(function Client(this: any) {
     const index = clients.length;
@@ -34,7 +35,7 @@ const mocks = vi.hoisted(() => {
     .fn()
     .mockImplementation(function StreamableHTTPClientTransport(this: any) {
       const index = transports.length;
-      this.close = vi.fn(() => Promise.resolve());
+      this.close = vi.fn(() => closeResults[index]?.() ?? Promise.resolve());
       this.finishAuth = vi.fn(
         () => finishAuthResults[index]?.() ?? Promise.resolve(),
       );
@@ -49,6 +50,7 @@ const mocks = vi.hoisted(() => {
     connectResults,
     listToolsResults,
     finishAuthResults,
+    closeResults,
   };
 });
 
@@ -102,6 +104,7 @@ const resetMocks = () => {
   mocks.connectResults.length = 0;
   mocks.listToolsResults.length = 0;
   mocks.finishAuthResults.length = 0;
+  mocks.closeResults.length = 0;
   mocks.Client.mockClear();
   mocks.StreamableHTTPClientTransport.mockClear();
 };
@@ -259,19 +262,65 @@ describe("McpServerResource connection lifecycle", () => {
         }),
     );
     const root = mount({ connectionTimeout: undefined });
-    const connectPromise = root.getValue().connect();
-    await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+    let didUnmount = false;
+    try {
+      const connectPromise = root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
 
-    root.unmount();
-    await flushMacrotask();
+      root.unmount();
+      didUnmount = true;
+      await flushMacrotask();
 
-    expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
 
-    resolveConnect();
-    await connectPromise;
+      resolveConnect();
+      await connectPromise;
 
-    expect(mocks.clients[0].listTools).not.toHaveBeenCalled();
-    expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+      expect(mocks.clients[0].listTools).not.toHaveBeenCalled();
+      expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+    } finally {
+      if (!didUnmount) root.unmount();
+    }
+  });
+
+  it("waits for pending transports to close before a newer reconnect", async () => {
+    let resolveFirstConnect!: () => void;
+    let resolveFirstClose!: () => void;
+    mocks.connectResults.push(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstConnect = resolve;
+        }),
+    );
+    mocks.closeResults.push(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstClose = resolve;
+        }),
+    );
+    const root = mount({ connectionTimeout: undefined });
+
+    try {
+      const firstConnect = root.getValue().connect();
+      await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+
+      const supersededReconnect = root.getValue().connect();
+      await waitFor(() => mocks.transports[0]?.close.mock.calls.length === 1);
+
+      const latestReconnect = root.getValue().connect();
+      await flushMacrotask();
+      expect(mocks.transports).toHaveLength(1);
+
+      resolveFirstClose();
+      await supersededReconnect;
+      await waitFor(() => mocks.clients[1]?.connect.mock.calls.length === 1);
+      await latestReconnect;
+
+      resolveFirstConnect();
+      await firstConnect;
+    } finally {
+      root.unmount();
+    }
   });
 });
 

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -247,6 +247,34 @@ describe("McpServerResource connectionTimeout", () => {
   });
 });
 
+describe("McpServerResource connection lifecycle", () => {
+  beforeEach(resetMocks);
+
+  it("closes a pending connection when the resource unmounts", async () => {
+    let resolveConnect!: () => void;
+    mocks.connectResults.push(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConnect = resolve;
+        }),
+    );
+    const root = mount({ connectionTimeout: undefined });
+    const connectPromise = root.getValue().connect();
+    await waitFor(() => mocks.clients[0]?.connect.mock.calls.length === 1);
+
+    root.unmount();
+    await flushMacrotask();
+
+    expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+
+    resolveConnect();
+    await connectPromise;
+
+    expect(mocks.clients[0].listTools).not.toHaveBeenCalled();
+    expect(mocks.transports[0].close).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("McpServerResource completeAuth", () => {
   beforeEach(resetMocks);
 

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -371,6 +371,37 @@ describe("McpServerResource completeAuth", () => {
       root.unmount();
     }
   });
+
+  it("rejects when the resource unmounts during auth completion", async () => {
+    let resolveFinishAuth!: () => void;
+    mocks.finishAuthResults.push(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFinishAuth = resolve;
+        }),
+    );
+    const root = mount({ auth: { type: "oauth" } });
+    let didUnmount = false;
+
+    try {
+      const completeAuth = root
+        .getValue()
+        .completeAuth("https://example.com/callback?code=abc");
+      await waitFor(
+        () => mocks.transports[0]?.finishAuth.mock.calls.length === 1,
+      );
+
+      root.unmount();
+      didUnmount = true;
+      resolveFinishAuth();
+
+      await expect(completeAuth).rejects.toThrow(
+        'MCP server "docs" authorization was interrupted before completion.',
+      );
+    } finally {
+      if (!didUnmount) root.unmount();
+    }
+  });
 });
 
 describe("McpServerResource resource methods", () => {

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -49,6 +49,7 @@ const useMcpServerResource = (
   const pendingTransportRef = useRef<StreamableHTTPClientTransport | null>(
     null,
   );
+  const transportCloseQueueRef = useRef(Promise.resolve());
   const connectionGenerationRef = useRef(0);
   const mountedRef = useRef(true);
 
@@ -62,10 +63,20 @@ const useMcpServerResource = (
     }
   };
 
+  const closeQueuedTransports = (
+    transports: StreamableHTTPClientTransport[],
+  ): Promise<void> => {
+    const task = transportCloseQueueRef.current.then(async () => {
+      await Promise.all(transports.map(closeTransportSafely));
+    });
+    transportCloseQueueRef.current = task;
+    return task;
+  };
+
   const closePendingTransport = async () => {
     const transport = pendingTransportRef.current;
     pendingTransportRef.current = null;
-    if (transport) await closeTransportSafely(transport);
+    await closeQueuedTransports(transport ? [transport] : []);
   };
 
   const closeTransports = async () => {
@@ -81,7 +92,7 @@ const useMcpServerResource = (
           transport !== null,
       ),
     );
-    await Promise.all([...transports].map(closeTransportSafely));
+    await closeQueuedTransports([...transports]);
   };
 
   const isCurrentConnection = (generation: number) =>
@@ -205,7 +216,7 @@ const useMcpServerResource = (
     try {
       transport = await buildTransport();
       if (!isCurrentConnection(generation)) {
-        await closeTransportSafely(transport);
+        await closeQueuedTransports([transport]);
         return;
       }
       pendingTransportRef.current = transport;
@@ -226,7 +237,7 @@ const useMcpServerResource = (
       } else {
         if (transport) {
           pendingTransportRef.current = null;
-          await closeTransportSafely(transport);
+          await closeQueuedTransports([transport]);
         }
         setLastError({
           message: err instanceof Error ? err.message : String(err),
@@ -259,7 +270,7 @@ const useMcpServerResource = (
       if (!transport) {
         transport = await buildTransport();
         if (!isCurrentConnection(generation)) {
-          await closeTransportSafely(transport);
+          await closeQueuedTransports([transport]);
           return;
         }
       }

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -51,6 +51,7 @@ const useMcpServerResource = (
   );
   const transportCloseQueueRef = useRef(Promise.resolve());
   const connectionGenerationRef = useRef(0);
+  const pendingDisposalRef = useRef<{ cancelled: boolean } | null>(null);
   const mountedRef = useRef(true);
 
   const closeTransportSafely = async (
@@ -331,14 +332,22 @@ const useMcpServerResource = (
 
   // Auto-connect on mount when usable auth exists.
   useEffect(() => {
+    const previousDisposal = pendingDisposalRef.current;
+    if (previousDisposal) previousDisposal.cancelled = true;
+    const pendingDisposal = { cancelled: false };
+    pendingDisposalRef.current = pendingDisposal;
     mountedRef.current = true;
     const signal = { cancelled: false };
     void tryAutoConnect(signal);
     return () => {
       mountedRef.current = false;
-      connectionGenerationRef.current += 1;
       signal.cancelled = true;
-      void closeTransports();
+      // Defer disposal so StrictMode can replay setup before closing the transport.
+      queueMicrotask(() => {
+        if (pendingDisposal.cancelled) return;
+        connectionGenerationRef.current += 1;
+        void closeTransports();
+      });
     };
   }, []);
 

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -46,6 +46,46 @@ const useMcpServerResource = (
 
   const clientRef = useRef<Client | null>(null);
   const transportRef = useRef<StreamableHTTPClientTransport | null>(null);
+  const pendingTransportRef = useRef<StreamableHTTPClientTransport | null>(
+    null,
+  );
+  const connectionGenerationRef = useRef(0);
+  const mountedRef = useRef(true);
+
+  const closeTransportSafely = async (
+    transport: StreamableHTTPClientTransport,
+  ): Promise<void> => {
+    try {
+      await transport.close();
+    } catch {
+      // ignore close errors
+    }
+  };
+
+  const closePendingTransport = async () => {
+    const transport = pendingTransportRef.current;
+    pendingTransportRef.current = null;
+    if (transport) await closeTransportSafely(transport);
+  };
+
+  const closeTransports = async () => {
+    const pendingTransport = pendingTransportRef.current;
+    const activeTransport = transportRef.current;
+    pendingTransportRef.current = null;
+    transportRef.current = null;
+    clientRef.current = null;
+
+    const transports = new Set(
+      [pendingTransport, activeTransport].filter(
+        (transport): transport is StreamableHTTPClientTransport =>
+          transport !== null,
+      ),
+    );
+    await Promise.all([...transports].map(closeTransportSafely));
+  };
+
+  const isCurrentConnection = (generation: number) =>
+    mountedRef.current && generation === connectionGenerationRef.current;
 
   const withConnectionTimeout = useEffectEvent(
     async <T>(
@@ -105,7 +145,7 @@ const useMcpServerResource = (
   );
 
   const finalizeConnect = useEffectEvent(
-    async (transport: StreamableHTTPClientTransport) => {
+    async (transport: StreamableHTTPClientTransport, generation: number) => {
       const client = new Client({
         name: "assistant-ui-mcp",
         version: "0.0.0",
@@ -120,6 +160,7 @@ const useMcpServerResource = (
         "connecting",
         startedAt,
       );
+      if (!isCurrentConnection(generation)) return;
       // Defer ref assignment until listTools() also succeeds — otherwise a
       // post-connect failure leaves stale refs that `callTool()` would
       // happily walk into, producing confusing SDK errors instead of
@@ -129,6 +170,9 @@ const useMcpServerResource = (
         "listing tools",
         startedAt,
       );
+      if (!isCurrentConnection(generation)) return;
+
+      pendingTransportRef.current = null;
       clientRef.current = client;
       transportRef.current = transport;
       setTools(
@@ -145,22 +189,12 @@ const useMcpServerResource = (
     },
   );
 
-  const closeTransport = async () => {
-    const t = transportRef.current;
-    transportRef.current = null;
-    clientRef.current = null;
-    if (t) {
-      try {
-        await t.close();
-      } catch {
-        // ignore close errors
-      }
-    }
-  };
-
   const doConnect = useEffectEvent(async () => {
+    const generation = ++connectionGenerationRef.current;
     // Close any prior transport/client so a re-connect doesn't leak.
-    await closeTransport();
+    await closeTransports();
+    if (!isCurrentConnection(generation)) return;
+
     setConnectionState("connecting");
     setLastError(null);
     setAuthorizationUrl(null);
@@ -170,24 +204,29 @@ const useMcpServerResource = (
     let transport: StreamableHTTPClientTransport | null = null;
     try {
       transport = await buildTransport();
+      if (!isCurrentConnection(generation)) {
+        await closeTransportSafely(transport);
+        return;
+      }
+      pendingTransportRef.current = transport;
       // Don't assign to transportRef until connect succeeds — otherwise a
       // failed `listTools()` leaves an orphaned transport that future
       // doConnect / doDisconnect calls treat as live.
-      await finalizeConnect(transport);
+      await finalizeConnect(transport, generation);
     } catch (err) {
+      if (!isCurrentConnection(generation)) return;
+
       if (err instanceof UnauthorizedError) {
         // OAuth: keep the transport alive so completeAuth can call
         // finishAuth on it. Closing it before storing would leave a
         // closed transport on transportRef.
+        pendingTransportRef.current = null;
         transportRef.current = transport;
         setConnectionState("authRequired");
       } else {
         if (transport) {
-          try {
-            await transport.close();
-          } catch {
-            // ignore close errors
-          }
+          pendingTransportRef.current = null;
+          await closeTransportSafely(transport);
         }
         setLastError({
           message: err instanceof Error ? err.message : String(err),
@@ -198,13 +237,18 @@ const useMcpServerResource = (
   });
 
   const doDisconnect = useEffectEvent(async () => {
+    connectionGenerationRef.current += 1;
     setTools([]);
     setAuthorizationUrl(null);
     setConnectionState("disconnected");
-    await closeTransport();
+    await closeTransports();
   });
 
   const doCompleteAuth = useEffectEvent(async (callbackUrl: string) => {
+    const generation = ++connectionGenerationRef.current;
+    await closePendingTransport();
+    if (!isCurrentConnection(generation)) return;
+
     setConnectionState("authPending");
     setLastError(null);
     try {
@@ -214,13 +258,22 @@ const useMcpServerResource = (
       let transport = transportRef.current;
       if (!transport) {
         transport = await buildTransport();
-        transportRef.current = transport;
+        if (!isCurrentConnection(generation)) {
+          await closeTransportSafely(transport);
+          return;
+        }
       }
+      transportRef.current = null;
+      clientRef.current = null;
+      pendingTransportRef.current = transport;
       await transport.finishAuth(code);
+      if (!isCurrentConnection(generation)) return;
       setAuthorizationUrl(null);
-      await finalizeConnect(transport);
+      await finalizeConnect(transport, generation);
     } catch (err) {
-      await closeTransport();
+      if (!isCurrentConnection(generation)) return;
+
+      await closeTransports();
       const error = err instanceof Error ? err : new Error(String(err));
       setLastError({
         message: error.message,
@@ -255,14 +308,14 @@ const useMcpServerResource = (
 
   // Auto-connect on mount when usable auth exists.
   useEffect(() => {
+    mountedRef.current = true;
     const signal = { cancelled: false };
     void tryAutoConnect(signal);
     return () => {
+      mountedRef.current = false;
+      connectionGenerationRef.current += 1;
       signal.cancelled = true;
-      const t = transportRef.current;
-      transportRef.current = null;
-      clientRef.current = null;
-      if (t) t.close().catch(() => {});
+      void closeTransports();
     };
   }, []);
 

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -98,6 +98,11 @@ const useMcpServerResource = (
   const isCurrentConnection = (generation: number) =>
     mountedRef.current && generation === connectionGenerationRef.current;
 
+  const createInterruptedAuthError = () =>
+    new Error(
+      `MCP server "${props.id}" authorization was interrupted before completion.`,
+    );
+
   const withConnectionTimeout = useEffectEvent(
     async <T>(
       promise: Promise<T>,
@@ -156,7 +161,10 @@ const useMcpServerResource = (
   );
 
   const finalizeConnect = useEffectEvent(
-    async (transport: StreamableHTTPClientTransport, generation: number) => {
+    async (
+      transport: StreamableHTTPClientTransport,
+      generation: number,
+    ): Promise<boolean> => {
       const client = new Client({
         name: "assistant-ui-mcp",
         version: "0.0.0",
@@ -171,7 +179,7 @@ const useMcpServerResource = (
         "connecting",
         startedAt,
       );
-      if (!isCurrentConnection(generation)) return;
+      if (!isCurrentConnection(generation)) return false;
       // Defer ref assignment until listTools() also succeeds — otherwise a
       // post-connect failure leaves stale refs that `callTool()` would
       // happily walk into, producing confusing SDK errors instead of
@@ -181,7 +189,7 @@ const useMcpServerResource = (
         "listing tools",
         startedAt,
       );
-      if (!isCurrentConnection(generation)) return;
+      if (!isCurrentConnection(generation)) return false;
 
       pendingTransportRef.current = null;
       clientRef.current = client;
@@ -197,6 +205,7 @@ const useMcpServerResource = (
         }),
       );
       setConnectionState("connected");
+      return true;
     },
   );
 
@@ -258,7 +267,7 @@ const useMcpServerResource = (
   const doCompleteAuth = useEffectEvent(async (callbackUrl: string) => {
     const generation = ++connectionGenerationRef.current;
     await closePendingTransport();
-    if (!isCurrentConnection(generation)) return;
+    if (!isCurrentConnection(generation)) throw createInterruptedAuthError();
 
     setConnectionState("authPending");
     setLastError(null);
@@ -271,21 +280,22 @@ const useMcpServerResource = (
         transport = await buildTransport();
         if (!isCurrentConnection(generation)) {
           await closeQueuedTransports([transport]);
-          return;
+          throw createInterruptedAuthError();
         }
       }
       transportRef.current = null;
       clientRef.current = null;
       pendingTransportRef.current = transport;
       await transport.finishAuth(code);
-      if (!isCurrentConnection(generation)) return;
+      if (!isCurrentConnection(generation)) throw createInterruptedAuthError();
       setAuthorizationUrl(null);
-      await finalizeConnect(transport, generation);
+      const connected = await finalizeConnect(transport, generation);
+      if (!connected) throw createInterruptedAuthError();
     } catch (err) {
-      if (!isCurrentConnection(generation)) return;
+      const error = err instanceof Error ? err : new Error(String(err));
+      if (!isCurrentConnection(generation)) throw error;
 
       await closeTransports();
-      const error = err instanceof Error ? err : new Error(String(err));
       setLastError({
         message: error.message,
       });

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -98,9 +98,10 @@ const useMcpServerResource = (
   const isCurrentConnection = (generation: number) =>
     mountedRef.current && generation === connectionGenerationRef.current;
 
-  const createInterruptedAuthError = () =>
+  const createInterruptedAuthError = (cause?: unknown) =>
     new Error(
       `MCP server "${props.id}" authorization was interrupted before completion.`,
+      cause === undefined ? undefined : { cause },
     );
 
   const withConnectionTimeout = useEffectEvent(
@@ -293,7 +294,8 @@ const useMcpServerResource = (
       if (!connected) throw createInterruptedAuthError();
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      if (!isCurrentConnection(generation)) throw createInterruptedAuthError();
+      if (!isCurrentConnection(generation))
+        throw createInterruptedAuthError(error);
 
       await closeTransports();
       setLastError({

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -293,7 +293,7 @@ const useMcpServerResource = (
       if (!connected) throw createInterruptedAuthError();
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      if (!isCurrentConnection(generation)) throw error;
+      if (!isCurrentConnection(generation)) throw createInterruptedAuthError();
 
       await closeTransports();
       setLastError({


### PR DESCRIPTION
## Summary

- track the MCP transport while `connect()` and `listTools()` are still pending
- invalidate stale connection attempts when the resource unmounts, disconnects, or starts a newer attempt
- serialize transport cleanup so rapid reconnects wait for earlier closes to finish
- reject interrupted OAuth completion without writing stale resource state
- defer true disposal across StrictMode effect replay so one-shot OAuth callbacks can finish

## Why

When a React MCP resource unmounted during a slow connection, the transport was not yet stored in `transportRef`, so cleanup could not close it. The connection could then finish after disposal, publish tools/state into the disposed resource, and leave its transport open. This can happen when navigating away, removing a connector, or during React lifecycle cleanup while an MCP server is slow.

StrictMode also replays effect cleanup and setup without truly disposing the resource. Treating that replay as a real unmount interrupted the one-shot OAuth callback in development, so disposal is deferred long enough for the replayed setup to cancel it.

## Verification

- added a regression test that unmounts while `Client.connect()` is pending, confirms the transport closes exactly once, and confirms the late attempt never calls `listTools()`
- added a three-attempt reconnect test confirming newer handshakes wait for transport cleanup already in progress
- added OAuth regression tests confirming real unmounts reject while StrictMode cleanup/setup replay completes successfully
- `pnpm --filter @assistant-ui/react-mcp test` (30 tests)
- `pnpm --filter @assistant-ui/react-mcp build`
- targeted formatting check for the changed files

Repository-wide `pnpm lint` reaches pre-existing formatting drift in unrelated docs files; no unrelated formatting changes are included here.