### PR TITLE
fix(react-streamdown): keep inline math that opens with a digit

### DIFF
--- a/.changeset/digit-initial-inline-math.md
+++ b/.changeset/digit-initial-inline-math.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-streamdown": patch
+"@assistant-ui/react-markdown": patch
+---
+
+fix: keep inline math that opens with a digit out of currency escaping

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -155,4 +155,14 @@ describe("escapeCurrencyDollars", () => {
       "see `unclosed then \\$5 and \\$7 later",
     );
   });
+
+  it("escapes currency glued to a preceding word", () => {
+    expect(escapeCurrencyDollars("Prices range from US$50 to US$100")).toBe(
+      "Prices range from US\\$50 to US\\$100",
+    );
+  });
+
+  it("escapes an amount whose next dollar opens another amount", () => {
+    expect(escapeCurrencyDollars("$50 to US$60")).toBe("\\$50 to US\\$60");
+  });
 });

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -131,4 +131,28 @@ describe("escapeCurrencyDollars", () => {
       "```\nconst price = $5;\n```",
     );
   });
+
+  it("escapes an amount when the prose before the next span carries latex syntax", () => {
+    expect(
+      escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),
+    ).toBe("Pay \\$20 when x_1 rises, then $n$ holds");
+  });
+
+  it("keeps digit-initial math that carries latex syntax", () => {
+    expect(escapeCurrencyDollars("Solve $5x_2 = 10$ now")).toBe(
+      "Solve $5x_2 = 10$ now",
+    );
+  });
+
+  it("escapes a currency range written with a unicode minus", () => {
+    expect(escapeCurrencyDollars("Prices: $5\u2212$10 each")).toBe(
+      "Prices: \\$5\u2212\\$10 each",
+    );
+  });
+
+  it("escapes currency after an unclosed backtick", () => {
+    expect(escapeCurrencyDollars("see `unclosed then $5 and $7 later")).toBe(
+      "see `unclosed then \\$5 and \\$7 later",
+    );
+  });
 });

--- a/packages/react-markdown/src/preprocess.test.ts
+++ b/packages/react-markdown/src/preprocess.test.ts
@@ -77,4 +77,58 @@ describe("escapeCurrencyDollars", () => {
   it("escapes currency after an escaped backslash", () => {
     expect(escapeCurrencyDollars("\\\\$5")).toBe("\\\\\\$5");
   });
+
+  it("escapes each amount in a list of prices", () => {
+    expect(escapeCurrencyDollars("Prices are $10, $20, and $30.")).toBe(
+      "Prices are \\$10, \\$20, and \\$30.",
+    );
+  });
+
+  it("keeps inline math that opens with a digit", () => {
+    expect(
+      escapeCurrencyDollars("gives $0$ points, $1$ to the second, up to $m-1$"),
+    ).toBe("gives $0$ points, $1$ to the second, up to $m-1$");
+  });
+
+  it("keeps an expression that opens with a digit", () => {
+    expect(escapeCurrencyDollars("Solve $5x = 10$ for x.")).toBe(
+      "Solve $5x = 10$ for x.",
+    );
+  });
+
+  it("escapes currency but keeps math in the same line", () => {
+    expect(escapeCurrencyDollars("Pay $20 when $n=3$ holds.")).toBe(
+      "Pay \\$20 when $n=3$ holds.",
+    );
+  });
+
+  it("does not shift the delimiters that follow an escaped amount", () => {
+    expect(escapeCurrencyDollars("costs $5 and $7, and $n$ holds")).toBe(
+      "costs \\$5 and \\$7, and $n$ holds",
+    );
+  });
+
+  it("escapes a currency range", () => {
+    expect(escapeCurrencyDollars("Prices: $5-$10 each")).toBe(
+      "Prices: \\$5-\\$10 each",
+    );
+  });
+
+  it("escapes a currency range written with a slash", () => {
+    expect(escapeCurrencyDollars("Pay $5/$10 split")).toBe(
+      "Pay \\$5/\\$10 split",
+    );
+  });
+
+  it("does not rewrite a code span", () => {
+    expect(escapeCurrencyDollars("Use `$5` as the placeholder.")).toBe(
+      "Use `$5` as the placeholder.",
+    );
+  });
+
+  it("does not rewrite a fenced block", () => {
+    expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
+      "```\nconst price = $5;\n```",
+    );
+  });
 });

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -54,19 +54,134 @@ export function normalizeMathDelimiters(text: string): string {
   return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
 }
 
