### PR TITLE
fix(docs): pass tools client to AssistantRuntimeProvider in Artifacts example

### DIFF
--- a/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
+++ b/apps/docs/contexts/ArtifactsRuntimeProvider.tsx
@@ -7,7 +7,6 @@ import {
   AssistantCloud,
   useAui,
   Tools,
-  AuiProvider,
   type Toolkit,
 } from "@assistant-ui/react";
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
@@ -64,12 +63,10 @@ export function ArtifactsRuntimeProvider({
   });
 
   return (
-    <AuiProvider value={aui}>
-      <AssistantRuntimeProvider runtime={runtime}>
-        {children}
+    <AssistantRuntimeProvider runtime={runtime} aui={aui}>
+      {children}
 
-        <DevToolsModal />
-      </AssistantRuntimeProvider>
-    </AuiProvider>
+      <DevToolsModal />
+    </AssistantRuntimeProvider>
   );
 }


### PR DESCRIPTION
## What

Fixes #4856 — the hosted docs Artifacts demo never invokes `render_html`; asking for a webpage yields plain text instead of a rendered preview.

## Why

The bug is in the hosted docs example, not `examples/with-artifacts` (which is wired correctly). In `apps/docs/contexts/ArtifactsRuntimeProvider.tsx`, the artifacts tools client (`useAui` with the artifacts toolkit) was mounted as an `AuiProvider` **around** `AssistantRuntimeProvider`. But the runtime provider never reads ambient context: it passes an explicit `{ parent: aui ?? null }` into `useAui`, which bypasses the ambient-context default. With `parent: null`, the runtime client creates a fresh empty ModelContext, so the toolkit's `render_html` registration never reached the runtime — the model saw no tools.

## How

Pass the tools client via the `aui` prop and drop the now-redundant outer `AuiProvider` (one file). `AssistantProviderBase` re-installs the parent as an outer `AuiProvider` itself, so descendants (children, DevToolsModal) keep seeing the tools scope — now correctly inherited by the runtime client via the scope prototype chain.

Note: `examples/with-artifacts` wires the same relationship in the opposite direction (runtime provider outside, tools client inside with the runtime client as ambient parent). Both directions are supported by the scope-inheritance design; this fix is the minimal change for the existing file structure and matches the documented purpose of the `aui` prop.

## Verification

- Before/after demo videos attached below (before: request for a webpage returns plain text, no artifact panel; after: `render_html` fires and the preview renders).
- Affected package build passes; oxlint/oxfmt clean.
- `apps/docs` is private → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nJrLFzQ0d2PSswXpFPmEXkAc8Xg7VwtotIwsumG-ngIR6CSo__1wLb4I5xg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

## Demo videos

Before (plain text, no artifact panel) / After (render_html fires, preview renders):

https://github.com/user-attachments/assets/e0173122-d00a-4cfe-ba3c-12aca934eba0


https://github.com/user-attachments/assets/c0b34aeb-00f6-4022-9268-10a1834b8447

