### PR TITLE
fix(assistant-stream): validate per-type chunk fields and drop wrong-part-type chunks

### DIFF
--- a/.changeset/transport-per-field-validation.md
+++ b/.changeset/transport-per-field-validation.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: validate per-type required fields at the assistant-transport decode boundary and drop malformed chunks in the accumulator

--- a/.changeset/transport-per-field-validation.md
+++ b/.changeset/transport-per-field-validation.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: validate per-type required fields at the assistant-transport decode boundary and drop malformed chunks in the accumulator
+fix: validate per-type required fields at the assistant-transport decode boundary and drop malformed chunks in the accumulator instead of aborting the response; an unsupported part-start now inserts an empty reasoning placeholder to keep later part indices aligned

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -240,6 +240,19 @@ describe("AssistantMessageAccumulator error chunks", () => {
     });
   });
 
+  it("defaults a missing error message", async () => {
+    const messages = await collectStream([
+      { type: "error", path: [] } as unknown as AssistantStreamChunk,
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      error: { code: "unknown", message: "unknown error" },
+    });
+  });
+
   it("carries code and severity through unchanged", async () => {
     const messages = await collectStream([
       {
@@ -368,6 +381,88 @@ describe("AssistantMessageAccumulator part path bounds", () => {
       state: "result",
       result: { ok: true },
     });
+    warn.mockRestore();
+  });
+});
+
+describe("AssistantMessageAccumulator wrong part type chunks", () => {
+  const sourcePart = {
+    type: "source",
+    sourceType: "url",
+    id: "s1",
+    url: "https://example.com",
+  } as const;
+
+  it("drops a text-delta addressed to a source part", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: sourcePart },
+      { type: "text-delta", path: [0], textDelta: "x" },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts[0]).toMatchObject({ type: "source", id: "s1" });
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped text-delta chunk: part is neither text nor tool-call",
+    );
+    warn.mockRestore();
+  });
+
+  it("drops a result addressed to a text part", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [0], textDelta: "hi" },
+      { type: "result", path: [0], result: { ok: true }, isError: false },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts[0]).toMatchObject({ type: "text", text: "hi" });
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped result chunk: part is not a tool-call",
+    );
+    warn.mockRestore();
+  });
+
+  it("drops an args-text-finish addressed to a text part", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "tool-call-args-text-finish", path: [0] },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts[0]).toMatchObject({ type: "text" });
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped tool-call-args-text-finish chunk: part is not a tool-call",
+    );
+    warn.mockRestore();
+  });
+
+  it("inserts a placeholder for an unsupported part-start so later part indices stay aligned", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: { type: "bogus" },
+      } as unknown as AssistantStreamChunk,
+      { type: "part-start", path: [1], part: { type: "text" } },
+      { type: "text-delta", path: [1], textDelta: "ok" },
+      { type: "part-finish", path: [0] },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(2);
+    expect(last.parts[0]).toMatchObject({
+      type: "reasoning",
+      text: "",
+      status: { type: "complete", reason: "unknown" },
+    });
+    expect(last.parts[1]).toMatchObject({ type: "text", text: "ok" });
+    expect(warn).toHaveBeenCalledWith(
+      "Unsupported part-start type bogus: inserting an empty reasoning part to preserve part indices",
+    );
     warn.mockRestore();
   });
 });

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -251,6 +251,28 @@ describe("AssistantMessageAccumulator timing", () => {
     warn.mockRestore();
   });
 
+  it("does not record firstTokenTime when a text-delta is dropped for a wrong part type", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: {
+          type: "source",
+          sourceType: "url",
+          id: "s1",
+          url: "https://example.com",
+        },
+      },
+      { type: "text-delta", path: [0], textDelta: "x" },
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.metadata.timing).toBeDefined();
+    expect(last.metadata.timing!.firstTokenTime).toBeUndefined();
+    warn.mockRestore();
+  });
+
   it("records firstTokenTime on the first applied text-delta, not a preceding dropped one", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -149,7 +149,22 @@ const handlePartStart = (
       },
     };
   } else {
-    throw new Error(`Unsupported part type: ${partInit.type}`);
+    console.warn(
+      `Unsupported part-start type ${(partInit as { type?: unknown }).type}: inserting an empty reasoning part to preserve part indices`,
+    );
+    // reasoning rather than a data sentinel: auiV0Encode rejects data parts, so a data placeholder would fail cloud persistence
+    const placeholderPart: ReasoningPart = {
+      type: "reasoning",
+      text: "",
+      status: { type: "running" },
+    };
+    return {
+      ...message,
+      parts: [...message.parts, placeholderPart],
+      get content() {
+        return this.parts;
+      },
+    };
   }
 };
 
