### PR TITLE
fix(assistant-stream-py): emit canonical assistant-transport wire

### DIFF
--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -5,8 +5,11 @@ from assistant_stream.serialization.assistant_stream_response import (
 from assistant_stream.serialization.heartbeat import HeartbeatOption
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
-from typing import AsyncGenerator, Any
+from typing import Any, AsyncGenerator, Optional
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class StateProxyJSONEncoder(json.JSONEncoder):
@@ -18,40 +21,194 @@ class StateProxyJSONEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+class _CanonicalChunkTranslator:
+    """Translates the package's flat internal chunks into the canonical
+    assistant-transport wire chunks (part-start/path addressing), mirroring the
+    part-boundary semantics of the TS AssistantStreamController. Tool-call args
+    are addressed by tool_call_id throughout, so they close only on the call's
+    own result or at stream end, never by inference from unrelated chunks."""
+
+    def __init__(self) -> None:
+        self._part_count = 0
+        self._append: Optional[tuple[str, Optional[str], int]] = None
+        self._tool_calls: dict[str, dict[str, Any]] = {}
+        self._warned_reasons: set[str] = set()
+
+    def _warn_once(self, reason: str, detail: str) -> None:
+        if reason in self._warned_reasons:
+            return
+        self._warned_reasons.add(reason)
+        logger.warning(
+            "Dropped assistant-transport chunk (%s): %s", reason, detail
+        )
+
+    def _close_append_part(self, out: list[dict]) -> None:
+        if self._append is None:
+            return
+        out.append({"type": "part-finish", "path": [self._append[2]]})
+        self._append = None
+
+    def _close_args(self, entry: dict[str, Any], out: list[dict]) -> None:
+        if entry["args_closed"]:
+            return
+        entry["args_closed"] = True
+        path = [entry["index"]]
+        if not entry["has_args_text"]:
+            out.append({"type": "text-delta", "textDelta": "{}", "path": path})
+        out.append({"type": "tool-call-args-text-finish", "path": path})
+
+    def _open_part(self, part: dict, out: list[dict]) -> int:
+        self._close_append_part(out)
+        index = self._part_count
+        self._part_count += 1
+        out.append({"type": "part-start", "part": part, "path": []})
+        return index
+
+    def _append_delta(
+        self, kind: str, parent_id: Optional[str], text_delta: str, out: list[dict]
+    ) -> None:
+        if self._append is None or self._append[:2] != (kind, parent_id):
+            part: dict = {"type": kind}
+            if parent_id is not None:
+                part["parentId"] = parent_id
+            index = self._open_part(part, out)
+            self._append = (kind, parent_id, index)
+        out.append(
+            {"type": "text-delta", "textDelta": text_delta, "path": [self._append[2]]}
+        )
+
+    def translate(self, chunk: AssistantStreamChunk) -> list[dict]:
+        out: list[dict] = []
+        chunk_type = chunk.type
+
+        if chunk_type == "text-delta":
+            self._append_delta("text", chunk.parent_id, chunk.text_delta, out)
+        elif chunk_type == "reasoning-delta":
+            self._append_delta(
+                "reasoning", chunk.parent_id, chunk.reasoning_delta, out
+            )
+        elif chunk_type == "tool-call-begin":
+            if chunk.tool_call_id in self._tool_calls:
+                self._warn_once(
+                    "duplicate-tool-call-id",
+                    f"tool-call-begin for {chunk.tool_call_id}",
+                )
+            else:
+                part = {
+                    "type": "tool-call",
+                    "toolCallId": chunk.tool_call_id,
+                    "toolName": chunk.tool_name,
+                }
+                if chunk.parent_id is not None:
+                    part["parentId"] = chunk.parent_id
+                index = self._open_part(part, out)
+                self._tool_calls[chunk.tool_call_id] = {
+                    "index": index,
+                    "has_args_text": False,
+                    "args_closed": False,
+                    "part_closed": False,
+                }
+        elif chunk_type == "tool-call-delta":
+            entry = self._tool_calls.get(chunk.tool_call_id)
+            if entry is None:
+                self._warn_once(
+                    "unknown-tool-call-id", f"tool-call-delta for {chunk.tool_call_id}"
+                )
+            elif entry["args_closed"]:
+                self._warn_once(
+                    "args-already-closed", f"tool-call-delta for {chunk.tool_call_id}"
+                )
+            else:
+                entry["has_args_text"] = True
+                out.append(
+                    {
+                        "type": "text-delta",
+                        "textDelta": chunk.args_text_delta,
+                        "path": [entry["index"]],
+                    }
+                )
+        elif chunk_type == "tool-result":
+            entry = self._tool_calls.get(chunk.tool_call_id)
+            if entry is None:
+                self._warn_once(
+                    "unknown-tool-call-id", f"tool-result for {chunk.tool_call_id}"
+                )
+            elif entry["part_closed"]:
+                self._warn_once(
+                    "part-already-closed", f"tool-result for {chunk.tool_call_id}"
+                )
+            else:
+                self._close_args(entry, out)
+                path = [entry["index"]]
+                result: dict = {
+                    "type": "result",
+                    "result": chunk.result,
+                    "isError": chunk.is_error,
+                    "path": path,
+                }
+                if chunk.artifact is not None:
+                    result["artifact"] = chunk.artifact
+                out.append(result)
+                out.append({"type": "part-finish", "path": path})
+                entry["part_closed"] = True
+        elif chunk_type == "source":
+            part = {
+                "type": "source",
+                "sourceType": chunk.source_type,
+                "id": chunk.id,
+                "url": chunk.url,
+            }
+            if chunk.title is not None:
+                part["title"] = chunk.title
+            if chunk.parent_id is not None:
+                part["parentId"] = chunk.parent_id
+            index = self._open_part(part, out)
+            out.append({"type": "part-finish", "path": [index]})
+        elif chunk_type == "data":
+            out.append({"type": "data", "data": [chunk.data], "path": []})
+        elif chunk_type == "error":
+            out.append({"type": "error", "error": chunk.error, "path": []})
+        elif chunk_type == "update-state":
+            out.append(
+                {"type": "update-state", "operations": chunk.operations, "path": []}
+            )
+        else:
+            self._warn_once("unknown-chunk-type", chunk_type)
+
+        return out
+
+    def flush(self) -> list[dict]:
+        out: list[dict] = []
+        self._close_append_part(out)
+        for entry in self._tool_calls.values():
+            if entry["part_closed"]:
+                continue
+            self._close_args(entry, out)
+            out.append({"type": "part-finish", "path": [entry["index"]]})
+            entry["part_closed"] = True
+        return out
+
+
 class AssistantTransportEncoder(StreamEncoder):
     """
-    AssistantTransportEncoder encodes AssistantStreamChunks into SSE format
-    and emits [DONE] when the stream completes.
+    AssistantTransportEncoder encodes AssistantStreamChunks into the canonical
+    assistant-transport SSE wire format and emits [DONE] when the stream
+    completes.
     """
 
     def get_media_type(self) -> str:
         return "text/event-stream"
 
-    def _chunk_to_dict(self, chunk: AssistantStreamChunk) -> dict[str, Any]:
-        """Convert a chunk to a JSON-serializable dictionary."""
-        chunk_dict = {"type": chunk.type}
-
-        # Add all attributes from the chunk
-        for key, value in vars(chunk).items():
-            if key != "type":  # Already added
-                chunk_dict[self._snake_to_camel(key)] = value
-
-        return chunk_dict
-
-    def _snake_to_camel(self, snake_str: str) -> str:
-        """Convert snake_case to camelCase."""
-        components = snake_str.split("_")
-        return components[0] + "".join(x.title() for x in components[1:])
-
     async def encode_stream(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]
     ) -> AsyncGenerator[str, None]:
