### PR TITLE
test(tap): caller-side keying in withKey resource tests

### DIFF
--- a/packages/tap/src/__tests__/basic/withKey.resource.test.ts
+++ b/packages/tap/src/__tests__/basic/withKey.resource.test.ts
@@ -21,8 +21,7 @@ const useConnection = (options: ConnectionOptions, props: ConnectionProps) => {
   };
 };
 
-const ConnectionResource = (options: ConnectionOptions) =>
-  withKey(options.id, resource(useConnection).bind(null, options));
+const ConnectionResource = resource(useConnection);
 
 describe("withKey on a Resource", () => {
   afterEach(() => {
@@ -30,7 +29,7 @@ describe("withKey on a Resource", () => {
   });
 
   it("stamps the key onto every produced element", () => {
-    const Keyed = withKey("conn-1", resource(useConnection));
+    const Keyed = withKey("conn-1", ConnectionResource);
 
     const el1 = Keyed({ id: "a", initial: 0 }, { mult: 1 });
     const el2 = Keyed({ id: "b", initial: 5 }, { mult: 2 });

--- a/packages/tap/src/__tests__/basic/withKey.resource.test.ts
+++ b/packages/tap/src/__tests__/basic/withKey.resource.test.ts
@@ -41,31 +41,40 @@ describe("withKey on a Resource", () => {
   });
 
   it("threads .bind args through to the hook", () => {
-    const el = ConnectionResource({ id: "ws-1", initial: 3 })({ mult: 10 });
+    const conn = withKey(
+      "conn-ws",
+      ConnectionResource.bind(null, { id: "ws-1", initial: 3 }),
+    );
+    const el = conn({ mult: 10 });
 
-    expect(el.key).toBe("ws-1");
+    expect(el.key).toBe("conn-ws");
 
     const testFiber = createTestResource(() => useResources([el]));
-    const [conn] = renderTest(testFiber);
-    expect(conn).toMatchObject({ id: "ws-1", value: 30 });
+    const [result] = renderTest(testFiber);
+    expect(result).toMatchObject({ id: "ws-1", value: 30 });
   });
 
-  it("reconciles keyed curried resources by key across reorder", () => {
-    const a = ConnectionResource({ id: "a", initial: 1 });
-    const b = ConnectionResource({ id: "b", initial: 20 });
+  it("reconciles keyed resources by key across reorder", () => {
+    const a = withKey(
+      "a",
+      ConnectionResource.bind(null, { id: "a", initial: 1 }),
+    );
+    const b = withKey(
+      "b",
+      ConnectionResource.bind(null, { id: "b", initial: 20 }),
+    );
 
-    const testFiber = createTestResource(
-      (props: { conns: ReturnType<typeof ConnectionResource>[] }) =>
-        useResources(props.conns.map((conn) => conn({ mult: 1 }))),
+    const testFiber = createTestResource((props: { conns: (typeof a)[] }) =>
+      useResources(props.conns.map((conn) => conn({ mult: 1 }))),
     );
 
     const result1 = renderTest(testFiber, { conns: [a, b] });
-    expect(result1.map((c: any) => c.value)).toEqual([1, 20]);
+    expect(result1.map((c) => c.value)).toEqual([1, 20]);
 
     result1[0]!.bump();
 
     const result2 = renderTest(testFiber, { conns: [b, a] });
-    expect(result2.map((c: any) => c.id)).toEqual(["b", "a"]);
-    expect(result2.map((c: any) => c.value)).toEqual([20, 2]);
+    expect(result2.map((c) => c.id)).toEqual(["b", "a"]);
+    expect(result2.map((c) => c.value)).toEqual([20, 2]);
   });
 });


### PR DESCRIPTION
Follow-up to #5186 (landed moments before this direction arrived): the fixture pattern of a factory stamping its own key from its options (author-side keying) is an antipattern. The tests keep covering the `withKey(key, Resource)` overload and `.bind` partial application, but the key is now attached at the call site — `withKey("conn-a", ConnectionResource.bind(null, options))` — and the host applies `ConnectionProps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

