### PR TITLE
chore: enable erasableSyntaxOnly + verbatimModuleSyntax in the shared tsconfig base

### DIFF
--- a/.changeset/erasable-syntax-only.md
+++ b/.changeset/erasable-syntax-only.md
@@ -15,4 +15,4 @@
 "@assistant-ui/store": patch
 ---
 
-Enable `erasableSyntaxOnly` and `verbatimModuleSyntax` in the shared tsconfig base. Constructor parameter properties are now explicit field declarations, and the four public enums (`CommitPriority`, `HideAndFloatStatus`, `LangGraphKnownEventTypes`, `DataStreamStreamChunkType`) are `as const` objects with equivalent union types — runtime values are unchanged, but code relying on enum-nominal typing now sees the literal union instead.
+Compile with `erasableSyntaxOnly` and `verbatimModuleSyntax`: parameter properties become explicit fields, public enums become `as const` objects with equivalent union types.

--- a/.changeset/erasable-syntax-only.md
+++ b/.changeset/erasable-syntax-only.md
@@ -1,0 +1,18 @@
+---
+"@assistant-ui/x-buildutils": patch
+"@assistant-ui/tap": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+"assistant-cloud": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"assistant-stream": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-data-stream": patch
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-opencode": patch
+"@assistant-ui/react-pi": patch
+"safe-content-frame": patch
+"@assistant-ui/store": patch
+---
+
+Enable `erasableSyntaxOnly` and `verbatimModuleSyntax` in the shared tsconfig base. Constructor parameter properties are now explicit field declarations, and the four public enums (`CommitPriority`, `HideAndFloatStatus`, `LangGraphKnownEventTypes`, `DataStreamStreamChunkType`) are `as const` objects with equivalent union types — runtime values are unchanged, but code relying on enum-nominal typing now sees the literal union instead.

--- a/.changeset/erasable-syntax-only.md
+++ b/.changeset/erasable-syntax-only.md
@@ -15,4 +15,4 @@
 "@assistant-ui/store": patch
 ---
 
-Compile with `erasableSyntaxOnly` and `verbatimModuleSyntax`: parameter properties become explicit fields, public enums become `as const` objects with equivalent union types.
+Adopt `erasableSyntaxOnly`; public enums are now `as const` objects.

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -80,8 +80,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -184,8 +184,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -84,8 +84,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -188,8 +188,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread$1>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -143,8 +143,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -247,8 +247,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -393,9 +393,9 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
+  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -577,11 +577,11 @@ declare const AttachmentRuntimeClient: Resource<ClientOutput<"attachment">, [
 ]>;
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
   abstract get source(): Source;
+  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -784,7 +784,6 @@ type BaseThreadMessage = {
 };
 
 declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
-  private readonly _contextProvider;
   private _subscriptions;
   private _isInitialized;
   protected readonly repository: MessageRepository;
@@ -815,6 +814,7 @@ declare abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
   get messages(): readonly ThreadMessage[];
   get state(): string | number | boolean | ReadonlyJSONObject | ReadonlyJSONArray | null;
   readonly composer: DefaultThreadComposerRuntimeCore;
+  private readonly _contextProvider;
   constructor(_contextProvider: ModelContextProvider);
   getModelContext(): ModelContext$1;
   private _editComposers;
@@ -1003,8 +1003,8 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
-  private cloud;
   accept: string;