+        translator = _CanonicalChunkTranslator()
         async for chunk in stream:
-            chunk_dict = self._chunk_to_dict(chunk)
-            chunk_json = json.dumps(chunk_dict, cls=StateProxyJSONEncoder)
-            yield f"data: {chunk_json}\n\n"
+            for wire_chunk in translator.translate(chunk):
+                yield f"data: {json.dumps(wire_chunk, cls=StateProxyJSONEncoder)}\n\n"
+        for wire_chunk in translator.flush():
+            yield f"data: {json.dumps(wire_chunk, cls=StateProxyJSONEncoder)}\n\n"
 
-        # Emit [DONE] marker when stream completes
         yield "data: [DONE]\n\n"
 
 

--- a/python/assistant-stream/tests/test_assistant_transport.py
+++ b/python/assistant-stream/tests/test_assistant_transport.py
@@ -1,150 +1,427 @@
 import pytest
 from assistant_stream import create_run, RunController
-from assistant_stream.assistant_stream_chunk import UpdateStateChunk
+from assistant_stream.assistant_stream_chunk import (
+    DataChunk,
+    ErrorChunk,
+    ReasoningDeltaChunk,
+    SourceChunk,
+    TextDeltaChunk,
+    ToolCallBeginChunk,
+    ToolCallDeltaChunk,
+    ToolResultChunk,
+    UpdateStateChunk,
+)
 from assistant_stream.serialization.assistant_transport import AssistantTransportEncoder
 import json
 
 
