### PR TITLE
fix(core): stabilize cloud thread list adapters

### DIFF
--- a/.changeset/stable-cloud-thread-adapters.md
+++ b/.changeset/stable-cloud-thread-adapters.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: avoid reloading Cloud thread lists on unchanged runtime rerenders

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -76,94 +76,96 @@ export const useCloudThreadListAdapter = (
   );
 
   const cloud = adapter.cloud ?? autoCloud;
-  if (!cloud) {
-    const ref = adapterRef;
-    const inMemory = new InMemoryThreadListAdapter();
-    inMemory.initialize = async (threadId: string) => {
-      const result = await ref.current.create?.();
-      return { remoteId: threadId, externalId: result?.externalId };
-    };
-    return inMemory;
-  }
+  return useMemo<RemoteThreadListAdapter>(() => {
+    if (!cloud) {
+      const ref = adapterRef;
+      const inMemory = new InMemoryThreadListAdapter();
+      inMemory.initialize = async (threadId: string) => {
+        const result = await ref.current.create?.();
+        return { remoteId: threadId, externalId: result?.externalId };
+      };
+      return inMemory;
+    }
 
-  return {
-    list: async () => {
-      const { threads } = await cloud.threads.list();
-      return {
-        threads: threads.map((t) => ({
-          status: t.is_archived ? "archived" : "regular",
-          remoteId: t.id,
-          title: t.title,
-          lastMessageAt: t.last_message_at
-            ? new Date(t.last_message_at)
+    return {
+      list: async () => {
+        const { threads } = await cloud.threads.list();
+        return {
+          threads: threads.map((t) => ({
+            status: t.is_archived ? "archived" : "regular",
+            remoteId: t.id,
+            title: t.title,
+            lastMessageAt: t.last_message_at
+              ? new Date(t.last_message_at)
+              : undefined,
+            externalId: t.external_id ?? undefined,
+            custom: toCustom(t.metadata),
+          })),
+        };
+      },
+
+      initialize: async () => {
+        const createTask = adapterRef.current.create?.() ?? Promise.resolve();
+        const t = await createTask;
+        const external_id = t ? t.externalId : undefined;
+        const { thread_id: remoteId } = await cloud.threads.create({
+          last_message_at: new Date(),
+          external_id,
+        });
+
+        return { externalId: external_id, remoteId: remoteId };
+      },
+
+      rename: async (threadId, newTitle) => {
+        return cloud.threads.update(threadId, { title: newTitle });
+      },
+      updateCustom: async (threadId, custom) => {
+        return cloud.threads.update(threadId, { metadata: custom ?? null });
+      },
+      archive: async (threadId) => {
+        return cloud.threads.update(threadId, { is_archived: true });
+      },
+      unarchive: async (threadId) => {
+        return cloud.threads.update(threadId, { is_archived: false });
+      },
+      delete: async (threadId) => {
+        await adapterRef.current.delete?.(threadId);
+        return cloud.threads.delete(threadId);
+      },
+
+      generateTitle: async (threadId, messages) => {
+        // Filter messages to only include content types the title generator understands
+        // (reasoning, source, etc. are not needed for title generation)
+        // TODO serialize these to a more efficient format
+        const filteredMessages = messages.map((msg) => ({
+          ...msg,
+          content: msg.content.filter(
+            (part) => part.type === "text" || part.type === "tool-call",
+          ),
+        }));
+
+        return cloud.runs.stream({
+          thread_id: threadId,
+          assistant_id: "system/thread_title",
+          messages: filteredMessages,
+        });
+      },
+
+      fetch: async (threadId: string) => {
+        const thread = await cloud.threads.get(threadId);
+        return {
+          status: thread.is_archived ? "archived" : "regular",
+          remoteId: thread.id,
+          title: thread.title,
+          lastMessageAt: thread.last_message_at
+            ? new Date(thread.last_message_at)
             : undefined,
-          externalId: t.external_id ?? undefined,
-          custom: toCustom(t.metadata),
-        })),
-      };
-    },
+          externalId: thread.external_id ?? undefined,
+          custom: toCustom(thread.metadata),
+        };
+      },
 
-    initialize: async () => {
-      const createTask = adapter.create?.() ?? Promise.resolve();
-      const t = await createTask;
-      const external_id = t ? t.externalId : undefined;
-      const { thread_id: remoteId } = await cloud.threads.create({
-        last_message_at: new Date(),
-        external_id,
-      });
-
-      return { externalId: external_id, remoteId: remoteId };
-    },
-
-    rename: async (threadId, newTitle) => {
-      return cloud.threads.update(threadId, { title: newTitle });
-    },
-    updateCustom: async (threadId, custom) => {
-      return cloud.threads.update(threadId, { metadata: custom ?? null });
-    },
-    archive: async (threadId) => {
-      return cloud.threads.update(threadId, { is_archived: true });
-    },
-    unarchive: async (threadId) => {
-      return cloud.threads.update(threadId, { is_archived: false });
-    },
-    delete: async (threadId) => {
-      await adapter.delete?.(threadId);
-      return cloud.threads.delete(threadId);
-    },
-
-    generateTitle: async (threadId, messages) => {
-      // Filter messages to only include content types the title generator understands
-      // (reasoning, source, etc. are not needed for title generation)
-      // TODO serialize these to a more efficient format
-      const filteredMessages = messages.map((msg) => ({
-        ...msg,
-        content: msg.content.filter(
-          (part) => part.type === "text" || part.type === "tool-call",
-        ),
-      }));
-
-      return cloud.runs.stream({
-        thread_id: threadId,
-        assistant_id: "system/thread_title",
-        messages: filteredMessages,
-      });
-    },
-
-    fetch: async (threadId: string) => {
-      const thread = await cloud.threads.get(threadId);
-      return {
-        status: thread.is_archived ? "archived" : "regular",
-        remoteId: thread.id,
-        title: thread.title,
-        lastMessageAt: thread.last_message_at
-          ? new Date(thread.last_message_at)
-          : undefined,
-        externalId: thread.external_id ?? undefined,
-        custom: toCustom(thread.metadata),
-      };
-    },
-
-    unstable_Provider,
-  };
+      unstable_Provider,
+    };
+  }, [cloud, unstable_Provider]);
 };

