### PR TITLE
chore: add missing changesets for the v0.15 train

### DIFF
--- a/.changeset/adapter-accessor-migration.md
+++ b/.changeset/adapter-accessor-migration.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/react-mcp": patch
+"@assistant-ui/react-lexical": patch
+"@assistant-ui/react-o11y": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/react-hook-form": patch
+"@assistant-ui/react-pi": patch
+"@assistant-ui/react-devtools": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+refactor: migrate to aui property accessors

--- a/.changeset/ink-native-accessor-migration.md
+++ b/.changeset/ink-native-accessor-migration.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ink": patch
+"@assistant-ui/react-native": patch
+---
+
+refactor: migrate primitives to aui property accessors; drop deprecated part-type handling

--- a/.changeset/tap-uses-retain-memocache.md
+++ b/.changeset/tap-uses-retain-memocache.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: useSyncExternalStore retains the last committed value when the snapshot getter throws; export `useMemoCache` from the package root


### PR DESCRIPTION
Adds the changesets missing ahead of the v0.15 release train. Changesets only — no package.json or source changes.

## Covered gaps

- `@assistant-ui/tap` (patch): useSyncExternalStore retains the last committed value when the snapshot getter throws (#5274); `useMemoCache` exported from the package root (#5270). Deliberately **patch**, not minor — a tap minor escapes dependents' `^0.9.0` peer ranges and cascades majors across the ecosystem.
- Adapter aui property-accessor migrations (all patch):
  - `@assistant-ui/react-ink`, `@assistant-ui/react-native`: migrate primitives to aui property accessors; drop deprecated part-type handling
  - `@assistant-ui/react-mcp`, `@assistant-ui/react-lexical`, `@assistant-ui/react-o11y`, `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-google-adk`, `@assistant-ui/react-hook-form`, `@assistant-ui/react-pi`, `@assistant-ui/react-devtools`, `@assistant-ui/react-langgraph`: migrate to aui property accessors

All twelve packages were verified to have non-test `src/` changes since 57bf429cc; none skipped.

## Resulting version diff (scratch `pnpm changeset version` on this branch, all pending changesets — reference for hand-fixing the upcoming version PR)

| Package | Old | New |
| --- | --- | --- |
| assistant-ui | 0.0.107 | 0.0.108 |
| @assistant-ui/core | 0.2.23 | 1.0.0 |
| create-assistant-ui | 0.0.70 | 0.0.71 |
| @assistant-ui/eve | 0.0.5 | 0.0.6 |
| @assistant-ui/react-a2a | 0.2.23 | 0.2.24 |
| @assistant-ui/react-ag-ui | 0.0.47 | 0.0.48 |
| @assistant-ui/react-ai-sdk | 1.4.0 | 1.4.1 |
| @assistant-ui/react-data-stream | 0.12.21 | 0.12.22 |
| @assistant-ui/react-devtools | 1.2.10 | 2.0.0 |
| @assistant-ui/react-generative-ui | 0.0.9 | 1.0.0 |
| @assistant-ui/react-google-adk | 0.0.18 | 0.0.19 |
| @assistant-ui/react-hook-form | 0.12.24 | 0.12.25 |
| @assistant-ui/react-ink-markdown | 0.0.33 | 0.0.34 |
| @assistant-ui/react-ink | 0.0.34 | 0.0.35 |
| @assistant-ui/react-langchain | 0.0.20 | 0.0.21 |
| @assistant-ui/react-langgraph | 0.14.14 | 0.14.15 |
| @assistant-ui/react-lexical | 0.2.6 | 1.0.0 |
| @assistant-ui/react-markdown | 0.14.7 | 1.0.0 |
| @assistant-ui/react-mcp | 0.0.20 | 0.0.21 |
| @assistant-ui/react-native | 0.1.32 | 0.1.33 |
| @assistant-ui/react-o11y | 0.0.28 | 0.0.29 |
| @assistant-ui/react-opencode | 0.2.13 | 1.0.0 |
| @assistant-ui/react-pi | 0.0.9 | 1.0.0 |
| @assistant-ui/react-streamdown | 0.3.7 | 1.0.0 |
| @assistant-ui/react-syntax-highlighter | 0.14.3 | 1.0.0 |
| @assistant-ui/react | 0.14.29 | 0.15.0 |
| @assistant-ui/store | 0.2.22 | 0.3.0 |
| @assistant-ui/tap | 0.9.6 | 0.9.7 |

Several 1.0.0 entries above are peer-range major cascades from the `@assistant-ui/react` 0.15 minor — flagged here for the version-PR hand-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eydEw1KuJ7rQrEHg6_HXnx5lYYCXWL6c_VUPf7nqEnVTpu5dwenfWoUAo-I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->