### PR TITLE
fix(react-a2a): validate task api responses

### DIFF
--- a/.changeset/tidy-tasks-respond.md
+++ b/.changeset/tidy-tasks-respond.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: validate successful task API responses before exposing them to runtimes

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -724,6 +724,14 @@ describe("A2AClient", () => {
       const [url] = fetchMock.mock.calls[0]!;
       expect(url).toBe("https://agent.test/tasks/t1?history_length=5");
     });
+
+    it("rejects malformed successful responses", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({}));
+
+      await expect(client.getTask("t1")).rejects.toThrow(
+        "Invalid A2A tasks:get response: expected a valid task payload.",
+      );
+    });
   });
 
   // --- listTasks ---
@@ -751,6 +759,29 @@ describe("A2AClient", () => {
       expect(url).toContain("status=TASK_STATE_WORKING");
       expect(url).toContain("page_size=10");
     });
+
+    it("rejects malformed successful responses", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({}));
+
+      await expect(client.listTasks()).rejects.toThrow(
+        "Invalid A2A tasks:list response: expected a valid task list payload.",
+      );
+    });
+
+    it("rejects malformed tasks in successful responses", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          tasks: [{}],
+          nextPageToken: "",
+          pageSize: 1,
+          totalSize: 1,
+        }),
+      );
+
+      await expect(client.listTasks()).rejects.toThrow(
+        "Invalid A2A tasks:list response: expected a valid task list payload.",
+      );
+    });
   });
 
   // --- cancelTask ---
@@ -777,6 +808,14 @@ describe("A2AClient", () => {
 
       const body = JSON.parse(fetchMock.mock.calls[0]![1].body);
       expect(body.metadata).toEqual({ reason: "user requested" });
+    });
+
+    it("rejects malformed successful responses", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({}));
+
+      await expect(client.cancelTask("t1")).rejects.toThrow(
+        "Invalid A2A tasks:cancel response: expected a valid task payload.",
+      );
     });
   });
 

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -782,6 +782,31 @@ describe("A2AClient", () => {
         "Invalid A2A tasks:list response: expected a valid task list payload.",
       );
     });