--- a/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
+++ b/packages/core/src/react/runtimes/useLocalRuntime.test.tsx
@@ -3,6 +3,7 @@
 import { render, waitFor } from "@testing-library/react";
 import { StrictMode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AssistantCloud } from "assistant-cloud";
 import type { ChatModelAdapter } from "../../runtime/utils/chat-model-adapter";
 import { AssistantRuntimeProvider } from "../AssistantRuntimeProvider";
 import { useLocalRuntime } from "./useLocalRuntime";
@@ -11,11 +12,53 @@ const chatModel: ChatModelAdapter = {
   run: async () => ({ content: [] }),
 };
 
+const makeCloud = () =>
+  ({
+    threads: {
+      list: vi.fn().mockResolvedValue({ threads: [] }),
+    },
+  }) as unknown as AssistantCloud;
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("useLocalRuntime", () => {
+  it("keeps the Cloud thread list loaded across unrelated rerenders", async () => {
+    const firstCloud = makeCloud();
+    const secondCloud = makeCloud();
+
+    const App = ({
+      cloud,
+      label,
+    }: {
+      cloud: AssistantCloud;
+      label: string;
+    }) => {
+      const runtime = useLocalRuntime(chatModel, { cloud });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <div>{label}</div>
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const { rerender } = render(<App cloud={firstCloud} label="first" />);
+
+    await waitFor(() => {
+      expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+    });
+
+    rerender(<App cloud={firstCloud} label="second" />);
+    expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+
+    rerender(<App cloud={secondCloud} label="third" />);
+    await waitFor(() => {
+      expect(secondCloud.threads.list).toHaveBeenCalledOnce();
+    });
+    expect(firstCloud.threads.list).toHaveBeenCalledOnce();
+  });
+
   it("handles rejected history loads", async () => {
     const error = new Error("history unavailable");
     const consoleError = vi


### PR DESCRIPTION
## Summary

- memoize the Cloud thread-list adapter by the resolved Cloud client
- keep mutable create and delete callbacks fresh through the existing adapter ref
- cover unchanged rerenders and real Cloud-client replacements with a regression test

## Why

While testing `useLocalRuntime`, I found that every ordinary rerender created a new thread-list adapter object. The remote thread-list runtime treats a new adapter identity as a backend change, resets its loading state, and calls `cloud.threads.list()` again even when the Cloud client has not changed.

This avoids redundant Cloud requests and loading-state flicker while preserving the intentional reload when an app actually switches Cloud clients, accounts, or workspaces.

## Verification

- reproduced the failure before the fix: one unrelated rerender caused the same client's `threads.list()` call count to increase from one to two
- focused `useLocalRuntime` regression tests pass
- all @assistant-ui/core tests pass: 74 files, 677 tests
- @assistant-ui/core package build passes
- changed files pass oxlint and oxfmt

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

