### PR TITLE
fix(core): cloud history adapter resolves aui through clientRef at call time

### DIFF
--- a/.changeset/cloud-adapter-aui-ref.md
+++ b/.changeset/cloud-adapter-aui-ref.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: cloud history adapter resolves the aui client at call time instead of capturing the client from the first render

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -6,20 +6,22 @@ import { describe, expect, it, vi } from "vitest";
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 
 const mocks = vi.hoisted(() => {
-  const threadListItem = {
-    getState: () => ({ remoteId: "thread-1" }),
-  };
+  const makeClient = (remoteId: string) =>
+    ({
+      threadListItem: {
+        getState: () => ({ remoteId }),
+      },
+    }) as unknown as import("@assistant-ui/store").AssistantClient;
 
   return {
-    assistantClient: {
-      threadListItem,
-    },
+    makeClient,
+    aui: makeClient("thread-1"),
   };
 });
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/store")>()),
-  useAui: () => mocks.assistantClient,
+  useAui: () => mocks.aui,
 }));
 
 const makeCloud = () =>
@@ -33,6 +35,7 @@ const makeCloud = () =>
 
 describe("useAssistantCloudThreadHistoryAdapter", () => {
   it("refreshes formatted persistence when the Cloud client changes", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
     const firstCloud = makeCloud();
     const secondCloud = makeCloud();
     const cloudRef = { current: firstCloud };
@@ -64,6 +67,28 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(secondCloud.threads.messages.list).toHaveBeenCalledOnce();
     expect(secondCloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
       format: "test",
+    });
+  });
+
+  it("resolves the aui client at call time instead of capturing it", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const { result, rerender } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+
+    await result.current.load();
+    expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-1", {
+      format: "aui/v0",
+    });
+
+    mocks.aui = mocks.makeClient("thread-2");
+    rerender();
+
+    await result.current.load();
+    expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
+      format: "aui/v0",
     });
   });
 });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useState } from "react";
+import { type RefObject, useEffect, useRef, useState } from "react";
 import type {
   GenericThreadHistoryAdapter,
   ThreadHistoryAdapter,
@@ -23,11 +23,18 @@ const globalPersistence = new WeakMap<
 
 class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   private cloudRef: RefObject<AssistantCloud>;
-  private aui: AssistantClient;
+  private auiRef: RefObject<AssistantClient>;
 
-  constructor(cloudRef: RefObject<AssistantCloud>, aui: AssistantClient) {
+  constructor(
+    cloudRef: RefObject<AssistantCloud>,
+    auiRef: RefObject<AssistantClient>,
+  ) {
     this.cloudRef = cloudRef;
-    this.aui = aui;
+    this.auiRef = auiRef;
+  }
+
+  private get aui(): AssistantClient {
+    return this.auiRef.current;
   }
 
   private get _persistence(): CloudMessagePersistence {
@@ -810,8 +817,12 @@ export function useAssistantCloudThreadHistoryAdapter(
   cloudRef: RefObject<AssistantCloud>,
 ): ThreadHistoryAdapter {
   const aui = useAui();
+  const auiRef = useRef(aui);
+  useEffect(() => {
+    auiRef.current = aui;
+  });
   const [adapter] = useState(
-    () => new AssistantCloudThreadHistoryAdapter(cloudRef, aui),
+    () => new AssistantCloudThreadHistoryAdapter(cloudRef, auiRef),
   );
   return adapter;
 }


### PR DESCRIPTION
## Problem

`useAssistantCloudThreadHistoryAdapter` constructs the adapter once via `useState` and the class stores the resolved `AssistantClient` for its whole lifetime. aui clients are render-bound and immutable, so once the composed client is replaced, every `this.aui.threadListItem...` read in the adapter's methods and async closures goes through a stale client.

## Fix

The adapter now holds a `RefObject<AssistantClient>` that the hook mirrors to the latest `useAui()` client on every render; a private `aui` getter resolves it at call time. Class shape is otherwise unchanged.

Note: the originally suggested `useAssistantClientRef()` cannot be used here — it reads the tap-side `AssistantTapContext`, which is only available inside tap resources, while this hook runs in a plain React component (`useCloudThreadListAdapter`'s `unstable_Provider`); the existing `useLocalRuntime` test fails with "AssistantTapContext is not available" under that approach. The ref-mirror pattern matches the sibling `useCloudThreadListAdapter` idiom and achieves the same call-time resolution.

Pairs with #PRB — the two conflict trivially in the `_persistence` key-lookup line; whichever merges second needs a one-line rebase.

## Tests

- Updated the existing adapter contract test and added one asserting the adapter resolves the aui client at call time (loads from the new client's thread after the client is swapped).
- `pnpm turbo test --filter=@assistant-ui/core`: 762 passed. Build and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Sr0S3YuIGpqFRly2E6wcmNTqx-b0kJNKQZpjTzt2SW4t6aewCrSLTaPlm_o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->