### PR TITLE
fix(assistant-stream): PlainTextEncoder emits assistant text only

### DIFF
--- a/.changeset/plain-text-encoder-text-only.md
+++ b/.changeset/plain-text-encoder-text-only.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: PlainTextEncoder emits assistant text only. Reasoning and tool-call argument deltas no longer leak into the output, non-text chunks (result, annotations, data, update-state, tool-call-args-text-finish) are skipped instead of throwing mid-stream, and the incorrect x-vercel-ai-data-stream header is removed from the response headers.

--- a/packages/assistant-stream/src/core/serialization/PlainText.test.ts
+++ b/packages/assistant-stream/src/core/serialization/PlainText.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { AssistantStream } from "../AssistantStream";
+import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import { createAssistantStream } from "../modules/assistant-stream";
 import { PlainTextEncoder } from "./PlainText";
 
@@ -19,6 +20,30 @@ describe("PlainTextEncoder", () => {
 
     const response = AssistantStream.toResponse(stream, new PlainTextEncoder());
     await expect(response.text()).resolves.toBe("Hello!");
+  });
+
+  it("skips annotations, data, and update-state chunks without throwing", async () => {
+    const chunks: AssistantStreamChunk[] = [
+      { type: "part-start", path: [], part: { type: "text" } },
+      { type: "text-delta", path: [0], textDelta: "Hi" },
+      { type: "annotations", path: [], annotations: [{ note: "cited" }] },
+      { type: "data", path: [], data: [{ progress: 1 }] },
+      {
+        type: "update-state",
+        path: [],
+        operations: [{ type: "set", path: ["k"], value: "v" }],
+      },
+      { type: "part-finish", path: [0] },
+    ];
+    const stream = new ReadableStream<AssistantStreamChunk>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+
+    const response = AssistantStream.toResponse(stream, new PlainTextEncoder());
+    await expect(response.text()).resolves.toBe("Hi");
   });
 
   it("sends plain text headers without the data-stream protocol marker", () => {

--- a/packages/assistant-stream/src/core/serialization/PlainText.test.ts
+++ b/packages/assistant-stream/src/core/serialization/PlainText.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { AssistantStream } from "../AssistantStream";
+import { createAssistantStream } from "../modules/assistant-stream";
+import { PlainTextEncoder } from "./PlainText";
+
+describe("PlainTextEncoder", () => {
+  it("emits only the assistant text for a reasoning + tool-call + text stream", async () => {
+    const stream = createAssistantStream(async (controller) => {
+      controller.appendReasoning("internal chain of thought. ");
+      const tool = controller.addToolCallPart({
+        toolCallId: "call_1",
+        toolName: "search",
+      });
+      tool.argsText.append('{"query":"secret"}');
+      tool.setResponse({ result: "ok" });
+      tool.close();
+      controller.appendText("Hello!");
+    });
+
+    const response = AssistantStream.toResponse(stream, new PlainTextEncoder());
+    await expect(response.text()).resolves.toBe("Hello!");
+  });
+
+  it("sends plain text headers without the data-stream protocol marker", () => {
+    const headers = new PlainTextEncoder().headers;
+    expect(headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    expect(headers.has("x-vercel-ai-data-stream")).toBe(false);
+  });
+});

--- a/packages/assistant-stream/src/core/serialization/PlainText.ts
+++ b/packages/assistant-stream/src/core/serialization/PlainText.ts
@@ -1,5 +1,9 @@
 import type { AssistantStreamEncoder } from "../AssistantStream";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
+import {
+  AssistantMetaTransformStream,
+  type AssistantMetaStreamChunk,
+} from "../utils/stream/AssistantMetaTransformStream";
 import { AssistantTransformStream } from "../utils/stream/AssistantTransformStream";
 import { PipeableTransformStream } from "../utils/stream/PipeableTransformStream";
 
@@ -9,43 +13,20 @@ export class PlainTextEncoder
 {
   headers = new Headers({
     "Content-Type": "text/plain; charset=utf-8",
-    "x-vercel-ai-data-stream": "v1",
   });
 
   constructor() {
     super((readable) => {
-      const transform = new TransformStream<AssistantStreamChunk, string>({
+      const transform = new TransformStream<AssistantMetaStreamChunk, string>({
         transform(chunk, controller) {
-          const type = chunk.type;
-          switch (type) {
-            case "text-delta":
-              controller.enqueue(chunk.textDelta);
-              break;
-
-            case "part-start":
-            case "part-finish":
-            case "step-start":
-            case "step-finish":
-            case "message-finish":
-            case "error":
-              break;
-
-            default: {
-              const unsupportedType:
-                | "tool-call-args-text-finish"
-                | "data"
-                | "annotations"
-                | "tool-call-begin"
-                | "tool-call-delta"
-                | "result"
-                | "update-state" = type;
-              throw new Error(`unsupported chunk type: ${unsupportedType}`);
-            }
+          if (chunk.type === "text-delta" && chunk.meta.type === "text") {
+            controller.enqueue(chunk.textDelta);
           }
         },
       });
 
       return readable
+        .pipeThrough(new AssistantMetaTransformStream())
         .pipeThrough(transform)
         .pipeThrough(new TextEncoderStream());
     });


### PR DESCRIPTION
Closes #5277

## What
PlainTextEncoder now pipes through `AssistantMetaTransformStream` and emits only deltas from text parts, mirroring how DataStreamEncoder routes deltas. Non-text chunks are skipped instead of throwing, and the incorrect `x-vercel-ai-data-stream: v1` header is removed.

## Why
Reproducing this on main, a stream with reasoning enabled printed the chain of thought straight into the plain-text body, and a tool call leaked its args text and then aborted the response with `unsupported chunk type: result`. The header made it worse: react-data-stream protocol detection keys on exactly that header, so plain-text responses got routed to DataStreamDecoder. 
## Impact
- Plain-text responses now contain only assistant-visible text; no more reasoning or tool-args leakage.
- Streams with tool calls, results, annotations, data, or update-state chunks no longer crash mid-response.
- Protocol sniffers no longer misdetect plain text as the data-stream format.

## Scope 
- The diff bundles three visible fixes (header, delta leak, stale union names) because they are one contract in one module: plain-text output is assistant text only.
- Behavior changes are deliberate: non-text chunks went from throw to skip, reasoning/tool-args deltas from leak to skip, and the data-stream header is gone. No working setup depended on any of the old behavior.
- `error` chunks were already silently skipped before this change; that is unchanged, not a regression introduced here.
- Skip-by-default (no exhaustiveness check) is the intended forward-compat posture: future chunk types drop silently instead of killing plain-text responses, matching the decoders' direction.
- PlainTextDecoder is untouched; the only in-repo consumer (`@assistant-ui/cloud`) uses the decoder only.
- Tests: one colocated contract test covers the seam (reasoning + tool call + text encodes to exactly the assistant text, plus header assertions); annotations/data/update-state share the same skip path and are not separately covered.
- No exports added or removed; the class shape is unchanged.
- Changeset: patch (assistant-stream).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.83Z7YR6n0BinqnkH7idHHidvoTstJ8WFVoXVLBsO1h6_81MdQb0DajWdZrQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->