### PR TITLE
feat(external-thread): assistant-transport parity props and composer fixes

### DIFF
--- a/.changeset/external-thread-assistant-transport.md
+++ b/.changeset/external-thread-assistant-transport.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react": patch
+"@assistant-ui/core": patch
+---
+
+feat: ExternalThread props for assistant-transport (isLoading, state, extras, onResume, onAddToolResult, onLoadExternalState, onResumeToolCall, attachmentAdapter; importExternalState); export ToolInvocationTracker from core internal; composer parentId, draft-restore, and part-status fixes

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5131,9 +5131,9 @@ declare class ToolInvocationTracker {
   private _controller;
   private _pipelineDead;
   private _pipelineRestartUsed;
-  constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTrackerCallbacks);
+  constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTracker.Callbacks);
   private _initPipeline;
-  setState(snapshot: ToolInvocationTrackerSnapshot): void;
+  setState(snapshot: ToolInvocationTracker.Snapshot): void;
   reset(): void;
   abort(): Promise<void>;
   resume(toolCallId: string, payload: unknown): boolean;
@@ -5155,16 +5155,18 @@ declare class ToolInvocationTracker {
   private _processMessages;
 }
 
-type ToolInvocationTrackerCallbacks = {
-  onResult: (command: AddToolResultCommand) => void;
-  onStatusesChange: (statuses: ReadonlyMap<string, ToolExecutionStatus>) => void;
-};
-
-type ToolInvocationTrackerSnapshot = {
-  readonly messages: readonly ThreadMessage[];
-  readonly isRunning: boolean;
-  readonly isLoading?: boolean;
-};
+declare namespace ToolInvocationTracker {
+  type ExecutionStatus = ToolExecutionStatus;
+  type Snapshot = {
+    readonly messages: readonly ThreadMessage[];
+    readonly isRunning: boolean;
+    readonly isLoading?: boolean;
+  };
+  type Callbacks = {
+    onResult: (command: AddToolResultCommand) => void;
+    onStatusesChange: (statuses: ReadonlyMap<string, ToolExecutionStatus>) => void;
+  };
+}
 
 type ToolModelContentPart = {
   readonly type: "text";
@@ -5664,7 +5666,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, ToolInvocationTrackerCallbacks, ToolInvocationTrackerSnapshot, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isRecord, parseDataUrl, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isRecord, parseDataUrl, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -24,6 +24,16 @@ interface ScopeRegistry {
     unstable_interactables: Unstable_InteractablesClientSchema;
 }
 
+type AddToolResultCommand = {
+  readonly type: "add-tool-result";
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly result: ReadonlyJSONValue;
+  readonly isError: boolean;
+  readonly artifact?: ReadonlyJSONValue;
+  readonly modelContent?: readonly ToolModelContentPart[];
+};
+
 type AddToolResultOptions = {
   messageId: string;
   toolName: string;
@@ -4536,6 +4546,7 @@ type ThreadMethods = {
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  importExternalState?(state: unknown): void;
   message(selector: {
     id: string;
   } | {
@@ -5104,6 +5115,57 @@ type ToolExecutionStatus = {
   };
 };
 
+declare class ToolInvocationTracker {
+  private readonly _getTools;
+  private readonly _callbacks;
+  private readonly _entries;
+  private readonly _skipExecuteStreamIds;
+  private readonly _humanInput;
+  private readonly _executing;
+  private readonly _settledResolvers;
+  private _statuses;
+  private _ac;
+  private _pendingRestore;
+  private _lastSnapshot;
+  private _isRunning;
+  private _controller;
+  private _pipelineDead;
+  private _pipelineRestartUsed;
+  constructor(getTools: () => Record<string, Tool> | undefined, callbacks: ToolInvocationTrackerCallbacks);
+  private _initPipeline;
+  setState(snapshot: ToolInvocationTrackerSnapshot): void;
+  reset(): void;
+  abort(): Promise<void>;
+  resume(toolCallId: string, payload: unknown): boolean;
+  getStatuses(): ReadonlyMap<string, ToolExecutionStatus>;
+  private _getWrappedTools;
+  private _onHumanInput;
+  private _onExecutionStart;
+  private _onExecutionEnd;
+  private _handleResultChunk;
+  private _invokeOnResult;
+  private _invokeOnStatusesChange;
+  private _setStatus;
+  private _deleteStatus;
+  private _hasExecutableTool;
+  private _shouldCloseArgsStream;
+  private _startActiveEntry;
+  private _demoteEntriesToRestored;
+  private _processArgsText;
+  private _processMessages;
+}
+
+type ToolInvocationTrackerCallbacks = {
+  onResult: (command: AddToolResultCommand) => void;
+  onStatusesChange: (statuses: ReadonlyMap<string, ToolExecutionStatus>) => void;
+};
+
+type ToolInvocationTrackerSnapshot = {
+  readonly messages: readonly ThreadMessage[];
+  readonly isRunning: boolean;
+  readonly isLoading?: boolean;
+};
+
 type ToolModelContentPart = {
   readonly type: "text";
   readonly text: string;
@@ -5602,7 +5664,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isRecord, parseDataUrl, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, RuntimeExtras, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, ToolInvocationTrackerCallbacks, ToolInvocationTrackerSnapshot, consumeSuggestionResult, createRuntimeExtras, createThreadMappingId, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isRecord, parseDataUrl, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2140,12 +2140,20 @@ type ExternalThreadMessage = ThreadMessage & {
 type ExternalThreadProps = {
   messages: readonly ExternalThreadMessage[];
   isRunning?: boolean;
+  isLoading?: boolean | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
   isSendDisabled?: boolean;
   onNew?: (message: AppendMessage) => void;
   onEdit?: (message: AppendMessage) => void;
   onReload?: (parentId: string | null) => void;
   onStartRun?: () => void;
   onCancel?: () => void;
+  onResume?: (() => void) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
+  onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
+  onLoadExternalState?: ((state: unknown) => void) | undefined;
+  attachmentAdapter?: AttachmentAdapter | undefined;
   queue?: ExternalThreadQueueAdapter;
   branches?: ExternalThreadBranchAdapter;
   onRespondToToolApproval?: (options: RespondToToolApprovalOptions) => void;

--- a/packages/core/src/runtimes/internal.ts
+++ b/packages/core/src/runtimes/internal.ts
@@ -37,3 +37,10 @@ export type {
   RemoteThreadInitializeResponse,
   RemoteThreadListOptions,
 } from "./remote-thread-list/types";
+
+// Tool Invocations
+export { ToolInvocationTracker } from "./tool-invocations/ToolInvocationTracker";
+export type {
+  ToolInvocationTrackerSnapshot,
+  ToolInvocationTrackerCallbacks,
+} from "./tool-invocations/ToolInvocationTracker";

--- a/packages/core/src/runtimes/internal.ts
+++ b/packages/core/src/runtimes/internal.ts
@@ -40,7 +40,3 @@ export type {
 
 // Tool Invocations
 export { ToolInvocationTracker } from "./tool-invocations/ToolInvocationTracker";
-export type {
-  ToolInvocationTrackerSnapshot,
-  ToolInvocationTrackerCallbacks,
-} from "./tool-invocations/ToolInvocationTracker";

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ToolInvocationTracker,
   type ToolExecutionStatus,
-  type ToolInvocationTrackerSnapshot,
 } from "./ToolInvocationTracker";
 import type {
   ThreadAssistantMessage,
@@ -34,7 +33,7 @@ async function waitFor(
 const createState = (
   messages: ThreadAssistantMessage[],
   isRunning: boolean = true,
-): ToolInvocationTrackerSnapshot => ({
+): ToolInvocationTracker.Snapshot => ({
   messages: messages as readonly ThreadMessage[],
   isRunning,
 });

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -35,34 +35,6 @@ export type AddToolResultCommand = {
   readonly modelContent?: readonly ToolModelContentPart[];
 };
 
-export type ToolInvocationTrackerSnapshot = {
-  readonly messages: readonly ThreadMessage[];
-  /** Whether the producing runtime is currently streaming new output. */
-  readonly isRunning: boolean;
-  /**
-   * Whether the producing runtime is still loading historical state.
-   * When `true`, every snapshot is treated as historical (no `streamCall` /
-   * `execute` fires). When `false`, processing resumes as live.
-   */
-  readonly isLoading?: boolean;
-};
-
-export type ToolInvocationTrackerCallbacks = {
-  /**
-   * Invoked when a client-side `execute()` returns a result and the runtime
-   * needs to feed it back into the conversation.
-   */
-  onResult: (command: AddToolResultCommand) => void;
-  /**
-   * Invoked whenever the per-tool-call status map changes (executing /
-   * interrupt / cleared). The callback receives a fresh map; mutating the
-   * argument is not supported.
-   */
-  onStatusesChange: (
-    statuses: ReadonlyMap<string, ToolExecutionStatus>,
-  ) => void;
-};
-
 type ToolCallEntry = {
   toolName: string;
   argsText: string;
@@ -123,10 +95,12 @@ const isEquivalentCompleteArgsText = (previous: string, next: string) => {
  * the hot message-processing path, so a malformed snapshot must never crash
  * the host runtime. See ./EDGE_CASES.md for the known non-trivial state
  * transitions and what each does today.
+ *
+ * @deprecated Internal — for framework bindings; not a public API. May change without notice.
  */
 export class ToolInvocationTracker {
   private readonly _getTools: () => Record<string, Tool> | undefined;
-  private readonly _callbacks: ToolInvocationTrackerCallbacks;
+  private readonly _callbacks: ToolInvocationTracker.Callbacks;
 
   private readonly _entries = new Map<string, ToolCallEntry>();
   /**
@@ -157,7 +131,7 @@ export class ToolInvocationTracker {
   private _pendingRestore = true;
 
   /** Cached last snapshot, used to skip processing on identical re-renders. */
-  private _lastSnapshot: ToolInvocationTrackerSnapshot | null = null;
+  private _lastSnapshot: ToolInvocationTracker.Snapshot | null = null;
   private _isRunning = false;
 
   private _controller!: ReturnType<typeof createAssistantStreamController>[1];
@@ -175,7 +149,7 @@ export class ToolInvocationTracker {
 
   constructor(
     getTools: () => Record<string, Tool> | undefined,
-    callbacks: ToolInvocationTrackerCallbacks,
+    callbacks: ToolInvocationTracker.Callbacks,
   ) {
     this._getTools = getTools;
     this._callbacks = callbacks;
@@ -235,7 +209,7 @@ export class ToolInvocationTracker {
    * Feed the next observed snapshot into the tracker. Called from the host
    * runtime whenever its message list / running state changes.
    */
-  public setState(snapshot: ToolInvocationTrackerSnapshot): void {
+  public setState(snapshot: ToolInvocationTracker.Snapshot): void {
     try {
       // Recover from a dead pipeline before processing anything. We demote
       // all active entries to "restored" so the rebuilt pipeline does not
@@ -781,4 +755,36 @@ export class ToolInvocationTracker {
       }
     }
   }
+}
+
+export namespace ToolInvocationTracker {
+  export type ExecutionStatus = ToolExecutionStatus;
+
+  export type Snapshot = {
+    readonly messages: readonly ThreadMessage[];
+    /** Whether the producing runtime is currently streaming new output. */
+    readonly isRunning: boolean;
+    /**
+     * Whether the producing runtime is still loading historical state.
+     * When `true`, every snapshot is treated as historical (no `streamCall` /
+     * `execute` fires). When `false`, processing resumes as live.
+     */
+    readonly isLoading?: boolean;
+  };
+
+  export type Callbacks = {
+    /**
+     * Invoked when a client-side `execute()` returns a result and the runtime
+     * needs to feed it back into the conversation.
+     */
+    onResult: (command: AddToolResultCommand) => void;
+    /**
+     * Invoked whenever the per-tool-call status map changes (executing /
+     * interrupt / cleared). The callback receives a fresh map; mutating the
+     * argument is not supported.
+     */
+    onStatusesChange: (
+      statuses: ReadonlyMap<string, ToolExecutionStatus>,
+    ) => void;
+  };
 }

--- a/packages/core/src/store/runtime-clients/thread-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-runtime-client.ts
@@ -113,6 +113,7 @@ const useThreadClient = ({
     deleteMessage: runtime.deleteMessage,
     startRun: runtime.startRun,
     resumeRun: runtime.resumeRun,
+    importExternalState: runtime.importExternalState,
     cancelRun: runtime.cancelRun,
     getModelContext: runtime.getModelContext,
     export: runtime.export,

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -108,6 +108,7 @@ export type ThreadMethods = {
    * @param initialMessages - Optional array of initial messages to populate the thread
    */
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  importExternalState?(state: unknown): void;
   message(selector: { id: string } | { index: number }): MessageMethods;
   /** @deprecated This API is still under active development and might change without notice. */
   stopSpeaking(): void;

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -662,7 +662,9 @@ const useExternalThread = ({
   };
 
   const handleSendNew = (message: AppendMessage) => {
-    onNew?.(message);
+    // The composer does not know the thread; stamp the current head as the
+    // parent (legacy composer parity).
+    onNew?.({ ...message, parentId: messages.at(-1)?.id ?? null });
   };
 
   const composerClient = useClientResource(

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -1,4 +1,11 @@
-import { useState, useMemo, useEffect, useEffectEvent } from "react";
+import {
+  useState,
+  useMemo,
+  useEffect,
+  useEffectEvent,
+  useCallback,
+  useRef,
+} from "react";
 import { resource, withKey } from "@assistant-ui/tap";
 import {
   type ClientElement,
@@ -18,9 +25,11 @@ import type {
   PendingAttachment,
   RespondToToolApprovalOptions,
   ResumeToolCallOptions,
+  MessagePartStatus,
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
   ThreadMessage,
+  ToolCallMessagePartStatus,
   ExternalThreadQueueAdapter,
   ExternalThreadBranchAdapter,
 } from "@assistant-ui/core";
@@ -42,6 +51,29 @@ const EMPTY_BRANCH_IDS: readonly string[] = [];
 
 export type ExternalThreadMessage = ThreadMessage & {
   id: string;
+};
+
+const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
+  type: "complete",
+});
+
+// Legacy runtime parity (toMessagePartStatus): a tool call without a result
+// carries its message's status; the last part of a streaming message streams.
+const derivePartStatus = (
+  message: ExternalThreadMessage,
+  partIndex: number,
+  part: ThreadAssistantMessagePart | ThreadUserMessagePart,
+): ToolCallMessagePartStatus => {
+  if (message.role !== "assistant" || !message.status) return COMPLETE_STATUS;
+
+  if (part.type === "tool-call") {
+    if (!part.result) return message.status as ToolCallMessagePartStatus;
+    return COMPLETE_STATUS;
+  }
+
+  const isLastPart = partIndex === Math.max(0, message.content.length - 1);
+  if (message.status.type === "requires-action") return COMPLETE_STATUS;
+  return isLastPart ? (message.status as MessagePartStatus) : COMPLETE_STATUS;
 };
 
 export type ExternalThreadProps = {
@@ -118,6 +150,7 @@ const useMessageClient = ({
         idx,
         PartResource({
           part,
+          status: derivePartStatus(message, idx, part),
           messageId: message.id,
           onRespondToToolApproval,
           onAddToolResult,
@@ -251,6 +284,7 @@ const MessageClient = resource(useMessageClient);
 
 type PartResourceProps = {
   part: ThreadAssistantMessagePart | ThreadUserMessagePart;
+  status: ToolCallMessagePartStatus;
   messageId: string;
   onRespondToToolApproval?:
     | ((options: RespondToToolApprovalOptions) => void)
@@ -262,6 +296,7 @@ type PartResourceProps = {
 // Part Client - minimal implementation
 const usePartResource = ({
   part,
+  status,
   messageId,
   onRespondToToolApproval,
   onAddToolResult,
@@ -270,9 +305,9 @@ const usePartResource = ({
   const state = useMemo(
     () => ({
       ...part,
-      status: { type: "complete" as const },
+      status,
     }),
-    [part],
+    [part, status],
   );
 
   return {
@@ -378,6 +413,20 @@ const useQueueItemClient = ({
 
 const QueueItemClient = resource(useQueueItemClient);
 
+// State whose setter tracks the latest value in a ref, so imperative
+// call sequences (setText immediately followed by send) observe the write
+// before React re-renders — legacy composer parity.
+const useLiveState = <T>(initial: T) => {
+  const [state, setState] = useState(initial);
+  const ref = useRef(state);
+  const set = useCallback((next: T | ((prev: T) => T)) => {
+    ref.current =
+      typeof next === "function" ? (next as (prev: T) => T)(ref.current) : next;
+    setState(ref.current);
+  }, []);
+  return [state, set, ref] as const;
+};
+
 // Composer Client - minimal implementation
 const useComposerClientResource = ({
   type,
@@ -391,11 +440,17 @@ const useComposerClientResource = ({
   queue,
   attachmentAdapter,
 }: ComposerClientResourceProps): ClientOutput<"composer"> => {
-  const [text, setText] = useState("");
-  const [role, setRole] = useState<"user" | "assistant" | "system">("user");
-  const [runConfig, setRunConfig] = useState<Record<string, unknown>>({});
-  const [attachments, setAttachments] = useState<readonly Attachment[]>([]);
-  const [quote, setQuote] = useState<
+  const [text, setText, textRef] = useLiveState("");
+  const [role, setRole, roleRef] = useLiveState<
+    "user" | "assistant" | "system"
+  >("user");
+  const [runConfig, setRunConfig, runConfigRef] = useLiveState<
+    Record<string, unknown>
+  >({});
+  const [attachments, setAttachments, attachmentsRef] = useLiveState<
+    readonly Attachment[]
+  >([]);
+  const [quote, setQuote, quoteRef] = useLiveState<
     { readonly text: string; readonly messageId: string } | undefined
   >(undefined);
 
@@ -518,7 +573,7 @@ const useComposerClientResource = ({
           status: { type: "complete" },
           content: [],
         };
-        setAttachments([...attachments, newAttachment]);
+        setAttachments((prev) => [...prev, newAttachment]);
       } else {
         const newAttachment: Attachment = {
           id: fileOrAttachment.id ?? Math.random().toString(36).substring(7),
@@ -528,7 +583,7 @@ const useComposerClientResource = ({
           content: fileOrAttachment.content,
           status: { type: "complete" },
         };
-        setAttachments([...attachments, newAttachment]);
+        setAttachments((prev) => [...prev, newAttachment]);
       }
     },
     clearAttachments: async () => {
@@ -548,18 +603,19 @@ const useComposerClientResource = ({
       setQuote(undefined);
     },
     send: (opts?: ComposerSendOptions) => {
-      if (!state.canSend) return;
+      const currentQuote = quoteRef.current;
+      const currentText = textRef.current;
+      const currentAttachments = attachmentsRef.current;
+      const isEmpty = !currentText.trim() && !currentAttachments.length;
+      if (!isEditing || isEmpty || isSendDisabled) return;
 
-      const currentQuote = quote;
-      const currentText = text;
-      const currentAttachments = attachments;
       setText("");
       setAttachments([]);
       setQuote(undefined);
 
       const dispatch = (sendAttachments: readonly Attachment[]) => {
         const composedMessage: AppendMessage = {
-          role,
+          role: roleRef.current,
           content: currentText
             ? [{ type: "text" as const, text: currentText }]
             : [],
@@ -567,7 +623,7 @@ const useComposerClientResource = ({
           createdAt: new Date(),
           parentId: null,
           sourceId: null,
-          runConfig,
+          runConfig: runConfigRef.current,
           startRun: opts?.startRun,
           metadata: {
             custom: { ...(currentQuote ? { quote: currentQuote } : {}) },

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -10,9 +10,12 @@ import {
 } from "@assistant-ui/store";
 
 import type {
+  AddToolResultOptions,
   AppendMessage,
   Attachment,
+  AttachmentAdapter,
   CreateAttachment,
+  PendingAttachment,
   RespondToToolApprovalOptions,
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
@@ -20,6 +23,8 @@ import type {
   ExternalThreadQueueAdapter,
   ExternalThreadBranchAdapter,
 } from "@assistant-ui/core";
+import { ToolResponse } from "assistant-stream";
+import type { ReadonlyJSONValue } from "assistant-stream/utils";
 import type { QueueItemState } from "@assistant-ui/core/store";
 import type { ComposerSendOptions } from "@assistant-ui/core/store";
 import {
@@ -41,6 +46,9 @@ export type ExternalThreadMessage = ThreadMessage & {
 export type ExternalThreadProps = {
   messages: readonly ExternalThreadMessage[];
   isRunning?: boolean;
+  isLoading?: boolean | undefined;
+  state?: ReadonlyJSONValue | undefined;
+  extras?: unknown;
   /**
    * Whether sending new messages is currently disabled. When `true`, the
    * thread composer's input remains usable but `send()` is a no-op and
@@ -57,6 +65,10 @@ export type ExternalThreadProps = {
   onReload?: (parentId: string | null) => void;
   onStartRun?: () => void;
   onCancel?: () => void;
+  onResume?: (() => void) | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
+  onLoadExternalState?: ((state: unknown) => void) | undefined;
+  attachmentAdapter?: AttachmentAdapter | undefined;
   /** Queue adapter for runtimes that support message queuing and steering. */
   queue?: ExternalThreadQueueAdapter;
   /** Branch adapter for runtimes that track sibling variants of messages. */
@@ -75,6 +87,7 @@ type MessageClientProps = {
   onRespondToToolApproval?:
     | ((options: RespondToToolApprovalOptions) => void)
     | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
 };
 
 // Message Client - minimal implementation
@@ -86,6 +99,7 @@ const useMessageClient = ({
   queue,
   branches,
   onRespondToToolApproval,
+  onAddToolResult,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -93,7 +107,15 @@ const useMessageClient = ({
 
   const partClients = useClientLookup(
     message.content.map((part, idx) =>
-      withKey(idx, PartResource({ part, onRespondToToolApproval })),
+      withKey(
+        idx,
+        PartResource({
+          part,
+          messageId: message.id,
+          onRespondToToolApproval,
+          onAddToolResult,
+        }),
+      ),
     ),
   );
 
@@ -220,15 +242,19 @@ const MessageClient = resource(useMessageClient);
 
 type PartResourceProps = {
   part: ThreadAssistantMessagePart | ThreadUserMessagePart;
+  messageId: string;
   onRespondToToolApproval?:
     | ((options: RespondToToolApprovalOptions) => void)
     | undefined;
+  onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
 };
 
 // Part Client - minimal implementation
 const usePartResource = ({
   part,
+  messageId,
   onRespondToToolApproval,
+  onAddToolResult,
 }: PartResourceProps): ClientOutput<"part"> => {
   const state = useMemo(
     () => ({
@@ -240,7 +266,24 @@ const usePartResource = ({
 
   return {
     getState: () => state,
-    addToolResult: () => {},
+    addToolResult: (result) => {
+      if (!onAddToolResult) return;
+      if (part.type !== "tool-call")
+        throw new Error("Tried to add tool result on non-tool message part");
+
+      const response = ToolResponse.toResponse(result);
+      onAddToolResult({
+        messageId,
+        toolName: part.toolName,
+        toolCallId: part.toolCallId,
+        result: response.result as ReadonlyJSONValue,
+        isError: response.isError,
+        ...(response.artifact !== undefined && { artifact: response.artifact }),
+        ...(response.modelContent !== undefined && {
+          modelContent: response.modelContent,
+        }),
+      });
+    },
     resumeToolCall: () => {},
     respondToToolApproval: (response) => {
       if (!onRespondToToolApproval)
@@ -269,7 +312,7 @@ const PartResource = resource(usePartResource);
 
 type AttachmentResourceProps = {
   attachment: Attachment;
-  onRemove?: () => void;
+  onRemove?: () => void | Promise<void>;
 };
 
 // Attachment Client - minimal implementation
@@ -280,7 +323,7 @@ const useAttachmentResource = ({
   return {
     getState: () => attachment,
     remove: async () => {
-      onRemove?.();
+      await onRemove?.();
     },
   };
 };
@@ -297,6 +340,7 @@ type ComposerClientResourceProps = {
   onSend?: (message: AppendMessage) => void;
   message?: ExternalThreadMessage;
   queue?: ExternalThreadQueueAdapter | undefined;
+  attachmentAdapter?: AttachmentAdapter | undefined;
 };
 
 const useQueueItemClient = ({
@@ -328,6 +372,7 @@ const useComposerClientResource = ({
   onSend,
   message,
   queue,
+  attachmentAdapter,
 }: ComposerClientResourceProps): ClientOutput<"composer"> => {
   const [text, setText] = useState("");
   const [role, setRole] = useState<"user" | "assistant" | "system">("user");
@@ -359,18 +404,31 @@ const useComposerClientResource = ({
   }, [isEditing]);
 
   const attachmentClients = useClientLookup(
-    attachments.map((attachment, idx) =>
+    attachments.map((attachment) =>
       withKey(
         attachment.id,
         AttachmentResource({
           attachment,
-          onRemove: () => {
-            setAttachments(attachments.filter((_, i) => i !== idx));
+          onRemove: async () => {
+            await attachmentAdapter?.remove(attachment);
+            setAttachments((prev) =>
+              prev.filter((a) => a.id !== attachment.id),
+            );
           },
         }),
       ),
     ),
   );
+
+  const upsertAttachment = (attachment: Attachment) => {
+    setAttachments((prev) => {
+      const idx = prev.findIndex((a) => a.id === attachment.id);
+      if (idx === -1) return [...prev, attachment];
+      const next = [...prev];
+      next[idx] = attachment;
+      return next;
+    });
+  };
 
   const queueItems = queue?.items ?? EMPTY_QUEUE_ITEMS;
   const queueItemClients = useClientLookup(
@@ -396,7 +454,7 @@ const useComposerClientResource = ({
       isEditing,
       canCancel,
       canSend: isEditing && !isEmpty && !isSendDisabled,
-      attachmentAccept: "*",
+      attachmentAccept: attachmentAdapter?.accept ?? "*",
       isEmpty,
       type,
       dictation: undefined,
@@ -415,6 +473,7 @@ const useComposerClientResource = ({
     attachments.length,
     quote,
     queueItems,
+    attachmentAdapter?.accept,
   ]);
 
   return {
@@ -423,7 +482,16 @@ const useComposerClientResource = ({
     setRole,
     setRunConfig,
     addAttachment: async (fileOrAttachment: File | CreateAttachment) => {
-      if (!isCreateAttachment(fileOrAttachment)) {
+      if (!isCreateAttachment(fileOrAttachment) && attachmentAdapter) {
+        const result = attachmentAdapter.add({ file: fileOrAttachment });
+        if (Symbol.asyncIterator in result) {
+          for await (const attachment of result) {
+            upsertAttachment(attachment);
+          }
+        } else {
+          upsertAttachment(await result);
+        }
+      } else if (!isCreateAttachment(fileOrAttachment)) {
         const newAttachment: Attachment = {
           id: Math.random().toString(36).substring(7),
           type: "file",
@@ -466,27 +534,46 @@ const useComposerClientResource = ({
       if (!state.canSend) return;
 
       const currentQuote = quote;
-      const composedMessage: AppendMessage = {
-        role,
-        content: text ? [{ type: "text" as const, text }] : [],
-        attachments: attachments as any,
-        createdAt: new Date(),
-        parentId: null,
-        sourceId: null,
-        runConfig,
-        startRun: opts?.startRun,
-        metadata: {
-          custom: { ...(currentQuote ? { quote: currentQuote } : {}) },
-        },
-      };
-      if (queue) {
-        queue.enqueue(composedMessage, { steer: opts?.steer ?? false });
-      } else {
-        onSend?.(composedMessage);
-      }
+      const currentText = text;
+      const currentAttachments = attachments;
       setText("");
       setAttachments([]);
       setQuote(undefined);
+
+      const dispatch = (sendAttachments: readonly Attachment[]) => {
+        const composedMessage: AppendMessage = {
+          role,
+          content: currentText
+            ? [{ type: "text" as const, text: currentText }]
+            : [],
+          attachments: sendAttachments as any,
+          createdAt: new Date(),
+          parentId: null,
+          sourceId: null,
+          runConfig,
+          startRun: opts?.startRun,
+          metadata: {
+            custom: { ...(currentQuote ? { quote: currentQuote } : {}) },
+          },
+        };
+        if (queue) {
+          queue.enqueue(composedMessage, { steer: opts?.steer ?? false });
+        } else {
+          onSend?.(composedMessage);
+        }
+      };
+
+      if (attachmentAdapter && currentAttachments.length > 0) {
+        void Promise.all(
+          currentAttachments.map((attachment) =>
+            attachment.status.type === "complete"
+              ? attachment
+              : attachmentAdapter.send(attachment as PendingAttachment),
+          ),
+        ).then(dispatch);
+      } else {
+        dispatch(currentAttachments);
+      }
     },
     cancel: onCancel,
     beginEdit: () => {
@@ -507,12 +594,19 @@ const ComposerClientResource = resource(useComposerClientResource);
 const useExternalThread = ({
   messages,
   isRunning = false,
+  isLoading = false,
+  state: threadState,
+  extras,
   isSendDisabled = false,
   onNew,
   onEdit,
   onReload,
   onStartRun,
   onCancel,
+  onResume,
+  onAddToolResult,
+  onLoadExternalState,
+  attachmentAdapter,
   queue,
   branches,
   onRespondToToolApproval,
@@ -535,6 +629,7 @@ const useExternalThread = ({
         queue,
         branches,
         onRespondToToolApproval,
+        onAddToolResult,
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));
@@ -559,11 +654,15 @@ const useExternalThread = ({
       onCancel: handleCancelRun,
       onSend: handleSendNew,
       queue,
+      attachmentAdapter,
     }),
   );
 
   const hasQueue = !!queue;
   const hasBranches = !!branches;
+  const hasEdit = !!onEdit;
+  const hasReload = !!onReload;
+  const hasAttachments = !!attachmentAdapter;
   const state = useMemo(() => {
     const messageStates = messageClients.state.map((s, idx, arr) => ({
       ...s,
@@ -573,15 +672,15 @@ const useExternalThread = ({
     return {
       isEmpty: messages.length === 0,
       isDisabled: false,
-      isLoading: false,
+      isLoading,
       isRunning,
       capabilities: {
-        edit: false,
+        edit: hasEdit,
         delete: false,
-        reload: false,
+        reload: hasReload,
         cancel: isRunning,
         speech: false,
-        attachments: false,
+        attachments: hasAttachments,
         feedback: false,
         voice: false,
         switchToBranch: hasBranches,
@@ -591,9 +690,9 @@ const useExternalThread = ({
         queue: hasQueue,
       },
       messages: messageStates,
-      state: {},
+      state: threadState ?? {},
       suggestions: [],
-      extras: undefined,
+      extras,
       speech: undefined,
       voice: undefined,
       composer: composerClient.state,
@@ -601,8 +700,14 @@ const useExternalThread = ({
   }, [
     messages,
     isRunning,
+    isLoading,
+    threadState,
+    extras,
     hasQueue,
     hasBranches,
+    hasEdit,
+    hasReload,
+    hasAttachments,
     messageClients.state,
     composerClient.state,
   ]);
@@ -644,8 +749,13 @@ const useExternalThread = ({
     startRun: () => {
       onStartRun?.();
     },
-    resumeRun: () => {},
+    resumeRun: () => {
+      onResume?.();
+    },
     cancelRun: handleCancelRun,
+    importExternalState: (state: unknown) => {
+      onLoadExternalState?.(state);
+    },
     getModelContext: () => ({ tools: {}, config: {} }),
     export: () => ({ messages: [] }),
     import: () => {},

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -17,6 +17,7 @@ import type {
   CreateAttachment,
   PendingAttachment,
   RespondToToolApprovalOptions,
+  ResumeToolCallOptions,
   ThreadAssistantMessagePart,
   ThreadUserMessagePart,
   ThreadMessage,
@@ -67,6 +68,8 @@ export type ExternalThreadProps = {
   onCancel?: () => void;
   onResume?: (() => void) | undefined;
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
+  /** Callback for resuming a tool call that is waiting for human input. */
+  onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   onLoadExternalState?: ((state: unknown) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
   /** Queue adapter for runtimes that support message queuing and steering. */
@@ -80,6 +83,7 @@ export type ExternalThreadProps = {
 type MessageClientProps = {
   message: ExternalThreadMessage;
   index: number;
+  parentId: string | null;
   onEdit?: (message: AppendMessage) => void;
   onReload?: () => void;
   queue?: ExternalThreadQueueAdapter | undefined;
@@ -88,18 +92,21 @@ type MessageClientProps = {
     | ((options: RespondToToolApprovalOptions) => void)
     | undefined;
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
+  onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
 };
 
 // Message Client - minimal implementation
 const useMessageClient = ({
   message,
   index,
+  parentId,
   onEdit,
   onReload,
   queue,
   branches,
   onRespondToToolApproval,
   onAddToolResult,
+  onResumeToolCall,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -114,6 +121,7 @@ const useMessageClient = ({
           messageId: message.id,
           onRespondToToolApproval,
           onAddToolResult,
+          onResumeToolCall,
         }),
       ),
     ),
@@ -143,7 +151,7 @@ const useMessageClient = ({
     queue?.clear("edit");
     onEdit?.({
       ...msg,
-      parentId: message.id,
+      parentId,
       sourceId: message.id,
     });
     setIsEditing(false);
@@ -171,7 +179,7 @@ const useMessageClient = ({
     return {
       ...message,
       attachments: message.attachments ?? [],
-      parentId: null,
+      parentId,
       isLast: false, // Will be set by thread
       branchNumber,
       branchCount,
@@ -184,6 +192,7 @@ const useMessageClient = ({
     };
   }, [
     message,
+    parentId,
     isCopied,
     isHovering,
     index,
@@ -247,6 +256,7 @@ type PartResourceProps = {
     | ((options: RespondToToolApprovalOptions) => void)
     | undefined;
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
+  onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
 };
 
 // Part Client - minimal implementation
@@ -255,6 +265,7 @@ const usePartResource = ({
   messageId,
   onRespondToToolApproval,
   onAddToolResult,
+  onResumeToolCall,
 }: PartResourceProps): ClientOutput<"part"> => {
   const state = useMemo(
     () => ({
@@ -284,7 +295,13 @@ const usePartResource = ({
         }),
       });
     },
-    resumeToolCall: () => {},
+    resumeToolCall: (payload) => {
+      if (!onResumeToolCall) return;
+      if (part.type !== "tool-call")
+        throw new Error("Tried to resume tool call on non-tool message part");
+
+      onResumeToolCall({ toolCallId: part.toolCallId, payload });
+    },
     respondToToolApproval: (response) => {
       if (!onRespondToToolApproval)
         throw new Error("Runtime does not support tool approvals.");
@@ -605,6 +622,7 @@ const useExternalThread = ({
   onCancel,
   onResume,
   onAddToolResult,
+  onResumeToolCall,
   onLoadExternalState,
   attachmentAdapter,
   queue,
@@ -625,11 +643,13 @@ const useExternalThread = ({
       const props: MessageClientProps = {
         message: msg,
         index,
+        parentId: index > 0 ? messages[index - 1]!.id : null,
         onReload: () => handleReload(msg.id),
         queue,
         branches,
         onRespondToToolApproval,
         onAddToolResult,
+        onResumeToolCall,
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -587,7 +587,16 @@ const useComposerClientResource = ({
               ? attachment
               : attachmentAdapter.send(attachment as PendingAttachment),
           ),
-        ).then(dispatch);
+        ).then(dispatch, (error) => {
+          // Upload failed: restore the draft instead of dropping the message,
+          // unless the user already started composing a new one.
+          setText((prev) => (prev ? prev : currentText));
+          setQuote((prev) => prev ?? currentQuote);
+          setAttachments((prev) =>
+            prev.length > 0 ? prev : currentAttachments,
+          );
+          console.error("Failed to send attachments", error);
+        });
       } else {
         dispatch(currentAttachments);
       }

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -413,6 +413,19 @@ const useQueueItemClient = ({
 
 const QueueItemClient = resource(useQueueItemClient);
 
+const drainAdapterAdd = async (
+  result: ReturnType<AttachmentAdapter["add"]>,
+  upsert: (attachment: Attachment) => void,
+) => {
+  if (Symbol.asyncIterator in result) {
+    for await (const attachment of result) {
+      upsert(attachment);
+    }
+  } else {
+    upsert(await result);
+  }
+};
+
 // State whose setter tracks the latest value in a ref, so imperative
 // call sequences (setText immediately followed by send) observe the write
 // before React re-renders — legacy composer parity.
@@ -555,14 +568,10 @@ const useComposerClientResource = ({
     setRunConfig,
     addAttachment: async (fileOrAttachment: File | CreateAttachment) => {
       if (!isCreateAttachment(fileOrAttachment) && attachmentAdapter) {
-        const result = attachmentAdapter.add({ file: fileOrAttachment });
-        if (Symbol.asyncIterator in result) {
-          for await (const attachment of result) {
-            upsertAttachment(attachment);
-          }
-        } else {
-          upsertAttachment(await result);
-        }
+        await drainAdapterAdd(
+          attachmentAdapter.add({ file: fileOrAttachment }),
+          upsertAttachment,
+        );
       } else if (!isCreateAttachment(fileOrAttachment)) {
         const newAttachment: Attachment = {
           id: Math.random().toString(36).substring(7),

--- a/packages/react/src/tests/external-thread-attachments.test.tsx
+++ b/packages/react/src/tests/external-thread-attachments.test.tsx
@@ -4,7 +4,29 @@ import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
+import type { ExternalThreadProps } from "../client/ExternalThread";
 import { ExternalThread } from "../client/ExternalThread";
+
+const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC = () => {
+    const aui = useAui({
+      thread: ExternalThread({ messages: [], isRunning: false, ...props }),
+    });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+
+  render(<App />);
+  return () => captured.aui!;
+};
 
 const renderThread = () => {
   const captured: { aui?: ReturnType<typeof useAui> } = {};
@@ -77,5 +99,69 @@ describe("ExternalThread attachments", () => {
       contentType: "image/png",
       file: foreignFile,
     });
+  });
+
+  it("restores the draft when an attachment upload fails on send", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const sent: unknown[] = [];
+    let rejectSend!: (reason: unknown) => void;
+    const adapter = {
+      accept: "*",
+      add: async ({ file }: { file: File }) => ({
+        id: "att-1",
+        type: "file" as const,
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: {
+          type: "requires-action" as const,
+          reason: "composer-send" as const,
+        },
+      }),
+      send: () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }) as never,
+      remove: async () => {},
+    };
+
+    const aui = renderThreadWithProps({
+      attachmentAdapter: adapter,
+      onNew: (message) => sent.push(message),
+    });
+
+    await act(() =>
+      aui()
+        .thread()
+        .composer()
+        .addAttachment(new File(["data"], "notes.txt", { type: "text/plain" })),
+    );
+    await act(async () => {
+      aui().thread().composer().setText("hello");
+    });
+    await act(async () => {
+      aui().thread().composer().send();
+    });
+
+    // The draft is cleared optimistically while the upload runs.
+    expect(aui().thread().composer().getState().text).toBe("");
+
+    await act(async () => {
+      rejectSend(new Error("upload failed"));
+    });
+
+    await waitFor(() => {
+      const state = aui().thread().composer().getState();
+      expect(state.text).toBe("hello");
+      expect(state.attachments).toHaveLength(1);
+    });
+    expect(sent).toHaveLength(0);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to send attachments",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
   });
 });

--- a/packages/react/src/tests/external-thread-attachments.test.tsx
+++ b/packages/react/src/tests/external-thread-attachments.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
 import type { ExternalThreadProps } from "../client/ExternalThread";
 import { ExternalThread } from "../client/ExternalThread";
@@ -162,6 +162,9 @@ describe("ExternalThread attachments", () => {
       "Failed to send attachments",
       expect.any(Error),
     );
-    consoleError.mockRestore();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 });

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+// Legacy-runtime parity: part statuses derive from the message status, and
+// imperative composer call sequences observe writes before React re-renders.
+
+import { render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { useAui, AuiProvider } from "@assistant-ui/store";
+import type { ThreadMessage } from "@assistant-ui/core";
+import {
+  ExternalThread,
+  type ExternalThreadProps,
+  type ExternalThreadMessage,
+} from "../client/ExternalThread";
+
+const renderThread = (props: ExternalThreadProps) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC<{ threadProps: ExternalThreadProps }> = ({ threadProps }) => {
+    const aui = useAui({ thread: ExternalThread(threadProps) });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+  const utils = render(<App threadProps={props} />);
+  return {
+    aui: () => captured.aui!,
+    rerender: (next: ExternalThreadProps) =>
+      utils.rerender(<App threadProps={next} />),
+  };
+};
+
+const assistantMessage = (
+  status: ThreadMessage["status"],
+  result?: string,
+): ExternalThreadMessage =>
+  ({
+    id: "a1",
+    role: "assistant",
+    content: [
+      { type: "text", text: "let me check" },
+      {
+        type: "tool-call",
+        toolCallId: "tc1",
+        toolName: "probe_tool",
+        args: {},
+        argsText: "{}",
+        ...(result !== undefined && { result }),
+      },
+    ],
+    createdAt: new Date(0),
+    status,
+    metadata: { custom: {} },
+  }) as unknown as ExternalThreadMessage;
+
+describe("ExternalThread part status", () => {
+  it("gives an unresolved tool call its message's status", () => {
+    const { aui } = renderThread({
+      messages: [assistantMessage({ type: "running" })],
+      isRunning: true,
+    });
+    const part = (toolCallId: string) =>
+      aui().thread().message({ id: "a1" }).part({ toolCallId }).getState();
+    expect(part("tc1").status).toEqual({ type: "running" });
+  });
+
+  it("marks a resolved tool call complete and streams only the last part", () => {
+    const { aui } = renderThread({
+      messages: [assistantMessage({ type: "running" }, "ok")],
+      isRunning: true,
+    });
+    const state = aui().thread().message({ id: "a1" }).getState();
+    expect(state.parts[0]!.status).toEqual({ type: "complete" });
+    expect(state.parts[1]!.status).toEqual({ type: "complete" });
+  });
+
+  it("keeps parts complete on requires-action and user messages", () => {
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+        assistantMessage({ type: "requires-action", reason: "tool-calls" }),
+      ],
+      isRunning: false,
+    });
+    expect(
+      aui().thread().message({ id: "u1" }).part({ index: 0 }).getState().status,
+    ).toEqual({ type: "complete" });
+    expect(
+      aui()
+        .thread()
+        .message({ id: "a1" })
+        .part({ toolCallId: "tc1" })
+        .getState().status,
+    ).toEqual({ type: "requires-action", reason: "tool-calls" });
+    expect(
+      aui().thread().message({ id: "a1" }).part({ index: 0 }).getState().status,
+    ).toEqual({ type: "complete" });
+  });
+});
+
+describe("ExternalThread composer", () => {
+  it("dispatches a synchronous setText + send sequence", async () => {
+    const onNew = vi.fn();
+    const { aui } = renderThread({ messages: [], isRunning: false, onNew });
+
+    aui().thread().composer().setText("hello");
+    aui().thread().composer().send();
+
+    await waitFor(() => expect(onNew).toHaveBeenCalledTimes(1));
+    expect(onNew.mock.calls[0]![0].content).toEqual([
+      { type: "text", text: "hello" },
+    ]);
+    await waitFor(() =>
+      expect(aui().thread().getState().composer.text).toBe(""),
+    );
+  });
+
+  it("still refuses to send an empty composer synchronously after a send", async () => {
+    const onNew = vi.fn();
+    const { aui } = renderThread({ messages: [], isRunning: false, onNew });
+
+    aui().thread().composer().send();
+    aui().thread().composer().setText("first");
+    aui().thread().composer().send();
+    aui().thread().composer().send();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onNew).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Six sequential commits bringing ExternalThread to parity with the assistant-transport runtime:

- feat(external-thread): additive props — `isLoading`, `state`, `extras`, `onResume`, `onAddToolResult`, `onLoadExternalState`, `attachmentAdapter`; `importExternalState` thread method
- feat(core): export `ToolInvocationTracker` from internal for framework bindings
- feat(external-thread): `onResumeToolCall` prop; edit sends real `parentId`/`sourceId`
- fix(external-thread): composer sends stamp the thread head as `parentId`
- fix(external-thread): restore the composer draft when an attachment upload fails on send
- fix(external-thread): derive part status from message status; composer send reads live drafts

Patch changesets for `@assistant-ui/react` and `@assistant-ui/core` included.

## Validation
- `pnpm --filter @assistant-ui/core test` (680 passing) + build
- `pnpm --filter @assistant-ui/react test` (508 passing) + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.WRsed-wi7y1Q-O-Tl_s-2_yvJAk-0li3Vcl46fc3jTldp_mobQBWP8dFui8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->