### PR TITLE
fix(core): isolate public runtime event listeners

### DIFF
--- a/.changeset/quiet-runtime-events-listen.md
+++ b/.changeset/quiet-runtime-events-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate public runtime event subscribers

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -705,7 +705,7 @@ declare abstract class BaseSubject {
   private _connection;
   protected get isConnected(): boolean;
   protected abstract _connect(): Unsubscribe$1;
-  protected notifySubscribers(payload?: unknown): void;
+  protected notifySubscribers(payload?: unknown, reportError?: (error: unknown) => void): void;
   private _updateConnection;
   subscribe(callback: (payload?: unknown) => void): () => void;
 }

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -705,7 +705,7 @@ declare abstract class BaseSubject {
   private _connection;
   protected get isConnected(): boolean;
   protected abstract _connect(): Unsubscribe$1;
-  protected notifySubscribers(payload?: unknown, reportError?: (error: unknown) => void): void;
+  protected notifySubscribers(payload?: unknown, errorContext?: string): void;
   private _updateConnection;
   subscribe(callback: (payload?: unknown) => void): () => void;
 }

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -2,6 +2,7 @@ import type { Unsubscribe } from "../../types/unsubscribe";
 import type { SubscribableWithState } from "../../subscribable/subscribable";
 import type { ThreadListItemRuntimePath } from "./paths";
 import type { ThreadListRuntimeCoreBinding } from "./thread-list-runtime";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 
 export type ThreadListItemEventPayload = {
   /**
@@ -162,7 +163,11 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
 
       if (event === "switchedTo" && !newIsMain) return;
       if (event === "switchedAway" && newIsMain) return;
-      (callback as (payload?: unknown) => void)({});
+      notifyEventListeners(
+        [callback as (payload?: unknown) => void],
+        {},
+        `Thread list item "${event}"`,
+      );
     });
   }
 

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -29,6 +29,7 @@ import {
   type QueueItemState,
 } from "../../store/scopes/queue-item";
 import { generateId } from "../../utils/id";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 
 const isAttachmentComplete = (a: Attachment): a is CompleteAttachment =>
   a.status.type === "complete";
@@ -565,28 +566,7 @@ export abstract class BaseComposerRuntimeCore
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
-    const reportError = (error: unknown) => {
-      console.error(
-        `[assistant-ui] Composer runtime "${event}" listener threw an error`,
-        error,
-      );
-    };
-
-    for (const callback of subscribers) {
-      try {
-        const result = callback(payload) as unknown;
-        if (
-          typeof result === "object" &&
-          result !== null &&
-          "then" in result &&
-          typeof result.then === "function"
-        ) {
-          void Promise.resolve(result).catch(reportError);
-        }
-      } catch (error) {
-        reportError(error);
-      }
-    }
+    notifyEventListeners(subscribers, payload, `Composer runtime "${event}"`);
   }
 
   public unstable_on<E extends ComposerRuntimeEventType>(

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -34,6 +34,7 @@ import type { FeedbackAdapter } from "../../adapters/feedback";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { RealtimeVoiceAdapter } from "../../adapters/voice";
 import type { ThreadMessageLike } from "../utils/thread-message-like";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 
 type BaseThreadAdapters = {
   speech?: SpeechSynthesisAdapter | undefined;
@@ -182,28 +183,7 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
     const subscribers = this._eventSubscribers.get(event);
     if (!subscribers) return;
 
-    const reportError = (error: unknown) => {
-      console.error(
-        `[assistant-ui] Thread runtime "${event}" listener threw an error`,
-        error,
-      );
-    };
-
-    for (const callback of subscribers) {
-      try {
-        const result = callback(payload) as unknown;
-        if (
-          typeof result === "object" &&
-          result !== null &&
-          "then" in result &&
-          typeof result.then === "function"
-        ) {
-          void Promise.resolve(result).catch(reportError);
-        }
-      } catch (error) {
-        reportError(error);
-      }
-    }
+    notifyEventListeners(subscribers, payload, `Thread runtime "${event}"`);
   }
 
   public subscribe(callback: () => void): Unsubscribe {

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -1,4 +1,5 @@
 import type { Unsubscribe } from "../types/unsubscribe";
+import { notifyEventListeners } from "../utils/notify-event-listeners";
 
 export const SKIP_UPDATE = Symbol("skip-update");
 export type SKIP_UPDATE = typeof SKIP_UPDATE;
@@ -102,30 +103,13 @@ export abstract class BaseSubject {
 
   protected abstract _connect(): Unsubscribe;
 
-  protected notifySubscribers(
-    payload?: unknown,
-    reportError?: (error: unknown) => void,
-  ) {
-    if (!reportError) {
-      for (const callback of this._subscriptions) callback(payload);
+  protected notifySubscribers(payload?: unknown, errorContext?: string) {
+    if (errorContext) {
+      notifyEventListeners(this._subscriptions, payload, errorContext);
       return;
     }
 
-    for (const callback of this._subscriptions) {
-      try {
-        const result = callback(payload) as unknown;
-        if (
-          typeof result === "object" &&
-          result !== null &&
-          "then" in result &&
-          typeof result.then === "function"
-        ) {
-          void Promise.resolve(result).catch(reportError);
-        }
-      } catch (error) {
-        reportError(error);
-      }
-    }
+    for (const callback of this._subscriptions) callback(payload);
   }
 
   private _updateConnection() {
@@ -298,14 +282,9 @@ export class EventSubscriptionSubject<
   }
 
   protected _connect(): Unsubscribe {
-    const reportError = (error: unknown) => {
-      console.error(
-        `[assistant-ui] Runtime event "${this.config.event}" listener threw an error`,
-        error,
-      );
-    };
+    const errorContext = `Runtime event "${this.config.event}"`;
     const callback = (payload?: unknown) => {
-      this.notifySubscribers(payload, reportError);
+      this.notifySubscribers(payload, errorContext);
     };
 
     let lastState = this.config.binding.getState();

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -102,8 +102,30 @@ export abstract class BaseSubject {
 
   protected abstract _connect(): Unsubscribe;
 
-  protected notifySubscribers(payload?: unknown) {
-    for (const callback of this._subscriptions) callback(payload);
+  protected notifySubscribers(
+    payload?: unknown,
+    reportError?: (error: unknown) => void,
+  ) {
+    if (!reportError) {
+      for (const callback of this._subscriptions) callback(payload);
+      return;
+    }
+
+    for (const callback of this._subscriptions) {
+      try {
+        const result = callback(payload) as unknown;
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "then" in result &&
+          typeof result.then === "function"
+        ) {
+          void Promise.resolve(result).catch(reportError);
+        }
+      } catch (error) {
+        reportError(error);
+      }
+    }
   }
 
   private _updateConnection() {
@@ -276,8 +298,14 @@ export class EventSubscriptionSubject<
   }
 
   protected _connect(): Unsubscribe {
+    const reportError = (error: unknown) => {
+      console.error(
+        `[assistant-ui] Runtime event "${this.config.event}" listener threw an error`,
+        error,
+      );
+    };
     const callback = (payload?: unknown) => {
-      this.notifySubscribers(payload);
+      this.notifySubscribers(payload, reportError);
     };
 
     let lastState = this.config.binding.getState();

--- a/packages/core/src/tests/event-subscription-listener-errors.test.ts
+++ b/packages/core/src/tests/event-subscription-listener-errors.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ThreadComposerRuntimeImpl,
+  type ThreadComposerRuntimeCoreBinding,
+} from "../runtime/api/composer-runtime";
+import {
+  ThreadRuntimeImpl,
+  type ThreadListItemRuntimeBinding,
+  type ThreadRuntimeCoreBinding,
+} from "../runtime/api/thread-runtime";
+import { ReadonlyThreadRuntimeCore } from "../runtimes/readonly/ReadonlyThreadRuntimeCore";
+import type { Unsubscribe } from "../types/unsubscribe";
+
+type EventListener = (payload?: unknown) => unknown;
+
+class GuardedEventSource {
+  private listeners = new Set<EventListener>();
+
+  public unstable_on = (
+    _event: string,
+    listener: EventListener,
+  ): Unsubscribe => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  public emit(payload?: unknown) {
+    for (const listener of this.listeners) {
+      try {
+        const result = listener(payload);
+        if (
+          typeof result === "object" &&
+          result !== null &&
+          "then" in result &&
+          typeof result.then === "function"
+        ) {
+          void Promise.resolve(result).catch((error) => {
+            console.error("[test source] listener error", error);
+          });
+        }
+      } catch (error) {
+        console.error("[test source] listener error", error);
+      }
+    }
+  }
+}
+
+type RuntimeHarness = {
+  subscribe: (listener: EventListener) => Unsubscribe;
+  emit: () => void;
+  errorContext: string;
+};
+
+const makeComposerHarness = (): RuntimeHarness => {
+  const source = new GuardedEventSource();
+  const binding = {
+    path: {
+      ref: "test.composer",
+      threadSelector: { type: "main" },
+      composerSource: "thread",
+    },
+    getState: () => ({ unstable_on: source.unstable_on }),
+    subscribe: () => () => {},
+  } as unknown as ThreadComposerRuntimeCoreBinding;
+  const runtime = new ThreadComposerRuntimeImpl(binding);
+
+  return {
+    subscribe: (listener) =>
+      runtime.unstable_on("attachmentAdd", listener as never),
+    emit: () => source.emit({}),
+    errorContext: 'Runtime event "attachmentAdd"',
+  };
+};
+
+const makeThreadHarness = (): RuntimeHarness => {
+  const source = new GuardedEventSource();
+  const core = new ReadonlyThreadRuntimeCore();
+  core.unstable_on = source.unstable_on as typeof core.unstable_on;
+
+  const path = {
+    ref: "test.thread",
+    threadSelector: { type: "main" as const },
+  };
+  const threadBinding: ThreadRuntimeCoreBinding = {
+    path,
+    getState: () => core,
+    subscribe: (listener) => core.subscribe(listener),
+    outerSubscribe: (listener) => core.subscribe(listener),
+  };
+  const threadListItemBinding: ThreadListItemRuntimeBinding = {
+    path,
+    getState: () => ({
+      id: "test",
+      remoteId: undefined,
+      externalId: undefined,
+      isMain: true,
+      status: "regular",
+      title: undefined,
+    }),
+    subscribe: () => () => {},
+  };
+  const runtime = new ThreadRuntimeImpl(threadBinding, threadListItemBinding);
+
+  return {
+    subscribe: (listener) => runtime.unstable_on("initialize", listener),
+    emit: () => source.emit({}),
+    errorContext: 'Runtime event "initialize"',
+  };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe.each([
+  ["composer", makeComposerHarness],
+  ["thread", makeThreadHarness],
+] as const)("%s public unstable_on", (_name, makeHarness) => {
+  it("continues notifying sibling listeners after a synchronous error", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const harness = makeHarness();
+    const sibling = vi.fn();
+
+    harness.subscribe(() => {
+      throw new Error("listener failed");
+    });
+    harness.subscribe(sibling);
+
+    harness.emit();
+
+    expect(sibling).toHaveBeenCalledOnce();
+  });
+
+  it("handles rejected thenables returned by listeners", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const harness = makeHarness();
+    const listenerError = new Error("async listener failed");
+    const then = vi.fn(
+      (
+        _resolve: (value?: unknown) => void,
+        reject: (reason?: unknown) => void,
+      ) => reject(listenerError),
+    );
+
+    harness.subscribe(() => ({ then }));
+    harness.emit();
+
+    await vi.waitFor(() => {
+      expect(then).toHaveBeenCalledOnce();
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(harness.errorContext),
+        listenerError,
+      );
+    });
+  });
+});

--- a/packages/core/src/tests/event-subscription-listener-errors.test.ts
+++ b/packages/core/src/tests/event-subscription-listener-errors.test.ts
@@ -8,6 +8,8 @@ import {
   type ThreadListItemRuntimeBinding,
   type ThreadRuntimeCoreBinding,
 } from "../runtime/api/thread-runtime";
+import { ThreadListItemRuntimeImpl } from "../runtime/api/thread-list-item-runtime";
+import type { ThreadListRuntimeCoreBinding } from "../runtime/api/thread-list-runtime";
 import { ReadonlyThreadRuntimeCore } from "../runtimes/readonly/ReadonlyThreadRuntimeCore";
 import type { Unsubscribe } from "../types/unsubscribe";
 
@@ -108,6 +110,43 @@ const makeThreadHarness = (): RuntimeHarness => {
   };
 };
 
+const makeThreadListItemHarness = (): RuntimeHarness => {
+  let isMain = true;
+  const stateListeners = new Set<() => void>();
+  const binding = {
+    path: {
+      ref: "test.threadListItem",
+      threadSelector: { type: "main" as const },
+    },
+    getState: () => ({
+      id: "test",
+      remoteId: undefined,
+      externalId: undefined,
+      isMain,
+      status: "regular" as const,
+      title: undefined,
+    }),
+    subscribe: (listener: () => void) => {
+      stateListeners.add(listener);
+      return () => stateListeners.delete(listener);
+    },
+  } as unknown as ThreadListItemRuntimeBinding;
+  const runtime = new ThreadListItemRuntimeImpl(
+    binding,
+    {} as ThreadListRuntimeCoreBinding,
+  );
+
+  return {
+    subscribe: (listener) =>
+      runtime.unstable_on("switchedAway", listener as never),
+    emit: () => {
+      isMain = !isMain;
+      for (const listener of [...stateListeners]) listener();
+    },
+    errorContext: 'Thread list item "switchedAway"',
+  };
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -115,6 +154,7 @@ afterEach(() => {
 describe.each([
   ["composer", makeComposerHarness],
   ["thread", makeThreadHarness],
+  ["thread list item", makeThreadListItemHarness],
 ] as const)("%s public unstable_on", (_name, makeHarness) => {
   it("continues notifying sibling listeners after a synchronous error", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/core/src/tests/event-subscription-listener-errors.test.ts
+++ b/packages/core/src/tests/event-subscription-listener-errors.test.ts
@@ -131,28 +131,35 @@ describe.each([
     expect(sibling).toHaveBeenCalledOnce();
   });
 
-  it("handles rejected thenables returned by listeners", async () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const harness = makeHarness();
-    const listenerError = new Error("async listener failed");
-    const then = vi.fn(
-      (
-        _resolve: (value?: unknown) => void,
-        reject: (reason?: unknown) => void,
-      ) => reject(listenerError),
-    );
-
-    harness.subscribe(() => ({ then }));
-    harness.emit();
-
-    await vi.waitFor(() => {
-      expect(then).toHaveBeenCalledOnce();
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining(harness.errorContext),
-        listenerError,
+  it.each(["object", "function"] as const)(
+    "handles rejected %s thenables returned by listeners",
+    async (thenableType) => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const harness = makeHarness();
+      const listenerError = new Error("async listener failed");
+      const then = vi.fn(
+        (
+          _resolve: (value?: unknown) => void,
+          reject: (reason?: unknown) => void,
+        ) => reject(listenerError),
       );
-    });
-  });
+      const thenable =
+        thenableType === "function"
+          ? Object.assign(() => {}, { then })
+          : { then };
+
+      harness.subscribe(() => thenable);
+      harness.emit();
+
+      await vi.waitFor(() => {
+        expect(then).toHaveBeenCalledOnce();
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining(harness.errorContext),
+          listenerError,
+        );
+      });
+    },
+  );
 });

--- a/packages/core/src/utils/notify-event-listeners.ts
+++ b/packages/core/src/utils/notify-event-listeners.ts
@@ -1,0 +1,30 @@
+type EventListener = (payload?: unknown) => void;
+
+export const notifyEventListeners = (
+  listeners: Iterable<EventListener>,
+  payload: unknown,
+  errorContext: string,
+) => {
+  const reportError = (error: unknown) => {
+    console.error(
+      `[assistant-ui] ${errorContext} listener threw an error`,
+      error,
+    );
+  };
+
+  for (const listener of listeners) {
+    try {
+      const result = listener(payload) as unknown;
+      if (
+        result !== null &&
+        (typeof result === "object" || typeof result === "function") &&
+        "then" in result &&
+        typeof result.then === "function"
+      ) {
+        void Promise.resolve(result).catch(reportError);
+      }
+    } catch (error) {
+      reportError(error);
+    }
+  }
+};


### PR DESCRIPTION
## Summary

- route composer, thread, and public runtime-subject event listeners through one shared isolation helper
- continue notifying sibling listeners after synchronous failures and observe rejected promises, object thenables, and callable thenables
- keep ordinary state-subscription error propagation unchanged while preventing public `modelContextUpdate` listeners from escaping registry updates

Fixes #5175

## Testing

- `pnpm --filter @assistant-ui/core test` (70 files, 635 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`
- `pnpm api-surface`
