### PR TITLE
fix(core): prevent removed attachments from reappearing

### DIFF
--- a/.changeset/attachment-add-removal-race.md
+++ b/.changeset/attachment-add-removal-race.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: prevent async attachment uploads from restoring removed attachments
+fix: prevent canceled attachment uploads from reappearing and settle failed removals as attachment errors

--- a/.changeset/attachment-add-removal-race.md
+++ b/.changeset/attachment-add-removal-race.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: prevent async attachment uploads from restoring removed attachments

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -695,6 +695,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected _isSending: boolean;
   private _removedDuringSend;
   private _sendGeneration;
+  private _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -675,6 +675,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
+  private readonly _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -675,9 +675,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
-  private readonly _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -671,6 +671,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected _isSending: boolean;
   private _removedDuringSend;
   private _sendGeneration;
+  private _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -651,6 +651,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
+  private readonly _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -651,9 +651,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
-  private readonly _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -663,6 +663,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected _isSending: boolean;
   private _removedDuringSend;
   private _sendGeneration;
+  private _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -643,6 +643,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
+  private readonly _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -643,9 +643,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
-  private readonly _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -970,6 +970,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   protected _isSending: boolean;
   private _removedDuringSend;
   private _sendGeneration;
+  private _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   private _emptyTextAndAttachments;
   private _onClearAttachments;
   reset(): Promise<void>;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -950,6 +950,9 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
+  private readonly _attachmentAddOperations;
+  private _cancelAttachmentAdd;
+  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -950,9 +950,6 @@ declare abstract class BaseComposerRuntimeCore extends BaseSubscribable implemen
   }>(message: T, composerMetadata: Record<string, unknown> | undefined): T;
   get attachmentAccept(): string;
   private _attachments;
-  private readonly _attachmentAddOperations;
-  private _cancelAttachmentAdd;
-  private _cancelAllAttachmentAdds;
   get attachments(): readonly Attachment[];
   protected setAttachments(value: readonly Attachment[]): void;
   abstract get canCancel(): boolean;

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -39,6 +39,41 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
+const attachmentAddOperations = new WeakMap<
+  object,
+  Set<AttachmentAddOperation>
+>();
+
+const getAttachmentAddOperations = (owner: object) => {
+  let operations = attachmentAddOperations.get(owner);
+  if (!operations) {
+    operations = new Set();
+    attachmentAddOperations.set(owner, operations);
+  }
+  return operations;
+};
+
+const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
+  const operations = attachmentAddOperations.get(owner);
+  if (!operations) return;
+
+  for (const operation of [...operations]) {
+    if (!operation.attachmentIds.has(attachmentId)) continue;
+    operation.cancelled = true;
+    operations.delete(operation);
+  }
+};
+
+const cancelAllAttachmentAdds = (owner: object) => {
+  const operations = attachmentAddOperations.get(owner);
+  if (!operations) return;
+
+  for (const operation of operations) {
+    operation.cancelled = true;
+  }
+  operations.clear();
+};
+
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -66,23 +101,6 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private _attachments: readonly Attachment[] = [];
-  private readonly _attachmentAddOperations = new Set<AttachmentAddOperation>();
-
-  private _cancelAttachmentAdd(attachmentId: string) {
-    for (const operation of [...this._attachmentAddOperations]) {
-      if (!operation.attachmentIds.has(attachmentId)) continue;
-      operation.cancelled = true;
-      this._attachmentAddOperations.delete(operation);
-    }
-  }
-
-  private _cancelAllAttachmentAdds() {
-    for (const operation of this._attachmentAddOperations) {
-      operation.cancelled = true;
-    }
-    this._attachmentAddOperations.clear();
-  }
-
   public get attachments() {
     return this._attachments;
   }
