### PR TITLE
fix(external-thread): stamp the thread head as parentId on queue-adapter sends

### DIFF
--- a/.changeset/external-thread-queue-parent-stamping.md
+++ b/.changeset/external-thread-queue-parent-stamping.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread queue-adapter sends stamp the thread head as parentId

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -741,6 +741,20 @@ const useExternalThread = ({
     onNew?.({ ...message, parentId: messages.at(-1)?.id ?? null });
   };
 
+  const headId = messages.at(-1)?.id ?? null;
+  const composerQueue = useMemo(
+    (): ExternalThreadQueueAdapter | undefined =>
+      queue && {
+        ...queue,
+        enqueue: (message, options) =>
+          queue.enqueue(
+            { ...message, parentId: message.parentId ?? headId },
+            options,
+          ),
+      },
+    [queue, headId],
+  );
+
   const composerClient = useClientResource(
     ComposerClientResource({
       type: "thread",
@@ -749,7 +763,7 @@ const useExternalThread = ({
       isSendDisabled,
       onCancel: handleCancelRun,
       onSend: handleSendNew,
-      queue,
+      queue: composerQueue,
       attachmentAdapter,
     }),
   );

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -128,6 +128,36 @@ describe("ExternalThread composer", () => {
     );
   });
 
+  it("stamps the thread head as parentId on queue-adapter sends", async () => {
+    const enqueue = vi.fn();
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: true,
+      queue: {
+        items: [],
+        enqueue,
+        steer: vi.fn(),
+        remove: vi.fn(),
+        clear: vi.fn(),
+      },
+    });
+
+    aui().thread().composer().setText("queued");
+    aui().thread().composer().send();
+
+    await waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1));
+    expect(enqueue.mock.calls[0]![0].parentId).toBe("u1");
+  });
+
   it("still refuses to send an empty composer synchronously after a send", async () => {
     const onNew = vi.fn();
     const { aui } = renderThread({ messages: [], isRunning: false, onNew });


### PR DESCRIPTION
## Summary
Follow-up from #5237 (review): composer sends through a `queue` adapter bypassed the head stamping the `onSend` path got, so the same thread could enqueue messages with `parentId: null` from the composer but a real parent from `append()`.

The thread now hands the composer a wrapped queue whose `enqueue` stamps the current thread head as `parentId` when none is set — the same rule `handleSendNew` and `append()` already apply. Queue support is experimental; the change is deliberately minimal and does not touch the `append()` path (already stamped) or edit-composer queue semantics.

## Validation
- `pnpm --filter @assistant-ui/react test` (517 passing, +1 contract test pinning the enqueued parentId)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AiWjcbHIv0Ytt3Myhox5H4LUP1HCHkjsm5HgyPJBr5fz0SL-ObiQ3azQx-E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->