### PR TITLE
docs(skills): butflow review policy — approaches, not diffs

### DIFF
--- a/.claude/skills/butflow/SKILL.md
+++ b/.claude/skills/butflow/SKILL.md
@@ -18,7 +18,7 @@ Implement the change, open a PR through GitButler, monitor CI and reviews, addre
 7. Push with `but push <branch>`.
 8. Open the PR with `gh pr create --title "<title>" --body "<body>"` or another non-interactive form such as `--fill`.
 9. Schedule a 2-minute recurring monitor using the environment's native automation mechanism. In Claude Code, use the available `schedule` or `loop` skill.
-10. Monitor checks and review threads until the merge gate is satisfied, then merge with `gh pr merge <n> --squash --admin`.
+10. Monitor checks and review threads until the merge gate is satisfied, then merge with `gh pr merge <n> --squash --admin` or leave the PR open per the review policy in Merge Gate.
 
 Add a patch changeset only if a published package changed. Private packages such as `@assistant-ui/docs` and `@assistant-ui/shadcn-registry` are exempt.
 
@@ -42,7 +42,7 @@ Every unresolved thread must get a reply and be resolved.
 - Invalid: reply with a short rationale, then resolve.
 - Outdated: if `isOutdated: true`, reply that the diff moved, then resolve.
 
-Use judgment on bot nits. Common-sense suggestions that duplicate what a competent agent already knows are usually reply-and-resolve. Scope creep from long bot-feedback loops is a signal to cut and merge.
+Use judgment on bot nits. Common-sense suggestions that duplicate what a competent agent already knows are usually reply-and-resolve. Scope creep from long bot-feedback loops is a signal to cut.
 
 Do not add comments or changeset prose that only exist to acknowledge review feedback. Test: would you write it if no reviewer had flagged the code? If no, drop it.
 
@@ -58,3 +58,5 @@ gh api graphql -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$
 - No non-cubic reviewer has a current `CHANGES_REQUESTED` state. Address and wait for re-approval instead of dismissing.
 
 Cubic is optional; do not wait for it if the other gates are clear.
+
+A clear gate makes the PR mergeable; whether to merge is a separate call. The maintainer reviews approaches, not diffs. Self-merge when the change is the obvious execution of the prompt. Leave the PR open when getting there took judgment the prompt did not supply: a novel mechanism, a real tradeoff, or any public API change. Say in the PR what needs judging.


### PR DESCRIPTION
Replaces butflow's always-merge-when-gate-clear behavior with the maintainer's review policy: a clear merge gate makes the PR mergeable, but merging is a separate call. Agents self-merge only when the change is the obvious execution of the prompt, and leave the PR open (saying what needs judging) when it took judgment the prompt did not supply: a novel mechanism, a real tradeoff, or any public API change.

Also trims the bot-nit paragraph's "cut and merge" to "cut" so merging is governed in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.LMPJkdR3IKsj2yCO8z5RPhqRmljOUeXcqGZSCJvxLiPJj07Y1abJGFlXfbY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->