### PR TITLE
test(react-ai-sdk): pin history append retry semantics

### DIFF
--- a/.changeset/ai-sdk-history-retry-regressions.md
+++ b/.changeset/ai-sdk-history-retry-regressions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+test: pin history append retry semantics after a failed persistence pass

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -316,6 +316,65 @@ describe("useExternalHistory persistence", () => {
     };
   };
 
+  it("retries a failed append on the next persistence pass", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { append, runCycle, flush } = createPersistenceHarness(false);
+    const innerMessage = { id: "inner-a", parts: ["final"] };
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [innerMessage],
+    );
+    append.mockRejectedValueOnce(new Error("temporary storage failure"));
+
+    await runCycle([message]);
+    await flush();
+    expect(append).toHaveBeenCalledTimes(1);
+
+    await runCycle([message]);
+    await flush();
+    expect(append).toHaveBeenCalledTimes(2);
+    expect(append).toHaveBeenLastCalledWith({
+      parentId: null,
+      message: innerMessage,
+    });
+
+    await runCycle([message]);
+    await flush();
+    expect(append).toHaveBeenCalledTimes(2);
+    consoleError.mockRestore();
+  });
+
+  it("does not replay appends that succeeded before a mid-batch failure", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { append, runCycle, flush } = createPersistenceHarness(false);
+    const first = { id: "inner-1", parts: ["first"] };
+    const second = { id: "inner-2", parts: ["second"] };
+    const message = createAssistantMessage(
+      { type: "complete", reason: "stop" },
+      [first, second],
+    );
+    append.mockImplementationOnce(async () => {});
+    append.mockRejectedValueOnce(new Error("temporary storage failure"));
+
+    await runCycle([message]);
+    await flush();
+    expect(append).toHaveBeenCalledTimes(2);
+
+    await runCycle([message]);
+    await flush();
+    expect(append).toHaveBeenCalledTimes(3);
+    expect(append.mock.calls.map((c) => c[0].message.id)).toEqual([
+      "inner-1",
+      "inner-2",
+      "inner-2",
+    ]);
+    consoleError.mockRestore();
+  });
+
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {
     const { append, runCycle } = createPersistenceHarness(true);
     const innerMessage = { id: "inner-a", parts: ["pending"] };

--- a/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useExternalHistory.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { bindExternalStoreMessage } from "@assistant-ui/core";
 import type {
   AssistantRuntime,
@@ -320,6 +320,7 @@ describe("useExternalHistory persistence", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
     const { append, runCycle, flush } = createPersistenceHarness(false);
     const innerMessage = { id: "inner-a", parts: ["final"] };
     const message = createAssistantMessage(
@@ -343,13 +344,13 @@ describe("useExternalHistory persistence", () => {
     await runCycle([message]);
     await flush();
     expect(append).toHaveBeenCalledTimes(2);
-    consoleError.mockRestore();
   });
 
   it("does not replay appends that succeeded before a mid-batch failure", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
     const { append, runCycle, flush } = createPersistenceHarness(false);
     const first = { id: "inner-1", parts: ["first"] };
     const second = { id: "inner-2", parts: ["second"] };
@@ -372,7 +373,6 @@ describe("useExternalHistory persistence", () => {
       "inner-2",
       "inner-2",
     ]);
-    consoleError.mockRestore();
   });
 
   it("persists assistant messages awaiting tool approval when the adapter supports update", async () => {


### PR DESCRIPTION
## what

two regression tests in the `useExternalHistory` persistence harness pinning what happens when a history append fails mid-pass:

- a failed append is retried on the next persistence pass, and a later pass does not append again after the retry succeeds
- appends that succeeded before a mid-batch failure are not replayed on the retry (call sequence `inner-1, inner-2, inner-2`)

## why

#4861 diagnosed a real durability bug against the july 12 file: `historyIds` was marked before the awaited appends, so a failed append left the message marked persisted and it never retried. the file has since been rewritten three times, and the #5051 / #5052 / #5087 series closed that bug as an emergent property of three interacting mechanisms: a failed append aborts the pass before the `persistedExternalMessages` snapshot write, which keeps the message in `changedRunMessageIds` on the next pass, and the per-inner-item `persistedInnerIds` bookkeeping dedupes the replay.

both tests pass on current main, which is the verification that the bug is gone. nothing pinned this behavior though, and semantics that only hold as the interplay of three mechanisms are exactly the kind that regress silently when any one of them is refactored.

supersedes #4861, which carried the same test intent against the old file structure.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