@@ -168,16 +186,15 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
-    const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
-
     const adapter = this.getAttachmentAdapter();
     if (adapter) {
+      const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
       await Promise.all(pending.map((a) => adapter.remove(a)));
     }
   }
 
   public async reset() {
-    this._cancelAllAttachmentAdds();
+    cancelAllAttachmentAdds(this);
 
     // A send whose adapter never settles must not brick the composer; reset is
     // the escape hatch that releases the in-flight lock. Bumping the generation
@@ -207,7 +224,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async clearAttachments() {
-    this._cancelAllAttachmentAdds();
+    cancelAllAttachmentAdds(this);
     const task = this._onClearAttachments();
     this.setAttachments([]);
 
@@ -374,7 +391,7 @@ export abstract class BaseComposerRuntimeCore
       cancelled: false,
       attachmentIds: new Set(),
     };
-    const operations = this._attachmentAddOperations;
+    const operations = getAttachmentAddOperations(this);
     operations.add(operation);
     const upsertAttachment = (a: PendingAttachment) => {
       if (operation.cancelled) return false;
@@ -480,7 +497,7 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
-    this._cancelAttachmentAdd(attachmentId);
+    cancelAttachmentAdd(this, attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -427,7 +427,9 @@ export abstract class BaseComposerRuntimeCore
         }
       } else {
         lastAttachment = await promiseOrGenerator;
-        upsertAttachment(lastAttachment);
+        if (!upsertAttachment(lastAttachment)) {
+          await adapter.remove(lastAttachment);
+        }
       }
     } catch (e) {
       try {

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -41,13 +41,13 @@ type AttachmentAddOperation = {
 
 const attachmentAddOperations = new WeakMap<
   object,
-  Map<string, AttachmentAddOperation>
+  Set<AttachmentAddOperation>
 >();
 
 const getAttachmentAddOperations = (owner: object) => {
   let operations = attachmentAddOperations.get(owner);
   if (!operations) {
-    operations = new Map();
+    operations = new Set();
     attachmentAddOperations.set(owner, operations);
   }
   return operations;
@@ -55,15 +55,23 @@ const getAttachmentAddOperations = (owner: object) => {
 
 const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
   const operations = attachmentAddOperations.get(owner);
-  const operation = operations?.get(attachmentId);
-  if (!operation || !operations) return;
+  if (!operations) return;
 
-  operation.cancelled = true;
-  for (const id of operation.attachmentIds) {
-    if (operations.get(id) === operation) {
-      operations.delete(id);
-    }
+  for (const operation of [...operations]) {
+    if (!operation.attachmentIds.has(attachmentId)) continue;
+    operation.cancelled = true;
+    operations.delete(operation);
   }
+};
+
+const cancelAllAttachmentAdds = (owner: object) => {
+  const operations = attachmentAddOperations.get(owner);
+  if (!operations) return;
+
+  for (const operation of operations) {
+    operation.cancelled = true;
+  }
+  operations.clear();
 };
 
 export abstract class BaseComposerRuntimeCore
@@ -178,10 +186,8 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
+    cancelAllAttachmentAdds(this);
     const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
-    for (const attachment of pending) {
-      cancelAttachmentAdd(this, attachment.id);
-    }
 
     const adapter = this.getAttachmentAdapter();
     if (adapter) {
@@ -360,41 +366,6 @@ export abstract class BaseComposerRuntimeCore
       return;
     }
 
-    const operation: AttachmentAddOperation = {
-      cancelled: false,
-      attachmentIds: new Set(),
-    };
-    const operations = getAttachmentAddOperations(this);
-    const upsertAttachment = (a: PendingAttachment) => {
-      operation.attachmentIds.add(a.id);
-      operations.set(a.id, operation);
-      if (operation.cancelled) return false;
-
-      const idx = this._attachments.findIndex(
-        (attachment) => attachment.id === a.id,
-      );
-      if (idx !== -1)
-        this._attachments = [
-          ...this._attachments.slice(0, idx),
-          a,
-          ...this._attachments.slice(idx + 1),
-        ];
-      else {
-        this._attachments = [...this._attachments, a];
-      }
-
-      this._notifySubscribers();
-      return true;
-    };
-    const finishOperation = () => {
-      for (const attachmentId of operation.attachmentIds) {
-        if (operations.get(attachmentId) === operation) {
-          operations.delete(attachmentId);
-        }
-      }
-      if (operations.size === 0) attachmentAddOperations.delete(this);
-    };
-
     const adapter = this.getAttachmentAdapter();
     if (!adapter) {
       const message = "Attachments are not supported";
@@ -414,6 +385,36 @@ export abstract class BaseComposerRuntimeCore
       this._safeEmitAttachmentAddError("not-accepted", message, undefined, err);
       throw err;
     }
+
+    const operation: AttachmentAddOperation = {
+      cancelled: false,
+      attachmentIds: new Set(),
+    };
+    const operations = getAttachmentAddOperations(this);
+    operations.add(operation);
+    const upsertAttachment = (a: PendingAttachment) => {
+      if (operation.cancelled) return false;
+
+      operation.attachmentIds.add(a.id);
+      const idx = this._attachments.findIndex(
+        (attachment) => attachment.id === a.id,
+      );
+      if (idx !== -1)
+        this._attachments = [
+          ...this._attachments.slice(0, idx),
+          a,
+          ...this._attachments.slice(idx + 1),
+        ];
+      else {
+        this._attachments = [...this._attachments, a];
+      }
+
+      this._notifySubscribers();
+      return true;
+    };
+    const finishOperation = () => {
+      operations.delete(operation);
+    };
 
     let lastAttachment: PendingAttachment | undefined;
     try {

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -34,6 +34,38 @@ import { notifyEventListeners } from "../../utils/notify-event-listeners";
 const isAttachmentComplete = (a: Attachment): a is CompleteAttachment =>
   a.status.type === "complete";
 
+type AttachmentAddOperation = {
+  cancelled: boolean;
+  attachmentIds: Set<string>;
+};
+
+const attachmentAddOperations = new WeakMap<
+  object,
+  Map<string, AttachmentAddOperation>
+>();
+
+const getAttachmentAddOperations = (owner: object) => {
+  let operations = attachmentAddOperations.get(owner);
+  if (!operations) {
+    operations = new Map();
+    attachmentAddOperations.set(owner, operations);
+  }
+  return operations;
+};
+
+const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
+  const operations = attachmentAddOperations.get(owner);
+  const operation = operations?.get(attachmentId);
+  if (!operation || !operations) return;
+
+  operation.cancelled = true;
+  for (const id of operation.attachmentIds) {
+    if (operations.get(id) === operation) {
+      operations.delete(id);
+    }
+  }
+};
+
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -146,9 +178,13 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
+    const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
+    for (const attachment of pending) {
+      cancelAttachmentAdd(this, attachment.id);
+    }
+
     const adapter = this.getAttachmentAdapter();
     if (adapter) {
-      const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
       await Promise.all(pending.map((a) => adapter.remove(a)));
     }
   }
@@ -324,7 +360,16 @@ export abstract class BaseComposerRuntimeCore
       return;
     }
 
+    const operation: AttachmentAddOperation = {
+      cancelled: false,
+      attachmentIds: new Set(),
+    };
+    const operations = getAttachmentAddOperations(this);
     const upsertAttachment = (a: PendingAttachment) => {
+      operation.attachmentIds.add(a.id);
+      operations.set(a.id, operation);
+      if (operation.cancelled) return false;
+
       const idx = this._attachments.findIndex(
         (attachment) => attachment.id === a.id,
       );
@@ -339,6 +384,15 @@ export abstract class BaseComposerRuntimeCore
       }
 
       this._notifySubscribers();
+      return true;
+    };
+    const finishOperation = () => {
+      for (const attachmentId of operation.attachmentIds) {
+        if (operations.get(attachmentId) === operation) {
+          operations.delete(attachmentId);
+        }
+      }
+      if (operations.size === 0) attachmentAddOperations.delete(this);
     };
 
     const adapter = this.getAttachmentAdapter();
@@ -367,32 +421,39 @@ export abstract class BaseComposerRuntimeCore
       if (Symbol.asyncIterator in promiseOrGenerator) {
         for await (const r of promiseOrGenerator) {
           lastAttachment = r;
-          upsertAttachment(r);
+          if (!upsertAttachment(r)) break;
         }
       } else {
         lastAttachment = await promiseOrGenerator;
         upsertAttachment(lastAttachment);
       }
     } catch (e) {
-      if (lastAttachment) {
-        upsertAttachment({
-          ...lastAttachment,
-          status: {
-            type: "incomplete",
-            reason: "error",
-            message: e instanceof Error ? e.message : String(e),
-          },
-        });
+      try {
+        if (operation.cancelled) return;
+        if (lastAttachment) {
+          upsertAttachment({
+            ...lastAttachment,
+            status: {
+              type: "incomplete",
+              reason: "error",
+              message: e instanceof Error ? e.message : String(e),
+            },
+          });
+        }
+        this._safeEmitAttachmentAddError(
+          "adapter-error",
+          e instanceof Error ? e.message : String(e),
+          lastAttachment?.id,
+          e instanceof Error ? e : undefined,
+        );
+        throw e;
+      } finally {
+        finishOperation();
       }
-      this._safeEmitAttachmentAddError(
-        "adapter-error",
-        e instanceof Error ? e.message : String(e),
-        lastAttachment?.id,
-        e instanceof Error ? e : undefined,
-      );
-      throw e;
     }
 
+    finishOperation();
+    if (operation.cancelled) return;
     if (
       lastAttachment?.status.type === "incomplete" &&
       lastAttachment.status.reason === "error"
@@ -433,6 +494,8 @@ export abstract class BaseComposerRuntimeCore
     const index = this._attachments.findIndex((a) => a.id === attachmentId);
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
+
+    cancelAttachmentAdd(this, attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -39,41 +39,6 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
-const attachmentAddOperations = new WeakMap<
-  object,
-  Set<AttachmentAddOperation>
->();
-
-const getAttachmentAddOperations = (owner: object) => {
-  let operations = attachmentAddOperations.get(owner);
-  if (!operations) {
-    operations = new Set();
-    attachmentAddOperations.set(owner, operations);
-  }
-  return operations;
-};
-
-const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of [...operations]) {
-    if (!operation.attachmentIds.has(attachmentId)) continue;
-    operation.cancelled = true;
-    operations.delete(operation);
-  }
-};
-
-const cancelAllAttachmentAdds = (owner: object) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of operations) {
-    operation.cancelled = true;
-  }
-  operations.clear();
-};
-
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -178,6 +143,22 @@ export abstract class BaseComposerRuntimeCore
   protected _isSending = false;
   private _removedDuringSend = new Set<string>();
   private _sendGeneration = 0;