-const CURRENCY_DOLLAR = /(^|[^\\$])((?:\\\\)*)\$(?=\d)/g;
+const LATEX_SYNTAX = /\\[a-zA-Z]|[_^{}]/;
+const BLANK_LINE = /\n[ \t]*\n/;
+const ADJACENT_WORDS = /[A-Za-z]{3,}\s+[A-Za-z]{3,}/;
+const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014]$/;
+
+/** Length of the run of `char` starting at `start`. */
+function runLength(text: string, start: number, char: string): number {
+  let length = 0;
+  while (text[start + length] === char) length++;
+  return length;
+}
 
 /**
- * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
- * remark-math with single-dollar math enabled does not consume currency amounts in
- * prose as math delimiters. A math expression almost always opens with a letter or a
- * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
- * is left intact, and an already-escaped `\$` is not escaped twice (the even run of
- * backslashes before the `$` is preserved).
+ * End index (exclusive) of the code span or fence whose backtick run starts at
+ * `start`, or the end of the text when that run is never closed.
+ */
+function codeSpanEnd(text: string, start: number): number {
+  const fence = "`".repeat(runLength(text, start, "`"));
+  const closed = text.indexOf(fence, start + fence.length);
+  return closed === -1 ? text.length : closed + fence.length;
+}
+
+/**
+ * Index of the `$` that would close an inline math span opened at `openIndex`, or
+ * -1 when none does. Escapes and code spans are stepped over so that a `$` inside
+ * them is not mistaken for the closing delimiter.
+ */
+function findClosingDollar(text: string, openIndex: number): number {
+  let index = openIndex + 1;
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "$") return index;
+    if (char === "\\") index += 2;
+    else if (char === "`") index = codeSpanEnd(text, index);
+    else index += 1;
+  }
+  return -1;
+}
+
+/**
+ * Prose separating two currency amounts always ends on a space (`5 and ` in
+ * `$5 and $7`), whereas math is never written `$x $`.
+ */
+function endsMidSentence(body: string): boolean {
+  return /\s$/.test(body) && !/^\s/.test(body);
+}
+
+/**
+ * A currency range leaves a dangling operator (`5-` in `$5-$10`), which no inline
+ * expression ends on.
+ */
+function endsOnOperator(body: string): boolean {
+  return TRAILING_OPERATOR.test(body);
+}
+
+/**
+ * Whether the body reads as the text between two currency amounts rather than as an
+ * expression: running prose (`5 and `), a range (`5-`), or two adjacent words.
+ */
+function separatesTwoAmounts(body: string): boolean {
+  return (
+    endsMidSentence(body) || endsOnOperator(body) || ADJACENT_WORDS.test(body)
+  );
+}
+
+/**
+ * Whether the text between two single `$` reads as an inline math expression rather
+ * than the text separating two currency amounts. LaTeX syntax settles it; failing
+ * that, anything that reads as surrounding text is rejected.
+ */
+function isMathBody(body: string): boolean {
+  if (body.length === 0) return false;
+  if (BLANK_LINE.test(body)) return false;
+  if (LATEX_SYNTAX.test(body)) return true;
+  return !separatesTwoAmounts(body);
+}
+
+/** Whether the `$` at `index` opens a currency amount such as `$5` or `$1,299`. */
+function opensCurrencyAmount(text: string, index: number): boolean {
+  return /\d/.test(text[index + 1] ?? "");
+}
+
+/**
+ * End index (exclusive) of the run at `index` that must be copied unchanged: a `\x`
+ * escape, a code span, a `$$` display delimiter, an inline math span, or a plain
+ * character. Returns `index` itself for a single `$`, which the caller has to decide.
+ */
+function endOfVerbatimRun(text: string, index: number): number {
+  const char = text[index];
+  if (char === "\\") return Math.min(index + 2, text.length);
+  if (char === "`") return codeSpanEnd(text, index);
+  if (char !== "$") return index + 1;
+
+  const dollars = runLength(text, index, "$");
+  if (dollars >= 2) return index + dollars;
+
+  const close = findClosingDollar(text, index);
+  const opensMath = close !== -1 && isMathBody(text.slice(index + 1, close));
+  return opensMath ? close + 1 : index;
+}
+
+/**
+ * Escapes a `$` that opens a currency amount (`$5`, `$19.99`, `$1,299`) so that
+ * remark-math with single-dollar math enabled does not consume prices in prose as
+ * math delimiters. The `$$` of display math is left intact, an already-escaped `\$`
+ * is not escaped twice, and code spans and fences are never rewritten.
  *
- * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
- * leading `$` escaped as well. This is rare in practice.
+ * A `$` followed by a digit is only currency when it does not open a plausible math
+ * span, so the text up to the next `$` is inspected first: `$0$` and `$5x = 10$`
+ * survive, while `$5 and $7` is escaped as before. Deciding on the delimiter pair
+ * rather than on the digit alone is what keeps a wrong guess local: an accepted span
+ * contains no `$`, so an inserted escape can never fall between a delimiter pair and
+ * shift every delimiter that follows it.
  */
 export function escapeCurrencyDollars(text: string): string {
-  return text.replace(CURRENCY_DOLLAR, "$1$2\\$");
+  let out = "";
+  let index = 0;
+
+  while (index < text.length) {
+    const verbatimEnd = endOfVerbatimRun(text, index);
+    if (verbatimEnd > index) {
+      out += text.slice(index, verbatimEnd);
+      index = verbatimEnd;
+      continue;
+    }
+    out += opensCurrencyAmount(text, index) ? "\\$" : "$";
+    index += 1;
+  }
+
+  return out;
 }

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -150,7 +150,10 @@ function endOfVerbatimRun(text: string, index: number): number {
   if (dollars >= 2) return index + dollars;
 
   const close = findClosingDollar(text, index);
-  const opensMath = close !== -1 && isMathBody(text.slice(index + 1, close));
+  const opensMath =
+    close !== -1 &&
+    !opensCurrencyAmount(text, close) &&
+    isMathBody(text.slice(index + 1, close));
   return opensMath ? close + 1 : index;
 }
 

