### PR TITLE
fix(external-thread): unset optional callbacks throw a capability error naming the missing prop

### DIFF
--- a/.changeset/external-thread-unset-callback-throws.md
+++ b/.changeset/external-thread-unset-callback-throws.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread throws a capability error when an unset optional callback is invoked

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -313,7 +313,10 @@ const usePartResource = ({
   return {
     getState: () => state,
     addToolResult: (result) => {
-      if (!onAddToolResult) return;
+      if (!onAddToolResult)
+        throw new Error(
+          "Runtime does not support tool results (onAddToolResult is not set).",
+        );
       if (part.type !== "tool-call")
         throw new Error("Tried to add tool result on non-tool message part");
 
@@ -331,7 +334,10 @@ const usePartResource = ({
       });
     },
     resumeToolCall: (payload) => {
-      if (!onResumeToolCall) return;
+      if (!onResumeToolCall)
+        throw new Error(
+          "Runtime does not support resuming tool calls (onResumeToolCall is not set).",
+        );
       if (part.type !== "tool-call")
         throw new Error("Tried to resume tool call on non-tool message part");
 
@@ -846,11 +852,19 @@ const useExternalThread = ({
       onStartRun?.();
     },
     resumeRun: () => {
-      onResume?.();
+      if (!onResume)
+        throw new Error(
+          "Runtime does not support resuming runs (onResume is not set).",
+        );
+      onResume();
     },
     cancelRun: handleCancelRun,
     importExternalState: (state: unknown) => {
-      onLoadExternalState?.(state);
+      if (!onLoadExternalState)
+        throw new Error(
+          "Runtime does not support importing external states (onLoadExternalState is not set).",
+        );
+      onLoadExternalState(state);
     },
     getModelContext: () => ({ tools: {}, config: {} }),
     export: () => ({ messages: [] }),

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -111,6 +111,32 @@ describe("ExternalThread part status", () => {
   });
 });
 
+describe("ExternalThread unset optional callbacks", () => {
+  it("throws a capability error when the callback prop is not set", () => {
+    const { aui } = renderThread({
+      messages: [
+        assistantMessage({ type: "requires-action", reason: "tool-calls" }),
+      ],
+      isRunning: false,
+    });
+    const part = () =>
+      aui().thread().message({ id: "a1" }).part({ toolCallId: "tc1" });
+
+    expect(() => part().addToolResult("ok")).toThrow(
+      "Runtime does not support tool results (onAddToolResult is not set).",
+    );
+    expect(() => part().resumeToolCall(undefined)).toThrow(
+      "Runtime does not support resuming tool calls (onResumeToolCall is not set).",
+    );
+    expect(() => aui().thread().resumeRun()).toThrow(
+      "Runtime does not support resuming runs (onResume is not set).",
+    );
+    expect(() => aui().thread().importExternalState({})).toThrow(
+      "Runtime does not support importing external states (onLoadExternalState is not set).",
+    );
+  });
+});
+
 describe("ExternalThread composer", () => {
   it("dispatches a synchronous setText + send sequence", async () => {
     const onNew = vi.fn();


### PR DESCRIPTION
## Summary
**This PR is a contract decision — please review the policy, not just the diff.**

Follow-up from #5237 (review): the additive optional callbacks silently no-oped when unset, so `part.addToolResult()` on a runtime without `onAddToolResult` dropped the result with no signal — the flagged integration-bug hazard.

Decision implemented: **throw a capability error naming the missing prop**, consistently across the additive set:
- `addToolResult` without `onAddToolResult`
- `resumeToolCall` without `onResumeToolCall`
- `resumeRun` without `onResume`
- `importExternalState` without `onLoadExternalState`

Legacy comparison: the legacy `ExternalStoreThreadRuntimeCore` already throws for all four ("Runtime does not support tool results.", "Runtime does not support resuming runs.", "Runtime does not support importing external states.", and `resumeToolCall` throws when no handler accepts the call), so throwing is the parity behavior — the messages here additionally name the ExternalThread prop to set. `respondToToolApproval` already threw and is unchanged, as are the pre-existing base props (`onNew`/`onEdit`/`onReload`/`onStartRun`/`onCancel`), which UI capability flags already gate.

## Validation
- `pnpm --filter @assistant-ui/react test` (517 passing, +1 contract test pinning all four errors)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AatOyTjQ7yadcyL7LQ0vSChWGtV9Qbh90d2KKgM6CCxANyr8u9dy6cqIqPY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->