### PR TITLE
fix(ui): keep ModelSelector popover side stable while filtering

### DIFF
--- a/packages/ui/src/components/assistant-ui/model-selector.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.radix.tsx
@@ -374,6 +374,38 @@ export type ModelSelectorContentProps = ComponentPropsWithoutRef<
   searchable?: boolean;
 };
 
+// The popover re-evaluates collision flipping whenever the popup resizes, so
+// filtering the list down flips the popup back to the preferred side
+// mid-interaction. Feed the rendered side back as the preferred side, making
+// the popup keep its side until it no longer fits.
+function useLazyFlipSide(): {
+  side: ModelSelectorContentProps["side"];
+  popupRef: (node: HTMLDivElement | null) => void;
+} {
+  const [side, setSide] = useState<ModelSelectorContentProps["side"]>();
+  const observerRef = useRef<MutationObserver | null>(null);
+  const popupRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
+      setSide(undefined);
+      return;
+    }
+    const sync = () => {
+      const rendered = node.getAttribute("data-side");
+      if (rendered) setSide(rendered as ModelSelectorContentProps["side"]);
+    };
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(node, {
+      attributes: true,
+      attributeFilter: ["data-side"],
+    });
+    observerRef.current = observer;
+  }, []);
+  return { side, popupRef };
+}
+
 /**
  * Hidden input that anchors cmdk's keyboard navigation, keeping the list
  * keyboard-operable without a visible search box. ModelSelectorContent renders
@@ -390,19 +422,23 @@ function ModelSelectorFocusAnchor() {
 function ModelSelectorContent({
   className,
   align = "start",
+  side,
   sideOffset = 6,
   searchable,
   children,
   ...props
 }: ModelSelectorContentProps) {
   const { value } = useModelSelectorContext();
+  const { side: renderedSide, popupRef } = useLazyFlipSide();
   const unfiltered =
     searchable === false || (!searchable && children === undefined);
 
   return (
     <PopoverContent
+      ref={popupRef}
       data-slot="model-selector-content"
       align={align}
+      side={renderedSide ?? side ?? "bottom"}
       sideOffset={sideOffset}
       className={cn(
         "bg-popover/95 w-72 min-w-(--radix-popover-trigger-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",

--- a/packages/ui/src/components/assistant-ui/model-selector.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.radix.tsx
@@ -368,9 +368,16 @@ function ModelSelectorValue({
   );
 }
 
-export type ModelSelectorContentProps = ComponentPropsWithoutRef<
-  typeof PopoverContent
+export type ModelSelectorContentProps = Omit<
+  ComponentPropsWithoutRef<typeof PopoverContent>,
+  "side"
 > & {
+  /**
+   * Preferred side for the initial placement. Once the popover is open, the
+   * rendered side takes over until it closes, so the popup does not jump
+   * between sides while filtering resizes the list.
+   */
+  side?: ComponentPropsWithoutRef<typeof PopoverContent>["side"];
   searchable?: boolean;
 };
 

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -375,6 +375,39 @@ export type ModelSelectorContentProps = ComponentPropsWithoutRef<
   searchable?: boolean;
 };
 
+// Base UI's Popover re-evaluates collision flipping whenever the popup
+// resizes, so filtering the list down flips the popup back to the preferred
+// side mid-interaction. Base UI only exposes its lazy-flip behavior on the
+// Combobox positioner, so mirror it here: feed the rendered side back as the
+// preferred side, making the popup keep its side until it no longer fits.
+function useLazyFlipSide(): {
+  side: ModelSelectorContentProps["side"];
+  popupRef: (node: HTMLDivElement | null) => void;
+} {
+  const [side, setSide] = useState<ModelSelectorContentProps["side"]>();
+  const observerRef = useRef<MutationObserver | null>(null);
+  const popupRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
+      setSide(undefined);
+      return;
+    }
+    const sync = () => {
+      const rendered = node.getAttribute("data-side");
+      if (rendered) setSide(rendered as ModelSelectorContentProps["side"]);
+    };
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(node, {
+      attributes: true,
+      attributeFilter: ["data-side"],
+    });
+    observerRef.current = observer;
+  }, []);
+  return { side, popupRef };
+}
+
 /**
  * Hidden input that anchors cmdk's keyboard navigation, keeping the list
  * keyboard-operable without a visible search box. ModelSelectorContent renders
@@ -391,19 +424,23 @@ function ModelSelectorFocusAnchor() {
 function ModelSelectorContent({
   className,
   align = "start",
+  side,
   sideOffset = 6,
   searchable,
   children,
   ...props
 }: ModelSelectorContentProps) {
   const { value } = useModelSelectorContext();
+  const { side: renderedSide, popupRef } = useLazyFlipSide();
   const unfiltered =
     searchable === false || (!searchable && children === undefined);
 
   return (
     <PopoverContent
+      ref={popupRef}
       data-slot="model-selector-content"
       align={align}
+      side={renderedSide ?? side ?? "bottom"}
       sideOffset={sideOffset}
       className={cn(
         "bg-popover/95 w-72 min-w-(--anchor-width) overflow-hidden rounded-xl p-0 shadow-lg backdrop-blur-sm",

--- a/packages/ui/src/components/assistant-ui/model-selector.tsx
+++ b/packages/ui/src/components/assistant-ui/model-selector.tsx
@@ -369,9 +369,16 @@ function ModelSelectorValue({
   );
 }
 
-export type ModelSelectorContentProps = ComponentPropsWithoutRef<
-  typeof PopoverContent
+export type ModelSelectorContentProps = Omit<
+  ComponentPropsWithoutRef<typeof PopoverContent>,
+  "side"
 > & {
+  /**
+   * Preferred side for the initial placement. Once the popover is open, the
+   * rendered side takes over until it closes, so the popup does not jump
+   * between sides while filtering resizes the list.
+   */
+  side?: ComponentPropsWithoutRef<typeof PopoverContent>["side"];
   searchable?: boolean;
 };
 