+  private _attachmentAddOperations = new Set<AttachmentAddOperation>();
+
+  private _cancelAttachmentAdd(attachmentId: string) {
+    for (const operation of [...this._attachmentAddOperations]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      this._attachmentAddOperations.delete(operation);
+    }
+  }
+
+  private _cancelAllAttachmentAdds() {
+    for (const operation of this._attachmentAddOperations) {
+      operation.cancelled = true;
+    }
+    this._attachmentAddOperations.clear();
+  }
 
   private _emptyTextAndAttachments() {
     this._attachments = [];
@@ -194,7 +175,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async reset() {
-    cancelAllAttachmentAdds(this);
+    this._cancelAllAttachmentAdds();
 
     // A send whose adapter never settles must not brick the composer; reset is
     // the escape hatch that releases the in-flight lock. Bumping the generation
@@ -224,7 +205,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async clearAttachments() {
-    cancelAllAttachmentAdds(this);
+    this._cancelAllAttachmentAdds();
     const task = this._onClearAttachments();
     this.setAttachments([]);
 
@@ -391,7 +372,7 @@ export abstract class BaseComposerRuntimeCore
       cancelled: false,
       attachmentIds: new Set(),
     };
-    const operations = getAttachmentAddOperations(this);
+    const operations = this._attachmentAddOperations;
     operations.add(operation);
     const upsertAttachment = (a: PendingAttachment) => {
       if (operation.cancelled) return false;
@@ -490,7 +471,7 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
-    cancelAttachmentAdd(this, attachmentId);
+    this._cancelAttachmentAdd(attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -39,41 +39,6 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
-const attachmentAddOperations = new WeakMap<
-  object,
-  Set<AttachmentAddOperation>
->();
-
-const getAttachmentAddOperations = (owner: object) => {
-  let operations = attachmentAddOperations.get(owner);
-  if (!operations) {
-    operations = new Set();
-    attachmentAddOperations.set(owner, operations);
-  }
-  return operations;
-};
-
-const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of [...operations]) {
-    if (!operation.attachmentIds.has(attachmentId)) continue;
-    operation.cancelled = true;
-    operations.delete(operation);
-  }
-};
-
-const cancelAllAttachmentAdds = (owner: object) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of operations) {
-    operation.cancelled = true;
-  }
-  operations.clear();
-};
-
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -101,6 +66,23 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private _attachments: readonly Attachment[] = [];
+  private readonly _attachmentAddOperations = new Set<AttachmentAddOperation>();
+
+  private _cancelAttachmentAdd(attachmentId: string) {
+    for (const operation of [...this._attachmentAddOperations]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      this._attachmentAddOperations.delete(operation);
+    }
+  }
+
+  private _cancelAllAttachmentAdds() {
+    for (const operation of this._attachmentAddOperations) {
+      operation.cancelled = true;
+    }
+    this._attachmentAddOperations.clear();
+  }
+
   public get attachments() {
     return this._attachments;
   }