-@pytest.mark.anyio
-async def test_assistant_transport_encoder_format():
-    """Test that AssistantTransportEncoder produces SSE format."""
+async def _encode(chunks):
+    async def stream():
+        for chunk in chunks:
+            yield chunk
+
     encoder = AssistantTransportEncoder()
-    collected_output = []
+    return [line async for line in encoder.encode_stream(stream())]
 
-    async def run_callback(controller: RunController):
-        controller.append_text("Hello")
-        controller.append_text(" world")
 
-    # Create the run and encode it
-    chunks = create_run(run_callback)
-    encoded = encoder.encode_stream(chunks)
-
-    async for line in encoded:
-        collected_output.append(line)
-
-    # Verify SSE format
-    assert len(collected_output) > 0
-
-    # All lines except the last should be SSE formatted chunks
-    for line in collected_output[:-1]:
+def _parse(lines):
+    assert lines[-1] == "data: [DONE]\n\n"
+    parsed = []
+    for line in lines[:-1]:
         assert line.startswith("data: ")
         assert line.endswith("\n\n")
-        # Verify it's valid JSON (excluding the "data: " prefix and newlines)
-        json_str = line[6:-2]  # Remove "data: " and "\n\n"
-        chunk_data = json.loads(json_str)
-        assert "type" in chunk_data
-
-    # Last line should be [DONE]
-    assert collected_output[-1] == "data: [DONE]\n\n"
+        parsed.append(json.loads(line[6:-2]))
+    return parsed
 
 
 @pytest.mark.anyio
-async def test_assistant_transport_encoder_text_chunks():
-    """Test that text chunks are properly encoded."""
-    encoder = AssistantTransportEncoder()
-    collected_chunks = []
+async def test_media_type():
+    assert AssistantTransportEncoder().get_media_type() == "text/event-stream"
 
