### PR TITLE
fix(tap): create the scheduler MessageChannel lazily

### DIFF
--- a/.changeset/tap-lazy-message-channel.md
+++ b/.changeset/tap-lazy-message-channel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: create the scheduler MessageChannel lazily so importing tap does not hold the Node event loop open

--- a/packages/tap/src/__tests__/scheduler.lazy-channel.test.ts
+++ b/packages/tap/src/__tests__/scheduler.lazy-channel.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+class FakePort {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  refCount = 0;
+  other!: FakePort;
+  ref() {
+    this.refCount++;
+  }
+  unref() {
+    this.refCount--;
+  }
+  postMessage(data: unknown) {
+    queueMicrotask(() => this.other.onmessage?.({ data }));
+  }
+}
+
+class FakeMessageChannel {
+  static instances: FakeMessageChannel[] = [];
+  port1 = new FakePort();
+  port2 = new FakePort();
+  constructor() {
+    this.port1.other = this.port2;
+    this.port2.other = this.port1;
+    FakeMessageChannel.instances.push(this);
+  }
+}
+
+describe("scheduler lazy MessageChannel", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    FakeMessageChannel.instances = [];
+  });
+
+  it("creates the channel on first schedule, not at import", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", FakeMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+    expect(FakeMessageChannel.instances).toHaveLength(0);
+
+    let ran = false;
+    const scheduler = new UpdateScheduler(() => {
+      ran = true;
+    });
+    scheduler.markDirty();
+    expect(FakeMessageChannel.instances).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(ran).toBe(true);
+  });
+
+  it("refs the port only while a flush is pending", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", FakeMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    const scheduler = new UpdateScheduler(() => {});
+    scheduler.markDirty();
+
+    const [channel] = FakeMessageChannel.instances;
+    expect(channel!.port1.refCount).toBe(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(channel!.port1.refCount).toBe(0);
+
+    scheduler.markDirty();
+    expect(FakeMessageChannel.instances).toHaveLength(1);
+    expect(channel!.port1.refCount).toBe(1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(channel!.port1.refCount).toBe(0);
+  });
+});

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -82,18 +82,27 @@ const flushScheduled = () => {
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
 // This allows more state updates to batch into a single re-render.
-// The channel is created on first use: an open MessagePort holds the Node
-// event loop open, so merely importing tap must not create one.
+// The channel is created on first use and its port is ref'd only while a flush
+// is pending: an active MessagePort holds the Node event loop open, so neither
+// importing tap nor an idle scheduler may keep one alive. ref/unref are
+// Node-only, hence the optional calls.
 const scheduleMacrotask = (() => {
   if (typeof MessageChannel !== "undefined") {
-    let port2: MessagePort | undefined;
+    let port1: (MessagePort & { ref?: () => void; unref?: () => void }) | null =
+      null;
+    let port2: MessagePort;
     return () => {
-      if (!port2) {
+      if (!port1) {
         const channel = new MessageChannel();
-        channel.port1.onmessage = flushScheduled;
+        channel.port1.onmessage = () => {
+          port1?.unref?.();
+          flushScheduled();
+        };
+        port1 = channel.port1;
         port2 = channel.port2;
       }
-      port2.postMessage(null);
+      port1.ref?.();
+      port2!.postMessage(null);
     };
   }
   // Fallback for environments without MessageChannel

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -82,11 +82,19 @@ const flushScheduled = () => {
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
 // This allows more state updates to batch into a single re-render.
+// The channel is created on first use: an open MessagePort holds the Node
+// event loop open, so merely importing tap must not create one.
 const scheduleMacrotask = (() => {
   if (typeof MessageChannel !== "undefined") {
-    const channel = new MessageChannel();
-    channel.port1.onmessage = flushScheduled;
-    return () => channel.port2.postMessage(null);
+    let port2: MessagePort | undefined;
+    return () => {
+      if (!port2) {
+        const channel = new MessageChannel();
+        channel.port1.onmessage = flushScheduled;
+        port2 = channel.port2;
+      }
+      port2.postMessage(null);
+    };
   }
   // Fallback for environments without MessageChannel
   return () => setTimeout(flushScheduled, 0);


### PR DESCRIPTION
An open MessagePort holds the Node event loop open, so merely importing tap must not create one; create the channel on first scheduled flush instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