@@ -161,7 +176,10 @@ const handleToolCallArgsTextFinish = (
 ): AssistantMessage => {
   return updatePartForPath(message, chunk, (part) => {
     if (part.type !== "tool-call") {
-      throw new Error("Last is not a tool call");
+      console.warn(
+        "Dropped tool-call-args-text-finish chunk: part is not a tool-call",
+      );
+      return part;
     }
 
     // TODO this should never be hit; this happens if args-text-finish is emitted after result
@@ -200,9 +218,10 @@ const handleTextDelta = (
 
       return { ...part, argsText: newArgsText, args: newArgs };
     } else {
-      throw new Error(
-        "text-delta received but part is neither text nor tool-call",
+      console.warn(
+        "Dropped text-delta chunk: part is neither text nor tool-call",
       );
+      return part;
     }
   });
 };
@@ -234,7 +253,8 @@ const handleResult = (
         status: { type: "complete", reason: "stop" },
       };
     } else {
-      throw new Error("Result chunk received but part is not a tool-call");
+      console.warn("Dropped result chunk: part is not a tool-call");
+      return part;
     }
   });
 };
@@ -379,7 +399,7 @@ const handleErrorChunk = (
       reason: "error",
       error: {
         code: chunk.code ?? "unknown",
-        message: chunk.error,
+        message: chunk.error ?? "unknown error",
         ...(severity !== undefined && { severity }),
       },
     },

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.test.ts
@@ -346,6 +346,56 @@ describe("AssistantTransportDecoder", () => {
     warn.mockRestore();
   });
 
