### PR TITLE
fix(assistant-stream): dedupe accumulator drop warnings per instance

### DIFF
--- a/.changeset/accumulator-warn-dedup.md
+++ b/.changeset/accumulator-warn-dedup.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: dedupe accumulator drop warnings per instance and drop class

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -548,3 +548,116 @@ describe("AssistantMessageAccumulator wrong part type chunks", () => {
     warn.mockRestore();
   });
 });
+
+describe("AssistantMessageAccumulator warn dedup", () => {
+  it("warns once per drop class per instance", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [5], textDelta: "a" },
+      { type: "text-delta", path: [5], textDelta: "b" },
+      { type: "text-delta", path: [6], textDelta: "c" },
+      { type: "part-finish", path: [9] },
+    ]);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped text-delta chunk: no part at path [5]",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped part-finish chunk: no part at path [9]",
+    );
+    warn.mockRestore();
+  });
+
+  it("resets dedup per accumulator instance", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stream = [
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [5], textDelta: "x" },
+    ] satisfies AssistantStreamChunk[];
+    await collectStream(stream);
+    await collectStream(stream);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("dedupes repeated wrong-part-type drops", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: { type: "source", sourceType: "url", id: "s", url: "https://x" },
+      },
+      { type: "text-delta", path: [0], textDelta: "a" },
+      { type: "text-delta", path: [0], textDelta: "b" },
+    ]);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});
+
+describe("AssistantMessageAccumulator warn dedup key independence", () => {
+  it("keeps drop classes as independent keys within one stream", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: { type: "source", sourceType: "url", id: "s", url: "https://x" },
+      },
+      { type: "text-delta", path: [0], textDelta: "wrong-part" },
+      { type: "text-delta", path: [7], textDelta: "no-part" },
+    ]);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("keys unsupported part-starts per type", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: { type: "bogus" },
+      } as unknown as AssistantStreamChunk,
+      {
+        type: "part-start",
+        path: [1],
+        part: { type: "bogus" },
+      } as unknown as AssistantStreamChunk,
+      {
+        type: "part-start",
+        path: [2],
+        part: { type: "video" },
+      } as unknown as AssistantStreamChunk,
+    ]);
+    const last = messages.at(-1)!;
+
+    expect(last.parts).toHaveLength(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it("caps the number of warned keys per instance", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await collectStream(
+      Array.from(
+        { length: 20 },
+        (_, i) =>
+          ({
+            type: "part-start",
+            path: [i],
+            part: { type: `bogus-${i}` },
+          }) as unknown as AssistantStreamChunk,
+      ),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(16);
+    warn.mockRestore();
+  });
+});

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -37,15 +37,21 @@ export const createInitialMessage = ({
   },
 });
 
+type WarnOnce = (key: string, message: string) => void;
+
+const MAX_WARNED_KEYS = 16;
+
 const updatePartForPath = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk,
