### PR TITLE
Revert "fix(core,store): warn instead of throw on recoverable inconsistencies (port of Athena hardening patches)"

### DIFF
--- a/.changeset/core-store-warn-instead-of-throw.md
+++ b/.changeset/core-store-warn-instead-of-throw.md
@@ -1,6 +1,0 @@
----
-"@assistant-ui/core": patch
-"@assistant-ui/store": patch
----
-
-Warn instead of throw on recoverable inconsistencies: duplicate same-priority tool registrations merge with the latest registration taking precedence, duplicate message ids skip linking, stale client lookup indices are clamped, and null tool names in tool result messages are tolerated.

--- a/packages/core/src/model-context/types.ts
+++ b/packages/core/src/model-context/types.ts
@@ -79,8 +79,8 @@ export const mergeModelContexts = (
         if (existing && existing !== tool) {
           const existingPriority = toolPriorities[name]!;
           if (existingPriority === priority) {
-            console.warn(
-              `[assistant-ui] Duplicate tool definition for "${name}" — overwriting with latest registration.`,
+            throw new Error(
+              `You tried to define a tool with the name ${name}, but it already exists.`,
             );
           }
 

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -118,7 +118,7 @@ const joinExternalMessages = (
         const toolCall = assistantMessage.content[
           toolCallIdx
         ]! as ToolCallMessagePart;
-        if (output.toolName != null) {
+        if (output.toolName !== undefined) {
           if (toolCall.toolName !== output.toolName)
             throw new Error(
               `Tool call name ${output.toolCallId} ${output.toolName} does not match existing tool call ${toolCall.toolName}`,

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -135,23 +135,6 @@ export class MessageRepository {
 
     if (operation === "relink" && parentOrRoot === newParentOrRoot) return;
 
-    if (operation !== "cut") {
-      for (
-        let current: RepositoryMessage | null = newParent;
-        current;
-        current = current.prev
-      ) {
-        if (current.current.id === child.current.id) {
-          console.error(
-            new Error(
-              "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
-            ),
-          );
-          return;
-        }
-      }
-    }
-
     if (operation !== "link") {
       parentOrRoot.children = parentOrRoot.children.filter(
         (m) => m !== child.current.id,
@@ -170,6 +153,18 @@ export class MessageRepository {
     }
 
     if (operation !== "cut") {
+      for (
+        let current: RepositoryMessage | null = newParent;
+        current;
+        current = current.prev
+      ) {
+        if (current.current.id === child.current.id) {
+          throw new Error(
+            "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
+          );
+        }
+      }
+
       newParentOrRoot.children = [
         ...newParentOrRoot.children,
         child.current.id,

--- a/packages/core/src/store/clients/model-context-client.test.ts
+++ b/packages/core/src/store/clients/model-context-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import type { Tool } from "assistant-stream";
 import { ModelContext } from "./model-context-client";
@@ -149,27 +149,15 @@ describe("mergeModelContexts", () => {
     });
   });
 
-  it("warns and keeps the latest registration for duplicate tools at the same priority", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      const latest = {
-        ...toolFixture(),
-        description: "latest",
-      } as Tool<any, any>;
-      const merged = mergeModelContexts(
+  it("still rejects duplicate tools at the same priority", () => {
+    expect(() =>
+      mergeModelContexts(
         new Set([
           provider({ tools: { duplicate: toolFixture() } }),
-          provider({ tools: { duplicate: latest } }),
+          provider({ tools: { duplicate: toolFixture() } }),
         ]),
-      );
-
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('Duplicate tool definition for "duplicate"'),
-      );
-      expect(merged.tools?.duplicate?.description).toBe("latest");
-    } finally {
-      warn.mockRestore();
-    }
+      ),
+    ).toThrow(/already exists/);
   });
 
   it("preserves the highest priority when a lower-priority provider reuses the same tool object", () => {

--- a/packages/react/src/tests/messagePartSwitchRace.test.tsx
+++ b/packages/react/src/tests/messagePartSwitchRace.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { flushSync } from "react-dom";
 import { useEffect, useState, type FC } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { useAui, useAuiState } from "@assistant-ui/store";
 import { AssistantRuntimeProvider, PartByIndexProvider } from "../context";
 import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
@@ -83,12 +83,8 @@ const ChildrenMessage: FC = () => (
 );
 
 const InvalidPartReader: FC = () => {
-  const part = useAuiState((s) => s.part);
-  return (
-    <p data-testid="clamped-part">
-      {part.type === "text" ? part.text : part.type}
-    </p>
-  );
+  useAuiState((s) => s.part.type);
+  return null;
 };
 
 const InvalidPartMessage: FC = () => (
@@ -152,21 +148,11 @@ describe("part hooks under a thread-switch race", () => {
     },
   );
 
-  it("warns and clamps an index that was never valid", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      let view!: ReturnType<typeof render>;
-      await act(async () => {
-        view = render(<App MessageComponent={InvalidPartMessage} />);
-      });
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "useClientLookup: Clamped stale index 2 to 1 (length: 2)",
-        ),
-      );
-      expect(view.getByTestId("clamped-part").textContent).toBe("world");
-    } finally {
-      warn.mockRestore();
-    }
+  it("still rejects an index that was never valid", async () => {
+    await expect(
+      act(async () => {
+        render(<App MessageComponent={InvalidPartMessage} />);
+      }),
+    ).rejects.toThrow("useClientLookup: Index 2 out of bounds (length: 2)");
   });
 });

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -50,18 +50,12 @@ export function useClientLookup<TMethods extends ClientMethods>(
     state,
     get: (lookup: { index: number } | { key: string }) => {
       if ("index" in lookup) {
-        if (lookup.index < 0 || keys.length === 0) {
+        if (lookup.index < 0 || lookup.index >= keys.length) {
           throw new Error(
             `useClientLookup: Index ${lookup.index} out of bounds (length: ${keys.length})`,
           );
         }
-        const clampedIndex = Math.min(lookup.index, keys.length - 1);
-        if (clampedIndex !== lookup.index) {
-          console.warn(
-            `useClientLookup: Clamped stale index ${lookup.index} to ${clampedIndex} (length: ${keys.length})`,
-          );
-        }
-        return resources[clampedIndex]!.methods;
+        return resources[lookup.index]!.methods;
       }
 
       const index = keyToIndex[lookup.key];


### PR DESCRIPTION
Reverts #5250 (merge commit d4bdf2c50f). The maintainer has not signed off on loosening these invariants; #5250 was merged in a race with that decision. This restores main to the pre-merge state. The port is resubmitted as a separate PR left open for maintainer review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