+  it("drops frames missing per-type required fields", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"part-start","path":[]}',
+        '{"type":"part-start","part":[],"path":[]}',
+        '{"type":"text-delta","textDelta":5,"path":[0]}',
+        '{"type":"annotations","path":[]}',
+        '{"type":"data","path":[]}',
+        '{"type":"update-state","path":[]}',
+        '{"type":"message-finish","path":[]}',
+        '{"type":"step-finish","path":[]}',
+        '{"type":"error","path":[]}',
+        '{"type":"error","error":42,"path":[]}',
+        '{"type":"message-finish","finishReason":"stop","path":[]}',
+        '{"type":"error","error":"boom","path":[]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "error", path: [] },
+      { type: "error", error: 42, path: [] },
+      { type: "message-finish", finishReason: "stop", path: [] },
+      { type: "error", error: "boom", path: [] },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(7);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("(invalid-fields:part-start)"),
+    );
+    warn.mockRestore();
+  });
+
+  it("tolerates a result without isError or result but rejects a non-boolean isError", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const decodedChunks = await collectChunks(
+      sseStream([
+        '{"type":"result","result":null,"path":[0]}',
+        '{"type":"result","path":[0]}',
+        '{"type":"result","result":1,"isError":"no","path":[0]}',
+      ]),
+    );
+
+    expect(decodedChunks).toEqual([
+      { type: "result", result: null, path: [0] },
+      { type: "result", path: [0] },
+    ]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
   it("round-trips error chunks with code and severity", async () => {
     const originalChunks: AssistantStreamChunk[] = [
       {

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -7,22 +7,42 @@ import {
 } from "../../utils/stream/SSEEventDecoderStream";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
-const KNOWN_CHUNK_TYPES: Record<
-  AssistantStreamChunk["type"],
-  "message" | "part-addressed"
-> = {
-  "part-start": "message",
-  "part-finish": "part-addressed",
-  "tool-call-args-text-finish": "part-addressed",
-  "text-delta": "part-addressed",
-  annotations: "message",
-  data: "message",
-  "step-start": "message",
-  "step-finish": "message",
-  "message-finish": "message",
-  result: "part-addressed",
-  error: "message",
-  "update-state": "message",
+type ChunkRule = {
+  kind: "message" | "part-addressed";
+  valid: (chunk: Record<string, unknown>) => boolean;
+};
+
+const isNonNullObject = (value: unknown): boolean =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const KNOWN_CHUNK_TYPES: Record<AssistantStreamChunk["type"], ChunkRule> = {
+  "part-start": { kind: "message", valid: (c) => isNonNullObject(c.part) },
+  "part-finish": { kind: "part-addressed", valid: () => true },
+  "tool-call-args-text-finish": { kind: "part-addressed", valid: () => true },
+  "text-delta": {
+    kind: "part-addressed",
+    valid: (c) => typeof c.textDelta === "string",
+  },
+  annotations: { kind: "message", valid: (c) => Array.isArray(c.annotations) },
+  data: { kind: "message", valid: (c) => Array.isArray(c.data) },
+  "step-start": { kind: "message", valid: () => true },
+  "step-finish": {
+    kind: "message",
+    valid: (c) => typeof c.finishReason === "string",
+  },
+  "message-finish": {
+    kind: "message",
+    valid: (c) => typeof c.finishReason === "string",
+  },
+  result: {
+    kind: "part-addressed",
+    valid: (c) => c.isError === undefined || typeof c.isError === "boolean",
+  },
+  error: { kind: "message", valid: () => true },
+  "update-state": {
+    kind: "message",
+    valid: (c) => Array.isArray(c.operations),
+  },
 };
 
 const parseChunk = (data: string): AssistantStreamChunk | string => {
@@ -40,9 +60,11 @@ const parseChunk = (data: string): AssistantStreamChunk | string => {
     !Object.prototype.hasOwnProperty.call(KNOWN_CHUNK_TYPES, type)
   )
     return "unknown-type";
+  const rule = KNOWN_CHUNK_TYPES[type as AssistantStreamChunk["type"]];
+  if (!rule.valid(value as Record<string, unknown>))
+    return `invalid-fields:${type}`;
   if (path === undefined) {
-    if (KNOWN_CHUNK_TYPES[type as AssistantStreamChunk["type"]] !== "message")
-      return `missing-path:${type}`;
+    if (rule.kind !== "message") return `missing-path:${type}`;
     return { ...value, path: [] } as unknown as AssistantStreamChunk;
   }
   if (

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -7,42 +7,38 @@ import {
 } from "../../utils/stream/SSEEventDecoderStream";
 import type { AssistantStreamEncoder } from "../../AssistantStream";
 
+type ChunkFields = Record<string, unknown>;
+
 type ChunkRule = {
   kind: "message" | "part-addressed";
-  valid: (chunk: Record<string, unknown>) => boolean;
+  valid: (chunk: ChunkFields) => boolean;
 };
 
-const isNonNullObject = (value: unknown): boolean =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
+const noFields = () => true;
+const requiredObject = (key: string) => (c: ChunkFields) => {
+  const value = c[key];
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+const requiredString = (key: string) => (c: ChunkFields) =>
+  typeof c[key] === "string";
+const requiredArray = (key: string) => (c: ChunkFields) =>
+  Array.isArray(c[key]);
+const optionalBoolean = (key: string) => (c: ChunkFields) =>
+  c[key] === undefined || typeof c[key] === "boolean";
 
 const KNOWN_CHUNK_TYPES: Record<AssistantStreamChunk["type"], ChunkRule> = {
-  "part-start": { kind: "message", valid: (c) => isNonNullObject(c.part) },
-  "part-finish": { kind: "part-addressed", valid: () => true },
-  "tool-call-args-text-finish": { kind: "part-addressed", valid: () => true },
-  "text-delta": {
-    kind: "part-addressed",
-    valid: (c) => typeof c.textDelta === "string",
-  },
-  annotations: { kind: "message", valid: (c) => Array.isArray(c.annotations) },
-  data: { kind: "message", valid: (c) => Array.isArray(c.data) },
-  "step-start": { kind: "message", valid: () => true },
-  "step-finish": {
-    kind: "message",
-    valid: (c) => typeof c.finishReason === "string",
-  },
-  "message-finish": {
-    kind: "message",
-    valid: (c) => typeof c.finishReason === "string",
-  },
-  result: {
-    kind: "part-addressed",
-    valid: (c) => c.isError === undefined || typeof c.isError === "boolean",
-  },
-  error: { kind: "message", valid: () => true },
-  "update-state": {
-    kind: "message",
-    valid: (c) => Array.isArray(c.operations),
-  },
+  "part-start": { kind: "message", valid: requiredObject("part") },
+  "part-finish": { kind: "part-addressed", valid: noFields },
+  "tool-call-args-text-finish": { kind: "part-addressed", valid: noFields },
+  "text-delta": { kind: "part-addressed", valid: requiredString("textDelta") },
+  annotations: { kind: "message", valid: requiredArray("annotations") },
+  data: { kind: "message", valid: requiredArray("data") },
+  "step-start": { kind: "message", valid: noFields },
+  "step-finish": { kind: "message", valid: requiredString("finishReason") },
+  "message-finish": { kind: "message", valid: requiredString("finishReason") },
+  result: { kind: "part-addressed", valid: optionalBoolean("isError") },
+  error: { kind: "message", valid: noFields },
+  "update-state": { kind: "message", valid: requiredArray("operations") },
 };
 
 const parseChunk = (data: string): AssistantStreamChunk | string => {


### PR DESCRIPTION
Closes #5158
## What

- The transport decoder's `KNOWN_CHUNK_TYPES` map now carries a per-type `valid` check alongside the kind: a frame with a known type but a malformed payload drops with reason `invalid-fields:<type>` through the existing deduped warn. Validation is consumer-driven: only fields whose absence crashes or corrupts are required (`part-start`'s `part`, `text-delta`'s `textDelta`, the arrays, `finishReason` on finish chunks); fields the accumulator already tolerates absent (`result`'s `result`/`isError`, `error`'s `error`, `usage`, `isContinued`, `messageId`) are type-checked only when present.
- The accumulator's wrong-part-type throw sites (`text-delta`/`result`/`args-text-finish` addressed to the wrong part kind) become warn-and-drop; an unsupported `part-start` type warns and appends an empty reasoning placeholder so the parts array stays in lockstep with the producer's index counter; the compile-time-unreachable exhaustive `default` throw stays.

## Why

Deferred from #5152: the shape guard admitted a one-key frame like `{"type":"part-start"}` straight into a TypeError one layer down, and a bare `message-finish` silently corrupted status to `reason: undefined`. 

## Impact

- A known-type frame with a malformed payload no longer aborts the response or corrupts state; it drops with a warning and valid chunks keep flowing.
- Wrong-part-type chunks that previously threw from the accumulator (reachable from every decoder, not just this transport) now warn and leave the message unchanged; unsupported part types produce a collapsed-by-default placeholder instead of desynchronizing later part indices.
- Well-formed streams are unaffected, including bare-but-valid finish frames and `result` frames whose `result` was `undefined` (which `JSON.stringify` omits on the wire); encode→decode is closed under our own encoder.

## Review cycle

- Round 1: dropping an unsupported `part-start` desynchronized every later part index (three reviewers converged); fixed with the reasoning placeholder. Requiring `usage` on finish chunks turned working finishes into fabricated flush statuses; narrowed to `finishReason` only.
- Round 2: `"result" in c` rejected a frame our own encoder emits (`result: undefined` is dropped by `JSON.stringify`), fabricating `requires-action`; presence check removed, round trip closed under the encoder.
- Round 3: the reasoning placeholder flavor is pinned with a comment (a `data` sentinel would fail cloud persistence: `auiV0Encode` rejects `data` parts); a positive test locks the bare-finish narrowing; `error` relaxed to tolerate an absent `error` field, since dropping an error-typed frame masks a failure as success - the same fabrication class the finish and result fixes closed.

## Scope & caveats

- Placeholder trade-off is deliberate: deltas addressed to an unsupported part absorb into the collapsed-by-default reasoning part rather than rendering raw payload as transcript prose; preventing absorption entirely would need a marker on a published part shape.
- A `finishReason` enum check is deliberately absent: it would recreate the fabrication failure for future reason values; `typeof string` is the line.
- Nested `PartInit` fields are not validated: no crash, degenerate part only.
- `update-state` operation elements can still throw inside `GorpStreamAccumulator`: element validation belongs in the gorp layer next to the #5142 guard work, recorded as a follow-up.
- The new accumulator warns have no per-instance dedup yet: that is #5170 item 2, the next PR. First-token timing on dropped deltas is pre-existing, filed as #5173.
- UIMS per-field validation is not included: different dialect with defaulting semantics.
- Additive only, nothing exported or reshaped; published wire-chunk unions untouched. One code comment added, pinning the placeholder flavor to the aui/v0 persistence constraint per the non-obvious-invariant rule.
- Tests: one malformed frame per validated type plus paired valid frames (bare finish, bare error, resultless result), each folded throw site, the placeholder index-lockstep lifecycle; not covered: gorp element shapes, per the follow-up above.
- Changeset: patch (`assistant-stream`).