--- a/packages/react-markdown/src/preprocess.ts
+++ b/packages/react-markdown/src/preprocess.ts
@@ -57,7 +57,7 @@ export function normalizeMathDelimiters(text: string): string {
 const LATEX_SYNTAX = /\\[a-zA-Z]|[_^{}]/;
 const BLANK_LINE = /\n[ \t]*\n/;
 const ADJACENT_WORDS = /[A-Za-z]{3,}\s+[A-Za-z]{3,}/;
-const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014]$/;
+const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014\u2212]$/;
 
 /** Length of the run of `char` starting at `start`. */
 function runLength(text: string, start: number, char: string): number {
@@ -68,12 +68,13 @@ function runLength(text: string, start: number, char: string): number {
 
 /**
  * End index (exclusive) of the code span or fence whose backtick run starts at
- * `start`, or the end of the text when that run is never closed.
+ * `start`, or -1 when that run is never closed and its backticks read as literal
+ * text.
  */
 function codeSpanEnd(text: string, start: number): number {
   const fence = "`".repeat(runLength(text, start, "`"));
   const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? text.length : closed + fence.length;
+  return closed === -1 ? -1 : closed + fence.length;
 }
 
 /**
@@ -87,8 +88,10 @@ function findClosingDollar(text: string, openIndex: number): number {
     const char = text[index];
     if (char === "$") return index;
     if (char === "\\") index += 2;
-    else if (char === "`") index = codeSpanEnd(text, index);
-    else index += 1;
+    else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      index = end === -1 ? index + runLength(text, index, "`") : end;
+    } else index += 1;
   }
   return -1;
 }
@@ -110,25 +113,18 @@ function endsOnOperator(body: string): boolean {
 }
 
 /**
- * Whether the body reads as the text between two currency amounts rather than as an
- * expression: running prose (`5 and `), a range (`5-`), or two adjacent words.
- */
-function separatesTwoAmounts(body: string): boolean {
-  return (
-    endsMidSentence(body) || endsOnOperator(body) || ADJACENT_WORDS.test(body)
-  );
-}
-
-/**
  * Whether the text between two single `$` reads as an inline math expression rather
- * than the text separating two currency amounts. LaTeX syntax settles it; failing
- * that, anything that reads as surrounding text is rejected.
+ * than the text separating two currency amounts. A body that ends the way prose
+ * between two amounts does (mid-sentence space, dangling operator) is rejected even
+ * when it carries LaTeX syntax, since that prose may itself contain `_` or `\word`;
+ * otherwise LaTeX syntax accepts the span and two adjacent words reject it.
  */
 function isMathBody(body: string): boolean {
   if (body.length === 0) return false;
   if (BLANK_LINE.test(body)) return false;
+  if (endsMidSentence(body) || endsOnOperator(body)) return false;
   if (LATEX_SYNTAX.test(body)) return true;
-  return !separatesTwoAmounts(body);
+  return !ADJACENT_WORDS.test(body);
 }
 
 /** Whether the `$` at `index` opens a currency amount such as `$5` or `$1,299`. */
@@ -144,7 +140,10 @@ function opensCurrencyAmount(text: string, index: number): boolean {
 function endOfVerbatimRun(text: string, index: number): number {
   const char = text[index];
   if (char === "\\") return Math.min(index + 2, text.length);
-  if (char === "`") return codeSpanEnd(text, index);
+  if (char === "`") {
+    const end = codeSpanEnd(text, index);
+    return end === -1 ? index + runLength(text, index, "`") : end;
+  }
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -155,4 +155,14 @@ describe("escapeCurrencyDollars", () => {
       "see `unclosed then \\$5 and \\$7 later",
     );
   });
+
+  it("escapes currency glued to a preceding word", () => {
+    expect(escapeCurrencyDollars("Prices range from US$50 to US$100")).toBe(
+      "Prices range from US\\$50 to US\\$100",
+    );
+  });
+
+  it("escapes an amount whose next dollar opens another amount", () => {
+    expect(escapeCurrencyDollars("$50 to US$60")).toBe("\\$50 to US\\$60");
+  });
 });

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -131,4 +131,28 @@ describe("escapeCurrencyDollars", () => {
       "```\nconst price = $5;\n```",
     );
   });
