### PR TITLE
test(react-langgraph): dedupe reconcile tests; reframe regression-tagged suites as contracts

### DIFF
--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -156,7 +156,7 @@ describe("useAISDKRuntime", () => {
     expect(chat.messages[0].parts[1].state).toBe("output-available");
   });
 
-  it("strips stale approval when cancelling a tool pending approval so history stays valid (#4195)", async () => {
+  it("strips stale approval when cancelling a tool pending approval so history stays valid", async () => {
     const chat = createChatHelpers([
       {
         id: "a1",

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -41,7 +41,7 @@ const aiChunk = (
   tool_call_chunks: toolCallChunks,
 });
 
-describe("appendLangChainChunk tool_call id merging (regression #3526)", () => {
+describe("appendLangChainChunk tool_call id merging", () => {
   it("merges chunk arriving with real id into entry that started with empty id", () => {
     let acc: AiMessage | undefined;
     acc = append(
@@ -136,7 +136,7 @@ describe("appendLangChainChunk tool_call id merging (regression #3526)", () => {
   });
 });
 
-describe("appendLangChainChunk updates-event partial_json (regression #5098)", () => {
+describe("appendLangChainChunk updates-event partial_json", () => {
   // Anthropic streams input_json_delta with its own whitespace; the `messages`
   // stream-mode chunks accumulate that text as partial_json. When the node
   // completes, the `updates` event delivers the full AIMessage with parsed

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -802,7 +802,7 @@ describe("convertLangChainMessages UI messages", () => {
   });
 });
 
-describe("convertLangChainMessages tool call id stability (regression #3526)", () => {
+describe("convertLangChainMessages tool call id stability", () => {
   it("synthesizes a stable toolCallId when chunk.id is empty string", () => {
     const result = convertLangChainMessages({
       type: "ai",
@@ -894,28 +894,6 @@ describe("convertLangChainMessages tool call id stability (regression #3526)", (
       .filter((p) => p.type === "tool-call")
       .map((p) => (p as { toolCallId: string }).toolCallId);
     expect(ids).toEqual(["lc-toolcall-ai-1-0", "call_real_abc"]);
-  });
-
-  it("synthesized id is stable across re-renders of the same message", () => {
-    const message: LangChainMessage = {
-      type: "ai",
-      id: "ai-1",
-      content: "",
-      tool_calls: [{ id: "", name: "weather", args: {}, index: 0 }],
-    };
-
-    const r1 = convertLangChainMessages(message);
-    const r2 = convertLangChainMessages(message);
-
-    if (!("content" in r1) || !("content" in r2))
-      throw new Error("Expected assistant messages");
-    const id1 = (
-      r1.content.find((p) => p.type === "tool-call") as { toolCallId: string }
-    ).toolCallId;
-    const id2 = (
-      r2.content.find((p) => p.type === "tool-call") as { toolCallId: string }
-    ).toolCallId;
-    expect(id1).toBe(id2);
   });
 
   it("matches tool_call_chunks by index when chunk.id is empty (preserves args_json)", () => {

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -1061,7 +1061,7 @@ describe("useLangGraphMessages", {}, () => {
     });
   });
 
-  it("uses fresh messages after setMessages (stale closure fix)", async () => {
+  it("uses fresh messages after setMessages", async () => {
     const streamSpy = vi
       .fn()
       .mockImplementation(mockStreamCallbackFactory([metadataEvent]));
@@ -1097,7 +1097,6 @@ describe("useLangGraphMessages", {}, () => {
 
     await waitFor(() => {
       // After truncation + send, should only have the new message
-      // NOT the old "h1" message (which would happen with stale closure)
       expect(result.current.messages).toHaveLength(1);
       expect(result.current.messages[0]!.id).toBe("h2");
       expect(result.current.messages[0]!.content).toBe("edited");
@@ -1795,57 +1794,7 @@ describe("useLangGraphMessages", {}, () => {
     });
   });
 
-  it("reconciles tuple-accumulated messages with final values snapshot", async () => {
-    const mockStreamCallback = mockStreamCallbackFactory([
-      metadataEvent,
-      {
-        event: "messages",
-        data: [
-          {
-            id: "run-1",
-            content: "Streaming response",
-            type: "AIMessageChunk",
-            tool_call_chunks: [],
-          },
-          { run_attempt: 1 },
-        ],
-      },
-      {
-        event: "values",
-        data: {
-          messages: [
-            { id: "user-1", type: "human" as const, content: "hi" },
-            { id: "run-1", type: "ai" as const, content: "Final value" },
-          ],
-        },
-      },
-    ]);
-
-    const { result } = renderHook(() =>
-      useLangGraphMessages({
-        stream: mockStreamCallback,
-        appendMessage: appendLangChainChunk,
-      }),
-    );
-
-    act(() => {
-      result.current.sendMessage(
-        [{ id: "user-1", type: "human", content: "hi" }],
-        {},
-      );
-    });
-
-    await waitFor(() => {
-      expect(result.current.messages).toHaveLength(2);
-      // After stream ends, final values snapshot becomes authoritative
-      const aiMessage = result.current.messages[1]!;
-      expect(aiMessage.id).toBe("run-1");
-      expect(aiMessage.content).toEqual("Final value");
-    });
-  });
-
   it("shows messages from pure node after LLM node (mixed tuple + values)", async () => {
-    // Reproduces the exact issue #3598 scenario:
     // Node A (validate_input) has LLM → produces messages-tuple events
     // Node B (generate_plan) is pure Python → only produces values events
     const mockStreamCallback = mockStreamCallbackFactory([

--- a/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
+++ b/packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx
@@ -45,7 +45,7 @@ const createTestAuiClient = () => {
 };
 
 describe("RenderChildrenWithAccessor", () => {
-  it("re-renders when accessed state updates (regression: issue #3838)", () => {
+  it("re-renders when accessed state updates", () => {
     const testClient = createTestAuiClient();
     const wrapper = ({ children }: { children: ReactNode }) => (
       <AuiProvider value={testClient.client as never}>{children}</AuiProvider>


### PR DESCRIPTION
Applying the repro-vs-contract test policy.

- `packages/react-langgraph/src/useLangGraphMessages.test.ts`: 1 deleted ('reconciles tuple-accumulated messages with final values snapshot' — strict subset of 'reconciles with final values snapshot after stream ends', which streams two chunks and asserts the same values-wins rule); 'stale closure fix' retitle and old-vs-new comments dropped.
- `packages/react-langgraph/src/convertLangChainMessages.test.ts`: 1 deleted ('synthesized id is stable across re-renders' — calls a pure function twice and asserts equal outputs; the derivation contract is pinned exactly by the neighbouring tests); regression tag stripped from the describe.
- `packages/react-langgraph/src/appendLangChainChunk.test.ts`: 0 deleted; two regression tags stripped — the merge-matrix and partial_json carryover blocks are contracts and now read as such.
- `packages/store/src/__tests__/RenderChildrenWithAccessor.test.tsx`: 0 deleted; issue tag stripped from a contract title.
- `packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts`: 0 deleted; issue tag stripped from a contract title.

Validation: `turbo test` for react-langgraph, store, react-ai-sdk passes. Pre-existing `tsc --noEmit` errors in untouched test files unchanged. Test-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wtcYe60Fw257gL1rHts8JAHIWRapKw1rFBZ91yiO3eCDVFHrze3QGp2Lf_U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->