### PR TITLE
fix(cli): await async command handlers

### DIFF
--- a/.changeset/calm-clis-wait.md
+++ b/.changeset/calm-clis-wait.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: await asynchronous CLI command handlers

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -48,9 +48,9 @@ export const upgradeCommand = addTransformOptions(
   new Command()
     .command("upgrade")
     .description("Upgrade ai package dependencies and apply codemods"),
-).action((options: TransformOptions) => {
+).action(async (options: TransformOptions) => {
   try {
-    upgrade(options);
+    await upgrade(options);
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     const errorStack = err instanceof Error ? err.stack : undefined;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 
-import { buildProgram } from "./program";
+import { runCli } from "./run";
 
 process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
-function main() {
-  buildProgram().parse();
-}
-
-main();
+void runCli().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,6 @@ process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
 void runCli().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
+  console.error(error);
   process.exitCode = 1;
 });

--- a/packages/cli/src/run.test.ts
+++ b/packages/cli/src/run.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  parseAsync: vi.fn(),
+}));
+
+vi.mock("./program", () => ({
+  buildProgram: () => ({
+    parseAsync: mocks.parseAsync,
+  }),
+}));
+
+import { runCli } from "./run";
+
+describe("runCli", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("awaits and propagates asynchronous command failures", async () => {
+    const error = new Error("command failed");
+    mocks.parseAsync.mockRejectedValue(error);
+
+    await expect(runCli()).rejects.toBe(error);
+    expect(mocks.parseAsync).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -1,0 +1,5 @@
+import { buildProgram } from "./program";
+
+export async function runCli(): Promise<void> {
+  await buildProgram().parseAsync();
+}

--- a/packages/cli/test/commands/upgrade.test.ts
+++ b/packages/cli/test/commands/upgrade.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  upgrade: vi.fn(),
+}));
+
+vi.mock("../../src/lib/upgrade", () => ({
+  upgrade: mocks.upgrade,
+}));
+
+vi.mock("debug", () => ({
+  default: Object.assign(() => vi.fn(), { enable: vi.fn() }),
+}));
+
+import { upgradeCommand } from "../../src/commands/upgrade";
+
+describe("upgrade command", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("handles asynchronous upgrade failures", async () => {
+    mocks.upgrade.mockRejectedValue(new Error("upgrade failed"));
+
+    await expect(
+      upgradeCommand.parseAsync(["node", "upgrade"], { from: "node" }),
+    ).rejects.toThrow("process.exit");
+
+    expect(mocks.upgrade).toHaveBeenCalledOnce();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary

- run Commander through `parseAsync()` so the CLI waits for asynchronous actions
- await the `upgrade()` promise so its existing error handler catches asynchronous failures
- report unexpected top-level command failures and exit with a nonzero status
- add regression coverage and a patch changeset

## Why

Most assistant-ui commands use asynchronous Commander action handlers, but the CLI entrypoint called synchronous `parse()`. In a minimal reproduction against the installed Commander version, `parse()` returned before the action settled and the rejected action became a global unhandled rejection. `parseAsync()` awaited and surfaced the same rejection normally.

The upgrade command had a second dropped promise inside its action, which meant its `try/catch` only handled synchronous failures. A failed asynchronous upgrade could therefore bypass the command error message and lifecycle.

This matters for commands doing network requests, filesystem work, or child-process execution: the process should remain attached to the command and return a reliable failure status instead of leaking an unhandled rejection.

## Validation

- CLI test suite: 21 files, 247 tests passed
- focused regression tests for CLI execution and upgrade failures
- `aui-build` for the `assistant-ui` package
- oxlint 1.75.0 on changed TypeScript files
- oxfmt 0.60.0 on all changed files
- built CLI `--help` smoke test