### PR TITLE
feat(tap): configurableResource

### DIFF
--- a/.changeset/tap-configurable-resource.md
+++ b/.changeset/tap-configurable-resource.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+feat: `configurableResource()` — curries an options-first hook into `(options) => Resource<V, A>`, replacing `.bind(null, options)` boilerplate

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -11,6 +11,8 @@ type ResourceElement<V> = {
   readonly deps?: readonly unknown[];
 };
 
+declare const configurableResource: <V, A extends any[], O>(hook: (options: O, ...args: A) => V) => (options: O) => Resource<V, A>;
+
 declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
   unmount: () => void;
 };
@@ -18,7 +20,7 @@ declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, configurableResource, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -11,7 +11,7 @@ type ResourceElement<V> = {
   readonly deps?: readonly unknown[];
 };
 
-declare const configurableResource: <V, A extends any[], O>(hook: (options: O, ...args: A) => V) => (options: O) => Resource<V, A>;
+declare const configurableResource: <V, A extends readonly unknown[], O>(hook: (options: O, ...args: A) => V) => (options: O) => Resource<V, A>;
 
 declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
   unmount: () => void;

--- a/packages/tap/src/__tests__/basic/configurableResource.test.ts
+++ b/packages/tap/src/__tests__/basic/configurableResource.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { configurableResource } from "../../core/configurableResource";
+import { withKey } from "../../core/withKey";
+import { useResource } from "../../hooks/useResource";
+import { useResources } from "../../hooks/useResources";
+import { useState } from "../../react-hooks/useState";
+import {
+  createTestResource,
+  renderTest,
+  cleanupAllResources,
+} from "../test-utils";
+
+type ConnectionOptions = { id: string; initial: number };
+type ConnectionProps = { mult: number };
+
+const useConnection = (options: ConnectionOptions, props: ConnectionProps) => {
+  const [count, setCount] = useState(options.initial);
+  return {
+    id: options.id,
+    value: count * props.mult,
+    bump: () => setCount((c) => c + 1),
+  };
+};
+
+const ConnectionResource = configurableResource(useConnection);
+
+describe("configurableResource", () => {
+  afterEach(() => {
+    cleanupAllResources();
+  });
+
+  it("bakes options into the factory and applies args later", () => {
+    const conn = ConnectionResource({ id: "ws-1", initial: 3 });
+    const el = conn({ mult: 10 });
+
+    expect(el.hook).toBe(useConnection);
+    expect(el.args).toEqual([{ id: "ws-1", initial: 3 }, { mult: 10 }]);
+
+    const testFiber = createTestResource(() => useResource(el));
+    const result = renderTest(testFiber);
+    expect(result).toMatchObject({ id: "ws-1", value: 30 });
+  });
+
+  it("reuses the fiber across re-application", () => {
+    const conn = ConnectionResource({ id: "c-1", initial: 1 });
+
+    const testFiber = createTestResource((props: ConnectionProps) =>
+      useResource(conn(props)),
+    );
+
+    const result1 = renderTest(testFiber, { mult: 1 });
+    expect(result1.value).toBe(1);
+
+    result1.bump();
+
+    const result2 = renderTest(testFiber, { mult: 10 });
+    expect(result2.value).toBe(20);
+  });
+
+  it("composes with caller-side withKey", () => {
+    const a = withKey("a", ConnectionResource({ id: "a", initial: 1 }));
+    const b = withKey("b", ConnectionResource({ id: "b", initial: 20 }));
+
+    expect(a({ mult: 1 }).key).toBe("a");
+
+    const testFiber = createTestResource((props: { conns: (typeof a)[] }) =>
+      useResources(props.conns.map((conn) => conn({ mult: 1 }))),
+    );
+
+    const result1 = renderTest(testFiber, { conns: [a, b] });
+    expect(result1.map((c) => c.value)).toEqual([1, 20]);
+
+    result1[0]!.bump();
+
+    const result2 = renderTest(testFiber, { conns: [b, a] });
+    expect(result2.map((c) => c.id)).toEqual(["b", "a"]);
+    expect(result2.map((c) => c.value)).toEqual([20, 2]);
+  });
+});

--- a/packages/tap/src/core/configurableResource.ts
+++ b/packages/tap/src/core/configurableResource.ts
@@ -4,5 +4,4 @@ import type { Resource } from "./types";
 export const configurableResource =
   <V, A extends any[], O>(hook: (options: O, ...args: A) => V) =>
   (options: O): Resource<V, A> =>
-  (...args) =>
-    resource(hook)(options, ...args);
+    resource(hook).bind(null, options);

--- a/packages/tap/src/core/configurableResource.ts
+++ b/packages/tap/src/core/configurableResource.ts
@@ -1,0 +1,8 @@
+import { resource } from "./resource";
+import type { Resource } from "./types";
+
+export const configurableResource =
+  <V, A extends any[], O>(hook: (options: O, ...args: A) => V) =>
+  (options: O): Resource<V, A> =>
+  (...args) =>
+    resource(hook)(options, ...args);

--- a/packages/tap/src/core/configurableResource.ts
+++ b/packages/tap/src/core/configurableResource.ts
@@ -2,6 +2,7 @@ import { resource } from "./resource";
 import type { Resource } from "./types";
 
 export const configurableResource =
-  <V, A extends any[], O>(hook: (options: O, ...args: A) => V) =>
+  <V, A extends readonly unknown[], O>(hook: (options: O, ...args: A) => V) =>
   (options: O): Resource<V, A> =>
-    resource(hook).bind(null, options);
+  (...args) =>
+    resource(hook)(options, ...args);

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -1,4 +1,5 @@
 export { resource } from "./core/resource";
+export { configurableResource } from "./core/configurableResource";
 export { withKey } from "./core/withKey";
 
 // imperative


### PR DESCRIPTION
Adds `configurableResource()` — curries an options-first hook into an options-taking factory that returns a plain `Resource`, replacing the `.bind(null, options)` boilerplate:

```ts
export const configurableResource =
  <V, A extends any[], O>(hook: (options: O, ...args: A) => V) =>
  (options: O): Resource<V, A> =>
  (...args) =>
    resource(hook)(options, ...args);
```

No keying involved — keys stay at the call site (`withKey("conn-a", ConnectionResource(options))`), per the settled convention that author-side keying is an antipattern.

- Exported from tap public index.
- Tests: options baked + args applied later (element carries the original hook identity and `[options, ...args]`); fiber reuse across re-application (state survives, options thread through); caller-side `withKey` composing on top (key stamping + reconciliation by key across reorder).
- Patch changeset (repo CI requires patch for 0.x).

Note: api-surface regeneration for the new export will follow once #5190 (single-param `ResourceElement`) lands and this branch rebases — the regenerated surface depends on the redesigned types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

