### PR TITLE
feat(store): opaque client identity via getClientId; drop instance deref

### DIFF
--- a/.changeset/client-id-identity.md
+++ b/.changeset/client-id-identity.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/store": patch
+"@assistant-ui/core": patch
+---
+
+feat: `getClientId(client)` returns an opaque, WeakMap-legal identity for a bound client — the same object regardless of accessor wrapping depth. The cloud message persistence cache is now keyed on it instead of the per-mount accessor proxy. Removes `unwrapClientAccessor` and `getBoundClient` (introduced and replaced pre-release, never published).

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -177,10 +177,20 @@ type WildcardPayload = {
 
 declare function attachTransformScopes(hook: Hook, transform: TransformScopesFn): void;
 
+declare const clientIdBrand: unique symbol;
+
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
 
+declare const getClientId: (client: object) => getClientId.ClientId;
+
+declare namespace getClientId {
+  type ClientId = {
+    readonly [clientIdBrand]: never;
+  };
+}
+
 declare namespace entry_root_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
+  export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, getClientId, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
 }
 
 declare const normalizeEventSelector: <TEvent extends AssistantEventName>(selector: AssistantEventSelector<TEvent>) => {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -13,11 +13,10 @@ import {
   createFormattedPersistence,
 } from "assistant-cloud";
 import { auiV0Decode, auiV0Encode } from "./auiV0";
-import { type AssistantClient, useAui } from "@assistant-ui/store";
-import type { ThreadListItemMethods } from "../../../store/scopes/thread-list-item";
+import { type AssistantClient, getClientId, useAui } from "@assistant-ui/store";
 
 const globalPersistence = new WeakMap<
-  ThreadListItemMethods,
+  getClientId.ClientId,
   CloudMessagePersistence
 >();
 
@@ -31,7 +30,7 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   }
 
   private get _persistence(): CloudMessagePersistence {
-    const key = this.aui.threadListItem;
+    const key = getClientId(this.aui.threadListItem);
     if (!globalPersistence.has(key)) {
       globalPersistence.set(
         key,

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -7,7 +7,6 @@ import type {
   ClientMeta,
 } from "./types/client";
 import { useBuildingClient } from "./utils/tap-assistant-context";
-import { unwrapClientAccessor } from "./utils/client-accessor";
 
 type DerivedInstance<K extends ClientNames> = ReturnType<
   AssistantClientAccessor<K>
@@ -17,7 +16,7 @@ export const useDerived = <K extends ClientNames>({
   get,
 }: Derived.Props<K>): DerivedInstance<K> => {
   const client = useBuildingClient();
-  const select = () => unwrapClientAccessor(get(client)) as DerivedInstance<K>;
+  const select = () => get(client) as DerivedInstance<K>;
   return useSyncExternalStore(client.subscribe, select, select);
 };
 

--- a/packages/store/src/__tests__/client-id.test.ts
+++ b/packages/store/src/__tests__/client-id.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  createClientAccessor,
+  createErrorClientAccessor,
+  getClientId,
+} from "../utils/client-accessor";
+import type { ClientMethods, ClientNames } from "../types/client";
+
+const meta = {
+  name: "thread" as ClientNames,
+  source: "root" as const,
+  query: {},
+};
+
+describe("getClientId", () => {
+  it("resolves accessors over the same client to the same identity", () => {
+    const methods: ClientMethods = { getState: () => ({}) };
+    const first = createClientAccessor(meta, () => methods);
+    const second = createClientAccessor(meta, () => methods);
+
+    expect(Object.is(first, second)).toBe(false);
+    expect(getClientId(first)).toBe(getClientId(second));
+    expect(getClientId(first)).toBe(getClientId(methods));
+  });
+
+  it("is stable across nested accessor layers", () => {
+    const methods: ClientMethods = { getState: () => ({}) };
+    const inner = createClientAccessor(meta, () => methods);
+    const outer = createClientAccessor(
+      meta,
+      () => inner as unknown as ClientMethods,
+    );
+
+    expect(getClientId(outer)).toBe(getClientId(methods));
+    expect(getClientId(outer)).toBe(getClientId(inner));
+  });
+
+  it("is distinct per bound instance", () => {
+    const a: ClientMethods = { getState: () => ({}) };
+    const b: ClientMethods = { getState: () => ({}) };
+
+    expect(getClientId(createClientAccessor(meta, () => a))).not.toBe(
+      getClientId(createClientAccessor(meta, () => b)),
+    );
+  });
+
+  it("works as a WeakMap key shared between accessors of the same client", () => {
+    const methods: ClientMethods = { getState: () => ({}) };
+    const cache = new WeakMap<getClientId.ClientId, string>();
+
+    cache.set(getClientId(createClientAccessor(meta, () => methods)), "value");
+
+    expect(
+      cache.get(getClientId(createClientAccessor(meta, () => methods))),
+    ).toBe("value");
+  });
+
+  it("throws for an unavailable scope's accessor", () => {
+    const accessor = createErrorClientAccessor(
+      "Scope lookup failed: no AuiProvider",
+      "thread",
+    );
+
+    expect(() => getClientId(accessor)).toThrow(/AuiProvider/);
+  });
+});

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -21,6 +21,7 @@ export {
   useAssistantClientRef,
   useAssistantEmit,
 } from "./utils/tap-assistant-context";
+export { getClientId } from "./utils/client-accessor";
 export { useClientResource } from "./useClientResource";
 export { useClientLookup } from "./useClientLookup";
 export { useClientList } from "./useClientList";

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -41,7 +41,7 @@ import {
   useBuildingClient,
 } from "./utils/tap-assistant-context";
 import { ClientResource } from "./useClientResource";
-import { createClientAccessor, getBoundClient } from "./utils/client-accessor";
+import { createClientAccessor, getClientId } from "./utils/client-accessor";
 import { getClientIndex } from "./utils/tap-client-stack-context";
 import {
   PROXIED_ASSISTANT_STATE_SYMBOL,
@@ -168,7 +168,9 @@ const useClientFields = ({
             return;
           }
 
-          const scopeClient = getBoundClient(this[scope as ClientNames]);
+          const scopeClient = getClientId(
+            this[scope as ClientNames],
+          ) as unknown as ClientMethods;
           const index = getClientIndex(scopeClient);
           if (scopeClient === clientStack[index]) {
             callback(payload);

--- a/packages/store/src/utils/client-accessor.ts
+++ b/packages/store/src/utils/client-accessor.ts
@@ -5,7 +5,9 @@ import type {
 } from "../types/client";
 import { handleIntrospectionProp } from "./BaseProxyHandler";
 
-const AUI_INSTANCE_SYMBOL = Symbol("assistant-ui.store.auiInstance");
+const CLIENT_ID_SYMBOL = Symbol("assistant-ui.store.clientId");
+
+declare const clientIdBrand: unique symbol;
 
 type AccessorMeta = {
   name: ClientNames;
@@ -28,14 +30,14 @@ export const createClientAccessor = <K extends ClientNames>(
       if (prop === "source") return meta.source;
       if (prop === "query") return meta.query;
       if (prop === "name") return meta.name;
-      if (prop === AUI_INSTANCE_SYMBOL) return read();
+      if (prop === CLIENT_ID_SYMBOL) return getClientId(read());
       return (read() as AnyRecord)[prop];
     },
     has: (_, prop) =>
       prop === "source" ||
       prop === "query" ||
       prop === "name" ||
-      prop === AUI_INSTANCE_SYMBOL ||
+      prop === CLIENT_ID_SYMBOL ||
       prop in read(),
     ownKeys: () => Reflect.ownKeys(read()),
     getOwnPropertyDescriptor: (_, prop) => {
@@ -65,6 +67,7 @@ export const createErrorClientAccessor = (
       get: (_, prop) => {
         if (prop === "source" || prop === "query") return null;
         if (prop === "name") return name;
+        if (prop === CLIENT_ID_SYMBOL) return fail();
         const introspection = handleIntrospectionProp(
           prop,
           "AssistantClientAccessor",
@@ -80,8 +83,17 @@ export const createErrorClientAccessor = (
   );
 };
 
-export const getBoundClient = (accessor: object): ClientMethods =>
-  (accessor as AnyRecord)[AUI_INSTANCE_SYMBOL] as ClientMethods;
+/**
+ * Returns the opaque identity of a bound client instance.
+ *
+ * The identity is stable for the lifetime of the bound client: the same
+ * object is returned no matter how many accessor layers wrap the client, so
+ * it is a reliable `WeakMap` key for per-client caches. Throws if the client
+ * is an accessor for an unavailable scope.
+ */
+export const getClientId = (client: object): getClientId.ClientId =>
+  ((client as AnyRecord)[CLIENT_ID_SYMBOL] ?? client) as getClientId.ClientId;
 
-export const unwrapClientAccessor = <T>(value: T): T =>
-  ((value as AnyRecord)[AUI_INSTANCE_SYMBOL] as T) ?? value;
+export namespace getClientId {
+  export type ClientId = { readonly [clientIdBrand]: never };
+}


### PR DESCRIPTION
## Summary

Replaces the instance-deref API with a client identity API, per design review (sw-98, thread_6l4gvb8m2gvk9k).

- **Identity, not deref**: new public export `getClientId(client)` from `@assistant-ui/store` returns an opaque branded identity object (`getClientId.ClientId`). It is stable per bound client instance, WeakMap-legal, and resolves to the same object no matter how many accessor layers wrap the client (the accessor trap forwards the internal symbol recursively, bottoming out at the raw instance). Unavailable-scope (error) accessors throw their lookup error on the read.
- **No symbol export**: the instance symbol stays module-internal; consumers can only use the result as an identity key.
- **Removed**: `unwrapClientAccessor` and `getBoundClient` (both introduced in the unreleased 0.15 train, never published — changeset notes introduced-and-replaced pre-release). `Derived` now stores whatever its getter returned as-is; accessor traps forward reads, so a stored accessor double-wraps harmlessly.
- **WeakMap re-key folded in** (supersedes #5280): `globalPersistence` in `AssistantCloudThreadHistoryAdapter` is keyed on `getClientId(this.aui.threadListItem)` instead of the per-mount accessor proxy, so remounts share persistence for the same thread list item.
- Contract tests: same identity across accessors and wrapping depth, distinct per instance, WeakMap-key sharing, throws on error accessor.
- Patch changesets for `@assistant-ui/store` and `@assistant-ui/core`; api-surface regenerated.

Note: may have a one-line conflict with #5279 (sw96-cloud-adapter-clientref) in `AssistantCloudThreadHistoryAdapter.ts`; based on origin/main as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nnHdLaXjHmqnXZJKzHA5INle1QhA3gT4xTzdCUXoWrIgeC6q0vbuv1Tb3Mo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->