+
+@pytest.mark.anyio
+async def test_text_deltas_share_one_text_part():
+    lines = await _encode(
+        [TextDeltaChunk(text_delta="Hello"), TextDeltaChunk(text_delta=" world")]
+    )
+    assert _parse(lines) == [
+        {"type": "part-start", "part": {"type": "text"}, "path": []},
+        {"type": "text-delta", "textDelta": "Hello", "path": [0]},
+        {"type": "text-delta", "textDelta": " world", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_reasoning_then_text_opens_separate_parts():
+    lines = await _encode(
+        [
+            ReasoningDeltaChunk(reasoning_delta="Thinking..."),
+            TextDeltaChunk(text_delta="Answer"),
+        ]
+    )
+    assert _parse(lines) == [
+        {"type": "part-start", "part": {"type": "reasoning"}, "path": []},
+        {"type": "text-delta", "textDelta": "Thinking...", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+        {"type": "part-start", "part": {"type": "text"}, "path": []},
+        {"type": "text-delta", "textDelta": "Answer", "path": [1]},
+        {"type": "part-finish", "path": [1]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_parent_id_change_opens_new_part():
+    lines = await _encode(
+        [
+            TextDeltaChunk(text_delta="a"),
+            TextDeltaChunk(text_delta="b", parent_id="p1"),
+        ]
+    )
+    assert _parse(lines) == [
+        {"type": "part-start", "part": {"type": "text"}, "path": []},
+        {"type": "text-delta", "textDelta": "a", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+        {"type": "part-start", "part": {"type": "text", "parentId": "p1"}, "path": []},
+        {"type": "text-delta", "textDelta": "b", "path": [1]},
+        {"type": "part-finish", "path": [1]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_tool_call_with_streamed_args_and_result():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="get_weather"),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta='{"location":'),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta=' "NYC"}'),
+            ToolResultChunk(tool_call_id="tool_1", result={"temp": 70}),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {
+                "type": "tool-call",
+                "toolCallId": "tool_1",
+                "toolName": "get_weather",
+            },
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": '{"location":', "path": [0]},
+        {"type": "text-delta", "textDelta": ' "NYC"}', "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "result", "result": {"temp": 70}, "isError": False, "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_tool_call_without_args_defaults_to_empty_object():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolResultChunk(tool_call_id="tool_1", result="ok"),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "tool_1", "toolName": "noop"},
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": "{}", "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "result", "result": "ok", "isError": False, "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_tool_result_carries_artifact_and_error_flag():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="fail"),
+            ToolResultChunk(
+                tool_call_id="tool_1",
+                result="boom",
+                artifact={"trace": 1},
+                is_error=True,
+            ),
+        ]
+    )
+    result_chunks = [c for c in _parse(lines) if c["type"] == "result"]
+    assert result_chunks == [
+        {
+            "type": "result",
+            "result": "boom",
+            "isError": True,
+            "artifact": {"trace": 1},
+            "path": [0],
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_text_delta_does_not_close_tool_args():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            TextDeltaChunk(text_delta="hi"),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta='{"a": 1}'),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "tool_1", "toolName": "noop"},
+            "path": [],
+        },
+        {"type": "part-start", "part": {"type": "text"}, "path": []},
+        {"type": "text-delta", "textDelta": "hi", "path": [1]},
+        {"type": "text-delta", "textDelta": '{"a": 1}', "path": [0]},
+        {"type": "part-finish", "path": [1]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_data_and_update_state_do_not_close_args():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            DataChunk(data={"x": 1}),
+            UpdateStateChunk(operations=[{"type": "set", "path": [], "value": 1}]),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta="{}"),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "tool_1", "toolName": "noop"},
+            "path": [],
+        },
+        {"type": "data", "data": [{"x": 1}], "path": []},
+        {
+            "type": "update-state",
+            "operations": [{"type": "set", "path": [], "value": 1}],
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": "{}", "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_data_value_is_wrapped_in_list():
+    lines = await _encode([DataChunk(data=[1, 2])])
+    assert _parse(lines) == [{"type": "data", "data": [[1, 2]], "path": []}]
+
+
+@pytest.mark.anyio
+async def test_error_is_message_level_and_leaves_args_open():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ErrorChunk(error="boom"),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "tool_1", "toolName": "noop"},
+            "path": [],
+        },
+        {"type": "error", "error": "boom", "path": []},
+        {"type": "text-delta", "textDelta": "{}", "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_update_state_preserves_operation_shape():
+    operations = [
+        {"type": "append-text", "path": ["messages", "0", "text"], "value": "hi"}
+    ]
+    lines = await _encode([UpdateStateChunk(operations=operations)])
+    assert _parse(lines) == [
+        {"type": "update-state", "operations": operations, "path": []}
+    ]
+
+
+@pytest.mark.anyio
+async def test_source_emits_self_closing_part():
+    lines = await _encode(
+        [SourceChunk(id="s1", url="https://example.com", title="Example")]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {
+                "type": "source",
+                "sourceType": "url",
+                "id": "s1",
+                "url": "https://example.com",
+                "title": "Example",
+            },
+            "path": [],
+        },
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_unclosed_tool_call_is_finished_on_flush():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta='{"a": 1}'),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "tool_1", "toolName": "noop"},
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": '{"a": 1}', "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_concurrent_tool_calls_interleave_without_arg_loss():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="call_a", tool_name="search"),
+            ToolCallBeginChunk(tool_call_id="call_b", tool_name="lookup"),
+            ToolCallDeltaChunk(tool_call_id="call_a", args_text_delta='{"q": "cats"}'),
+            ToolResultChunk(tool_call_id="call_a", result="r1"),
+            ToolResultChunk(tool_call_id="call_b", result="r2"),
+        ]
+    )
+    assert _parse(lines) == [
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "call_a", "toolName": "search"},
+            "path": [],
+        },
+        {
+            "type": "part-start",
+            "part": {"type": "tool-call", "toolCallId": "call_b", "toolName": "lookup"},
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": '{"q": "cats"}', "path": [0]},
+        {"type": "tool-call-args-text-finish", "path": [0]},
+        {"type": "result", "result": "r1", "isError": False, "path": [0]},
+        {"type": "part-finish", "path": [0]},
+        {"type": "text-delta", "textDelta": "{}", "path": [1]},
+        {"type": "tool-call-args-text-finish", "path": [1]},
+        {"type": "result", "result": "r2", "isError": False, "path": [1]},
+        {"type": "part-finish", "path": [1]},
+    ]
+
+
+@pytest.mark.anyio
+async def test_delta_after_result_is_dropped():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolResultChunk(tool_call_id="tool_1", result="ok"),
+            ToolCallDeltaChunk(tool_call_id="tool_1", args_text_delta="late"),
+        ]
+    )
+    late_deltas = [
+        c for c in _parse(lines) if c["type"] == "text-delta" and c["textDelta"] == "late"
+    ]
+    assert late_deltas == []
+
+
+@pytest.mark.anyio
+async def test_duplicate_tool_call_begin_is_dropped():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolResultChunk(tool_call_id="tool_1", result="ok"),
+        ]
+    )
+    chunks = _parse(lines)
+    part_starts = [c for c in chunks if c["type"] == "part-start"]
+    assert len(part_starts) == 1
+    assert chunks[-1] == {"type": "part-finish", "path": [0]}
+
+
+@pytest.mark.anyio
+async def test_chunks_for_unknown_tool_call_are_dropped():
+    lines = await _encode(
+        [
+            ToolCallDeltaChunk(tool_call_id="nope", args_text_delta="{}"),
+            ToolResultChunk(tool_call_id="nope", result="ok"),
+        ]
+    )
+    assert _parse(lines) == []
+
+
+@pytest.mark.anyio
+async def test_duplicate_tool_result_is_dropped():
+    lines = await _encode(
+        [
+            ToolCallBeginChunk(tool_call_id="tool_1", tool_name="noop"),
+            ToolResultChunk(tool_call_id="tool_1", result="first"),
+            ToolResultChunk(tool_call_id="tool_1", result="second"),
+        ]
+    )
+    result_chunks = [c for c in _parse(lines) if c["type"] == "result"]
+    assert result_chunks == [
+        {"type": "result", "result": "first", "isError": False, "path": [0]}
+    ]
+
+
+@pytest.mark.anyio
+async def test_create_run_text_stream():
     async def run_callback(controller: RunController):
         controller.append_text("Hello")
         controller.append_text(" world")
 
