### PR TITLE
fix(core): restore repository duplicate-id throw; dedupe external-store messages at ingestion

### DIFF
--- a/.changeset/core-repository-duplicate-id-throw.md
+++ b/.changeset/core-repository-duplicate-id-throw.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+Restore the MessageRepository duplicate-id throw (it detects internal corruption); duplicate ids in an external-store messages array are now deduped at ingestion with a warning, keeping the last occurrence.

--- a/.changeset/react-external-thread-duplicate-ids.md
+++ b/.changeset/react-external-thread-duplicate-ids.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+ExternalThread: dedupe duplicate message ids with a warning (last occurrence wins) instead of throwing on duplicate resource keys.

--- a/packages/core/src/runtime/utils/message-repository.ts
+++ b/packages/core/src/runtime/utils/message-repository.ts
@@ -142,12 +142,9 @@ export class MessageRepository {
         current = current.prev
       ) {
         if (current.current.id === child.current.id) {
-          console.error(
-            new Error(
-              "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
-            ),
+          throw new Error(
+            "MessageRepository(performOp/link): A message with the same id already exists in the parent tree. This error occurs if the same message id is found multiple times. This is likely an internal bug in assistant-ui.",
           );
-          return;
         }
       }
     }

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -251,6 +251,21 @@ export class ExternalStoreThreadRuntimeCore
             return newMessage;
           });
 
+      const seenIds = new Set<string>();
+      const deduped: ThreadMessage[] = [];
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const message = messages[i]!;
+        if (seenIds.has(message.id)) {
+          console.warn(
+            `ExternalStoreThreadRuntimeCore: duplicate message id "${message.id}" in the provided messages array; keeping the last occurrence.`,
+          );
+          continue;
+        }
+        seenIds.add(message.id);
+        deduped.push(message);
+      }
+      if (deduped.length !== messages.length) messages = deduped.reverse();
+
       for (let i = 0; i < messages.length; i++) {
         const message = messages[i]!;
         const parent = messages[i - 1];

--- a/packages/core/src/tests/MessageRepository.test.ts
+++ b/packages/core/src/tests/MessageRepository.test.ts
@@ -110,6 +110,18 @@ describe("MessageRepository", () => {
       }).toThrow(/Parent message not found/);
     });
 
+    it("should throw when a message would be linked under an ancestor with the same id", () => {
+      const message = createTestMessage({ id: "message-id" });
+      repository.addOrUpdateMessage(null, message);
+
+      expect(() => {
+        repository.addOrUpdateMessage(
+          "message-id",
+          createTestMessage({ id: "message-id" }),
+        );
+      }).toThrow(/same id already exists in the parent tree/);
+    });
+
     it("should retrieve all messages in the current branch", () => {
       const parent = createTestMessage({ id: "parent-id" });
       const child = createTestMessage({ id: "child-id" });

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -353,6 +353,33 @@ describe("ExternalStoreThreadRuntimeCore - optimistic message reconciliation", (
 
     expect(childrenOf(runtime, "u")).toEqual(["a1", "a2"]);
   });
+
+  it("warns and keeps the last occurrence when the messages array repeats an id", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        makeStore({
+          messages: [
+            { id: "u", role: "user", text: "hi" },
+            { id: "a", role: "assistant", text: "stale" },
+            { id: "a", role: "assistant", text: "fresh" },
+          ] satisfies Raw[],
+          convertMessage,
+        }),
+      );
+
+      expect(runtime.messages.map((m) => m.id)).toEqual(["u", "a"]);
+      expect(runtime.messages[1]!.content[0]).toMatchObject({
+        type: "text",
+        text: "fresh",
+      });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"a"'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -380,6 +380,33 @@ describe("ExternalStoreThreadRuntimeCore - optimistic message reconciliation", (
       warn.mockRestore();
     }
   });
