### PR TITLE
fix(tap): useSyncExternalStore retains committed value when snapshot throws

### DIFF
--- a/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
+++ b/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
@@ -149,4 +149,29 @@ describe("useSyncExternalStore", () => {
     cleanupAllResources();
     expect(storeB.unsubscribeCalls).toBe(1);
   });
+
+  it("keeps the committed value when getSnapshot throws on a notification and resumes once the store is consistent again", async () => {
+    const store = createStore(["a", "b"]);
+    const testFiber = createTestResource(() =>
+      useSyncExternalStore(
+        useCallback((cb) => store.subscribe(cb), []),
+        useCallback(() => {
+          const items = store.getState();
+          if (items.length < 2) throw new Error("index out of bounds");
+          return items[1];
+        }, []),
+      ),
+    );
+
+    expect(renderTest(testFiber)).toBe("b");
+
+    // the notification makes the snapshot throw; nothing escapes the store's notify loop
+    expect(() => store.setState(["a"])).not.toThrow();
+    await waitForNextTick();
+    expect(getCommittedValue(testFiber)).toBe("b");
+
+    store.setState(["a", "c"]);
+    await waitForNextTick();
+    expect(getCommittedValue(testFiber)).toBe("c");
+  });
 });

--- a/packages/tap/src/react-hooks/useSyncExternalStore.ts
+++ b/packages/tap/src/react-hooks/useSyncExternalStore.ts
@@ -15,7 +15,13 @@ export const useSyncExternalStore = <T>(
   const [, forceUpdate] = useState(0);
 
   const onStoreChange = useEffectEvent(() => {
-    if (!Object.is(value, getSnapshot())) forceUpdate((c) => c + 1);
+    // mirrors React's checkIfSnapshotChanged: a throwing snapshot keeps the committed value
+    try {
+      if (Object.is(value, getSnapshot())) return;
+    } catch {
+      return;
+    }
+    forceUpdate((c) => c + 1);
   });
 
   useEffect(() => {

--- a/packages/tap/src/react-hooks/useSyncExternalStore.ts
+++ b/packages/tap/src/react-hooks/useSyncExternalStore.ts
@@ -16,6 +16,7 @@ export const useSyncExternalStore = <T>(
 
   const onStoreChange = useEffectEvent(() => {
     // mirrors React's checkIfSnapshotChanged: a throwing snapshot keeps the committed value
+    // TODO: ideally notify our parent (host) to rerender, mirroring React's force-re-render
     try {
       if (Object.is(value, getSnapshot())) return;
     } catch {


### PR DESCRIPTION
## Problem

tap's useSyncExternalStore shim compared snapshots in the store-change handler without the try/catch React's real implementation has (`checkIfSnapshotChanged`). A `getSnapshot` that throws during a store notification propagated into whatever catch sits above the notify loop (e.g. NotificationManager's per-subscriber catch, producing console.error noise).

## Semantics

The changed-check now catches the throw and skips the forceUpdate: the hook retains its last committed value until the next successful update or unmount. This deliberately differs from React, which treats a throw as "changed" and re-renders — React can rely on its render-phase recovery, while tap has none (scheduler.ts rethrows render errors out of the flush), so re-rendering immediately would just move the throw into tap's render.

## Tests

Contract test added to `packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts`: a snapshot that starts throwing after a notification escapes nothing, the hook keeps returning the last committed value, and a later notification on a consistent store resumes normal updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SKunbN_etHNSFyMfMHmHbRlOfAdJTu7LJp4MwkyYJIOTtHcuQKE9PhSJXaY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->