### PR TITLE
fix(assistant-transport): empty follow-up run no-ops instead of erroring

### DIFF
--- a/.changeset/assistant-transport-empty-followup-noop.md
+++ b/.changeset/assistant-transport-empty-followup-noop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(assistant-transport): a follow-up run that finds an empty command queue no-ops instead of erroring "No commands to send"

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -14,6 +14,7 @@ Command Scheduling
   - If a run is in progress: do not start another; mark that a follow-up run is pending.
   - When the current run ends: if commands were scheduled during the run, start a new run and publish them.
   - If no run is in progress: start a run immediately and flush commands to the server.
+- A follow-up run that finds an empty queue is a no-op: no request is sent and no error is surfaced.
 - Scheduling uses `queueMicrotask` to coalesce multiple synchronous enqueues into a single run start.
 
 Command Queue

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -15,13 +15,13 @@ Command Scheduling
   - When the current run ends: if commands were scheduled during the run, start a new run and publish them.
   - If no run is in progress: start a run immediately and flush commands to the server.
 - A follow-up run that finds an empty queue is a no-op: no request is sent and no error is surfaced.
-- Scheduling uses `queueMicrotask` to coalesce multiple synchronous enqueues into a single run start.
+- Runs execute on a `queueMicrotask`, so multiple synchronous enqueues coalesce into a single request: the first run's flush takes all of them, and the coalesced follow-up run no-ops.
 
 Command Queue
 
 `useCommandQueue({ onQueue() { runManager.schedule(); } })`
 
-- `enqueue(cmd)`: Adds a command to the queue. Calls `onQueue` when transitioning from empty → non-empty (coalesced via `queueMicrotask`).
+- `enqueue(cmd, { schedule? })`: Adds a command to the queue. Calls `onQueue` unless `schedule: false`.
 - `flush(): Command[]`: Returns all queued commands, moves them into `inTransit`, and clears the queue.
 - Internal state tracks `inTransit: Command[]` and `queued: Command[]`.
 

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAui } from "@assistant-ui/store";
+import { AssistantRuntimeProvider } from "../../../context";
+import {
+  useAssistantTransportRuntime,
+  useAssistantTransportSendCommand,
+} from "./useAssistantTransportRuntime";
+import type {
+  AssistantTransportCommand,
+  AssistantTransportOptions,
+  AssistantTransportStateConverter,
+} from "./types";
+
+const converter: AssistantTransportStateConverter<unknown> = (
+  _state,
+  meta,
+) => ({
+  messages: [],
+  isRunning: meta.isSending,
+});
+
+const createMessageCommand = (text: string): AssistantTransportCommand => ({
+  type: "add-message",
+  message: {
+    role: "user",
+    parts: [{ type: "text", text }],
+  },
+  parentId: null,
+  sourceId: null,
+});
+
+const createStreamResponse = () => {
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    response: new Response(stream, { status: 200 }),
+    close: () => controller.close(),
+  };
+};
+
+type StreamResponse = ReturnType<typeof createStreamResponse>;
+
+type RecordedRequest = {
+  url: string;
+  init: RequestInit;
+  body: Record<string, any>;
+};
+
+const installFetch = () => {
+  const requests: RecordedRequest[] = [];
+  const servers: StreamResponse[] = [];
+
+  vi.stubGlobal(
+    "fetch",
+    async (url: RequestInfo | URL, init: RequestInit = {}) => {
+      requests.push({
+        url: String(url),
+        init,
+        body: JSON.parse(init.body as string),
+      });
+      const server = createStreamResponse();
+      servers.push(server);
+      return server.response;
+    },
+  );
+
+  return { requests, servers };
+};
+
+const mountRuntime = (
+  options?: Partial<AssistantTransportOptions<unknown>>,
+) => {
+  const captured: {
+    aui?: ReturnType<typeof useAui>;
+    sendCommand?: (command: AssistantTransportCommand) => void;
+  } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    captured.sendCommand = useAssistantTransportSendCommand();
+    return null;
+  };
+  const App: FC = () => {
+    const runtime = useAssistantTransportRuntime({
+      initialState: {},
+      api: "https://example.com/api",
+      headers: {},
+      converter,
+      ...options,
+    });
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <Capture />
+      </AssistantRuntimeProvider>
+    );
+  };
+  const utils = render(<App />);
+  return {
+    aui: () => captured.aui!,
+    sendCommand: (command: AssistantTransportCommand) =>
+      captured.sendCommand!(command),
+    ...utils,
+  };
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useAssistantTransportRuntime", () => {
+  it("no-ops a follow-up run that finds an empty queue", async () => {
+    const fetchMock = installFetch();
+    const onError = vi.fn();
+    const { aui, sendCommand } = mountRuntime({ onError });
+    await waitFor(() =>
+      expect(
+        (aui().thread().getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    // Two synchronous sends coalesce into one request plus one follow-up run.
+    act(() => {
+      sendCommand(createMessageCommand("a"));
+      sendCommand(createMessageCommand("b"));
+    });
+
+    await waitFor(() => expect(fetchMock.requests).toHaveLength(1));
+    expect(
+      fetchMock.requests[0]!.body["commands"].map((c: any) => c.type),
+    ).toEqual(["add-message", "add-message"]);
+
+    act(() => fetchMock.servers[0]!.close());
+
+    await waitFor(() =>
+      expect(aui().thread().getState().isRunning).toBe(false),
+    );
+    await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
+    expect(onError).not.toHaveBeenCalled();
+    expect(fetchMock.requests).toHaveLength(1);
+  });
+});

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -142,7 +142,7 @@ describe("useAssistantTransportRuntime", () => {
     await waitFor(() =>
       expect(aui().thread().getState().isRunning).toBe(false),
     );
-    await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
+    await act(async () => {});
     expect(onError).not.toHaveBeenCalled();
     expect(fetchMock.requests).toHaveLength(1);
   });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -135,8 +135,7 @@ const useAssistantTransportThreadRuntime = <T>(
       resumeFlagRef.current = false;
       setIsReplaying(false);
       const commands: QueuedCommand[] = isResume ? [] : commandQueue.flush();
-      if (commands.length === 0 && !isResume)
-        throw new Error("No commands to send");
+      if (commands.length === 0 && !isResume) return;
 
       const headers = await createRequestHeaders(options.headers);
       const bodyValue =


### PR DESCRIPTION
## Bug

Two synchronous `sendCommand` calls coalesce: the first starts a run whose flush takes both commands, the second marks a follow-up run as pending. When the follow-up run starts, its flush finds an empty queue and the runtime threw `No commands to send` — surfacing an error to `onError` for a race the scheduling itself creates.

## Fix

A run that flushes zero commands (and is not a resume) no-ops: no request is sent, no error is surfaced.

Regression test mounts the full runtime with a mocked fetch, issues two synchronous sends, and asserts exactly one request and no `onError` call. Spec prose updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.tVf8OHgy_VW_3hVctNGN3sduAh6osR9EWLR44LBOEsftjt_VZsUnvk07OxI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->