### PR TITLE
refactor(tap): single-param ResourceElement

### DIFF
--- a/.changeset/tap-single-param-element.md
+++ b/.changeset/tap-single-param-element.md
@@ -3,4 +3,4 @@
 "@assistant-ui/store": patch
 ---
 
-refactor: `ResourceElement<Result>` drops its args type parameter — elements are opaque descriptors; `Resource<Result, Args>` keeps the callable typing and `ContravariantResource` is a deprecated alias of it
+refactor: `ResourceElement<Result>` drops its args type parameter — elements are opaque descriptors; `Resource<Result, Args>` keeps the callable typing and `ContravariantResource` is removed

--- a/.changeset/tap-single-param-element.md
+++ b/.changeset/tap-single-param-element.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/tap": patch
+"@assistant-ui/store": patch
+---
+
+refactor: `ResourceElement<Result>` drops its args type parameter — elements are opaque descriptors; `Resource<Result, Args>` keeps the callable typing and `ContravariantResource` is a deprecated alias of it

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1455,19 +1455,9 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
+type DerivedElement<K extends ClientNames> = ResourceElement<{
+  [derivedKey]: K;
+}>;
 
 declare namespace DictationAdapter {
   type Status = {
@@ -3681,11 +3671,11 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
   [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
 }[Keys];
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -5547,6 +5537,8 @@ declare function defineToolkit<TArgsByName extends {
 };
 
 declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
+
+declare const derivedKey: unique symbol;
 
 declare function externalTool(): never;
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1300,19 +1300,9 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
+type DerivedElement<K extends ClientNames> = ResourceElement<{
+  [derivedKey]: K;
+}>;
 
 declare namespace DictationAdapter {
   type Status = {
@@ -2861,11 +2851,11 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
   [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
 }[Keys];
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -4541,6 +4531,8 @@ declare function defineToolkit$1<TArgsByName extends {
 };
 
 declare function defineToolkit$1<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
+
+declare const derivedKey: unique symbol;
 
 declare namespace diff_d_exports {
   export { DiffContent as Content, DiffContentProps as ContentProps, DiffFileInput, DiffLineType, DisplayLine, FoldedRegion, DiffHeader as Header, DiffHeaderProps as HeaderProps, DiffLine as Line, DiffLineProps as LineProps, ParsedFile, ParsedLine, DiffRoot as Root, DiffRootProps as RootProps, DiffStats as Stats, DiffStatsProps as StatsProps };

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -452,11 +452,11 @@ type McpServerResourceProps = {
   onRemove: () => Promise<void>;
 };
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1211,19 +1211,9 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
+type DerivedElement<K extends ClientNames> = ResourceElement<{
+  [derivedKey]: K;
+}>;
 
 declare namespace DictationAdapter {
   type Status = {
@@ -2477,11 +2467,11 @@ type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyo
   [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
 }[Keys];
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -4014,6 +4004,8 @@ declare function defineToolkit<TArgsByName extends {
 };
 
 declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
+
+declare const derivedKey: unique symbol;
 
 declare function externalTool(): never;
 

--- a/api-surface/assistant-ui__react-o11y.ts
+++ b/api-surface/assistant-ui__react-o11y.ts
@@ -39,11 +39,11 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   [K in keyof ScopeRegistry]: ValidateClient<K>;
 };
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1855,19 +1855,9 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
-
-declare namespace Derived {
-  type Props<K extends ClientNames> = {
-    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
-  } & ClientMeta<K>;
-}
-
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
+type DerivedElement<K extends ClientNames> = ResourceElement<{
+  [derivedKey]: K;
+}>;
 
 interface DevToolsApiEntry {
   api: Partial<AssistantClient>;
@@ -3638,11 +3628,11 @@ type RequireAtLeastOne$1<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<ke
   [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
 }[Keys];
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -5779,6 +5769,8 @@ declare function defineToolkit<TArgsByName extends {
 };
 
 declare function defineToolkit<const TDefinition extends ToolkitDefinition>(_definition: TDefinition): Toolkit & TDefinition;
+
+declare const derivedKey: unique symbol;
 
 declare namespace error_d_exports {
   export { ErrorPrimitiveMessage as Message, ErrorPrimitiveRoot as Root };

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -100,11 +100,7 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   [K in keyof ScopeRegistry]: ValidateClient<K>;
 };
 
-type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
-
-declare const Derived: <K extends ClientNames>(_config: Derived.Props<K>) => ResourceElement<null, [
-  _config: Derived.Props<K>
-]>;
+declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
 
 declare namespace Derived {
   type Props<K extends ClientNames> = {
@@ -112,9 +108,9 @@ declare namespace Derived {
   } & ClientMeta<K>;
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<null, [
-  Derived.Props<K>
-]>;
+type DerivedElement<K extends ClientNames> = ResourceElement<{
+  [derivedKey]: K;
+}>;
 
 type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${string}` ? Source : never;
 
@@ -141,9 +137,11 @@ declare function RenderChildrenWithAccessor<T>(_param1: {
   children: (getItem: () => T) => ReactNode;
 }): ReactNode;
 
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
+
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -174,6 +172,8 @@ type WildcardPayload = {
 }[Extract<keyof ClientEventMap, string>];
 
 declare function attachTransformScopes(hook: Hook, transform: TransformScopesFn): void;
+
+declare const derivedKey: unique symbol;
 
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
 
@@ -230,7 +230,7 @@ declare namespace useClientList {
   type Props<TData, TMethods extends ClientMethods> = {
     initialValues: TData[];
     getKey: (data: TData) => string;
-    resource: ContravariantResource<TMethods, [
+    resource: Resource<TMethods, [
       ResourceProps<TData>
     ]>;
   };

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -178,7 +178,7 @@ declare const derivedKey: unique symbol;
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
 
 declare namespace entry_root_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
+  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
 }
 
 declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -1,14 +1,12 @@
 import { Context } from "react";
 
-type ContravariantResource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R>;
+type ExtractResourceReturnType<T> = T extends ResourceElement<infer V> ? V : T extends Resource<infer V, any> ? V : never;
 
-type ExtractResourceReturnType<T> = T extends ResourceElement<infer R, any> ? R : T extends Resource<infer R, any> ? R : never;
+type Resource<V, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<V>;
 
-type Resource<R, A extends readonly unknown[] = any[]> = (...args: A) => ResourceElement<R, A>;
-
-type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
@@ -20,16 +18,16 @@ declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { ContravariantResource, Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
 
 declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn: () => TResult) => TResult;
 
-declare function useResource<E extends ResourceElement<any, any[]>>(element: E): ExtractResourceReturnType<E>;
+declare function useResource<E extends ResourceElement<any>>(element: E): ExtractResourceReturnType<E>;
 
-declare function useResources<E extends ResourceElement<any, any[]>>(elements: readonly E[]): ExtractResourceReturnType<E>[];
+declare function useResources<E extends ResourceElement<any>>(elements: readonly E[]): ExtractResourceReturnType<E>[];
 
 declare namespace useTapHost {
   interface Result<R> {
@@ -50,7 +48,7 @@ declare namespace useTapRoot {
 
 declare const useTapRoot: <R>(render: () => R) => useTapRoot.Root<R>;
 
-declare function withKey<E extends ResourceElement<any, any>>(key: string | number, element: E, deps?: readonly unknown[]): E;
+declare function withKey<E extends ResourceElement<any>>(key: string | number, element: E, deps?: readonly unknown[]): E;
 
 declare function withKey<F extends Resource<any, any[]>>(key: string | number, resource: F): F;
 

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -27,15 +27,20 @@ import type {
  */
 // Exported so consumers (e.g. splitClients) can identify a derived element by its
 // hook: a `Derived(...)` element carries `hook === useDerived`.
-export const useDerived = <K extends ClientNames>(_config: Derived.Props<K>) =>
-  ({}) as { __derivedKey?: K };
+export declare const derivedKey: unique symbol;
+
+export const useDerived = <K extends ClientNames>(
+  _config: Derived.Props<K>,
+): { [derivedKey]: K } => {
+  throw new Error("Derived elements are config-only and must not be mounted");
+};
 
 export const Derived = resource(useDerived) as <K extends ClientNames>(
   config: Derived.Props<K>,
 ) => DerivedElement<K>;
 
 export type DerivedElement<K extends ClientNames> = ResourceElement<{
-  __derivedKey?: K;
+  [derivedKey]: K;
 }>;
 
 export namespace Derived {

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -33,12 +33,13 @@ export const useDerived = <K extends ClientNames>(
   return null;
 };
 
-export const Derived = resource(useDerived);
+export const Derived = resource(useDerived) as <K extends ClientNames>(
+  config: Derived.Props<K>,
+) => DerivedElement<K>;
 
-export type DerivedElement<K extends ClientNames> = ResourceElement<
-  null,
-  [Derived.Props<K>]
->;
+export type DerivedElement<K extends ClientNames> = ResourceElement<null> & {
+  readonly args: readonly [Derived.Props<K>];
+};
 
 export namespace Derived {
   /**

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -27,19 +27,16 @@ import type {
  */
 // Exported so consumers (e.g. splitClients) can identify a derived element by its
 // hook: a `Derived(...)` element carries `hook === useDerived`.
-export const useDerived = <K extends ClientNames>(
-  _config: Derived.Props<K>,
-): null => {
-  return null;
-};
+export const useDerived = <K extends ClientNames>(_config: Derived.Props<K>) =>
+  ({}) as { __derivedKey?: K };
 
 export const Derived = resource(useDerived) as <K extends ClientNames>(
   config: Derived.Props<K>,
 ) => DerivedElement<K>;
 
-export type DerivedElement<K extends ClientNames> = ResourceElement<null> & {
-  readonly __derivedKey?: K;
-};
+export type DerivedElement<K extends ClientNames> = ResourceElement<{
+  __derivedKey?: K;
+}>;
 
 export namespace Derived {
   /**

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -25,10 +25,10 @@ import type {
  * });
  * ```
  */
-// Exported so consumers (e.g. splitClients) can identify a derived element by its
-// hook: a `Derived(...)` element carries `hook === useDerived`.
 export declare const derivedKey: unique symbol;
 
+// Exported so consumers (e.g. splitClients) can identify a derived element by its
+// hook: a `Derived(...)` element carries `hook === useDerived`.
 export const useDerived = <K extends ClientNames>(
   _config: Derived.Props<K>,
 ): { [derivedKey]: K } => {

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -38,7 +38,7 @@ export const Derived = resource(useDerived) as <K extends ClientNames>(
 ) => DerivedElement<K>;
 
 export type DerivedElement<K extends ClientNames> = ResourceElement<null> & {
-  readonly args: readonly [Derived.Props<K>];
+  readonly __derivedKey?: K;
 };
 
 export namespace Derived {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -9,7 +9,7 @@ export { AuiIf } from "./AuiIf";
 export { AuiProvider } from "./utils/react-assistant-context";
 
 // resources
-export { Derived } from "./Derived";
+export { Derived, type DerivedElement } from "./Derived";
 export {
   attachTransformScopes,
   forwardTransformScopes,

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -17,7 +17,7 @@ import type {
   ClientElement,
   ClientMeta,
 } from "./types/client";
-import type { DerivedElement } from "./Derived";
+import type { Derived, DerivedElement } from "./Derived";
 import {
   useAssistantContextValue,
   DefaultAssistantClient,
@@ -239,8 +239,8 @@ const useDerivedClientAccessorResource = <K extends ClientNames>({
   // value that can change between renders for the same fiber is the
   // identity of the `get` closure. Routing reads through the ref so
   // they take effect without a one-commit lag.
-  const propsRef = useRef(element.args[0]);
-  propsRef.current = element.args[0];
+  const propsRef = useRef(element.args[0] as Derived.Props<K>);
+  propsRef.current = element.args[0] as Derived.Props<K>;
 
   return useMemo(() => {
     const clientFunction = () => propsRef.current.get(clientRef.current!);
@@ -297,7 +297,7 @@ const useDerivedClientsAccessorsResource = ({
         const name = key as keyof typeof clients;
         const element = clients[name]!;
         return withKey(
-          serializeMeta(name, element.args[0]),
+          serializeMeta(name, element.args[0] as Derived.Props<typeof name>),
           DerivedClientAccessorResource({
             element,
             clientRef,

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { withKey, type ContravariantResource } from "@assistant-ui/tap";
+import { withKey, type Resource } from "@assistant-ui/tap";
 
 import { useClientLookup } from "./useClientLookup";
 import type { ClientMethods } from "./types/client";
@@ -118,6 +118,6 @@ export namespace useClientList {
   export type Props<TData, TMethods extends ClientMethods> = {
     initialValues: TData[];
     getKey: (data: TData) => string;
-    resource: ContravariantResource<TMethods, [ResourceProps<TData>]>;
+    resource: Resource<TMethods, [ResourceProps<TData>]>;
   };
 }

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -72,9 +72,7 @@ export function renderTest<R, A extends readonly unknown[]>(
 /**
  * Unmounts a specific resource fiber and removes it from tracking.
  */
-export function unmountResource<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
-) {
+export function unmountResource<R>(fiber: ResourceFiber<R>) {
   if (activeResources.has(fiber)) {
     unmountResourceFiber(fiber);
     activeResources.delete(fiber);
@@ -93,9 +91,7 @@ export function cleanupAllResources() {
  * Gets the current committed state of a resource fiber.
  * Returns the state from the last render/commit cycle.
  */
-export function getCommittedValue<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
-): R {
+export function getCommittedValue<R>(fiber: ResourceFiber<R>): R {
   if (!lastRenderValueMap.has(fiber)) {
     throw new Error(
       "No render result found for fiber. Make sure to call renderResource first.",
@@ -111,9 +107,9 @@ export function getCommittedValue<R, A extends readonly unknown[]>(
 export class TestSubscriber<T> {
   public callCount = 0;
   public lastState: T;
-  private fiber: ResourceFiber<any, any>;
+  private fiber: ResourceFiber<any>;
 
-  constructor(fiber: ResourceFiber<any, any>) {
+  constructor(fiber: ResourceFiber<any>) {
     this.fiber = fiber;
     // Need to render once to get initial state
     const lastArgs = propsMap.get(fiber) ?? [];
@@ -139,7 +135,7 @@ export class TestSubscriber<T> {
 export class TestResourceManager<R, A extends readonly unknown[]> {
   private isActive = false;
 
-  constructor(public fiber: ResourceFiber<R, A>) {}
+  constructor(public fiber: ResourceFiber<R>) {}
 
   renderAndMount(...args: A): R {
     if (this.isActive) {

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -39,9 +39,9 @@ export function createTestResource<R, A extends readonly unknown[]>(
 }
 
 // Track resources for cleanup
-const activeResources = new Set<ResourceFiber<any, any>>();
-const propsMap = new WeakMap<ResourceFiber<any, any>, any>();
-const lastRenderValueMap = new WeakMap<ResourceFiber<any, any>, any>();
+const activeResources = new Set<ResourceFiber<any>>();
+const propsMap = new WeakMap<ResourceFiber<any>, any>();
+const lastRenderValueMap = new WeakMap<ResourceFiber<any>, any>();
 
 /**
  * Renders a test resource fiber with the given props and manages its lifecycle.
@@ -49,7 +49,7 @@ const lastRenderValueMap = new WeakMap<ResourceFiber<any, any>, any>();
  * - Returns the current state after render
  */
 export function renderTest<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
+  fiber: ResourceFiber<R>,
   ...args: A
 ): R {
   propsMap.set(fiber, args);

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -6,12 +6,12 @@ import { withReactDispatcher } from "./react-dispatcher";
 import { isDevelopment } from "./helpers/env";
 import { commitRoot } from "./helpers/root";
 
-export function createResourceFiber<R, A extends readonly unknown[]>(
-  hook: (...args: A) => R,
+export function createResourceFiber<R>(
+  hook: (...args: any[]) => R,
   root: TapRoot,
   markDirty: (() => void) | undefined = undefined,
   strictMode: "root" | "child" | null,
-): ResourceFiber<R, A> {
+): ResourceFiber<R> {
   return {
     hook,
     root,

--- a/packages/tap/src/core/ResourceFiber.ts
+++ b/packages/tap/src/core/ResourceFiber.ts
@@ -35,9 +35,7 @@ export function createResourceFiber<R>(
   };
 }
 
-export function unmountResourceFiber<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
-): void {
+export function unmountResourceFiber<R>(fiber: ResourceFiber<R>): void {
   if (!fiber.isMounted)
     throw new Error("Tried to unmount a fiber that is already unmounted");
 
@@ -45,9 +43,9 @@ export function unmountResourceFiber<R, A extends readonly unknown[]>(
   cleanupAllEffects(fiber);
 }
 
-export function renderResourceFiber<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
-  args: Readonly<A>,
+export function renderResourceFiber<R>(
+  fiber: ResourceFiber<R>,
+  args: readonly unknown[],
 ): R {
   fiber.memoCache.workInProgress = null;
 
@@ -78,9 +76,7 @@ export function renderResourceFiber<R, A extends readonly unknown[]>(
   return value!;
 }
 
-export function commitResourceFiber<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
-): void {
+export function commitResourceFiber<R>(fiber: ResourceFiber<R>): void {
   const commitCallbacks =
     fiber.wipCommitCallbacks ?? fiber.commitCallbacks ?? [];
   fiber.wipCommitCallbacks = null;

--- a/packages/tap/src/core/context.ts
+++ b/packages/tap/src/core/context.ts
@@ -204,7 +204,7 @@ export const bubbleContextDeps = (
 
 export const hasChangedContexts = () => changedContexts.size > 0;
 
-export const hasContextDepsChanged = (fiber: ResourceFiber<any, any[]>) => {
+export const hasContextDepsChanged = (fiber: ResourceFiber<any>) => {
   if (!fiber.contextDeps || !hasChangedContexts()) return false;
 
   for (const context of changedContexts.keys()) {

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -44,9 +44,7 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
   }
 }
 
-export function cleanupAllEffects<R, A extends readonly unknown[]>(
-  executionContext: ResourceFiber<R, A>,
-) {
+export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {
   const errors: unknown[] = [];
   for (const cell of executionContext.cells) {
     if (cell?.type === "effect") {

--- a/packages/tap/src/core/helpers/execution-context.ts
+++ b/packages/tap/src/core/helpers/execution-context.ts
@@ -1,9 +1,9 @@
 import type { ResourceFiber } from "../types";
 
-let currentResourceFiber: ResourceFiber<any, any> | null = null;
+let currentResourceFiber: ResourceFiber<any> | null = null;
 
-export function withResourceFiber<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R, A>,
+export function withResourceFiber<R>(
+  fiber: ResourceFiber<R>,
   fn: () => void,
 ): void {
   fiber.currentIndex = 0;

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -64,7 +64,7 @@ export const applyChangelogRecord = (record: ChangelogRecord): void => {
 };
 
 export const addCommit = (
-  fiber: ResourceFiber<any, any>,
+  fiber: ResourceFiber<any>,
   priority: CommitPriority,
   callback: () => void,
 ): void => {
@@ -77,7 +77,7 @@ export const addRollback = (root: TapRoot, callback: () => void): void => {
 };
 
 export const markReducerDirty = (
-  fiber: ResourceFiber<any, any>,
+  fiber: ResourceFiber<any>,
   cell: ReducerCell,
 ): void => {
   if (cell.isDirty) return;

--- a/packages/tap/src/core/resource.ts
+++ b/packages/tap/src/core/resource.ts
@@ -3,5 +3,5 @@ import type { Resource, ResourceElement } from "./types";
 export function resource<R, A extends readonly unknown[]>(
   hook: (...args: A) => R,
 ): Resource<R, A> {
-  return (...args: A): ResourceElement<R, A> => ({ hook, args });
+  return (...args: A): ResourceElement<R> => ({ hook, args });
 }

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -8,12 +8,6 @@ export type ResourceElement<Result> = {
 export type Resource<Result, Args extends readonly unknown[] = any[]> = (
   ...args: Args
 ) => ResourceElement<Result>;
-/** @deprecated Use Resource instead. */
-export type ContravariantResource<
-  Result,
-  Args extends readonly unknown[] = any[],
-> = Resource<Result, Args>;
-
 export type ExtractResourceReturnType<T> =
   T extends ResourceElement<infer Result>
     ? Result

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -1,18 +1,18 @@
-export type ResourceElement<Result> = {
-  readonly hook: (...args: any[]) => Result;
+export type ResourceElement<V> = {
+  readonly hook: (...args: any[]) => V;
   readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
 
-export type Resource<Result, Args extends readonly unknown[] = any[]> = (
-  ...args: Args
-) => ResourceElement<Result>;
+export type Resource<V, A extends readonly unknown[] = any[]> = (
+  ...args: A
+) => ResourceElement<V>;
 export type ExtractResourceReturnType<T> =
-  T extends ResourceElement<infer Result>
-    ? Result
-    : T extends Resource<infer Result, any>
-      ? Result
+  T extends ResourceElement<infer V>
+    ? V
+    : T extends Resource<infer V, any>
+      ? V
       : never;
 
 export interface ChangelogRecord {

--- a/packages/tap/src/core/types.ts
+++ b/packages/tap/src/core/types.ts
@@ -1,26 +1,28 @@
-export type ResourceElement<R, A extends readonly unknown[] = any[]> = {
-  readonly hook: (...args: A) => R;
-  readonly args: Readonly<A>;
+export type ResourceElement<Result> = {
+  readonly hook: (...args: any[]) => Result;
+  readonly args: readonly unknown[];
   readonly key?: string | number;
   readonly deps?: readonly unknown[];
 };
 
-export type Resource<R, A extends readonly unknown[] = any[]> = (
-  ...args: A
-) => ResourceElement<R, A>;
-export type ContravariantResource<R, A extends readonly unknown[] = any[]> = (
-  ...args: A
-) => ResourceElement<R>;
+export type Resource<Result, Args extends readonly unknown[] = any[]> = (
+  ...args: Args
+) => ResourceElement<Result>;
+/** @deprecated Use Resource instead. */
+export type ContravariantResource<
+  Result,
+  Args extends readonly unknown[] = any[],
+> = Resource<Result, Args>;
 
 export type ExtractResourceReturnType<T> =
-  T extends ResourceElement<infer R, any>
-    ? R
-    : T extends Resource<infer R, any>
-      ? R
+  T extends ResourceElement<infer Result>
+    ? Result
+    : T extends Resource<infer Result, any>
+      ? Result
       : never;
 
 export interface ChangelogRecord {
-  readonly fiber: ResourceFiber<any, any>;
+  readonly fiber: ResourceFiber<any>;
   readonly cell: ReducerCell;
   readonly action: any;
 
@@ -83,9 +85,9 @@ export interface TapRoot {
   readonly rollbackCallbacks: (() => void)[];
 }
 
-export interface ResourceFiber<R, A extends readonly unknown[] = any[]> {
+export interface ResourceFiber<R> {
   readonly root: TapRoot;
-  readonly hook: (...args: A) => R;
+  readonly hook: (...args: any[]) => R;
   readonly markDirty: (() => void) | undefined;
   readonly devStrictMode: "root" | "child" | null;
 

--- a/packages/tap/src/core/withKey.ts
+++ b/packages/tap/src/core/withKey.ts
@@ -1,6 +1,6 @@
 import type { Resource, ResourceElement } from "./types";
 
-export function withKey<E extends ResourceElement<any, any>>(
+export function withKey<E extends ResourceElement<any>>(
   key: string | number,
   element: E,
   deps?: readonly unknown[],
@@ -11,7 +11,7 @@ export function withKey<F extends Resource<any, any[]>>(
 ): F;
 export function withKey(
   key: string | number,
-  target: ResourceElement<any, any> | Resource<any, any[]>,
+  target: ResourceElement<any> | Resource<any, any[]>,
   deps?: readonly unknown[],
 ) {
   if (typeof target === "function") {

--- a/packages/tap/src/hooks/useResource.ts
+++ b/packages/tap/src/hooks/useResource.ts
@@ -9,7 +9,7 @@ import { useResourceFiberHost } from "./utils/useResourceFiberHostUtils";
 import { useEffect, useMemo } from "react";
 import { useRenderMemo } from "./utils/useRenderMemo";
 
-export function useResource<E extends ResourceElement<any, any[]>>(
+export function useResource<E extends ResourceElement<any>>(
   element: E,
 ): ExtractResourceReturnType<E> {
   const { version, createFiber } = useResourceFiberHost();

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -70,7 +70,7 @@ const hasAnyChildContextDepsChanged = (
   return false;
 };
 
-export function useResources<E extends ResourceElement<any, any[]>>(
+export function useResources<E extends ResourceElement<any>>(
   elements: readonly E[],
 ): ExtractResourceReturnType<E>[] {
   const [fibers] = useState(() => new Map<string | number, FiberState>());

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -15,8 +15,4 @@ export { useTapRoot } from "./hooks/useTapRoot";
 export { useTapHost } from "./hooks/useTapHost";
 
 // types
-export type {
-  Resource,
-  ContravariantResource,
-  ResourceElement,
-} from "./core/types";
+export type { Resource, ResourceElement } from "./core/types";

--- a/packages/tap/src/react-hooks/useMemo.ts
+++ b/packages/tap/src/react-hooks/useMemo.ts
@@ -9,10 +9,7 @@ import {
   throwRenderedMoreHooks,
 } from "./utils/hookErrors";
 
-const addMemoCommit = <T>(
-  fiber: ResourceFiber<any, any>,
-  cell: MemoCell<T>,
-) => {
+const addMemoCommit = <T>(fiber: ResourceFiber<any>, cell: MemoCell<T>) => {
   addCommit(fiber, CommitPriority.HookState, () => {
     cell.current = cell.wip;
     cell.currentDeps = cell.wipDeps;

--- a/packages/tap/src/react-hooks/useReducer.ts
+++ b/packages/tap/src/react-hooks/useReducer.ts
@@ -18,7 +18,7 @@ import {
 type Dispatch<A> = (action: A) => void;
 
 const dispatchOnFiber = (
-  fiber: ResourceFiber<any, any>,
+  fiber: ResourceFiber<any>,
   record: ChangelogRecord,
   eagerReducer: ((state: any, action: any) => any) | undefined,
 ): void => {
@@ -62,7 +62,7 @@ const dispatchOnFiber = (
 };
 
 const createReducerCell = (
-  fiber: ResourceFiber<any, any>,
+  fiber: ResourceFiber<any>,
   reducer: (state: any, action: any) => any,
   initialArg: any,
   initFn: ((arg: any) => any) | undefined,


### PR DESCRIPTION
`ResourceElement<V>` drops its second type parameter: elements are opaque result descriptors, and only `Resource<V, A>` (the callable) knows the args. `ContravariantResource` is deleted — the erased element makes every resource contravariant-compatible by construction, and 0.x type breaks need no transitional alias. In the two-prop convention vocabulary: a factory takes `Options`, the produced resource is applied with `Props`, and neither leaks into the element type.

tap:
- `core/types.ts`: `ResourceElement<V>` (`hook: (...args: any[]) => V`, `args: readonly unknown[]`); `Resource<V, A>` unchanged in shape; `ContravariantResource` removed; `ExtractResourceReturnType` adjusted.
- Internal plumbing follows: `ResourceFiber<R>`, `renderResourceFiber(fiber, args: readonly unknown[])`, `withKey`/`useResource`/`useResources` generics, execution-context/commit/root helpers, react-hooks cells, test utils.

store (adapts):
- `useClientList`: `resource` option typed as `Resource<TMethods, [ResourceProps<TData>]>`.
- `useAui`: `element.args[0]` reads cast to `Derived.Props<K>`.
- `Derived`: `DerivedElement<K> = ResourceElement<{ [derivedKey]: K }>` — `derivedKey` is a declare-only `unique symbol` (exported so downstream declaration emit works) and the brand rides in the element Result type. `useDerived` throws if mounted: Derived elements are config-only markers, discriminated at runtime by `hook === useDerived`, so nothing ever observes the value. Contextual `K` inference at `Derived({...})` call sites and mapped-type assignability are preserved with strict branding (arbitrary elements no longer satisfy derived slots).

Validation: tap 453/453; all 79 tap-dependent package/app builds green; 63 test tasks green; repo lint clean; harness-sdk (external consumer) fully typechecks against the new tap dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

