### PR TITLE
refactor(eve): migrate convertEveMessage onto fromThreadMessageLike

### DIFF
--- a/.changeset/eve-from-thread-message-like.md
+++ b/.changeset/eve-from-thread-message-like.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+refactor: migrate convertEveMessage onto fromThreadMessageLike

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -141,6 +141,124 @@ describe("convertEveMessages", () => {
     });
   });
 
+  it("drops empty and whitespace-only assistant text and reasoning parts", () => {
+    const data = {
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "" },
+            { type: "reasoning", text: "   " },
+            { type: "text", text: "Hi" },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([{ type: "text", text: "Hi" }]);
+  });
+
+  it("preserves isOptimistic on optimistic user messages", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          metadata: { optimistic: true },
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.metadata.isOptimistic).toBe(true);
+  });
+
+  it("omits isOptimistic on confirmed user messages", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          metadata: { status: "submitted" },
+          parts: [{ type: "text", text: "Hello" }],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.metadata).not.toHaveProperty("isOptimistic");
+  });
+
+  it("falls back to an empty text part for user messages without convertible parts", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [{ type: "file", mediaType: "image/png" }],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  it("drops non-convertible user parts without triggering the fallback", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            { type: "file", mediaType: "image/png" },
+            { type: "text", text: "Hello" },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("drops non-convertible part types instead of throwing", () => {
+    const data = {
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            { type: "step-start" },
+            {
+              type: "authorization",
+              state: "required",
+              name: "github",
+              description: "Sign in to GitHub",
+              displayName: "GitHub",
+              stepIndex: 0,
+              turnId: "turn_1",
+            },
+            { type: "file", mediaType: "application/pdf" },
+            { type: "text", text: "Done" },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([{ type: "text", text: "Done" }]);
+  });
+
   it("uses the supplied message creation time", () => {
     const createdAt = new Date("2026-06-17T00:00:00.000Z");
     const data = {

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -1,13 +1,14 @@
-import type {
-  AppendMessage,
-  MessageStatus,
-  RespondToToolApprovalOptions,
-  TextMessagePart,
-  ThreadAssistantMessagePart,
-  ThreadMessage,
-  ThreadUserMessagePart,
-  ToolApprovalOption,
-  ToolCallMessagePart,
+import {
+  fromThreadMessageLike,
+  type AppendMessage,
+  type MessageStatus,
+  type RespondToToolApprovalOptions,
+  type ThreadAssistantMessagePart,
+  type ThreadMessage,
+  type ThreadMessageLike,
+  type ThreadUserMessagePart,
+  type ToolApprovalOption,
+  type ToolCallMessagePart,
 } from "@assistant-ui/core";
 import type {
   EveDynamicToolPart,
@@ -205,6 +206,13 @@ const convertUserPart = (
   }
 };
 
+const toUserContent = (
+  parts: readonly EveMessagePart[],
+): readonly ThreadUserMessagePart[] => {
+  const content = parts.map(convertUserPart).filter((part) => part !== null);
+  return content.length > 0 ? content : [{ type: "text", text: "" }];
+};
+
 /**
  * Converts a single Eve message into an assistant-ui thread message.
  */
@@ -222,47 +230,31 @@ export const convertEveMessage = (
     },
   };
 
-  const content =
-    message.role === "assistant"
-      ? message.parts.map(convertAssistantPart).filter((part) => part !== null)
-      : message.parts.map(convertUserPart).filter((part) => part !== null);
+  const like: ThreadMessageLike =
+    message.role === "user"
+      ? {
+          role: "user",
+          id: message.id,
+          createdAt,
+          content: toUserContent(message.parts),
+          attachments: [],
+          metadata,
+        }
+      : {
+          role: "assistant",
+          id: message.id,
+          createdAt,
+          content: message.parts
+            .map(convertAssistantPart)
+            .filter((part) => part !== null),
+          metadata,
+        };
 
-  const fallbackTextPart: TextMessagePart = {
-    type: "text",
-    text: "",
-  };
-
-  if (message.role === "user") {
-    return {
-      id: message.id,
-      createdAt,
-      role: "user",
-      content:
-        content.length > 0
-          ? (content as readonly ThreadUserMessagePart[])
-          : [fallbackTextPart],
-      attachments: [],
-      metadata,
-    };
-  }
-
-  return {
-    id: message.id,
-    createdAt,
-    role: "assistant",
-    content:
-      content.length > 0
-        ? (content as readonly ThreadAssistantMessagePart[])
-        : [],
-    status: toMessageStatus(message, index, messages, options),
-    metadata: {
-      unstable_state: null,
-      unstable_annotations: [],
-      unstable_data: [],
-      steps: [],
-      ...metadata,
-    },
-  };
+  return fromThreadMessageLike(
+    like,
+    message.id,
+    toMessageStatus(message, index, messages, options),
+  );
 };
 
 /**


### PR DESCRIPTION
Closes #5135.

## What

`convertEveMessage` previously hand-assembled `ThreadMessage` for both roles, carrying its own copy of the assistant metadata defaults and two unchecked `as readonly ...[]` casts. It now keeps all eve-specific pre-processing (part switches, dynamic-tool state machine, approval mapping, status computation, user fallback text part) and delegates final assembly to core's `fromThreadMessageLike`, matching how eve's own staged path already builds messages. No public surface change.

### Behavior deltas (named in #5135, pinned by tests)

- Empty and whitespace-only assistant text/reasoning parts are now dropped, matching the shared helper's assistant semantics. Practical impact is a transiently absent empty part during streaming.
- `metadata.isOptimistic` on user messages survives conversion. Note for reviewers: this test also passes against the old hand-built converter; what it pins is the dependency on #5122, without which the helper's user branch dropped the flag.

## Mechanics

- Status flows through the helper's `fallbackStatus` parameter, same as the staged path in `useEveAgentRuntime`; user messages never carry status, so the helper's throw path stays unreachable.
- User fallback empty text part is preserved as pre-processing, so eve user messages are never content-empty (unchanged behavior).
- Both content casts deleted; the converter now typechecks against `ThreadMessageLike` with no casts.
- Tests: 6 new pins (delta 1, delta 2 both directions, user fallback, non-convertible parts dropped on both roles); existing 6 tests pass unmodified.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