+
+  it("escapes an amount when the prose before the next span carries latex syntax", () => {
+    expect(
+      escapeCurrencyDollars("Pay $20 when x_1 rises, then $n$ holds"),
+    ).toBe("Pay \\$20 when x_1 rises, then $n$ holds");
+  });
+
+  it("keeps digit-initial math that carries latex syntax", () => {
+    expect(escapeCurrencyDollars("Solve $5x_2 = 10$ now")).toBe(
+      "Solve $5x_2 = 10$ now",
+    );
+  });
+
+  it("escapes a currency range written with a unicode minus", () => {
+    expect(escapeCurrencyDollars("Prices: $5\u2212$10 each")).toBe(
+      "Prices: \\$5\u2212\\$10 each",
+    );
+  });
+
+  it("escapes currency after an unclosed backtick", () => {
+    expect(escapeCurrencyDollars("see `unclosed then $5 and $7 later")).toBe(
+      "see `unclosed then \\$5 and \\$7 later",
+    );
+  });
 });

--- a/packages/react-streamdown/src/__tests__/preprocess.test.ts
+++ b/packages/react-streamdown/src/__tests__/preprocess.test.ts
@@ -77,4 +77,58 @@ describe("escapeCurrencyDollars", () => {
   it("escapes currency after an escaped backslash", () => {
     expect(escapeCurrencyDollars("\\\\$5")).toBe("\\\\\\$5");
   });
+
+  it("escapes each amount in a list of prices", () => {
+    expect(escapeCurrencyDollars("Prices are $10, $20, and $30.")).toBe(
+      "Prices are \\$10, \\$20, and \\$30.",
+    );
+  });
+
+  it("keeps inline math that opens with a digit", () => {
+    expect(
+      escapeCurrencyDollars("gives $0$ points, $1$ to the second, up to $m-1$"),
+    ).toBe("gives $0$ points, $1$ to the second, up to $m-1$");
+  });
+
+  it("keeps an expression that opens with a digit", () => {
+    expect(escapeCurrencyDollars("Solve $5x = 10$ for x.")).toBe(
+      "Solve $5x = 10$ for x.",
+    );
+  });
+
+  it("escapes currency but keeps math in the same line", () => {
+    expect(escapeCurrencyDollars("Pay $20 when $n=3$ holds.")).toBe(
+      "Pay \\$20 when $n=3$ holds.",
+    );
+  });
+
+  it("does not shift the delimiters that follow an escaped amount", () => {
+    expect(escapeCurrencyDollars("costs $5 and $7, and $n$ holds")).toBe(
+      "costs \\$5 and \\$7, and $n$ holds",
+    );
+  });
+
+  it("escapes a currency range", () => {
+    expect(escapeCurrencyDollars("Prices: $5-$10 each")).toBe(
+      "Prices: \\$5-\\$10 each",
+    );
+  });
+
+  it("escapes a currency range written with a slash", () => {
+    expect(escapeCurrencyDollars("Pay $5/$10 split")).toBe(
+      "Pay \\$5/\\$10 split",
+    );
+  });
+
+  it("does not rewrite a code span", () => {
+    expect(escapeCurrencyDollars("Use `$5` as the placeholder.")).toBe(
+      "Use `$5` as the placeholder.",
+    );
+  });
+
+  it("does not rewrite a fenced block", () => {
+    expect(escapeCurrencyDollars("```\nconst price = $5;\n```")).toBe(
+      "```\nconst price = $5;\n```",
+    );
+  });
 });

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -54,19 +54,134 @@ export function normalizeMathDelimiters(text: string): string {
   return rewriteLatexBracketDelimiters(rewriteCustomMathTags(text));
 }
 
