### PR TITLE
fix(core,store): warn instead of throw on recoverable inconsistencies (port of Athena hardening patches)

### DIFF
--- a/.changeset/core-store-warn-instead-of-throw.md
+++ b/.changeset/core-store-warn-instead-of-throw.md
@@ -3,4 +3,4 @@
 "@assistant-ui/store": patch
 ---
 
-Warn instead of throw on recoverable inconsistencies: duplicate same-priority tool registrations overwrite with the latest definition, duplicate message ids skip linking, stale client lookup indices are clamped, and null tool names in tool result messages are tolerated.
+Warn instead of throw on recoverable inconsistencies: duplicate same-priority tool registrations merge with the latest registration taking precedence, duplicate message ids skip linking, stale client lookup indices are clamped, and null tool names in tool result messages are tolerated.

--- a/.changeset/core-store-warn-instead-of-throw.md
+++ b/.changeset/core-store-warn-instead-of-throw.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/store": patch
+---
+
+Warn instead of throw on recoverable inconsistencies: duplicate same-priority tool registrations overwrite with the latest definition, duplicate message ids skip linking, stale client lookup indices are clamped, and null tool names in tool result messages are tolerated.

--- a/packages/core/src/model-context/types.ts
+++ b/packages/core/src/model-context/types.ts
@@ -79,8 +79,8 @@ export const mergeModelContexts = (
         if (existing && existing !== tool) {
           const existingPriority = toolPriorities[name]!;
           if (existingPriority === priority) {
-            throw new Error(
-              `You tried to define a tool with the name ${name}, but it already exists.`,
+            console.warn(
+              `[assistant-ui] Duplicate tool definition for "${name}" — overwriting with latest registration.`,
             );
           }
 

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -118,7 +118,7 @@ const joinExternalMessages = (
         const toolCall = assistantMessage.content[
           toolCallIdx
         ]! as ToolCallMessagePart;
-        if (output.toolName !== undefined) {
+        if (output.toolName != null) {
           if (toolCall.toolName !== output.toolName)
             throw new Error(
               `Tool call name ${output.toolCallId} ${output.toolName} does not match existing tool call ${toolCall.toolName}`,

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -159,9 +159,12 @@ export class MessageRepository {
         current = current.prev
       ) {
         if (current.current.id === child.current.id) {
-          throw new Error(
-            "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
+          console.error(
+            new Error(
+              "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
+            ),
           );
+          return;
         }
       }
 

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -135,6 +135,23 @@ export class MessageRepository {
 
     if (operation === "relink" && parentOrRoot === newParentOrRoot) return;
 
+    if (operation !== "cut") {
+      for (
+        let current: RepositoryMessage | null = newParent;
+        current;
+        current = current.prev
+      ) {
+        if (current.current.id === child.current.id) {
+          console.error(
+            new Error(
+              "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
+            ),
+          );
+          return;
+        }
+      }
+    }
+
     if (operation !== "link") {
       parentOrRoot.children = parentOrRoot.children.filter(
         (m) => m !== child.current.id,
@@ -153,21 +170,6 @@ export class MessageRepository {
     }
 
     if (operation !== "cut") {
-      for (
-        let current: RepositoryMessage | null = newParent;
-        current;
-        current = current.prev
-      ) {
-        if (current.current.id === child.current.id) {
-          console.error(
-            new Error(
-              "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
-            ),
-          );
-          return;
-        }
-      }
-
       newParentOrRoot.children = [
         ...newParentOrRoot.children,
         child.current.id,

--- a/packages/core/src/store/clients/model-context-client.test.ts
+++ b/packages/core/src/store/clients/model-context-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import type { Tool } from "assistant-stream";
 import { ModelContext } from "./model-context-client";
@@ -149,15 +149,27 @@ describe("mergeModelContexts", () => {
     });
   });
 
-  it("still rejects duplicate tools at the same priority", () => {
-    expect(() =>
-      mergeModelContexts(
+  it("warns and keeps the latest registration for duplicate tools at the same priority", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const latest = {
+        ...toolFixture(),
+        description: "latest",
+      } as Tool<any, any>;
+      const merged = mergeModelContexts(
         new Set([
           provider({ tools: { duplicate: toolFixture() } }),
-          provider({ tools: { duplicate: toolFixture() } }),
+          provider({ tools: { duplicate: latest } }),
         ]),
-      ),
-    ).toThrow(/already exists/);
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Duplicate tool definition for "duplicate"'),
+      );
+      expect(merged.tools?.duplicate?.description).toBe("latest");
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("preserves the highest priority when a lower-priority provider reuses the same tool object", () => {

--- a/packages/react/src/tests/messagePartSwitchRace.test.tsx
+++ b/packages/react/src/tests/messagePartSwitchRace.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { flushSync } from "react-dom";
 import { useEffect, useState, type FC } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { AssistantRuntimeProvider, PartByIndexProvider } from "../context";
 import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
@@ -148,11 +148,19 @@ describe("part hooks under a thread-switch race", () => {
     },
   );
 
-  it("still rejects an index that was never valid", async () => {
-    await expect(
-      act(async () => {
+  it("warns and clamps an index that was never valid", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await act(async () => {
         render(<App MessageComponent={InvalidPartMessage} />);
-      }),
-    ).rejects.toThrow("useClientLookup: Index 2 out of bounds (length: 2)");
+      });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "useClientLookup: Clamped stale index 2 to 1 (length: 2)",
+        ),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/react/src/tests/messagePartSwitchRace.test.tsx
+++ b/packages/react/src/tests/messagePartSwitchRace.test.tsx
@@ -83,8 +83,12 @@ const ChildrenMessage: FC = () => (
 );
 
 const InvalidPartReader: FC = () => {
-  useAuiState((s) => s.part.type);
-  return null;
+  const part = useAuiState((s) => s.part);
+  return (
+    <p data-testid="clamped-part">
+      {part.type === "text" ? part.text : part.type}
+    </p>
+  );
 };
 
 const InvalidPartMessage: FC = () => (
@@ -151,14 +155,16 @@ describe("part hooks under a thread-switch race", () => {
   it("warns and clamps an index that was never valid", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {
+      let view!: ReturnType<typeof render>;
       await act(async () => {
-        render(<App MessageComponent={InvalidPartMessage} />);
+        view = render(<App MessageComponent={InvalidPartMessage} />);
       });
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "useClientLookup: Clamped stale index 2 to 1 (length: 2)",
         ),
       );
+      expect(view.getByTestId("clamped-part").textContent).toBe("world");
     } finally {
       warn.mockRestore();
     }

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -50,12 +50,18 @@ export function useClientLookup<TMethods extends ClientMethods>(
     state,
     get: (lookup: { index: number } | { key: string }) => {
       if ("index" in lookup) {
-        if (lookup.index < 0 || lookup.index >= keys.length) {
+        if (lookup.index < 0 || keys.length === 0) {
           throw new Error(
             `useClientLookup: Index ${lookup.index} out of bounds (length: ${keys.length})`,
           );
         }
-        return resources[lookup.index]!.methods;
+        const clampedIndex = Math.min(lookup.index, keys.length - 1);
+        if (clampedIndex !== lookup.index) {
+          console.warn(
+            `useClientLookup: Clamped stale index ${lookup.index} to ${clampedIndex} (length: ${keys.length})`,
+          );
+        }
+        return resources[clampedIndex]!.methods;
       }
 
       const index = keyToIndex[lookup.key];


### PR DESCRIPTION
Ports the throw-to-warn hardening patches that Athena runs in production (pnpm patches on @assistant-ui/core@0.2.19 and @assistant-ui/store@0.2.19) into upstream sources, so the new assistant-transport stack behaves the same as prod before cut-over.

## Relaxations

- **Duplicate tool registration** (core, `mergeModelContexts` in `packages/core/src/model-context/types.ts`) — same-priority duplicate tool definitions now `console.warn` (string verbatim from the prod patch) instead of throwing; the existing shallow merge then applies with the latest registration taking precedence per field. Origin: `patches/@assistant-ui%2Fcore@0.2.19.patch` (dist/model-context/types.js hunk).
- **Duplicate-id repository link** (core, `MessageRepository.performOp` in `packages/core/src/runtime/utils/message-repository.ts`) — linking a message whose id already exists in the parent tree now logs the error via `console.error` and skips the link instead of throwing. The duplicate-id scan is hoisted above the cut block so the skip is atomic (behavior-identical to the prod patch on the `link` path it exercises; strictly safer for `relink`). Origin: same patch (dist/runtime/utils/message-repository.js hunk).
- **Null tool name tolerated** (core, `joinExternalMessages` in `packages/core/src/react/runtimes/external-message-converter.ts`) — the tool-name mismatch check now uses `!= null` so a `null` toolName on a tool result no longer throws. Origin: same patch (dist/react/runtimes/external-message-converter.js hunk).
- **Stale-index clamp** (store, `useClientLookup` in `packages/store/src/useClientLookup.ts`) — an out-of-range positive index is clamped to the last element with a `console.warn`; negative index or empty list still throws. Origin: `patches/@assistant-ui%2Fstore@0.2.19.patch`.

## Tests

- Flipped `packages/core/src/store/clients/model-context-client.test.ts` ("still rejects duplicate tools at the same priority") to assert the warn + latest-wins-per-field merge.
- Flipped `packages/react/src/tests/messagePartSwitchRace.test.tsx` ("still rejects an index that was never valid") to assert the clamp warning and the observable outcome (the clamped read resolves to the last part's content).
- Per test policy no new incident tests were added.

## Validation

- `@assistant-ui/core`: 676 tests pass, build (dts typecheck) passes.
- `@assistant-ui/store`: 10 tests pass, build passes.
- `@assistant-ui/react`: 506 tests pass.

Patch changeset included for @assistant-ui/core and @assistant-ui/store (react change is test-only).

## Follow-up candidates (post cut-over, deliberately not in this parity port)

- Dedupe/once-per-key warnings; enrich the duplicate-id error with the offending id.
- Revisit whether the store clamp is still needed now that `PartByIndexProvider` guards the shrink race at the provider level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)