### PR TITLE
fix(react): edit controlled assistant-visible inputs

### DIFF
--- a/.changeset/fresh-inputs-listen.md
+++ b/.changeset/fresh-inputs-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep controlled assistant-visible inputs in sync after edits

--- a/packages/react/src/model-context/makeAssistantVisible.test.tsx
+++ b/packages/react/src/model-context/makeAssistantVisible.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import {
+  forwardRef,
+  useState,
+  type ComponentProps,
+  type ChangeEvent,
+} from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { registerMock, auiMock } = vi.hoisted(() => {
+  const register = vi.fn((_provider: unknown) => () => {});
+  return {
+    registerMock: register,
+    auiMock: {
+      modelContext: () => ({ register }),
+    },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => auiMock,
+}));
+
+import { makeAssistantVisible } from "./makeAssistantVisible";
+
+type EditTool = {
+  execute: (args: { editId: string; value: string }) => Promise<unknown>;
+};
+
+type ModelContextProvider = {
+  getModelContext: () => {
+    tools: {
+      edit: EditTool;
+    };
+  };
+};
+
+const ControlledInput = forwardRef<HTMLInputElement, ComponentProps<"input">>(
+  ({ onChange, ...props }, ref) => {
+    const [value, setValue] = useState("initial");
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      setValue(event.target.value);
+      onChange?.(event);
+    };
+
+    return (
+      <input
+        {...props}
+        ref={ref}
+        value={value}
+        data-react-value={value}
+        onChange={handleChange}
+      />
+    );
+  },
+);
+
+const ControlledTextarea = forwardRef<
+  HTMLTextAreaElement,
+  ComponentProps<"textarea">
+>(({ onChange, ...props }, ref) => {
+  const [value, setValue] = useState("initial");
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(event.target.value);
+    onChange?.(event);
+  };
+
+  return (
+    <textarea
+      {...props}
+      ref={ref}
+      value={value}
+      data-react-value={value}
+      onChange={handleChange}
+    />
+  );
+});
+
+const runEditTool = async (
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  const editId = element.dataset.editId;
+  if (editId === undefined) throw new Error("Missing edit id");
+
+  const provider = registerMock.mock.calls[0]![0] as ModelContextProvider;
+  const task = provider.getModelContext().tools.edit.execute({
+    editId,
+    value,
+  });
+  await vi.runAllTimersAsync();
+  await task;
+};
+
+describe("makeAssistantVisible editable components", () => {
+  beforeEach(() => {
+    registerMock.mockClear();
+    vi.stubGlobal("CSS", { escape: (value: string) => value });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("updates controlled input state through the edit tool", async () => {
+    const EditableInput = makeAssistantVisible(ControlledInput, {
+      editable: true,
+    });
+    const onChange = vi.fn();
+    const input = render(<EditableInput onChange={onChange} />).getByRole(
+      "textbox",
+    );
+
+    await act(async () => {
+      await runEditTool(input as HTMLInputElement, "updated");
+    });
+
+    expect(input).toHaveProperty("value", "updated");
+    expect(input.getAttribute("data-react-value")).toBe("updated");
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it("updates controlled textarea state through the edit tool", async () => {
+    const EditableTextarea = makeAssistantVisible(ControlledTextarea, {
+      editable: true,
+    });
+    const onChange = vi.fn();
+    const textarea = render(<EditableTextarea onChange={onChange} />).getByRole(
+      "textbox",
+    );
+
+    await act(async () => {
+      await runEditTool(textarea as HTMLTextAreaElement, "updated");
+    });
+
+    expect(textarea).toHaveProperty("value", "updated");
+    expect(textarea.getAttribute("data-react-value")).toBe("updated");
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react/src/model-context/makeAssistantVisible.tsx
+++ b/packages/react/src/model-context/makeAssistantVisible.tsx
@@ -40,6 +40,23 @@ const click = tool({
   },
 });
 
+const setNativeValue = (
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) => {
+  const prototype =
+    element instanceof HTMLInputElement
+      ? HTMLInputElement.prototype
+      : HTMLTextAreaElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+
+  if (setter) {
+    setter.call(element, value);
+  } else {
+    element.value = value;
+  }
+};
+
 const edit = tool({
   parameters: {
     type: "object",
@@ -57,7 +74,7 @@ const edit = tool({
     const escapedEditId = CSS.escape(editId);
     const el = document.querySelector(`[data-edit-id='${escapedEditId}']`);
     if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-      el.value = value;
+      setNativeValue(el, value);
       el.dispatchEvent(new Event("input", { bubbles: true }));
       el.dispatchEvent(new Event("change", { bubbles: true }));
 


### PR DESCRIPTION
## Summary

- set editable input and textarea values through their native DOM setters
- preserve the existing `input` and `change` events so controlled React state receives the edit
- add regression coverage for controlled inputs and textareas

## Why

`makeAssistantVisible()` assigned `element.value` directly before dispatching events. For a React-controlled field, that assignment also updated React's value tracker, so the following event did not call `onChange`. The DOM briefly showed the new value while application state remained stale and could restore the old value on the next render.

Using the native prototype setter lets React observe the dispatched event as a real value change without changing the existing behavior for editable elements.

## Verification

- reproduced on the previous implementation: the DOM value became `updated`, while React state remained `initial` and `onChange` was not called
- `@assistant-ui/react` tests: 48 files, 497 tests passed
- `@assistant-ui/react` package build passed
- oxlint passed for the changed source and test
- oxfmt check passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