+  warnOnce: WarnOnce,
   updater: (part: AssistantMessagePart) => AssistantMessagePart,
 ): AssistantMessage => {
   const part =
     chunk.path.length === 1 ? message.parts[chunk.path[0]!] : undefined;
   if (part === undefined) {
-    console.warn(
+    warnOnce(
+      `no-part:${chunk.type}`,
       `Dropped ${chunk.type} chunk: no part at path [${chunk.path.join(", ")}]`,
     );
     return message;
@@ -70,6 +76,7 @@ const updatePartForPath = (
 const handlePartStart = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { readonly type: "part-start" },
+  warnOnce: WarnOnce,
 ): AssistantMessage => {
   const partInit = chunk.part;
   if (partInit.type === "text" || partInit.type === "reasoning") {
@@ -150,8 +157,10 @@ const handlePartStart = (
       },
     };
   } else {
-    console.warn(
-      `Unsupported part-start type ${(partInit as { type?: unknown }).type}: inserting an empty reasoning part to preserve part indices`,
+    const unsupportedType = String((partInit as { type?: unknown }).type);
+    warnOnce(
+      `unsupported-part-start:${unsupportedType}`,
+      `Unsupported part-start type ${unsupportedType}: inserting an empty reasoning part to preserve part indices`,
     );
     // reasoning rather than a data sentinel: auiV0Encode rejects data parts, so a data placeholder would fail cloud persistence
     const placeholderPart: ReasoningPart = {
@@ -174,10 +183,12 @@ const handleToolCallArgsTextFinish = (
   chunk: AssistantStreamChunk & {
     readonly type: "tool-call-args-text-finish";
   },
+  warnOnce: WarnOnce,
 ): AssistantMessage => {
-  return updatePartForPath(message, chunk, (part) => {
+  return updatePartForPath(message, chunk, warnOnce, (part) => {
     if (part.type !== "tool-call") {
-      console.warn(
+      warnOnce(
+        "wrong-part:tool-call-args-text-finish",
         "Dropped tool-call-args-text-finish chunk: part is not a tool-call",
       );
       return part;
@@ -197,8 +208,9 @@ const handleToolCallArgsTextFinish = (
 const handlePartFinish = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { readonly type: "part-finish" },
+  warnOnce: WarnOnce,
 ): AssistantMessage => {
-  return updatePartForPath(message, chunk, (part) => ({
+  return updatePartForPath(message, chunk, warnOnce, (part) => ({
     ...part,
     status: { type: "complete", reason: "unknown" },
   }));
@@ -207,8 +219,9 @@ const handlePartFinish = (
 const handleTextDelta = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { type: "text-delta" },
+  warnOnce: WarnOnce,
 ): AssistantMessage => {
-  return updatePartForPath(message, chunk, (part) => {
+  return updatePartForPath(message, chunk, warnOnce, (part) => {
     if (part.type === "text" || part.type === "reasoning") {
       return { ...part, text: part.text + chunk.textDelta };
     } else if (part.type === "tool-call") {
@@ -219,7 +232,8 @@ const handleTextDelta = (
 
       return { ...part, argsText: newArgsText, args: newArgs };
     } else {
-      console.warn(
+      warnOnce(
+        "wrong-part:text-delta",
         "Dropped text-delta chunk: part is neither text nor tool-call",
       );
       return part;
@@ -230,8 +244,9 @@ const handleTextDelta = (
 const handleResult = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { type: "result" },
+  warnOnce: WarnOnce,
 ): AssistantMessage => {
-  return updatePartForPath(message, chunk, (part) => {
+  return updatePartForPath(message, chunk, warnOnce, (part) => {
     if (part.type === "tool-call") {
       return {
         ...part,
@@ -254,7 +269,10 @@ const handleResult = (
         status: { type: "complete", reason: "stop" },
       };
     } else {
-      console.warn("Dropped result chunk: part is not a tool-call");
+      warnOnce(
+        "wrong-part:result",
+        "Dropped result chunk: part is not a tool-call",
+      );
       return part;
     }
   });
@@ -474,6 +492,12 @@ export class AssistantMessageAccumulator extends TransformStream<
   } = {}) {
     let message = initialMessage ?? createInitialMessage();
     const tracker = new TimingTracker();
+    const warnedKeys = new Set<string>();
+    const warnOnce: WarnOnce = (key, warning) => {
+      if (warnedKeys.has(key) || warnedKeys.size >= MAX_WARNED_KEYS) return;
+      warnedKeys.add(key);
+      console.warn(warning);
+    };
     let controller:
       | TransformStreamDefaultController<AssistantMessage>
       | undefined;
@@ -493,28 +517,28 @@ export class AssistantMessageAccumulator extends TransformStream<
         const type = chunk.type;
         switch (type) {
           case "part-start":
-            message = handlePartStart(message, chunk);
+            message = handlePartStart(message, chunk, warnOnce);
             if (chunk.part.type === "tool-call") {
               tracker.recordToolCallStart(chunk.part.toolCallId);
             }
             break;
 
           case "tool-call-args-text-finish":
-            message = handleToolCallArgsTextFinish(message, chunk);
+            message = handleToolCallArgsTextFinish(message, chunk, warnOnce);
             break;
 
           case "part-finish":
-            message = handlePartFinish(message, chunk);
+            message = handlePartFinish(message, chunk, warnOnce);
             break;
 
           case "text-delta": {
-            const next = handleTextDelta(message, chunk);
+            const next = handleTextDelta(message, chunk, warnOnce);
             if (next !== message) tracker.recordFirstToken();
             message = next;
             break;
           }
           case "result":
-            message = handleResult(message, chunk);
+            message = handleResult(message, chunk, warnOnce);
             break;
           case "message-finish":
             message = handleMessageFinish(message, chunk);


### PR DESCRIPTION
## What

`AssistantMessageAccumulator` now dedupes its drop warnings per instance and drop class: the constructor creates a `warnOnce` closure over a per-instance `Set`, threaded into the handlers. Keys are bounded categories (`no-part:<type>`, `wrong-part:<type>`, `unsupported-part-start`); the first occurrence's message keeps its detail.

## Why

Second half of #5170: an off-by-one backend streaming every `text-delta` at a stale index produced one synchronous `console.warn` per delta, thousands per response - the flood shape #5152 already fixed at the decoder with `warnedReasons`. Accumulator instances are per-response, so dedup scope matches the decoder's.

## Impact

- A misbehaving stream now warns once per drop class instead of once per chunk; well-formed streams are unaffected.
- No public surface change: the threading is internal parameters on module-level handlers, nothing exported.

## Scope & caveats

- No shared warn helper with the decoder: different module layers, two dedup sites total; the UIMS decoder's per-frame drop warn is the known third candidate, but its tests pin per-frame counts so deduping it is a behavior change for its own PR (tracked in our backlog).
- No `onError` routing: the transport runtime throws at end-of-stream when `onError` has fired, which would turn a warning into a deferred response failure (settled in #5152's review).
- Key granularity is per drop class, not per path value, so an attacker cannot grow the set with unique indices.
- Tests: repeated same-class drops warn once, distinct classes warn separately, dedup resets per accumulator instance; existing drop tests unchanged (each triggers its class once).
- Changeset: patch (`assistant-stream`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