@@ -186,7 +168,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
-    cancelAllAttachmentAdds(this);
+    this._cancelAllAttachmentAdds();
     const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
 
     const adapter = this.getAttachmentAdapter();
@@ -390,7 +372,7 @@ export abstract class BaseComposerRuntimeCore
       cancelled: false,
       attachmentIds: new Set(),
     };
-    const operations = getAttachmentAddOperations(this);
+    const operations = this._attachmentAddOperations;
     operations.add(operation);
     const upsertAttachment = (a: PendingAttachment) => {
       if (operation.cancelled) return false;
@@ -496,7 +478,7 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
-    cancelAttachmentAdd(this, attachmentId);
+    this._cancelAttachmentAdd(attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -39,41 +39,6 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
-const attachmentAddOperations = new WeakMap<
-  object,
-  Set<AttachmentAddOperation>
->();
-
-const getAttachmentAddOperations = (owner: object) => {
-  let operations = attachmentAddOperations.get(owner);
-  if (!operations) {
-    operations = new Set();
-    attachmentAddOperations.set(owner, operations);
-  }
-  return operations;
-};
-
-const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of [...operations]) {
-    if (!operation.attachmentIds.has(attachmentId)) continue;
-    operation.cancelled = true;
-    operations.delete(operation);
-  }
-};
-
-const cancelAllAttachmentAdds = (owner: object) => {
-  const operations = attachmentAddOperations.get(owner);
-  if (!operations) return;
-
-  for (const operation of operations) {
-    operation.cancelled = true;
-  }
-  operations.clear();
-};
-
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -101,6 +66,23 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private _attachments: readonly Attachment[] = [];
+  private readonly _attachmentAddOperations = new Set<AttachmentAddOperation>();
+
+  private _cancelAttachmentAdd(attachmentId: string) {
+    for (const operation of [...this._attachmentAddOperations]) {
+      if (!operation.attachmentIds.has(attachmentId)) continue;
+      operation.cancelled = true;
+      this._attachmentAddOperations.delete(operation);
+    }
+  }
+
+  private _cancelAllAttachmentAdds() {
+    for (const operation of this._attachmentAddOperations) {
+      operation.cancelled = true;
+    }
+    this._attachmentAddOperations.clear();
+  }
+
   public get attachments() {
     return this._attachments;
   }
@@ -186,7 +168,6 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
-    cancelAllAttachmentAdds(this);
     const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
 
     const adapter = this.getAttachmentAdapter();
