### PR TITLE
fix(core): abort assistant frame tool calls

### DIFF
--- a/.changeset/calm-frames-abort.md
+++ b/.changeset/calm-frames-abort.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: abort pending AssistantFrame tool calls when their run is cancelled

--- a/packages/core/src/model-context/frame/host.test.ts
+++ b/packages/core/src/model-context/frame/host.test.ts
@@ -88,6 +88,53 @@ describe("AssistantFrameHost", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it("rejects pending tool calls when execution is aborted", async () => {
+    const { execute, host } = createHost();
+    const abortController = new AbortController();
+    const abortError = new Error("Run cancelled");
+    abortError.name = "AbortError";
+    const result = Promise.resolve(
+      execute(
+        {},
+        {
+          ...executionContext,
+          abortSignal: abortController.signal,
+        },
+      ),
+    );
+    const onRejected = vi.fn();
+    void result.catch(onRejected);
+
+    abortController.abort(abortError);
+    await Promise.resolve();
+
+    expect(onRejected).toHaveBeenCalledWith(abortError);
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
+  it("does not post tool calls when execution is already aborted", async () => {
+    const { execute, host, postMessage } = createHost();
+    const abortController = new AbortController();
+    const abortError = new Error("Run cancelled");
+    abortError.name = "AbortError";
+    abortController.abort(abortError);
+
+    await expect(
+      execute(
+        {},
+        {
+          ...executionContext,
+          abortSignal: abortController.signal,
+        },
+      ),
+    ).rejects.toBe(abortError);
+
+    expect(postMessage).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+    host.dispose();
+  });
+
   it("rejects tool calls made after disposal without posting a request", async () => {
     const { execute, host, postMessage } = createHost();
     host.dispose();

--- a/packages/core/src/model-context/frame/host.ts
+++ b/packages/core/src/model-context/frame/host.ts
@@ -40,6 +40,13 @@ const deserializeModelContext = (
   }),
 });
 
+const getAbortReason = (signal: AbortSignal): unknown => {
+  if (signal.reason !== undefined) return signal.reason;
+  const error = new Error("Tool call was aborted");
+  error.name = "AbortError";
+  return error;
+};
+
 export class AssistantFrameHost implements ModelContextProvider {
   private _context: ModelContext = {};
   private _subscribers = new Set<() => void>();
@@ -105,7 +112,8 @@ export class AssistantFrameHost implements ModelContextProvider {
             name,
             {
               ...tool,
-              execute: (args: any) => this.callTool(name, args),
+              execute: (args: any, context: { abortSignal: AbortSignal }) =>
+                this.callTool(name, args, context.abortSignal),
             } as Tool<any, any>,
           ]),
         ),
@@ -113,7 +121,11 @@ export class AssistantFrameHost implements ModelContextProvider {
     this.notifySubscribers();
   }
 
-  private callTool(toolName: string, args: any): Promise<any> {
+  private callTool(
+    toolName: string,
+    args: any,
+    abortSignal: AbortSignal,
+  ): Promise<any> {
     return this.sendRequest(
       {
         type: "tool-call",
@@ -123,6 +135,7 @@ export class AssistantFrameHost implements ModelContextProvider {
       },
       30000,
       `Tool call "${toolName}" timed out`,
+      abortSignal,
     );
   }
 
@@ -130,40 +143,54 @@ export class AssistantFrameHost implements ModelContextProvider {
     message: T,
     timeout = 30000,
     timeoutMessage = "Request timed out",
+    abortSignal?: AbortSignal,
   ): Promise<any> {
     if (this._disposed) {
       return Promise.reject(new Error("AssistantFrameHost has been disposed"));
     }
+    if (abortSignal?.aborted) {
+      return Promise.reject(getAbortReason(abortSignal));
+    }
 
     return new Promise((resolve, reject) => {
-      this._pendingRequests.set(message.id, { resolve, reject });
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const onAbort = () => {
+        if (!abortSignal) return;
+        const pending = this._pendingRequests.get(message.id);
+        if (pending) {
+          pending.reject(getAbortReason(abortSignal));
+          this._pendingRequests.delete(message.id);
+        }
+      };
+      const cleanup = () => {
+        if (timeoutId !== undefined) clearTimeout(timeoutId);
+        abortSignal?.removeEventListener("abort", onAbort);
+      };
 
-      this._iframeWindow.postMessage(
-        { channel: FRAME_MESSAGE_CHANNEL, message },
-        this._targetOrigin,
-      );
+      this._pendingRequests.set(message.id, {
+        resolve: (value: any) => {
+          cleanup();
+          resolve(value);
+        },
+        reject: (error: any) => {
+          cleanup();
+          reject(error);
+        },
+      });
 
-      const timeoutId = setTimeout(() => {
+      timeoutId = setTimeout(() => {
         const pending = this._pendingRequests.get(message.id);
         if (pending) {
           pending.reject(new Error(timeoutMessage));
           this._pendingRequests.delete(message.id);
         }
       }, timeout);
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
 
-      const originalResolve = this._pendingRequests.get(message.id)!.resolve;
-      const originalReject = this._pendingRequests.get(message.id)!.reject;
-
-      this._pendingRequests.set(message.id, {
-        resolve: (value: any) => {
-          clearTimeout(timeoutId);
-          originalResolve(value);
-        },
-        reject: (error: any) => {
-          clearTimeout(timeoutId);
-          originalReject(error);
-        },
-      });
+      this._iframeWindow.postMessage(
+        { channel: FRAME_MESSAGE_CHANNEL, message },
+        this._targetOrigin,
+      );
     });
   }
 


### PR DESCRIPTION
## Summary

- forward each frame tool's execution `abortSignal` to its pending request
- reject aborted requests with the signal reason and clean up their timeout and listener
- avoid posting a tool request when its run is already aborted

## Why

Stopping a run while an `AssistantFrame` tool was pending did not settle the host-side request. The request remained alive until its 30-second timeout or host disposal, even though the run had already been cancelled.

This is a follow-up to #5081, which handles host disposal but not run cancellation.

Closes #5167.

## Testing

- reproduced the bug with a regression test that failed before the fix
- `pnpm --filter @assistant-ui/core exec vitest run src/model-context/frame/host.test.ts`
- `pnpm --filter @assistant-ui/core test` (73 files, 662 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm exec oxlint packages/core/src/model-context/frame/host.ts packages/core/src/model-context/frame/host.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

