### PR TITLE
test(assistant-stream): cross-language interop fixture for assistant-transport

### DIFF
--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts
@@ -6,7 +6,7 @@ import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
 import type { AssistantMessage } from "../../utils/types";
 
 // Fixture produced by the Python encoder; regenerate with
-// `PYTHONPATH=src python3 tests/generate_interop_fixture.py` in python/assistant-stream.
+// `uv run python tests/generate_interop_fixture.py` in python/assistant-stream.
 const fixture = readFileSync(
   new URL("./__fixtures__/python-encoder.sse", import.meta.url),
 );

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { AssistantTransportDecoder } from "./AssistantTransport";
+import { AssistantMessageAccumulator } from "../../accumulators/assistant-message-accumulator";
+import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
+import type { AssistantMessage } from "../../utils/types";
+
+// Fixture produced by the Python encoder; regenerate with
+// `PYTHONPATH=src python3 tests/generate_interop_fixture.py` in python/assistant-stream.
+const fixture = readFileSync(
+  new URL("./__fixtures__/python-encoder.sse", import.meta.url),
+);
+
+const EXPECTED_CHUNKS: AssistantStreamChunk[] = [
+  { type: "part-start", part: { type: "reasoning" }, path: [] },
+  { type: "text-delta", textDelta: "Let me check the weather.", path: [0] },
+  { type: "part-finish", path: [0] },
+  { type: "part-start", part: { type: "text" }, path: [] },
+  { type: "text-delta", textDelta: "Checking", path: [1] },
+  { type: "text-delta", textDelta: " now.", path: [1] },
+  { type: "part-finish", path: [1] },
+  {
+    type: "part-start",
+    part: { type: "tool-call", toolCallId: "call_1", toolName: "get_weather" },
+    path: [],
+  },
+  { type: "text-delta", textDelta: '{"city": ', path: [2] },
+  { type: "text-delta", textDelta: '"NYC"}', path: [2] },
+  {
+    type: "update-state",
+    operations: [{ type: "set", path: ["status"], value: "running" }],
+    path: [],
+  },
+  { type: "result", result: { temp: 70 }, isError: false, path: [2] },
+  { type: "tool-call-args-text-finish", path: [2] },
+  { type: "part-finish", path: [2] },
+  { type: "data", data: [{ progress: 1 }], path: [] },
+  {
+    type: "part-start",
+    part: {
+      type: "source",
+      sourceType: "url",
+      id: "s1",
+      url: "https://example.com",
+      title: "Example",
+    },
+    path: [],
+  },
+  { type: "part-finish", path: [3] },
+  { type: "part-start", part: { type: "text" }, path: [] },
+  { type: "text-delta", textDelta: "It is sunny.", path: [4] },
+  { type: "part-finish", path: [4] },
+];
+
+const decodeFixture = async (chunkSize: number) => {
+  const bytes = new Uint8Array(fixture);
+  const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+        controller.enqueue(
+          new Uint8Array(bytes.slice(offset, offset + chunkSize)),
+        );
+      }
+      controller.close();
+    },
+  });
+
+  const chunks: AssistantStreamChunk[] = [];
+  const reader = stream
+    .pipeThrough(new AssistantTransportDecoder())
+    .getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+};
+
+describe("Python encoder interop", () => {
+  it("decodes the captured Python encoder output into canonical chunks", async () => {
+    expect(await decodeFixture(fixture.length)).toEqual(EXPECTED_CHUNKS);
+  });
+
+  it("decodes the fixture identically under network fragmentation", async () => {
+    expect(await decodeFixture(5)).toEqual(EXPECTED_CHUNKS);
+  });
+
+  it("accumulates the decoded fixture into a canonical message", async () => {
+    const decoded = await decodeFixture(fixture.length);
+    const source = new ReadableStream<AssistantStreamChunk>({
+      start(controller) {
+        for (const chunk of decoded) {
+          controller.enqueue(chunk);
+        }
+        controller.close();
+      },
+    });
+
+    const messages: AssistantMessage[] = [];
+    await source.pipeThrough(new AssistantMessageAccumulator()).pipeTo(
+      new WritableStream({
+        write(message) {
+          messages.push(message);
+        },
+      }),
+    );
+
+    const message = messages.at(-1)!;
+    expect(message.parts).toHaveLength(5);
+    expect(message.parts[0]).toMatchObject({
+      type: "reasoning",
+      text: "Let me check the weather.",
+    });
+    expect(message.parts[1]).toMatchObject({
+      type: "text",
+      text: "Checking now.",
+    });
+    expect(message.parts[2]).toMatchObject({
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "get_weather",
+      state: "result",
+      argsText: '{"city": "NYC"}',
+      args: { city: "NYC" },
+      result: { temp: 70 },
+      isError: false,
+    });
+    expect(message.parts[3]).toMatchObject({
+      type: "source",
+      sourceType: "url",
+      id: "s1",
+      url: "https://example.com",
+      title: "Example",
+    });
+    expect(message.parts[4]).toMatchObject({
+      type: "text",
+      text: "It is sunny.",
+    });
+    expect(message.metadata.unstable_state).toEqual({ status: "running" });
+    expect(message.metadata.unstable_data).toEqual([{ progress: 1 }]);
+  });
+});

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/__fixtures__/python-encoder.sse
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/__fixtures__/python-encoder.sse
@@ -1,0 +1,42 @@
+data: {"type": "part-start", "part": {"type": "reasoning"}, "path": []}
+
+data: {"type": "text-delta", "textDelta": "Let me check the weather.", "path": [0]}
+
+data: {"type": "part-finish", "path": [0]}
+
+data: {"type": "part-start", "part": {"type": "text"}, "path": []}
+
+data: {"type": "text-delta", "textDelta": "Checking", "path": [1]}
+
+data: {"type": "text-delta", "textDelta": " now.", "path": [1]}
+
+data: {"type": "part-finish", "path": [1]}
+
+data: {"type": "part-start", "part": {"type": "tool-call", "toolCallId": "call_1", "toolName": "get_weather"}, "path": []}
+
+data: {"type": "text-delta", "textDelta": "{\"city\": ", "path": [2]}
+
+data: {"type": "text-delta", "textDelta": "\"NYC\"}", "path": [2]}
+
+data: {"type": "update-state", "operations": [{"type": "set", "path": ["status"], "value": "running"}]}
+
+data: {"type": "result", "result": {"temp": 70}, "isError": false, "path": [2]}
+
+data: {"type": "tool-call-args-text-finish", "path": [2]}
+
+data: {"type": "part-finish", "path": [2]}
+
+data: {"type": "data", "data": [{"progress": 1}]}
+
+data: {"type": "part-start", "part": {"type": "source", "sourceType": "url", "id": "s1", "url": "https://example.com", "title": "Example"}, "path": []}
+
+data: {"type": "part-finish", "path": [3]}
+
+data: {"type": "part-start", "part": {"type": "text"}, "path": []}
+
+data: {"type": "text-delta", "textDelta": "It is sunny.", "path": [4]}
+
+data: {"type": "part-finish", "path": [4]}
+
+data: [DONE]
+

