### PR TITLE
fix(assistant-transport): mark commands delivered on chunk-less successful runs

### DIFF
--- a/.changeset/assistant-transport-markdelivered-on-completion.md
+++ b/.changeset/assistant-transport-markdelivered-on-completion.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: assistant-transport marks in-transit commands delivered when a run completes successfully without state chunks, instead of leaving them pending forever

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
@@ -22,13 +22,7 @@ const emptySuccessfulResponse = () =>
   );
 
 const setupRuntime = () => {
-  const requestBodies: { commands: AssistantTransportCommand[] }[] = [];
-  const fetchMock = vi.fn(
-    async (_url: RequestInfo | URL, init?: RequestInit) => {
-      requestBodies.push(JSON.parse(init!.body as string));
-      return emptySuccessfulResponse();
-    },
-  );
+  const fetchMock = vi.fn(async () => emptySuccessfulResponse());
   vi.stubGlobal("fetch", fetchMock);
 
   const pendingRef: { current: AssistantTransportCommand[] } = { current: [] };
@@ -56,7 +50,7 @@ const setupRuntime = () => {
     );
   };
 
-  return { App, fetchMock, requestBodies, pendingRef, runtimeRef };
+  return { App, fetchMock, pendingRef, runtimeRef };
 };
 
 describe("assistant transport delivery contracts", () => {
@@ -64,9 +58,8 @@ describe("assistant transport delivery contracts", () => {
     vi.unstubAllGlobals();
   });
 
-  it("clears in-transit commands when a run succeeds without state chunks and does not re-send them", async () => {
-    const { App, fetchMock, requestBodies, pendingRef, runtimeRef } =
-      setupRuntime();
+  it("clears in-transit commands when a run succeeds without state chunks", async () => {
+    const { App, fetchMock, pendingRef, runtimeRef } = setupRuntime();
 
     await act(async () => {
       render(<App />);
@@ -82,13 +75,5 @@ describe("assistant transport delivery contracts", () => {
       expect(runtimeRef.current!.thread.getState().isRunning).toBe(false),
     );
     expect(pendingRef.current).toHaveLength(0);
-
-    await act(async () => {
-      runtimeRef.current!.thread.append("m2");
-    });
-
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
-    expect(requestBodies[1]!.commands).toHaveLength(1);
-    expect(JSON.stringify(requestBodies[1])).not.toContain("m1");
   });
 });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FC } from "react";
+import { useAssistantTransportRuntime } from "./useAssistantTransportRuntime";
+import type { AssistantRuntime } from "../../runtime/AssistantRuntime";
+import { AssistantRuntimeProvider } from "../../../context";
+import type {
+  AssistantTransportCommand,
+  AssistantTransportStateConverter,
+} from "./types";
+
+const emptySuccessfulResponse = () =>
+  new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+
+const setupRuntime = () => {
+  const requestBodies: { commands: AssistantTransportCommand[] }[] = [];
+  const fetchMock = vi.fn(
+    async (_url: RequestInfo | URL, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(init!.body as string));
+      return emptySuccessfulResponse();
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  const pendingRef: { current: AssistantTransportCommand[] } = { current: [] };
+  const converter: AssistantTransportStateConverter<Record<string, never>> = (
+    _state,
+    { pendingCommands, isSending },
+  ) => {
+    pendingRef.current = pendingCommands;
+    return { messages: [], isRunning: isSending };
+  };
+
+  const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+  const App: FC = () => {
+    const runtime = useAssistantTransportRuntime({
+      initialState: {},
+      api: "http://localhost/api",
+      converter,
+      headers: {},
+    });
+    runtimeRef.current = runtime;
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        {null}
+      </AssistantRuntimeProvider>
+    );
+  };
+
+  return { App, fetchMock, requestBodies, pendingRef, runtimeRef };
+};
+
+describe("assistant transport delivery contracts", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("clears in-transit commands when a run succeeds without state chunks and does not re-send them", async () => {
+    const { App, fetchMock, requestBodies, pendingRef, runtimeRef } =
+      setupRuntime();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await waitFor(() => expect(runtimeRef.current).not.toBeNull());
+
+    await act(async () => {
+      runtimeRef.current!.thread.append("m1");
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(runtimeRef.current!.thread.getState().isRunning).toBe(false),
+    );
+    expect(pendingRef.current).toHaveLength(0);
+
+    await act(async () => {
+      runtimeRef.current!.thread.append("m2");
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(requestBodies[1]!.commands).toHaveLength(1);
+    expect(JSON.stringify(requestBodies[1])).not.toContain("m1");
+  });
+});

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-delivery.test.tsx
@@ -74,6 +74,6 @@ describe("assistant transport delivery contracts", () => {
     await waitFor(() =>
       expect(runtimeRef.current!.thread.getState().isRunning).toBe(false),
     );
-    expect(pendingRef.current).toHaveLength(0);
+    await waitFor(() => expect(pendingRef.current).toHaveLength(0));
   });
 });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -49,6 +49,10 @@ setInTransitCommands(commands);
         setInTransitCommands(EMPTY_ARRAY);
         setSnapshot(snapshot);
       }
+
+      // A run that completes successfully confirms delivery even if no
+      // state chunk arrived — clear in-transit commands here as well.
+      setInTransitCommands(EMPTY_ARRAY);
     } catch (error) {
       // Do not restore commands. Surface error to onError for state update.
       callbacks.onError?.({

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -50,8 +50,9 @@ setInTransitCommands(commands);
         setSnapshot(snapshot);
       }
 
-      // A run that completes successfully confirms delivery even if no
-      // state chunk arrived — clear in-transit commands here as well.
+      // A run that completes successfully confirms delivery even when no
+      // state-changing chunk was observed — clear in-transit commands here
+      // as well.
       setInTransitCommands(EMPTY_ARRAY);
     } catch (error) {
       // Do not restore commands. Surface error to onError for state update.

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -233,7 +233,8 @@ const useAssistantTransportThreadRuntime = <T>(
         throw new Error(err);
       }
 
-      // A successful run confirms delivery even if no state chunk arrived.
+      // A successful run confirms delivery even when no state-changing
+      // chunk was observed.
       if (!markedDelivered) {
         commandQueue.markDelivered();
       }

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -232,6 +232,11 @@ const useAssistantTransportThreadRuntime = <T>(
       if (err) {
         throw new Error(err);
       }
+
+      // A successful run confirms delivery even if no state chunk arrived.
+      if (!markedDelivered) {
+        commandQueue.markDelivered();
+      }
     },
     onFinish: options.onFinish,
     onCancel: () => {


### PR DESCRIPTION
## Summary
- In the legacy assistant-transport runtime, delivery was only inferred from the first state-mutating chunk (`commandQueue.markDelivered()` on the first `unstable_state` change). A run that completed successfully with zero state chunks never cleared `inTransit` commands, leaving them in `pendingCommands` indefinitely — so converters kept rendering the optimistic pending UI forever.
- Fix: on successful stream completion, `markDelivered` is called even when no state chunk arrived. Error and cancel paths are unchanged.
- Adds a regression test (`transport-delivery.test.tsx`) exercising the real runtime with a mocked fetch: a chunk-less successful run clears pending commands. The test fails without the fix.
- Updates `useAssistantTransport.spec.md` to state the delivery rule; patch changeset for `@assistant-ui/react`.

No exported/public API changes.

## Validation
- `pnpm --filter @assistant-ui/react test` (all passing, includes new regression test)
- `pnpm --filter @assistant-ui/react build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)