### PR TITLE
fix(assistant-stream): DataStreamChunkDecoder skips blank framing lines

### DIFF
--- a/.changeset/assistant-stream-blank-line-decoder.md
+++ b/.changeset/assistant-stream-blank-line-decoder.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: DataStreamChunkDecoder skips blank framing lines and drops colon-less lines with a warning instead of throwing

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LineDecoderStream } from "../../utils/stream/LineDecoderStream";
 import {
   DataStreamChunkDecoder,
@@ -31,6 +31,10 @@ function createLineStream(lines: string[]): ReadableStream<string> {
 }
 
 describe("DataStreamChunkDecoder", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("decodes text-delta chunks", async () => {
     const chunks = await collectChunks(
       createLineStream(['0:"hello"', '0:" world"']).pipeThrough(
@@ -76,7 +80,6 @@ describe("DataStreamChunkDecoder", () => {
     expect(chunks).toEqual([
       { type: DataStreamStreamChunkType.TextDelta, value: "ok" },
     ]);
-    warn.mockRestore();
   });
 
   it("drops chunks that are not valid JSON", async () => {
@@ -93,7 +96,6 @@ describe("DataStreamChunkDecoder", () => {
     expect(chunks).toEqual([
       { type: DataStreamStreamChunkType.TextDelta, value: "ok" },
     ]);
-    warn.mockRestore();
   });
 
   it("skips blank and whitespace-only lines silently", async () => {
@@ -112,7 +114,6 @@ describe("DataStreamChunkDecoder", () => {
       { type: DataStreamStreamChunkType.TextDelta, value: "hello" },
       { type: DataStreamStreamChunkType.TextDelta, value: " world" },
     ]);
-    warn.mockRestore();
   });
 
   it("drops a chunk without a colon separator with a warning", async () => {
@@ -128,6 +129,5 @@ describe("DataStreamChunkDecoder", () => {
     expect(chunks).toEqual([
       { type: DataStreamStreamChunkType.TextDelta, value: "ok" },
     ]);
-    warn.mockRestore();
   });
 });

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.test.ts
@@ -96,11 +96,38 @@ describe("DataStreamChunkDecoder", () => {
     warn.mockRestore();
   });
 
-  it("throws on a chunk without a colon separator", async () => {
-    await expect(
-      collectChunks(
-        createLineStream(["garbage"]).pipeThrough(new DataStreamChunkDecoder()),
+  it("skips blank and whitespace-only lines silently", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const chunks = await collectChunks(
+      createLineStream([
+        "",
+        '0:"hello"',
+        "   ",
+        "\t",
+        '0:" world"',
+      ]).pipeThrough(new DataStreamChunkDecoder()),
+    );
+    expect(warn).not.toHaveBeenCalled();
+    expect(chunks).toEqual([
+      { type: DataStreamStreamChunkType.TextDelta, value: "hello" },
+      { type: DataStreamStreamChunkType.TextDelta, value: " world" },
+    ]);
+    warn.mockRestore();
+  });
+
+  it("drops a chunk without a colon separator with a warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const chunks = await collectChunks(
+      createLineStream(["garbage", '0:"ok"']).pipeThrough(
+        new DataStreamChunkDecoder(),
       ),
-    ).rejects.toThrow("Invalid stream part");
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Dropped invalid data-stream chunk: garbage",
+    );
+    expect(chunks).toEqual([
+      { type: DataStreamStreamChunkType.TextDelta, value: "ok" },
+    ]);
+    warn.mockRestore();
   });
 });

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
@@ -22,7 +22,13 @@ export class DataStreamChunkDecoder extends TransformStream<
     super({
       transform: (chunk, controller) => {
         const index = chunk.indexOf(":");
-        if (index === -1) throw new Error("Invalid stream part");
+        if (index === -1) {
+          // Blank lines are benign data-stream framing (keepalive newlines,
+          // replay-buffer separators emitted on resume/reconnect).
+          if (chunk.trim().length === 0) return;
+          console.warn(`Dropped invalid data-stream chunk: ${chunk}`);
+          return;
+        }
         let value;
         try {
           value = sjson.parse(chunk.slice(index + 1));

--- a/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/serialization.ts
@@ -26,7 +26,9 @@ export class DataStreamChunkDecoder extends TransformStream<
           // Blank lines are benign data-stream framing (keepalive newlines,
           // replay-buffer separators emitted on resume/reconnect).
           if (chunk.trim().length === 0) return;
-          console.warn(`Dropped invalid data-stream chunk: ${chunk}`);
+          console.warn(
+            `Dropped invalid data-stream chunk: ${chunk.slice(0, 200)}`,
+          );
           return;
         }
         let value;


### PR DESCRIPTION
## Summary
- `DataStreamChunkDecoder` no longer throws `Invalid stream part` on blank/whitespace-only lines — these are benign data-stream framing (keepalive newlines, replay-buffer separators on resume/reconnect) and previously killed the stream.
- Other colon-less lines are dropped with a `console.warn` instead of aborting the stream.
- Patch changeset for `assistant-stream` included. No public API signature changes.

## Validation
- `pnpm --filter assistant-stream test` (387 passing)
- `pnpm --filter assistant-stream build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.duAsO3BvJc6XYLi9gGUuOjubdBb-EFzHgllZnES2LMgLHcVD0SfZNnUqLCs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->