### PR TITLE
fix(external-thread): clearAttachments and reset call adapter.remove for pending attachments

### DIFF
--- a/.changeset/external-thread-clear-adapter-remove.md
+++ b/.changeset/external-thread-clear-adapter-remove.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread clearAttachments/reset call adapter.remove for pending attachments

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -505,6 +505,15 @@ const useComposerClientResource = ({
     ),
   );
 
+  const removePendingAttachments = async (removed: readonly Attachment[]) => {
+    if (!attachmentAdapter) return;
+    await Promise.all(
+      removed
+        .filter((a) => a.status.type !== "complete")
+        .map((a) => attachmentAdapter.remove(a)),
+    );
+  };
+
   const upsertAttachment = (attachment: Attachment) => {
     setAttachments((prev) => {
       const idx = prev.findIndex((a) => a.id === attachment.id);
@@ -596,7 +605,9 @@ const useComposerClientResource = ({
       }
     },
     clearAttachments: async () => {
+      const removed = attachmentsRef.current;
       setAttachments([]);
+      await removePendingAttachments(removed);
     },
     attachment: (selector) => {
       if ("id" in selector) {
@@ -605,11 +616,13 @@ const useComposerClientResource = ({
       return attachmentClients.get(selector);
     },
     reset: async () => {
+      const removed = attachmentsRef.current;
       setText("");
       setRole("user");
       setRunConfig({});
       setAttachments([]);
       setQuote(undefined);
+      await removePendingAttachments(removed);
     },
     send: (opts?: ComposerSendOptions) => {
       const currentQuote = quoteRef.current;

--- a/packages/react/src/tests/external-thread-attachments.test.tsx
+++ b/packages/react/src/tests/external-thread-attachments.test.tsx
@@ -164,6 +164,54 @@ describe("ExternalThread attachments", () => {
     );
   });
 
+  it.each([
+    [
+      "clearAttachments",
+      (c: { clearAttachments(): Promise<void> }) => c.clearAttachments(),
+    ],
+    ["reset", (c: { reset(): Promise<void> }) => c.reset()],
+  ] as const)(
+    "calls adapter.remove for pending attachments on %s",
+    async (_name, invoke) => {
+      const remove = vi.fn(async () => {});
+      const adapter = {
+        accept: "*",
+        add: async ({ file }: { file: File }) => ({
+          id: "att-1",
+          type: "file" as const,
+          name: file.name,
+          contentType: file.type,
+          file,
+          status: {
+            type: "requires-action" as const,
+            reason: "composer-send" as const,
+          },
+        }),
+        send: async () => ({}) as never,
+        remove,
+      };
+
+      const aui = renderThreadWithProps({ attachmentAdapter: adapter });
+
+      await act(() =>
+        aui()
+          .thread()
+          .composer()
+          .addAttachment(
+            new File(["data"], "notes.txt", { type: "text/plain" }),
+          ),
+      );
+
+      await act(() => invoke(aui().thread().composer()));
+
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(remove).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "att-1" }),
+      );
+      expect(aui().thread().composer().getState().attachments).toHaveLength(0);
+    },
+  );
+
   afterEach(() => {
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary
Follow-up from #5237 (review): `clearAttachments` and `reset` dropped pending attachments without notifying the adapter, while the per-attachment `remove()` path did call `adapter.remove`. Legacy routes all three through `_onClearAttachments`, which awaits `adapter.remove` for every non-complete attachment — an adapter that allocates on `add` (temp upload, multipart session) was orphaned on clear/reset.

Both methods now snapshot the current attachment set, clear the composer, and await `adapter.remove` for each pending (non-complete) attachment, matching legacy.

## Validation
- `pnpm --filter @assistant-ui/react test` (518 passing, +2 contract tests pinning adapter.remove on clearAttachments and on reset)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mXo7nUphQRF6l7vnWrjHWcWigSGJgQdPHkXC4qmgWEbEZSW7tCOGUkwWox4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->