### PR TITLE
feat(core): per-tool overwrite escape hatch; same-priority tool conflicts throw again

### DIFF
--- a/.changeset/tool-overwrite-escape-hatch.md
+++ b/.changeset/tool-overwrite-escape-hatch.md
@@ -1,0 +1,6 @@
+---
+"assistant-stream": patch
+"@assistant-ui/core": patch
+---
+
+Same-priority duplicate tool registrations throw again. The `Tool` type gains an optional `overwrite` flag (discouraged escape hatch) that lets a later registration silently replace a same-priority tool of the same name; the flag is stripped from the merged output.

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11612,6 +11612,7 @@ type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResu
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -4997,6 +4997,7 @@ type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unkno
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1276,6 +1276,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1638,6 +1638,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1370,6 +1370,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1816,6 +1816,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1642,6 +1642,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-devtools.ts
+++ b/api-surface/assistant-ui__react-devtools.ts
@@ -421,6 +421,7 @@ type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResu
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -1209,6 +1209,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -2106,6 +2106,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -4058,6 +4058,7 @@ type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unkno
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1803,6 +1803,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1956,6 +1956,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3565,6 +3565,7 @@ type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unkno
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1714,6 +1714,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -2171,6 +2171,7 @@ type ToolApprovalResponse = {
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -5069,6 +5069,7 @@ type ToolArgsStatus<TArgs extends Record<string, unknown> = Record<string, unkno
 type ToolBase<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = {
   streamCall?: ToolStreamCallFunction<TArgs, TResult>;
   display?: ToolDisplay;
+  overwrite?: boolean;
 };
 
 interface ToolCallArgsReader<TArgs extends Record<string, unknown>> {

--- a/packages/assistant-stream/src/core/tool/tool-types.ts
+++ b/packages/assistant-stream/src/core/tool/tool-types.ts
@@ -226,6 +226,13 @@ type ToolBase<
   unstable_backendDefault?: {
     parameters?: boolean;
   };
+
+  /**
+   * Replaces an already-registered same-priority tool with the same name
+   * instead of throwing. Discouraged escape hatch — overwriting a same-priority
+   * tool is usually a design smell; prefer distinct names or priorities.
+   */
+  overwrite?: boolean;
 };
 
 type BackendTool<

--- a/packages/core/src/model-context/types.ts
+++ b/packages/core/src/model-context/types.ts
@@ -55,6 +55,12 @@ export type AssistantContextConfig = {
   disabled?: boolean | undefined;
 };
 
+const stripOverwrite = (tool: Tool<any, any>): Tool<any, any> => {
+  if (!tool.overwrite) return tool;
+  const { overwrite: _, ...rest } = tool;
+  return rest as Tool<any, any>;
+};
+
 export const mergeModelContexts = (
   configSet: Set<ModelContextProvider>,
 ): ModelContext => {
@@ -79,25 +85,29 @@ export const mergeModelContexts = (
         if (existing && existing !== tool) {
           const existingPriority = toolPriorities[name]!;
           if (existingPriority === priority) {
-            console.warn(
-              `[assistant-ui] Duplicate tool definition for "${name}" — overwriting with latest registration.`,
-            );
+            if (!tool.overwrite) {
+              throw new Error(
+                `You tried to define a tool with the name ${name}, but it already exists.`,
+              );
+            }
+            acc.tools![name] = stripOverwrite(tool);
+            continue;
           }
 
           const higherPriorityTool =
             existingPriority > priority ? existing : tool;
           const lowerPriorityTool =
             existingPriority > priority ? tool : existing;
-          acc.tools![name] = {
+          acc.tools![name] = stripOverwrite({
             ...lowerPriorityTool,
             ...higherPriorityTool,
-          } as Tool<any, any>;
+          } as Tool<any, any>);
           toolPriorities[name] = Math.max(existingPriority, priority);
           continue;
         }
 
         if (!acc.tools) acc.tools = {};
-        acc.tools[name] = tool;
+        acc.tools[name] = stripOverwrite(tool);
         toolPriorities[name] ??= priority;
       }
     }

--- a/packages/core/src/store/clients/model-context-client.test.ts
+++ b/packages/core/src/store/clients/model-context-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createTapRoot, useResource } from "@assistant-ui/tap";
 import type { Tool } from "assistant-stream";
 import { ModelContext } from "./model-context-client";
@@ -149,27 +149,35 @@ describe("mergeModelContexts", () => {
     });
   });
 
-  it("warns and keeps the latest registration for duplicate tools at the same priority", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      const latest = {
-        ...toolFixture(),
-        description: "latest",
-      } as Tool<any, any>;
-      const merged = mergeModelContexts(
+  it("rejects duplicate tools at the same priority", () => {
+    expect(() =>
+      mergeModelContexts(
         new Set([
           provider({ tools: { duplicate: toolFixture() } }),
-          provider({ tools: { duplicate: latest } }),
+          provider({ tools: { duplicate: toolFixture() } }),
         ]),
-      );
+      ),
+    ).toThrow(/already exists/);
+  });
 
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('Duplicate tool definition for "duplicate"'),
-      );
-      expect(merged.tools?.duplicate?.description).toBe("latest");
-    } finally {
-      warn.mockRestore();
-    }
+  it("silently replaces a same-priority tool when the later registration sets overwrite", () => {
+    const merged = mergeModelContexts(
+      new Set([
+        provider({ tools: { duplicate: toolFixture() } }),
+        provider({
+          tools: {
+            duplicate: {
+              ...toolFixture(),
+              description: "latest",
+              overwrite: true,
+            } as Tool<any, any>,
+          },
+        }),
+      ]),
+    );
+
+    expect(merged.tools?.duplicate?.description).toBe("latest");
+    expect(merged.tools?.duplicate?.overwrite).toBeUndefined();
   });
 
   it("preserves the highest priority when a lower-priority provider reuses the same tool object", () => {


### PR DESCRIPTION
Restores the duplicate-tool invariant that d4bdf2c relaxed to a console.warn: registering two tools with the same name at the same priority throws again (`You tried to define a tool with the name ${name}, but it already exists.`).

For intentional replacement, the `Tool` type gains an optional `overwrite: boolean` flag: when the later registration (Set insertion order) sets it, it silently replaces the existing same-priority tool. The flag is documented as a discouraged escape hatch — prefer distinct names or priorities — and is stripped from the merged output so it cannot cascade through nested `CompositeContextProvider` merges. Different-priority behavior is unchanged (higher priority wins, spread-merged).

Note: this touches the public `Tool` type (defined in `assistant-stream`, on `ToolBase`, so all tool variants accept it). Patch changesets for `assistant-stream` and `@assistant-ui/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nk2fsDLhYwuGCmxGzd82DiaB-DPztYzX_knYyLODhq4V9OBlhcINWJhYS4o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->