### PR TITLE
fix(assistant-stream): validate assistant-transport chunks and drop out-of-range part paths

### DIFF
--- a/.changeset/transport-chunk-validation.md
+++ b/.changeset/transport-chunk-validation.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: validate assistant-transport chunk shape at the decode boundary and bounds-check accumulator part paths

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { AssistantMessageAccumulator } from "./assistant-message-accumulator";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import type { AssistantMessage } from "../utils/types";
@@ -286,5 +286,88 @@ describe("AssistantMessageAccumulator error chunks", () => {
     expect(last.status).toMatchObject({
       error: expect.not.objectContaining({ severity: expect.anything() }),
     });
+  });
+});
+
+describe("AssistantMessageAccumulator part path bounds", () => {
+  it("drops a text-delta whose path is out of range with a warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [5], textDelta: "x" },
+      { type: "text-delta", path: [0], textDelta: "hi" },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(1);
+    expect(last.parts[0]).toMatchObject({ type: "text", text: "hi" });
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped text-delta chunk: no part at path [5]",
+    );
+    warn.mockRestore();
+  });
+
+  it("drops an out-of-range part-finish instead of fabricating a part", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "part-finish", path: [3] },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(1);
+    expect(last.parts[0]!.type).toBe("text");
+    warn.mockRestore();
+  });
+
+  it("drops part chunks when no parts exist", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "text-delta", path: [0], textDelta: "x" },
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [0], textDelta: "ok" },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(1);
+    expect(last.parts[0]).toMatchObject({ type: "text", text: "ok" });
+    warn.mockRestore();
+  });
+
+  it("drops chunks with nested paths", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [0, 1], textDelta: "x" },
+      { type: "text-delta", path: [0], textDelta: "ok" },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(1);
+    expect(last.parts[0]).toMatchObject({ type: "text", text: "ok" });
+    warn.mockRestore();
+  });
+
+  it("drops an out-of-range result without touching existing tool calls", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: { type: "tool-call", toolCallId: "t1", toolName: "f" },
+      },
+      { type: "text-delta", path: [0], textDelta: "{}" },
+      { type: "result", path: [7], result: { ok: true } },
+      { type: "result", path: [0], result: { ok: true } },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(1);
+    expect(last.parts[0]).toMatchObject({
+      type: "tool-call",
+      state: "result",
+      result: { ok: true },
+    });
+    warn.mockRestore();
   });
 });

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -357,8 +357,8 @@ describe("AssistantMessageAccumulator part path bounds", () => {
         part: { type: "tool-call", toolCallId: "t1", toolName: "f" },
       },
       { type: "text-delta", path: [0], textDelta: "{}" },
-      { type: "result", path: [7], result: { ok: true } },
-      { type: "result", path: [0], result: { ok: true } },
+      { type: "result", path: [7], result: { ok: true }, isError: false },
+      { type: "result", path: [0], result: { ok: true }, isError: false },
     ]);
     const last = messages.at(-1)!;
 

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -42,15 +42,17 @@ const updatePartForPath = (
   chunk: AssistantStreamChunk,
   updater: (part: AssistantMessagePart) => AssistantMessagePart,
 ): AssistantMessage => {
-  if (message.parts.length === 0) {
-    throw new Error("No parts available to update.");
+  const part =
+    chunk.path.length === 1 ? message.parts[chunk.path[0]!] : undefined;
+  if (part === undefined) {
+    console.warn(
+      `Dropped ${chunk.type} chunk: no part at path [${chunk.path.join(", ")}]`,
+    );
+    return message;
   }
 
-  if (chunk.path.length !== 1)
-    throw new Error("Nested paths are not supported yet.");
-
   const partIndex = chunk.path[0]!;
-  const updatedPart = updater(message.parts[partIndex]!);
+  const updatedPart = updater(part);
   return {
     ...message,
     parts: [

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
@@ -250,7 +250,10 @@ describe("AssistantTransportDecoder", () => {
     expect(decodedChunks).toEqual([
       { type: "text-delta", textDelta: "Hello", path: [] },
     ]);
-    expect(warn).toHaveBeenCalledTimes(4);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("(not-an-object)"),
+    );
     warn.mockRestore();
   });
 
@@ -267,6 +270,7 @@ describe("AssistantTransportDecoder", () => {
     );
 
     expect(decodedChunks).toEqual([{ type: "part-finish", path: [] }]);
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 
@@ -285,6 +289,7 @@ describe("AssistantTransportDecoder", () => {
     expect(decodedChunks).toEqual([
       { type: "text-delta", textDelta: "f", path: [0] },
     ]);
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 
@@ -337,6 +342,7 @@ describe("AssistantTransportDecoder", () => {
     expect(decodedChunks).toEqual([
       { type: "text-delta", textDelta: "ok", path: [0] },
     ]);
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   AssistantTransportEncoder,
   AssistantTransportDecoder,
@@ -45,6 +45,18 @@ async function encodeAndDecode(
 
   // Decode the reconstructed stream
   return reconstructedStream.pipeThrough(new AssistantTransportDecoder());
+}
+
+function sseStream(frames: string[]): ReadableStream<AssistantStreamChunk> {
+  const sseText =
+    frames.map((frame) => `data: ${frame}\n\n`).join("") + "data: [DONE]\n\n";
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(sseText));
+      controller.close();
+    },
+  }).pipeThrough(new AssistantTransportDecoder());
 }
 
 describe("AssistantTransportEncoder", () => {
@@ -221,6 +233,111 @@ describe("AssistantTransportDecoder", () => {
     await expect(collectChunks(decodedStream)).rejects.toThrow(
       "Stream ended abruptly without receiving [DONE] marker",
     );
+  });
+
+  it("drops frames that are not objects", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        "null",
+        "5",
+        '"text"',
+        "[1,2]",
+        '{"type":"text-delta","textDelta":"Hello","path":[]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "text-delta", textDelta: "Hello", path: [] },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(4);
+    warn.mockRestore();
+  });
+
+  it("drops frames with a missing or unknown type", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"path":[]}',
+        '{"type":5,"path":[]}',
+        '{"type":"bogus","path":[]}',
+        '{"type":"toString","path":[]}',
+        '{"type":"part-finish","path":[]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([{ type: "part-finish", path: [] }]);
+    warn.mockRestore();
+  });
+
+  it("drops frames with an invalid path", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"text-delta","textDelta":"b","path":"0"}',
+        '{"type":"text-delta","textDelta":"c","path":[-1]}',
+        '{"type":"text-delta","textDelta":"d","path":[1.5]}',
+        '{"type":"text-delta","textDelta":"e","path":["0"]}',
+        '{"type":"text-delta","textDelta":"f","path":[0]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "text-delta", textDelta: "f", path: [0] },
+    ]);
+    warn.mockRestore();
+  });
+
+  it("normalizes a missing path to an empty path on message-level chunks", async () => {
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"update-state","operations":[{"type":"set","path":["messages"],"value":[]}]}',
+        '{"type":"error","error":"boom"}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      {
+        type: "update-state",
+        operations: [{ type: "set", path: ["messages"], value: [] }],
+        path: [],
+      },
+      { type: "error", error: "boom", path: [] },
+    ]);
+  });
+
+  it("drops part-addressed chunks with a missing path", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"text-delta","textDelta":"a"}',
+        '{"type":"part-finish"}',
+        '{"type":"result","result":{"ok":true}}',
+        '{"type":"text-delta","textDelta":"ok","path":[0]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "text-delta", textDelta: "ok", path: [0] },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(3);
+    warn.mockRestore();
+  });
+
+  it("drops frames that are not valid JSON", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"text-delta"',
+        "not json",
+        '{"type":"text-delta","textDelta":"ok","path":[0]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "text-delta", textDelta: "ok", path: [0] },
+    ]);
+    warn.mockRestore();
   });
 
   it("round-trips error chunks with code and severity", async () => {

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -25,31 +25,31 @@ const KNOWN_CHUNK_TYPES: Record<
   "update-state": "message",
 };
 
-const parseChunk = (data: string): AssistantStreamChunk | null => {
+const parseChunk = (data: string): AssistantStreamChunk | string => {
   let value: unknown;
   try {
     value = sjson.parse(data);
   } catch {
-    return null;
+    return "unparseable";
   }
   if (typeof value !== "object" || value === null || Array.isArray(value))
-    return null;
+    return "not-an-object";
   const { type, path } = value as { type?: unknown; path?: unknown };
   if (
     typeof type !== "string" ||
     !Object.prototype.hasOwnProperty.call(KNOWN_CHUNK_TYPES, type)
   )
-    return null;
+    return "unknown-type";
   if (path === undefined) {
     if (KNOWN_CHUNK_TYPES[type as AssistantStreamChunk["type"]] !== "message")
-      return null;
+      return `missing-path:${type}`;
     return { ...value, path: [] } as unknown as AssistantStreamChunk;
   }
   if (
     !Array.isArray(path) ||
     !path.every((entry) => Number.isInteger(entry) && entry >= 0)
   )
-    return null;
+    return "invalid-path";
   return value as AssistantStreamChunk;
 };
 
@@ -96,6 +96,7 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
   constructor() {
     super((readable) => {
       let receivedDone = false;
+      const warnedReasons = new Set<string>();
 
       return readable
         .pipeThrough(new TextDecoderStream())
@@ -112,12 +113,15 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
                     controller.terminate();
                   } else {
                     const chunk = parseChunk(event.data);
-                    if (chunk) {
-                      controller.enqueue(chunk);
+                    if (typeof chunk === "string") {
+                      if (!warnedReasons.has(chunk)) {
+                        warnedReasons.add(chunk);
+                        console.warn(
+                          `Dropped invalid assistant-transport chunk (${chunk}): ${event.data.slice(0, 200)}`,
+                        );
+                      }
                     } else {
-                      console.warn(
-                        `Dropped invalid assistant-transport chunk: ${event.data.slice(0, 200)}`,
-                      );
+                      controller.enqueue(chunk);
                     }
                   }
                   break;

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -6,6 +6,52 @@ import {
 } from "../../utils/stream/SSEEventDecoderStream";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
+const KNOWN_CHUNK_TYPES: Record<
+  AssistantStreamChunk["type"],
+  "message" | "part-addressed"
+> = {
+  "part-start": "message",
+  "part-finish": "part-addressed",
+  "tool-call-args-text-finish": "part-addressed",
+  "text-delta": "part-addressed",
+  annotations: "message",
+  data: "message",
+  "step-start": "message",
+  "step-finish": "message",
+  "message-finish": "message",
+  result: "part-addressed",
+  error: "message",
+  "update-state": "message",
+};
+
+const parseChunk = (data: string): AssistantStreamChunk | null => {
+  let value: unknown;
+  try {
+    value = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return null;
+  const { type, path } = value as { type?: unknown; path?: unknown };
+  if (
+    typeof type !== "string" ||
+    !Object.prototype.hasOwnProperty.call(KNOWN_CHUNK_TYPES, type)
+  )
+    return null;
+  if (path === undefined) {
+    if (KNOWN_CHUNK_TYPES[type as AssistantStreamChunk["type"]] !== "message")
+      return null;
+    return { ...value, path: [] } as unknown as AssistantStreamChunk;
+  }
+  if (
+    !Array.isArray(path) ||
+    !path.every((entry) => Number.isInteger(entry) && entry >= 0)
+  )
+    return null;
+  return value as AssistantStreamChunk;
+};
+
 /**
  * AssistantTransportEncoder encodes AssistantStreamChunks into SSE format
  * and emits [DONE] when the stream completes.
@@ -64,7 +110,14 @@ export class AssistantTransportDecoder extends PipeableTransformStream<
                     // Stop processing when we encounter [DONE]
                     controller.terminate();
                   } else {
-                    controller.enqueue(JSON.parse(event.data));
+                    const chunk = parseChunk(event.data);
+                    if (chunk) {
+                      controller.enqueue(chunk);
+                    } else {
+                      console.warn(
+                        `Dropped invalid assistant-transport chunk: ${event.data.slice(0, 200)}`,
+                      );
+                    }
                   }
                   break;
                 default:

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -1,3 +1,4 @@
+import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import { PipeableTransformStream } from "../../utils/stream/PipeableTransformStream";
 import {
@@ -27,7 +28,7 @@ const KNOWN_CHUNK_TYPES: Record<
 const parseChunk = (data: string): AssistantStreamChunk | null => {
   let value: unknown;
   try {
-    value = JSON.parse(data);
+    value = sjson.parse(data);
   } catch {
     return null;
   }


### PR DESCRIPTION
Closes #5151.
## What

- `AssistantTransportDecoder` now parses each SSE frame through a guard (`secure-json-parse`, matching the package's tool-args parsing): unparseable JSON, prototype-pollution payloads, non-object values, unknown chunk types, and invalid `path` values are dropped with a `console.warn`; a missing `path` is normalized to `[]` for message-level chunk types only (the Python encoder's pathless `update-state`/`error`/`data` wire shape), while a pathless part-addressed chunk (`text-delta`, `part-finish`, `result`) is dropped with the same warning since `[]` is not a valid part address.
- `AssistantMessageAccumulator` now drops part chunks it cannot address (out-of-range index, nested path, empty parts) with a `console.warn` instead of throwing or fabricating a phantom typeless part.

## Why

While fuzzing The transport decoder enqueues whatever `JSON.parse` returns, so a server sending `data: null` or a chunk with `path: [5]` kills the client with a TypeError, and an out-of-range `part-finish` silently inserts a typeless part into the message. The path index is remote-controlled input reaching an unchecked array access, and assistant-transport backends are user-written, so the client cannot assume well-formed frames. 

## Impact

- A frame that fails the shape guard no longer aborts the whole response; it is dropped with a console warning and valid chunks keep flowing.
- Behavior changes on malformed input only: the accumulator's "No parts available" and "Nested paths" throws become warn-and-drop, and unparseable frames drop instead of throwing.
- Pathless frames from the Python `AssistantTransportEncoder` (`update-state`, `error`, `data`) behave exactly as before via the `path: []` normalization; streams from the TS encoder are unaffected.

## Review cycle

Summarizing the two review rounds so the thread history is not required reading:

- Round 1 (all fixed): the strict path requirement was a real regression for pathless Python frames, fixed by normalizing missing `path`; `JSON.parse` moved inside the guard's try/catch so truncated frames drop instead of aborting; the lying `value is AssistantStreamChunk` predicate became `parseChunk(data): chunk | null` with one explicit cast.
- Round 2 (all fixed): blanket `[]` normalization laundered pathless part-addressed chunks into silent accumulator misses, fixed by splitting the known-type map into message vs part-addressed kinds; the accumulator's drops now warn with chunk type and path.
- On routing drops through `onError` (raised in review): the transport runtime throws at end-of-stream when `onError` has fired (`useAssistantTransportRuntime.ts:232`), so a drop signal there becomes a deferred response failure, the exact abort drop semantics exist to avoid; `console.warn` matches the existing `toolResultStream`/`ToolCallReader` pattern.
- Follow-ups tracked: Python wire interop in #5153 (also absorbs the `DataChunk.data` non-array note); the same defect in the sibling UIMessageStream decoder in #5154, fixed by #5155; per-field validation of known chunk types is deliberately a noted follow-up here rather than an issue, since it extends `parseChunk` directly and sequences after this merges (the accumulator's remaining throw sites fold into it).

## Scope & caveats

- The guard checks shape (object, known type, valid-or-absent path), not per-type fields: a known-type frame missing nested fields (e.g. `part-start` without `part`) can still throw in the accumulator. Deferred as noted above.
- `path: []` normalization is deliberate: `path` is required in the TS type but absent on the Python wire, and the #4854 convention is to normalize dialects at the parse boundary. Frames with a present-but-invalid path are still rejected.
- Python chunk types outside the TS union (`tool-call-begin`, `tool-result`, `reasoning-delta`, `source`) crashed the accumulator before this PR and are dropped-with-warning after; that interop gap is pre-existing, tracked in #5153.
- The known-type map is compile-time synced to the union (`Record<AssistantStreamChunk["type"], ...>`), and membership is an own-property check so prototype keys like `"toString"` are rejected.
- The accumulator guard is defense in depth: it is fed by every decoder plus replay paths, not just this transport.
- Additive only, nothing exported or reshaped; published wire-chunk unions untouched.
- Tests: decoder drop cases (non-object, unknown/prototype type, invalid path, unparseable JSON, pathless part-addressed), path normalization on the Python wire shapes, accumulator bounds with warn assertions; not covered: an exhaustive per-chunk-type round-trip matrix, tracked separately in the DataStream round-trip suite item.
- Changeset: patch (`assistant-stream`).
