### PR TITLE
fix(assistant-transport): consume parentId once per run

### DIFF
--- a/.changeset/assistant-transport-parentid-consumed-per-run.md
+++ b/.changeset/assistant-transport-parentid-consumed-per-run.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: assistant-transport consumes parentId once per run; later unrelated runs no longer re-send the last append's parentId

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-parentid.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-parentid.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FC } from "react";
+import { useAssistantTransportRuntime } from "./useAssistantTransportRuntime";
+import type { AssistantRuntime } from "../../runtime/AssistantRuntime";
+import { AssistantRuntimeProvider } from "../../../context";
+import type {
+  AssistantTransportCommand,
+  AssistantTransportStateConverter,
+} from "./types";
+
+const emptySuccessfulResponse = () =>
+  new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+
+const setupRuntime = () => {
+  const requestBodies: Record<string, unknown>[] = [];
+  const fetchMock = vi.fn(
+    async (_url: RequestInfo | URL, init?: RequestInit) => {
+      requestBodies.push(JSON.parse(init!.body as string));
+      return emptySuccessfulResponse();
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+
+  const converter: AssistantTransportStateConverter<Record<string, never>> = (
+    _state,
+    { isSending },
+  ) => ({ messages: [], isRunning: isSending });
+
+  const runtimeRef: { current: AssistantRuntime | null } = { current: null };
+  const App: FC = () => {
+    const runtime = useAssistantTransportRuntime({
+      initialState: {},
+      api: "http://localhost/api",
+      converter,
+      headers: {},
+    });
+    runtimeRef.current = runtime;
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        {null}
+      </AssistantRuntimeProvider>
+    );
+  };
+
+  return { App, fetchMock, requestBodies, runtimeRef };
+};
+
+describe("assistant transport parentId lifetime", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("consumes parentId per run: the append's run carries it, a later sendCommand run omits it", async () => {
+    const { App, fetchMock, requestBodies, runtimeRef } = setupRuntime();
+
+    await act(async () => {
+      render(<App />);
+    });
+    await waitFor(() => expect(runtimeRef.current).not.toBeNull());
+
+    await act(async () => {
+      runtimeRef.current!.thread.append("m1");
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(runtimeRef.current!.thread.getState().isRunning).toBe(false),
+    );
+    expect(Object.hasOwn(requestBodies[0]!, "parentId")).toBe(true);
+
+    const extras = runtimeRef.current!.thread.getState().extras as {
+      sendCommand: (command: AssistantTransportCommand) => void;
+    };
+    await act(async () => {
+      extras.sendCommand({
+        type: "add-tool-result",
+        toolCallId: "t1",
+        toolName: "tool",
+        result: {},
+        isError: false,
+      });
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    expect(Object.hasOwn(requestBodies[1]!, "parentId")).toBe(false);
+  });
+});

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -139,9 +139,9 @@ const useAssistantTransportThreadRuntime = <T>(
         throw new Error("No commands to send");
 
       // The flushed batch consumes the parentId; read it alongside the flush
-      // (before any awaits) so a mid-run append keeps its own value, and skip
-      // the clear on resume runs, whose queued commands are yet to be sent.
-      const parentId = parentIdRef.current;
+      // (before any awaits) so a mid-run append keeps its own value. Resume
+      // runs send no commands, so they neither send nor consume it.
+      const parentId = isResume ? undefined : parentIdRef.current;
       if (!isResume) parentIdRef.current = undefined;
 
       const headers = await createRequestHeaders(options.headers);

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -145,14 +145,18 @@ const useAssistantTransportThreadRuntime = <T>(
           : options.body;
       const context = runtime.thread.getModelContext();
 
+      // Each run consumes the parentId once; unrelated later runs omit it.
+      const parentId = parentIdRef.current;
+      parentIdRef.current = undefined;
+
       let requestBody: Record<string, unknown> = {
         commands,
         state: agentStateRef.current,
         system: context.system,
         tools: context.tools ? toToolsJSONSchema(context.tools) : undefined,
         threadId,
-        ...(parentIdRef.current !== undefined && {
-          parentId: parentIdRef.current,
+        ...(parentId !== undefined && {
+          parentId,
         }),
         // nested (new format, aligned with AssistantChatTransport)
         callSettings: context.callSettings,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -138,16 +138,18 @@ const useAssistantTransportThreadRuntime = <T>(
       if (commands.length === 0 && !isResume)
         throw new Error("No commands to send");
 
+      // The flushed batch consumes the parentId; read it alongside the flush
+      // (before any awaits) so a mid-run append keeps its own value, and skip
+      // the clear on resume runs, whose queued commands are yet to be sent.
+      const parentId = parentIdRef.current;
+      if (!isResume) parentIdRef.current = undefined;
+
       const headers = await createRequestHeaders(options.headers);
       const bodyValue =
         typeof options.body === "function"
           ? await options.body()
           : options.body;
       const context = runtime.thread.getModelContext();
-
-      // Each run consumes the parentId once; unrelated later runs omit it.
-      const parentId = parentIdRef.current;
-      parentIdRef.current = undefined;
 
       let requestBody: Record<string, unknown> = {
         commands,


### PR DESCRIPTION
## Summary
- In the legacy assistant-transport runtime, `parentIdRef` was written by append/edit/reload and never cleared, so every subsequent run posted the last-written value — including runs triggered purely by `sendCommand` that have nothing to do with that message.
- Fix: each run consumes the parentId once — it is read when the request body is built and the ref is reset immediately after the consuming read. A later unrelated run omits the field; an append landing mid-run still carries its value into the coalesced next flush because it rewrites the ref after the read.
- Adds a regression test (`transport-parentid.test.tsx`) exercising the real runtime with a mocked fetch: the append's run carries `parentId`, a later `sendCommand`-triggered run omits it. The test fails without the fix.
- Patch changeset for `@assistant-ui/react`. `useAssistantTransport.spec.md` does not document parentId lifetime, so no spec change.

No exported/public API changes.

## Validation
- `pnpm --filter @assistant-ui/react test` (all passing, includes new regression test)
- `pnpm --filter @assistant-ui/react build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-hsHnyiLwOJzAo9Xkn49q_PHxk_0YvsCMX33XvfLcSsmFLdbtVHb6eBzAXg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->