### PR TITLE
fix(core): restrict assistant frame messages to the parent window

### DIFF
--- a/.changeset/bright-frames-listen.md
+++ b/.changeset/bright-frames-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: restrict AssistantFrame provider messages to the parent window

--- a/packages/core/src/model-context/frame/provider.test.ts
+++ b/packages/core/src/model-context/frame/provider.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AssistantFrameProvider } from "./provider";
+import { FRAME_MESSAGE_CHANNEL } from "./types";
+
+describe("AssistantFrameProvider", () => {
+  let messageHandler: ((event: MessageEvent) => void) | undefined;
+  let parentWindow: Window;
+
+  beforeEach(() => {
+    parentWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+
+    Object.defineProperty(window, "parent", {
+      value: parentWindow,
+      configurable: true,
+    });
+
+    vi.spyOn(window, "addEventListener").mockImplementation(
+      (event, listener) => {
+        if (event === "message" && typeof listener === "function") {
+          messageHandler = listener as (event: MessageEvent) => void;
+        }
+      },
+    );
+    vi.spyOn(window, "removeEventListener").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    AssistantFrameProvider.dispose();
+    vi.restoreAllMocks();
+  });
+
+  it("only accepts tool calls from the parent window", async () => {
+    const execute = vi.fn(async () => "result");
+    AssistantFrameProvider.addModelContextProvider(
+      {
+        getModelContext: () => ({
+          tools: {
+            sensitiveTool: { execute },
+          },
+        }),
+      },
+      "https://parent.example",
+    );
+
+    const toolCall = {
+      channel: FRAME_MESSAGE_CHANNEL,
+      message: {
+        type: "tool-call",
+        id: "tool-call-1",
+        toolName: "sensitiveTool",
+        args: {},
+      },
+    };
+    const otherWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+
+    messageHandler?.(
+      new MessageEvent("message", {
+        data: toolCall,
+        origin: "https://parent.example",
+        source: otherWindow,
+      }),
+    );
+
+    expect(execute).not.toHaveBeenCalled();
+
+    messageHandler?.(
+      new MessageEvent("message", {
+        data: toolCall,
+        origin: "https://parent.example",
+        source: parentWindow,
+      }),
+    );
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce());
+  });
+});

--- a/packages/core/src/model-context/frame/provider.ts
+++ b/packages/core/src/model-context/frame/provider.ts
@@ -59,6 +59,7 @@ export class AssistantFrameProvider {
   private handleMessage(event: MessageEvent) {
     if (this._targetOrigin !== "*" && event.origin !== this._targetOrigin)
       return;
+    if (event.source !== window.parent) return;
     if (event.data?.channel !== FRAME_MESSAGE_CHANNEL) return;
 
     const message = event.data.message as FrameMessage;


### PR DESCRIPTION
## Summary

- require `AssistantFrameProvider` messages to originate from `window.parent`
- preserve the existing origin and channel validation
- add a regression test covering both rejected non-parent calls and accepted parent calls

## Why

The host already verifies that messages come from its exact iframe window, but the provider only checked the origin and channel. I reproduced another window with an accepted origin sending a `tool-call` message and executing a registered tool.

Checking `event.source` tightens the frame trust boundary without changing the intended parent-to-iframe flow.

## Validation

- confirmed the regression test fails on unchanged `main` and passes with this fix
- `@assistant-ui/core`: 65 test files, 590 tests passed
- existing `AssistantFrame` integration: 8 tests passed
- `@assistant-ui/core` build passed
- targeted oxlint passed

Includes a patch changeset for `@assistant-ui/core`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