-const CURRENCY_DOLLAR = /(^|[^\\$])((?:\\\\)*)\$(?=\d)/g;
+const LATEX_SYNTAX = /\\[a-zA-Z]|[_^{}]/;
+const BLANK_LINE = /\n[ \t]*\n/;
+const ADJACENT_WORDS = /[A-Za-z]{3,}\s+[A-Za-z]{3,}/;
+const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014]$/;
+
+/** Length of the run of `char` starting at `start`. */
+function runLength(text: string, start: number, char: string): number {
+  let length = 0;
+  while (text[start + length] === char) length++;
+  return length;
+}
 
 /**
- * Escapes a `$` immediately followed by a digit (`$5`, `$19.99`, `$1,299`) so that
- * remark-math with single-dollar math enabled does not consume currency amounts in
- * prose as math delimiters. A math expression almost always opens with a letter or a
- * `\command`, so a digit after `$` is treated as currency. The `$$` of display math
- * is left intact, and an already-escaped `\$` is not escaped twice (the even run of
- * backslashes before the `$` is preserved).
+ * End index (exclusive) of the code span or fence whose backtick run starts at
+ * `start`, or the end of the text when that run is never closed.
+ */
+function codeSpanEnd(text: string, start: number): number {
+  const fence = "`".repeat(runLength(text, start, "`"));
+  const closed = text.indexOf(fence, start + fence.length);
+  return closed === -1 ? text.length : closed + fence.length;
+}
+
+/**
+ * Index of the `$` that would close an inline math span opened at `openIndex`, or
+ * -1 when none does. Escapes and code spans are stepped over so that a `$` inside
+ * them is not mistaken for the closing delimiter.
+ */
+function findClosingDollar(text: string, openIndex: number): number {
+  let index = openIndex + 1;
+  while (index < text.length) {
+    const char = text[index];
+    if (char === "$") return index;
+    if (char === "\\") index += 2;
+    else if (char === "`") index = codeSpanEnd(text, index);
+    else index += 1;
+  }
+  return -1;
+}
+
+/**
+ * Prose separating two currency amounts always ends on a space (`5 and ` in
+ * `$5 and $7`), whereas math is never written `$x $`.
+ */
+function endsMidSentence(body: string): boolean {
+  return /\s$/.test(body) && !/^\s/.test(body);
+}
+
+/**
+ * A currency range leaves a dangling operator (`5-` in `$5-$10`), which no inline
+ * expression ends on.
+ */
+function endsOnOperator(body: string): boolean {
+  return TRAILING_OPERATOR.test(body);
+}
+
+/**
+ * Whether the body reads as the text between two currency amounts rather than as an
+ * expression: running prose (`5 and `), a range (`5-`), or two adjacent words.
+ */
+function separatesTwoAmounts(body: string): boolean {
+  return (
+    endsMidSentence(body) || endsOnOperator(body) || ADJACENT_WORDS.test(body)
+  );
+}
+
+/**
+ * Whether the text between two single `$` reads as an inline math expression rather
+ * than the text separating two currency amounts. LaTeX syntax settles it; failing
+ * that, anything that reads as surrounding text is rejected.
+ */
+function isMathBody(body: string): boolean {
+  if (body.length === 0) return false;
+  if (BLANK_LINE.test(body)) return false;
+  if (LATEX_SYNTAX.test(body)) return true;
+  return !separatesTwoAmounts(body);
+}
+
+/** Whether the `$` at `index` opens a currency amount such as `$5` or `$1,299`. */
+function opensCurrencyAmount(text: string, index: number): boolean {
+  return /\d/.test(text[index + 1] ?? "");
+}
+
+/**
+ * End index (exclusive) of the run at `index` that must be copied unchanged: a `\x`
+ * escape, a code span, a `$$` display delimiter, an inline math span, or a plain
+ * character. Returns `index` itself for a single `$`, which the caller has to decide.
+ */
+function endOfVerbatimRun(text: string, index: number): number {
+  const char = text[index];
+  if (char === "\\") return Math.min(index + 2, text.length);
+  if (char === "`") return codeSpanEnd(text, index);
+  if (char !== "$") return index + 1;
+
+  const dollars = runLength(text, index, "$");
+  if (dollars >= 2) return index + dollars;
+
+  const close = findClosingDollar(text, index);
+  const opensMath = close !== -1 && isMathBody(text.slice(index + 1, close));
+  return opensMath ? close + 1 : index;
+}
+
+/**
+ * Escapes a `$` that opens a currency amount (`$5`, `$19.99`, `$1,299`) so that
+ * remark-math with single-dollar math enabled does not consume prices in prose as
+ * math delimiters. The `$$` of display math is left intact, an already-escaped `\$`
+ * is not escaped twice, and code spans and fences are never rewritten.
  *
- * Trade-off: an expression that genuinely opens with a digit (`$5x = 10$`) has its
- * leading `$` escaped as well. This is rare in practice.
+ * A `$` followed by a digit is only currency when it does not open a plausible math
+ * span, so the text up to the next `$` is inspected first: `$0$` and `$5x = 10$`
+ * survive, while `$5 and $7` is escaped as before. Deciding on the delimiter pair
+ * rather than on the digit alone is what keeps a wrong guess local: an accepted span
+ * contains no `$`, so an inserted escape can never fall between a delimiter pair and
+ * shift every delimiter that follows it.
  */
 export function escapeCurrencyDollars(text: string): string {
-  return text.replace(CURRENCY_DOLLAR, "$1$2\\$");
+  let out = "";
+  let index = 0;
+
+  while (index < text.length) {
+    const verbatimEnd = endOfVerbatimRun(text, index);
+    if (verbatimEnd > index) {
+      out += text.slice(index, verbatimEnd);
+      index = verbatimEnd;
+      continue;
+    }
+    out += opensCurrencyAmount(text, index) ? "\\$" : "$";
+    index += 1;
+  }
+
+  return out;
 }

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -150,7 +150,10 @@ function endOfVerbatimRun(text: string, index: number): number {
   if (dollars >= 2) return index + dollars;
 
   const close = findClosingDollar(text, index);
-  const opensMath = close !== -1 && isMathBody(text.slice(index + 1, close));
+  const opensMath =
+    close !== -1 &&
+    !opensCurrencyAmount(text, close) &&
+    isMathBody(text.slice(index + 1, close));
   return opensMath ? close + 1 : index;
 }
 

