### PR TITLE
fix(react-a2a): cancel streams on early exit

### DIFF
--- a/.changeset/a2a-stream-early-cancel.md
+++ b/.changeset/a2a-stream-early-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: cancel A2A response streams when consumers stop iteration early

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -931,6 +931,36 @@ describe("A2AClient", () => {
       expect(evt.event.status.message?.role).toBe("agent");
     });
 
+    it("cancels the response body when iteration stops early", async () => {
+      const sseData = JSON.stringify({
+        status_update: {
+          task_id: "t1",
+          context_id: "ctx-1",
+          status: { state: "TASK_STATE_WORKING" },
+        },
+      });
+      const cancel = vi.fn();
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(`data: ${sseData}\n\n`));
+        },
+        cancel,
+      });
+
+      fetchMock.mockResolvedValue(
+        new Response(body, {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+
+      for await (const _event of client.streamMessage(userMessage)) {
+        break;
+      }
+
+      expect(cancel).toHaveBeenCalledOnce();
+    });
+
     it("parses CRLF-delimited SSE events", async () => {
       const sseData = JSON.stringify({
         status_update: {

--- a/packages/react-a2a/src/A2AClient.test.ts
+++ b/packages/react-a2a/src/A2AClient.test.ts
@@ -961,6 +961,39 @@ describe("A2AClient", () => {
       expect(cancel).toHaveBeenCalledOnce();
     });
 
+    it("does not surface cancellation errors on early exit", async () => {
+      const sseData = JSON.stringify({
+        status_update: {
+          task_id: "t1",
+          context_id: "ctx-1",
+          status: { state: "TASK_STATE_WORKING" },
+        },
+      });
+      const encoder = new TextEncoder();
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const body = new ReadableStream<Uint8Array>({
+        start(streamController) {
+          controller = streamController;
+          controller.enqueue(encoder.encode(`data: ${sseData}\n\n`));
+        },
+      });
+
+      fetchMock.mockResolvedValue(
+        new Response(body, {
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+
+      const consume = async () => {
+        for await (const _event of client.streamMessage(userMessage)) {
+          controller.error(new Error("stream failed"));
+          break;
+        }
+      };
+
+      await expect(consume()).resolves.toBeUndefined();
+    });
+
     it("parses CRLF-delimited SSE events", async () => {
       const sseData = JSON.stringify({
         status_update: {

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -637,10 +637,20 @@ export class A2AClient {
       }
     };
 
+    let shouldCancel = true;
     try {
       while (true) {
-        const { done, value } = await reader.read();
+        let result: ReadableStreamReadResult<Uint8Array>;
+        try {
+          result = await reader.read();
+        } catch (error) {
+          shouldCancel = false;
+          throw error;
+        }
+
+        const { done, value } = result;
         if (done) {
+          shouldCancel = false;
           for (const event of sseDecoder.push(decoder.decode())) {
             const parsed = readEvent(event);
             if (parsed) yield parsed;
@@ -656,7 +666,11 @@ export class A2AClient {
         }
       }
     } finally {
-      reader.releaseLock();
+      try {
+        if (shouldCancel) await reader.cancel();
+      } finally {
+        reader.releaseLock();
+      }
     }
   }
 }

--- a/packages/react-a2a/src/A2AClient.ts
+++ b/packages/react-a2a/src/A2AClient.ts
@@ -667,7 +667,7 @@ export class A2AClient {
       }
     } finally {
       try {
-        if (shouldCancel) await reader.cancel();
+        if (shouldCancel) await reader.cancel().catch(() => undefined);
       } finally {
         reader.releaseLock();
       }


### PR DESCRIPTION
## Summary

- cancel an A2A SSE response reader when its consumer stops iteration before EOF
- keep cancellation best-effort so an already-failed response body cannot turn a clean early exit into an exception
- preserve normal stream completion and reader-error behavior
- add regression coverage and a patch changeset

## Why

While testing a consumer that stops after receiving the A2A event it needs, I found that breaking from `for await` only released the reader lock. Releasing a lock does not cancel the response body, so the remote agent could continue model work and keep sending data after the application stopped consuming the stream.

A review also identified a cleanup race: the body can error after its last successful read but before the consumer breaks. Cancelling an already-errored reader rejects with the stored stream error, which previously made that intentional `break` throw.

## Implementation

`parseSSE()` now tracks whether the reader reached its natural end. An early iterator return attempts to cancel the active reader before releasing its lock, while normal completion remains unchanged. Cancellation is best-effort so cleanup errors do not escape iteration, and a failed `read()` continues to surface its original stream error without attempting a second cancellation.

## Verification

- reproduced on `main`: the early-exit regression expected one cancellation but observed zero
- reproduced the review edge before the follow-up: an already-errored body made the consumer's `break` reject with `Error: stream failed`
- `A2AClient.test.ts`: 76 tests passed
- `@assistant-ui/react-a2a` package build passed
- oxlint passed for the changed source and test files
- `git diff --check` passed