### PR TITLE
fix(react-a2a): forward audio and data parts and handle zero-byte data URLs

### DIFF
--- a/.changeset/brave-otters-attack.md
+++ b/.changeset/brave-otters-attack.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: forward audio and data parts to the wire and pass unparseable data URLs through as URLs

--- a/.changeset/light-geese-shave.md
+++ b/.changeset/light-geese-shave.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: parse zero-byte base64 payloads in parseDataUrl

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1847,9 +1847,13 @@ declare function contentPartsToA2AParts(content: ReadonlyArray<{
   type: string;
   text?: string | undefined;
   image?: string | undefined;
-  data?: string | undefined;
+  data?: unknown;
   mimeType?: string | undefined;
   filename?: string | undefined;
+  audio?: {
+    data: string;
+    format: string;
+  } | undefined;
 }>, fallbackMimeType?: string): A2APart[];
 
 declare global {

--- a/packages/core/src/utils/data-url.test.ts
+++ b/packages/core/src/utils/data-url.test.ts
@@ -20,8 +20,11 @@ describe("parseDataUrl", () => {
     expect(parseDataUrl("data:text/plain,hello")).toBeNull();
   });
 
-  it("returns null for data URLs with an empty payload", () => {
-    expect(parseDataUrl("data:image/png;base64,")).toBeNull();
+  it("parses a data URL with an empty payload as zero-byte data", () => {
+    expect(parseDataUrl("data:image/png;base64,")).toEqual({
+      mimeType: "image/png",
+      data: "",
+    });
   });
 
   it("returns null for plain strings", () => {

--- a/packages/core/src/utils/data-url.ts
+++ b/packages/core/src/utils/data-url.ts
@@ -3,7 +3,7 @@ export const httpUrlPattern = /^https?:\/\//i;
 export function parseDataUrl(
   value: string,
 ): { mimeType: string; data: string } | null {
-  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.+)$/);
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.*)$/);
   if (!match) return null;
   return { mimeType: match[1]!, data: match[2]! };
 }

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -366,10 +366,71 @@ describe("contentPartsToA2AParts", () => {
     expect(result).toEqual([]);
   });
 
+  it("skips file parts with non-string data", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: { nested: true }, mimeType: "application/pdf" },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it("passes non-base64 data URLs through as URLs for file parts", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: "data:text/plain,hello", mimeType: "text/plain" },
+    ]);
+    expect(result).toEqual([
+      { url: "data:text/plain,hello", mediaType: "text/plain" },
+    ]);
+  });
+
+  it("converts zero-byte data URLs in file parts to empty raw bytes", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: "data:application/pdf;base64,", mimeType: "" },
+    ]);
+    expect(result).toEqual([{ raw: "", mediaType: "application/pdf" }]);
+  });
+
+  it("converts zero-byte data URLs in image parts to empty raw bytes", () => {
+    const result = contentPartsToA2AParts([
+      { type: "image", image: "data:image/png;base64," },
+    ]);
+    expect(result).toEqual([{ raw: "", mediaType: "image/png" }]);
+  });
+
+  it("converts audio parts to raw bytes with the format MIME type", () => {
+    const result = contentPartsToA2AParts([
+      { type: "audio", audio: { data: "c291bmQ=", format: "mp3" } },
+    ]);
+    expect(result).toEqual([{ raw: "c291bmQ=", mediaType: "audio/mp3" }]);
+  });
+
+  it("skips audio parts with no payload", () => {
+    const result = contentPartsToA2AParts([{ type: "audio" }]);
+    expect(result).toEqual([]);
+  });
+
+  it("converts data parts to the a2a data field", () => {
+    const result = contentPartsToA2AParts([
+      { type: "data", data: { chart: "bar", values: [1, 2] } },
+    ]);
+    expect(result).toEqual([{ data: { chart: "bar", values: [1, 2] } }]);
+  });
+
+  it("keeps falsy but defined data part payloads", () => {
+    const result = contentPartsToA2AParts([
+      { type: "data", data: null },
+      { type: "data", data: 0 },
+    ]);
+    expect(result).toEqual([{ data: null }, { data: 0 }]);
+  });
+
+  it("skips data parts with an undefined payload", () => {
+    const result = contentPartsToA2AParts([{ type: "data" }]);
+    expect(result).toEqual([]);
+  });
+
   it("skips unknown part types", () => {
     const result = contentPartsToA2AParts([
       { type: "text", text: "hi" },
-      { type: "audio" },
       { type: "video" },
     ]);
     expect(result).toEqual([{ text: "hi" }]);

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -403,6 +403,16 @@ describe("contentPartsToA2AParts", () => {
     expect(result).toEqual([{ raw: "c291bmQ=", mediaType: "audio/mp3" }]);
   });
 
+  it("strips data URL envelopes from audio payloads and keeps the format MIME type", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "audio",
+        audio: { data: "data:audio/mpeg;base64,c291bmQ=", format: "mp3" },
+      },
+    ]);
+    expect(result).toEqual([{ raw: "c291bmQ=", mediaType: "audio/mp3" }]);
+  });
+
   it("skips audio parts with no payload", () => {
     const result = contentPartsToA2AParts([{ type: "audio" }]);
     expect(result).toEqual([]);

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -154,7 +154,7 @@ export function contentPartsToA2AParts(
         case "audio": {
           if (!part.audio) return null;
           return {
-            raw: part.audio.data,
+            raw: parseDataUrl(part.audio.data)?.data ?? part.audio.data,
             mediaType: `audio/${part.audio.format}`,
           };
         }

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -92,9 +92,10 @@ export function contentPartsToA2AParts(
     type: string;
     text?: string | undefined;
     image?: string | undefined;
-    data?: string | undefined;
+    data?: unknown;
     mimeType?: string | undefined;
     filename?: string | undefined;
+    audio?: { data: string; format: string } | undefined;
   }>,
   fallbackMimeType?: string,
 ): A2APart[] {
@@ -120,7 +121,7 @@ export function contentPartsToA2AParts(
           };
         }
         case "file": {
-          if (!part.data) return null;
+          if (typeof part.data !== "string" || !part.data) return null;
           const declaredMimeType = part.mimeType || fallbackMimeType;
           if (httpUrlPattern.test(part.data)) {
             return {
@@ -137,11 +138,29 @@ export function contentPartsToA2AParts(
               ...(part.filename && { filename: part.filename }),
             };
           }
+          if (part.data.startsWith("data:")) {
+            return {
+              url: part.data,
+              ...(declaredMimeType && { mediaType: declaredMimeType }),
+              ...(part.filename && { filename: part.filename }),
+            };
+          }
           return {
             raw: part.data,
             ...(declaredMimeType && { mediaType: declaredMimeType }),
             ...(part.filename && { filename: part.filename }),
           };
+        }
+        case "audio": {
+          if (!part.audio) return null;
+          return {
+            raw: part.audio.data,
+            mediaType: `audio/${part.audio.format}`,
+          };
+        }
+        case "data": {
+          if (part.data === undefined) return null;
+          return { data: part.data };
         }
         default:
           return null;


### PR DESCRIPTION
## What
`contentPartsToA2AParts` now converts audio parts to `{raw, mediaType: "audio/<format>"}` and data parts to the a2a `data` field instead of silently dropping both, and the file branch passes unparseable `data:` URLs through as `url` like the image branch already does. Core's shared `parseDataUrl` accepts zero-byte base64 payloads (`data:<mime>;base64,`), which fixes mislabeling in all four consuming adapters.

## Why
While landing #5036 kept the diff on the reported attachment bug, so two pre-existing gaps that review surfaced were left for a follow-up: audio and data parts still fell through the converter's default arm and vanished, and a zero-byte `data:<mime>;base64,` URL slipped past the shared parser. This is that follow-up. The parser fix goes in the core helper from #5039 so ag-ui, langchain, and langgraph pick it up too.

## Impact
- User messages with audio or data parts no longer lose those parts on the wire in react-a2a.
- Zero-byte files now ship as `{raw: "", mediaType}` instead of leaking the whole data URL into a `url` or base64-labeled field (a2a, ag-ui, langchain, langgraph).
- Non-base64 data URLs in file parts go out as `url` instead of a URI string mislabeled as base64 bytes.

## Scope 
- `DataMessagePart.name` is intentionally dropped on the wire: a2a's `DataPart` has no name slot, and inventing a `metadata` convention has no sibling precedent (ag-ui skips data parts, adk throws on them).
- Data parts with an `undefined` payload are skipped, but falsy defined values (`null`, `0`, `""`, `false`) ship, since they are legitimate protobuf Values; both pinned by tests.
- Inbound direction (`a2aPartToContent` rendering wire files as text placeholders) is a known separate gap, deliberately out of scope here.
- The converter's accepted part type widens (`data?: unknown`, new optional `audio`); parameter widening is caller-safe and the file branch gains a string narrow. No exports removed or reshaped.
- Tests: new cases for audio, data, zero-byte payloads in image and file branches, non-base64 `data:` passthrough, and all skip paths; full suites of core and the four consuming adapters pass against the rebuilt core dist.
- Changesets: patch (`@assistant-ui/core`), patch (`@assistant-ui/react-a2a`). langchain/langgraph/ag-ui need no release; they get the helper fix through their caret dep on core.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SJ3hqmqTwHip76SmLT65NEU4k6GvawudnoMxKBrTHKG0YaePMlTwQ1Dxxac?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->