### PR TITLE
ci: right-size 7 GitHub Actions runners

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   autofix:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Checkout code repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -83,7 +83,7 @@ jobs:
     concurrency:
       group: claude-code-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       contents: read
@@ -175,7 +175,7 @@ jobs:
     concurrency:
       group: claude-code-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -44,7 +44,7 @@ concurrency:
 jobs:
   lint:
     name: Oxlint + Oxfmt
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
       - name: Checkout code repository
@@ -97,7 +97,7 @@ jobs:
 
   build:
     name: Build Changed Packages
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout code repository
@@ -152,7 +152,7 @@ jobs:
 
   build-apps:
     name: Build Changed Apps
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout code repository
@@ -230,7 +230,7 @@ jobs:
 
   test:
     name: Test Changed Packages
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 5
     # Note: No dependency on 'build' job - Turbo handles test->build dependencies internally via dependsOn
     steps:


### PR DESCRIPTION
Applies the seven runner-sizing changes selected from the Blacksmith right-sizing card, based on 30 days of observed CPU, memory, and runtime data (2026-06-29 to 2026-07-29). Only the seven listed `runs-on:` lines change; `Template Sync` and `API Reference Drift` in `code-quality.yaml` keep their current 4 vCPU runners.

Net effect: the two Claude review jobs get cheaper, the CPU-saturated build/test jobs get faster. Estimated spend moves from about $184/month to about $220/month across these seven jobs (roughly +$36/month), buying a 35-42% wall-time cut on the Code Quality build and test jobs, which are the slowest jobs on every PR.

## Apply for savings

**`Claude Code Review` / `claude-review`** (`.github/workflows/claude-code-review.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-2vcpu-ubuntu-2404`, high confidence.
Average CPU is 3.5% with 95th percentile CPU at 16.7% and peak memory at 5.4%, so more than half the machine is idle. Estimated at about $32.72/month today and about $16.36/month after (-$16.36/month) across roughly 1,229 runs/month, with no projected runtime change (p50 stays at 163s, p95 at 339s). Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/29245860632/jobs/86802489015?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/28624912815/jobs/84889063593?tab=metrics).

**`Claude Code Review` / `claude-fork-review`** (`.github/workflows/claude-code-review.yml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-2vcpu-ubuntu-2404`, high confidence.
Same job shape on the fork path: average CPU 6.5%, 95th percentile CPU 26.5%, peak memory 4.0%. Estimated at about $11.87/month today and about $5.95/month after (-$5.92/month) across roughly 259 runs/month, with projected runtime growth under 0.3% (p50 335.5s -> 336.4s, p95 530.2s -> 531.7s). Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/30187773606/jobs/89755438056?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/30188893346/jobs/89758308319?tab=metrics).

Both jobs are dominated by waiting on the model API rather than local compute, which is why halving the runner does not move their wall time.

## Apply for speed

**`Code Quality` / `Build Changed Apps`** (`.github/workflows/code-quality.yaml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, high confidence.
Average CPU is 91% with 95th percentile CPU pinned at 100% and peak memory at 82.5%: the job already uses every core at its peak, and it is also the closest to memory pressure of the seven. Projected runtime drops about 42% (p50 214s -> 124s, p95 407s -> 252s) for about +$10.23/month across roughly 2,038 runs/month. Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/29682960365/jobs/88182268905?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/29761943450/jobs/88418445083?tab=metrics).

**`Code Quality` / `Build Changed Packages`** (`.github/workflows/code-quality.yaml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, high confidence.
Average CPU is 86.7% with 95th percentile CPU at 100% and peak memory at 80.9%, spending 79% of the run above 80% CPU. Projected runtime drops about 39% (p50 103s -> 63s, p95 435s -> 282s) for about +$10.30/month across roughly 1,821 runs/month. Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/29756699838/jobs/88400803865?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/29303639952/jobs/86992509142?tab=metrics).

## Test before applying

These three are worth running on the larger runner for a week and then confirming against fresh data; the wall-time win is real but smaller relative to the added spend.

**`Code Quality` / `Test Changed Packages`** (`.github/workflows/code-quality.yaml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, medium confidence.
Average CPU is 80% with 95th percentile CPU at 100% across roughly 1,822 runs/month. Projected runtime drops about 35% (p50 57s -> 37s, p95 143s -> 97s) for about +$7.23/month. The realized gain depends on how well vitest saturates the extra cores. Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/28658533069/jobs/84993369768?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/29261441475/jobs/86858170353?tab=metrics).

**`autofix.ci` / `autofix`** (`.github/workflows/autofix.yaml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, medium confidence.
Average CPU is 63.4% with 95th percentile CPU at 99.9%, so it saturates in bursts rather than throughout. Projected runtime drops about 18% (p50 85s -> 69s, p95 134s -> 114s) for about +$16.99/month across roughly 1,565 runs/month, the largest spend increase of the set. Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/28937550237/jobs/85851561934?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/30291265380/jobs/90061346575?tab=metrics).

**`Code Quality` / `Oxlint + Oxfmt`** (`.github/workflows/code-quality.yaml`): `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`, low confidence.
Average CPU is 41.7% with brief peaks near 85.5%, so the job is short and only intermittently CPU-bound. Projected runtime drops only about 6% (p50 36s -> 34s, p95 58s -> 55s) for about +$13.33/month across roughly 1,821 runs/month. This is the weakest row in the set: if you want to trim one change back to 4 vCPU after a week of data, this is the one. Samples: [median run](https://app.blacksmith.sh/assistant-ui/runs/28788295897/jobs/85360277294?tab=metrics), [slow run (p95)](https://app.blacksmith.sh/assistant-ui/runs/29954929150/jobs/89041453338?tab=metrics).

No changeset: this touches CI workflow configuration only, no published package.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.991Piu149l9qq1mV0ox7XDVysU_QF0FJwyM2PInM4emct3X2ulvyuOKOtg0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->