### PR TITLE
fix(tap): stop shipping react-shim declarations the exports map disclaims

### DIFF
--- a/.changeset/tap-shim-untyped.md
+++ b/.changeset/tap-shim-untyped.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+Stop shipping react-shim declaration files the exports map disclaims — the shim subpaths are now genuinely untyped in every resolution mode instead of accidentally typed via TypeScript's fallback resolution.

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -30,6 +30,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "!dist/react-shim/**/*.d.ts",
+    "!dist/react-shim/**/*.d.ts.map",
     "src",
     "react-shim",
     "README.md"


### PR DESCRIPTION
## Background

The `react-shim` subpaths declare `"types": null` — the shim is meant to be a runtime-only alias target with no types of its own. But TypeScript's non-conforming fallback resolution walks past the null condition to `default`, resolves the JS, and picks up the adjacent `dist/react-shim/index.d.ts` shipped in the tarball. Consumers were getting shim types by accident, and arethetypeswrong flags every modern resolution mode with 🐛 "Used fallback condition".

## Summary

Exclude the shim declarations from the published tarball via `files` negation patterns — no build tooling changes. The subpaths are now genuinely untyped in every resolution mode (node16, bundler, and node10 via the types-free stub packages); `"types": null` stays as the intent marker for conforming resolvers.

Verified with `npm pack --dry-run`: `dist/react-shim/` carries only `.js` + `.js.map`.

## Checklist

- [x] Changeset added (patch, `@assistant-ui/tap`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

