### PR TITLE
fix(core): key cloud persistence cache on resolved threadListItem methods (sw-96)

### DIFF
--- a/.changeset/persistence-weakmap-key.md
+++ b/.changeset/persistence-weakmap-key.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/store": minor
+"@assistant-ui/core": patch
+---
+
+fix: key the cloud message persistence cache on the resolved threadListItem client instead of the per-mount accessor proxy; export unwrapClientAccessor from @assistant-ui/store

--- a/.changeset/persistence-weakmap-key.md
+++ b/.changeset/persistence-weakmap-key.md
@@ -1,5 +1,5 @@
 ---
-"@assistant-ui/store": minor
+"@assistant-ui/store": patch
 "@assistant-ui/core": patch
 ---
 

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -180,13 +180,15 @@ declare function attachTransformScopes(hook: Hook, transform: TransformScopesFn)
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
 
 declare namespace entry_root_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
+  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, unwrapClientAccessor, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
 }
 
 declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {
   scope: AssistantEventScope<TEvent>;
   event: TEvent;
 };
+
+declare const unwrapClientAccessor: <T>(value: T) => T;
 
 declare const useAssistantClientRef: () => {
   parent: AssistantClient;

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -13,7 +13,11 @@ import {
   createFormattedPersistence,
 } from "assistant-cloud";
 import { auiV0Decode, auiV0Encode } from "./auiV0";
-import { type AssistantClient, useAui } from "@assistant-ui/store";
+import {
+  type AssistantClient,
+  unwrapClientAccessor,
+  useAui,
+} from "@assistant-ui/store";
 import type { ThreadListItemMethods } from "../../../store/scopes/thread-list-item";
 
 const globalPersistence = new WeakMap<
@@ -31,7 +35,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   }
 
   private get _persistence(): CloudMessagePersistence {
-    const key = this.aui.threadListItem;
+    const key = unwrapClientAccessor(this.aui.threadListItem);
     if (!globalPersistence.has(key)) {
       globalPersistence.set(
         key,

--- a/packages/store/src/__tests__/unwrap-client-accessor.test.ts
+++ b/packages/store/src/__tests__/unwrap-client-accessor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  createClientAccessor,
+  unwrapClientAccessor,
+} from "../utils/client-accessor";
+import type { ClientMethods, ClientNames } from "../types/client";
+
+const meta = {
+  name: "thread" as ClientNames,
+  source: "root" as const,
+  query: {},
+};
+
+describe("unwrapClientAccessor", () => {
+  it("resolves accessors of the same client to the same instance", () => {
+    const methods: ClientMethods = { getState: () => ({}) };
+    const first = createClientAccessor(meta, () => methods);
+    const second = createClientAccessor(meta, () => methods);
+
+    expect(Object.is(first, second)).toBe(false);
+    expect(unwrapClientAccessor(first)).toBe(methods);
+    expect(unwrapClientAccessor(second)).toBe(methods);
+  });
+
+  it("returns non-accessor values as-is", () => {
+    const plain = { getState: () => ({}) };
+    expect(unwrapClientAccessor(plain)).toBe(plain);
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -21,6 +21,7 @@ export {
   useAssistantClientRef,
   useAssistantEmit,
 } from "./utils/tap-assistant-context";
+export { unwrapClientAccessor } from "./utils/client-accessor";
 export { useClientResource } from "./useClientResource";
 export { useClientLookup } from "./useClientLookup";
 export { useClientList } from "./useClientList";

--- a/packages/store/src/utils/client-accessor.ts
+++ b/packages/store/src/utils/client-accessor.ts
@@ -83,5 +83,10 @@ export const createErrorClientAccessor = (
 export const getBoundClient = (accessor: object): ClientMethods =>
   (accessor as AnyRecord)[AUI_INSTANCE_SYMBOL] as ClientMethods;
 
+/**
+ * Resolves a client accessor to its bound client instance. The instance keeps
+ * its identity across value-only updates, so it is a stable cache key for a
+ * logical scope. Non-accessor values are returned as-is.
+ */
 export const unwrapClientAccessor = <T>(value: T): T =>
   ((value as AnyRecord)[AUI_INSTANCE_SYMBOL] as T) ?? value;


### PR DESCRIPTION
## Problem

Regression from the property-API migration (#5275): the `globalPersistence` WeakMap in `AssistantCloudThreadHistoryAdapter` used to key on `aui.threadListItem()` — the bound client instance, stable per logical thread list item. Post-migration it keys on the `aui.threadListItem` accessor proxy, which is minted per host mount, so two mounts of the same logical item get separate `CloudMessagePersistence` caches.

## Fix

Key on the resolved bound client again via `unwrapClientAccessor`, newly exported from `@assistant-ui/store` (previously internal, already used by `Derived`). Restoring `apply` to return `read()` was considered instead, but `accessor-properties.test.tsx` pins `Object.is(aui.thread, aui.thread())` as the post-migration contract, so the call form intentionally returns the proxy — hence resolving through the unwrap helper. This adds a store export (api-surface regenerated); flagging for API-surface review.

Written against main independently of #5279 — the pair conflicts trivially in the `_persistence` key-lookup line; whichever merges second needs a one-line rebase.

## Tests

- Added a store contract test: two accessors over the same client unwrap to the same instance; non-accessor values pass through.
- `pnpm turbo test --filter=@assistant-ui/core --filter=@assistant-ui/store`: 761 + 26 passed. Build, lint, and `api-surface:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.gsS0cIMDFGIyqiGFc14G6pk3l2vIZm2nxeJrT2Sn81OrsC-i2hpdnWohgko?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->