--- a/packages/ui/src/components/ui/base/popover.tsx
+++ b/packages/ui/src/components/ui/base/popover.tsx
@@ -13,18 +13,24 @@ function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
-function PopoverContent({
-  className,
-  align = "center",
-  alignOffset = 0,
-  side = "bottom",
-  sideOffset = 4,
-  ...props
-}: PopoverPrimitive.Popup.Props &
-  Pick<
-    PopoverPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+const PopoverContent = React.forwardRef<
+  HTMLDivElement,
+  PopoverPrimitive.Popup.Props &
+    Pick<
+      PopoverPrimitive.Positioner.Props,
+      "align" | "alignOffset" | "side" | "sideOffset"
+    >
+>(function PopoverContent(
+  {
+    className,
+    align = "center",
+    alignOffset = 0,
+    side = "bottom",
+    sideOffset = 4,
+    ...props
+  },
+  ref,
+) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
@@ -35,6 +41,7 @@ function PopoverContent({
         className="isolate z-50"
       >
         <PopoverPrimitive.Popup
+          ref={ref}
           data-slot="popover-content"
           className={cn(
             "bg-popover text-popover-foreground ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 outline-hidden duration-100",
@@ -45,7 +52,7 @@ function PopoverContent({
       </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
   );
-}
+});
 
 function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/ui/src/components/ui/radix/popover.tsx
+++ b/packages/ui/src/components/ui/radix/popover.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type * as React from "react";
+import * as React from "react";
 import { Popover as PopoverPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
@@ -17,15 +17,17 @@ function PopoverTrigger({
   return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
-function PopoverContent({
-  className,
-  align = "center",
-  sideOffset = 4,
-  ...props
-}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+const PopoverContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof PopoverPrimitive.Content>
+>(function PopoverContent(
+  { className, align = "center", sideOffset = 4, ...props },
+  ref,
+) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
+        ref={ref}
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
@@ -37,7 +39,7 @@ function PopoverContent({
       />
     </PopoverPrimitive.Portal>
   );
-}
+});
 
 function PopoverAnchor({
   ...props


### PR DESCRIPTION
## What

Fixes #5124 — the ModelSelector popover jumps between opening upward and downward on every keystroke while typing in its filter when near a viewport edge.

## Why

Base UI Popover's flip collision-avoidance is eager and memoryless: opened near the viewport bottom it flips the popup to top; typing shrinks the filtered list until it fits below again, flipping it back — so each keystroke can bounce the side. Base UI fixed this exact case upstream with an internal `lazyFlip` flag, but in `@base-ui/react` 1.6.0 it is only wired into the Combobox positioner and is not exposed on Popover.

## How

A `useLazyFlipSide` hook in `ModelSelectorContent` observes the popup's `data-side` attribute and feeds the rendered side back as the preferred side — replicating upstream lazyFlip semantics:

- The side stays put while the list grows/shrinks during filtering.
- Flipping remains enabled: if the locked side genuinely stops fitting, floating-ui flips, `data-side` changes, and the new side becomes preferred. No UX regression.
- Once open, a consumer-passed `side` prop acts as the initial preference and the rendered side wins until close (side resets on unmount). This is intentional and matches Base UI's own lazyFlip behavior.

Applied to both flavors — Radix's Popper repositions on popup resize the same way, just less dramatically — keeping base/radix parity. The hook is duplicated per file to match the kit's standalone-file convention for registry copying.

A migration to Base UI Combobox was considered and rejected: it would rewrite the publicly-composable cmdk-based `ModelSelector.*` surface for what is a positioning bug.

## Verification

- Before/after demo videos attached below (before: popover bounces up/down per keystroke; after: side stays stable while filtering, still flips when it truly no longer fits).
- `tsc --noEmit` on packages/ui exit 0; oxlint `--deny-warnings` and oxfmt clean on both files; no template copies of model-selector exist, so Template Sync is unaffected.
- `packages/ui` is private → no changeset.
- No unit test: jsdom performs no layout; the mechanism was verified against Base UI's own lazyFlip implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.RuOliaOELPByEycITQUoo1mUraW4f-qbMEGgFcpdA0qtDggVhuskMWoPf3o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

## Demo videos

Before (popover bounces between sides per keystroke) / After (side stays stable while filtering):

https://github.com/user-attachments/assets/59682412-929d-4288-87ad-be4a956d0b8f


https://github.com/user-attachments/assets/2883ce82-2f54-4900-a723-59d6cd9d0d44

