### PR TITLE
fix(assistant-stream): harden SSE and data-stream decoders against prototype pollution

### DIFF
--- a/.changeset/harden-json-parse-decode-boundaries.md
+++ b/.changeset/harden-json-parse-decode-boundaries.md
@@ -1,0 +1,7 @@
+---
+"assistant-stream": patch
+---
+
+fix(assistant-stream): harden SSE and data-stream decoders against prototype pollution
+
+The `SSEDecoder` and `DataStreamChunkDecoder` decoded untrusted wire input with bare `JSON.parse`, so a frame carrying `__proto__` or `constructor.prototype` keys decoded the pollution key as an own property. Both now parse with `secure-json-parse` (already used by the assistant-transport and UIMessage stream decoders), while preserving the existing throw-on-malformed-JSON error semantics.

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
@@ -19,7 +19,9 @@ const decode = async (lines: string[]): Promise<DataStreamChunk[]> => {
 
 describe("DataStreamChunkDecoder", () => {
   it("decodes a chunk into type and value", async () => {
-    const [chunk] = await decode([`9:{"toolCallId":"1","toolName":"x","args":{}}`]);
+    const [chunk] = await decode([
+      `9:{"toolCallId":"1","toolName":"x","args":{}}`,
+    ]);
     expect(chunk).toEqual({
       type: "9",
       value: { toolCallId: "1", toolName: "x", args: {} },
@@ -28,9 +30,9 @@ describe("DataStreamChunkDecoder", () => {
 
   it("does not decode __proto__ as an own property", async () => {
     const [chunk] = await decode([`2:{"__proto__":{"polluted":true}}`]);
-    expect(
-      Object.prototype.hasOwnProperty.call(chunk.value, "__proto__"),
-    ).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(chunk.value, "__proto__")).toBe(
+      false,
+    );
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 
@@ -40,7 +42,9 @@ describe("DataStreamChunkDecoder", () => {
   });
 
   it("throws on a chunk without a type separator", async () => {
-    await expect(decode([`no-separator`])).rejects.toThrow("Invalid stream part");
+    await expect(decode([`no-separator`])).rejects.toThrow(
+      "Invalid stream part",
+    );
   });
 
   it("errors the stream on malformed JSON", async () => {

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { DataStreamChunkDecoder } from "./serialization";
+import type { DataStreamChunk } from "./chunk-types";
+
+const decode = async (lines: string[]): Promise<DataStreamChunk[]> => {
+  const stream = new ReadableStream<string>({
+    start(controller) {
+      for (const line of lines) controller.enqueue(line);
+      controller.close();
+    },
+  }).pipeThrough(new DataStreamChunkDecoder());
+
+  const out: DataStreamChunk[] = [];
+  for await (const chunk of stream as unknown as AsyncIterable<DataStreamChunk>) {
+    out.push(chunk);
+  }
+  return out;
+};
+
+describe("DataStreamChunkDecoder", () => {
+  it("decodes a chunk into type and value", async () => {
+    const [chunk] = await decode([`9:{"toolCallId":"1","toolName":"x","args":{}}`]);
+    expect(chunk).toEqual({
+      type: "9",
+      value: { toolCallId: "1", toolName: "x", args: {} },
+    });
+  });
+
+  it("does not decode __proto__ as an own property", async () => {
+    const [chunk] = await decode([`2:{"__proto__":{"polluted":true}}`]);
+    expect(
+      Object.prototype.hasOwnProperty.call(chunk.value, "__proto__"),
+    ).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("does not pollute the prototype via constructor.prototype", async () => {
+    await decode([`2:{"constructor":{"prototype":{"polluted":true}}}`]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("throws on a chunk without a type separator", async () => {
+    await expect(decode([`no-separator`])).rejects.toThrow("Invalid stream part");
+  });
+
+  it("errors the stream on malformed JSON", async () => {
+    await expect(decode([`2:{not json}`])).rejects.toThrow();
+  });
+});

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
@@ -1,3 +1,4 @@
+import sjson from "secure-json-parse";
 import type { DataStreamChunk, DataStreamStreamChunkType } from "./chunk-types";
 
 export class DataStreamChunkEncoder extends TransformStream<
@@ -24,7 +25,7 @@ export class DataStreamChunkDecoder extends TransformStream<
         if (index === -1) throw new Error("Invalid stream part");
         controller.enqueue({
           type: chunk.slice(0, index) as DataStreamStreamChunkType,
-          value: JSON.parse(chunk.slice(index + 1)),
+          value: sjson.parse(chunk.slice(index + 1)),
         });
       },
     });

--- a/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { SSEDecoder, SSEEncoder } from "./SSE";
+
+const decode = async <T>(events: string[]): Promise<T[]> => {
+  const encoded = events.map((e) => new TextEncoder().encode(e));
+  const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      for (const chunk of encoded) controller.enqueue(chunk);
+      controller.close();
+    },
+  }).pipeThrough(new SSEDecoder<T>());
+
+  const out: T[] = [];
+  for await (const value of stream as unknown as AsyncIterable<T>) {
+    out.push(value);
+  }
+  return out;
+};
+
+describe("SSEDecoder", () => {
+  it("decodes a JSON message frame", async () => {
+    const out = await decode<{ hello: string }>([`data: {"hello":"world"}\n\n`]);
+    expect(out).toEqual([{ hello: "world" }]);
+  });
+
+  it("does not decode __proto__ as an own property", async () => {
+    const [value] = await decode<Record<string, unknown>>([
+      `data: {"__proto__":{"polluted":true}}\n\n`,
+    ]);
+    expect(Object.prototype.hasOwnProperty.call(value, "__proto__")).toBe(
+      false,
+    );
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("does not pollute the prototype via constructor.prototype", async () => {
+    await decode([
+      `data: {"constructor":{"prototype":{"polluted":true}}}\n\n`,
+    ]);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("errors the stream on malformed JSON", async () => {
+    await expect(decode([`data: {not json}\n\n`])).rejects.toThrow();
+  });
+
+  it("round-trips through the encoder", async () => {
+    const encoded = new ReadableStream<{ n: number }>({
+      start(controller) {
+        controller.enqueue({ n: 1 });
+        controller.close();
+      },
+    }).pipeThrough(new SSEEncoder<{ n: number }>());
+
+    const decoded = encoded.pipeThrough(new SSEDecoder<{ n: number }>());
+    const out: { n: number }[] = [];
+    for await (const value of decoded as unknown as AsyncIterable<{
+      n: number;
+    }>) {
+      out.push(value);
+    }
+    expect(out).toEqual([{ n: 1 }]);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.test.ts
@@ -19,7 +19,9 @@ const decode = async <T>(events: string[]): Promise<T[]> => {
 
 describe("SSEDecoder", () => {
   it("decodes a JSON message frame", async () => {
-    const out = await decode<{ hello: string }>([`data: {"hello":"world"}\n\n`]);
+    const out = await decode<{ hello: string }>([
+      `data: {"hello":"world"}\n\n`,
+    ]);
     expect(out).toEqual([{ hello: "world" }]);
   });
 
@@ -34,9 +36,7 @@ describe("SSEDecoder", () => {
   });
 
   it("does not pollute the prototype via constructor.prototype", async () => {
-    await decode([
-      `data: {"constructor":{"prototype":{"polluted":true}}}\n\n`,
-    ]);
+    await decode([`data: {"constructor":{"prototype":{"polluted":true}}}\n\n`]);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
 

--- a/packages/assistant-stream/src/core/utils/stream/SSE.ts
+++ b/packages/assistant-stream/src/core/utils/stream/SSE.ts
@@ -1,3 +1,4 @@
+import sjson from "secure-json-parse";
 import { PipeableTransformStream } from "./PipeableTransformStream";
 import {
   SSEEventDecoderStream,
@@ -45,7 +46,7 @@ export class SSEDecoder<T> extends PipeableTransformStream<
             transform(event, controller) {
               switch (event.event) {
                 case "message":
-                  controller.enqueue(JSON.parse(event.data));
+                  controller.enqueue(sjson.parse(event.data));
                   break;
                 default:
                   throw new Error(`Unknown SSE event type: ${event.event}`);


### PR DESCRIPTION
## What

Swap the bare `JSON.parse` at the two remaining untrusted-wire decode boundaries in `assistant-stream` to `secure-json-parse` (`sjson.parse`):

- `packages/assistant-stream/src/core/utils/stream/SSE.ts` — `SSEDecoder` (used by `GorpStreamResponse`)
- `packages/assistant-stream/src/core/serialization/data-stream/serialization.ts` — `DataStreamChunkDecoder`

## Why

Both boundaries parse untrusted wire input. With bare `JSON.parse`, a frame carrying `__proto__` or `constructor.prototype` keys decodes the pollution key as an own property. #5152 (assistant-transport) and #5200 (UIMessage stream) already moved to `secure-json-parse`; this brings the last two decoders in line.

`secure-json-parse` is already a declared dependency of the package, so no new dependency is added.

## How

`sjson.parse` is a drop-in for `JSON.parse` that strips prototype-pollution keys. Per the issue, this is deliberately **not** a blind replace: neither site has the try/catch drop path the transport/UIMS decoders use — both intentionally *throw* on malformed JSON to error the stream. Only the parser is swapped; the throw-on-malformed error semantics are preserved at both sites.

## Tests

Colocated vitest coverage added for both decoders:

- decodes a normal JSON frame
- `__proto__` does not become an own property and does not pollute `Object.prototype`
- `constructor.prototype` does not pollute the prototype
- malformed JSON still errors the stream (semantics unchanged)

Closes #5204

> Note: local Node is v20 and the repo's pnpm requires v22.13+, so the tests were not run locally; relying on CI (Node 22+) to execute them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