@@ -196,6 +177,8 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async reset() {
+    this._cancelAllAttachmentAdds();
+
     // A send whose adapter never settles must not brick the composer; reset is
     // the escape hatch that releases the in-flight lock. Bumping the generation
     // invalidates that send entirely so a late-settling upload can neither
@@ -224,6 +207,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   public async clearAttachments() {
+    this._cancelAllAttachmentAdds();
     const task = this._onClearAttachments();
     this.setAttachments([]);
 
@@ -390,7 +374,7 @@ export abstract class BaseComposerRuntimeCore
       cancelled: false,
       attachmentIds: new Set(),
     };
-    const operations = getAttachmentAddOperations(this);
+    const operations = this._attachmentAddOperations;
     operations.add(operation);
     const upsertAttachment = (a: PendingAttachment) => {
       if (operation.cancelled) return false;
@@ -496,7 +480,7 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
-    cancelAttachmentAdd(this, attachmentId);
+    this._cancelAttachmentAdd(attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message
@@ -506,7 +490,21 @@ export abstract class BaseComposerRuntimeCore
     if (!isAttachmentComplete(attachment)) {
       const adapter = this.getAttachmentAdapter();
       if (!adapter) throw new Error("Attachments are not supported");
-      await adapter.remove(attachment);
+      try {
+        await adapter.remove(attachment);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this._attachments = this._attachments.map((candidate) =>
+          candidate.id === attachmentId && !isAttachmentComplete(candidate)
+            ? {
+                ...candidate,
+                status: { type: "incomplete", reason: "error", message },
+              }
+            : candidate,
+        );
+        this._notifySubscribers();
+        throw error;
+      }
     }
     this._attachments = this._attachments.filter((a) => a.id !== attachmentId);
     this._notifySubscribers();

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -427,9 +427,7 @@ export abstract class BaseComposerRuntimeCore
         }
       } else {
         lastAttachment = await promiseOrGenerator;
-        if (!upsertAttachment(lastAttachment)) {
-          await adapter.remove(lastAttachment);
-        }
+        upsertAttachment(lastAttachment);
       }
     } catch (e) {
       try {

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -39,6 +39,41 @@ type AttachmentAddOperation = {
   attachmentIds: Set<string>;
 };
 
+const attachmentAddOperations = new WeakMap<
+  object,
+  Set<AttachmentAddOperation>
+>();
+
+const getAttachmentAddOperations = (owner: object) => {
+  let operations = attachmentAddOperations.get(owner);
+  if (!operations) {
+    operations = new Set();
+    attachmentAddOperations.set(owner, operations);
+  }
+  return operations;
+};
+
+const cancelAttachmentAdd = (owner: object, attachmentId: string) => {
+  const operations = attachmentAddOperations.get(owner);
+  if (!operations) return;
+
+  for (const operation of [...operations]) {
+    if (!operation.attachmentIds.has(attachmentId)) continue;
+    operation.cancelled = true;
+    operations.delete(operation);
+  }
+};
+
+const cancelAllAttachmentAdds = (owner: object) => {
+  const operations = attachmentAddOperations.get(owner);
+  if (!operations) return;
+
+  for (const operation of operations) {
+    operation.cancelled = true;
+  }
+  operations.clear();
+};
+
 export abstract class BaseComposerRuntimeCore
   extends BaseSubscribable
   implements ComposerRuntimeCore
@@ -66,23 +101,6 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private _attachments: readonly Attachment[] = [];
-  private readonly _attachmentAddOperations = new Set<AttachmentAddOperation>();
-
-  private _cancelAttachmentAdd(attachmentId: string) {
-    for (const operation of [...this._attachmentAddOperations]) {
-      if (!operation.attachmentIds.has(attachmentId)) continue;
-      operation.cancelled = true;
-      this._attachmentAddOperations.delete(operation);
-    }
-  }
-
-  private _cancelAllAttachmentAdds() {
-    for (const operation of this._attachmentAddOperations) {
-      operation.cancelled = true;
-    }
-    this._attachmentAddOperations.clear();
-  }
-
   public get attachments() {
     return this._attachments;
   }
@@ -168,7 +186,7 @@ export abstract class BaseComposerRuntimeCore
   }
 
   private async _onClearAttachments() {
-    this._cancelAllAttachmentAdds();
+    cancelAllAttachmentAdds(this);
     const pending = this._attachments.filter((a) => !isAttachmentComplete(a));
 
     const adapter = this.getAttachmentAdapter();
@@ -372,7 +390,7 @@ export abstract class BaseComposerRuntimeCore
       cancelled: false,
       attachmentIds: new Set(),
     };
-    const operations = this._attachmentAddOperations;
+    const operations = getAttachmentAddOperations(this);
     operations.add(operation);
     const upsertAttachment = (a: PendingAttachment) => {
       if (operation.cancelled) return false;
@@ -478,7 +496,7 @@ export abstract class BaseComposerRuntimeCore
     if (index === -1) throw new Error("Attachment not found");
     const attachment = this._attachments[index]!;
 
-    this._cancelAttachmentAdd(attachmentId);
+    cancelAttachmentAdd(this, attachmentId);
 
     // A send in flight may already be uploading this attachment; the upload
     // can't be cancelled, so mark it to be dropped from the outgoing message

--- a/packages/core/src/runtime/base/base-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/base-composer-runtime-core.ts
@@ -413,10 +413,6 @@ export abstract class BaseComposerRuntimeCore
       this._notifySubscribers();
       return true;
     };
-    const finishOperation = () => {
-      operations.delete(operation);
-    };
-
     let lastAttachment: PendingAttachment | undefined;
     try {
       const promiseOrGenerator = adapter.add({ file: fileOrAttachment });
@@ -430,31 +426,28 @@ export abstract class BaseComposerRuntimeCore
         upsertAttachment(lastAttachment);
       }
     } catch (e) {
-      try {
-        if (operation.cancelled) return;
-        if (lastAttachment) {
-          upsertAttachment({
-            ...lastAttachment,
-            status: {
-              type: "incomplete",
-              reason: "error",
-              message: e instanceof Error ? e.message : String(e),
-            },
-          });
-        }
-        this._safeEmitAttachmentAddError(
-          "adapter-error",
-          e instanceof Error ? e.message : String(e),
-          lastAttachment?.id,
-          e instanceof Error ? e : undefined,
-        );
-        throw e;
-      } finally {
-        finishOperation();
+      if (operation.cancelled) return;
+      if (lastAttachment) {
+        upsertAttachment({
+          ...lastAttachment,
+          status: {
+            type: "incomplete",
+            reason: "error",
+            message: e instanceof Error ? e.message : String(e),
+          },
+        });
       }
+      this._safeEmitAttachmentAddError(
+        "adapter-error",
+        e instanceof Error ? e.message : String(e),
+        lastAttachment?.id,
+        e instanceof Error ? e : undefined,
+      );
+      throw e;
+    } finally {
+      operations.delete(operation);
     }
 
-    finishOperation();
     if (operation.cancelled) return;
     if (
       lastAttachment?.status.type === "incomplete" &&

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -331,6 +331,33 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(onAdd).not.toHaveBeenCalled();
   });
 
