### PR TITLE
fix(react-native): wrap ThreadListItems rows in ThreadListItemByIndexProvider

### DIFF
--- a/.changeset/react-native-thread-list-item-scope.md
+++ b/.changeset/react-native-thread-list-item-scope.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-native": patch
+---
+
+fix: wrap ThreadListItems rows in ThreadListItemByIndexProvider

--- a/examples/with-expo/components/thread-list/ThreadListDrawer.tsx
+++ b/examples/with-expo/components/thread-list/ThreadListDrawer.tsx
@@ -1,10 +1,6 @@
 import { View, Text, Pressable, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import {
-  ThreadListPrimitive,
-  ThreadListItemByIndexProvider,
-  useAui,
-} from "@assistant-ui/react-native";
+import { ThreadListPrimitive, useAui } from "@assistant-ui/react-native";
 import type { DrawerContentComponentProps } from "expo-router/build/react-navigation/drawer/types";
 import { ThreadListItem } from "./ThreadListItem";
 import { Icon } from "@/components/ui/icon";
@@ -47,10 +43,8 @@ export function ThreadListDrawer({ navigation }: DrawerContentComponentProps) {
         </Text>
 
         <ThreadListPrimitive.Items
-          renderItem={({ index }) => (
-            <ThreadListItemByIndexProvider index={index} archived={false}>
-              <ThreadListItem onSelect={() => navigation.closeDrawer()} />
-            </ThreadListItemByIndexProvider>
+          renderItem={() => (
+            <ThreadListItem onSelect={() => navigation.closeDrawer()} />
           )}
           style={styles.list}
           contentContainerStyle={styles.listContent}

--- a/packages/react-native/src/primitives/threadList/ThreadListItems.test.tsx
+++ b/packages/react-native/src/primitives/threadList/ThreadListItems.test.tsx
@@ -1,0 +1,166 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Text } from "react-native";
+import { ThreadListItems } from "./ThreadListItems";
+
+const h = vi.hoisted(() => ({
+  state: { threads: { threadIds: [] as string[] } },
+  flatListProps: null as Record<string, unknown> | null,
+  providerProps: vi.fn(),
+}));
+
+vi.mock("react-native", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-native")>();
+  const React = await import("react");
+
+  const FlatListMock = React.forwardRef(function FlatListMock(
+    props: Record<string, unknown>,
+    _ref,
+  ) {
+    h.flatListProps = props;
+
+    const data = (props.data as unknown[]) ?? [];
+    const renderItem = props.renderItem as
+      | ((value: { item: unknown; index: number }) => React.ReactNode)
+      | undefined;
+    const keyExtractor = props.keyExtractor as
+      | ((item: unknown, index: number) => string)
+      | undefined;
+
+    return React.createElement(
+      "div",
+      { "data-testid": "flatlist" },
+      data.map((item, index) =>
+        React.createElement(
+          "div",
+          { key: keyExtractor?.(item, index) ?? index },
+          renderItem?.({ item, index }),
+        ),
+      ),
+    );
+  });
+
+  return {
+    ...actual,
+    FlatList: FlatListMock,
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAuiState: <T,>(selector: (s: typeof h.state) => T) => selector(h.state),
+  };
+});
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@assistant-ui/core/react")>();
+  return {
+    ...actual,
+    ThreadListItemByIndexProvider: ({
+      index,
+      archived,
+      children,
+    }: {
+      index: number;
+      archived: boolean;
+      children?: React.ReactNode;
+    }) => {
+      h.providerProps({ index, archived });
+      return <>{children}</>;
+    },
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ThreadListItems", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    h.state.threads.threadIds = [];
+    h.flatListProps = null;
+    h.providerProps.mockReset();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const mount = async (
+    props: Partial<Parameters<typeof ThreadListItems>[0]> = {},
+  ) => {
+    await act(async () => {
+      root.render(
+        <ThreadListItems
+          renderItem={({ threadId }) => <Text>{threadId}</Text>}
+          {...props}
+        />,
+      );
+    });
+  };
+
+  it("wraps each row in ThreadListItemByIndexProvider with its index", async () => {
+    h.state.threads.threadIds = ["t-1", "t-2", "t-3"];
+
+    await mount();
+
+    expect(h.providerProps.mock.calls.map((call) => call[0])).toEqual([
+      { index: 0, archived: false },
+      { index: 1, archived: false },
+      { index: 2, archived: false },
+    ]);
+    expect(container.textContent).toContain("t-1");
+    expect(container.textContent).toContain("t-3");
+  });
+
+  it("passes threadId and index to renderItem", async () => {
+    const renderItem = vi.fn(
+      ({ threadId }: { threadId: string; index: number }) => (
+        <Text>{threadId}</Text>
+      ),
+    );
+    h.state.threads.threadIds = ["a", "b"];
+
+    await mount({ renderItem });
+
+    expect(renderItem.mock.calls.map((call) => call[0])).toEqual([
+      { threadId: "a", index: 0 },
+      { threadId: "b", index: 1 },
+    ]);
+  });
+
+  it("keys rows by threadId via keyExtractor", async () => {
+    h.state.threads.threadIds = ["t-1", "t-2"];
+
+    await mount();
+
+    const keyExtractor = h.flatListProps?.keyExtractor as (
+      item: string,
+      index: number,
+    ) => string;
+    expect(keyExtractor("t-1", 0)).toBe("t-1");
+    expect(keyExtractor("t-2", 1)).toBe("t-2");
+    expect(h.flatListProps?.data).toEqual(["t-1", "t-2"]);
+  });
+
+  it("forwards extra FlatList props", async () => {
+    h.state.threads.threadIds = ["t-1"];
+
+    await mount({ horizontal: true, testID: "thread-list" });
+
+    expect(h.flatListProps?.horizontal).toBe(true);
+    expect(h.flatListProps?.testID).toBe("thread-list");
+  });
+});

--- a/packages/react-native/src/primitives/threadList/ThreadListItems.tsx
+++ b/packages/react-native/src/primitives/threadList/ThreadListItems.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement, useCallback } from "react";
 import { FlatList, type FlatListProps } from "react-native";
 import { useAuiState } from "@assistant-ui/store";
