### PR TITLE
fix(react): handle file picker attachment errors

### DIFF
--- a/.changeset/quiet-files-settle.md
+++ b/.changeset/quiet-files-settle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: handle rejected file picker attachment additions

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.test.tsx
@@ -62,6 +62,8 @@ describe("ComposerPrimitiveAddAttachment", () => {
   });
 
   it("handles rejected file picker attachments and continues processing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
     addAttachment
       .mockRejectedValueOnce(new Error("unsupported file"))
       .mockResolvedValueOnce(undefined);
@@ -98,9 +100,9 @@ describe("ComposerPrimitiveAddAttachment", () => {
       target: input,
     } as unknown as Event);
 
-    expect(result).toBeInstanceOf(Promise);
-    await expect(result).resolves.toBeUndefined();
+    await expect(Promise.resolve(result)).resolves.toBeUndefined();
     expect(addAttachment).toHaveBeenCalledTimes(2);
+    expect(errorSpy).not.toHaveBeenCalled();
     expect(input!.isConnected).toBe(false);
   });
 });

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type * as CoreReact from "@assistant-ui/core/react";
+import type * as AssistantStore from "@assistant-ui/store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComposerPrimitiveAddAttachment } from "./ComposerAddAttachment";
+
+const { addAttachment } = vi.hoisted(() => ({
+  addAttachment: vi.fn<(file: File) => Promise<void>>(),
+}));
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@assistant-ui/core/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof CoreReact>();
+  return {
+    ...actual,
+    useComposerAddAttachment: () => ({
+      disabled: false,
+      addAttachment,
+    }),
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof AssistantStore>();
+  return {
+    ...actual,
+    useAui: () => ({
+      composer: () => ({
+        getState: () => ({ attachmentAccept: "*" }),
+      }),
+    }),
+  };
+});
+
+describe("ComposerPrimitiveAddAttachment", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    addAttachment.mockReset();
+    vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    document.querySelectorAll('input[type="file"]').forEach((input) => {
+      input.remove();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("handles rejected file picker attachments and continues processing", async () => {
+    addAttachment
+      .mockRejectedValueOnce(new Error("unsupported file"))
+      .mockResolvedValueOnce(undefined);
+
+    await act(async () => {
+      root.render(
+        <ComposerPrimitiveAddAttachment>
+          Add attachment
+        </ComposerPrimitiveAddAttachment>,
+      );
+    });
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+
+    await act(async () => {
+      button!.click();
+    });
+
+    const input =
+      document.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(input).not.toBeNull();
+
+    const files = [
+      new File(["a"], "unsupported.bin"),
+      new File(["b"], "supported.txt", { type: "text/plain" }),
+    ];
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: files,
+    });
+
+    const result = input!.onchange?.call(input, {
+      target: input,
+    } as unknown as Event);
+
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
+    expect(addAttachment).toHaveBeenCalledTimes(2);
+    expect(input!.isConnected).toBe(false);
+  });
+});

--- a/packages/react/src/primitives/composer/ComposerAddAttachment.ts
+++ b/packages/react/src/primitives/composer/ComposerAddAttachment.ts
@@ -31,14 +31,20 @@ const useComposerAddAttachment = ({
 
     document.body.appendChild(input);
 
-    input.onchange = (e) => {
+    input.onchange = async (e) => {
       const fileList = (e.target as HTMLInputElement).files;
       if (!fileList) return;
-      for (const file of fileList) {
-        addAttachment(file);
-      }
+
+      const attachmentPromises = Array.from(fileList, async (file) => {
+        try {
+          await addAttachment(file);
+        } catch {
+          // The composer runtime emits composer.attachmentAddError before rejecting.
+        }
+      });
 
       document.body.removeChild(input);
+      await Promise.all(attachmentPromises);
     };
 
     input.oncancel = () => {


### PR DESCRIPTION
## Summary

- handle rejected attachment additions from `ComposerPrimitive.AddAttachment`
- keep processing every file selected through the picker
- add regression coverage for the rejected picker path

## Why

While reproducing #5221, selecting an unsupported file (or hitting an attachment adapter failure) emitted the expected `composer.attachmentAddError`, but the picker also left the rejected `addAttachment()` promise unhandled. Paste and drag-and-drop already consume these rejections because the runtime event is the structured error surface; this makes the file-picker path consistent with them.

Closes #5221

## Testing

- `vitest run` in `packages/react` (49 files, 502 tests)
- `aui-build` in `packages/react`
- `oxlint` on changed TypeScript files
- `oxfmt --check` on changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

