### PR TITLE
fix(external-thread): plumb the attachmentAdapter into edit composers

### DIFF
--- a/.changeset/external-thread-edit-composer-adapter.md
+++ b/.changeset/external-thread-edit-composer-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread edit composers receive the attachmentAdapter

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -126,6 +126,7 @@ type MessageClientProps = {
     | undefined;
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
+  attachmentAdapter?: AttachmentAdapter | undefined;
 };
 
 // Message Client - minimal implementation
@@ -140,6 +141,7 @@ const useMessageClient = ({
   onRespondToToolApproval,
   onAddToolResult,
   onResumeToolCall,
+  attachmentAdapter,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -201,6 +203,7 @@ const useMessageClient = ({
       onSend: handleSendEdit,
       message,
       queue,
+      attachmentAdapter,
     }),
   );
 
@@ -756,6 +759,7 @@ const useExternalThread = ({
         onRespondToToolApproval,
         onAddToolResult,
         onResumeToolCall,
+        attachmentAdapter,
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));

--- a/packages/react/src/tests/external-thread-attachments.test.tsx
+++ b/packages/react/src/tests/external-thread-attachments.test.tsx
@@ -4,7 +4,10 @@ import { act, render, waitFor } from "@testing-library/react";
 import type { FC } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { AuiProvider, useAui } from "@assistant-ui/store";
-import type { ExternalThreadProps } from "../client/ExternalThread";
+import type {
+  ExternalThreadMessage,
+  ExternalThreadProps,
+} from "../client/ExternalThread";
 import { ExternalThread } from "../client/ExternalThread";
 
 const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
@@ -261,6 +264,55 @@ describe("ExternalThread attachments", () => {
       expect(aui().thread().composer().getState().attachments).toHaveLength(0);
     },
   );
+
+  it("routes edit-composer attachments through the adapter", async () => {
+    const add = vi.fn(async ({ file }: { file: File }) => ({
+      id: "att-edit",
+      type: "file" as const,
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: {
+        type: "requires-action" as const,
+        reason: "composer-send" as const,
+      },
+    }));
+    const aui = renderThreadWithProps({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      onEdit: () => {},
+      attachmentAdapter: {
+        accept: "*",
+        add,
+        send: async () => ({}) as never,
+        remove: async () => {},
+      },
+    });
+
+    const composer = () => aui().thread().message({ id: "u1" }).composer();
+    await act(async () => {
+      composer().beginEdit();
+    });
+    await act(() =>
+      composer().addAttachment(
+        new File(["data"], "notes.txt", { type: "text/plain" }),
+      ),
+    );
+
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(composer().getState().attachments[0]).toMatchObject({
+      id: "att-edit",
+      name: "notes.txt",
+    });
+  });
 
   afterEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
## Summary
Follow-up from #5237 (review): `capabilities.attachments` reported true for the whole thread, but only the thread composer received `attachmentAdapter` — edit composers were built without it, so edit-mode `addAttachment` took the no-adapter branch and produced a local attachment with empty `content` that `adapter.send` never processed.

The adapter is now passed through `MessageClientProps` into the edit composer, so edit-mode attachments take the same adapter path as the thread composer (add, send on dispatch, remove, accept string).

## Validation
- `pnpm --filter @assistant-ui/react test` (517 passing, +1 contract test pinning that edit-composer addAttachment routes through adapter.add)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZPBoyWmFHRG_bxubmfUbEcKniWH_Juw9qglz-ANAugPTN3fyHzAYivd6N7k?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->