+import { ThreadListItemByIndexProvider } from "@assistant-ui/core/react";
 
 export type ThreadListItemsProps = Omit<
   FlatListProps<string>,
@@ -17,7 +18,11 @@ export const ThreadListItems = ({
 
   const renderFlatListItem = useCallback(
     ({ item, index }: { item: string; index: number }) => {
-      return renderItem({ threadId: item, index });
+      return (
+        <ThreadListItemByIndexProvider index={index} archived={false}>
+          {renderItem({ threadId: item, index })}
+        </ThreadListItemByIndexProvider>
+      );
     },
     [renderItem],
   );


### PR DESCRIPTION
## What
`ThreadListPrimitive.Items` in react-native now wraps each row in `ThreadListItemByIndexProvider`, so thread list item primitives (Trigger, Archive, Delete, Unarchive) work inside `renderItem` instead of crashing on a missing scope. Also removes the manual provider wrap the with-expo example carried as a workaround.

## Why
Same crash class fixed in ink with #4885: the primitive calls `renderItem` bare, so any threadListItem-scoped child throws. The with-expo drawer was already hand-wrapping rows in the provider to survive, which is exactly the workaround this fix removes.

## Impact
- Thread list item primitives become usable inside `Items` rows, matching core and ink behavior.
- Existing apps that hand-wrapped rows keep working: the inner provider just shadows the new outer one with an identical scope.
- No public surface change, props and types untouched.

## Scope & caveats
- Sibling of merged #4885 (ink); FlatList key mechanics differ from ink's `.map()` + `key`, covered by dedicated `keyExtractor` tests.
- `archived={false}` is hardcoded per core's shared impl, same cut as #4885; an `archived` prop is new surface and tracked as the parity follow-up on the ink side.
- Tests: provider wiring, renderItem args, keyExtractor identity, FlatList prop pass-through; no real-store integration test, the package suite mocks the store everywhere.
- with-expo change is only the now-redundant double-wrap removal, no behavior change there.
- Additive only, no exports removed or reshaped.
- Changeset: patch (`@assistant-ui/react-native`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.P-nKYf8XfIdu3YWgFBtuRiN3hjLc-gMoV7NWnNupT0NP8-wMl4H21IJQId8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->