### PR TITLE
fix(tap): lazy scheduler MessageChannel; dispatcher implements useMemoCache

### DIFF
--- a/.changeset/tap-lazy-channel-memo-cache.md
+++ b/.changeset/tap-lazy-channel-memo-cache.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: create the scheduler MessageChannel lazily so importing tap does not hold the Node event loop open; implement useMemoCache on tap's dispatcher so compiled components work under duplicated tap copies

--- a/packages/tap/src/__tests__/react-dispatcher.test.ts
+++ b/packages/tap/src/__tests__/react-dispatcher.test.ts
@@ -104,6 +104,35 @@ describe("react dispatcher", () => {
     expect(cell.currentDeps).toEqual([2]);
   });
 
+  it("routes React's __COMPILER_RUNTIME.c to the tap fiber's memo cache", () => {
+    // A duplicated tap copy misses its own shim fiber and falls through to
+    // React's c(), which reads useMemoCache off the live dispatcher.
+    const runtimeC = (React as any).__COMPILER_RUNTIME?.c;
+    if (!runtimeC) return; // React 18 has no __COMPILER_RUNTIME
+
+    let computes = 0;
+    const fiber = createTestResource((p: { x: number }) => {
+      const $ = runtimeC(2);
+      let double;
+      if ($[0] !== p.x) {
+        computes++;
+        double = p.x * 2;
+        $[0] = p.x;
+        $[1] = double;
+      } else {
+        double = $[1];
+      }
+      return double;
+    });
+
+    expect(renderTest(fiber, { x: 2 })).toBe(4);
+    expect(computes).toBe(1);
+    expect(renderTest(fiber, { x: 2 })).toBe(4);
+    expect(computes).toBe(1);
+    expect(renderTest(fiber, { x: 3 })).toBe(6);
+    expect(computes).toBe(2);
+  });
+
   it("throws for a hook tap does not implement", () => {
     const fiber = createTestResource(() => React.useId());
     // render directly: a mid-render throw must not leave a tracked, unmounted

--- a/packages/tap/src/core/helpers/memo-cache.ts
+++ b/packages/tap/src/core/helpers/memo-cache.ts
@@ -1,0 +1,36 @@
+import type { ResourceFiber } from "../types";
+import { isDevelopment } from "./env";
+
+export const MEMO_CACHE_SENTINEL = Symbol.for("react.memo_cache_sentinel");
+
+export const createMemoCache = (size: number): unknown[] =>
+  new Array(size).fill(MEMO_CACHE_SENTINEL);
+
+export const nextFiberMemoCache = (
+  fiber: ResourceFiber<unknown>,
+  size: number,
+): unknown[] => {
+  const memoCache = fiber.memoCache;
+  let data = memoCache.workInProgress;
+
+  if (data === null) {
+    const current = memoCache.current;
+    data = current === null ? [] : current.map((array) => array.slice());
+    memoCache.workInProgress = data;
+  }
+
+  const index = memoCache.index++;
+  let cache = data[index];
+  if (cache === undefined) {
+    cache = createMemoCache(size);
+    data[index] = cache;
+  } else if (isDevelopment && cache.length !== size) {
+    console.error(
+      "Expected a constant size argument for each invocation of c(). " +
+        "The previous cache was allocated with size " +
+        `${cache.length} but size ${size} was requested.`,
+    );
+  }
+
+  return cache;
+};

--- a/packages/tap/src/core/react-dispatcher.ts
+++ b/packages/tap/src/core/react-dispatcher.ts
@@ -10,6 +10,8 @@ import { useEffectEvent } from "../react-hooks/useEffectEvent";
 import { use } from "../react-hooks/use";
 import { useSyncExternalStore } from "../react-hooks/useSyncExternalStore";
 import { useDebugValue } from "../react-hooks/useDebugValue";
+import { getCurrentResourceFiber } from "./helpers/execution-context";
+import { nextFiberMemoCache } from "./helpers/memo-cache";
 
 // The dispatcher React reads while a resource renders, so hooks imported from
 // "react" route to tap with no build step. Hooks tap has no equivalent for are
@@ -29,6 +31,10 @@ const tapDispatcher = {
   use,
   useSyncExternalStore,
   useDebugValue,
+  // React's `__COMPILER_RUNTIME.c` reads this off the live dispatcher; a
+  // duplicated tap copy whose shim misses its own fiber lands here.
+  useMemoCache: (size: number) =>
+    nextFiberMemoCache(getCurrentResourceFiber(), size),
 };
 
 // React's live dispatcher slot differs by version: React 19 exposes it as `H` on

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -82,11 +82,19 @@ const flushScheduled = () => {
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
 // This allows more state updates to batch into a single re-render.
+// The channel is created on first use: an open MessagePort holds the Node
+// event loop open, so merely importing tap must not create one.
 const scheduleMacrotask = (() => {
   if (typeof MessageChannel !== "undefined") {
-    const channel = new MessageChannel();
-    channel.port1.onmessage = flushScheduled;
-    return () => channel.port2.postMessage(null);
+    let port2: MessagePort | undefined;
+    return () => {
+      if (!port2) {
+        const channel = new MessageChannel();
+        channel.port1.onmessage = flushScheduled;
+        port2 = channel.port2;
+      }
+      port2.postMessage(null);
+    };
   }
   // Fallback for environments without MessageChannel
   return () => setTimeout(flushScheduled, 0);

--- a/packages/tap/src/react-shim/compiler-runtime.ts
+++ b/packages/tap/src/react-shim/compiler-runtime.ts
@@ -1,6 +1,10 @@
 /* oxlint-disable react/rules-of-hooks, react-hooks/exhaustive-deps -- this module deliberately routes c() between tap and React at runtime */
 import React from "react";
-import { isDevelopment } from "../core/helpers/env";
+import {
+  MEMO_CACHE_SENTINEL,
+  createMemoCache,
+  nextFiberMemoCache,
+} from "../core/helpers/memo-cache";
 import { peekResourceFiber } from "../core/helpers/execution-context";
 
 // Runtime drop-in for "react/compiler-runtime": React Compiler output calls
@@ -11,10 +15,6 @@ const ReactRuntime = React as any;
 
 // React 18 lacks `__COMPILER_RUNTIME`, so mirror Meta's compiler-runtime
 // polyfill: a once-per-mount memo cell.
-const MEMO_CACHE_SENTINEL = Symbol.for("react.memo_cache_sentinel");
-const createMemoCache = (size: number): unknown[] =>
-  new Array(size).fill(MEMO_CACHE_SENTINEL);
-
 const cPolyfill = (size: number): unknown[] =>
   ReactRuntime.useMemo(() => {
     const $ = createMemoCache(size);
@@ -29,27 +29,5 @@ export const c = (size: number): unknown[] => {
     return (ReactRuntime.__COMPILER_RUNTIME?.c ?? cPolyfill)(size);
   }
 
-  const memoCache = fiber.memoCache;
-  let data = memoCache.workInProgress;
-
-  if (data === null) {
-    const current = memoCache.current;
-    data = current === null ? [] : current.map((array) => array.slice());
-    memoCache.workInProgress = data;
-  }
-
-  const index = memoCache.index++;
-  let cache = data[index];
-  if (cache === undefined) {
-    cache = createMemoCache(size);
-    data[index] = cache;
-  } else if (isDevelopment && cache.length !== size) {
-    console.error(
-      "Expected a constant size argument for each invocation of c(). " +
-        "The previous cache was allocated with size " +
-        `${cache.length} but size ${size} was requested.`,
-    );
-  }
-
-  return cache;
+  return nextFiberMemoCache(fiber, size);
 };


### PR DESCRIPTION
Creating the scheduler's MessageChannel at import time holds the Node event loop open; create it on first flush instead.

Implement `useMemoCache` on tap's React dispatcher so React's `__COMPILER_RUNTIME.c` reaches the correct fiber when a duplicated tap copy's shim misses its own module-local fiber state (module state is per-copy, but React's dispatcher slot is shared). The fiber memo-cache logic is now shared between the dispatcher and the compiler-runtime shim, and the shim's fiber-miss path is simply `(__COMPILER_RUNTIME?.c ?? cPolyfill)(size)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