-    # Create the run and encode it
-    chunks = create_run(run_callback)
-    encoded = encoder.encode_stream(chunks)
-
-    async for line in encoded:
-        if line != "data: [DONE]\n\n":
-            json_str = line[6:-2]  # Remove "data: " and "\n\n"
-            chunk_data = json.loads(json_str)
-            collected_chunks.append(chunk_data)
-
-    # Verify we got text-delta chunks with camelCase
-    text_chunks = [c for c in collected_chunks if c["type"] == "text-delta"]
-    assert len(text_chunks) == 2
-    assert text_chunks[0]["textDelta"] == "Hello"
-    assert text_chunks[1]["textDelta"] == " world"
+    encoder = AssistantTransportEncoder()
+    lines = [line async for line in encoder.encode_stream(create_run(run_callback))]
+    assert _parse(lines) == [
+        {"type": "part-start", "part": {"type": "text"}, "path": []},
+        {"type": "text-delta", "textDelta": "Hello", "path": [0]},
+        {"type": "text-delta", "textDelta": " world", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]
 
 
 @pytest.mark.anyio
-async def test_assistant_transport_encoder_reasoning():
-    """Test that reasoning chunks are properly encoded."""
-    encoder = AssistantTransportEncoder()
-    collected_chunks = []
-
-    async def run_callback(controller: RunController):
-        controller.append_reasoning("Thinking...")
-
-    # Create the run and encode it
-    chunks = create_run(run_callback)
-    encoded = encoder.encode_stream(chunks)
-
-    async for line in encoded:
-        if line != "data: [DONE]\n\n":
-            json_str = line[6:-2]
-            chunk_data = json.loads(json_str)
-            collected_chunks.append(chunk_data)
-
-    # Verify we got reasoning-delta chunks with camelCase
-    reasoning_chunks = [c for c in collected_chunks if c["type"] == "reasoning-delta"]
-    assert len(reasoning_chunks) == 1
-    assert reasoning_chunks[0]["reasoningDelta"] == "Thinking..."
-
-
-@pytest.mark.anyio
-async def test_assistant_transport_encoder_media_type():
-    """Test that the encoder returns the correct media type."""
-    encoder = AssistantTransportEncoder()
-    assert encoder.get_media_type() == "text/event-stream"
-
-
-@pytest.mark.anyio
-async def test_assistant_transport_encoder_tool_calls():
-    """Test that tool call chunks are properly encoded."""
-    encoder = AssistantTransportEncoder()
-    collected_chunks = []
-
+async def test_create_run_tool_call():
     async def run_callback(controller: RunController):
         tool_controller = await controller.add_tool_call("get_weather", "tool_1")
         tool_controller.append_args_text('{"location": "NYC"}')
         tool_controller.set_response({"temp": 70})
 
-    # Create the run and encode it
-    chunks = create_run(run_callback)
-    encoded = encoder.encode_stream(chunks)
-
-    async for line in encoded:
-        if line != "data: [DONE]\n\n":
-            json_str = line[6:-2]
-            chunk_data = json.loads(json_str)
-            collected_chunks.append(chunk_data)
-
-    # Verify we got tool-call chunks with camelCase
-    tool_begin_chunks = [c for c in collected_chunks if c["type"] == "tool-call-begin"]
-    assert len(tool_begin_chunks) == 1
-    assert tool_begin_chunks[0]["toolCallId"] == "tool_1"
-    assert tool_begin_chunks[0]["toolName"] == "get_weather"
-
-    tool_delta_chunks = [c for c in collected_chunks if c["type"] == "tool-call-delta"]
-    assert len(tool_delta_chunks) > 0
-
-    tool_result_chunks = [c for c in collected_chunks if c["type"] == "tool-result"]
-    assert len(tool_result_chunks) == 1
-    assert tool_result_chunks[0]["toolCallId"] == "tool_1"
-
-
-@pytest.mark.anyio
-async def test_assistant_transport_encoder_update_state_shape():
-    """Test that update-state chunks preserve operation payload shape."""
     encoder = AssistantTransportEncoder()
-    operations = [
-        {"type": "append-text", "path": ["messages", "0", "text"], "value": "hi"}
+    lines = [line async for line in encoder.encode_stream(create_run(run_callback))]
+    chunks = _parse(lines)
+
+    part_starts = [c for c in chunks if c["type"] == "part-start"]
+    assert part_starts == [
+        {
+            "type": "part-start",
+            "part": {
+                "type": "tool-call",
+                "toolCallId": "tool_1",
+                "toolName": "get_weather",
+            },
+            "path": [],
+        }
     ]
-
-    async def stream():
-        yield UpdateStateChunk(operations=operations)
-
-    collected_output = [line async for line in encoder.encode_stream(stream())]
-
-    assert collected_output[-1] == "data: [DONE]\n\n"
-    update_state_payload = json.loads(collected_output[0][6:-2])
-    assert update_state_payload == {"type": "update-state", "operations": operations}
+    assert {"type": "text-delta", "textDelta": '{"location": "NYC"}', "path": [0]} in chunks
+    assert {"type": "tool-call-args-text-finish", "path": [0]} in chunks
+    assert {"type": "result", "result": {"temp": 70}, "isError": False, "path": [0]} in chunks
+    assert chunks[-1] == {"type": "part-finish", "path": [0]}

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -50,7 +50,8 @@ async def test_heartbeat_emitted_when_idle():
     data_lines = [line for line in lines if line.startswith("data: ")]
     assert data_lines[-1] == "data: [DONE]\n\n"
     payloads = [json.loads(line[6:-2]) for line in data_lines[:-1]]
-    assert [p["textDelta"] for p in payloads] == ["hello", "world"]
+    deltas = [p["textDelta"] for p in payloads if p["type"] == "text-delta"]
+    assert deltas == ["hello", "world"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION

Part of #5153
## What
Rewrites the Python `AssistantTransportEncoder` to emit the canonical assistant-transport wire (part-start/path addressing, the TS `AssistantStreamChunk` type names) instead of serializing the internal flat chunk dataclasses verbatim. A stateful translator inside the encoder allocates part indices and frames parts, mirroring the part-boundary semantics of the TS `AssistantStreamController`; tool-call args are keyed by tool_call_id and close only on the call's own result or at stream end.


## Why
While mapping the wire for #5153, found only `update-state`, `error`, and list-shaped `data` ever survived the TS decoder: text, reasoning, tool calls, and sources were dropped as unknown or path-less, so the Python encoder was exported but unusable for actual streaming.

## Impact
- `AssistantTransportResponse` now produces a stream the TS `AssistantTransportDecoder` accepts in full and `AssistantMessageAccumulator` builds into correct message parts: text, reasoning, tool calls with streamed args and results, and sources.
- Rendering is narrower than decoding: `useAssistantTransportRuntime` reads only `unstable_state` from the accumulated stream and renders via the user's converter, so these chunks go from dropped with a warning to decoded but not rendered; having the transport runtime consume `message.parts` is a runtime-side follow-up, tracked in #5153.
- One observable change for the previously-working subset: `data` values are now wrapped as `[value]`, matching data-stream semantics (`add_data(x)` appends one datum); `update-state` and `error` are unchanged apart from an explicit `path: []`.
- Python public API is untouched; this is wire output only.

## Scope 
- Smaller than the issue predicted: the issue assumed `RunController` needs path allocation, but on the TS side paths are not in the producer API either (part indices are order-implicit, per-part paths come from `PathAppendEncoder`), so the translation fits entirely in the encoder and `RunController` plus all other encoders stay untouched.
- Tool-call args close only on the call's own result or at stream end (flush before `[DONE]`): every chunk is addressed by tool_call_id, so unlike the TS data-stream decoder's positional heuristic there is no ambiguity to infer around, and closing on unrelated chunks would silently lose interleaved args from concurrent tool calls (per review).
- Malformed sequences (unknown or duplicate tool call id, delta after result, duplicate result) drop with a warn-once log instead of raising: the TS decoder throws on these because it sits on the consuming side, but an encoder exception would kill the HTTP response mid-flight. `add_tool_result` for an id never begun in the stream is one of these drops, so that public method is a logged no-op on this wire.
- The never-decodable chunk types have no possible consumers, so aligning them is not a wire break in practice; the `data` list-wrap is the only change a hypothetical existing consumer could observe, and nothing in-repo, in examples, or in docs pairs this encoder with the TS decoder today.
- Parity gaps (file, annotations, step chunks missing from the Python package entirely) are out of scope, as scoped in #5153.
- A cross-language interop test (TS decoder consuming captured Python encoder output, the issue's acceptance criterion) follows as a stacked test-only PR.
- Tests: golden contract tests assert exact wire sequences for every chunk type, part switching, parentId changes, concurrent tool-call interleaving, flush, and all drop paths; one heartbeat test assertion updated to filter for text-delta chunks since the wire now includes part boundaries.
- Changeset: none, Python package (PyPI, not covered by changesets).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._NNYD7B5pPH9nsbL7XLsB0FawyjPhPTpaz_33ZrPHgcwqrdwpyiY1S0_e2c?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->