+  it("cancels a promise add cleared before it resolves", async () => {
+    let finishUpload!: () => void;
+    const uploadPending = new Promise<void>((resolve) => {
+      finishUpload = resolve;
+    });
+    const composer = makeComposer(
+      makeAdapter({
+        add: async ({ file }: { file: File }) => {
+          await uploadPending;
+          return makeUploadingAttachment(file, "att-1");
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTask = composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+    await composer.clearAttachments();
+    finishUpload();
+    await addTask;
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
   it("cancels an add reset before its first yield", async () => {
     let startUpload!: () => void;
     const uploadPending = new Promise<void>((resolve) => {

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -200,6 +200,57 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(composer.attachments).toHaveLength(0);
   });
 
+  it("settles a pending attachment when adapter removal fails", async () => {
+    let finishUpload!: () => void;
+    const uploadPending = new Promise<void>((resolve) => {
+      finishUpload = resolve;
+    });
+    const cleanUpUpload = vi.fn();
+    const composer = makeComposer(
+      makeAdapter({
+        remove: vi.fn().mockRejectedValue(new Error("remove failed")),
+        async *add({ file }: { file: File }) {
+          const attachment = makeUploadingAttachment(file, "att-1");
+          try {
+            yield attachment;
+            await uploadPending;
+            yield {
+              ...attachment,
+              status: { type: "requires-action", reason: "composer-send" },
+            };
+          } finally {
+            cleanUpUpload();
+          }
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTask = composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+    await vi.waitFor(() => {
+      expect(composer.attachments).toHaveLength(1);
+    });
+
+    await expect(composer.removeAttachment("att-1")).rejects.toThrow(
+      "remove failed",
+    );
+    expect(composer.attachments[0]?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      message: "remove failed",
+    });
+
+    finishUpload();
+    await addTask;
+
+    expect(composer.attachments[0]?.status.type).toBe("incomplete");
+    expect(cleanUpUpload).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
   it("keeps a concurrent add registered before its first yield", async () => {
     let startSlowUpload!: () => void;
     const slowUploadStarted = new Promise<void>((resolve) => {
@@ -273,6 +324,33 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
       new File(["x"], "f.png", { type: "image/png" }),
     );
     await composer.clearAttachments();
+    startUpload();
+    await addTask;
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("cancels an add reset before its first yield", async () => {
+    let startUpload!: () => void;
+    const uploadPending = new Promise<void>((resolve) => {
+      startUpload = resolve;
+    });
+    const composer = makeComposer(
+      makeAdapter({
+        async *add({ file }: { file: File }) {
+          await uploadPending;
+          yield makeUploadingAttachment(file, "att-1");
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTask = composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+    await composer.reset();
     startUpload();
     await addTask;
 

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -38,6 +38,22 @@ const makeComposer = (adapter?: AttachmentAdapter) => {
   return new DefaultThreadComposerRuntimeCore(runtime);
 };
 
+const makeUploadingAttachment = (
+  file: File,
+  id: string,
+): PendingAttachment => ({
+  id,
+  type: "image",
+  name: file.name,
+  contentType: file.type,
+  file,
+  status: {
+    type: "running",
+    reason: "uploading",
+    progress: 0,
+  },
+});
+
 describe("BaseComposerRuntimeCore.addAttachment error events", () => {
   it("emits attachmentAddError when no adapter is configured", async () => {
     const composer = makeComposer();
@@ -144,18 +160,7 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
       makeAdapter({
         remove,
         async *add({ file }: { file: File }) {
-          const attachment: PendingAttachment = {
-            id: "att-1",
-            type: "image",
-            name: file.name,
-            contentType: file.type,
-            file,
-            status: {
-              type: "running",
-              reason: "uploading",
-              progress: 0,
-            },
-          };
+          const attachment = makeUploadingAttachment(file, "att-1");
           try {
             yield attachment;
             await uploadPending;
@@ -193,6 +198,125 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     finishRemoval();
     await removeTask;
     expect(composer.attachments).toHaveLength(0);
+  });
+
+  it("keeps a concurrent add registered before its first yield", async () => {
+    let startSlowUpload!: () => void;
+    const slowUploadStarted = new Promise<void>((resolve) => {
+      startSlowUpload = resolve;
+    });
+    let finishSlowUpload!: () => void;
+    const slowUploadPending = new Promise<void>((resolve) => {
+      finishSlowUpload = resolve;
+    });
+    const composer = makeComposer(
+      makeAdapter({
+        async *add({ file }: { file: File }) {
+          const attachment = makeUploadingAttachment(file, `att-${file.name}`);
+          if (file.name === "slow.png") await slowUploadStarted;
+          yield attachment;
+          if (file.name === "slow.png") await slowUploadPending;
+          yield {
+            ...attachment,
+            status: { type: "requires-action", reason: "composer-send" },
+          };
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const slowAddTask = composer.addAttachment(
+      new File(["slow"], "slow.png", { type: "image/png" }),
+    );
+    await composer.addAttachment(
+      new File(["fast"], "fast.png", { type: "image/png" }),
+    );
+
+    startSlowUpload();
+    await vi.waitFor(() => {
+      expect(
+        composer.attachments.some(
+          (attachment) => attachment.id === "att-slow.png",
+        ),
+      ).toBe(true);
+    });
+    await composer.removeAttachment("att-slow.png");
+    finishSlowUpload();
+    await slowAddTask;
+
+    expect(
+      composer.attachments.some(
+        (attachment) => attachment.id === "att-slow.png",
+      ),
+    ).toBe(false);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an add cleared before its first yield", async () => {
+    let startUpload!: () => void;
+    const uploadPending = new Promise<void>((resolve) => {
+      startUpload = resolve;
+    });
+    const composer = makeComposer(
+      makeAdapter({
+        async *add({ file }: { file: File }) {
+          await uploadPending;
+          yield makeUploadingAttachment(file, "att-1");
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTask = composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+    await composer.clearAttachments();
+    startUpload();
+    await addTask;
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it("cancels every concurrent add sharing an attachment id", async () => {
+    let finishUploads!: () => void;
+    const uploadsPending = new Promise<void>((resolve) => {
+      finishUploads = resolve;
+    });
+    const firstYieldsConsumed = vi.fn();
+    const composer = makeComposer(
+      makeAdapter({
+        async *add({ file }: { file: File }) {
+          const attachment = makeUploadingAttachment(file, "shared");
+          yield attachment;
+          firstYieldsConsumed();
+          await uploadsPending;
+          yield {
+            ...attachment,
+            status: { type: "requires-action", reason: "composer-send" },
+          };
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTasks = [
+      composer.addAttachment(new File(["a"], "a.png", { type: "image/png" })),
+      composer.addAttachment(new File(["b"], "b.png", { type: "image/png" })),
+    ];
+    await vi.waitFor(() => {
+      expect(firstYieldsConsumed).toHaveBeenCalledTimes(2);
+    });
+
+    await composer.removeAttachment("shared");
+    finishUploads();
+    await Promise.all(addTasks);
+
+    expect(composer.attachments).toHaveLength(0);
+    expect(onAdd).not.toHaveBeenCalled();
   });
 
   it("adds prepared attachments when File is unavailable", async () => {

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -358,33 +358,6 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(onAdd).not.toHaveBeenCalled();
   });
 
-  it("cleans up a promise-based add cleared before it resolves", async () => {
-    let finishUpload!: (attachment: PendingAttachment) => void;
-    const uploadPending = new Promise<PendingAttachment>((resolve) => {
-      finishUpload = resolve;
-    });
-    const remove = vi.fn(async () => {});
-    const composer = makeComposer(
-      makeAdapter({
-        add: () => uploadPending,
-        remove,
-      }),
-    );
-    const onAdd = vi.fn();
-    composer.unstable_on("attachmentAdd", onAdd);
-    const file = new File(["x"], "f.png", { type: "image/png" });
-    const attachment = makeUploadingAttachment(file, "att-1");
-
-    const addTask = composer.addAttachment(file);
-    await composer.clearAttachments();
-    finishUpload(attachment);
-    await addTask;
-
-    expect(remove).toHaveBeenCalledWith(attachment);
-    expect(composer.attachments).toHaveLength(0);
-    expect(onAdd).not.toHaveBeenCalled();
-  });
-
   it("cancels every concurrent add sharing an attachment id", async () => {
     let finishUploads!: () => void;
     const uploadsPending = new Promise<void>((resolve) => {

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -358,6 +358,33 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(onAdd).not.toHaveBeenCalled();
   });
 
+  it("cleans up a promise-based add cleared before it resolves", async () => {
+    let finishUpload!: (attachment: PendingAttachment) => void;
+    const uploadPending = new Promise<PendingAttachment>((resolve) => {
+      finishUpload = resolve;
+    });
+    const remove = vi.fn(async () => {});
+    const composer = makeComposer(
+      makeAdapter({
+        add: () => uploadPending,
+        remove,
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+    const file = new File(["x"], "f.png", { type: "image/png" });
+    const attachment = makeUploadingAttachment(file, "att-1");
+
+    const addTask = composer.addAttachment(file);
+    await composer.clearAttachments();
+    finishUpload(attachment);
+    await addTask;
+
+    expect(remove).toHaveBeenCalledWith(attachment);
+    expect(composer.attachments).toHaveLength(0);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
   it("cancels every concurrent add sharing an attachment id", async () => {
     let finishUploads!: () => void;
     const uploadsPending = new Promise<void>((resolve) => {

--- a/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
+++ b/packages/core/src/tests/base-composer-runtime-core-addAttachment.test.ts
@@ -128,6 +128,73 @@ describe("BaseComposerRuntimeCore.addAttachment error events", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("does not restore an attachment removed while add is still running", async () => {
+    let finishUpload!: () => void;
+    const uploadPending = new Promise<void>((resolve) => {
+      finishUpload = resolve;
+    });
+    let finishRemoval!: () => void;
+    const removalPending = new Promise<void>((resolve) => {
+      finishRemoval = resolve;
+    });
+    const remove = vi.fn(() => removalPending);
+    const continueUpload = vi.fn();
+    const cleanUpUpload = vi.fn();
+    const composer = makeComposer(
+      makeAdapter({
+        remove,
+        async *add({ file }: { file: File }) {
+          const attachment: PendingAttachment = {
+            id: "att-1",
+            type: "image",
+            name: file.name,
+            contentType: file.type,
+            file,
+            status: {
+              type: "running",
+              reason: "uploading",
+              progress: 0,
+            },
+          };
+          try {
+            yield attachment;
+            await uploadPending;
+            yield {
+              ...attachment,
+              status: { type: "requires-action", reason: "composer-send" },
+            };
+            continueUpload();
+            yield attachment;
+          } finally {
+            cleanUpUpload();
+          }
+        },
+      }),
+    );
+    const onAdd = vi.fn();
+    composer.unstable_on("attachmentAdd", onAdd);
+
+    const addTask = composer.addAttachment(
+      new File(["x"], "f.png", { type: "image/png" }),
+    );
+    await vi.waitFor(() => {
+      expect(composer.attachments).toHaveLength(1);
+    });
+
+    const removeTask = composer.removeAttachment("att-1");
+    finishUpload();
+    await addTask;
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(continueUpload).not.toHaveBeenCalled();
+    expect(cleanUpUpload).toHaveBeenCalledTimes(1);
+
+    finishRemoval();
+    await removeTask;
+    expect(composer.attachments).toHaveLength(0);
+  });
+
   it("adds prepared attachments when File is unavailable", async () => {
     const composer = makeComposer();
     const fileConstructor = globalThis.File;


### PR DESCRIPTION
## Summary

- track every in-flight attachment addition before its first async yield
- cancel matching additions before awaiting removal, so late upload yields cannot restore removed attachments
- cancel pre-yield additions when attachments are cleared or reset
- settle failed removals as `incomplete/error` instead of leaving a permanently running attachment
- stop cancelled async generators so adapter cleanup runs and no success event is emitted

## Why

`AttachmentAdapter.add()` can yield an uploading attachment and later yield its completed state. If the user removed the attachment while the upload was still running, a later yield previously inserted it back into the composer and emitted `attachmentAdd`.

A stable per-composer operation set handles concurrent additions, additions that have not yielded yet, and multiple additions returning the same ID. The registry remains module-private to avoid changing exported class declarations. Cancellation after sending an in-flight attachment is a separate pre-existing path and intentionally outside this removal-focused PR.

A clear or reset can cancel an add before the adapter returns its first attachment. The runtime drops that late result from composer state. It intentionally does not call `remove()` afterward because the returned ID may already belong to a newer add; doing so could delete the newer resource. Async generators still receive iterator `return()` so their `finally` cleanup can run. Reliable adapter-side cancellation before the first value would require a separate operation-scoped cancellation API.

## Verification

- `@assistant-ui/core` build
- 75 core test files / 687 tests
- 39 focused attachment and composer-send tests
- React Compiler suite: 6 tests
- oxlint and oxfmt checks

Closes #5216