### PR TITLE
fix(assistant-stream): validate UIMessageStream frames and clear args alias on tool-result

### DIFF
--- a/.changeset/uims-decoder-frame-guards.md
+++ b/.changeset/uims-decoder-frame-guards.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: drop malformed UIMessageStream frames at the decode boundary and fix tool-result closing the active args stream

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -575,4 +575,115 @@ describe("UIMessageStreamDecoder", () => {
     // Should not throw, should complete successfully
     expect(chunks.some((c) => c.type === "message-finish")).toBe(true);
   });
+
+  it("drops frames that are not objects with a string type", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const invalidFrames = [
+      "null",
+      "5",
+      '"text"',
+      "[1,2]",
+      '{"foo":1}',
+      '{"type":5}',
+    ];
+    const events = [
+      ...invalidFrames,
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-delta", id: "t", delta: "ok" }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    expect(warn.mock.calls.map((c) => c[0])).toEqual(
+      invalidFrames.map((f) => `Dropped invalid UIMessageStream chunk: ${f}`),
+    );
+    expect(chunks.some((c) => c.type === "text-delta")).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("drops frames that are not valid JSON", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const invalidFrames = ['{"type":"te', "not json"];
+    const events = [
+      ...invalidFrames,
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-delta", id: "t", delta: "ok" }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    expect(warn.mock.calls.map((c) => c[0])).toEqual(
+      invalidFrames.map((f) => `Dropped invalid UIMessageStream chunk: ${f}`),
+    );
+    expect(chunks.some((c) => c.type === "text-delta")).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("ignores a tool-call-delta arriving after tool-result", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "tool-call-start",
+        toolCallId: "call_abc",
+        toolName: "weather",
+      }),
+      JSON.stringify({ type: "tool-call-delta", argsText: '{"city":"NYC"}' }),
+      JSON.stringify({
+        type: "tool-result",
+        toolCallId: "call_abc",
+        result: { temp: 72 },
+      }),
+      JSON.stringify({ type: "tool-call-delta", argsText: '{"late":true}' }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    const argDeltas = chunks.filter((c) => c.type === "text-delta");
+    expect(argDeltas).toHaveLength(1);
+    expect(chunks.some((c) => c.type === "result")).toBe(true);
+  });
+
+  it("keeps the active tool call writable when another call receives its result", async () => {
+    const events = [
+      JSON.stringify({
+        type: "tool-call-start",
+        toolCallId: "call_a",
+        toolName: "first",
+      }),
+      JSON.stringify({
+        type: "tool-call-start",
+        toolCallId: "call_b",
+        toolName: "second",
+      }),
+      JSON.stringify({
+        type: "tool-result",
+        toolCallId: "call_a",
+        result: { ok: true },
+      }),
+      JSON.stringify({ type: "tool-call-delta", argsText: '{"x":1}' }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    const argDeltas = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+        c.type === "text-delta",
+    );
+    expect(argDeltas).toHaveLength(2);
+    const byPath = new Map(argDeltas.map((c) => [c.path[0], c.textDelta]));
+    expect(byPath.get(0)).toBe("{}");
+    expect(byPath.get(1)).toBe('{"x":1}');
+  });
 });

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -149,6 +149,9 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                   `Encountered tool result with unknown id: ${chunk.toolCallId}`,
                 );
               }
+              if (toolCallController.argsText === activeToolCallArgsText) {
+                activeToolCallArgsText = undefined;
+              }
               toolCallController.setResponse({
                 result: chunk.result,
                 isError: chunk.isError ?? false,
@@ -222,7 +225,23 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
                 return;
               }
 
-              const chunk = JSON.parse(event.data);
+              let chunk;
+              try {
+                chunk = JSON.parse(event.data);
+              } catch {
+                chunk = undefined;
+              }
+              if (
+                typeof chunk !== "object" ||
+                chunk === null ||
+                Array.isArray(chunk) ||
+                typeof chunk.type !== "string"
+              ) {
+                console.warn(
+                  `Dropped invalid UIMessageStream chunk: ${event.data.slice(0, 200)}`,
+                );
+                return;
+              }
               if (
                 chunk.type === "text-delta" &&
                 chunk.textDelta === undefined


### PR DESCRIPTION

Closes https://github.com/assistant-ui/assistant-ui/issues/5154
## What

- `UIMessageStreamDecoder` now validates each SSE frame after `JSON.parse`: unparseable JSON and frames that are not objects with a string `type` are dropped with a `console.warn` instead of crashing the stream.
- Fixed the `tool-call-start -> tool-result -> tool-call-delta` crash: `setResponse` closes the args text stream but the decoder's `activeToolCallArgsText` alias kept pointing at it, so a late delta wrote into a closed controller. The alias is now cleared (identity-guarded) when the active call receives its result.

## Why

Same trust boundary as #5151: `data: null` throws reading `.type`, `data: 5` throws in `isDataChunk`'s `.startsWith`, and a misordered tool frame aborts with "Controller is already closed" - each a single remote frame killing the whole response. 

## Impact

- A malformed or misordered frame no longer aborts the response; it is dropped with a warning (shape failures) or ignored (late tool deltas), and valid chunks keep flowing.
- Well-formed streams are unaffected; all existing decoder tests pass unchanged.
- The sole in-repo consumer is `useDataStreamRuntime`, which pipes into the accumulator, so the change strictly reduces client crashes there.

## Scope & caveats

- No known-type allowlist, deliberately diverging from the transport guard in #5152: this decoder handles the AI SDK's evolving external dialect and already ignores unknown types for forward compatibility, so the guard only ensures `type` is safely dereferenceable.
- The duplicate-toolCallId and unknown-toolCallId throws stay: they are deliberate protocol-violation detection (added on purpose in #2621), not accidental crashes.
- Late and orphan `tool-call-delta`s drop silently via the existing `?.` posture; adding a warn there is a separable policy change for streams that are valid by AI SDK semantics.
- The fuzz-era `{"type":"source"}` / `{"type":"file"}` crashes are absent on main: #4854's skip guards already cover them.
- The `"{}"` args delta asserted in the two-tool-call test is pre-existing controller behavior (empty args stream closes as `{}`) being pinned, not new behavior.
- Per-field validation of known types is deferred, same as in #5152.
- Additive only, nothing exported or reshaped.
- Tests: garbage frames, invalid JSON, delta-after-result, and result-for-non-active-call; not covered: per-field shapes (deferred as above).
- Changeset: patch (`assistant-stream`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