+
+  it("reparents the message after a dropped duplicate onto the preceding message", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const runtime = new ExternalStoreThreadRuntimeCore(
+        mockContextProvider,
+        makeStore({
+          messages: [
+            { id: "u", role: "user", text: "hi" },
+            { id: "dup", role: "assistant", text: "stale" },
+            { id: "u2", role: "user", text: "again" },
+            { id: "dup", role: "assistant", text: "fresh" },
+          ] satisfies Raw[],
+          convertMessage,
+        }),
+      );
+
+      expect(runtime.messages.map((m) => m.id)).toEqual(["u", "u2", "dup"]);
+      const parentOf = (id: string) =>
+        runtime.export().messages.find((m) => m.message.id === id)!.parentId;
+      expect(parentOf("u")).toBeNull();
+      expect(parentOf("u2")).toBe("u");
+      expect(parentOf("dup")).toBe("u2");
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });
 
 describe("ExternalStoreThreadRuntimeCore - branch change callback", () => {

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -681,9 +681,26 @@ const useComposerClientResource = ({
 
 const ComposerClientResource = resource(useComposerClientResource);
 
+const dedupeMessagesById = (messages: readonly ExternalThreadMessage[]) => {
+  const seenIds = new Set<string>();
+  const deduped: ExternalThreadMessage[] = [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]!;
+    if (seenIds.has(message.id)) {
+      console.warn(
+        `ExternalThread: duplicate message id "${message.id}" in the provided messages array; keeping the last occurrence.`,
+      );
+      continue;
+    }
+    seenIds.add(message.id);
+    deduped.push(message);
+  }
+  return deduped.length === messages.length ? messages : deduped.reverse();
+};
+
 // External Thread Client
 const useExternalThread = ({
-  messages,
+  messages: messagesProp,
   isRunning = false,
   isLoading = false,
   state: threadState,
@@ -703,6 +720,11 @@ const useExternalThread = ({
   branches,
   onRespondToToolApproval,
 }: ExternalThreadProps): ClientOutput<"thread"> => {
+  const messages = useMemo(
+    () => dedupeMessagesById(messagesProp),
+    [messagesProp],
+  );
+
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);
     if (messageIndex === -1) return;

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -141,3 +141,36 @@ describe("ExternalThread composer", () => {
     expect(onNew).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ExternalThread duplicate message ids", () => {
+  const userMessage = (id: string, text: string): ExternalThreadMessage =>
+    ({
+      id,
+      role: "user",
+      content: [{ type: "text", text }],
+      createdAt: new Date(0),
+      metadata: { custom: {} },
+    }) as unknown as ExternalThreadMessage;
+
+  it("warns and keeps the last occurrence instead of throwing on a duplicate id", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const { aui } = renderThread({
+        messages: [
+          userMessage("u1", "hi"),
+          userMessage("dup", "stale"),
+          userMessage("dup", "fresh"),
+        ],
+      });
+
+      const state = aui().thread().getState();
+      expect(state.messages.map((m) => m.id)).toEqual(["u1", "dup"]);
+
+      const dup = aui().thread().message({ id: "dup" }).getState();
+      expect(dup.parts[0]).toMatchObject({ type: "text", text: "fresh" });
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('"dup"'));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
MessageRepository's performOp duplicate-id ancestor scan detects internal tree corruption, so it must fail loudly: the `console.error` + skip introduced by d4bdf2c is restored to a hard `throw`. The scan stays hoisted above the cut block (atomic check-before-mutate). This partially reverts d4bdf2c per maintainer decision.

The recoverable case — an app-provided external-store `messages` array containing the same id twice — is now handled at the trust boundary instead: the external-store ingestion loop dedupes by id before linking, keeping the last occurrence (fresher snapshot) and emitting a `console.warn` naming the duplicated id. The optimistic-placeholder and resetHead logic below the loop is unaffected.

Tests: a contract test pinning the repository throw, and one at the external-store seam (duplicate ids warn, last one wins, no throw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.XMvMJWfPpA5k5W3cLVhTxHhV3vdsEPbB_kXp8aG9kXeONImsv4-runHr28U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->