### PR TITLE
fix(assistant-transport): onError reads live queue state, not a render snapshot

### DIFF
--- a/.changeset/assistant-transport-onerror-live-commands.md
+++ b/.changeset/assistant-transport-onerror-live-commands.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(assistant-transport): onError reads the live in-transit commands at error time instead of a stale render snapshot

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/commandQueue.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/commandQueue.ts
@@ -56,7 +56,10 @@ export const useCommandQueue = (opts: { onQueue: () => void }) => {
   }, []);
 
   return {
-    state: queueStateRef.current,
+    // live getter — callbacks firing between renders must not see a stale snapshot
+    get state() {
+      return queueStateRef.current;
+    },
     enqueue,
     flush,
     markDelivered,

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -29,6 +29,7 @@ const useTransportSchedulingHarness = (
   opts: {
     onRun?: (signal: AbortSignal) => Promise<void> | void;
     onCancel?: (commands: AssistantTransportCommand[]) => void;
+    onError?: (commands: AssistantTransportCommand[]) => void;
   } = {},
 ) => {
   const commandQueueRef = useRef<ReturnType<typeof useCommandQueue> | null>(
@@ -49,7 +50,8 @@ const useTransportSchedulingHarness = (
       opts.onCancel?.(commands);
     },
     onError: async () => {
-      // not needed for these contract tests
+      const queue = commandQueueRef.current!;
+      opts.onError?.([...queue.state.inTransit]);
     },
   });
 
@@ -119,6 +121,27 @@ describe("assistant transport scheduling contracts", () => {
       expect(result.current.runBatchesRef.current).toHaveLength(1);
     });
     expect(result.current.runBatchesRef.current[0]).toHaveLength(1);
+  });
+
+  it("onError receives the live in-transit commands at error time", async () => {
+    const seen: AssistantTransportCommand[][] = [];
+    const { result } = renderHook(() =>
+      useTransportSchedulingHarness({
+        onRun: () => {
+          throw new Error("network error");
+        },
+        onError: (commands) => seen.push(commands),
+      }),
+    );
+
+    act(() => {
+      result.current.commandQueue.enqueue(createMessageCommand("m1"));
+    });
+
+    // The flush that moved m1 into transit has not re-rendered yet when the
+    // error fires; the queue state must be read live, not from a render snapshot.
+    await waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0]).toEqual([createMessageCommand("m1")]);
   });
 
   it("cancel returns combined in-flight and queued commands", async () => {


### PR DESCRIPTION
## Bug

`useCommandQueue` returned `state` as a value snapshotted at render time. The run's `flush()` mutates the queue ref and schedules a re-render, but when the run fails in the same microtask, `onError` fires before that re-render commits — so it read a stale snapshot in which the in-transit commands still looked queued (`commands` was `[]`).

## Fix

`state` is now a live getter over the queue ref, so callbacks firing between renders (`onError`, `onCancel`) see the current queue.

Regression test: a run that flushes a command and throws synchronously must surface that command as in-transit to `onError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sac1iQj6vNsjARN1EWdqIT1HX37l3RjyF73DF1RHF6Sp4dURu64jFDB98wg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->