### PR TITLE
fix(external-thread): merge a failed send back into the draft

### DIFF
--- a/.changeset/external-thread-failed-send-restore.md
+++ b/.changeset/external-thread-failed-send-restore.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread merges a failed send back into the draft (text prepended, attachments and quote preserved)

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -688,13 +688,14 @@ const useComposerClientResource = ({
               : attachmentAdapter.send(attachment as PendingAttachment),
           ),
         ).then(dispatch, (error) => {
-          // Upload failed: restore the draft instead of dropping the message,
-          // unless the user already started composing a new one.
-          setText((prev) => (prev ? prev : currentText));
-          setQuote((prev) => prev ?? currentQuote);
-          setAttachments((prev) =>
-            prev.length > 0 ? prev : currentAttachments,
+          // Upload failed: merge the failed send back into the draft.
+          setText((prev) =>
+            currentText && prev
+              ? currentText + "\n" + prev
+              : currentText || prev,
           );
+          setQuote((prev) => prev ?? currentQuote);
+          setAttachments((prev) => [...currentAttachments, ...prev]);
           console.error("Failed to send attachments", error);
         });
       } else {

--- a/packages/react/src/tests/external-thread-attachments.test.tsx
+++ b/packages/react/src/tests/external-thread-attachments.test.tsx
@@ -314,6 +314,58 @@ describe("ExternalThread attachments", () => {
     });
   });
 
+  it("merges the failed send into a draft the user already modified", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    let rejectSend!: (reason: unknown) => void;
+    const adapter = {
+      accept: "*",
+      add: async ({ file }: { file: File }) => ({
+        id: "att-1",
+        type: "file" as const,
+        name: file.name,
+        contentType: file.type,
+        file,
+        status: {
+          type: "requires-action" as const,
+          reason: "composer-send" as const,
+        },
+      }),
+      send: () =>
+        new Promise((_resolve, reject) => {
+          rejectSend = reject;
+        }) as never,
+      remove: async () => {},
+    };
+
+    const aui = renderThreadWithProps({
+      attachmentAdapter: adapter,
+      onNew: () => {},
+    });
+
+    await act(() =>
+      aui()
+        .thread()
+        .composer()
+        .addAttachment(new File(["data"], "notes.txt", { type: "text/plain" })),
+    );
+    await act(async () => {
+      aui().thread().composer().setText("hello");
+      aui().thread().composer().send();
+    });
+    await act(async () => {
+      aui().thread().composer().setText("meanwhile");
+    });
+
+    await act(async () => {
+      rejectSend(new Error("upload failed"));
+    });
+
+    const state = aui().thread().composer().getState();
+    expect(state.text).toBe("hello\nmeanwhile");
+    expect(state.attachments).toHaveLength(1);
+    expect(state.attachments[0]).toMatchObject({ id: "att-1" });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });


### PR DESCRIPTION
## Summary
Follow-up from #5237 (review): the failed-send restore guarded each field independently, so a draft typed during an in-flight send could end up with the previous message's attachments glued on (text guard kept the new text, attachment guard saw an empty list and restored the old uploads — the next send shipped them with the wrong message).

The restore now MERGES the failed send into whatever draft exists: the failed text is prepended (newline-separated when both are non-empty), the failed attachments go in front of any the user added since, and the quote fills the slot only if the new draft has none. An untouched draft is the degenerate case and is restored in full.

**Tradeoff:** merge semantics never drop the failed message's data — uploaded attachments and typed text always come back — at the cost of the user occasionally seeing the failed text spliced above what they typed meanwhile. The existing `console.error` remains the failure signal. Legacy avoids the dilemma by not clearing attachments optimistically at all; matching that wholesale would be a larger composer restructure than this follow-up warrants.

## Validation
- `pnpm --filter @assistant-ui/react test` (all passing; contract tests pin the merge into a modified draft — `"hello\nmeanwhile"` with the failed attachment present — and the full restore into an untouched draft)
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
