### PR TITLE
docs: test policy — repro vs contract tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ Default to zero code comments. Delete any comment that restates the code, record
 
 Tests are vitest, colocated beside the module under test and importing it by relative path (never by package name). Cover the converter both ways, the reducer or controller, and each accessor hook in its own `.test.tsx`. Mock with `vi.hoisted` and always spread `...await importOriginal()`; do not use `toMatchSnapshot`.
 
+Repro tests are temporary: marked "repro", written to prove completion of a task, deleted when the work is done, anything worth keeping folded into the real suite.
+
+Contract tests document how complex machinery behaves at its public seams. They stay, and they read as the contract.
+
 ## Do's and don'ts
 
 Do:


### PR DESCRIPTION
Adds the maintainer's test policy (repro tests are temporary; contract tests stay and read as the contract) to the Testing section of AGENTS.md. Docs only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.j6s3f8kaLm2tSrREDt1Zst2bSH5SWdupkATREXDqEE03b-Y3wTUvkOlct7w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->