+
+    it("normalizes omitted pagination defaults", async () => {
+      const tasks = [{ id: "t1", status: { state: "completed" } }];
+      fetchMock.mockResolvedValue(mockFetchResponse({ tasks }));
+
+      await expect(client.listTasks()).resolves.toEqual({
+        tasks,
+        nextPageToken: "",
+        pageSize: 0,
+        totalSize: 0,
+      });
+    });
+
+    it("rejects malformed pagination fields", async () => {
+      fetchMock.mockResolvedValue(
+        mockFetchResponse({
+          tasks: [],
+          nextPageToken: 42,
+        }),
+      );
+
+      await expect(client.listTasks()).rejects.toThrow(
+        "Invalid A2A tasks:list response: expected a valid task list payload.",
+      );
+    });
   });
 
   // --- cancelTask ---

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -761,11 +761,22 @@ describe("A2AClient", () => {
     });
 
     it("rejects malformed successful responses", async () => {
-      fetchMock.mockResolvedValue(mockFetchResponse({}));
+      fetchMock.mockResolvedValue(mockFetchResponse({ tasks: 42 }));
 
       await expect(client.listTasks()).rejects.toThrow(
         "Invalid A2A tasks:list response: expected a valid task list payload.",
       );
+    });
+
+    it("normalizes empty responses", async () => {
+      fetchMock.mockResolvedValue(mockFetchResponse({}));
+
+      await expect(client.listTasks()).resolves.toEqual({
+        tasks: [],
+        nextPageToken: "",
+        pageSize: 0,
+        totalSize: 0,
+      });
     });
 
     it("rejects malformed tasks in successful responses", async () => {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -276,20 +276,37 @@ const parseTaskResponse = (
 const isNonNegativeInteger = (value: unknown): value is number =>
   typeof value === "number" && Number.isInteger(value) && value >= 0;
 
-const isListTasksResponse = (value: unknown): value is A2AListTasksResponse =>
-  isRecord(value) &&
-  Array.isArray(value.tasks) &&
-  value.tasks.every(isTask) &&
-  typeof value.nextPageToken === "string" &&
-  isNonNegativeInteger(value.pageSize) &&
-  isNonNegativeInteger(value.totalSize);
-
-const parseListTasksResponse = (value: unknown): A2AListTasksResponse => {
-  if (isListTasksResponse(value)) return value;
-
+const invalidListTasksResponse = (): never => {
   throw new Error(
     "Invalid A2A tasks:list response: expected a valid task list payload.",
   );
+};
+
+const parseListTasksResponse = (value: unknown): A2AListTasksResponse => {
+  if (
+    !isRecord(value) ||
+    !Array.isArray(value.tasks) ||
+    !value.tasks.every(isTask)
+  ) {
+    return invalidListTasksResponse();
+  }
+
+  const { nextPageToken, pageSize, totalSize } = value;
+  if (
+    (nextPageToken != null && typeof nextPageToken !== "string") ||
+    (pageSize != null && !isNonNegativeInteger(pageSize)) ||
+    (totalSize != null && !isNonNegativeInteger(totalSize))
+  ) {
+    return invalidListTasksResponse();
+  }
+
+  return {
+    ...value,
+    tasks: value.tasks,
+    nextPageToken: nextPageToken ?? "",
+    pageSize: pageSize ?? 0,
+    totalSize: totalSize ?? 0,
+  };
 };
 
 function signalInit(signal?: AbortSignal): RequestInit {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -283,11 +283,10 @@ const invalidListTasksResponse = (): never => {
 };
 
 const parseListTasksResponse = (value: unknown): A2AListTasksResponse => {
-  if (
-    !isRecord(value) ||
-    !Array.isArray(value.tasks) ||
-    !value.tasks.every(isTask)
-  ) {
+  if (!isRecord(value)) return invalidListTasksResponse();
+
+  const tasks = value.tasks ?? [];
+  if (!Array.isArray(tasks) || !tasks.every(isTask)) {
     return invalidListTasksResponse();
   }
 
@@ -302,7 +301,7 @@ const parseListTasksResponse = (value: unknown): A2AListTasksResponse => {
 
   return {
     ...value,
-    tasks: value.tasks,
+    tasks,
     nextPageToken: nextPageToken ?? "",
     pageSize: pageSize ?? 0,
     totalSize: totalSize ?? 0,

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -262,6 +262,36 @@ const parseSendMessageResponse = (value: unknown): A2ATask | A2AMessage => {
   );
 };
 
+const parseTaskResponse = (
+  value: unknown,
+  operation: "tasks:get" | "tasks:cancel",
+): A2ATask => {
+  if (isTask(value)) return value;
+
+  throw new Error(
+    `Invalid A2A ${operation} response: expected a valid task payload.`,
+  );
+};
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= 0;
+
+const isListTasksResponse = (value: unknown): value is A2AListTasksResponse =>
+  isRecord(value) &&
+  Array.isArray(value.tasks) &&
+  value.tasks.every(isTask) &&
+  typeof value.nextPageToken === "string" &&
+  isNonNegativeInteger(value.pageSize) &&
+  isNonNegativeInteger(value.totalSize);
+
+const parseListTasksResponse = (value: unknown): A2AListTasksResponse => {
+  if (isListTasksResponse(value)) return value;
+
+  throw new Error(
+    "Invalid A2A tasks:list response: expected a valid task list payload.",
+  );
+};
+
 function signalInit(signal?: AbortSignal): RequestInit {
   return signal ? { signal } : {};
 }
@@ -464,10 +494,11 @@ export class A2AClient {
       params.set("history_length", String(historyLength));
     }
     const qs = params.toString();
-    return this.fetchJSON<A2ATask>(
+    const result = await this.fetchJSON<unknown>(
       `${this.getBasePath()}/tasks/${encodeURIComponent(taskId)}${qs ? `?${qs}` : ""}`,
       signalInit(signal),
     );
+    return parseTaskResponse(result, "tasks:get");
   }
 
   async listTasks(
@@ -487,10 +518,11 @@ export class A2AClient {
     if (request?.includeArtifacts !== undefined)
       params.set("include_artifacts", String(request.includeArtifacts));
     const qs = params.toString();
-    return this.fetchJSON<A2AListTasksResponse>(
+    const result = await this.fetchJSON<unknown>(
       `${this.getBasePath()}/tasks${qs ? `?${qs}` : ""}`,
       signalInit(signal),
     );
+    return parseListTasksResponse(result);
   }
 
   async cancelTask(
@@ -499,7 +531,7 @@ export class A2AClient {
     signal?: AbortSignal,
   ): Promise<A2ATask> {
     const body = metadata ? { metadata } : {};
-    return this.fetchJSON<A2ATask>(
+    const result = await this.fetchJSON<unknown>(
       `${this.getBasePath()}/tasks/${encodeURIComponent(taskId)}:cancel`,
       {
         method: "POST",
@@ -507,6 +539,7 @@ export class A2AClient {
         ...signalInit(signal),
       },
     );
+    return parseTaskResponse(result, "tasks:cancel");
   }
 
   async *subscribeToTask(


### PR DESCRIPTION
## Summary

- validate successful `getTask()` and `cancelTask()` responses before returning them
- validate the `listTasks()` envelope, pagination fields, and every returned task
- add regression coverage for malformed HTTP 200 responses

## Why

While testing an A2A endpoint, a successful `200 {}` response was accepted as if it matched the published task types. `getTask()` and `cancelTask()` therefore exposed an invalid task, while consumers of `listTasks()` could fail later when reading `response.tasks`.

The generic JSON helper only asserted its TypeScript return type; it did not validate the runtime payload. This change reuses the existing task guard and reports an operation-specific error at the request boundary instead.

## Validation

- `A2AClient.test.ts`: 78 tests passed
- TypeScript 6 no-emit check passed for `A2AClient.ts`
- oxlint passed for the changed source and test files
- regression tests were confirmed to fail before the implementation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZVtyx0iW2bJFa57xdbOCRkMmRZSn5MJDHKFEXz6_fmsU2XCSebWx07-jVDM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->