### PR TITLE
fix(core): keep replacement runs cancellable

### DIFF
--- a/.changeset/quiet-runs-cancel.md
+++ b/.changeset/quiet-runs-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep replacement runs cancellable after superseded runs settle

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -497,6 +497,44 @@ describe("LocalThreadRuntimeCore tool approvals", () => {
 });
 
 describe("LocalThreadRuntimeCore cancellation", () => {
+  it("keeps a replacement run cancellable after the previous run settles", async () => {
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    const signals: AbortSignal[] = [];
+    const thread = createThread({
+      async *run({ abortSignal }) {
+        signals.push(abortSignal);
+        await (signals.length === 1 ? firstGate : secondGate);
+      },
+    });
+
+    const firstAppend = thread.append(userMessage("first"));
+    await flush();
+    const secondAppend = thread.append(userMessage("second"));
+    await flush();
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+
+    releaseFirst();
+    await firstAppend;
+
+    thread.cancelRun();
+    const replacementWasAborted = signals[1]?.aborted;
+
+    releaseSecond();
+    await secondAppend;
+
+    expect(replacementWasAborted).toBe(true);
+  });
+
   it("marks the message cancelled when a streaming adapter returns after abort", async () => {
     let released!: () => void;
     const streaming = new Promise<void>((resolve) => {

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -459,7 +459,8 @@ export class LocalThreadRuntimeCore
 
     // abort existing run
     this.abortController?.abort();
-    this.abortController = new AbortController();
+    const abortController = new AbortController();
+    this.abortController = abortController;
 
     const initialContent = message.content;
     const initialAnnotations = message.metadata?.unstable_annotations;
@@ -550,7 +551,7 @@ export class LocalThreadRuntimeCore
         runCallback ??
         this.adapters.chatModel.run.bind(this.adapters.chatModel);
 
-      const abortSignal = this.abortController.signal;
+      const abortSignal = abortController.signal;
       const threadId = this._getThreadId?.();
       const promiseOrGenerator = runCallback({
         messages,
@@ -609,7 +610,9 @@ export class LocalThreadRuntimeCore
         throw e;
       }
     } finally {
-      this.abortController = null;
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
 
       const history = this._options.adapters.history;
       const item = {


### PR DESCRIPTION
## Summary

- keep each local-runtime roundtrip bound to the `AbortController` it created
- clear the shared controller only when the settling roundtrip still owns it
- add a regression test and patch changeset for `@assistant-ui/core`

## Why

Starting run B correctly aborts run A. However, if A settles after B has started, A's `finally` block previously cleared the shared abort-controller reference. A later Cancel action could no longer reach B, so the replacement request kept running.

The regression test reproduces the ordering directly: start A, replace it with B, let A settle late, then cancel B. Before this fix B's signal remained active; now it is aborted as expected.

## Testing

- Core Vitest suite: 78 files, 760 tests passed
- Focused replacement-run cancellation regression passed
- `@assistant-ui/core` package build passed
- Changed files pass oxlint, oxfmt, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.P6PrBsE9b2KVy8WvH0LoRwDl0gICQMcAIUDbzE8V50l8oSCG8r2aqzeP0xo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->