### PR TITLE
test(core): reframe regression-tagged titles as contracts

### DIFF
--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -154,11 +154,11 @@ describe("ToolInvocationTracker", () => {
 
   it("does not auto-submit a parse-error result when divergent argsText closes without a backend result", async () => {
     // A human-in-the-loop tool whose argsText diverges mid-stream and never
-    // re-converges, with no backend result at close time. The args stream
-    // must not close on the divergent
-    // snapshot (which holds a stale prefix the execution path would parse),
-    // so no bogus parse-error result is auto-submitted to resume the host
-    // graph and abandon the pending interrupt.
+    // re-converges, with no backend result at close time. The args stream must
+    // not close on the divergent snapshot (which holds a stale prefix the
+    // execution path would parse), so no bogus parse-error result is
+    // auto-submitted to resume the host graph and abandon the pending
+    // interrupt.
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const streamCall = vi.fn((_reader, { human }) => {
       // Request human input immediately — sets up the pending interrupt.

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -153,9 +153,9 @@ describe("ToolInvocationTracker", () => {
   });
 
   it("does not auto-submit a parse-error result when divergent argsText closes without a backend result", async () => {
-    // A human-in-the-loop tool whose
-    // argsText diverges mid-stream and never re-converges, with no backend
-    // result at close time. The args stream must not close on the divergent
+    // A human-in-the-loop tool whose argsText diverges mid-stream and never
+    // re-converges, with no backend result at close time. The args stream
+    // must not close on the divergent
     // snapshot (which holds a stale prefix the execution path would parse),
     // so no bogus parse-error result is auto-submitted to resume the host
     // graph and abandon the pending interrupt.

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -152,8 +152,8 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
-  it("does not auto-submit a parse-error result when divergent argsText closes without a backend result (#5130)", async () => {
-    // Mirrors the #5098 production shape: a human-in-the-loop tool whose
+  it("does not auto-submit a parse-error result when divergent argsText closes without a backend result", async () => {
+    // A human-in-the-loop tool whose
     // argsText diverges mid-stream and never re-converges, with no backend
     // result at close time. The args stream must not close on the divergent
     // snapshot (which holds a stale prefix the execution path would parse),
@@ -236,7 +236,7 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
-  it("does not auto-submit a parse-error result for a non-executable tool whose divergent argsText closes (#5130)", async () => {
+  it("does not auto-submit a parse-error result for a non-executable tool whose divergent argsText closes", async () => {
     // Same close-gating mismatch as the executable case, but for a tool with
     // no frontend execute. Closing on the divergent complete snapshot would
     // still parse the incomplete stale prefix and fabricate a parse-error

--- a/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-list-runtime-core.test.ts
@@ -27,7 +27,7 @@ describe("ExternalStoreThreadListRuntimeCore - construction", () => {
     expect(core.getItemById(core.mainThreadId)).toBeDefined();
   });
 
-  it("picks up mainThreadId from adapter.threadId on construction (regression: #2577)", () => {
+  it("picks up mainThreadId from adapter.threadId on construction", () => {
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha" }),
       makeFactory(),
@@ -147,7 +147,7 @@ describe("ExternalStoreThreadListRuntimeCore - __internal_setAdapter", () => {
     expect(callback).toHaveBeenCalled();
   });
 
-  it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list (regression: #3971)", () => {
+  it("synthesizes mainThreadId entry after a switch to a threadId not in the threads list", () => {
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha" }),
       makeFactory(),
@@ -158,7 +158,7 @@ describe("ExternalStoreThreadListRuntimeCore - __internal_setAdapter", () => {
     expect(item?.id).toBe("thread-beta");
   });
 
-  it("does not retain stale synthesized entries across mainThreadId switches (regression: #3971)", () => {
+  it("does not retain stale synthesized entries across mainThreadId switches", () => {
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha" }),
       makeFactory(),
@@ -190,7 +190,7 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
     );
   };
 
-  it("reports isMain=true for adapter.threadId on construction (user-visible regression: #2577)", () => {
+  it("reports isMain=true for adapter.threadId on construction", () => {
     const impl = buildImpl({
       threadId: "thread-alpha",
       threads: [
@@ -215,7 +215,7 @@ describe("ExternalStoreThreadListRuntimeCore - isMain via ThreadListRuntimeImpl"
     expect(state.threadIds).toEqual(["thread-alpha", "thread-beta"]);
   });
 
-  it("does not throw when adapter.threadId has no matching threads entry (regression: #3971)", () => {
+  it("does not throw when adapter.threadId has no matching threads entry", () => {
     const impl = buildImpl({ threadId: "thread-alpha" });
     expect(impl.mainItem.getState().id).toBe("thread-alpha");
     expect(impl.mainItem.getState().isMain).toBe(true);
@@ -234,7 +234,7 @@ describe("ExternalStoreThreadListRuntimeCore - switchToThread", () => {
     expect(onSwitchToThread).toHaveBeenCalledWith("thread-beta");
   });
 
-  it("early-returns without calling onSwitchToThread when target equals initial threadId (regression: #2577)", async () => {
+  it("early-returns without calling onSwitchToThread when target equals initial threadId", async () => {
     const onSwitchToThread = vi.fn(async () => {});
     const core = new ExternalStoreThreadListRuntimeCore(
       makeAdapter({ threadId: "thread-alpha", onSwitchToThread }),

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -343,7 +343,7 @@ describe("ExternalStoreThreadRuntimeCore - optimistic message reconciliation", (
     );
 
     // Simulates onEdit/onReload producing a new branch under the same parent;
-    // the prior branch must survive (regression guard for #4131).
+    // the prior branch must survive.
     runtime.__internal_setAdapter(
       makeStore({
         messages: [u, { id: "a2", role: "assistant", text: "second" }],


### PR DESCRIPTION
Applying the repro-vs-contract test policy: these tests all assert real behavior at public seams and stay; only the incident framing goes.

- `packages/core/src/tests/external-store-thread-list-runtime-core.test.ts`: 0 deleted; 6 '(regression: #2577/#3971)' title tags stripped.
- `packages/core/src/tests/external-store-thread-runtime-core.test.ts`: 0 deleted; '(regression guard for #4131)' comment reference dropped.
- `packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts`: 0 deleted; two '(#5130)' title tags and a '#5098 production shape' comment reference stripped — the machinery explanation stays.

Validation: `turbo test --filter=@assistant-ui/core` passes. Test-only, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lPZW5g-TY5o3dbPRMfFHlpAkrqjTMUpiRn5CldGNKFTDZ3jq34t_pL8ydjk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->