--- a/packages/react-streamdown/src/preprocess.ts
+++ b/packages/react-streamdown/src/preprocess.ts
@@ -57,7 +57,7 @@ export function normalizeMathDelimiters(text: string): string {
 const LATEX_SYNTAX = /\\[a-zA-Z]|[_^{}]/;
 const BLANK_LINE = /\n[ \t]*\n/;
 const ADJACENT_WORDS = /[A-Za-z]{3,}\s+[A-Za-z]{3,}/;
-const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014]$/;
+const TRAILING_OPERATOR = /[-+*/=<>,;:([\u2013\u2014\u2212]$/;
 
 /** Length of the run of `char` starting at `start`. */
 function runLength(text: string, start: number, char: string): number {
@@ -68,12 +68,13 @@ function runLength(text: string, start: number, char: string): number {
 
 /**
  * End index (exclusive) of the code span or fence whose backtick run starts at
- * `start`, or the end of the text when that run is never closed.
+ * `start`, or -1 when that run is never closed and its backticks read as literal
+ * text.
  */
 function codeSpanEnd(text: string, start: number): number {
   const fence = "`".repeat(runLength(text, start, "`"));
   const closed = text.indexOf(fence, start + fence.length);
-  return closed === -1 ? text.length : closed + fence.length;
+  return closed === -1 ? -1 : closed + fence.length;
 }
 
 /**
@@ -87,8 +88,10 @@ function findClosingDollar(text: string, openIndex: number): number {
     const char = text[index];
     if (char === "$") return index;
     if (char === "\\") index += 2;
-    else if (char === "`") index = codeSpanEnd(text, index);
-    else index += 1;
+    else if (char === "`") {
+      const end = codeSpanEnd(text, index);
+      index = end === -1 ? index + runLength(text, index, "`") : end;
+    } else index += 1;
   }
   return -1;
 }
@@ -110,25 +113,18 @@ function endsOnOperator(body: string): boolean {
 }
 
 /**
- * Whether the body reads as the text between two currency amounts rather than as an
- * expression: running prose (`5 and `), a range (`5-`), or two adjacent words.
- */
-function separatesTwoAmounts(body: string): boolean {
-  return (
-    endsMidSentence(body) || endsOnOperator(body) || ADJACENT_WORDS.test(body)
-  );
-}
-
-/**
  * Whether the text between two single `$` reads as an inline math expression rather
- * than the text separating two currency amounts. LaTeX syntax settles it; failing
- * that, anything that reads as surrounding text is rejected.
+ * than the text separating two currency amounts. A body that ends the way prose
+ * between two amounts does (mid-sentence space, dangling operator) is rejected even
+ * when it carries LaTeX syntax, since that prose may itself contain `_` or `\word`;
+ * otherwise LaTeX syntax accepts the span and two adjacent words reject it.
  */
 function isMathBody(body: string): boolean {
   if (body.length === 0) return false;
   if (BLANK_LINE.test(body)) return false;
+  if (endsMidSentence(body) || endsOnOperator(body)) return false;
   if (LATEX_SYNTAX.test(body)) return true;
-  return !separatesTwoAmounts(body);
+  return !ADJACENT_WORDS.test(body);
 }
 
 /** Whether the `$` at `index` opens a currency amount such as `$5` or `$1,299`. */
@@ -144,7 +140,10 @@ function opensCurrencyAmount(text: string, index: number): boolean {
 function endOfVerbatimRun(text: string, index: number): number {
   const char = text[index];
   if (char === "\\") return Math.min(index + 2, text.length);
-  if (char === "`") return codeSpanEnd(text, index);
+  if (char === "`") {
+    const end = codeSpanEnd(text, index);
+    return end === -1 ? index + runLength(text, index, "`") : end;
+  }
   if (char !== "$") return index + 1;
 
   const dollars = runLength(text, index, "$");


### PR DESCRIPTION
`escapeCurrencyDollars` escapes every `$` followed by a digit, which also escapes the opening delimiter of digit-initial math. `micromark` doesn't honour `\$` inside a math span, so the leftover `$` re-pairs with the next one and every delimiter after it shifts:

```ts
escapeCurrencyDollars("gives $0$ points, $1$ to the second, up to $m-1$");
// "gives \$0$ points, \$1$ to the second, up to $m-1$"
```

Two expressions are lost and prose renders as italic math. It's easy to miss because `@streamdown/math` sets `errorColor` to a muted token (vercel/streamdown#43), so the KaTeX error reads as ordinary grey prose.

Separately, code was rewritten too: `` `$5` `` → `` `\$5` ``.

**Fix:** decide on the delimiter *pair*, not the digit alone — inspect the text up to the next `$` and keep the delimiter when that body reads as an expression. An accepted span contains no `$`, so an inserted escape can never fall between a pair and shift the rest. Code spans and fences are skipped.

`$0$`, `$1$`, `$5x = 10$` now render; `$49`, `$5 and $7`, `$10, $20, and $30`, `$5-$10` stay escaped as before.

`packages/react-markdown/src/preprocess.ts` is a byte-identical copy, so it had the same bug — both packages fixed.

All existing assertions pass unchanged. react-streamdown 127/127, react-markdown 26/26, oxlint/oxfmt/tsc clean. Changeset included (`patch`, both packages).

Fixes #5159 

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

