### PR TITLE
docs: property accessor sweep for guides and tap-docs

### DIFF
--- a/apps/docs/content/docs/copilots/model-context.mdx
+++ b/apps/docs/content/docs/copilots/model-context.mdx
@@ -112,7 +112,7 @@ function MyComponent() {
 
   useEffect(() => {
     // Register context provider
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({
         system: "You are a helpful search assistant...",
         tools: { myTool },

--- a/apps/docs/content/docs/copilots/motivation.mdx
+++ b/apps/docs/content/docs/copilots/motivation.mdx
@@ -158,7 +158,7 @@ function SmartTransactionHistory({ userProfile }) {
   const aui = useAui();
 
   useEffect(() => {
-    return aui.modelContext().register({
+    return aui.modelContext.register({
       getModelContext: () => ({
         system: `
           User spending patterns:

--- a/apps/docs/content/docs/guides/attachments.mdx
+++ b/apps/docs/content/docs/guides/attachments.mdx
@@ -503,14 +503,14 @@ Add attachments from external sources (URLs, API data, CMS references) without n
 const aui = useAui();
 
 // Add an attachment from an external source
-await aui.composer().addAttachment({
+await aui.composer.addAttachment({
   name: "report.pdf",
   contentType: "application/pdf",
   content: [{ type: "text", text: "Extracted document content..." }],
 });
 
 // Optionally provide id and type
-await aui.composer().addAttachment({
+await aui.composer.addAttachment({
   id: "cms-doc-123",
   type: "document",
   name: "Product Spec",
@@ -532,7 +532,7 @@ const handleMultipleFiles = async (files: FileList) => {
   const filesToAdd = Array.from(files).slice(0, maxFiles);
 
   for (const file of filesToAdd) {
-    await aui.composer().addAttachment(file);
+    await aui.composer.addAttachment(file);
   }
 };
 ```

--- a/apps/docs/content/docs/guides/branching.mdx
+++ b/apps/docs/content/docs/guides/branching.mdx
@@ -54,7 +54,7 @@ const AssistantMessage = () => (
 
 ## Programmatic Branch Navigation
 
-For headless or keyboard-shortcut flows, navigate directly to a branch by id via `aui.message().switchToBranch`:
+For headless or keyboard-shortcut flows, navigate directly to a branch by id via `aui.message.switchToBranch`:
 
 ```tsx
 import { useAui } from "@assistant-ui/react";
@@ -62,7 +62,7 @@ import { useAui } from "@assistant-ui/react";
 const SwitchToBranch = ({ branchId }: { branchId: string }) => {
   const aui = useAui();
   return (
-    <button onClick={() => aui.message().switchToBranch({ branchId })}>
+    <button onClick={() => aui.message.switchToBranch({ branchId })}>
       Go to branch
     </button>
   );

--- a/apps/docs/content/docs/guides/context-api.mdx
+++ b/apps/docs/content/docs/guides/context-api.mdx
@@ -122,7 +122,7 @@ const content = useAuiState((s) => s.message.content);
 
 ### useAui
 
-Access the API instance for imperative operations and actions. Unlike `useAuiState`, this hook returns a stable object that never changes, making it perfect for event handlers and imperative operations.
+Access the API instance for imperative operations and actions. Unlike `useAuiState`, this hook does not subscribe to state updates: the client's identity only changes on structural changes (a scope resolving to a different instance), making it well suited for event handlers and imperative operations.
 
 ```tsx
 import { useAui } from "@assistant-ui/react";
@@ -132,20 +132,20 @@ function CustomMessageActions() {
 
   // Perform actions in event handlers
   const handleSend = () => {
-    aui.composer().send();
+    aui.composer.send();
   };
 
   const handleReload = () => {
-    aui.message().reload();
+    aui.message.reload();
   };
 
   // Read state imperatively when needed
   const handleConditionalAction = () => {
-    const { isRunning } = aui.thread().getState();
-    const { text } = aui.composer().getState();
+    const { isRunning } = aui.thread.getState();
+    const { text } = aui.composer.getState();
 
     if (!isRunning && text.length > 0) {
-      aui.composer().send();
+      aui.composer.send();
     }
   };
 
@@ -159,7 +159,7 @@ function CustomMessageActions() {
 }
 ```
 
-The API object is stable and doesn't cause re-renders. Use it for:
+The API object doesn't cause re-renders on state updates. Use it for:
 
 - **Triggering actions** in event handlers and callbacks
 - **Reading current state** imperatively when you don't need subscriptions
@@ -170,80 +170,80 @@ The API object is stable and doesn't cause re-renders. Use it for:
 
 ```tsx
 // Thread actions
-aui.thread().append(message);
-aui.thread().startRun(config);
-aui.thread().resumeRun(config);
-aui.thread().cancelRun();
-aui.thread().getState();
-aui.thread().message({ index: idx });
-aui.thread().message({ id: messageId });
-aui.thread().composer();
+aui.thread.append(message);
+aui.thread.startRun(config);
+aui.thread.resumeRun(config);
+aui.thread.cancelRun();
+aui.thread.getState();
+aui.thread.message({ index: idx });
+aui.thread.message({ id: messageId });
+aui.thread.composer();
 
 // Message actions
-aui.message().reload();
-aui.message().speak();
-aui.message().stopSpeaking();
-aui.message().submitFeedback({ type: "positive" | "negative" });
-aui.message().switchToBranch({ position, branchId });
-aui.message().getState();
-aui.message().part({ index: idx });
-aui.message().part({ toolCallId });
-aui.message().composer();
+aui.message.reload();
+aui.message.speak();
+aui.message.stopSpeaking();
+aui.message.submitFeedback({ type: "positive" | "negative" });
+aui.message.switchToBranch({ position, branchId });
+aui.message.getState();
+aui.message.part({ index: idx });
+aui.message.part({ toolCallId });
+aui.message.composer();
 
 // Part actions
-aui.part().addToolResult(result);
-aui.part().resumeToolCall(result);
-aui.part().getState();
+aui.part.addToolResult(result);
+aui.part.resumeToolCall(result);
+aui.part.getState();
 
 // Composer actions
-aui.composer().send();
-aui.composer().setText(text);
-aui.composer().setRole(role);
-aui.composer().addAttachment(file); // File object
-aui.composer().addAttachment({ name, content }); // external source
-await aui.composer().clearAttachments();
-await aui.composer().reset();
-aui.composer().getState();
+aui.composer.send();
+aui.composer.setText(text);
+aui.composer.setRole(role);
+aui.composer.addAttachment(file); // File object
+aui.composer.addAttachment({ name, content }); // external source
+await aui.composer.clearAttachments();
+await aui.composer.reset();
+aui.composer.getState();
 
 // Attachment actions
-aui.attachment().remove();
-aui.attachment().getState();
+aui.attachment.remove();
+aui.attachment.getState();
 
 // ThreadList actions
-aui.threads().switchToNewThread();
-aui.threads().switchToThread(threadId);
-aui.threads().reload();
-await aui.threads().getLoadThreadsPromise();
-aui.threads().getState();
+aui.threads.switchToNewThread();
+aui.threads.switchToThread(threadId);
+aui.threads.reload();
+await aui.threads.getLoadThreadsPromise();
+aui.threads.getState();
 
 // ThreadListItem actions
-aui.threadListItem().switchTo();
-aui.threadListItem().rename(title);
-aui.threadListItem().updateCustom(custom);
-aui.threadListItem().archive();
-aui.threadListItem().unarchive();
-aui.threadListItem().delete();
-aui.threadListItem().getState();
+aui.threadListItem.switchTo();
+aui.threadListItem.rename(title);
+aui.threadListItem.updateCustom(custom);
+aui.threadListItem.archive();
+aui.threadListItem.unarchive();
+aui.threadListItem.delete();
+aui.threadListItem.getState();
 
 // Suggestions actions
-aui.suggestions().getState();
-aui.suggestions().suggestion({ index: 0 });
+aui.suggestions.getState();
+aui.suggestions.suggestion({ index: 0 });
 
 // Suggestion actions
-aui.suggestion().getState();
+aui.suggestion.getState();
 
 // ChainOfThought actions
-aui.chainOfThought().getState();
-aui.chainOfThought().setCollapsed(collapsed);
-aui.chainOfThought().part({ index: 0 });
+aui.chainOfThought.getState();
+aui.chainOfThought.setCollapsed(collapsed);
+aui.chainOfThought.part({ index: 0 });
 
 // ModelContext actions — see /docs/copilots/model-context for full usage
-aui.modelContext().register(provider);
-aui.modelContext().getState();
+aui.modelContext.register(provider);
+aui.modelContext.getState();
 
 // Tools actions
-aui.tools().setToolUI(toolName, render);
-aui.tools().getState();
+aui.tools.setToolUI(toolName, render);
+aui.tools.getState();
 ```
 
 ### useAuiEvent
@@ -320,7 +320,7 @@ function MessageButton() {
 
   // Automatically uses the current message scope
   const handleReload = () => {
-    aui.message().reload();
+    aui.message.reload();
   };
 
   return <button onClick={handleReload}>Reload</button>;
@@ -337,7 +337,7 @@ const aui = useAui();
 // Check if message scope exists
 if (aui.message.source) {
   // Safe to use message scope
-  const { role } = aui.message().getState();
+  const { role } = aui.message.getState();
 }
 ```
 
@@ -349,24 +349,24 @@ Navigate through the scope hierarchy programmatically:
 const aui = useAui();
 
 // Access specific message by ID or index
-const messageById = aui.thread().message({ id: "msg_123" });
-const messageByIndex = aui.thread().message({ index: 0 });
+const messageById = aui.thread.message({ id: "msg_123" });
+const messageByIndex = aui.thread.message({ index: 0 });
 
 // Access part by index or tool call ID
-const partByIndex = aui.message().part({ index: 0 });
-const partByToolCall = aui.message().part({ toolCallId: "call_123" });
+const partByIndex = aui.message.part({ index: 0 });
+const partByToolCall = aui.message.part({ toolCallId: "call_123" });
 
 // Access attachment by index
-const attachment = aui.composer().attachment({ index: 0 }).getState();
+const attachment = aui.composer.attachment({ index: 0 }).getState();
 
 // Access thread list item by ID, index, or the "main" selector
-const threadItem = aui.threads().item({ id: "thread_123" });
-const threadByIndex = aui.threads().item({ index: 0 });
-const archivedThread = aui.threads().item({ index: 0, archived: true });
+const threadItem = aui.threads.item({ id: "thread_123" });
+const threadByIndex = aui.threads.item({ index: 0 });
+const archivedThread = aui.threads.item({ index: 0, archived: true });
 
 // Traverse to the main thread directly
-const mainThread = aui.threads().thread("main");
-const message = aui.threads().thread("main").message({ id: "msg_123" });
+const mainThread = aui.threads.thread("main");
+const message = aui.threads.thread("main").message({ id: "msg_123" });
 ```
 
 ## Common Patterns
@@ -389,7 +389,7 @@ function CopyButton() {
   const aui = useAui();
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(aui.message().getCopyText());
+    navigator.clipboard.writeText(aui.message.getCopyText());
   };
 
   return <button onClick={handleCopy}>Copy</button>;
@@ -410,10 +410,10 @@ function SmartComposer() {
     <div>
       <textarea
         value={text}
-        onChange={(e) => aui.composer().setText(e.target.value)}
+        onChange={(e) => aui.composer.setText(e.target.value)}
         disabled={isRunning}
       />
-      <button onClick={() => aui.composer().send()} disabled={!canSend}>
+      <button onClick={() => aui.composer.send()} disabled={!canSend}>
         Send
       </button>
     </div>
@@ -439,23 +439,17 @@ function MessageCounter() {
 
 ### Resolution Dynamics
 
-When you call `aui.scope()`, the API resolves the current scope at that moment. This resolution happens each time you call the function, which matters when dealing with changing contexts:
+Scopes are resolved during render and bound into the client. State updates never change the client's identity; a structural change (for example, switching threads) produces a new client and re-renders consumers through React:
 
 ```tsx
 const aui = useAui();
 
-// Get current thread
-const thread1 = aui.thread();
-thread1.append({ role: "user", content: "Hello" });
+// Bound to the thread current at this render
+aui.thread.append({ role: "user", content: "Hello" });
 
-// User might switch threads here
-
-// This could be a different thread
-const thread2 = aui.thread();
-thread2.cancelRun(); // Cancels the current thread's run, not necessarily thread1's
+// After a thread switch, the component re-renders with a new client.
+// Accessors read from a previous render keep pointing at the old thread.
 ```
-
-For most use cases, this behavior is intuitive. In advanced scenarios where you need to track specific instances, store the resolved reference.
 
 ### Performance Optimization
 
@@ -575,7 +569,7 @@ function SafeMessageButton() {
   const aui = useAui();
 
   const role = useAuiState((s) =>
-    aui.message.source !== undefined ? s.message.role : "none",
+    aui.message.source != null ? s.message.role : "none",
   );
 
   return <div>Role: {role}</div>;
@@ -601,7 +595,7 @@ const content = useAuiState((s) => s.message.content);
 ```tsx
 // ❌ Storing scope references can lead to stale data
 const aui = useAui();
-const thread = aui.thread(); // This reference might become stale
+const thread = aui.thread; // This reference might become stale
 
 useEffect(() => {
   // This might reference the wrong thread if user switched
@@ -613,7 +607,7 @@ const aui = useAui();
 
 useEffect(() => {
   // Always gets the current thread
-  aui.thread().cancelRun();
+  aui.thread.cancelRun();
 }, [aui]);
 ```
 
@@ -625,7 +619,7 @@ const value = useAuiState((s) => s.scope.property);
 
 // Perform action
 const aui = useAui();
-aui.scope().action();
+aui.scope.action();
 
 // Listen to events
 useAuiEvent("source.event", (e) => {});
@@ -636,8 +630,8 @@ if (aui.scope.source) {
 }
 
 // Get state imperatively
-const state = aui.scope().getState();
+const state = aui.scope.getState();
 
 // Navigate scopes
-aui.thread().message({ id: "..." }).getState();
+aui.thread.message({ id: "..." }).getState();
 ```

--- a/apps/docs/content/docs/guides/editing.mdx
+++ b/apps/docs/content/docs/guides/editing.mdx
@@ -66,9 +66,9 @@ const AssistantMessage = () => {
 };
 ```
 
-`ActionBarPrimitive.Edit` calls `aui.composer().beginEdit()` under the hood and is disabled when the composer is already in edit mode.
+`ActionBarPrimitive.Edit` calls `aui.composer.beginEdit()` under the hood and is disabled when the composer is already in edit mode.
 
-`ComposerPrimitive.Cancel` calls `aui.composer().cancel()`, which exits edit mode and restores the original message content. See [Composer primitives](/docs/primitives/composer) for the full composer API.
+`ComposerPrimitive.Cancel` calls `aui.composer.cancel()`, which exits edit mode and restores the original message content. See [Composer primitives](/docs/primitives/composer) for the full composer API.
 
 ## Detecting Edit Mode
 
@@ -76,7 +76,7 @@ The `isEditing` flag is available on both `ThreadComposerState` and `EditCompose
 
 ## Imperative API
 
-`aui.composer().beginEdit()` is the programmatic entry point for entering edit mode on a message. Use it for headless or keyboard-shortcut-driven flows where `ActionBarPrimitive.Edit` is not rendered:
+`aui.composer.beginEdit()` is the programmatic entry point for entering edit mode on a message. Use it for headless or keyboard-shortcut-driven flows where `ActionBarPrimitive.Edit` is not rendered:
 
 ```tsx
 import { useAui } from "@assistant-ui/react";
@@ -84,12 +84,12 @@ import { useAui } from "@assistant-ui/react";
 const EditButton = () => {
   const aui = useAui();
   return (
-    <button onClick={() => aui.composer().beginEdit()}>Edit</button>
+    <button onClick={() => aui.composer.beginEdit()}>Edit</button>
   );
 };
 ```
 
-`aui.composer().cancel()` exits edit mode without re-submitting.
+`aui.composer.cancel()` exits edit mode without re-submitting.
 
 ## Editing While Streaming
 

--- a/apps/docs/content/docs/guides/quoting.mdx
+++ b/apps/docs/content/docs/guides/quoting.mdx
@@ -127,7 +127,7 @@ function CustomQuoteDisplay() {
 
 ## Programmatic API
 
-Set or clear quotes via `useAui` from `@assistant-ui/react`. Call `aui.thread().composer().setQuote()` when your component is rendered outside of a specific thread context, or `aui.composer().setQuote()` when it is rendered inside a thread:
+Set or clear quotes via `useAui` from `@assistant-ui/react`. Call `aui.thread.composer().setQuote()` when your component is rendered outside of a specific thread context, or `aui.composer.setQuote()` when it is rendered inside a thread:
 
 ```tsx
 import { useAui } from "@assistant-ui/react";
@@ -136,14 +136,14 @@ function MyComponent() {
   const aui = useAui();
 
   const quoteText = () => {
-    aui.thread().composer().setQuote({
+    aui.thread.composer().setQuote({
       text: "The text to quote",
       messageId: "msg-123",
     });
   };
 
   const clearQuote = () => {
-    aui.thread().composer().setQuote(undefined);
+    aui.thread.composer().setQuote(undefined);
   };
 
   return (

--- a/apps/docs/content/docs/ink/hooks.mdx
+++ b/apps/docs/content/docs/ink/hooks.mdx
@@ -41,11 +41,11 @@ import { useAui } from "@assistant-ui/react-ink";
 const aui = useAui();
 
 // Composer actions
-aui.composer().setText("Hello");
-aui.composer().send();
+aui.composer.setText("Hello");
+aui.composer.send();
 
 // Thread actions
-aui.thread().cancelRun();
+aui.thread.cancelRun();
 ```
 
 ### useAuiEvent

--- a/apps/docs/content/docs/ink/primitives.mdx
+++ b/apps/docs/content/docs/ink/primitives.mdx
@@ -396,7 +396,7 @@ Renders the quoted text from `s.composer.quote?.text`. Pass `children` to overri
 
 ### QuoteDismiss
 
-Pressable that clears the active quote by calling `aui.composer().setQuote(undefined)`.
+Pressable that clears the active quote by calling `aui.composer.setQuote(undefined)`.
 
 ```tsx
 <ComposerPrimitive.QuoteDismiss>
@@ -683,7 +683,7 @@ Container `Box` for an attachment. Forwards all `Box` props.
 
 ### Remove
 
-`Pressable` that calls `aui.attachment().remove()` when activated (Enter while focused). Disabled when not focused or when the `disabled` prop is set.
+`Pressable` that calls `aui.attachment.remove()` when activated (Enter while focused). Disabled when not focused or when the `disabled` prop is set.
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -725,7 +725,7 @@ Renders the queue item's prompt with Ink `<Text>`. Pass `children` to override t
 
 ### Remove
 
-Pressable that removes the queue item by calling `aui.queueItem().remove()`.
+Pressable that removes the queue item by calling `aui.queueItem.remove()`.
 
 ```tsx
 <QueueItemPrimitive.Remove>
@@ -742,7 +742,7 @@ Remaining props are forwarded to the underlying `Pressable` (Ink `Box` props).
 
 ### Steer
 
-Pressable that promotes the queue item to run next by calling `aui.queueItem().steer()`.
+Pressable that promotes the queue item to run next by calling `aui.queueItem.steer()`.
 
 ```tsx
 <QueueItemPrimitive.Steer>

--- a/apps/docs/content/docs/integrations/auth/better-auth.mdx
+++ b/apps/docs/content/docs/integrations/auth/better-auth.mdx
@@ -22,7 +22,7 @@ Three integration points:
 
 1. **Auth handlers** mounted at `/api/auth/[...all]/route.ts` via `toNextJsHandler(auth)`.
 2. **API routes** read the session server-side with `auth.api.getSession({ headers: await headers() })`.
-3. **Reload-on-auth** uses better-auth's React client to detect sign-in and trigger `aui.threads().reload()`.
+3. **Reload-on-auth** uses better-auth's React client to detect sign-in and trigger `aui.threads.reload()`.
 
 `session.user.id` is exposed on the session object directly, so route handlers can scope queries against it.
 
@@ -136,7 +136,7 @@ export function ReloadOnAuth() {
   const aui = useAui();
   const { data: session, isPending } = authClient.useSession();
   useEffect(() => {
-    if (!isPending && session) aui.threads().reload();
+    if (!isPending && session) aui.threads.reload();
   }, [isPending, session?.user?.id]);
   return null;
 }

--- a/apps/docs/content/docs/integrations/auth/clerk.mdx
+++ b/apps/docs/content/docs/integrations/auth/clerk.mdx
@@ -102,7 +102,7 @@ const rows = await db
 
 ### Reload threads after async auth
 
-The first render of `<MyProvider>` may run before Clerk resolves the user on the client. Drop a small effect inside `<AssistantRuntimeProvider>` that calls `aui.threads().reload()` once the user is loaded:
+The first render of `<MyProvider>` may run before Clerk resolves the user on the client. Drop a small effect inside `<AssistantRuntimeProvider>` that calls `aui.threads.reload()` once the user is loaded:
 
 ```tsx title="app/components/ReloadOnAuth.tsx"
 "use client";
@@ -115,7 +115,7 @@ export function ReloadOnAuth() {
   const aui = useAui();
   const { isLoaded, isSignedIn, user } = useUser();
   useEffect(() => {
-    if (isLoaded && isSignedIn) aui.threads().reload();
+    if (isLoaded && isSignedIn) aui.threads.reload();
   }, [isLoaded, isSignedIn, user?.id]);
   return null;
 }

--- a/apps/docs/content/docs/integrations/auth/next-auth.mdx
+++ b/apps/docs/content/docs/integrations/auth/next-auth.mdx
@@ -18,7 +18,7 @@ Three places auth touches the integration:
 
 1. **API routes** (`/api/chat`, `/api/threads/*`) call `auth()` server-side, return 401 if no session, then scope DB queries by `session.user.id`.
 2. **`RemoteThreadListAdapter`** does nothing auth-specific; the cookie travels with the `fetch` calls automatically (same origin).
-3. **Reload-on-auth**: if the session resolves after the initial render, call `aui.threads().reload()` so the list re-fetches with the new identity.
+3. **Reload-on-auth**: if the session resolves after the initial render, call `aui.threads.reload()` so the list re-fetches with the new identity.
 
 ## Setup
 
@@ -113,7 +113,7 @@ Apply the same pattern to `POST`, `PATCH`, and `DELETE` handlers. Always verify 
 
 ### Reload threads after async auth
 
-The first render of `<MyProvider>` may run before `auth()` resolves on the client. The thread list will be empty until the user refreshes. Drop a small effect into the layout to call `aui.threads().reload()` once the session resolves.
+The first render of `<MyProvider>` may run before `auth()` resolves on the client. The thread list will be empty until the user refreshes. Drop a small effect into the layout to call `aui.threads.reload()` once the session resolves.
 
 `useSession` requires `<SessionProvider>` higher in the tree. Wrap your root layout's client subtree once:
 
@@ -140,7 +140,7 @@ export function ReloadOnAuth() {
   const aui = useAui();
   const { status, data } = useSession();
   useEffect(() => {
-    if (status === "authenticated") aui.threads().reload();
+    if (status === "authenticated") aui.threads.reload();
   }, [status, data?.user?.id]);
   return null;
 }

--- a/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
@@ -305,7 +305,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
         async append() {},
         withFormat: (fmt) => ({
           async load() {
-            const { remoteId } = aui.threadListItem().getState();
+            const { remoteId } = aui.threadListItem.getState();
             if (!remoteId) return { messages: [] };
             const rows = await fetch(
               `/api/threads/${remoteId}/messages`,
@@ -322,7 +322,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
             };
           },
           async append(item) {
-            const { remoteId } = await aui.threadListItem().initialize();
+            const { remoteId } = await aui.threadListItem.initialize();
             await fetch(`/api/threads/${remoteId}/messages`, {
               method: "POST",
               body: JSON.stringify({
@@ -422,7 +422,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
         async append() {},
         withFormat: (fmt) => ({
           async load() {
-            const { remoteId } = aui.threadListItem().getState();
+            const { remoteId } = aui.threadListItem.getState();
             if (!remoteId) return { messages: [] };
             const rows = await fetch(
               `${API_URL}/threads/${remoteId}/messages`,
@@ -439,7 +439,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
             };
           },
           async append(item) {
-            const { remoteId } = await aui.threadListItem().initialize();
+            const { remoteId } = await aui.threadListItem.initialize();
             await fetch(`${API_URL}/threads/${remoteId}/messages`, {
               method: "POST",
               body: JSON.stringify({
@@ -541,7 +541,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
         async append() {},
         withFormat: (fmt) => ({
           async load() {
-            const { remoteId } = aui.threadListItem().getState();
+            const { remoteId } = aui.threadListItem.getState();
             if (!remoteId) return { messages: [] };
             const rows = await fetch(
               `${API_URL}/threads/${remoteId}/messages`,
@@ -558,7 +558,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
             };
           },
           async append(item) {
-            const { remoteId } = await aui.threadListItem().initialize();
+            const { remoteId } = await aui.threadListItem.initialize();
             await fetch(`${API_URL}/threads/${remoteId}/messages`, {
               method: "POST",
               body: JSON.stringify({
@@ -602,7 +602,7 @@ The runtime calls `update` after a run for persisted messages whose content chan
 
 ```tsx title="runtime/thread-adapter.tsx"
 async update(item, localMessageId) {
-  const { remoteId } = await aui.threadListItem().initialize();
+  const { remoteId } = await aui.threadListItem.initialize();
   await fetch(`${API_URL}/threads/${remoteId}/messages/${localMessageId}`, {
     method: "PATCH",
     body: JSON.stringify({
@@ -728,8 +728,8 @@ Send a message in a fresh thread. Check the database:
 
 ## Notes
 
-- **First-message race.** `append` may fire before the thread row exists. The `unstable_Provider` example above always awaits `aui.threadListItem().initialize()` before writing; do the same in any custom implementation.
-- **Reload after async auth.** If `auth()` resolves after the initial `list()` call, threads won't appear until the user refreshes. Call `aui.threads().reload()` from a `useEffect` watching the session. Pattern is documented in [threads](/docs/runtimes/concepts/threads#reloading-after-async-authentication).
+- **First-message race.** `append` may fire before the thread row exists. The `unstable_Provider` example above always awaits `aui.threadListItem.initialize()` before writing; do the same in any custom implementation.
+- **Reload after async auth.** If `auth()` resolves after the initial `list()` call, threads won't appear until the user refreshes. Call `aui.threads.reload()` from a `useEffect` watching the session. Pattern is documented in [threads](/docs/runtimes/concepts/threads#reloading-after-async-authentication).
 - **Format string.** The `format` column is *not* a free-text label; it identifies the on-disk shape so multiple runtimes can coexist. Don't strip it. Don't make assumptions about its value (`useChatRuntime` is responsible for setting and decoding it).
 - **Pending approvals need `update`.** Tool call approvals persist across reloads only when the formatted adapter implements `update`; omitting it keeps the pre-approval snapshot out of storage by design.
 - **`unstable_Provider` synchronous-children rule.** The Provider must render `children` on first commit; do not gate them behind suspense, loading state, or `useEffect`. Load data inside an always-rendered child.

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -570,7 +570,7 @@ When `isSendDisabled` is `true`:
 - `composer.canSend` becomes `false`
 - `<ComposerPrimitive.Send>` is disabled
 - Enter and the `Cmd/Ctrl+Shift+Enter` steer hotkey become no-ops
-- `aui.composer().send()` short-circuits at the runtime, so direct calls cannot escape the gate
+- `aui.composer.send()` short-circuits at the runtime, so direct calls cannot escape the gate
 
 Read the same flag from React with `<AuiIf>` to render hints alongside the input:
 

--- a/apps/docs/content/docs/primitives/thread-list.mdx
+++ b/apps/docs/content/docs/primitives/thread-list.mdx
@@ -253,7 +253,7 @@ Button that appends the next page of threads. Renders a `<button>` element unles
 </ThreadListPrimitive.LoadMore>
 ```
 
-For scroll-driven loading, wrap `aui.threads().loadMore()` in your own `IntersectionObserver` at the application layer; assistant-ui ships the explicit button to keep the primitive surface predictable.
+For scroll-driven loading, wrap `aui.threads.loadMore()` in your own `IntersectionObserver` at the application layer; assistant-ui ships the explicit button to keep the primitive surface predictable.
 
 ```tsx
 import { useAui, useAuiState } from "@assistant-ui/react";
@@ -271,7 +271,7 @@ function LoadMoreSentinel() {
     const el = ref.current;
     if (!el || disabled) return;
     const observer = new IntersectionObserver(([entry]) => {
-      if (entry?.isIntersecting) aui.threads().loadMore();
+      if (entry?.isIntersecting) aui.threads.loadMore();
     });
     observer.observe(el);
     return () => observer.disconnect();

--- a/apps/docs/content/docs/react-native/hooks.mdx
+++ b/apps/docs/content/docs/react-native/hooks.mdx
@@ -41,11 +41,11 @@ import { useAui } from "@assistant-ui/react-native";
 const aui = useAui();
 
 // Composer actions
-aui.composer().setText("Hello");
-aui.composer().send();
+aui.composer.setText("Hello");
+aui.composer.send();
 
 // Thread actions
-aui.thread().cancelRun();
+aui.thread.cancelRun();
 ```
 
 ### useAuiEvent

--- a/apps/docs/content/docs/react-native/index.mdx
+++ b/apps/docs/content/docs/react-native/index.mdx
@@ -197,7 +197,7 @@ function Composer() {
     >
       <TextInput
         value={text}
-        onChangeText={(t) => aui.composer().setText(t)}
+        onChangeText={(t) => aui.composer.setText(t)}
         placeholder="Message..."
         multiline
         style={{
@@ -211,7 +211,7 @@ function Composer() {
         }}
       />
       <Pressable
-        onPress={() => aui.composer().send()}
+        onPress={() => aui.composer.send()}
         disabled={isEmpty}
         style={{
           marginLeft: 8,

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -149,7 +149,7 @@ const adapterWithHistory: RemoteThreadListAdapter = {
     const history = useMemo<ThreadHistoryAdapter>(
       () => ({
         async load() {
-          const { remoteId } = aui.threadListItem().getState();
+          const { remoteId } = aui.threadListItem.getState();
           if (!remoteId) return { messages: [] };
           const rows = await fetch(
             `/api/threads/${remoteId}/messages`,
@@ -157,7 +157,7 @@ const adapterWithHistory: RemoteThreadListAdapter = {
           return { messages: rows.map(toThreadMessage) };
         },
         async append({ message, parentId }) {
-          const { remoteId } = await aui.threadListItem().initialize();
+          const { remoteId } = await aui.threadListItem.initialize();
           await fetch(`/api/threads/${remoteId}/messages`, {
             method: "POST",
             body: JSON.stringify({ message, parentId }),
@@ -181,11 +181,11 @@ const adapterWithHistory: RemoteThreadListAdapter = {
 
 ### Avoiding the first-message race
 
-`append` may be called before the thread record exists in your backend. Always await `aui.threadListItem().initialize()` before writing:
+`append` may be called before the thread record exists in your backend. Always await `aui.threadListItem.initialize()` before writing:
 
 ```ts
 async append({ message, parentId }) {
-  const { remoteId } = await aui.threadListItem().initialize();
+  const { remoteId } = await aui.threadListItem.initialize();
   await saveMessage(remoteId, parentId, message);
 }
 ```
@@ -194,14 +194,14 @@ async append({ message, parentId }) {
 
 ### Reloading after async authentication
 
-If your adapter depends on a user that resolves asynchronously (oidc, `next-auth`, `better-auth`), the initial `list()` may run before the user is available. Call `aui.threads().reload()` after auth completes:
+If your adapter depends on a user that resolves asynchronously (oidc, `next-auth`, `better-auth`), the initial `list()` may run before the user is available. Call `aui.threads.reload()` after auth completes:
 
 ```tsx
 function ReloadOnAuth() {
   const aui = useAui();
   const { isLoading, user } = useAuth();
   useEffect(() => {
-    if (!isLoading && user) aui.threads().reload();
+    if (!isLoading && user) aui.threads.reload();
   }, [isLoading, user?.id]);
   return null;
 }
@@ -211,7 +211,7 @@ function ReloadOnAuth() {
 
 ### Paginating the thread list
 
-If your backend returns thread pages, return a `nextCursor` from `list()` and consume `aui.threads().hasMore` plus `aui.threads().loadMore()` in the UI. The runtime threads `params.after` back through `list()` on every `loadMore()`; the initial call passes no `params`, so treat a missing `after` as "first page". `reload()` resets the cursor so the next load starts from page 1 again.
+If your backend returns thread pages, return a `nextCursor` from `list()` and consume `aui.threads.hasMore` plus `aui.threads.loadMore()` in the UI. The runtime threads `params.after` back through `list()` on every `loadMore()`; the initial call passes no `params`, so treat a missing `after` as "first page". `reload()` resets the cursor so the next load starts from page 1 again.
 
 ```ts title="threadListAdapter.ts (excerpt)"
 async list({ after } = {}) {
@@ -271,7 +271,7 @@ A few invariants worth knowing when wiring a custom UI on top of `loadMore()`:
       name: "list",
       type: "(params?: { after?: string }) => Promise<{ threads: RemoteThreadMetadata[]; nextCursor?: string }>",
       description:
-        "Hydrate threads on mount. Each thread must include status and remoteId; title, externalId, and custom are optional. Return a `nextCursor` to enable `aui.threads().loadMore()`; the runtime will pass it back as `params.after` on the next call.",
+        "Hydrate threads on mount. Each thread must include status and remoteId; title, externalId, and custom are optional. Return a `nextCursor` to enable `aui.threads.loadMore()`; the runtime will pass it back as `params.after` on the next call.",
       required: true,
     },
     {
@@ -291,7 +291,7 @@ A few invariants worth knowing when wiring a custom UI on top of `loadMore()`:
       name: "updateCustom",
       type: "(remoteId: string, custom: Record<string, unknown> | undefined) => Promise<void>",
       description:
-        "Optional. Persist replacement custom metadata from `aui.threadListItem().updateCustom(custom)`.",
+        "Optional. Persist replacement custom metadata from `aui.threadListItem.updateCustom(custom)`.",
     },
     {
       name: "archive",
@@ -361,7 +361,7 @@ function ThreadListItemMeta() {
 }
 ```
 
-`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To replace it from your UI, implement `RemoteThreadListAdapter.updateCustom` and call `aui.threadListItem().updateCustom(custom)`. The cloud adapter persists this through `cloud.threads.update(threadId, { metadata })`. If your adapter mutates thread metadata through a separate application path, return the updated values from `fetch()` or call `aui.threads().reload()` to re-run `list()`.
+`custom` is preserved across `rename`, `archive`, `unarchive`, and `generateTitle`. To replace it from your UI, implement `RemoteThreadListAdapter.updateCustom` and call `aui.threadListItem.updateCustom(custom)`. The cloud adapter persists this through `cloud.threads.update(threadId, { metadata })`. If your adapter mutates thread metadata through a separate application path, return the updated values from `fetch()` or call `aui.threads.reload()` to re-run `list()`.
 
 ## ExternalStoreThreadListAdapter
 

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -536,8 +536,8 @@ function useResumeOnMount(threadId: string) {
         r.json(),
       );
       if (status.isRunning) {
-        const parentId = aui.thread().getState().messages.at(-1)?.id ?? null;
-        aui.thread().resumeRun({ parentId });
+        const parentId = aui.thread.getState().messages.at(-1)?.id ?? null;
+        aui.thread.resumeRun({ parentId });
       }
     })();
   }, [aui, threadId]);

--- a/apps/docs/content/docs/runtimes/custom/external-store.mdx
+++ b/apps/docs/content/docs/runtimes/custom/external-store.mdx
@@ -741,7 +741,7 @@ useExternalStoreRuntime({
       name: "isSendDisabled",
       type: "boolean",
       description:
-        "Blocks new-message sending while leaving the input usable. When true, the thread composer's canSend becomes false, the Send button is disabled, Enter and the steer hotkey are no-ops, and aui.composer().send() short-circuits. Edit composers (saving message edits) ignore this flag. Use this to gate sending on external React state (e.g. while tools or auth are still loading).",
+        "Blocks new-message sending while leaving the input usable. When true, the thread composer's canSend becomes false, the Send button is disabled, Enter and the steer hotkey are no-ops, and aui.composer.send() short-circuits. Edit composers (saving message edits) ignore this flag. Use this to gate sending on external React state (e.g. while tools or auth are still loading).",
       default: "false",
     },
     {

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -595,7 +595,7 @@ async function* createCustomStream(): AsyncGenerator<ChatModelRunResult> {
   };
 }
 
-aui.thread().resumeRun({
+aui.thread.resumeRun({
   parentId: "message-id",
   stream: createCustomStream,
 });
@@ -617,8 +617,8 @@ function useStreamReconnect(threadId: string) {
         r.json(),
       );
       if (status.isRunning) {
-        const parentId = aui.thread().getState().messages.at(-1)?.id ?? null;
-        aui.thread().resumeRun({ parentId });
+        const parentId = aui.thread.getState().messages.at(-1)?.id ?? null;
+        aui.thread.resumeRun({ parentId });
       }
     })();
   }, [aui, threadId]);

--- a/apps/docs/content/docs/tools/interactables-legacy.mdx
+++ b/apps/docs/content/docs/tools/interactables-legacy.mdx
@@ -298,7 +298,7 @@ function MyRuntimeProvider({ children }) {
 
   useEffect(() => {
     // Set up persistence adapter
-    aui.interactables().setPersistenceAdapter({
+    aui.interactables.setPersistenceAdapter({
       save: async (state) => {
         localStorage.setItem("interactables", JSON.stringify(state));
       },
@@ -307,7 +307,7 @@ function MyRuntimeProvider({ children }) {
     // Restore saved state on mount
     const saved = localStorage.getItem("interactables");
     if (saved) {
-      aui.interactables().importState(JSON.parse(saved));
+      aui.interactables.importState(JSON.parse(saved));
     }
   }, [aui]);
 
@@ -334,10 +334,10 @@ State changes are automatically debounced (500ms) before saving. When a componen
 For custom persistence strategies, use `exportState` and `importState` directly:
 
 ```tsx
-const snapshot = aui.interactables().exportState();
+const snapshot = aui.interactables.exportState();
 // => { "note-1": { name: "note", state: { title: "Hello" } }, ... }
 
-aui.interactables().importState(snapshot);
+aui.interactables.importState(snapshot);
 // Imported state is picked up when components next register
 ```
 

--- a/apps/docs/content/docs/tools/interactables.mdx
+++ b/apps/docs/content/docs/tools/interactables.mdx
@@ -618,7 +618,7 @@ function MyRuntimeProvider({ children }) {
 
 `load` is called when the adapter is attached and may be async. Loaded state seeds interactables as they register; a local edit made while a slow `load` is still in flight wins over the loaded value. Thread-scoped interactables are not touched by the adapter; they persist via thread history.
 
-For dynamic setups (an adapter that depends on auth), call `aui.interactables().setPersistenceAdapter(adapter)` imperatively instead.
+For dynamic setups (an adapter that depends on auth), call `aui.interactables.setPersistenceAdapter(adapter)` imperatively instead.
 
 ### Sync Status
 
@@ -640,10 +640,10 @@ State changes are automatically debounced (500ms) before saving. When the owning
 For custom persistence strategies, use `exportState` and `importState` directly:
 
 ```tsx
-const snapshot = aui.interactables().exportState();
+const snapshot = aui.interactables.exportState();
 // => { "note-1": { name: "note", state: { title: "Hello" } }, ... }
 
-aui.interactables().importState(snapshot);
+aui.interactables.importState(snapshot);
 // Imported state is picked up when components next register
 ```
 

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -179,7 +179,7 @@ The iteration primitives wrap each item in an `McpServerByIdProvider`, so the ne
 </McpAddFormPrimitive.Root>
 ```
 
-The form owns its own draft state and submits via `aui.mcp().addCustomServer(...)`. Pass a render function to `AuthFields` to fully customize it.
+The form owns its own draft state and submits via `aui.mcp.addCustomServer(...)`. Pass a render function to `AuthFields` to fully customize it.
 
 </Step>
 <Step>
@@ -236,7 +236,7 @@ If no chat runtime is mounted, `McpManagerResource` brings its own minimal `mode
 ```ts
 // In an event handler, never in render.
 const aui = useAui();
-const out = await aui.mcp().server({ id: "linear" }).callTool("search", { q });
+const out = await aui.mcp.server({ id: "linear" }).callTool("search", { q });
 ```
 
 </Step>
@@ -312,9 +312,9 @@ Imperative methods: `useAui` + resolve in a callback (never during render):
 const aui = useAui();
 
 // inside an event handler:
-await aui.mcp().addCustomServer({ name, url, auth: { type: "bearer", token } });
-await aui.mcp().server({ id }).connect();
-await aui.mcp().server({ id }).callTool("echo", { text: "hi" });
+await aui.mcp.addCustomServer({ name, url, auth: { type: "bearer", token } });
+await aui.mcp.server({ id }).connect();
+await aui.mcp.server({ id }).callTool("echo", { text: "hi" });
 
 // Build a paginated resource browser/preview UI.
 type ResourcePage = {
@@ -322,7 +322,7 @@ type ResourcePage = {
   nextCursor?: string;
 };
 
-const server = aui.mcp().server({ id });
+const server = aui.mcp.server({ id });
 const resources: ResourcePage["resources"] = [];
 let nextCursor: string | undefined;
 

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -308,7 +308,7 @@ The picker implements the WAI-ARIA combobox pattern over Popover + Command.
 
 The default `ModelSelector` export registers the selection with assistant-ui's `ModelContext` system:
 
-1. The component calls `aui.modelContext().register()` with `config.modelName`, plus `config.reasoningEffort` when the selected model supports the chosen level
+1. The component calls `aui.modelContext.register()` with `config.modelName`, plus `config.reasoningEffort` when the selected model supports the chosen level
 2. The `AssistantChatTransport` includes `config` in the request body of every chat request
 3. Your API route reads `config.modelName` and `config.reasoningEffort`
 

--- a/apps/docs/content/examples/expo.mdx
+++ b/apps/docs/content/examples/expo.mdx
@@ -92,7 +92,7 @@ function NewChatButton() {
   return (
     <Pressable
       onPress={() => {
-        aui.threads().switchToNewThread();
+        aui.threads.switchToNewThread();
       }}
       style={{ marginRight: 16 }}
     >

--- a/apps/docs/content/tap-docs/store/api-reference.mdx
+++ b/apps/docs/content/tap-docs/store/api-reference.mdx
@@ -72,7 +72,7 @@ Renders children only when the condition returns `true`. Uses `useAuiState` inte
 
 ```tsx
 <RenderChildrenWithAccessor
-  getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+  getItemState={(aui) => aui.todoList.todo({ index }).getState()}
 >
   {(getItem) =>
     children({
@@ -109,7 +109,7 @@ Creates a derived scope that points to data in a parent scope.
 Derived({
   source: "thread",
   query: { index: 0 },
-  get: (aui) => aui.thread().message({ index: 0 }),
+  get: (aui) => aui.thread.message({ index: 0 }),
 });
 ```
 
@@ -291,7 +291,7 @@ type AssistantClientAccessor<K extends ClientNames> =
   { name: K };
 ```
 
-A scope accessor. Call it (`aui.counter()`) to resolve the scope's methods. Read `.source`, `.query`, and `.name` for metadata.
+A scope accessor exposing the scope's methods as properties (`aui.counter.increment()`). Read `.source`, `.query`, and `.name` for metadata. The call signature (`aui.counter()`) is deprecated and returns the same accessor.
 
 ### AssistantState
 

--- a/apps/docs/content/tap-docs/store/child-scopes.mdx
+++ b/apps/docs/content/tap-docs/store/child-scopes.mdx
@@ -150,7 +150,7 @@ const TodoItem = ({ index }: { index: number }) => {
     todo: Derived({
       source: "todoList",
       query: { index },
-      get: (aui) => aui.todoList().todo({ index }),
+      get: (aui) => aui.todoList.todo({ index }),
     }),
   });
 
@@ -181,7 +181,7 @@ const TodoDisplay = () => {
       <input
         type="checkbox"
         checked={done}
-        onChange={() => aui.todo().toggle()}
+        onChange={() => aui.todo.toggle()}
       />
       {text}
     </label>

--- a/apps/docs/content/tap-docs/store/meta.mdx
+++ b/apps/docs/content/tap-docs/store/meta.mdx
@@ -3,11 +3,12 @@ title: Meta
 description: Track scope origin with source and query.
 ---
 
-Every scope accessor has two metadata properties: `source` and `query`. They describe where a scope comes from.
+Every scope accessor has three metadata properties: `source` and `query` describe where a scope comes from, and `name` is the scope's own name. They are reserved — scope methods cannot use these names.
 
 ```tsx
 aui.thread.source; // "root" | "parentScope" | null
 aui.thread.query; // {} | { index: 0 } | null
+aui.thread.name; // "thread"
 ```
 
 ## Root scopes
@@ -32,7 +33,7 @@ const aui = useAui({
   message: Derived({
     source: "thread",
     query: { index: 0 },
-    get: (aui) => aui.thread().message({ index: 0 }),
+    get: (aui) => aui.thread.message({ index: 0 }),
   }),
 });
 
@@ -59,14 +60,22 @@ This makes the `source` and `query` types precise — TypeScript will enforce th
 
 ## Unavailable scopes
 
-When a scope hasn't been provided by any `AuiProvider` above the current component, its accessor has `source: null` and `query: null`:
+When a scope hasn't been provided by any `AuiProvider` above the current component, its accessor has `source: null` and `query: null`. `name` still answers; calling the accessor or reading any other property throws:
 
 ```tsx
 aui.message.source; // null — no message scope in context
 aui.message.query; // null
+aui.message.name; // "message"
+aui.message.getState(); // throws
 ```
 
-This is how you check whether a scope is available.
+The accessor itself is always truthy, so `if (aui.message)` does not tell you anything. Check availability with:
+
+```tsx
+if (aui.message.source != null) {
+  // scope is available
+}
+```
 
 ## Summary
 

--- a/apps/docs/content/tap-docs/store/methods.mdx
+++ b/apps/docs/content/tap-docs/store/methods.mdx
@@ -55,18 +55,17 @@ Call `useAui()` with no arguments inside any `AuiProvider` to get the current st
 const aui = useAui();
 ```
 
-The returned object has a property for every scope available in the current context. Crucially, `useAui()` does **not** re-render your component when scopes change: it returns a stable reference. The actual scope is only resolved when you call `aui.counter()`.
+The returned client has an accessor for every scope available in the current context. The client is immutable: state updates never change its identity, while a structural change (a scope resolving to a different instance) produces a new client and re-renders consumers through React.
 
-## Scope resolution
+## Scope accessors
 
-`aui.counter` is not the scope itself, it's an accessor. The scope resolves when you call it:
+`aui.counter` is the scope accessor: it exposes the scope's methods plus `source`/`query`/`name` metadata. Its identity is stable per scope binding and changes when the binding changes:
 
 ```tsx
-// resolves the counter scope, returns its methods
-aui.counter().increment();
+aui.counter.increment();
 ```
 
-This distinction matters. The `aui` object is stable across re-renders and scope changes. When a derived scope switches which item it points to, `aui` stays the same, but `aui.counter()` returns the new scope's methods. This is why you should always resolve at the point of use:
+When a derived scope switches which item it points to, the component re-renders with a new client and a new accessor. Access scopes at the point of use:
 
 ```tsx
 const MessageActions = () => {
@@ -76,58 +75,47 @@ const MessageActions = () => {
     <button
       onClick={() => {
         // resolves at click time, always gets the current scope
-        aui.message().reload();
-        aui.thread().cancelRun();
+        aui.message.reload();
+        aui.thread.cancelRun();
       }}
     />
   );
 };
 ```
 
-### Don't resolve during render
+### Don't read state during render
 
-Because `useAui()` doesn't subscribe to scope changes, resolving during render gives you a snapshot that can go stale. Use `useAuiState` to read state during render instead.
+`aui.counter.getState()` returns a snapshot without subscribing, so render output built from it goes stale. Use `useAuiState` to read state during render instead.
 
 ```tsx
 const Counter = () => {
   const aui = useAui();
 
-  // ❌ Don't resolve during render
-  const count = aui.counter().getState().count;
+  // ❌ Don't read state during render
+  const count = aui.counter.getState().count;
 
   // ✅ Use useAuiState for render-time reads
   const count = useAuiState((s) => s.counter.count);
 
-  // ✅ Resolve in event handlers, effects, or callbacks
-  const handleClick = () => aui.counter().increment();
+  // ✅ Read in event handlers, effects, or callbacks
+  const handleClick = () => aui.counter.increment();
 };
-```
-
-For the same reason, avoid storing a resolved scope in a variable during render:
-
-```tsx
-// ❌ Resolves during render, can go stale
-const counter = aui.counter();
-const handleClick = () => counter.increment();
-
-// ✅ Resolves at call time, always current
-const handleClick = () => aui.counter().increment();
 ```
 
 ## Checking if a scope exists
 
-Calling `aui.counter()` throws if the `counter` scope hasn't been provided by any `AuiProvider` above. To safely check, inspect the accessor's `source` property:
+Accessing `aui.counter` never throws, and the accessor is always truthy — `if (aui.counter)` does not tell you anything. When the scope hasn't been provided by any `AuiProvider` above, the accessor still answers `source` (`null`), `query`, and `name`; calling it or reading any other property throws. Check `source`:
 
 ```tsx
 const aui = useAui();
 
-if (aui.counter.source !== null) {
-  // safe to call
-  aui.counter().increment();
+if (aui.counter.source != null) {
+  // safe to use
+  aui.counter.increment();
 }
 ```
 
-`source` is `null` when the scope isn't available. Any other value (`"root"`, a parent scope name) means it's safe to resolve.
+`source` is `null` when the scope isn't available. Any other value (`"root"`, a parent scope name) means the scope is bound.
 
 ## Subscribing to scope identity
 
@@ -137,10 +125,10 @@ This is an advanced pattern. In the entire assistant-ui codebase, there are only
 
 Sometimes you need to know when the scope itself changes, for example to register/unregister with an external system when a derived scope switches to a different item.
 
-Since `useAui()` doesn't re-render on scope changes, you need to opt in explicitly. Use `useAuiState` to subscribe to the scope identity:
+Use `useAuiState` to subscribe to the scope identity:
 
 ```tsx
-const thread = useAuiState(() => aui.thread());
+const thread = useAuiState(() => aui.thread);
 
 useEffect(() => {
   analytics.register(thread);
@@ -148,4 +136,4 @@ useEffect(() => {
 }, [thread]);
 ```
 
-`aui.thread()` returns a stable methods object per scope instance. When a derived scope switches which thread it points to, `useAuiState` detects the new reference and re-renders, triggering the effect cleanup and re-registration.
+`aui.thread` is a stable accessor per scope binding. When a derived scope switches which thread it points to, `useAuiState` detects the new accessor and re-renders, triggering the effect cleanup and re-registration.

--- a/apps/docs/content/tap-docs/store/quickstart.mdx
+++ b/apps/docs/content/tap-docs/store/quickstart.mdx
@@ -93,7 +93,7 @@ export const CounterDisplay = () => {
   return (
     <div>
       <p>Count: {count}</p>
-      <button onClick={() => aui.counter().increment()}>+</button>
+      <button onClick={() => aui.counter.increment()}>+</button>
     </div>
   );
 };
@@ -101,7 +101,7 @@ export const CounterDisplay = () => {
 
 `useAuiState((s) => s.counter.count)` subscribes to just the `count` value, so the component only re-renders when it changes.
 
-`aui.counter()` returns the methods object, so `aui.counter().increment()` calls the `increment` method you defined in the resource.
+`aui.counter` exposes the scope's methods, so `aui.counter.increment()` calls the `increment` method you defined in the resource.
 
 ## Next steps
 

--- a/apps/docs/content/tap-docs/store/rendering-lists.mdx
+++ b/apps/docs/content/tap-docs/store/rendering-lists.mdx
@@ -27,7 +27,7 @@ const TodoList = ({
       Array.from({ length }, (_, index) => (
         <TodoProvider key={index} index={index}>
           <RenderChildrenWithAccessor
-            getItemState={(aui) => aui.todoList().todo({ index }).getState()}
+            getItemState={(aui) => aui.todoList.todo({ index }).getState()}
           >
             {(getItem) =>
               children({

--- a/apps/docs/content/tap-docs/store/sibling-scopes.mdx
+++ b/apps/docs/content/tap-docs/store/sibling-scopes.mdx
@@ -99,7 +99,7 @@ attachTransformScopes(ThreadResource, (scopes) => {
   scopes.composer ??= Derived({
     source: "thread",
     query: {},
-    get: (aui) => aui.thread().composer(),
+    get: (aui) => aui.thread.composer(),
   });
 });
 ```

--- a/apps/docs/content/tap-docs/store/state.mdx
+++ b/apps/docs/content/tap-docs/store/state.mdx
@@ -104,7 +104,7 @@ Accessing `s.counter` in a selector throws if the `counter` scope hasn't been pr
 ```tsx
 const aui = useAui();
 const count = useAuiState(
-  () => aui.counter.source !== null && aui.counter().getState().count,
+  () => aui.counter.source !== null && aui.counter.getState().count,
 );
 ```
 
@@ -127,7 +127,7 @@ It uses `useAuiState` internally, so it re-evaluates only when the selected valu
 Both `useAuiState` and `AuiIf` are built on two primitives available on the store:
 
 - `aui.subscribe(callback)`: calls `callback` whenever any scope's state changes
-- `aui.counter().getState()`: returns the current state snapshot
+- `aui.counter.getState()`: returns the current state snapshot
 
 Together, they form the standard `useSyncExternalStore` pattern. You can use them directly for non-React integrations or when you need imperative access:
 
@@ -135,10 +135,10 @@ Together, they form the standard `useSyncExternalStore` pattern. You can use the
 const aui = useAui();
 
 // imperative read
-const count = aui.counter().getState().count;
+const count = aui.counter.getState().count;
 
 // manual subscription
 const unsub = aui.subscribe(() => {
-  console.log("new count:", aui.counter().getState().count);
+  console.log("new count:", aui.counter.getState().count);
 });
 ```


### PR DESCRIPTION
## Summary

Docs follow-up to #5275 (sw-91): sweeps hand-written docs surfaces for content invalidated by the property accessor API. Auto-generated api-reference pages, migration docs, and CHANGELOGs are untouched.

- Rewrites nullary accessor calls to property form (`aui.thread().getState()` → `aui.thread.getState()`) across guides, runtimes, integrations, tools, ink/react-native pages, and the tap-docs store guide — prose and snippets the codemod does not reach.
- tap-docs `store/meta.mdx`: documents the third meta property `name`, the reserved-name rule, and dead-accessor semantics (`source`/`query` null, `name` answers, any other access throws). Adds the existence idiom `aui.message.source != null` and the note that the accessor is always truthy.
- tap-docs `store/methods.mdx` and `guides/context-api.mdx`: aligns identity/resolution prose with the render-bound immutable client from #5270 (state updates never change client identity; structural changes produce a new client through React; accessors are stable per scope binding).
- Fixes an incorrect availability check in `context-api.mdx` (`source !== undefined` → `source != null`).

## Verification

- `pnpm -C apps/docs build` green (440 static pages)
- `pnpm lint` clean

Docs-only change (34 mdx files). Do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uBXIgmqj0C1c6NwMHi5y0ObbteZtZUw2u_xf2_AIqR4jBatg30wEWOqgOI0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->