+  private cloud;
   constructor(cloud: AssistantCloud);
   private uploadedUrls;
   add(_param2: {
@@ -1249,9 +1249,9 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
+  protected _core: ComposerRuntimeCoreBinding;
   constructor(_core: ComposerRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   abstract getState(): ComposerState$1;
@@ -1408,8 +1408,6 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
-  private runtime;
-  private endEditCallback;
   get canCancel(): boolean;
   get canSend(): boolean;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
@@ -1419,6 +1417,8 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   private _nonTextPassthrough;
   private _parentId;
   private _sourceId;
+  private runtime;
+  private endEditCallback;
   constructor(runtime: ThreadRuntimeCore & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1435,7 +1435,6 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
 }
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
   private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
@@ -1444,6 +1443,7 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
+  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1523,12 +1523,12 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
   get type(): "edit";
   private _getState;
+  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -1704,7 +1704,6 @@ type ExternalStoreThreadListAdapter = {
 };
 
 declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore {
-  private threadFactory;
   private _mainThreadId;
   private _threads;
   private _archivedThreads;
@@ -1718,6 +1717,7 @@ declare class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCor
   getLoadThreadsPromise(): Promise<void>;
   private _mainThread;
   get mainThreadId(): string;
+  private threadFactory;
   constructor(adapter: ExternalStoreThreadListAdapter | undefined, threadFactory: ExternalStoreThreadFactory);
   getMainThreadRuntimeCore(): ExternalStoreThreadRuntimeCore;
   getThreadRuntimeCore(): never;
@@ -2122,8 +2122,8 @@ type LanguageModelV1CallSettings = {
 };
 
 declare class LazyMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
-  private binding;
   get path(): TPath;
+  private binding;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
   private _previousStateDirty;
   private _previousState;
@@ -2470,11 +2470,11 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
   get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  private contentBinding;
+  private messageApi;
+  private threadApi;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
   addToolResult(result: any | ToolResponse<any>): void;
@@ -2722,9 +2722,9 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  get path(): MessageRuntimePath;
   private _core;
   private _threadBinding;
-  get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
@@ -2909,8 +2909,8 @@ type ModelContextState = {
 type NestedSubscribable<TState extends Subscribable | undefined, TPath> = SubscribableWithState<TState, TPath>;
 
 declare class NestedSubscriptionSubject<TState extends Subscribable | undefined, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath>, NestedSubscribable<TState, TPath> {
-  private binding;
   get path(): TPath;
+  private binding;
   constructor(binding: NestedSubscribable<TState, TPath>);
   getState(): TState;
   outerSubscribe(callback: () => void): Unsubscribe$1;
@@ -3789,8 +3789,8 @@ type SerializedTool = {
 };
 
 declare class ShallowMemoizeSubject<TState extends object, TPath> extends BaseSubject implements SubscribableWithState<TState, TPath> {
-  private binding;
   get path(): TPath;
+  private binding;
   constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>);
   private _previousState;
   getState: () => TState;
@@ -4261,9 +4261,9 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  get path(): ThreadListItemRuntimePath;
   private _core;
   private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -4415,9 +4415,9 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _getState;
   private _core;
   private _runtimeFactory;
-  private _getState;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -153,8 +153,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -257,8 +257,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -92,8 +92,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -196,8 +196,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -468,8 +468,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -572,8 +572,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -161,8 +161,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -265,8 +265,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -359,9 +359,9 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
+  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -531,11 +531,11 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
   abstract get source(): Source;
+  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -1144,9 +1144,9 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
+  protected _core: ComposerRuntimeCoreBinding;
   constructor(_core: ComposerRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   abstract getState(): ComposerState$1;
@@ -1280,7 +1280,6 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
   private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
@@ -1289,6 +1288,7 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
+  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1445,12 +1445,12 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
   get type(): "edit";
   private _getState;
+  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -2132,11 +2132,11 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
   get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  private contentBinding;
+  private messageApi;
+  private threadApi;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
   addToolResult(result: any | ToolResponse<any>): void;
@@ -2329,9 +2329,9 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  get path(): MessageRuntimePath;
   private _core;
   private _threadBinding;
-  get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
@@ -3381,9 +3381,9 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  get path(): ThreadListItemRuntimePath;
   private _core;
   private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -3538,9 +3538,9 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _getState;
   private _core;
   private _runtimeFactory;
-  private _getState;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -104,8 +104,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -208,8 +208,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -104,8 +104,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -208,8 +208,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -915,7 +915,7 @@ type JSONSchema7Version = string;
 type JoinStrategy = "concat-content" | "none";
 
 type LangChainEvent = {
-  event: LangGraphKnownEventTypes.MessagesPartial | LangGraphKnownEventTypes.MessagesComplete;
+  event: typeof LangGraphKnownEventTypes.MessagesPartial | typeof LangGraphKnownEventTypes.MessagesComplete;
   data: LangChainMessage[];
 };
 
@@ -985,16 +985,18 @@ type LangGraphInterruptState = {
   ns?: string[];
 };
 
-declare enum LangGraphKnownEventTypes {
-  Messages = "messages",
-  MessagesPartial = "messages/partial",
-  MessagesComplete = "messages/complete",
-  Metadata = "metadata",
-  Updates = "updates",
-  Values = "values",
-  Info = "info",
-  Error = "error"
-}
+declare const LangGraphKnownEventTypes: {
+  readonly Messages: "messages";
+  readonly MessagesPartial: "messages/partial";
+  readonly MessagesComplete: "messages/complete";
+  readonly Metadata: "metadata";
+  readonly Updates: "updates";
+  readonly Values: "values";
+  readonly Info: "info";
+  readonly Error: "error";
+};
+
+type LangGraphKnownEventTypes = (typeof LangGraphKnownEventTypes)[keyof typeof LangGraphKnownEventTypes];
 
 declare class LangGraphMessageAccumulator<TMessage extends {
   id?: string;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -159,8 +159,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -263,8 +263,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -357,9 +357,9 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
+  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -529,11 +529,11 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
   abstract get source(): Source;
+  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState$1 & {
@@ -1061,9 +1061,9 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
+  protected _core: ComposerRuntimeCoreBinding;
   constructor(_core: ComposerRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   abstract getState(): ComposerState$1;
@@ -1191,7 +1191,6 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
   private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
@@ -1200,6 +1199,7 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
+  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1277,12 +1277,12 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
   get type(): "edit";
   private _getState;
+  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -1805,11 +1805,11 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
   get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  private contentBinding;
+  private messageApi;
+  private threadApi;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
   addToolResult(result: any | ToolResponse<any>): void;
@@ -2028,9 +2028,9 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  get path(): MessageRuntimePath;
   private _core;
   private _threadBinding;
-  get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
@@ -2905,9 +2905,9 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  get path(): ThreadListItemRuntimePath;
   private _core;
   private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -3062,9 +3062,9 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _getState;
   private _core;
   private _runtimeFactory;
-  private _getState;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -844,7 +844,6 @@ type ObjectKey<T> = keyof T & (string | number);
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
 declare class OpenCodeEventSource {
-  private readonly client;
   private readonly listeners;
   private readonly reconnectDelayMs;
   private readonly maxReconnectDelayMs;
@@ -853,6 +852,7 @@ declare class OpenCodeEventSource {
   private stopped;
   private nextReconnectDelayMs;
   private hadConnection;
+  private readonly client;
   constructor(client: OpencodeClient);
   subscribe(listener: Listener): () => void;
   dispose(): void;
@@ -1051,8 +1051,6 @@ type OpenCodeStateEvent = {
 };
 
 declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
-  private readonly client;
-  private readonly sessionId;
   private state;
   private readonly listeners;
   private readonly getEventSource;
@@ -1060,6 +1058,8 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private loadPromise;
   private reconnectSyncToken;
   private readonly stagedMessages;
+  private readonly client;
+  private readonly sessionId;
   constructor(client: OpencodeClient, getEventSource: OpenCodeEventSourceProvider, sessionId: string);
   private ensureEventSubscription;
   private handleStreamReconnect;

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1353,9 +1353,6 @@ interface PiThinkingContent {
 type PiThinkingLevel = "high" | "low" | "medium" | "minimal" | "off" | "xhigh";
 
 declare class PiThreadController implements PiThreadControllerLike {
-  private readonly client;
-  private readonly threadId;
-  private readonly options;
   private state;
   private projectedMessages;
   private messageRepository;
@@ -1370,6 +1367,9 @@ declare class PiThreadController implements PiThreadControllerLike {
   private loadPromise;
   private messageFlushScheduled;
   private readonly localSnapshotSeq;
+  private readonly client;
+  private readonly threadId;
+  private readonly options;
   constructor(client: PiClient, threadId: string, options?: {
     scheduleNotify?: PiNotificationScheduler;
   });

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -315,8 +315,8 @@ declare class AssistantCloudProjectThreadMessages {
 }
 
 declare class AssistantCloudProjectThreads {
-  private cloud;
   readonly messages: AssistantCloudProjectThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudProjectThreadsListQuery): Promise<AssistantCloudProjectThreadsListResponse>;
 }
@@ -419,8 +419,8 @@ declare class AssistantCloudThreadMessages {
 }
 
 declare class AssistantCloudThreads {
-  private cloud;
   readonly messages: AssistantCloudThreadMessages;
+  private cloud;
   constructor(cloud: AssistantCloudAPI);
   list(query?: AssistantCloudThreadsListQuery): Promise<AssistantCloudThreadsListResponse>;
   get(threadId: string): Promise<CloudThread>;
@@ -595,9 +595,9 @@ type AssistantRuntimeCore = {
 };
 
 declare class AssistantRuntimeImpl implements AssistantRuntime {
-  private readonly _core;
   readonly threads: ThreadListRuntimeImpl;
   readonly _thread: ThreadRuntime;
+  private readonly _core;
   constructor(_core: AssistantRuntimeCore);
   protected __internal_bindMethods(): void;
   get thread(): ThreadRuntime;
@@ -840,11 +840,11 @@ type AttachmentRuntime<TSource extends AttachmentRuntimeSource = AttachmentRunti
 };
 
 declare abstract class AttachmentRuntimeImpl<Source extends AttachmentRuntimeSource = AttachmentRuntimeSource> implements AttachmentRuntime {
-  private _core;
   get path(): AttachmentRuntimePath & {
     attachmentSource: Source;
   };
   abstract get source(): Source;
+  private _core;
   constructor(_core: AttachmentSnapshotBinding<Source>);
   protected __internal_bindMethods(): void;
   getState(): AttachmentState & {
@@ -1228,8 +1228,8 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
 };
 
 declare class CloudFileAttachmentAdapter implements AttachmentAdapter {
-  private cloud;
   accept: string;
+  private cloud;
   constructor(cloud: AssistantCloud);
   private uploadedUrls;
   add(_param1: {
@@ -1707,9 +1707,9 @@ type ComposerRuntimeEventPayload = {
 type ComposerRuntimeEventType = keyof ComposerRuntimeEventPayload;
 
 declare abstract class ComposerRuntimeImpl implements ComposerRuntime {
-  protected _core: ComposerRuntimeCoreBinding;
   get path(): ComposerRuntimePath;
   abstract get type(): "edit" | "thread";
+  protected _core: ComposerRuntimeCoreBinding;
   constructor(_core: ComposerRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   abstract getState(): ComposerState$1;
@@ -1835,7 +1835,6 @@ type DeepPartial<T> = T extends readonly any[] ? readonly DeepPartial<T[number]>
 } : T;
 
 declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore implements ThreadComposerRuntimeCore {
-  private runtime;
   private _canCancel;
   get canCancel(): boolean;
   get canSend(): boolean;
@@ -1844,6 +1843,7 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   removeQueueItem(queueItemId: string): void;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
+  private runtime;
   constructor(runtime: Omit<ThreadRuntimeCore, "composer"> & {
     adapters?: {
       attachments?: AttachmentAdapter | undefined;
@@ -1945,12 +1945,12 @@ type EditComposerRuntimeCoreBinding = SubscribableWithState<EditComposerRuntimeC
 }>;
 
 declare class EditComposerRuntimeImpl extends ComposerRuntimeImpl implements EditComposerRuntime {
-  private _beginEdit;
   get path(): ComposerRuntimePath & {
     composerSource: "edit";
   };
   get type(): "edit";
   private _getState;
+  private _beginEdit;
   constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void);
   __internal_bindMethods(): void;
   getState(): EditComposerState;
@@ -2716,11 +2716,11 @@ type MessagePartRuntime = {
 };
 
 declare class MessagePartRuntimeImpl implements MessagePartRuntime {
-  private contentBinding;
-  private messageApi?;
-  private threadApi?;
   get path(): MessagePartRuntimePath;
-  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding | undefined, threadApi?: ThreadRuntimeCoreBinding | undefined);
+  private contentBinding;
+  private messageApi;
+  private threadApi;
+  constructor(contentBinding: MessagePartSnapshotBinding, messageApi?: MessageStateBinding, threadApi?: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): MessagePartState;
   addToolResult(result: any | ToolResponse<any>): void;
@@ -3022,9 +3022,9 @@ type MessageRuntime = {
 };
 
 declare class MessageRuntimeImpl implements MessageRuntime {
+  get path(): MessageRuntimePath;
   private _core;
   private _threadBinding;
-  get path(): MessageRuntimePath;
   constructor(_core: MessageStateBinding, _threadBinding: ThreadRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   readonly composer: EditComposerRuntimeImpl;
@@ -4253,9 +4253,9 @@ type ThreadListItemRuntime = {
 type ThreadListItemRuntimeBinding = SubscribableWithState<ThreadListItemState$1, ThreadListItemRuntimePath>;
 
 declare class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
+  get path(): ThreadListItemRuntimePath;
   private _core;
   private _threadListBinding;
-  get path(): ThreadListItemRuntimePath;
   constructor(_core: ThreadListItemStateBinding, _threadListBinding: ThreadListRuntimeCoreBinding);
   protected __internal_bindMethods(): void;
   getState(): ThreadListItemState$1;
@@ -4440,9 +4440,9 @@ type ThreadListRuntimeCore = {
 type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 declare class ThreadListRuntimeImpl implements ThreadListRuntime {
+  private _getState;
   private _core;
   private _runtimeFactory;
-  private _getState;
   constructor(_core: ThreadListRuntimeCoreBinding, _runtimeFactory?: new (binding: ThreadRuntimeCoreBinding, threadListItemBinding: ThreadListItemRuntimeBinding) => ThreadRuntime);
   protected __internal_bindMethods(): void;
   switchToThread(threadId: string, options?: {

--- a/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
+++ b/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
@@ -7,7 +7,6 @@ export class AssistantMessageStream {
 
   constructor(readable: ReadableStream<AssistantMessage>) {
     this.readable = readable;
-    this.readable = readable;
   }
 
   static fromAssistantStream(stream: AssistantStream) {

--- a/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
+++ b/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
@@ -3,7 +3,10 @@ import type { AssistantMessage } from "../utils/types";
 import { AssistantMessageAccumulator } from "./assistant-message-accumulator";
 
 export class AssistantMessageStream {
-  constructor(public readonly readable: ReadableStream<AssistantMessage>) {
+  public readonly readable: ReadableStream<AssistantMessage>;
+
+  constructor(readable: ReadableStream<AssistantMessage>) {
+    this.readable = readable;
     this.readable = readable;
   }
 

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -16,9 +16,12 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _isClosed = false;
 
   private _mergeTask: Promise<void>;
+  private _controller: ReadableStreamDefaultController<AssistantStreamChunk>;
+
   constructor(
-    private _controller: ReadableStreamDefaultController<AssistantStreamChunk>,
+    _controller: ReadableStreamDefaultController<AssistantStreamChunk>,
   ) {
+    this._controller = _controller;
     const stream = createTextStream({
       start: (c) => {
         this._argsTextController = c;

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -208,7 +208,7 @@ export class DataStreamEncoder
   }
 }
 
-const TOOL_CALL_ARGS_CLOSING_CHUNKS = [
+const TOOL_CALL_ARGS_CLOSING_CHUNKS: DataStreamStreamChunkType[] = [
   DataStreamStreamChunkType.StartToolCall,
   DataStreamStreamChunkType.ToolCall,
   DataStreamStreamChunkType.TextDelta,

--- a/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
@@ -25,29 +25,31 @@ type LanguageModelV1Usage = {
   outputTokens: number;
 };
 
-export enum DataStreamStreamChunkType {
-  TextDelta = "0",
-  Data = "2",
-  Error = "3",
-  Annotation = "8",
-  ToolCall = "9",
-  ToolCallResult = "a",
-  StartToolCall = "b",
-  ToolCallArgsTextDelta = "c",
-  FinishMessage = "d",
-  FinishStep = "e",
-  StartStep = "f",
-  ReasoningDelta = "g",
-  Source = "h",
-  RedactedReasoning = "i",
-  ReasoningSignature = "j",
-  File = "k",
+export const DataStreamStreamChunkType = {
+  TextDelta: "0",
+  Data: "2",
+  Error: "3",
+  Annotation: "8",
+  ToolCall: "9",
+  ToolCallResult: "a",
+  StartToolCall: "b",
+  ToolCallArgsTextDelta: "c",
+  FinishMessage: "d",
+  FinishStep: "e",
+  StartStep: "f",
+  ReasoningDelta: "g",
+  Source: "h",
+  RedactedReasoning: "i",
+  ReasoningSignature: "j",
+  File: "k",
 
-  AuiUpdateStateOperations = "aui-state",
-  AuiTextDelta = "aui-text-delta",
-  AuiReasoningDelta = "aui-reasoning-delta",
-  AuiDataPart = "aui-data",
-}
+  AuiUpdateStateOperations: "aui-state",
+  AuiTextDelta: "aui-text-delta",
+  AuiReasoningDelta: "aui-reasoning-delta",
+  AuiDataPart: "aui-data",
+} as const;
+export type DataStreamStreamChunkType =
+  (typeof DataStreamStreamChunkType)[keyof typeof DataStreamStreamChunkType];
 type DataStreamStreamChunkValue = {
   [DataStreamStreamChunkType.TextDelta]: string;
   [DataStreamStreamChunkType.Data]: ReadonlyJSONValue[];

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -441,7 +441,11 @@ export class ToolCallArgsReaderImpl<
 export class ToolCallResponseReaderImpl<
   TResult extends ReadonlyJSONValue,
 > implements ToolCallResponseReader<TResult> {
-  constructor(private readonly promise: Promise<ToolResponse<TResult>>) {}
+  private readonly promise: Promise<ToolResponse<TResult>>;
+
+  constructor(promise: Promise<ToolResponse<TResult>>) {
+    this.promise = promise;
+  }
 
   public get() {
     return this.promise;

--- a/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
+++ b/packages/cloud-ai-sdk/src/chat/ChatRegistry.ts
@@ -7,7 +7,11 @@ export class ChatRegistry {
   private metaByKey = new Map<string, ChatMeta>();
   private keyByThreadId = new Map<string, string>();
 
-  constructor(private createChatFn: (chatKey: string) => Chat<UIMessage>) {}
+  private createChatFn: (chatKey: string) => Chat<UIMessage>;
+
+  constructor(createChatFn: (chatKey: string) => Chat<UIMessage>) {
+    this.createChatFn = createChatFn;
+  }
 
   getOrCreate(chatKey: string, threadId?: string | null): Chat<UIMessage> {
     const existing = this.chatByKey.get(chatKey);

--- a/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
+++ b/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
@@ -35,10 +35,13 @@ export class MessagePersistence {
   private persistenceByThread = new Map<string, CloudMessagePersistence>();
   private formattedByThread = new Map<string, FormattedPersistence>();
 
-  constructor(
-    private cloud: AssistantCloud,
-    private onError: (err: unknown) => void,
-  ) {}
+  private cloud: AssistantCloud;
+  private onError: (err: unknown) => void;
+
+  constructor(cloud: AssistantCloud, onError: (err: unknown) => void) {
+    this.cloud = cloud;
+    this.onError = onError;
+  }
 
   private getPersistence(threadId: string): CloudMessagePersistence {
     const existing = this.persistenceByThread.get(threadId);

--- a/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudTelemetryReporter.ts
@@ -19,7 +19,11 @@ export type TelemetryFinishEvent = {
 export class CloudTelemetryReporter {
   private reported = new Set<string>();
 
-  constructor(private cloud: AssistantCloud) {}
+  private cloud: AssistantCloud;
+
+  constructor(cloud: AssistantCloud) {
+    this.cloud = cloud;
+  }
 
   async reportFromMessages(
     threadId: string,

--- a/packages/cloud/src/AssistantCloudAPI.ts
+++ b/packages/cloud/src/AssistantCloudAPI.ts
@@ -49,11 +49,11 @@ export type AssistantCloudConfig = (
 };
 
 export class CloudAPIError extends Error {
-  constructor(
-    message: string,
-    public readonly status: number,
-  ) {
+  public readonly status: number;
+
+  constructor(message: string, status: number) {
     super(message);
+    this.status = status;
     this.name = "CloudAPIError";
   }
 }

--- a/packages/cloud/src/AssistantCloudAuthTokens.ts
+++ b/packages/cloud/src/AssistantCloudAuthTokens.ts
@@ -5,7 +5,11 @@ type AssistantCloudAuthTokensCreateResponse = {
 };
 
 export class AssistantCloudAuthTokens {
-  constructor(private cloud: AssistantCloudAPI) {}
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
+  }
 
   public async create(): Promise<AssistantCloudAuthTokensCreateResponse> {
     return this.cloud.makeRequest("/auth/tokens", { method: "POST" });

--- a/packages/cloud/src/AssistantCloudFiles.ts
+++ b/packages/cloud/src/AssistantCloudFiles.ts
@@ -23,7 +23,11 @@ type GeneratePresignedUploadUrlResponse = {
 };
 
 export class AssistantCloudFiles {
-  constructor(private cloud: AssistantCloudAPI) {}
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
+  }
 
   public async pdfToImages(
     body: PdfToImagesRequestBody,

--- a/packages/cloud/src/AssistantCloudProjectThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudProjectThreadMessages.ts
@@ -16,7 +16,11 @@ type AssistantCloudProjectThreadMessageListResponse = {
 };
 
 export class AssistantCloudProjectThreadMessages {
-  constructor(private cloud: AssistantCloudAPI) {}
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
+  }
 
   public async list(
     threadId: string,

--- a/packages/cloud/src/AssistantCloudProjectThreads.ts
+++ b/packages/cloud/src/AssistantCloudProjectThreads.ts
@@ -16,7 +16,10 @@ type AssistantCloudProjectThreadsListResponse = {
 export class AssistantCloudProjectThreads {
   public readonly messages: AssistantCloudProjectThreadMessages;
 
-  constructor(private cloud: AssistantCloudAPI) {
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
     this.messages = new AssistantCloudProjectThreadMessages(cloud);
   }
 

--- a/packages/cloud/src/AssistantCloudRuns.ts
+++ b/packages/cloud/src/AssistantCloudRuns.ts
@@ -48,7 +48,11 @@ export type AssistantCloudRunReport = {
 };
 
 export class AssistantCloudRuns {
-  constructor(private cloud: AssistantCloudAPI) {}
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
+  }
 
   public __internal_getAssistantOptions(assistantId: string) {
     return {

--- a/packages/cloud/src/AssistantCloudThreadMessages.ts
+++ b/packages/cloud/src/AssistantCloudThreadMessages.ts
@@ -59,7 +59,11 @@ export const decodeCloudMessage = (
 };
 
 export class AssistantCloudThreadMessages {
-  constructor(private cloud: AssistantCloudAPI) {}
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
+  }
 
   public async list(
     threadId: string,

--- a/packages/cloud/src/AssistantCloudThreads.ts
+++ b/packages/cloud/src/AssistantCloudThreads.ts
@@ -78,7 +78,10 @@ export const decodeCloudThread = (
 export class AssistantCloudThreads {
   public readonly messages: AssistantCloudThreadMessages;
 
-  constructor(private cloud: AssistantCloudAPI) {
+  private cloud: AssistantCloudAPI;
+
+  constructor(cloud: AssistantCloudAPI) {
+    this.cloud = cloud;
     this.messages = new AssistantCloudThreadMessages(cloud);
   }
 

--- a/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
+++ b/packages/core/src/react/adapters/LocalStorageThreadListAdapter.tsx
@@ -275,12 +275,22 @@ export const parseStoredMessageRepository = (
 };
 
 class AsyncStorageHistoryAdapter implements ThreadHistoryAdapter {
+  private storage: AsyncStorageLike;
+  private aui: ReturnType<typeof useAui>;
+  private prefix: string;
+  private mutationQueue: KeyedMutationQueue;
+
   constructor(
-    private storage: AsyncStorageLike,
-    private aui: ReturnType<typeof useAui>,
-    private prefix: string,
-    private mutationQueue: KeyedMutationQueue,
-  ) {}
+    storage: AsyncStorageLike,
+    aui: ReturnType<typeof useAui>,
+    prefix: string,
+    mutationQueue: KeyedMutationQueue,
+  ) {
+    this.storage = storage;
+    this.aui = aui;
+    this.prefix = prefix;
+    this.mutationQueue = mutationQueue;
+  }
 
   private _messagesKey(remoteId: string) {
     return `${this.prefix}messages:${remoteId}`;

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -22,10 +22,13 @@ const globalPersistence = new WeakMap<
 >();
 
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
-  constructor(
-    private cloudRef: RefObject<AssistantCloud>,
-    private aui: AssistantClient,
-  ) {}
+  private cloudRef: RefObject<AssistantCloud>;
+  private aui: AssistantClient;
+
+  constructor(cloudRef: RefObject<AssistantCloud>, aui: AssistantClient) {
+    this.cloudRef = cloudRef;
+    this.aui = aui;
+  }
 
   private get _persistence(): CloudMessagePersistence {
     const key = this.aui.threadListItem();

--- a/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/CloudFileAttachmentAdapter.ts
@@ -19,7 +19,11 @@ const guessAttachmentType = (
 export class CloudFileAttachmentAdapter implements AttachmentAdapter {
   public accept = "*";
 
-  constructor(private cloud: AssistantCloud) {}
+  private cloud: AssistantCloud;
+
+  constructor(cloud: AssistantCloud) {
+    this.cloud = cloud;
+  }
 
   private uploadedUrls = new Map<string, string>();
 

--- a/packages/core/src/runtime/api/assistant-runtime.ts
+++ b/packages/core/src/runtime/api/assistant-runtime.ts
@@ -31,7 +31,10 @@ export class AssistantRuntimeImpl implements AssistantRuntime {
 
   public readonly _thread: ThreadRuntime;
 
-  public constructor(private readonly _core: AssistantRuntimeCore) {
+  private readonly _core: AssistantRuntimeCore;
+
+  constructor(_core: AssistantRuntimeCore) {
+    this._core = _core;
     this.threads = new ThreadListRuntimeImpl(_core.threads);
     this._thread = this.threads.main;
 

--- a/packages/core/src/runtime/api/attachment-runtime.ts
+++ b/packages/core/src/runtime/api/attachment-runtime.ts
@@ -49,7 +49,10 @@ export abstract class AttachmentRuntimeImpl<
 
   public abstract get source(): Source;
 
-  constructor(private _core: AttachmentSnapshotBinding<Source>) {
+  private _core: AttachmentSnapshotBinding<Source>;
+
+  constructor(_core: AttachmentSnapshotBinding<Source>) {
+    this._core = _core;
     this.__internal_bindMethods();
   }
 
@@ -73,11 +76,14 @@ export abstract class AttachmentRuntimeImpl<
 abstract class ComposerAttachmentRuntime<
   Source extends "thread-composer" | "edit-composer",
 > extends AttachmentRuntimeImpl<Source> {
+  private _composerApi: ComposerRuntimeCoreBinding;
+
   constructor(
     core: AttachmentSnapshotBinding<Source>,
-    private _composerApi: ComposerRuntimeCoreBinding,
+    _composerApi: ComposerRuntimeCoreBinding,
   ) {
     super(core);
+    this._composerApi = _composerApi;
   }
 
   public remove() {

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -251,7 +251,11 @@ export abstract class ComposerRuntimeImpl implements ComposerRuntime {
 
   public abstract get type(): "edit" | "thread";
 
-  constructor(protected _core: ComposerRuntimeCoreBinding) {}
+  protected _core: ComposerRuntimeCoreBinding;
+
+  constructor(_core: ComposerRuntimeCoreBinding) {
+    this._core = _core;
+  }
 
   protected __internal_bindMethods() {
     this.setText = this.setText.bind(this);

--- a/packages/core/src/runtime/api/composer-runtime.ts
+++ b/packages/core/src/runtime/api/composer-runtime.ts
@@ -487,10 +487,9 @@ export class EditComposerRuntimeImpl
   }
 
   private _getState;
-  constructor(
-    core: EditComposerRuntimeCoreBinding,
-    private _beginEdit: () => void,
-  ) {
+  private _beginEdit: () => void;
+
+  constructor(core: EditComposerRuntimeCoreBinding, _beginEdit: () => void) {
     const stateBinding = new LazyMemoizeSubject({
       path: core.path,
       getState: () => getEditComposerState(core.getState()),
@@ -502,6 +501,7 @@ export class EditComposerRuntimeImpl
       getState: () => core.getState(),
       subscribe: (callback) => stateBinding.subscribe(callback),
     });
+    this._beginEdit = _beginEdit;
 
     this._getState = stateBinding.getState.bind(stateBinding);
 

--- a/packages/core/src/runtime/api/message-part-runtime.ts
+++ b/packages/core/src/runtime/api/message-part-runtime.ts
@@ -40,11 +40,18 @@ export class MessagePartRuntimeImpl implements MessagePartRuntime {
     return this.contentBinding.path;
   }
 
+  private contentBinding: MessagePartSnapshotBinding;
+  private messageApi: MessageStateBinding | undefined;
+  private threadApi: ThreadRuntimeCoreBinding | undefined;
+
   constructor(
-    private contentBinding: MessagePartSnapshotBinding,
-    private messageApi?: MessageStateBinding,
-    private threadApi?: ThreadRuntimeCoreBinding,
+    contentBinding: MessagePartSnapshotBinding,
+    messageApi?: MessageStateBinding,
+    threadApi?: ThreadRuntimeCoreBinding,
   ) {
+    this.contentBinding = contentBinding;
+    this.messageApi = messageApi;
+    this.threadApi = threadApi;
     this.__internal_bindMethods();
   }
 

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -134,10 +134,15 @@ export class MessageRuntimeImpl implements MessageRuntime {
     return this._core.path;
   }
 
+  private _core: MessageStateBinding;
+  private _threadBinding: ThreadRuntimeCoreBinding;
+
   constructor(
-    private _core: MessageStateBinding,
-    private _threadBinding: ThreadRuntimeCoreBinding,
+    _core: MessageStateBinding,
+    _threadBinding: ThreadRuntimeCoreBinding,
   ) {
+    this._core = _core;
+    this._threadBinding = _threadBinding;
     this.composer = new EditComposerRuntimeImpl(
       new NestedSubscriptionSubject({
         path: {

--- a/packages/core/src/runtime/api/thread-list-item-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-item-runtime.ts
@@ -66,10 +66,15 @@ export class ThreadListItemRuntimeImpl implements ThreadListItemRuntime {
     return this._core.path;
   }
 
+  private _core: ThreadListItemStateBinding;
+  private _threadListBinding: ThreadListRuntimeCoreBinding;
+
   constructor(
-    private _core: ThreadListItemStateBinding,
-    private _threadListBinding: ThreadListRuntimeCoreBinding,
+    _core: ThreadListItemStateBinding,
+    _threadListBinding: ThreadListRuntimeCoreBinding,
   ) {
+    this._core = _core;
+    this._threadListBinding = _threadListBinding;
     this.__internal_bindMethods();
   }
 

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -98,13 +98,21 @@ export type ThreadListRuntimeCoreBinding = ThreadListRuntimeCore;
 
 export class ThreadListRuntimeImpl implements ThreadListRuntime {
   private _getState;
+  private _core: ThreadListRuntimeCoreBinding;
+  private _runtimeFactory: new (
+    binding: ThreadRuntimeCoreBinding,
+    threadListItemBinding: ThreadListItemRuntimeBinding,
+  ) => ThreadRuntime;
+
   constructor(
-    private _core: ThreadListRuntimeCoreBinding,
-    private _runtimeFactory: new (
+    _core: ThreadListRuntimeCoreBinding,
+    _runtimeFactory: new (
       binding: ThreadRuntimeCoreBinding,
       threadListItemBinding: ThreadListItemRuntimeBinding,
     ) => ThreadRuntime = ThreadRuntimeImpl,
   ) {
+    this._core = _core;
+    this._runtimeFactory = _runtimeFactory;
     const stateBinding = new LazyMemoizeSubject({
       path: {},
       getState: () => getThreadListState(_core),

--- a/packages/core/src/runtime/base/base-thread-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-thread-runtime-core.ts
@@ -113,7 +113,11 @@ export abstract class BaseThreadRuntimeCore implements ThreadRuntimeCore {
 
   public readonly composer = new DefaultThreadComposerRuntimeCore(this);
 
-  constructor(private readonly _contextProvider: ModelContextProvider) {}
+  private readonly _contextProvider: ModelContextProvider;
+
+  constructor(_contextProvider: ModelContextProvider) {
+    this._contextProvider = _contextProvider;
+  }
 
   public getModelContext() {
     return this._contextProvider.getModelContext();

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -31,8 +31,18 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   private _nonTextPassthrough: readonly ThreadMessage["content"][number][];
   private _parentId: string | null;
   private _sourceId: string | null;
+  private runtime: ThreadRuntimeCore & {
+    adapters?:
+      | {
+          attachments?: AttachmentAdapter | undefined;
+          dictation?: DictationAdapter | undefined;
+        }
+      | undefined;
+  };
+  private endEditCallback: () => void;
+
   constructor(
-    private runtime: ThreadRuntimeCore & {
+    runtime: ThreadRuntimeCore & {
       adapters?:
         | {
             attachments?: AttachmentAdapter | undefined;
@@ -40,10 +50,12 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
           }
         | undefined;
     },
-    private endEditCallback: () => void,
+    endEditCallback: () => void,
     { parentId, message }: { parentId: string | null; message: ThreadMessage },
   ) {
     super();
+    this.runtime = runtime;
+    this.endEditCallback = endEditCallback;
     this._parentId = parentId;
     this._sourceId = message.id;
     this._previousText = getThreadMessageText(message);

--- a/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-thread-composer-runtime-core.ts
@@ -46,8 +46,17 @@ export class DefaultThreadComposerRuntimeCore
     return this.runtime.adapters?.dictation;
   }
 
+  private runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    adapters?:
+      | {
+          attachments?: AttachmentAdapter | undefined;
+          dictation?: DictationAdapter | undefined;
+        }
+      | undefined;
+  };
+
   constructor(
-    private runtime: Omit<ThreadRuntimeCore, "composer"> & {
+    runtime: Omit<ThreadRuntimeCore, "composer"> & {
       adapters?:
         | {
             attachments?: AttachmentAdapter | undefined;
@@ -57,6 +66,7 @@ export class DefaultThreadComposerRuntimeCore
     },
   ) {
     super();
+    this.runtime = runtime;
     this.connect();
   }
 

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -89,7 +89,11 @@ const findHead = (
 class CachedValue<T> {
   private _value: T | null = null;
 
-  constructor(private func: () => T) {}
+  private func: () => T;
+
+  constructor(func: () => T) {
+    this.func = func;
+  }
 
   get value() {
     if (this._value === null) {

--- a/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-list-runtime-core.ts
@@ -60,10 +60,13 @@ export class ExternalStoreThreadListRuntimeCore implements ThreadListRuntimeCore
     return this._mainThreadId;
   }
 
+  private threadFactory: ExternalStoreThreadFactory;
+
   constructor(
     adapter: ExternalStoreThreadListAdapter = {},
-    private threadFactory: ExternalStoreThreadFactory,
+    threadFactory: ExternalStoreThreadFactory,
   ) {
+    this.threadFactory = threadFactory;
     this.__internal_setAdapter(adapter, true);
   }
 

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -1,7 +1,7 @@
 import type { Unsubscribe } from "../../types/unsubscribe";
 import type { ThreadRuntimeEventType } from "../../runtime/interfaces/thread-runtime-core";
 import type { ThreadRuntime } from "../../runtime/api/thread-runtime";
-import { useMemo, useEffect, RefObject } from "react";
+import { useMemo, useEffect, type RefObject } from "react";
 import { useResource, resource, withKey } from "@assistant-ui/tap";
 import { liveRef } from "./liveRef";
 import {

--- a/packages/core/src/subscribable/subscribable.ts
+++ b/packages/core/src/subscribable/subscribable.ts
@@ -141,10 +141,11 @@ export class ShallowMemoizeSubject<TState extends object, TPath>
     return this.binding.path;
   }
 
-  constructor(
-    private binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>,
-  ) {
+  private binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>;
+
+  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>) {
     super();
+    this.binding = binding;
     const state = binding.getState();
     if (state === SKIP_UPDATE)
       throw new Error("Entry not available in the store");
@@ -184,10 +185,11 @@ export class LazyMemoizeSubject<TState extends object, TPath>
     return this.binding.path;
   }
 
-  constructor(
-    private binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>,
-  ) {
+  private binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>;
+
+  constructor(binding: SubscribableWithState<TState | SKIP_UPDATE, TPath>) {
     super();
+    this.binding = binding;
   }
 
   private _previousStateDirty = true;
@@ -228,8 +230,11 @@ export class NestedSubscriptionSubject<
     return this.binding.path;
   }
 
-  constructor(private binding: NestedSubscribable<TState, TPath>) {
+  private binding: NestedSubscribable<TState, TPath>;
+
+  constructor(binding: NestedSubscribable<TState, TPath>) {
     super();
+    this.binding = binding;
   }
 
   public getState() {
@@ -269,8 +274,11 @@ export class NestedSubscriptionSubject<
 export class EventSubscriptionSubject<
   TEvent extends string,
 > extends BaseSubject {
-  constructor(private config: EventSubscribable<TEvent>) {
+  private config: EventSubscribable<TEvent>;
+
+  constructor(config: EventSubscribable<TEvent>) {
     super();
+    this.config = config;
   }
 
   public getState() {

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -61,12 +61,13 @@ type DataStreamRuntimeRequestOptions = {
 };
 
 class DataStreamRuntimeAdapter implements ChatModelAdapter {
+  private options: Omit<UseDataStreamRuntimeOptions, keyof LocalRuntimeOptions>;
+
   constructor(
-    private options: Omit<
-      UseDataStreamRuntimeOptions,
-      keyof LocalRuntimeOptions
-    >,
-  ) {}
+    options: Omit<UseDataStreamRuntimeOptions, keyof LocalRuntimeOptions>,
+  ) {
+    this.options = options;
+  }
 
   async *run({
     messages,

--- a/packages/react-ink/src/adapters/FileStorage.ts
+++ b/packages/react-ink/src/adapters/FileStorage.ts
@@ -23,7 +23,11 @@ const isEnoent = (error: unknown): boolean =>
 export class FileStorage implements AsyncStorageLike {
   private ready: Promise<void> | undefined;
 
-  constructor(private dir: string) {}
+  private dir: string;
+
+  constructor(dir: string) {
+    this.dir = dir;
+  }
 
   private getFilePath(key: string) {
     return join(this.dir, `${encodeURIComponent(key)}.json`);

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -72,16 +72,18 @@ type MessageContentComputerCall = {
   index: number;
 };
 
-export enum LangGraphKnownEventTypes {
-  Messages = "messages",
-  MessagesPartial = "messages/partial",
-  MessagesComplete = "messages/complete",
-  Metadata = "metadata",
-  Updates = "updates",
-  Values = "values",
-  Info = "info",
-  Error = "error",
-}
+export const LangGraphKnownEventTypes = {
+  Messages: "messages",
+  MessagesPartial: "messages/partial",
+  MessagesComplete: "messages/complete",
+  Metadata: "metadata",
+  Updates: "updates",
+  Values: "values",
+  Info: "info",
+  Error: "error",
+} as const;
+export type LangGraphKnownEventTypes =
+  (typeof LangGraphKnownEventTypes)[keyof typeof LangGraphKnownEventTypes];
 
 type CustomEventType = string;
 
@@ -177,15 +179,15 @@ export type LangChainMessageChunk = {
 
 export type LangChainEvent = {
   event:
-    | LangGraphKnownEventTypes.MessagesPartial
-    | LangGraphKnownEventTypes.MessagesComplete;
+    | typeof LangGraphKnownEventTypes.MessagesPartial
+    | typeof LangGraphKnownEventTypes.MessagesComplete;
   data: LangChainMessage[];
 };
 
 export type LangGraphTupleMetadata = Record<string, unknown>;
 
 export type LangChainMessageTupleEvent = {
-  event: LangGraphKnownEventTypes.Messages;
+  event: typeof LangGraphKnownEventTypes.Messages;
   data: [LangChainMessage | LangChainMessageChunk, LangGraphTupleMetadata];
 };
 

--- a/packages/react-opencode/src/OpenCodeEventSource.ts
+++ b/packages/react-opencode/src/OpenCodeEventSource.ts
@@ -81,7 +81,11 @@ export class OpenCodeEventSource {
   private nextReconnectDelayMs = this.reconnectDelayMs;
   private hadConnection = false;
 
-  constructor(private readonly client: OpencodeClient) {}
+  private readonly client: OpencodeClient;
+
+  constructor(client: OpencodeClient) {
+    this.client = client;
+  }
 
   public subscribe(listener: Listener) {
     this.listeners.add(listener);

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -189,11 +189,16 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     }
   >();
 
+  private readonly client: OpencodeClient;
+  private readonly sessionId: string;
+
   constructor(
-    private readonly client: OpencodeClient,
+    client: OpencodeClient,
     getEventSource: OpenCodeEventSourceProvider,
-    private readonly sessionId: string,
+    sessionId: string,
   ) {
+    this.client = client;
+    this.sessionId = sessionId;
     this.state = createOpenCodeThreadState(sessionId);
     this.getEventSource = getEventSource;
   }

--- a/packages/react-pi/src/node/extensionUi.ts
+++ b/packages/react-pi/src/node/extensionUi.ts
@@ -26,10 +26,13 @@ import type { PiHostUiRequest, PiHostUiResponse } from "../types";
  * (it renders an arbitrary interactive TUI component). This gives extensions a
  * typed unsupported issue they can catch rather than hanging. */
 export class PiUnsupportedHostUiError extends Error {
-  constructor(public readonly method: string) {
+  public readonly method: string;
+
+  constructor(method: string) {
     super(
       `Pi host-UI method "${method}" is not supported in the assistant-ui node host.`,
     );
+    this.method = method;
     this.name = "PiUnsupportedHostUiError";
   }
 }

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -241,13 +241,22 @@ export class PiThreadController implements PiThreadControllerLike {
    * the supervisor's live seqs so they never suppress real events. */
   private readonly localSnapshotSeq = 0;
 
+  private readonly client: PiClient;
+  private readonly threadId: string;
+  private readonly options: {
+    scheduleNotify?: PiNotificationScheduler;
+  };
+
   constructor(
-    private readonly client: PiClient,
-    private readonly threadId: string,
-    private readonly options: {
+    client: PiClient,
+    threadId: string,
+    options: {
       scheduleNotify?: PiNotificationScheduler;
     } = {},
   ) {
+    this.client = client;
+    this.threadId = threadId;
+    this.options = options;
     this.state = createPiThreadState(threadId);
   }
 

--- a/packages/react/src/primitives/actionBar/useActionBarFloatStatus.ts
+++ b/packages/react/src/primitives/actionBar/useActionBarFloatStatus.ts
@@ -2,11 +2,13 @@
 
 import { useAuiState } from "@assistant-ui/store";
 
-export enum HideAndFloatStatus {
-  Hidden = "hidden",
-  Floating = "floating",
-  Normal = "normal",
-}
+export const HideAndFloatStatus = {
+  Hidden: "hidden",
+  Floating: "floating",
+  Normal: "normal",
+} as const;
+export type HideAndFloatStatus =
+  (typeof HideAndFloatStatus)[keyof typeof HideAndFloatStatus];
 
 export type UseActionBarFloatStatusProps = {
   hideWhenRunning?: boolean | undefined;

--- a/packages/react/src/utils/smooth/useSmooth.ts
+++ b/packages/react/src/utils/smooth/useSmooth.ts
@@ -58,10 +58,13 @@ class TextStreamAnimator {
   public maxCharsPerFrame: number = Infinity;
   public minCommitMs: number = 0;
 
-  constructor(
-    public currentText: string,
-    private setText: (newText: string) => void,
-  ) {}
+  public currentText: string;
+  private setText: (newText: string) => void;
+
+  constructor(currentText: string, setText: (newText: string) => void) {
+    this.currentText = currentText;
+    this.setText = setText;
+  }
 
   start() {
     if (this.animationFrameId !== null) return;

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -80,10 +80,13 @@ async function contentSalt(
 }
 
 export class SafeContentFrame {
-  constructor(
-    private product: string,
-    private options: SafeContentFrameOptions = {},
-  ) {}
+  private product: string;
+  private options: SafeContentFrameOptions;
+
+  constructor(product: string, options: SafeContentFrameOptions = {}) {
+    this.product = product;
+    this.options = options;
+  }
 
   async renderHtml(
     html: string,

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -78,13 +78,20 @@ class ClientProxyHandler
     | undefined;
   private cachedReceiver: unknown;
 
+  private readonly outputRef: {
+    current: ClientMethods;
+  };
+  private readonly index: number;
+
   constructor(
-    private readonly outputRef: {
+    outputRef: {
       current: ClientMethods;
     },
-    private readonly index: number,
+    index: number,
   ) {
     super();
+    this.outputRef = outputRef;
+    this.index = index;
   }
 
   get(_: unknown, prop: string | symbol, receiver: unknown) {

--- a/packages/tap/src/__tests__/test-utils.ts
+++ b/packages/tap/src/__tests__/test-utils.ts
@@ -139,7 +139,11 @@ export class TestSubscriber<T> {
 export class TestResourceManager<R, A extends readonly unknown[]> {
   private isActive = false;
 
-  constructor(public fiber: TestFiber<R, A>) {}
+  public fiber: TestFiber<R, A>;
+
+  constructor(fiber: TestFiber<R, A>) {
+    this.fiber = fiber;
+  }
 
   renderAndMount(...args: A): R {
     if (this.isActive) {

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -1,11 +1,13 @@
 import type { CommitCallbacks, ResourceFiber } from "../types";
 
-export enum CommitPriority {
-  HookState = 0,
-  EffectEvent = 1,
-  PassiveEffectCleanup = 2,
-  PassiveEffectSetup = 3,
-}
+export const CommitPriority = {
+  HookState: 0,
+  EffectEvent: 1,
+  PassiveEffectCleanup: 2,
+  PassiveEffectSetup: 3,
+} as const;
+export type CommitPriority =
+  (typeof CommitPriority)[keyof typeof CommitPriority];
 
 const COMMIT_PRIORITIES = [
   CommitPriority.HookState,

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -14,7 +14,11 @@ let flushState: GlobalFlushState = {
 export class UpdateScheduler {
   private _isDirty = false;
 
-  constructor(private readonly _task: Task) {}
+  private readonly _task: Task;
+
+  constructor(_task: Task) {
+    this._task = _task;
+  }
 
   get isDirty() {
     return this._isDirty;

--- a/packages/x-buildutils/ts/base.json
+++ b/packages/x-buildutils/ts/base.json
@@ -15,6 +15,8 @@
     ],
     "types": ["browser-process"],
     "moduleResolution": "bundler",
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
     "target": "ESNext",
     "module": "ESNext",
     "resolveJsonModule": true,


### PR DESCRIPTION
Adds `erasableSyntaxOnly` and `verbatimModuleSyntax` to `x-buildutils/ts/base`, making every package single-file transpilable (Node type stripping, esbuild/swc) with syntax-determined emit.

Mechanical fixes across 14 packages (68 violations):
- Constructor parameter properties (~60 sites) rewritten as explicit field declarations + assignments — identical runtime behavior to what tsc generated.
- Four public enums (`CommitPriority`, `HideAndFloatStatus`, `LangGraphKnownEventTypes`, `DataStreamStreamChunkType`) converted to `as const` objects with equivalent union types. Runtime values unchanged; enum-nominal typing becomes the literal union.
- One type-only import (`RefObject`) gains its `type` marker — the only verbatimModuleSyntax violation in the repo.

Typecheck is clean monorepo-wide (no TS1294/TS1484 remain; pre-existing test-file errors untouched). `turbo test build` passes for all 13 touched packages (29 tasks). Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

