### PR TITLE
fix(cloud): deduplicate concurrent auth requests

### DIFF
--- a/.changeset/calm-clouds-authenticate.md
+++ b/.changeset/calm-clouds-authenticate.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: deduplicate concurrent Cloud authentication requests

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -39,6 +39,7 @@ export class AssistantCloudJWTAuthStrategy implements AssistantCloudAuthStrategy
 
   private cachedToken: string | null = null;
   private tokenExpiry: number | null = null;
+  private tokenRequest: Promise<Record<string, string> | false> | null = null;
   #authTokenCallback: () => Promise<string | null>;
 
   constructor(authTokenCallback: () => Promise<string | null>) {
@@ -57,14 +58,28 @@ export class AssistantCloudJWTAuthStrategy implements AssistantCloudAuthStrategy
       return { Authorization: `Bearer ${this.cachedToken}` };
     }
 
-    // Fetch a new token via the callback
-    const newToken = await this.#authTokenCallback();
-    if (!newToken) return false;
+    if (!this.tokenRequest) {
+      this.tokenRequest = this.fetchAuthHeaders();
+    }
 
-    this.cachedToken = newToken;
-    this.tokenExpiry = getJwtExpiry(newToken);
+    const tokenRequest = this.tokenRequest;
+    try {
+      return await tokenRequest;
+    } finally {
+      if (this.tokenRequest === tokenRequest) {
+        this.tokenRequest = null;
+      }
+    }
+  }
 
-    return { Authorization: `Bearer ${newToken}` };
+  private async fetchAuthHeaders(): Promise<Record<string, string> | false> {
+    const token = await this.#authTokenCallback();
+    if (!token) return false;
+
+    this.cachedToken = token;
+    this.tokenExpiry = getJwtExpiry(token);
+
+    return { Authorization: `Bearer ${token}` };
   }
 
   public readAuthHeaders(headers: Headers) {

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AssistantCloudAnonymousAuthStrategy } from "../AssistantCloudAuthStrategy";
+import {
+  AssistantCloudAnonymousAuthStrategy,
+  AssistantCloudJWTAuthStrategy,
+} from "../AssistantCloudAuthStrategy";
 
 const baseUrl = "https://test.example.com";
 const accessToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(JSON.stringify({ exp: 4102444800 })).toString("base64url")}.sig`;
@@ -70,6 +73,25 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       `${baseUrl}/v1/auth/tokens/anonymous`,
       { method: "POST" },
     );
+  });
+
+  it("deduplicates concurrent anonymous token requests", async () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    const fetchMock = mockAnonymousTokenFetch();
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(
+      Promise.all([
+        strategy.getAuthHeaders(),
+        strategy.getAuthHeaders(),
+        strategy.getAuthHeaders(),
+      ]),
+    ).resolves.toEqual([
+      { Authorization: `Bearer ${accessToken}` },
+      { Authorization: `Bearer ${accessToken}` },
+      { Authorization: `Bearer ${accessToken}` },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("returns an anonymous access token without localStorage", async () => {
@@ -147,5 +169,23 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       Authorization: `Bearer ${accessToken}`,
     });
     expect(values.get("aui:refresh_token")).toBe(JSON.stringify(refreshToken));
+  });
+});
+
+describe("AssistantCloudJWTAuthStrategy", () => {
+  it("retries token acquisition after a failed request", async () => {
+    const authToken = vi
+      .fn<() => Promise<string | null>>()
+      .mockRejectedValueOnce(new Error("authentication unavailable"))
+      .mockResolvedValueOnce(accessToken);
+    const strategy = new AssistantCloudJWTAuthStrategy(authToken);
+
+    await expect(strategy.getAuthHeaders()).rejects.toThrow(
+      "authentication unavailable",
+    );
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(authToken).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- share one in-flight token request between concurrent Cloud auth callers
- cache the resulting token before releasing waiting requests
- clear failed requests so later authentication attempts can retry
- add regression coverage and a patch changeset for `assistant-cloud`

## Why

Anonymous Cloud authentication represents one browser-session user, but several initial Cloud operations can request auth headers at the same time. I reproduced three concurrent `getAuthHeaders()` calls making three anonymous-token requests and receiving three different identities before any token was cached. That can split one browser session across users and leave the last refresh token write winning.

The pending request is scoped to one auth strategy, so separate users and Cloud clients remain isolated. JWT auth callbacks receive the same protection without changing the public API.

## Testing

- `vitest run packages/cloud/src` (55 passed, 2 skipped)
- `oxlint packages/cloud/src/AssistantCloudAuthStrategy.ts packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts`
- `aui-build` in `packages/cloud`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

