### PR TITLE
fix(assistant-transport): flush commands coalesced into a resume run

### DIFF
--- a/.changeset/assistant-transport-resume-starvation.md
+++ b/.changeset/assistant-transport-resume-starvation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(assistant-transport): commands enqueued during a resume run are flushed in a follow-up run instead of starving in the queue

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -15,6 +15,7 @@ Command Scheduling
   - When the current run ends: if commands were scheduled during the run, start a new run and publish them.
   - If no run is in progress: start a run immediately and flush commands to the server.
 - A follow-up run that finds an empty queue is a no-op: no request is sent and no error is surfaced.
+- A resume run sends no commands; commands enqueued while it is pending or active are flushed in a follow-up run after it settles.
 - Runs execute on a `queueMicrotask`, so multiple synchronous enqueues coalesce into a single request: the first run's flush takes all of them, and the coalesced follow-up run no-ops.
 
 Command Queue

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -146,4 +146,44 @@ describe("useAssistantTransportRuntime", () => {
     expect(onError).not.toHaveBeenCalled();
     expect(fetchMock.requests).toHaveLength(1);
   });
+
+  it("flushes commands enqueued during a resume run in a follow-up run", async () => {
+    const fetchMock = installFetch();
+    const { aui, sendCommand } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread().getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() => sendCommand(createMessageCommand("a")));
+    await waitFor(() => expect(fetchMock.requests).toHaveLength(1));
+
+    // Both land while the first run is active and coalesce into one follow-up.
+    act(() => {
+      sendCommand(createMessageCommand("b"));
+      aui().thread().resumeRun({ parentId: null });
+    });
+
+    act(() => fetchMock.servers[0]!.close());
+    await waitFor(() => expect(fetchMock.requests).toHaveLength(2));
+    expect(fetchMock.requests[1]!.url).toBe("https://example.com/resume");
+    expect(fetchMock.requests[1]!.body["commands"]).toEqual([]);
+
+    // "b" coalesced into the resume run and must not starve in the queue.
+    act(() => fetchMock.servers[1]!.close());
+    await waitFor(() => expect(fetchMock.requests).toHaveLength(3));
+    expect(fetchMock.requests[2]!.url).toBe("https://example.com/api");
+    expect(fetchMock.requests[2]!.body["commands"]).toEqual([
+      createMessageCommand("b"),
+    ]);
+
+    act(() => fetchMock.servers[2]!.close());
+    await waitFor(() =>
+      expect(aui().thread().getState().isRunning).toBe(false),
+    );
+  });
 });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -243,6 +243,11 @@ const useAssistantTransportThreadRuntime = <T>(
       if (!markedDelivered) {
         commandQueue.markDelivered();
       }
+
+      // commands that coalesced into this resume run must not starve
+      if (isResume && commandQueue.state.queued.length > 0) {
+        runManager.schedule();
+      }
     },
     onFinish: options.onFinish,
     onCancel: () => {


### PR DESCRIPTION
## Bug

Commands enqueued while a resume run was pending or active starved: their `schedule()` coalesced into the already-pending resume follow-up, the resume run flushes nothing by design, and after it settled the queue sat idle until an unrelated later append finally triggered a run.

## Fix

After a resume run settles with commands still queued, the runtime schedules a follow-up run for them (mirrors the reference wire implementation's `followUpRequested` handling). Uses the live queue state from #5242.

Regression test: enqueue during an active run, request resume; after the resume request completes, the queued command is sent in its own follow-up request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.u16N_RgY_ZuIvmL0w_oW2vPxOvK6rfaCnKW9YMoL7HQF_x5jzBpTJnrEzbI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->