### PR TITLE
docs(store): re-parent Derived JSDoc; test(tap): phantom-typed TestFiber

### DIFF
--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -6,6 +6,16 @@ import type {
   ClientMeta,
 } from "./types/client";
 
+export declare const derivedKey: unique symbol;
+
+// Exported so consumers (e.g. splitClients) can identify a derived element by its
+// hook: a `Derived(...)` element carries `hook === useDerived`.
+export const useDerived = <K extends ClientNames>(
+  _config: Derived.Props<K>,
+): { [derivedKey]: K } => {
+  throw new Error("Derived elements are config-only and must not be mounted");
+};
+
 /**
  * Creates a derived client field that references a client from a parent scope.
  * The get callback always calls the most recent version (useEffectEvent pattern).
@@ -25,16 +35,6 @@ import type {
  * });
  * ```
  */
-export declare const derivedKey: unique symbol;
-
-// Exported so consumers (e.g. splitClients) can identify a derived element by its
-// hook: a `Derived(...)` element carries `hook === useDerived`.
-export const useDerived = <K extends ClientNames>(
-  _config: Derived.Props<K>,
-): { [derivedKey]: K } => {
-  throw new Error("Derived elements are config-only and must not be mounted");
-};
-
 export const Derived = resource(useDerived) as <K extends ClientNames>(
   config: Derived.Props<K>,
 ) => DerivedElement<K>;

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -8,15 +8,15 @@ import {
 import type { ResourceFiber } from "../core/types";
 import { useState } from "../react-hooks/useState";
 
+export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
+  readonly __args?: (args: A) => void;
+};
+
 /**
  * Creates a test resource fiber for unit testing.
  * This is a low-level utility that creates a ResourceFiber directly.
  * Sets up a rerender callback that automatically re-renders when state changes.
  */
-export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
-  readonly __args?: (args: A) => void;
-};
-
 export function createTestResource<R, A extends readonly unknown[]>(
   fn: (...args: A) => R,
 ): TestFiber<R, A> {

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -13,9 +13,13 @@ import { useState } from "../react-hooks/useState";
  * This is a low-level utility that creates a ResourceFiber directly.
  * Sets up a rerender callback that automatically re-renders when state changes.
  */
+export type TestFiber<R, A extends readonly unknown[]> = ResourceFiber<R> & {
+  readonly __args?: (args: A) => void;
+};
+
 export function createTestResource<R, A extends readonly unknown[]>(
   fn: (...args: A) => R,
-) {
+): TestFiber<R, A> {
   const rerenderCallback = (evaluate: () => boolean, apply: () => boolean) => {
     if (!evaluate()) return;
     apply();
@@ -49,7 +53,7 @@ const lastRenderValueMap = new WeakMap<ResourceFiber<any>, any>();
  * - Returns the current state after render
  */
 export function renderTest<R, A extends readonly unknown[]>(
-  fiber: ResourceFiber<R>,
+  fiber: TestFiber<R, A>,
   ...args: A
 ): R {
   propsMap.set(fiber, args);
@@ -135,7 +139,7 @@ export class TestSubscriber<T> {
 export class TestResourceManager<R, A extends readonly unknown[]> {
   private isActive = false;
 
-  constructor(public fiber: ResourceFiber<R>) {}
+  constructor(public fiber: TestFiber<R, A>) {}
 
   renderAndMount(...args: A): R {
     if (this.isActive) {


### PR DESCRIPTION
Follow-up to #5190 — lands the two review-thread fixes that were pushed after the merge:

- Derived's JSDoc moved off the `derivedKey` symbol onto the `Derived` factory (shows on hover at call sites)
- `TestFiber<R, A>` phantom threads `A` through `createTestResource`/`renderTest`/`TestResourceManager`, restoring args type-checking lost in the element erasure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