--- a/python/assistant-stream/tests/generate_interop_fixture.py
+++ b/python/assistant-stream/tests/generate_interop_fixture.py
@@ -1,0 +1,64 @@
+"""Regenerates the TS interop fixture consumed by
+packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts.
+
+Run from python/assistant-stream:
+    PYTHONPATH=src python3 tests/generate_interop_fixture.py
+"""
+
+import asyncio
+from pathlib import Path
+
+from assistant_stream.assistant_stream_chunk import (
+    DataChunk,
+    ReasoningDeltaChunk,
+    SourceChunk,
+    TextDeltaChunk,
+    ToolCallBeginChunk,
+    ToolCallDeltaChunk,
+    ToolResultChunk,
+    UpdateStateChunk,
+)
+from assistant_stream.serialization.assistant_transport import AssistantTransportEncoder
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "assistant-stream"
+    / "src"
+    / "core"
+    / "serialization"
+    / "assistant-transport"
+    / "__fixtures__"
+    / "python-encoder.sse"
+)
+
+CHUNKS = [
+    ReasoningDeltaChunk(reasoning_delta="Let me check the weather."),
+    TextDeltaChunk(text_delta="Checking"),
+    TextDeltaChunk(text_delta=" now."),
+    ToolCallBeginChunk(tool_call_id="call_1", tool_name="get_weather"),
+    ToolCallDeltaChunk(tool_call_id="call_1", args_text_delta='{"city": '),
+    ToolCallDeltaChunk(tool_call_id="call_1", args_text_delta='"NYC"}'),
+    UpdateStateChunk(
+        operations=[{"type": "set", "path": ["status"], "value": "running"}]
+    ),
+    ToolResultChunk(tool_call_id="call_1", result={"temp": 70}),
+    DataChunk(data={"progress": 1}),
+    SourceChunk(id="s1", url="https://example.com", title="Example"),
+    TextDeltaChunk(text_delta="It is sunny."),
+]
+
+
+async def main() -> None:
+    async def stream():
+        for chunk in CHUNKS:
+            yield chunk
+
+    encoder = AssistantTransportEncoder()
+    lines = [line async for line in encoder.encode_stream(stream())]
+    FIXTURE_PATH.write_text("".join(lines))
+    print(f"wrote {FIXTURE_PATH}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/python/assistant-stream/tests/generate_interop_fixture.py
+++ b/python/assistant-stream/tests/generate_interop_fixture.py
@@ -2,7 +2,7 @@
 packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.interop.test.ts.
 
 Run from python/assistant-stream:
-    PYTHONPATH=src python3 tests/generate_interop_fixture.py
+    uv run python tests/generate_interop_fixture.py
 """
 
 import asyncio

--- a/python/assistant-stream/tests/test_interop_fixture.py
+++ b/python/assistant-stream/tests/test_interop_fixture.py
@@ -1,0 +1,15 @@
+import pytest
+
+from assistant_stream.serialization.assistant_transport import AssistantTransportEncoder
+from tests.generate_interop_fixture import CHUNKS, FIXTURE_PATH
+
+
+@pytest.mark.anyio
+async def test_encoder_matches_committed_fixture():
+    async def stream():
+        for chunk in CHUNKS:
+            yield chunk
+
+    encoder = AssistantTransportEncoder()
+    encoded = "".join([line async for line in encoder.encode_stream(stream())])
+    assert encoded == FIXTURE_PATH.read_text()


### PR DESCRIPTION
## What
Adds the cross-language interop test #5153 names as its acceptance criterion: output captured from the Python `AssistantTransportEncoder` merged in #5287 is committed as a fixture, and a vitest pipes it through the TS `AssistantTransportDecoder`, asserting the exact canonical chunk sequence, both whole-buffer and under 5-byte network fragmentation, plus an `AssistantMessageAccumulator` pass asserting the decoded chunks compose into the expected message. The Python side gains a generator script to regenerate the fixture and a pytest guard asserting the encoder still reproduces the committed bytes.

## Why
#5153 called out that no cross-language test exists, which is how the encoder/decoder mismatch survived unnoticed, and the #5288 closing note left this test as the remaining follow-up on the issue. Closes #5153.

## Impact
Test-only, no runtime code changes on either side. The fixture locks the wire contract from both directions: TS decoder drift fails the vitest, Python encoder drift fails the pytest guard in the already-gating Python Tests job.

## Scope & caveats
- The fixture is regenerated from the encoder as merged in #5287 (ef58abb8d), so the pinned sequences are current main behavior, including `result` preceding `tool-call-args-text-finish`.
- The fixture is a committed artifact by design: CI for `packages/**` cannot run Python, so capture-and-commit is the only shape that keeps the test hermetic; the generator script documents provenance and regeneration.
- The scenario covers reasoning, multi-delta text, a tool call with streamed args and result, update-state mid-stream, data, source, and a trailing text part; parity-gap chunk types (file, annotations, step) do not exist in the Python package yet; tracked as #5292 so #5153 can close on the wire alignment plus this fixture.
- The generator script lives in `python/assistant-stream/tests/` without a `test_` prefix so pytest does not collect it; `test_interop_fixture.py` imports its `CHUNKS`/`FIXTURE_PATH` so the generator regenerates and the test guards, without duplicating the scenario.
- The accumulator case also pins that `result` arriving before `tool-call-args-text-finish` composes benignly (part ends `state: "result"` with parsed args), matching TS's own `setResponse` ordering.
- Tests: the three interop assertions plus the pytest guard and the existing transport suites; nothing else touched.
- Changeset: none, test-only change (no published output affected).

