### PR TITLE
fix(assistant-stream): settle the tool-call part on setResponse

### DIFF
--- a/.changeset/tool-call-response-settles-part.md
+++ b/.changeset/tool-call-response-settles-part.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: addToolCallPart({response}) settles the tool-call part so the stream closes

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -173,6 +173,55 @@ describe("createAssistantStream task settlement", () => {
   });
 });
 
+describe("addToolCallPart with an immediate response", () => {
+  it("completes the stream without an explicit tool close", async () => {
+    const chunks = await collectChunks(
+      createAssistantStream((controller) => {
+        controller.addToolCallPart({
+          toolName: "search",
+          response: { result: "done" },
+        });
+      }),
+    );
+
+    expect(chunks.map((c) => c.type)).toContain("result");
+    expect(chunks.at(-1)?.type).toBe("part-finish");
+  });
+
+  it("completes the stream when args accompany the response", async () => {
+    const chunks = await collectChunks(
+      createAssistantStream((controller) => {
+        controller.addToolCallPart({
+          toolName: "search",
+          args: { query: "x" },
+          response: { result: "done" },
+        });
+      }),
+    );
+
+    const deltas = chunks.filter((c) => c.type === "text-delta");
+    expect(deltas.map((c) => c.textDelta).join("")).toBe('{"query":"x"}');
+    expect(chunks.filter((c) => c.type === "result")).toHaveLength(1);
+    expect(chunks.at(-1)?.type).toBe("part-finish");
+  });
+
+  it("keeps working when the caller also closes explicitly", async () => {
+    const chunks = await collectChunks(
+      createAssistantStream((controller) => {
+        const tool = controller.addToolCallPart({
+          toolName: "search",
+          response: { result: "done" },
+        });
+        tool.close();
+      }),
+    );
+
+    expect(chunks.filter((c) => c.type === "result")).toHaveLength(1);
+    expect(chunks.filter((c) => c.type === "part-finish")).toHaveLength(1);
+    expect(chunks.at(-1)?.type).toBe("part-finish");
+  });
+});
+
 describe("AssistantStreamController withParentId", () => {
   it("attaches parentId to text parts across a data-stream round trip", async () => {
     const response = createAssistantStreamResponse((controller) => {

--- a/packages/assistant-stream/src/core/modules/tool-call.test.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantStreamController } from "./assistant-stream";
+import { createToolCallStreamController } from "./tool-call";
 import { ToolResponse } from "../tool/ToolResponse";
 import { toolResultStream } from "../tool/toolResultStream";
 import type { ToolCallReader } from "../tool/tool-types";
+import type { AssistantStream } from "../AssistantStream";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 
 type Reader = ToolCallReader<Record<string, unknown>, unknown>;
+
+const collectChunks = async (
+  stream: AssistantStream,
+): Promise<AssistantStreamChunk[]> => {
+  const chunks: AssistantStreamChunk[] = [];
+  await stream.pipeTo(
+    new WritableStream({
+      write(chunk) {
+        chunks.push(chunk);
+      },
+    }),
+  );
+  return chunks;
+};
 
 describe("ToolCallStreamController", () => {
   it("delivers a backend response before an args parse failure", async () => {
@@ -63,5 +79,39 @@ describe("ToolCallStreamController", () => {
       result: { source: "backend" },
       isError: false,
     });
+  });
+
+  it("setResponse settles the part without an explicit close", async () => {
+    const [stream, controller] = createToolCallStreamController();
+    controller.setResponse({ result: "done" });
+
+    const chunks = await collectChunks(stream);
+
+    expect(chunks.map((c) => c.type)).toContain("result");
+    expect(chunks.at(-1)?.type).toBe("part-finish");
+  });
+
+  it("ignores a second setResponse after the part is settled", async () => {
+    const [stream, controller] = createToolCallStreamController();
+    controller.setResponse({ result: "first" });
+    controller.setResponse({ result: "second" });
+
+    const chunks = await collectChunks(stream);
+
+    const results = chunks.filter((c) => c.type === "result");
+    expect(results).toEqual([expect.objectContaining({ result: "first" })]);
+    expect(chunks.filter((c) => c.type === "part-finish")).toHaveLength(1);
+  });
+
+  it("ignores setResponse after an explicit close", async () => {
+    const [stream, controller] = createToolCallStreamController();
+    controller.argsText.append('{"query":"x"}');
+    controller.close();
+    controller.setResponse({ result: "late" });
+
+    const chunks = await collectChunks(stream);
+
+    expect(chunks.filter((c) => c.type === "result")).toHaveLength(0);
+    expect(chunks.at(-1)?.type).toBe("part-finish");
   });
 });

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -8,6 +8,10 @@ import { createTextStream, type TextStreamController } from "./text";
 export type ToolCallStreamController = {
   argsText: TextStreamController;
 
+  /**
+   * Sets the tool response and settles the part. The part closes automatically
+   * and subsequent calls are ignored.
+   */
   setResponse(response: ToolResponseLike<ReadonlyJSONValue>): void;
   close(): void;
 };
@@ -68,6 +72,8 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
   private _argsTextController!: TextStreamController;
 
   async setResponse(response: ToolResponseLike<ReadonlyJSONValue>) {
+    if (this._isClosed) return;
+
     this._controller.enqueue({
       type: "result",
       path: [],
@@ -83,9 +89,7 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
         ? { messages: response.messages }
         : {}),
     });
-    this._argsTextController.close();
-    await Promise.resolve(); // flush microtask queue
-    // TODO switch argsTextController to be something that doesn'#t require this
+    await this.close();
   }
 
   async close() {

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -676,6 +676,47 @@ describe("UIMessageStreamDecoder", () => {
     expect(chunks.some((c) => c.type === "result")).toBe(true);
   });
 
+  it("settles the tool part at result time instead of decoder flush", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "tool-call-start",
+        toolCallId: "call_abc",
+        toolName: "weather",
+      }),
+      JSON.stringify({ type: "tool-call-delta", argsText: '{"city":"NYC"}' }),
+      JSON.stringify({ type: "tool-call-end" }),
+      JSON.stringify({
+        type: "tool-result",
+        toolCallId: "call_abc",
+        result: { temp: 72 },
+      }),
+      JSON.stringify({ type: "text-start", id: "text_1" }),
+      JSON.stringify({ type: "text-delta", id: "text_1", delta: "Hello" }),
+      JSON.stringify({ type: "text-end" }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const chunks = await collectChunks(
+      createUIMessageStream(events).pipeThrough(new UIMessageStreamDecoder()),
+    );
+
+    const toolPartFinish = chunks.findIndex(
+      (c) => c.type === "part-finish" && c.path[0] === 0,
+    );
+    const textPartStart = chunks.findIndex(
+      (c) => c.type === "part-start" && c.part.type === "text",
+    );
+    expect(toolPartFinish).toBeGreaterThan(-1);
+    expect(textPartStart).toBeGreaterThan(-1);
+    expect(toolPartFinish).toBeLessThan(textPartStart);
+  });
+
   it("keeps the active tool call writable when another call receives its result", async () => {
     const events = [
       JSON.stringify({

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -709,12 +709,12 @@ describe("UIMessageStreamDecoder", () => {
     const toolPartFinish = chunks.findIndex(
       (c) => c.type === "part-finish" && c.path[0] === 0,
     );
-    const textPartStart = chunks.findIndex(
-      (c) => c.type === "part-start" && c.part.type === "text",
-    );
-    expect(toolPartFinish).toBeGreaterThan(-1);
-    expect(textPartStart).toBeGreaterThan(-1);
-    expect(toolPartFinish).toBeLessThan(textPartStart);
+    const result = chunks.findIndex((c) => c.type === "result");
+    const messageFinish = chunks.findIndex((c) => c.type === "message-finish");
+    expect(result).toBeGreaterThan(-1);
+    expect(messageFinish).toBeGreaterThan(-1);
+    expect(toolPartFinish).toBeGreaterThan(result);
+    expect(toolPartFinish).toBeLessThan(messageFinish);
   });
 
   it("keeps the active tool call writable when another call receives its result", async () => {


### PR DESCRIPTION
Closes #5283
## What

`ToolCallStreamController.setResponse` now settles the part: it enqueues the `result` chunk and then closes the part, and repeated calls after settlement are ignored. This makes `addToolCallPart({ toolName, response })` complete the stream on its own, as its JSDoc already promised.

## Why

While fixing #5277 I hit this live: a stream built with `addToolCallPart({ response })` never terminates, because `setResponse` closes the args text but leaves the part open and the merge stream waits forever. The hang used to be masked by the pre #5045 rethrow crashing the process first. 

## Impact

- The documented immediate-response path now completes instead of hanging; no caller changes needed.
- Explicit-close callers are unaffected: `close()` after `setResponse` was already idempotent and stays a no-op.
- A duplicate `result` for a settled part is now dropped instead of being enqueued after the part settled.

## Scope 

- Every in-repo `setResponse` caller was audited: both decoders close controllers in flush (now a no-op), `ToolInvocationTracker` closes right after (no-op), and `ToolExecutionStream` targets the separate `ToolCallReader` class.
- The pre-existing `result` before `tool-call-args-text-finish` flush order is deliberately untouched (tracked separately as the accumulator ordering question); the new tests intentionally do not pin it.
- Decoded streams now emit the tool part's `part-finish` at result time instead of at decoder flush; the full assistant-stream suite and core's tool-invocation tests pass unchanged.
- Duplicate-result validation with a warning at the decode boundary is deliberately not added here; it folds into the planned UIMS per-field validation work.
- A fire-and-forget `setResponse` on a consumer-cancelled stream could still reject into a discarded promise; that exposure predates this change and is unchanged.
- No surface change: `setResponse` keeps its signature, the only type edit is added JSDoc.
- Tests: auto-close with and without args, duplicate and post-close `setResponse` no-ops, and explicit-close compatibility; nothing notable left uncovered.
- Changeset: patch (`assistant-stream`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Zbl4a1syvyVafskisUdCriLhNfGMH8zUeuTcmn2UddjMIcIAfjJ7a024N64?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->