### PR TITLE
fix(assistant-stream): parse UIMessageStream frames with secure-json-parse

### DIFF
--- a/.changeset/uims-secure-json-parse.md
+++ b/.changeset/uims-secure-json-parse.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: parse UIMessageStream frames with secure-json-parse, matching the transport decoder

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -604,6 +604,30 @@ describe("UIMessageStreamDecoder", () => {
     warn.mockRestore();
   });
 
+  it("drops frames carrying prototype-pollution keys", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const events = [
+      '{"type":"text-delta","delta":"x","__proto__":{"polluted":true}}',
+      '{"type":"text-delta","delta":"y","constructor":{"prototype":{"polluted":true}}}',
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({ type: "text-delta", id: "t", delta: "ok" }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    const deltas = chunks.filter(
+      (c): c is AssistantStreamChunk & { type: "text-delta" } =>
+        c.type === "text-delta",
+    );
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]!.textDelta).toBe("ok");
+    warn.mockRestore();
+  });
+
   it("drops frames that are not valid JSON", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const invalidFrames = ['{"type":"te', "not json"];

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.ts
@@ -1,3 +1,4 @@
+import sjson from "secure-json-parse";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import type { ToolCallStreamController } from "../../modules/tool-call";
 import type { TextStreamController } from "../../modules/text";
@@ -227,7 +228,7 @@ export class UIMessageStreamDecoder extends PipeableTransformStream<
 
               let chunk;
               try {
-                chunk = JSON.parse(event.data);
+                chunk = sjson.parse(event.data);
               } catch {
                 chunk = undefined;
               }


### PR DESCRIPTION
## What

`UIMessageStreamDecoder` now parses SSE frames with `secure-json-parse` instead of bare `JSON.parse`, matching the transport decoder. A frame carrying a `__proto__` or `constructor.prototype` key throws inside the existing try/catch and drops through the existing shape-guard warn.

## Why

#5152 moved the transport decoder to `secure-json-parse`; the UIMS guard from #5155 predates that and shipped with bare `JSON.parse`, leaving the two decode boundaries inconsistent on prototype-pollution handling. Under plain `JSON.parse` a `__proto__` key becomes an own property and the frame passes the shape guard as a normal chunk.

## Impact

- A prototype-pollution frame is now dropped with a warning instead of decoding as a normal chunk; all other frames behave identically.
- No output change for well-formed streams; existing decoder tests pass unchanged.

## Scope & caveats

- `secure-json-parse@^4.1.0` is an existing runtime dependency (transport decoder, `parse-partial-json-object`, `ToolExecutionStream`); no new dependency.
- The new test writes the polluted frame as a raw string literal deliberately: `JSON.stringify` of an object literal with `__proto__` silently drops the key, and under the old parser the frame decoded with zero warns, so the test fails without the change.
- Additive only, nothing exported or reshaped.
- Tests: pollution frame dropped with exactly one warn while a valid frame in the same stream decodes with its content asserted.
- Changeset: patch (`assistant-stream`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

