### PR TITLE
chore: drop private @assistant-ui/ui from migrate-optional-selectors changeset

### DIFF
--- a/.changeset/migrate-optional-selectors.md
+++ b/.changeset/migrate-optional-selectors.md
@@ -1,5 +1,4 @@
 ---
-"@assistant-ui/ui": patch
 "@assistant-ui/core": patch
 "@assistant-ui/react": patch
 ---


### PR DESCRIPTION
The changeset from #5304 mixed the private `@assistant-ui/ui` (versioning disabled) with public packages, which the Changesets workflow rejects ("Mixed changesets that contain both ignored and not ignored packages"). Dropping the private entry unblocks the version PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GYDW2_4xPN7ym4-IEFoqFfWg97rvlii9SdNdcsHaxijMsvwCrwk6uvVPFxw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->