### PR TITLE
fix(tap): drain large update batches across flush passes instead of dropping them

### DIFF
--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,13 +8,14 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, chunking
-silently across macrotasks when a batch exceeds one pass, so bulk updates
-of any size land without errors. Infinite-loop detection no longer depends
-on batch shape: a per-scheduler re-run guard (> 50 runs in one flush)
-drops just the offending scheduler, so self-re-dirtying resources and
-mutually re-dirtying rings throw "Maximum update depth exceeded" while the
-rest of the queue keeps flushing; and a documented last-resort bound of
-500000 tasks per burst terminates cascades of freshly minted schedulers
-without ever dropping queued work. `createTapRoot` now holds one
-UpdateScheduler per root (mirroring `useTapRoot`) so the guard covers
-every root type.
+silently across macrotasks when a batch exceeds one pass (1000 tasks), so
+bulk updates of any size land without errors. Infinite-loop detection no
+longer depends on batch size: a per-scheduler re-run guard (> 50 runs in
+one flush) skips just the offending scheduler and retries it next pass,
+so self-re-dirtying resources and mutually re-dirtying rings report
+"Maximum update depth exceeded" while the rest of the queue — and any
+deep-but-finite cascade — keeps flushing; a documented last-resort bound
+of 20000 tasks per burst (~33x a real 600-resource history-page load)
+terminates cascades of freshly minted schedulers without dropping queued
+work. `createTapRoot` now holds one UpdateScheduler per root (mirroring
+`useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -9,6 +9,8 @@ resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely; bulk updates of
 any size land in one batch. Infinite-loop detection no longer depends on
-batch size: it counts per-scheduler re-runs within a burst (> 50), so true
-update loops throw "Maximum update depth exceeded" immediately while finite
-batches of any size drain successfully.
+batch size: per-scheduler re-runs within a burst (> 50) catch resources
+that re-dirty themselves or each other, and a burst-wide task cap (10000)
+backstops unbounded cascades of fresh schedulers — so true update loops
+throw "Maximum update depth exceeded" while finite batches of any realistic
+size drain successfully.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -2,14 +2,13 @@
 "@assistant-ui/tap": patch
 ---
 
-fix: drain large update batches across multiple flush passes instead of throwing and dropping pending updates
+fix: drain large update batches in a single flush instead of throwing and dropping pending updates
 
-When more than 50 schedulers are dirty in a single flush (e.g. hundreds of
-resources mounting from one bulk state update), the scheduler aborted the
-flush and discarded the remaining dirty schedulers, leaving resources
-permanently stale. Flushes now process at most 50 tasks per pass and defer
-the rest to a follow-up pass, and `flushTapSync` drains synchronously until
-the queue is empty. Infinite-loop detection is based on per-scheduler
-re-runs within a burst (> 50), so finite batches of any size drain
-successfully while true update loops still throw "Maximum update depth
-exceeded" immediately.
+When more than 50 schedulers were dirty in one flush (e.g. hundreds of
+resources mounting from a single bulk state update), the scheduler aborted
+the flush and discarded the remaining dirty schedulers, leaving resources
+permanently stale. A flush now drains the queue completely; bulk updates of
+any size land in one batch. Infinite-loop detection no longer depends on
+batch size: it counts per-scheduler re-runs within a burst (> 50), so true
+update loops throw "Maximum update depth exceeded" immediately while finite
+batches of any size drain successfully.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,6 +8,8 @@ When more than 50 schedulers are dirty in a single flush (e.g. hundreds of
 resources mounting from one bulk state update), the scheduler aborted the
 flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. Flushes now process at most 50 tasks per pass and defer
-the rest to a follow-up pass; the "Maximum update depth exceeded" guard is
-kept, but only fires after many consecutive saturated passes (a true
-infinite update loop).
+the rest to a follow-up pass, and `flushTapSync` drains synchronously until
+the queue is empty. Infinite-loop detection is based on per-scheduler
+re-runs within a burst (> 50), so finite batches of any size drain
+successfully while true update loops still throw "Maximum update depth
+exceeded" immediately.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -12,7 +12,9 @@ of any size land in one batch. Infinite-loop detection no longer depends on
 batch size: a per-scheduler re-run guard (> 50 runs in one flush) drops
 just the offending scheduler, so self-re-dirtying resources and mutually
 re-dirtying rings throw "Maximum update depth exceeded" while the rest of
-the queue keeps flushing; an absolute per-flush task ceiling (50000)
-backstops cascades of freshly minted schedulers without ever dropping
-queued work. `createTapRoot` now holds one UpdateScheduler per root
-(mirroring `useTapRoot`) so the guard covers every root type.
+the queue keeps flushing (the failure cost of a genuine runaway is now
+bounded by 50 runs per dirty scheduler per flush, not 50 tasks total); an
+absolute per-flush task ceiling (50000) terminates cascades of freshly
+minted schedulers, keeping the remainder queued on the macrotask path.
+`createTapRoot` now holds one UpdateScheduler per root (mirroring
+`useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,9 +8,8 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely; bulk updates of
-any size land in one batch. Infinite-loop detection no longer depends on
-batch size: per-scheduler re-runs within a burst (> 50) catch resources
-that re-dirty themselves or each other, and a burst-wide task cap (10000)
-backstops unbounded cascades of fresh schedulers — so true update loops
-throw "Maximum update depth exceeded" while finite batches of any realistic
-size drain successfully.
+any size land in one batch. Loop guards throw but never drop queued work:
+per-scheduler re-runs within a burst (> 50) catch resources that re-dirty
+themselves or each other, and a burst-wide task cap (10000) backstops
+unbounded cascades of fresh schedulers — the remainder stays queued and
+continues on the next flush.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -9,12 +9,12 @@ resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, chunking
 silently across macrotasks when a batch exceeds one pass (1000 tasks), so
-bulk updates of any size land without errors. Infinite-loop detection no
-longer depends on batch size: a per-scheduler re-run guard (> 50 runs in
-one burst) drops just the offending scheduler — left dirty on purpose, so
-its root never publishes un-applied state and recovers consistently on
-the next dispatch — while the rest of the queue keeps flushing. The
-macrotask path has no total-task bound (a batch of any size completes);
-`flushTapSync` keeps a hard bound (5000 tasks) since a synchronous drain
-cannot defer. `createTapRoot` now holds one UpdateScheduler per root
-(mirroring `useTapRoot`) so the guard covers every root type.
+bulk updates of any size land without errors. Infinite-loop detection: a
+per-scheduler re-run guard (> 50 runs in one burst) drops just the
+offending scheduler — left dirty on purpose, so its root never publishes
+un-applied state and recovers on the next dispatch — and a runaway that
+saturates 20 consecutive passes (only possible for fresh-instance
+cascades, never for finite batches whose last pass is always partial)
+throws "Maximum update depth exceeded" and stops auto-continuing.
+`createTapRoot` now holds one UpdateScheduler per root (mirroring
+`useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -11,10 +11,10 @@ permanently stale. A flush now drains the queue completely, chunking
 silently across macrotasks when a batch exceeds one pass (1000 tasks), so
 bulk updates of any size land without errors. Infinite-loop detection no
 longer depends on batch size: a per-scheduler re-run guard (> 50 runs in
-one burst) drops just the offending scheduler and clears its dirty flag,
-so a genuinely looping resource degrades once while the rest of the app
-keeps flushing at full speed; a documented burst bound (5000 tasks, ~8x a
-real 600-resource history page) reports a likely loop once but keeps
-chunking, so even oversized finite batches complete. `createTapRoot` now
-holds one UpdateScheduler per root (mirroring `useTapRoot`) so the guard
-covers every root type.
+one burst) drops just the offending scheduler — left dirty on purpose, so
+its root never publishes un-applied state and recovers consistently on
+the next dispatch — while the rest of the queue keeps flushing. The
+macrotask path has no total-task bound (a batch of any size completes);
+`flushTapSync` keeps a hard bound (5000 tasks) since a synchronous drain
+cannot defer. `createTapRoot` now holds one UpdateScheduler per root
+(mirroring `useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -1,0 +1,13 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: drain large update batches across multiple flush passes instead of throwing and dropping pending updates
+
+When more than 50 schedulers are dirty in a single flush (e.g. hundreds of
+resources mounting from one bulk state update), the scheduler aborted the
+flush and discarded the remaining dirty schedulers, leaving resources
+permanently stale. Flushes now process at most 50 tasks per pass and defer
+the rest to a follow-up pass; the "Maximum update depth exceeded" guard is
+kept, but only fires after many consecutive saturated passes (a true
+infinite update loop).

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,10 +8,10 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, so bulk updates
-land in one batch. Two loop guards: a per-scheduler re-run guard (> 50 runs
-in one burst) drops the offending scheduler so the rest of the queue keeps
-flushing, and a burst-wide task cap (10000 tasks) backstops unbounded
-cascades of fresh schedulers — it reschedules so oversized batches continue
-on the next flush, and after 10 consecutive saturated flushes it stops
-auto-continuing (keeping, not dropping, the remainder) so a true runaway
-terminates without ever losing queued updates.
+land in one batch. Two loop guards, neither of which drops queued work: a
+per-scheduler re-run guard (> 50 runs in one burst) drops the offending
+scheduler so the rest of the queue keeps flushing, and a burst-wide task
+cap (10000 tasks) silently yields and continues oversized batches on the
+next macrotask — only MAX_CAP_STREAK (10) saturated flushes in a row are
+treated as a runaway cascade, which throws "Maximum update depth exceeded"
+and stops auto-continuing while keeping the queue intact.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,10 +8,10 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, so bulk updates
-land in one batch. Two loop guards, neither of which drops queued work: a
-per-scheduler re-run guard (> 50 runs in one burst) drops the offending
-scheduler so the rest of the queue keeps flushing, and a burst-wide task
-cap (10000 tasks) silently yields and continues oversized batches on the
-next macrotask — only MAX_CAP_STREAK (10) saturated flushes in a row are
-treated as a runaway cascade, which throws "Maximum update depth exceeded"
-and stops auto-continuing while keeping the queue intact.
+land in one batch. Loop guards: a per-scheduler re-run guard (> 50 runs in
+one burst) clears the queue so even mutually re-dirtying rings terminate,
+and a burst-wide task cap (10000 tasks) silently yields oversized batches
+onto the next macrotask — it only reports a runaway when the queue fails
+to shrink across several cap aborts (a true cascade signature), so finite
+batches of any size drain without errors and `flushTapSync` always lands
+its whole batch before returning.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -7,14 +7,14 @@ fix: drain large update batches in a single flush instead of throwing and droppi
 When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
-permanently stale. A flush now drains the queue completely, so bulk updates
-of any size land in one batch. Infinite-loop detection no longer depends on
-batch size: a per-scheduler re-run guard (> 50 runs in one flush) drops
-just the offending scheduler, so self-re-dirtying resources and mutually
-re-dirtying rings throw "Maximum update depth exceeded" while the rest of
-the queue keeps flushing (the failure cost of a genuine runaway is now
-bounded by 50 runs per dirty scheduler per flush, not 50 tasks total); an
-absolute per-flush task ceiling (50000) terminates cascades of freshly
-minted schedulers, keeping the remainder queued on the macrotask path.
-`createTapRoot` now holds one UpdateScheduler per root (mirroring
-`useTapRoot`) so the guard covers every root type.
+permanently stale. A flush now drains the queue completely, chunking
+silently across macrotasks when a batch exceeds one pass, so bulk updates
+of any size land without errors. Infinite-loop detection no longer depends
+on batch shape: a per-scheduler re-run guard (> 50 runs in one flush)
+drops just the offending scheduler, so self-re-dirtying resources and
+mutually re-dirtying rings throw "Maximum update depth exceeded" while the
+rest of the queue keeps flushing; and a documented last-resort bound of
+500000 tasks per burst terminates cascades of freshly minted schedulers
+without ever dropping queued work. `createTapRoot` now holds one
+UpdateScheduler per root (mirroring `useTapRoot`) so the guard covers
+every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -11,11 +11,10 @@ permanently stale. A flush now drains the queue completely, chunking
 silently across macrotasks when a batch exceeds one pass (1000 tasks), so
 bulk updates of any size land without errors. Infinite-loop detection no
 longer depends on batch size: a per-scheduler re-run guard (> 50 runs in
-one flush) skips just the offending scheduler and retries it next pass,
-so self-re-dirtying resources and mutually re-dirtying rings report
-"Maximum update depth exceeded" while the rest of the queue — and any
-deep-but-finite cascade — keeps flushing; a documented last-resort bound
-of 20000 tasks per burst (~33x a real 600-resource history-page load)
-terminates cascades of freshly minted schedulers without dropping queued
-work. `createTapRoot` now holds one UpdateScheduler per root (mirroring
-`useTapRoot`) so the guard covers every root type.
+one burst) drops just the offending scheduler and clears its dirty flag,
+so a genuinely looping resource degrades once while the rest of the app
+keeps flushing at full speed; a documented burst bound (5000 tasks, ~8x a
+real 600-resource history page) reports a likely loop once but keeps
+chunking, so even oversized finite batches complete. `createTapRoot` now
+holds one UpdateScheduler per root (mirroring `useTapRoot`) so the guard
+covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,8 +8,8 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely; bulk updates of
-any size land in one batch. Loop guards throw but never drop queued work:
-per-scheduler re-runs within a burst (> 50) catch resources that re-dirty
-themselves or each other, and a burst-wide task cap (10000) backstops
-unbounded cascades of fresh schedulers — the remainder stays queued and
-continues on the next flush.
+any size land in one batch. Two loop guards, both non-stalling: a
+per-scheduler re-run guard (> 50 runs in one burst) drops the offending
+scheduler so the rest of the queue keeps flushing, and a burst-wide task
+cap (10000) backstops unbounded cascades of fresh schedulers by throwing
+and rescheduling so the remainder continues on the next flush.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,10 +8,9 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, so bulk updates
-land in one batch. Loop guards: a per-scheduler re-run guard (> 50 runs in
-one burst) clears the queue so even mutually re-dirtying rings terminate,
-and a burst-wide task cap (10000 tasks) silently yields oversized batches
-onto the next macrotask — it only reports a runaway when the queue fails
-to shrink across several cap aborts (a true cascade signature), so finite
-batches of any size drain without errors and `flushTapSync` always lands
-its whole batch before returning.
+of any size land in one batch. Infinite-loop detection no longer depends on
+batch size: a per-scheduler re-run guard (> 50 runs in one flush) drops
+just the offending scheduler, so self-re-dirtying resources and mutually
+re-dirtying rings throw "Maximum update depth exceeded" while the rest of
+the queue keeps flushing. `createTapRoot` now holds one UpdateScheduler
+per root (mirroring `useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -7,9 +7,11 @@ fix: drain large update batches in a single flush instead of throwing and droppi
 When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
-permanently stale. A flush now drains the queue completely; bulk updates of
-any size land in one batch. Two loop guards, both non-stalling: a
-per-scheduler re-run guard (> 50 runs in one burst) drops the offending
-scheduler so the rest of the queue keeps flushing, and a burst-wide task
-cap (10000) backstops unbounded cascades of fresh schedulers by throwing
-and rescheduling so the remainder continues on the next flush.
+permanently stale. A flush now drains the queue completely, so bulk updates
+land in one batch. Two loop guards, both non-stalling: a per-scheduler
+re-run guard (> 50 runs in one burst) drops the offending scheduler so the
+rest of the queue keeps flushing, and a burst-wide task cap (10000 tasks)
+backstops unbounded cascades of fresh schedulers — it reschedules so
+oversized batches continue on the next flush, and gives up after 10
+consecutive saturated flushes so a true runaway terminates instead of
+hanging the tab.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -8,10 +8,10 @@ When more than 50 schedulers were dirty in one flush (e.g. hundreds of
 resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, so bulk updates
-land in one batch. Two loop guards, both non-stalling: a per-scheduler
-re-run guard (> 50 runs in one burst) drops the offending scheduler so the
-rest of the queue keeps flushing, and a burst-wide task cap (10000 tasks)
-backstops unbounded cascades of fresh schedulers — it reschedules so
-oversized batches continue on the next flush, and gives up after 10
-consecutive saturated flushes so a true runaway terminates instead of
-hanging the tab.
+land in one batch. Two loop guards: a per-scheduler re-run guard (> 50 runs
+in one burst) drops the offending scheduler so the rest of the queue keeps
+flushing, and a burst-wide task cap (10000 tasks) backstops unbounded
+cascades of fresh schedulers — it reschedules so oversized batches continue
+on the next flush, and after 10 consecutive saturated flushes it stops
+auto-continuing (keeping, not dropping, the remainder) so a true runaway
+terminates without ever losing queued updates.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -12,5 +12,7 @@ of any size land in one batch. Infinite-loop detection no longer depends on
 batch size: a per-scheduler re-run guard (> 50 runs in one flush) drops
 just the offending scheduler, so self-re-dirtying resources and mutually
 re-dirtying rings throw "Maximum update depth exceeded" while the rest of
-the queue keeps flushing. `createTapRoot` now holds one UpdateScheduler
-per root (mirroring `useTapRoot`) so the guard covers every root type.
+the queue keeps flushing; an absolute per-flush task ceiling (50000)
+backstops cascades of freshly minted schedulers without ever dropping
+queued work. `createTapRoot` now holds one UpdateScheduler per root
+(mirroring `useTapRoot`) so the guard covers every root type.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -9,11 +9,10 @@ resources mounting from a single bulk state update), the scheduler aborted
 the flush and discarded the remaining dirty schedulers, leaving resources
 permanently stale. A flush now drains the queue completely, chunking
 silently across macrotasks when a batch exceeds one pass (1000 tasks), so
-bulk updates of any size land without errors. Infinite-loop detection: a
-per-scheduler re-run guard (> 50 runs in one burst) drops just the
-offending scheduler — left dirty on purpose, so its root never publishes
-un-applied state and recovers on the next dispatch — and a burst
-saturating 20 consecutive passes (only possible for fresh-instance
-cascades; a finite batch's last pass is always partial) is reported once
-as a likely loop and then keeps chunking, so even oversized finite batches
-complete.
+bulk updates of any size land without errors. The only remaining exception
+is a per-scheduler re-run guard (> 50 runs in one burst), which drops just
+the offending scheduler — left dirty on purpose, so its root never
+publishes un-applied state and recovers on the next dispatch. A burst
+saturating 20 consecutive passes logs a one-time console warning (a likely
+loop) but keeps chunking, and an oversized `flushTapSync` batch defers its
+remainder to the outer state instead of throwing.

--- a/.changeset/scheduler-batched-drain.md
+++ b/.changeset/scheduler-batched-drain.md
@@ -12,9 +12,8 @@ silently across macrotasks when a batch exceeds one pass (1000 tasks), so
 bulk updates of any size land without errors. Infinite-loop detection: a
 per-scheduler re-run guard (> 50 runs in one burst) drops just the
 offending scheduler — left dirty on purpose, so its root never publishes
-un-applied state and recovers on the next dispatch — and a runaway that
-saturates 20 consecutive passes (only possible for fresh-instance
-cascades, never for finite batches whose last pass is always partial)
-throws "Maximum update depth exceeded" and stops auto-continuing.
-`createTapRoot` now holds one UpdateScheduler per root (mirroring
-`useTapRoot`) so the guard covers every root type.
+un-applied state and recovers on the next dispatch — and a burst
+saturating 20 consecutive passes (only possible for fresh-instance
+cascades; a finite batch's last pass is always partial) is reported once
+as a likely loop and then keeps chunking, so even oversized finite batches
+complete.

--- a/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
+++ b/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createTapRoot } from "../../core/createTapRoot";
+import { useState } from "../../react-hooks/useState";
+
+describe("createTapRoot dispatch batching", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("applies more than 50 dispatches into one root in a single macrotask", async () => {
+    // On main, each dispatch minted a fresh UpdateScheduler, so >50
+    // dispatches into one root in one macrotask tripped the flush-depth
+    // guard and the rest of the batch was cleared. One scheduler per root
+    // must drain them all.
+    let setCount!: (updater: (count: number) => number) => void;
+    const root = createTapRoot(() => {
+      const [count, set] = useState(0);
+      setCount = set;
+      return count;
+    });
+
+    for (let i = 0; i < 60; i += 1) {
+      setCount((count) => count + 1);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(root.getValue()).toBe(60);
+    root.unmount();
+  });
+});

--- a/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
+++ b/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
@@ -1,10 +1,23 @@
-import { describe, it, expect } from "vitest";
-import { createTapRoot } from "../../core/createTapRoot";
-import { useState } from "../../react-hooks/useState";
-import { useEffect } from "../../react-hooks/useEffect";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  ControlledMessageChannel,
+  lastChannel,
+  pump,
+} from "../controlled-channel";
 
 describe("createTapRoot dispatch batching", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    ControlledMessageChannel.instances = [];
+  });
+
   it("applies more than 50 dispatches into one root in a single macrotask", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { createTapRoot } = await import("../../core/createTapRoot");
+    const { useState } = await import("../../react-hooks/useState");
+
     let setCount!: (updater: (count: number) => number) => void;
     const root = createTapRoot(() => {
       const [count, set] = useState(0);
@@ -15,8 +28,7 @@ describe("createTapRoot dispatch batching", () => {
     for (let i = 0; i < 60; i += 1) {
       setCount((count) => count + 1);
     }
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    pump(lastChannel());
     expect(root.getValue()).toBe(60);
     root.unmount();
   });
@@ -25,43 +37,34 @@ describe("createTapRoot dispatch batching", () => {
     // A setState-in-effect loop trips the guard (~50 re-runs). The root is
     // dropped but left dirty, so the NEXT external dispatch re-queues it
     // and its task drains the stranded queue - no silent update loss.
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { createTapRoot } = await import("../../core/createTapRoot");
+    const { useState } = await import("../../react-hooks/useState");
+    const { useEffect } = await import("../../react-hooks/useEffect");
+
     let setCount!: (updater: (count: number) => number) => void;
     let setGo!: (updater: (go: boolean) => boolean) => void;
-    const uncaught: unknown[] = [];
-    const onError = (error: unknown) => {
-      uncaught.push(error);
-    };
-    process.on("uncaughtException", onError);
-    try {
-      const root = createTapRoot(() => {
-        const [count, setC] = useState(0);
-        const [go, setG] = useState(false);
-        setCount = setC;
-        setGo = setG;
-        useEffect(() => {
-          if (go) setC((c) => c + 1);
-        });
-        return count;
+    const root = createTapRoot(() => {
+      const [count, setC] = useState(0);
+      const [go, setG] = useState(false);
+      setCount = setC;
+      setGo = setG;
+      useEffect(() => {
+        if (go) setC((c) => c + 1);
       });
+      return count;
+    });
 
-      // Start the loop after mount, so it trips the guard in a macrotask
-      // flush rather than the synchronous mount commit.
-      setGo(() => true);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(
-        uncaught.some((error) =>
-          String(error).includes("Maximum update depth exceeded"),
-        ),
-      ).toBe(true);
+    // Start the loop after mount: it trips the guard in the next flush.
+    setGo(() => true);
+    expect(() => pump(lastChannel())).toThrow(/Maximum update depth exceeded/);
 
-      setGo(() => false);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      setCount(() => 42);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      expect(root.getValue()).toBe(42);
-      root.unmount();
-    } finally {
-      process.removeListener("uncaughtException", onError);
-    }
+    setGo(() => false);
+    expect(() => pump(lastChannel())).not.toThrow();
+    setCount(() => 42);
+    expect(() => pump(lastChannel())).not.toThrow();
+    expect(root.getValue()).toBe(42);
+    root.unmount();
   });
 });

--- a/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
+++ b/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
@@ -21,22 +21,47 @@ describe("createTapRoot dispatch batching", () => {
     root.unmount();
   });
 
-  it("drains a re-entrant dispatch (raised during the flush) in a follow-up task", async () => {
-    // A setState fired from an effect mid-flush must not loop the drain
-    // task forever: it is re-queued and lands in a follow-up run.
+  it("a root dropped by the run guard recovers on the next dispatch instead of losing updates", async () => {
+    // A setState-in-effect loop trips the guard (~50 re-runs). The root is
+    // dropped but left dirty, so the NEXT external dispatch re-queues it
+    // and its task drains the stranded queue - no silent update loss.
     let setCount!: (updater: (count: number) => number) => void;
-    const root = createTapRoot(() => {
-      const [count, set] = useState(0);
-      setCount = set;
-      useEffect(() => {
-        set(1);
-      }, []);
-      return count;
-    });
+    let setGo!: (updater: (go: boolean) => boolean) => void;
+    const uncaught: unknown[] = [];
+    const onError = (error: unknown) => {
+      uncaught.push(error);
+    };
+    process.on("uncaughtException", onError);
+    try {
+      const root = createTapRoot(() => {
+        const [count, setC] = useState(0);
+        const [go, setG] = useState(false);
+        setCount = setC;
+        setGo = setG;
+        useEffect(() => {
+          if (go) setC((c) => c + 1);
+        });
+        return count;
+      });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(root.getValue()).toBe(1);
-    expect(setCount).toBeTypeOf("function");
-    root.unmount();
+      // Start the loop after mount, so it trips the guard in a macrotask
+      // flush rather than the synchronous mount commit.
+      setGo(() => true);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(
+        uncaught.some((error) =>
+          String(error).includes("Maximum update depth exceeded"),
+        ),
+      ).toBe(true);
+
+      setGo(() => false);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      setCount(() => 42);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(root.getValue()).toBe(42);
+      root.unmount();
+    } finally {
+      process.removeListener("uncaughtException", onError);
+    }
   });
 });

--- a/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
+++ b/packages/tap/src/__tests__/basic/createTapRoot.dispatch.test.ts
@@ -1,17 +1,10 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createTapRoot } from "../../core/createTapRoot";
 import { useState } from "../../react-hooks/useState";
+import { useEffect } from "../../react-hooks/useEffect";
 
 describe("createTapRoot dispatch batching", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("applies more than 50 dispatches into one root in a single macrotask", async () => {
-    // On main, each dispatch minted a fresh UpdateScheduler, so >50
-    // dispatches into one root in one macrotask tripped the flush-depth
-    // guard and the rest of the batch was cleared. One scheduler per root
-    // must drain them all.
     let setCount!: (updater: (count: number) => number) => void;
     const root = createTapRoot(() => {
       const [count, set] = useState(0);
@@ -25,6 +18,25 @@ describe("createTapRoot dispatch batching", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(root.getValue()).toBe(60);
+    root.unmount();
+  });
+
+  it("drains a re-entrant dispatch (raised during the flush) in a follow-up task", async () => {
+    // A setState fired from an effect mid-flush must not loop the drain
+    // task forever: it is re-queued and lands in a follow-up run.
+    let setCount!: (updater: (count: number) => number) => void;
+    const root = createTapRoot(() => {
+      const [count, set] = useState(0);
+      setCount = set;
+      useEffect(() => {
+        set(1);
+      }, []);
+      return count;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(root.getValue()).toBe(1);
+    expect(setCount).toBeTypeOf("function");
     root.unmount();
   });
 });

--- a/packages/tap/src/__tests__/controlled-channel.ts
+++ b/packages/tap/src/__tests__/controlled-channel.ts
@@ -1,0 +1,38 @@
+// A MessageChannel whose deliveries are pumped manually, so flush passes can
+// be stepped through synchronously (and expected errors asserted) instead of
+// relying on un-catchable async callbacks.
+export class ControlledPort {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  pending = 0;
+  other!: ControlledPort;
+  ref() {}
+  unref() {}
+  postMessage(_data: unknown) {
+    // port2.postMessage delivers to port1.onmessage in a real channel.
+    this.other.pending++;
+  }
+}
+
+export class ControlledMessageChannel {
+  static instances: ControlledMessageChannel[] = [];
+  port1 = new ControlledPort();
+  port2 = new ControlledPort();
+  constructor() {
+    this.port1.other = this.port2;
+    this.port2.other = this.port1;
+    ControlledMessageChannel.instances.push(this);
+  }
+}
+
+export const pump = (channel: ControlledMessageChannel) => {
+  const port = channel.port1;
+  while (port.pending > 0) {
+    port.pending--;
+    port.onmessage?.({ data: null });
+  }
+};
+
+export const lastChannel = () =>
+  ControlledMessageChannel.instances[
+    ControlledMessageChannel.instances.length - 1
+  ]!;

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -63,7 +63,7 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(120);
   });
 
-  it("still throws when a resource re-dirties itself on every run", async () => {
+  it("still throws when a resource re-dirties itself on every run, then recovers", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
@@ -77,6 +77,43 @@ describe("scheduler batched draining", () => {
 
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+
+    // The looping scheduler is dropped instead of permanently poisoning the
+    // queue: later, unrelated work must flush normally.
+    let ran = false;
+    const other = new UpdateScheduler(() => {
+      ran = true;
+    });
+    other.markDirty();
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toBe(true);
+  });
+
+  it("drains the queue behind a looping scheduler instead of stalling", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    const looper: InstanceType<typeof UpdateScheduler> = new UpdateScheduler(
+      () => {
+        looper.markDirty();
+      },
+    );
+    looper.markDirty();
+    const ran: number[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      const index = i;
+      new UpdateScheduler(() => {
+        ran.push(index);
+      }).markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    // The guard reschedules after dropping the offender, so the queued
+    // remainder drains on the next pass without any external nudge.
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(10);
   });
 
   it("resets per-burst run counts once a flush fully drains", async () => {
@@ -151,9 +188,8 @@ describe("scheduler batched draining", () => {
     const ranBeforeAbort = ran.length;
     expect(ranBeforeAbort).toBeLessThan(10001);
 
-    // The remainder stays queued; the next flush (triggered by any later
-    // markDirty, as in production) continues it instead of dropping it.
-    schedulers[10000]!.markDirty();
+    // The cap reschedules automatically, so the remainder drains on the next
+    // pass with no external nudge (production has no manual markDirty).
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(10001);
   });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -89,6 +89,32 @@ describe("scheduler batched draining", () => {
     expect(ran).toBe(true);
   });
 
+  it("terminates a ring of mutually re-dirtying schedulers", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // A dirties B and B dirties A. Dropping only the current scheduler
+    // rebuilds the identical cycle next flush, so the loop abort must clear
+    // the queue — afterwards the app must keep flushing normally.
+    let a: InstanceType<typeof UpdateScheduler>;
+    let b: InstanceType<typeof UpdateScheduler>;
+    a = new UpdateScheduler(() => b.markDirty());
+    b = new UpdateScheduler(() => a.markDirty());
+    a.markDirty();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    expect(() => pump(channel!)).not.toThrow();
+
+    let ran = false;
+    new UpdateScheduler(() => {
+      ran = true;
+    }).markDirty();
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toBe(true);
+  });
+
   it("drains a 6000-scheduler batch in one flush", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
@@ -166,6 +192,31 @@ describe("scheduler batched draining", () => {
       pump(channel);
     }
     expect(ran).toHaveLength(120);
+  });
+
+  it("drains synchronously inside flushTapSync even past the burst cap", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
+
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 10001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+
+    // Everything must land before flushTapSync returns — the burst cap must
+    // not defer part of the queue to a macrotask that would outlive the
+    // temporary flushState (and silently lose it).
+    flushTapSync(() => {
+      for (const scheduler of schedulers) {
+        scheduler.markDirty();
+      }
+    });
+    expect(ran).toHaveLength(10001);
   });
 
   it("throws inside flushTapSync when a resource re-dirties itself", async () => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -41,7 +41,7 @@ describe("scheduler batched draining", () => {
     ControlledMessageChannel.instances = [];
   });
 
-  it("drains more than MAX_FLUSH_LIMIT dirty schedulers across passes instead of throwing", async () => {
+  it("drains more than 50 dirty schedulers in a single flush instead of throwing", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
@@ -79,41 +79,35 @@ describe("scheduler batched draining", () => {
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
   });
 
-  it("resets per-burst run counts after a fully drained pass", async () => {
+  it("resets per-burst run counts once a flush fully drains", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // A burst slightly above one pass budget, issued back-to-back: 75 dirty
-    // schedulers drain in two passes (50 + 25), after which runCounts is
-    // cleared, so separate bursts must not accumulate re-run counts.
-    const ran: number[] = [];
-    const make = (i: number) =>
-      new UpdateScheduler(() => {
-        ran.push(i);
-      });
+    // The SAME scheduler driven through many separate, fully-drained bursts:
+    // each burst must start its run count fresh, so no number of sequential
+    // bursts may trip the loop guard. (Pins runCounts.clear() on drain —
+    // with fresh schedulers per burst the clear would be untestable.)
+    let runs = 0;
+    const scheduler = new UpdateScheduler(() => {
+      runs += 1;
+    });
 
-    for (let burst = 0; burst < 40; burst++) {
-      const schedulers = Array.from({ length: 75 }, (_, i) =>
-        make(burst * 75 + i),
-      );
-      for (const scheduler of schedulers) {
-        scheduler.markDirty();
-      }
+    for (let burst = 0; burst < 60; burst++) {
+      scheduler.markDirty();
       const [channel] = ControlledMessageChannel.instances;
-      pump(channel!);
+      expect(() => pump(channel!)).not.toThrow();
     }
-
-    expect(ran).toHaveLength(40 * 75);
+    expect(runs).toBe(60);
   });
 
-  it("drains batches far larger than one pass budget with no total-size ceiling", async () => {
+  it("drains batches far larger than the old flush budget with no total-size ceiling", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Finite batches never re-run a scheduler, so they must drain no matter
-    // how many passes they need (6000 tasks = 120 passes at 50/pass).
+    // Finite batches never hit the per-scheduler guard no matter how large
+    // they are, because each scheduler runs exactly once.
     const ran: number[] = [];
     const schedulers = Array.from(
       { length: 6000 },
@@ -131,7 +125,7 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(6000);
   });
 
-  it("drains synchronously across passes inside flushTapSync", async () => {
+  it("drains synchronously inside flushTapSync", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -79,14 +79,14 @@ describe("scheduler batched draining", () => {
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
   });
 
-  it("resets the saturated-pass counter after a fully drained pass", async () => {
+  it("resets per-burst run counts after a fully drained pass", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // A burst slightly above one pass budget, issued twice back-to-back:
-    // 75 dirty schedulers drain in two passes (50 + 25), so the counter must
-    // reset rather than accumulate across separate bursts.
+    // A burst slightly above one pass budget, issued back-to-back: 75 dirty
+    // schedulers drain in two passes (50 + 25), after which runCounts is
+    // cleared, so separate bursts must not accumulate re-run counts.
     const ran: number[] = [];
     const make = (i: number) =>
       new UpdateScheduler(() => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -114,14 +114,13 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(6000);
   });
 
-  it("throws past MAX_TOTAL_TASKS_PER_BURST but keeps the remainder queued", async () => {
+  it("yields silently past MAX_TOTAL_TASKS_PER_BURST and keeps draining", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Contract of the burst-wide backstop: it fires loudly, but unlike the
-    // pre-fix behavior it does not drop the pending queue — the remainder
-    // drains on the next flush.
+    // The burst-wide cap is a yield boundary, not an error: oversized but
+    // finite batches drain across flushes without any throw.
     const ran: number[] = [];
     const schedulers = Array.from(
       { length: 10001 },
@@ -135,12 +134,6 @@ describe("scheduler batched draining", () => {
     }
 
     const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    const ranBeforeAbort = ran.length;
-    expect(ranBeforeAbort).toBeLessThan(10001);
-
-    // The cap reschedules automatically, so the remainder drains on the next
-    // pass with no external nudge (production has no manual markDirty).
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(10001);
   });
@@ -209,12 +202,12 @@ describe("scheduler batched draining", () => {
     makeCascadeScheduler().markDirty();
 
     const [channel] = ControlledMessageChannel.instances;
-    // MAX_CAP_STREAK (10) consecutive saturated flushes throw and
-    // auto-continue; the 11th stops rescheduling. Keep in sync with
-    // MAX_CAP_STREAK when changing it.
-    for (let i = 0; i < 11; i += 1) {
-      expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    }
+    // Saturated flushes yield silently and auto-continue; after
+    // MAX_CAP_STREAK (10) in a row the cascade is treated as a runaway: it
+    // throws and stops rescheduling. pump() drives every chained flush, so
+    // this first pump runs all 10 silent yields before the give-up throw.
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    // Nothing is rescheduled after the give-up.
     expect(() => pump(channel!)).not.toThrow();
 
     // The remainder is not dropped: any later markDirty triggers a flush

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -209,9 +209,17 @@ describe("scheduler batched draining", () => {
     makeCascadeScheduler().markDirty();
 
     const [channel] = ControlledMessageChannel.instances;
+    // MAX_CAP_STREAK (10) consecutive saturated flushes throw and
+    // auto-continue; the 11th stops rescheduling. Keep in sync with
+    // MAX_CAP_STREAK when changing it.
     for (let i = 0; i < 11; i += 1) {
       expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
     }
     expect(() => pump(channel!)).not.toThrow();
+
+    // The remainder is not dropped: any later markDirty triggers a flush
+    // that runs it (and throws again, since the cascade is unbounded).
+    new UpdateScheduler(() => {}).markDirty();
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -78,18 +78,16 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
 
-    // The offender is skipped, not dropped: it stays queued (still dirty,
-    // so its root doesn't publish half-applied state) and is retried on
-    // every pass - a true loop reports each pass while the rest of the
-    // queue keeps flushing.
+    // The offender is dropped and left clean: it does not tax later
+    // flushes, and its dirty flag is cleared so its root keeps publishing.
+    expect(scheduler.isDirty).toBe(false);
     let ran = false;
     const other = new UpdateScheduler(() => {
       ran = true;
     });
     other.markDirty();
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    expect(() => pump(channel!)).not.toThrow();
     expect(ran).toBe(true);
-    expect(scheduler.isDirty).toBe(true);
   });
 
   it("terminates a ring of mutually re-dirtying schedulers", async () => {
@@ -109,11 +107,13 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
 
+    // Both offenders were dropped in the first pass, so the queue is clean
+    // and later, unrelated work flushes normally.
     let ran = false;
     new UpdateScheduler(() => {
       ran = true;
     }).markDirty();
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    expect(() => pump(channel!)).not.toThrow();
     expect(ran).toBe(true);
   });
 
@@ -141,16 +141,17 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(2500);
   });
 
-  it("drains a 10001-scheduler batch in one flush", async () => {
+  it("drains a 4000-scheduler batch silently across chunked passes", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
     // Finite batches never hit the per-scheduler guard because each
-    // scheduler runs exactly once, so batches of any size drain in one pass.
+    // scheduler runs exactly once; under the burst bound they chunk
+    // silently, no depth error.
     const ran: number[] = [];
     const schedulers = Array.from(
-      { length: 10001 },
+      { length: 4000 },
       (_, i) =>
         new UpdateScheduler(() => {
           ran.push(i);
@@ -162,7 +163,7 @@ describe("scheduler batched draining", () => {
 
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).not.toThrow();
-    expect(ran).toHaveLength(10001);
+    expect(ran).toHaveLength(4000);
   });
 
   it("drains synchronously inside flushTapSync", async () => {
@@ -202,7 +203,7 @@ describe("scheduler batched draining", () => {
 
     const ran: number[] = [];
     const schedulers = Array.from(
-      { length: 10001 },
+      { length: 4000 },
       (_, i) =>
         new UpdateScheduler(() => {
           ran.push(i);
@@ -216,7 +217,7 @@ describe("scheduler batched draining", () => {
         scheduler.markDirty();
       }
     });
-    expect(ran).toHaveLength(10001);
+    expect(ran).toHaveLength(4000);
   });
 
   it("throws inside flushTapSync when the queue never shrinks (runaway)", async () => {
@@ -257,26 +258,30 @@ describe("scheduler batched draining", () => {
     ).toThrow(/Maximum update depth exceeded/);
   });
 
-  it("terminates an unbounded fresh-scheduler cascade at the absolute task ceiling", async () => {
+  it("reports a huge burst once but lets it finish instead of stalling", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Each task queues a brand-new scheduler, so the per-scheduler guard
-    // never trips (every instance runs once). Only the absolute per-flush
-    // task ceiling stops the pass; the remainder stays queued and the next
-    // triggered flush continues (and reports again).
-    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
-      new UpdateScheduler(() => {
-        makeCascadeScheduler().markDirty();
-      });
-    makeCascadeScheduler().markDirty();
+    // Past the documented burst bound (5000 tasks), the batch is REPORTED
+    // as a likely loop once - and still drains completely. A genuine
+    // runaway gets the loud error in the console and degrades to
+    // background chunking instead of wedging the tab.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 6001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
 
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    // No automatic continuation after the ceiling abort.
     expect(() => pump(channel!)).not.toThrow();
-    new UpdateScheduler(() => {}).markDirty();
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    expect(ran).toHaveLength(6001);
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -200,7 +200,7 @@ describe("scheduler batched draining", () => {
 
     const schedulers = Array.from(
       { length: 100001 },
-      (_, i) => new UpdateScheduler(() => {}),
+      (_, _i) => new UpdateScheduler(() => {}),
     );
 
     expect(() =>

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -94,9 +94,9 @@ describe("scheduler batched draining", () => {
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // A dirties B and B dirties A. Dropping only the current scheduler
-    // rebuilds the identical cycle next flush, so the loop abort must clear
-    // the queue — afterwards the app must keep flushing normally.
+    // A dirties B and B dirties A: both cross the per-scheduler run limit
+    // in turn and are dropped individually, so the ring terminates while
+    // unrelated work keeps flushing afterwards.
     let a: InstanceType<typeof UpdateScheduler>;
     let b: InstanceType<typeof UpdateScheduler>;
     a = new UpdateScheduler(() => b.markDirty());
@@ -113,31 +113,6 @@ describe("scheduler batched draining", () => {
     }).markDirty();
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toBe(true);
-  });
-
-  it("drains a 6000-scheduler batch in one flush", async () => {
-    vi.resetModules();
-    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
-    const { UpdateScheduler } = await import("../core/scheduler");
-
-    // Finite batches never hit the per-scheduler guard because each
-    // scheduler runs exactly once. (6000 < MAX_TOTAL_TASKS_PER_BURST; the
-    // burst-wide cap is pinned separately below.)
-    const ran: number[] = [];
-    const schedulers = Array.from(
-      { length: 6000 },
-      (_, i) =>
-        new UpdateScheduler(() => {
-          ran.push(i);
-        }),
-    );
-    for (const scheduler of schedulers) {
-      scheduler.markDirty();
-    }
-
-    const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).not.toThrow();
-    expect(ran).toHaveLength(6000);
   });
 
   it("drains a 10001-scheduler batch in one flush", async () => {
@@ -234,5 +209,28 @@ describe("scheduler batched draining", () => {
         scheduler.markDirty();
       }),
     ).toThrow(/Maximum update depth exceeded/);
+  });
+
+  it("terminates an unbounded fresh-scheduler cascade at the absolute task ceiling", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Each task queues a brand-new scheduler, so the per-scheduler guard
+    // never trips (every instance runs once). Only the absolute per-flush
+    // task ceiling stops the pass; the remainder stays queued and the next
+    // triggered flush continues (and reports again).
+    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
+      new UpdateScheduler(() => {
+        makeCascadeScheduler().markDirty();
+      });
+    makeCascadeScheduler().markDirty();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    // No automatic continuation after the ceiling abort.
+    expect(() => pump(channel!)).not.toThrow();
+    new UpdateScheduler(() => {}).markDirty();
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -106,4 +106,76 @@ describe("scheduler batched draining", () => {
 
     expect(ran).toHaveLength(40 * 75);
   });
+
+  it("drains batches far larger than one pass budget with no total-size ceiling", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Finite batches never re-run a scheduler, so they must drain no matter
+    // how many passes they need (6000 tasks = 120 passes at 50/pass).
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 6000 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(6000);
+  });
+
+  it("drains synchronously across passes inside flushTapSync", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
+
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 120 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+
+    flushTapSync(() => {
+      for (const scheduler of schedulers) {
+        scheduler.markDirty();
+      }
+    });
+
+    // Everything must have landed before flushTapSync returned — no deferred
+    // macrotask remainder (not even a channel gets created for leftovers).
+    expect(ran).toHaveLength(120);
+    const [channel] = ControlledMessageChannel.instances;
+    if (channel) {
+      pump(channel);
+    }
+    expect(ran).toHaveLength(120);
+  });
+
+  it("throws inside flushTapSync when a resource re-dirties itself", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
+
+    const scheduler: InstanceType<typeof UpdateScheduler> = new UpdateScheduler(
+      () => {
+        scheduler.markDirty();
+      },
+    );
+
+    expect(() =>
+      flushTapSync(() => {
+        scheduler.markDirty();
+      }),
+    ).toThrow(/Maximum update depth exceeded/);
+  });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -193,6 +193,25 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(10001);
   });
 
+  it("throws inside flushTapSync when the batch exceeds the task ceiling", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
+
+    const schedulers = Array.from(
+      { length: 100001 },
+      (_, i) => new UpdateScheduler(() => {}),
+    );
+
+    expect(() =>
+      flushTapSync(() => {
+        for (const scheduler of schedulers) {
+          scheduler.markDirty();
+        }
+      }),
+    ).toThrow(/Maximum update depth exceeded/);
+  });
+
   it("throws inside flushTapSync when a resource re-dirties itself", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -101,13 +101,14 @@ describe("scheduler batched draining", () => {
     expect(runs).toBe(60);
   });
 
-  it("drains batches far larger than the old flush budget with no total-size ceiling", async () => {
+  it("drains a 6000-scheduler batch in one flush", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Finite batches never hit the per-scheduler guard no matter how large
-    // they are, because each scheduler runs exactly once.
+    // Finite batches never hit the per-scheduler guard because each
+    // scheduler runs exactly once. (6000 < MAX_TOTAL_TASKS_PER_BURST; the
+    // burst-wide cap is pinned separately below.)
     const ran: number[] = [];
     const schedulers = Array.from(
       { length: 6000 },
@@ -123,6 +124,38 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(6000);
+  });
+
+  it("throws past MAX_TOTAL_TASKS_PER_BURST but keeps the remainder queued", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Contract of the burst-wide backstop: it fires loudly, but unlike the
+    // pre-fix behavior it does not drop the pending queue — the remainder
+    // drains on the next flush.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 10001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    const ranBeforeAbort = ran.length;
+    expect(ranBeforeAbort).toBeLessThan(10001);
+
+    // The remainder stays queued; the next flush (triggered by any later
+    // markDirty, as in production) continues it instead of dropping it.
+    schedulers[10000]!.markDirty();
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(10001);
   });
 
   it("drains synchronously inside flushTapSync", async () => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -189,24 +189,62 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(4000);
   });
 
-  it("throws inside flushTapSync when the queue never shrinks (runaway)", async () => {
+  it("defers a sync batch past MAX_SYNC_TASKS to the outer state instead of throwing", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
 
-    // Finite sync batches of any size finish first (their queue always
-    // shrinks); only a runaway — fresh schedulers minted mid-drain — hits
-    // the sync ceiling.
-    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
-      new UpdateScheduler(() => {
-        makeCascadeScheduler().markDirty();
-      });
-
+    // The work is fine; it just can't all land synchronously. No depth
+    // error is thrown - the remainder continues on the outer flush.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 6001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
     expect(() =>
       flushTapSync(() => {
-        makeCascadeScheduler().markDirty();
+        for (const scheduler of schedulers) {
+          scheduler.markDirty();
+        }
       }),
-    ).toThrow(/Maximum update depth exceeded/);
+    ).not.toThrow();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(6001);
+  });
+
+  it("warns once (not throws) when a burst saturates 20 consecutive passes, then completes", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const warn = vi.fn();
+    vi.stubGlobal("console", { ...console, warn });
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Saturation can't distinguish a large finite batch from a loop, so
+    // the streak is a console.warn diagnostic - never an exception.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 21001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(21001);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]![0])).toContain(
+      "Maximum update depth exceeded",
+    );
   });
 
   it("throws inside flushTapSync when a resource re-dirties itself", async () => {
@@ -249,5 +287,35 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(6001);
+  });
+
+  it("warns once (not throws) when a burst saturates 20 consecutive passes, then completes", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const warn = vi.fn();
+    vi.stubGlobal("console", { ...console, warn });
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Saturation can't distinguish a large finite batch from a loop, so
+    // the streak is a console.warn diagnostic - never an exception.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 21001 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(21001);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]![0])).toContain(
+      "Maximum update depth exceeded",
+    );
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -119,6 +119,30 @@ describe("scheduler batched draining", () => {
     expect(ran).toBe(true);
   });
 
+  it("drains a 60000-scheduler batch silently across chunked passes", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Bigger than one pass (50000) but under the burst bound: chunks
+    // continue silently on follow-up macrotasks, no depth error.
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 60000 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(60000);
+  });
+
   it("drains a 10001-scheduler batch in one flush", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -1,38 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
-// A MessageChannel whose deliveries are pumped manually, so flush passes can
-// be stepped through synchronously (and expected errors asserted) instead of
-// relying on un-catchable async callbacks.
-class ControlledPort {
-  onmessage: ((event: { data: unknown }) => void) | null = null;
-  pending = 0;
-  other!: ControlledPort;
-  ref() {}
-  unref() {}
-  postMessage(_data: unknown) {
-    // port2.postMessage delivers to port1.onmessage in a real channel.
-    this.other.pending++;
-  }
-}
-
-class ControlledMessageChannel {
-  static instances: ControlledMessageChannel[] = [];
-  port1 = new ControlledPort();
-  port2 = new ControlledPort();
-  constructor() {
-    this.port1.other = this.port2;
-    this.port2.other = this.port1;
-    ControlledMessageChannel.instances.push(this);
-  }
-}
-
-const pump = (channel: ControlledMessageChannel) => {
-  const port = channel.port1;
-  while (port.pending > 0) {
-    port.pending--;
-    port.onmessage?.({ data: null });
-  }
-};
+import { ControlledMessageChannel, pump } from "./controlled-channel";
 
 describe("scheduler batched draining", () => {
   afterEach(() => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -78,9 +78,10 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
 
-    // The offender is dropped and left clean: it does not tax later
-    // flushes, and its dirty flag is cleared so its root keeps publishing.
-    expect(scheduler.isDirty).toBe(false);
+    // The offender is dropped but left dirty on purpose: the flag gates
+    // publishing so the root never emits un-applied state, and the next
+    // markDirty re-queues it to drain consistently.
+    expect(scheduler.isDirty).toBe(true);
     let ran = false;
     const other = new UpdateScheduler(() => {
       ran = true;
@@ -258,15 +259,13 @@ describe("scheduler batched draining", () => {
     ).toThrow(/Maximum update depth exceeded/);
   });
 
-  it("reports a huge burst once but lets it finish instead of stalling", async () => {
+  it("drains a 6001-scheduler batch silently across chunked passes", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Past the documented burst bound (5000 tasks), the batch is REPORTED
-    // as a likely loop once - and still drains completely. A genuine
-    // runaway gets the loud error in the console and degrades to
-    // background chunking instead of wedging the tab.
+    // Finite batches of any size drain silently: chunking across
+    // macrotask passes has no total bound on this path.
     const ran: number[] = [];
     const schedulers = Array.from(
       { length: 6001 },
@@ -280,7 +279,6 @@ describe("scheduler batched draining", () => {
     }
 
     const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(6001);
   });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -78,19 +78,18 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
 
-    // The dropped offender is not left dirty: a stale isDirty would stall
-    // its root's publishing and re-burn 50 runs on every later markDirty.
-    expect(scheduler.isDirty).toBe(false);
-
-    // The looping scheduler is dropped instead of permanently poisoning the
-    // queue: later, unrelated work must flush normally.
+    // The offender is skipped, not dropped: it stays queued (still dirty,
+    // so its root doesn't publish half-applied state) and is retried on
+    // every pass - a true loop reports each pass while the rest of the
+    // queue keeps flushing.
     let ran = false;
     const other = new UpdateScheduler(() => {
       ran = true;
     });
     other.markDirty();
-    expect(() => pump(channel!)).not.toThrow();
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
     expect(ran).toBe(true);
+    expect(scheduler.isDirty).toBe(true);
   });
 
   it("terminates a ring of mutually re-dirtying schedulers", async () => {
@@ -98,9 +97,9 @@ describe("scheduler batched draining", () => {
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // A dirties B and B dirties A: both cross the per-scheduler run limit
-    // in turn and are dropped individually, so the ring terminates while
-    // unrelated work keeps flushing afterwards.
+    // A dirties B and B dirties A: both hit the run limit and are skipped
+    // (kept queued, retried each pass), so the ring degrades to a loud
+    // error per flush while the rest of the queue keeps flushing.
     let a: InstanceType<typeof UpdateScheduler>;
     let b: InstanceType<typeof UpdateScheduler>;
     a = new UpdateScheduler(() => b.markDirty());
@@ -109,26 +108,25 @@ describe("scheduler batched draining", () => {
 
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    expect(() => pump(channel!)).not.toThrow();
 
     let ran = false;
     new UpdateScheduler(() => {
       ran = true;
     }).markDirty();
-    expect(() => pump(channel!)).not.toThrow();
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
     expect(ran).toBe(true);
   });
 
-  it("drains a 60000-scheduler batch silently across chunked passes", async () => {
+  it("drains a 2500-scheduler batch silently across chunked passes", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Bigger than one pass (50000) but under the burst bound: chunks
+    // Bigger than one pass (1000) but under the burst bound: chunks
     // continue silently on follow-up macrotasks, no depth error.
     const ran: number[] = [];
     const schedulers = Array.from(
-      { length: 60000 },
+      { length: 2500 },
       (_, i) =>
         new UpdateScheduler(() => {
           ran.push(i);
@@ -140,7 +138,7 @@ describe("scheduler batched draining", () => {
 
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).not.toThrow();
-    expect(ran).toHaveLength(60000);
+    expect(ran).toHaveLength(2500);
   });
 
   it("drains a 10001-scheduler batch in one flush", async () => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+// A MessageChannel whose deliveries are pumped manually, so flush passes can
+// be stepped through synchronously (and expected errors asserted) instead of
+// relying on un-catchable async callbacks.
+class ControlledPort {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  pending = 0;
+  other!: ControlledPort;
+  ref() {}
+  unref() {}
+  postMessage(_data: unknown) {
+    // port2.postMessage delivers to port1.onmessage in a real channel.
+    this.other.pending++;
+  }
+}
+
+class ControlledMessageChannel {
+  static instances: ControlledMessageChannel[] = [];
+  port1 = new ControlledPort();
+  port2 = new ControlledPort();
+  constructor() {
+    this.port1.other = this.port2;
+    this.port2.other = this.port1;
+    ControlledMessageChannel.instances.push(this);
+  }
+}
+
+const pump = (channel: ControlledMessageChannel) => {
+  const port = channel.port1;
+  while (port.pending > 0) {
+    port.pending--;
+    port.onmessage?.({ data: null });
+  }
+};
+
+describe("scheduler batched draining", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    ControlledMessageChannel.instances = [];
+  });
+
+  it("drains more than MAX_FLUSH_LIMIT dirty schedulers across passes instead of throwing", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    const ran: number[] = [];
+    const schedulers = Array.from(
+      { length: 120 },
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
+    );
+    for (const scheduler of schedulers) {
+      scheduler.markDirty();
+    }
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toHaveLength(120);
+  });
+
+  it("still throws when a resource re-dirties itself on every run", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    const scheduler: InstanceType<typeof UpdateScheduler> = new UpdateScheduler(
+      () => {
+        scheduler.markDirty();
+      },
+    );
+    scheduler.markDirty();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+  });
+
+  it("resets the saturated-pass counter after a fully drained pass", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // A burst slightly above one pass budget, issued twice back-to-back:
+    // 75 dirty schedulers drain in two passes (50 + 25), so the counter must
+    // reset rather than accumulate across separate bursts.
+    const ran: number[] = [];
+    const make = (i: number) =>
+      new UpdateScheduler(() => {
+        ran.push(i);
+      });
+
+    for (let burst = 0; burst < 40; burst++) {
+      const schedulers = Array.from({ length: 75 }, (_, i) =>
+        make(burst * 75 + i),
+      );
+      for (const scheduler of schedulers) {
+        scheduler.markDirty();
+      }
+      const [channel] = ControlledMessageChannel.instances;
+      pump(channel!);
+    }
+
+    expect(ran).toHaveLength(40 * 75);
+  });
+});

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -189,6 +189,36 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(4000);
   });
 
+  it("terminates a wide ring (N=25) that no per-pass guard can catch", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // In a mutual-dirty ring of N >= 21 roots, each scheduler runs fewer
+    // than 50 times PER PASS, so only cumulative per-burst run counts
+    // (persisted on flushState) trip the guard.
+    const ring: InstanceType<typeof UpdateScheduler>[] = [];
+    for (let i = 0; i < 25; i += 1) {
+      ring.push(
+        new UpdateScheduler(() => {
+          ring[(i + 1) % 25].markDirty();
+        }),
+      );
+    }
+    ring[0]!.markDirty();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    // Every ring member was dropped, so the queue drains and later work
+    // flushes normally.
+    let ran = false;
+    new UpdateScheduler(() => {
+      ran = true;
+    }).markDirty();
+    expect(() => pump(channel!)).not.toThrow();
+    expect(ran).toBe(true);
+  });
+
   it("defers a sync batch past MAX_SYNC_TASKS to the outer state instead of throwing", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
@@ -287,35 +317,5 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).not.toThrow();
     expect(ran).toHaveLength(6001);
-  });
-
-  it("warns once (not throws) when a burst saturates 20 consecutive passes, then completes", async () => {
-    vi.resetModules();
-    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
-    const warn = vi.fn();
-    vi.stubGlobal("console", { ...console, warn });
-    const { UpdateScheduler } = await import("../core/scheduler");
-
-    // Saturation can't distinguish a large finite batch from a loop, so
-    // the streak is a console.warn diagnostic - never an exception.
-    const ran: number[] = [];
-    const schedulers = Array.from(
-      { length: 21001 },
-      (_, i) =>
-        new UpdateScheduler(() => {
-          ran.push(i);
-        }),
-    );
-    for (const scheduler of schedulers) {
-      scheduler.markDirty();
-    }
-
-    const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).not.toThrow();
-    expect(ran).toHaveLength(21001);
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(String(warn.mock.calls[0]![0])).toContain(
-      "Maximum update depth exceeded",
-    );
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -194,29 +194,26 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(120);
   });
 
-  it("drains synchronously inside flushTapSync even past the burst cap", async () => {
+  it("throws past the burst cap inside flushTapSync instead of hanging", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
 
-    const ran: number[] = [];
+    // There is no next macrotask to yield to inside flushTapSync, so an
+    // oversized batch hits a hard ceiling and reports instead of blocking
+    // the thread indefinitely.
     const schedulers = Array.from(
       { length: 10001 },
-      (_, i) =>
-        new UpdateScheduler(() => {
-          ran.push(i);
-        }),
+      (_, i) => new UpdateScheduler(() => {}),
     );
 
-    // Everything must land before flushTapSync returns — the burst cap must
-    // not defer part of the queue to a macrotask that would outlive the
-    // temporary flushState (and silently lose it).
-    flushTapSync(() => {
-      for (const scheduler of schedulers) {
-        scheduler.markDirty();
-      }
-    });
-    expect(ran).toHaveLength(10001);
+    expect(() =>
+      flushTapSync(() => {
+        for (const scheduler of schedulers) {
+          scheduler.markDirty();
+        }
+      }),
+    ).toThrow(/Maximum update depth exceeded/);
   });
 
   it("throws inside flushTapSync when a resource re-dirties itself", async () => {

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -172,4 +172,22 @@ describe("scheduler batched draining", () => {
       }),
     ).toThrow(/Maximum update depth exceeded/);
   });
+
+  it("throws on an unbounded cascade of fresh schedulers (burst-wide backstop)", async () => {
+    vi.resetModules();
+    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
+    const { UpdateScheduler } = await import("../core/scheduler");
+
+    // Each task queues a brand-new scheduler, so the per-scheduler guard
+    // never trips (every instance runs once) — only the burst-wide task cap
+    // prevents the macrotask from being monopolized forever.
+    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
+      new UpdateScheduler(() => {
+        makeCascadeScheduler().markDirty();
+      });
+    makeCascadeScheduler().markDirty();
+
+    const [channel] = ControlledMessageChannel.instances;
+    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+  });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -140,13 +140,13 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(6000);
   });
 
-  it("yields silently past MAX_TOTAL_TASKS_PER_BURST and keeps draining", async () => {
+  it("drains a 10001-scheduler batch in one flush", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // The burst-wide cap is a yield boundary, not an error: oversized but
-    // finite batches drain across flushes without any throw.
+    // Finite batches never hit the per-scheduler guard because each
+    // scheduler runs exactly once, so batches of any size drain in one pass.
     const ran: number[] = [];
     const schedulers = Array.from(
       { length: 10001 },
@@ -194,26 +194,28 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(120);
   });
 
-  it("throws past the burst cap inside flushTapSync instead of hanging", async () => {
+  it("drains synchronously inside flushTapSync even for huge batches", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
 
-    // There is no next macrotask to yield to inside flushTapSync, so an
-    // oversized batch hits a hard ceiling and reports instead of blocking
-    // the thread indefinitely.
+    const ran: number[] = [];
     const schedulers = Array.from(
       { length: 10001 },
-      (_, i) => new UpdateScheduler(() => {}),
+      (_, i) =>
+        new UpdateScheduler(() => {
+          ran.push(i);
+        }),
     );
 
-    expect(() =>
-      flushTapSync(() => {
-        for (const scheduler of schedulers) {
-          scheduler.markDirty();
-        }
-      }),
-    ).toThrow(/Maximum update depth exceeded/);
+    // Everything must land before flushTapSync returns — no deferral and no
+    // ceiling, since the per-scheduler guard bounds any single scheduler.
+    flushTapSync(() => {
+      for (const scheduler of schedulers) {
+        scheduler.markDirty();
+      }
+    });
+    expect(ran).toHaveLength(10001);
   });
 
   it("throws inside flushTapSync when a resource re-dirties itself", async () => {
@@ -232,35 +234,5 @@ describe("scheduler batched draining", () => {
         scheduler.markDirty();
       }),
     ).toThrow(/Maximum update depth exceeded/);
-  });
-
-  it("terminates an unbounded fresh-scheduler cascade after MAX_CAP_STREAK aborts", async () => {
-    vi.resetModules();
-    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
-    const { UpdateScheduler } = await import("../core/scheduler");
-
-    // Each task queues a brand-new scheduler, so every flush saturates the
-    // burst-wide cap and reschedules. After MAX_CAP_STREAK consecutive
-    // saturated flushes the queue must be dropped — the cascade gets a
-    // terminal state instead of wedging the tab with endless throws.
-    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
-      new UpdateScheduler(() => {
-        makeCascadeScheduler().markDirty();
-      });
-    makeCascadeScheduler().markDirty();
-
-    const [channel] = ControlledMessageChannel.instances;
-    // Saturated flushes yield silently and auto-continue; after
-    // MAX_CAP_STREAK (10) in a row the cascade is treated as a runaway: it
-    // throws and stops rescheduling. pump() drives every chained flush, so
-    // this first pump runs all 10 silent yields before the give-up throw.
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    // Nothing is rescheduled after the give-up.
-    expect(() => pump(channel!)).not.toThrow();
-
-    // The remainder is not dropped: any later markDirty triggers a flush
-    // that runs it (and throws again, since the cascade is unbounded).
-    new UpdateScheduler(() => {}).markDirty();
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
   });
 });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -78,6 +78,10 @@ describe("scheduler batched draining", () => {
     const [channel] = ControlledMessageChannel.instances;
     expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
 
+    // The dropped offender is not left dirty: a stale isDirty would stall
+    // its root's publishing and re-burn 50 runs on every later markDirty.
+    expect(scheduler.isDirty).toBe(false);
+
     // The looping scheduler is dropped instead of permanently poisoning the
     // queue: later, unrelated work must flush normally.
     let ran = false;
@@ -193,21 +197,22 @@ describe("scheduler batched draining", () => {
     expect(ran).toHaveLength(10001);
   });
 
-  it("throws inside flushTapSync when the batch exceeds the task ceiling", async () => {
+  it("throws inside flushTapSync when the queue never shrinks (runaway)", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler, flushTapSync } = await import("../core/scheduler");
 
-    const schedulers = Array.from(
-      { length: 100001 },
-      (_, _i) => new UpdateScheduler(() => {}),
-    );
+    // Finite sync batches of any size finish first (their queue always
+    // shrinks); only a runaway — fresh schedulers minted mid-drain — hits
+    // the sync ceiling.
+    const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
+      new UpdateScheduler(() => {
+        makeCascadeScheduler().markDirty();
+      });
 
     expect(() =>
       flushTapSync(() => {
-        for (const scheduler of schedulers) {
-          scheduler.markDirty();
-        }
+        makeCascadeScheduler().markDirty();
       }),
     ).toThrow(/Maximum update depth exceeded/);
   });

--- a/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
+++ b/packages/tap/src/__tests__/scheduler.batched-drain.test.ts
@@ -89,55 +89,6 @@ describe("scheduler batched draining", () => {
     expect(ran).toBe(true);
   });
 
-  it("drains the queue behind a looping scheduler instead of stalling", async () => {
-    vi.resetModules();
-    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
-    const { UpdateScheduler } = await import("../core/scheduler");
-
-    const looper: InstanceType<typeof UpdateScheduler> = new UpdateScheduler(
-      () => {
-        looper.markDirty();
-      },
-    );
-    looper.markDirty();
-    const ran: number[] = [];
-    for (let i = 0; i < 10; i += 1) {
-      const index = i;
-      new UpdateScheduler(() => {
-        ran.push(index);
-      }).markDirty();
-    }
-
-    const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
-    // The guard reschedules after dropping the offender, so the queued
-    // remainder drains on the next pass without any external nudge.
-    expect(() => pump(channel!)).not.toThrow();
-    expect(ran).toHaveLength(10);
-  });
-
-  it("resets per-burst run counts once a flush fully drains", async () => {
-    vi.resetModules();
-    vi.stubGlobal("MessageChannel", ControlledMessageChannel);
-    const { UpdateScheduler } = await import("../core/scheduler");
-
-    // The SAME scheduler driven through many separate, fully-drained bursts:
-    // each burst must start its run count fresh, so no number of sequential
-    // bursts may trip the loop guard. (Pins runCounts.clear() on drain —
-    // with fresh schedulers per burst the clear would be untestable.)
-    let runs = 0;
-    const scheduler = new UpdateScheduler(() => {
-      runs += 1;
-    });
-
-    for (let burst = 0; burst < 60; burst++) {
-      scheduler.markDirty();
-      const [channel] = ControlledMessageChannel.instances;
-      expect(() => pump(channel!)).not.toThrow();
-    }
-    expect(runs).toBe(60);
-  });
-
   it("drains a 6000-scheduler batch in one flush", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
@@ -242,14 +193,15 @@ describe("scheduler batched draining", () => {
     ).toThrow(/Maximum update depth exceeded/);
   });
 
-  it("throws on an unbounded cascade of fresh schedulers (burst-wide backstop)", async () => {
+  it("terminates an unbounded fresh-scheduler cascade after MAX_CAP_STREAK aborts", async () => {
     vi.resetModules();
     vi.stubGlobal("MessageChannel", ControlledMessageChannel);
     const { UpdateScheduler } = await import("../core/scheduler");
 
-    // Each task queues a brand-new scheduler, so the per-scheduler guard
-    // never trips (every instance runs once) — only the burst-wide task cap
-    // prevents the macrotask from being monopolized forever.
+    // Each task queues a brand-new scheduler, so every flush saturates the
+    // burst-wide cap and reschedules. After MAX_CAP_STREAK consecutive
+    // saturated flushes the queue must be dropped — the cascade gets a
+    // terminal state instead of wedging the tab with endless throws.
     const makeCascadeScheduler = (): InstanceType<typeof UpdateScheduler> =>
       new UpdateScheduler(() => {
         makeCascadeScheduler().markDirty();
@@ -257,6 +209,9 @@ describe("scheduler batched draining", () => {
     makeCascadeScheduler().markDirty();
 
     const [channel] = ControlledMessageChannel.instances;
-    expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    for (let i = 0; i < 11; i += 1) {
+      expect(() => pump(channel!)).toThrow(/Maximum update depth exceeded/);
+    }
+    expect(() => pump(channel!)).not.toThrow();
   });
 });

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -6,43 +6,22 @@ import {
 } from "./ResourceFiber";
 import { useTapRoot } from "../hooks/useTapRoot";
 import { isDevelopment } from "./helpers/env";
-import {
-  flushTapSync,
-  throwCollectedErrors,
-  UpdateScheduler,
-} from "./scheduler";
+import { flushTapSync, UpdateScheduler } from "./scheduler";
 import { createResourceFiberRoot } from "./helpers/root";
 
 export const createTapRoot = <R>(
   render: () => R,
 ): useTapRoot.Root<R> & { unmount: () => void } => {
-  // One scheduler per root (mirroring useTapRoot) so the per-scheduler
-  // re-run guard covers this root type too.
-  const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
-  const scheduler = new UpdateScheduler(() => {
-    const errors: unknown[] = [];
-    const batch = dispatchQueue.splice(0, dispatchQueue.length);
-    for (const { evaluate, apply } of batch) {
-      try {
+  const fiber = createResourceFiber(
+    useTapRoot,
+    createResourceFiberRoot((evaluate, apply) => {
+      new UpdateScheduler(() => {
         if (evaluate()) {
           apply();
           throw new Error("Unexpected rerender of createTapRoot outer fiber");
         }
-      } catch (error) {
-        errors.push(error);
-      }
-    }
-    throwCollectedErrors(
-      errors,
-      "Errors occurred during createTapRoot dispatch",
-    );
-  });
-
-  const fiber = createResourceFiber(
-    useTapRoot,
-    createResourceFiberRoot((evaluate, apply) => {
-      dispatchQueue.push({ evaluate, apply });
-      scheduler.markDirty();
+        return false;
+      }).markDirty();
     }),
     undefined,
     isDevelopment ? "root" : null,

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -16,10 +16,11 @@ export const createTapRoot = <R>(
   // guard then covers this root type too. Dispatches queue up and drain in
   // order within a single flush task; a failing update must not discard
   // the updates queued behind it, so entries are consumed one at a time
-  // and the first error is rethrown only after the rest were processed.
+  // and every failure is rethrown (single, or AggregateError) only after
+  // the rest were processed.
   const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
   const scheduler = new UpdateScheduler(() => {
-    let firstError: unknown = null;
+    const errors: unknown[] = [];
     while (dispatchQueue.length > 0) {
       const { evaluate, apply } = dispatchQueue.shift()!;
       try {
@@ -28,10 +29,14 @@ export const createTapRoot = <R>(
           throw new Error("Unexpected rerender of createTapRoot outer fiber");
         }
       } catch (error) {
-        firstError ??= error;
+        errors.push(error);
       }
     }
-    if (firstError !== null) throw firstError;
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      for (const error of errors) console.error(error);
+      throw new AggregateError(errors, "Errors occurred during flushSync");
+    }
     return false;
   });
 

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -18,14 +18,14 @@ export const createTapRoot = <R>(
 ): useTapRoot.Root<R> & { unmount: () => void } => {
   // One scheduler per root, mirroring useTapRoot: a per-scheduler re-run
   // guard then covers this root type too. Dispatches queue up and drain in
-  // order within a single flush task; a failing update must not discard
-  // the updates queued behind it, so entries are consumed one at a time
-  // and every failure is rethrown only after the rest were processed.
+  // order within a single flush task. Each task processes a snapshot of
+  // the queue; a dispatch raised DURING the drain falls to a follow-up
+  // task, so a re-entrant loop stays visible to the re-run guard.
   const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
   const scheduler = new UpdateScheduler(() => {
     const errors: unknown[] = [];
-    while (dispatchQueue.length > 0) {
-      const { evaluate, apply } = dispatchQueue.shift()!;
+    const batch = dispatchQueue.splice(0, dispatchQueue.length);
+    for (const { evaluate, apply } of batch) {
       try {
         if (evaluate()) {
           apply();
@@ -34,6 +34,9 @@ export const createTapRoot = <R>(
       } catch (error) {
         errors.push(error);
       }
+    }
+    if (dispatchQueue.length > 0) {
+      scheduler.markDirty();
     }
     throwCollectedErrors(errors);
   });

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -14,15 +14,24 @@ export const createTapRoot = <R>(
 ): useTapRoot.Root<R> & { unmount: () => void } => {
   // One scheduler per root, mirroring useTapRoot: a per-scheduler re-run
   // guard then covers this root type too. Dispatches queue up and drain in
-  // order within a single flush task.
+  // order within a single flush task; a failing update must not discard
+  // the updates queued behind it, so entries are consumed one at a time
+  // and the first error is rethrown only after the rest were processed.
   const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
   const scheduler = new UpdateScheduler(() => {
-    for (const { evaluate, apply } of dispatchQueue.splice(0)) {
-      if (evaluate()) {
-        apply();
-        throw new Error("Unexpected rerender of createTapRoot outer fiber");
+    let firstError: unknown = null;
+    while (dispatchQueue.length > 0) {
+      const { evaluate, apply } = dispatchQueue.shift()!;
+      try {
+        if (evaluate()) {
+          apply();
+          throw new Error("Unexpected rerender of createTapRoot outer fiber");
+        }
+      } catch (error) {
+        firstError ??= error;
       }
     }
+    if (firstError !== null) throw firstError;
     return false;
   });
 

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -32,11 +32,6 @@ export const createTapRoot = <R>(
         errors.push(error);
       }
     }
-    if (dispatchQueue.length > 0) {
-      // Re-entrant dispatch: re-queued and re-run in this same pass, so a
-      // re-entrant loop stays visible to the re-run guard.
-      scheduler.markDirty();
-    }
     throwCollectedErrors(
       errors,
       "Errors occurred during createTapRoot dispatch",

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -12,16 +12,25 @@ import { createResourceFiberRoot } from "./helpers/root";
 export const createTapRoot = <R>(
   render: () => R,
 ): useTapRoot.Root<R> & { unmount: () => void } => {
+  // One scheduler per root, mirroring useTapRoot: a per-scheduler re-run
+  // guard then covers this root type too. Dispatches queue up and drain in
+  // order within a single flush task.
+  const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
+  const scheduler = new UpdateScheduler(() => {
+    for (const { evaluate, apply } of dispatchQueue.splice(0)) {
+      if (evaluate()) {
+        apply();
+        throw new Error("Unexpected rerender of createTapRoot outer fiber");
+      }
+    }
+    return false;
+  });
+
   const fiber = createResourceFiber(
     useTapRoot,
     createResourceFiberRoot((evaluate, apply) => {
-      new UpdateScheduler(() => {
-        if (evaluate()) {
-          apply();
-          throw new Error("Unexpected rerender of createTapRoot outer fiber");
-        }
-        return false;
-      }).markDirty();
+      dispatchQueue.push({ evaluate, apply });
+      scheduler.markDirty();
     }),
     undefined,
     isDevelopment ? "root" : null,

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -6,7 +6,11 @@ import {
 } from "./ResourceFiber";
 import { useTapRoot } from "../hooks/useTapRoot";
 import { isDevelopment } from "./helpers/env";
-import { flushTapSync, UpdateScheduler } from "./scheduler";
+import {
+  flushTapSync,
+  throwCollectedErrors,
+  UpdateScheduler,
+} from "./scheduler";
 import { createResourceFiberRoot } from "./helpers/root";
 
 export const createTapRoot = <R>(
@@ -16,8 +20,7 @@ export const createTapRoot = <R>(
   // guard then covers this root type too. Dispatches queue up and drain in
   // order within a single flush task; a failing update must not discard
   // the updates queued behind it, so entries are consumed one at a time
-  // and every failure is rethrown (single, or AggregateError) only after
-  // the rest were processed.
+  // and every failure is rethrown only after the rest were processed.
   const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
   const scheduler = new UpdateScheduler(() => {
     const errors: unknown[] = [];
@@ -32,12 +35,7 @@ export const createTapRoot = <R>(
         errors.push(error);
       }
     }
-    if (errors.length === 1) throw errors[0];
-    if (errors.length > 1) {
-      for (const error of errors) console.error(error);
-      throw new AggregateError(errors, "Errors occurred during flushSync");
-    }
-    return false;
+    throwCollectedErrors(errors);
   });
 
   const fiber = createResourceFiber(

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -16,11 +16,8 @@ import { createResourceFiberRoot } from "./helpers/root";
 export const createTapRoot = <R>(
   render: () => R,
 ): useTapRoot.Root<R> & { unmount: () => void } => {
-  // One scheduler per root, mirroring useTapRoot: a per-scheduler re-run
-  // guard then covers this root type too. Dispatches queue up and drain in
-  // order within a single flush task. Each task processes a snapshot of
-  // the queue; a dispatch raised DURING the drain falls to a follow-up
-  // task, so a re-entrant loop stays visible to the re-run guard.
+  // One scheduler per root (mirroring useTapRoot) so the per-scheduler
+  // re-run guard covers this root type too.
   const dispatchQueue: { evaluate: () => boolean; apply: () => boolean }[] = [];
   const scheduler = new UpdateScheduler(() => {
     const errors: unknown[] = [];
@@ -36,9 +33,14 @@ export const createTapRoot = <R>(
       }
     }
     if (dispatchQueue.length > 0) {
+      // Re-entrant dispatch: re-queued and re-run in this same pass, so a
+      // re-entrant loop stays visible to the re-run guard.
       scheduler.markDirty();
     }
-    throwCollectedErrors(errors);
+    throwCollectedErrors(
+      errors,
+      "Errors occurred during createTapRoot dispatch",
+    );
   });
 
   const fiber = createResourceFiber(

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -94,7 +94,11 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   try {
     for (const scheduler of flushState.schedulers) {
       if (taskCount >= MAX_TASKS_PER_FLUSH) {
-        reportDepthError(errors);
+        // The per-pass ceiling only reports on the macrotask path; a sync
+        // caller chunks silently and applies its own total ceiling.
+        if (defer) {
+          reportDepthError(errors);
+        }
         break;
       }
       flushState.schedulers.delete(scheduler);
@@ -111,7 +115,15 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
       try {
         scheduler.runTask();
       } catch (error) {
-        errors.push(error);
+        // A task that throws deterministically on every re-run would
+        // otherwise flood the batch with identical entries.
+        const message = error instanceof Error ? error.message : String(error);
+        const duplicate = errors.some(
+          (e) => (e instanceof Error ? e.message : String(e)) === message,
+        );
+        if (!duplicate) {
+          errors.push(error);
+        }
       }
     }
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -5,11 +5,20 @@ type GlobalFlushState = {
   isScheduled: boolean;
 };
 
+// Maximum number of tasks a single flush pass may run. Large legitimate
+// batches (e.g. hundreds of resources mounting in one update) exceed this
+// easily, so overflowing work is deferred to follow-up passes instead of
+// being dropped.
 const MAX_FLUSH_LIMIT = 50;
+// Guard against true infinite update loops (a resource that re-dirties
+// itself on every run): if this many consecutive passes stay saturated
+// without the queue ever draining, give up and throw.
+const MAX_SATURATED_FLUSH_PASSES = 100;
 let flushState: GlobalFlushState = {
   schedulers: new Set([]),
   isScheduled: false,
 };
+let saturatedFlushPasses = 0;
 
 export class UpdateScheduler {
   private _isDirty = false;
@@ -44,44 +53,57 @@ const scheduleFlush = () => {
 };
 
 const flushScheduled = () => {
-  try {
-    const errors = [];
-    let flushDepth = 0;
+  const errors = [];
+  let flushDepth = 0;
 
-    for (const scheduler of flushState.schedulers) {
-      flushState.schedulers.delete(scheduler);
-      if (!scheduler.isDirty) continue;
+  for (const scheduler of flushState.schedulers) {
+    if (flushDepth >= MAX_FLUSH_LIMIT) break;
+    flushState.schedulers.delete(scheduler);
+    if (!scheduler.isDirty) continue;
 
-      flushDepth++;
+    flushDepth++;
 
-      if (flushDepth > MAX_FLUSH_LIMIT) {
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
-      }
-
-      try {
-        scheduler.runTask();
-      } catch (error) {
-        errors.push(error);
-      }
+    try {
+      scheduler.runTask();
+    } catch (error) {
+      errors.push(error);
     }
+  }
 
-    if (errors.length > 0) {
-      if (errors.length === 1) {
-        throw errors[0];
-      } else {
-        for (const error of errors) {
-          console.error(error);
-        }
-        throw new AggregateError(errors, "Errors occurred during flushSync");
-      }
-    }
-  } finally {
+  if (errors.length > 0) {
     flushState.schedulers.clear();
     flushState.isScheduled = false;
+    saturatedFlushPasses = 0;
+    if (errors.length === 1) {
+      throw errors[0];
+    } else {
+      for (const error of errors) {
+        console.error(error);
+      }
+      throw new AggregateError(errors, "Errors occurred during flushSync");
+    }
   }
+
+  if (flushState.schedulers.size > 0) {
+    saturatedFlushPasses += 1;
+    if (saturatedFlushPasses >= MAX_SATURATED_FLUSH_PASSES) {
+      flushState.schedulers.clear();
+      flushState.isScheduled = false;
+      saturatedFlushPasses = 0;
+      throw new Error(
+        `Maximum update depth exceeded. This can happen when a resource ` +
+          `repeatedly calls setState inside useEffect.`,
+      );
+    }
+    // More work remains: continue draining in the next pass instead of
+    // dropping the pending updates.
+    flushState.isScheduled = false;
+    scheduleFlush();
+    return;
+  }
+
+  saturatedFlushPasses = 0;
+  flushState.isScheduled = false;
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,11 +2,14 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  // Tasks run since the queue last drained, across chunked passes.
+  burstTaskTotal: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  burstTaskTotal: 0,
   isScheduled: false,
 });
 
@@ -14,17 +17,15 @@ const newFlushState = (): GlobalFlushState => ({
 // that keeps re-dirtying itself (or a cycle of resources re-dirtying each
 // other); the offender is dropped so the rest of the queue keeps flushing.
 const MAX_TASK_RUNS_PER_FLUSH = 50;
-// Last-resort termination: a task that synchronously mints NEW schedulers
-// (e.g. mounts another root mid-flush) never trips the per-scheduler
-// guard, so an unbounded cascade of fresh instances would otherwise lock
-// the thread in one macrotask. On hitting it the pass aborts with the
-// depth error; the remainder stays queued (never dropped) and the next
-// triggered flush continues it.
+// A pass yields at this many tasks and continues on the next flush, so
+// oversized batches chunk across macrotasks instead of blocking.
 const MAX_TASKS_PER_FLUSH = 50000;
-// "The queue did not shrink between sync passes" is what runaway means for
-// a flushTapSync drain; this many in a row throws (finite batches always
-// shrink, so they never hit it).
-const MAX_CAP_STREAK = 3;
+// Last-resort termination, documented as the real bound: nothing can
+// distinguish a huge finite cascade from an infinite one, so a burst that
+// runs more than this many tasks in total (~100x any realistic bulk
+// update) is declared a loop and reported. The queue is never dropped; a
+// stalled remainder continues on the next triggered flush.
+const MAX_BURST_TASKS = 500000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -101,14 +102,12 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   const errorContributors = new Set<UpdateScheduler>();
   let taskCount = 0;
 
+  let hitCeiling = false;
+
   try {
     for (const scheduler of flushState.schedulers) {
       if (taskCount >= MAX_TASKS_PER_FLUSH) {
-        // The per-pass ceiling only reports on the macrotask path; a sync
-        // caller chunks silently and applies its own total ceiling.
-        if (defer) {
-          reportDepthError(errors);
-        }
+        hitCeiling = true;
         break;
       }
       flushState.schedulers.delete(scheduler);
@@ -140,6 +139,19 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   } finally {
     if (defer) {
       flushState.isScheduled = false;
+      if (!hitCeiling) {
+        flushState.burstTaskTotal = 0;
+      } else {
+        flushState.burstTaskTotal += taskCount;
+        if (flushState.burstTaskTotal > MAX_BURST_TASKS) {
+          // Runaway: report and stop auto-continuing. The queue is kept.
+          flushState.burstTaskTotal = 0;
+          reportDepthError(errors);
+        } else {
+          // Oversized but under the bound: chunk on, silently.
+          scheduleFlush();
+        }
+      }
     }
   }
 
@@ -193,21 +205,13 @@ export const flushTapSync = <T>(callback: () => T): T => {
     // a runaway is bounded by the same task ceiling (checked before each
     // pass, so finite batches always finish first).
     const errors: CollectedErrors = [];
-    // A finite batch's queue always shrinks between passes; only a runaway
-    // (fresh schedulers minted mid-drain) fails to. The sync ceiling
-    // therefore counts non-shrinking passes, and finite batches of any
-    // size always finish first.
-    let lastQueueSize = Number.POSITIVE_INFINITY;
-    let streak = 0;
+    let total = 0;
     while (flushState.schedulers.size > 0) {
-      if (streak > MAX_CAP_STREAK) {
+      if (total > MAX_BURST_TASKS) {
         reportDepthError(errors);
         break;
       }
-      flushScheduled(errors, false);
-      const size = flushState.schedulers.size;
-      streak = size >= lastQueueSize ? streak + 1 : 0;
-      lastQueueSize = size;
+      total += flushScheduled(errors, false);
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,11 +2,15 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  // Consecutive saturated (ceiling-hitting) passes; reset when a pass
+  // drains the queue.
+  saturatedStreak: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  saturatedStreak: 0,
   isScheduled: false,
 });
 
@@ -23,6 +27,11 @@ const MAX_TASKS_PER_FLUSH = 1000;
 // re-run guard cannot see) must be cut somewhere. ~8x the repro; the
 // remainder is handed to the outer state and continues there.
 const MAX_SYNC_TASKS = 5000;
+// A runaway minting fresh schedulers saturates EVERY pass, while a finite
+// batch's last pass is always partial. This many saturated passes in a
+// row (x MAX_TASKS_PER_FLUSH tasks) declares a loop: report and stop
+// auto-continuing. The queue is kept, never dropped.
+const MAX_SATURATED_STREAK = 20;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -104,7 +113,7 @@ const flushScheduled = (
 ): number => {
   const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
   const errorContributors =
-    shared?.errorContributors ?? new Map<UpdateScheduler, number>();
+    shared?.errorContributors ?? new Map<UpdateScheduler, Set<string>>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -132,11 +141,13 @@ const flushScheduled = (
       try {
         scheduler.runTask();
       } catch (error) {
-        // A deterministically re-throwing task can't flood the batch; a
-        // different failure from the same scheduler still surfaces.
-        const contributed = errorContributors.get(scheduler) ?? 0;
-        if (contributed < 3) {
-          errorContributors.set(scheduler, contributed + 1);
+        // A deterministically re-throwing task can't flood the batch with
+        // copies; a different failure (different message) still surfaces.
+        const message = error instanceof Error ? error.message : String(error);
+        const seen = errorContributors.get(scheduler) ?? new Set<string>();
+        if (!seen.has(message)) {
+          seen.add(message);
+          errorContributors.set(scheduler, seen);
           errors.push(error);
         }
       }
@@ -145,7 +156,15 @@ const flushScheduled = (
     if (defer) {
       flushState.isScheduled = false;
       if (hitCeiling) {
-        scheduleFlush();
+        flushState.saturatedStreak += 1;
+        if (flushState.saturatedStreak > MAX_SATURATED_STREAK) {
+          flushState.saturatedStreak = 0;
+          reportDepthError(errors);
+        } else {
+          scheduleFlush();
+        }
+      } else {
+        flushState.saturatedStreak = 0;
       }
     }
   }

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,16 +2,11 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  // Tasks run since the queue last drained, across chunked passes.
-  burstTaskTotal: number;
-  burstDepthReported: boolean;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
-  burstTaskTotal: 0,
-  burstDepthReported: false,
   isScheduled: false,
 });
 
@@ -23,14 +18,11 @@ const MAX_TASK_RUNS_PER_FLUSH = 50;
 // oversized batches chunk across macrotasks instead of blocking. ~1.5x
 // the motivating repro (one 200-message history page ~= 600 resources).
 const MAX_TASKS_PER_FLUSH = 1000;
-// Last-resort bound, documented as the real line: nothing can distinguish
-// a huge finite cascade from an infinite one, so a burst running more
-// than this many tasks total (~8x the 600-resource repro, ~= 1600
-// messages in one update) is REPORTED once as a likely loop - and then
-// keeps chunking anyway: a finite batch that large still completes, an
-// infinite one degrades to background work with a loud error in the
-// console. The queue is never dropped and never stalled.
-const MAX_BURST_TASKS = 5000;
+// flushTapSync-only hard bound: a synchronous drain cannot defer, so an
+// unbounded batch (e.g. fresh schedulers minted mid-drain, which the
+// re-run guard cannot see) must be cut somewhere. ~8x the repro; the
+// remainder is handed to the outer state and continues there.
+const MAX_SYNC_TASKS = 5000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -51,11 +43,6 @@ export class UpdateScheduler {
 
     flushState.schedulers.add(this);
     scheduleFlush();
-  }
-
-  /** @internal Called when the run guard drops a scheduler, so the root is not left permanently dirty (which would suppress its own publishing). */
-  clearDirty() {
-    this._isDirty = false;
   }
 
   runTask() {
@@ -117,7 +104,7 @@ const flushScheduled = (
 ): number => {
   const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
   const errorContributors =
-    shared?.errorContributors ?? new Map<UpdateScheduler, Set<string>>();
+    shared?.errorContributors ?? new Map<UpdateScheduler, number>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -130,12 +117,11 @@ const flushScheduled = (
       }
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
-        // Dropped on every path (and left clean, not dirty): a resource
-        // re-dirtying itself this often in one burst is a genuine loop,
-        // and keeping it queued taxes every future flush.
+        // Dropped, but left dirty: the flag gates publish() so the root
+        // never emits un-applied state, and the next markDirty re-queues
+        // it so its task drains the stranded queue consistently.
         reportDepthError(errors);
         flushState.schedulers.delete(scheduler);
-        scheduler.clearDirty();
         continue;
       }
       flushState.schedulers.delete(scheduler);
@@ -146,14 +132,11 @@ const flushScheduled = (
       try {
         scheduler.runTask();
       } catch (error) {
-        // One entry per (scheduler, message): a deterministically
-        // re-throwing task can't flood the batch, and two different
-        // failures - even with the same message - both surface.
-        const message = error instanceof Error ? error.message : String(error);
-        const seen = errorContributors.get(scheduler) ?? new Set<string>();
-        if (!seen.has(message)) {
-          seen.add(message);
-          errorContributors.set(scheduler, seen);
+        // A deterministically re-throwing task can't flood the batch; a
+        // different failure from the same scheduler still surfaces.
+        const contributed = errorContributors.get(scheduler) ?? 0;
+        if (contributed < 3) {
+          errorContributors.set(scheduler, contributed + 1);
           errors.push(error);
         }
       }
@@ -161,18 +144,7 @@ const flushScheduled = (
   } finally {
     if (defer) {
       flushState.isScheduled = false;
-      if (!hitCeiling) {
-        flushState.burstTaskTotal = 0;
-        flushState.burstDepthReported = false;
-      } else {
-        flushState.burstTaskTotal += taskCount;
-        if (
-          flushState.burstTaskTotal > MAX_BURST_TASKS &&
-          !flushState.burstDepthReported
-        ) {
-          flushState.burstDepthReported = true;
-          reportDepthError(errors);
-        }
+      if (hitCeiling) {
         scheduleFlush();
       }
     }
@@ -239,7 +211,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
     };
     let total = 0;
     while (flushState.schedulers.size > 0) {
-      if (total > MAX_BURST_TASKS) {
+      if (total > MAX_SYNC_TASKS) {
         reportDepthError(errors);
         for (const scheduler of flushState.schedulers) {
           leftover.push(scheduler);

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -16,11 +16,13 @@ const newFlushState = (): GlobalFlushState => ({
 // other in a loop; a finite batch never re-runs one scheduler this often.
 const MAX_TASK_RUNS_PER_BURST = 50;
 // Backstop for cascades of FRESH schedulers (each runs once, so the
-// per-scheduler guard never trips); sized far above realistic bulk updates.
+// per-scheduler guard never trips). A flush yields silently at this many
+// tasks and continues on the next macrotask, so oversized batches drain
+// without errors; only MAX_CAP_STREAK consecutive saturated flushes are
+// treated as a runaway.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
-// Cap-aborts reschedule so oversized batches keep draining; after this many
-// consecutive saturated flushes, auto-continuing stops so a runaway cascade
-// terminates (the queue is kept, never dropped).
+// "Saturated this many flushes in a row" is what loop means for the burst
+// cap: stop auto-continuing and throw. The queue is kept — never dropped.
 const MAX_CAP_STREAK = 10;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -56,11 +58,11 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Guards throw loudly but never stall the queue: a looping scheduler is
-// dropped so the rest of the app keeps flushing; the burst-wide cap
-// reschedules so oversized batches continue next flush, but gives up after
-// MAX_CAP_STREAK consecutive saturated flushes so a runaway cascade
-// terminates instead of hanging the tab.
+// Guards never drop queued work. The burst-wide cap yields silently and
+// reschedules, so oversized batches drain across macrotasks with no error;
+// only MAX_CAP_STREAK saturated flushes in a row (a runaway) throws and
+// stops auto-continuing. A looping scheduler is dropped so the rest of the
+// app keeps flushing.
 const flushScheduled = () => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
@@ -92,27 +94,27 @@ const flushScheduled = () => {
     }
   } finally {
     flushState.isScheduled = false;
-    if (abort === "cap") {
-      flushState.capStreak += 1;
-      if (flushState.capStreak <= MAX_CAP_STREAK) {
-        scheduleFlush();
-      }
-      // Past the streak: stop auto-continuing so a runaway cascade
-      // terminates — but keep the queue; the remainder drains on the next
-      // externally triggered flush instead of being dropped.
-    } else {
-      flushState.capStreak = 0;
-      if (abort === "loop") {
-        scheduleFlush();
-      }
-    }
   }
 
-  if (abort !== null) {
-    throw new Error(
-      `Maximum update depth exceeded. This can happen when a resource ` +
-        `repeatedly calls setState inside useEffect.`,
-    );
+  if (abort === "cap") {
+    flushState.capStreak += 1;
+    if (flushState.capStreak <= MAX_CAP_STREAK) {
+      scheduleFlush();
+    } else {
+      throw new Error(
+        `Maximum update depth exceeded. This can happen when a resource ` +
+          `repeatedly calls setState inside useEffect.`,
+      );
+    }
+  } else {
+    flushState.capStreak = 0;
+    if (abort === "loop") {
+      scheduleFlush();
+      throw new Error(
+        `Maximum update depth exceeded. This can happen when a resource ` +
+          `repeatedly calls setState inside useEffect.`,
+      );
+    }
   }
 
   if (errors.length > 0) {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -17,9 +17,9 @@ const MAX_TASK_RUNS_PER_FLUSH = 50;
 // Last-resort termination: a task that synchronously mints NEW schedulers
 // (e.g. mounts another root mid-flush) never trips the per-scheduler
 // guard, so an unbounded cascade of fresh instances would otherwise lock
-// the thread in one macrotask. Set far above any real workload; on hitting
-// it the pass aborts with the depth error, the remainder stays queued, and
-// the next triggered flush continues - nothing is ever dropped.
+// the thread in one macrotask. On hitting it the pass aborts with the
+// depth error; the remainder stays queued (never dropped) and the next
+// triggered flush continues it.
 const MAX_TASKS_PER_FLUSH = 50000;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -55,30 +55,46 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Drains flushState.schedulers completely. Set iteration also visits
-// schedulers re-added mid-pass, so bulk updates of any size land in a
-// single batch. Termination is guaranteed by the per-scheduler run guard:
-// every scheduler runs at most MAX_TASK_RUNS_PER_FLUSH times per flush.
-const flushScheduled = () => {
-  const errors: unknown[] = [];
+const newDepthError = () =>
+  new Error(
+    `Maximum update depth exceeded. This can happen when a resource ` +
+      `repeatedly calls setState inside useEffect.`,
+  );
+
+type CollectedErrors = unknown[] & { depthErrorReported?: boolean };
+
+const reportDepthError = (errors: CollectedErrors) => {
+  if (errors.depthErrorReported) return;
+  errors.depthErrorReported = true;
+  errors.push(newDepthError());
+};
+
+export const throwCollectedErrors = (errors: unknown[]): void => {
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    for (const error of errors) {
+      console.error(error);
+    }
+    throw new AggregateError(errors, "Errors occurred during flushSync");
+  }
+};
+
+// Drains flushState.schedulers (Set iteration also visits schedulers
+// re-added mid-pass, so bulk updates of any size land in a single batch)
+// and appends failures to `errors` instead of throwing. Termination is
+// guaranteed by the two guards: every scheduler runs at most
+// MAX_TASK_RUNS_PER_FLUSH times, and the pass aborts at MAX_TASKS_PER_FLUSH
+// tasks, keeping the remainder queued for the next triggered flush.
+const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   const runCounts = new Map<UpdateScheduler, number>();
   let taskCount = 0;
-  let depthErrorReported = false;
-  const reportDepthError = () => {
-    if (depthErrorReported) return;
-    depthErrorReported = true;
-    errors.push(
-      new Error(
-        `Maximum update depth exceeded. This can happen when a resource ` +
-          `repeatedly calls setState inside useEffect.`,
-      ),
-    );
-  };
 
   try {
     for (const scheduler of flushState.schedulers) {
       if (taskCount >= MAX_TASKS_PER_FLUSH) {
-        reportDepthError();
+        reportDepthError(errors);
         break;
       }
       flushState.schedulers.delete(scheduler);
@@ -86,7 +102,7 @@ const flushScheduled = () => {
 
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
-        reportDepthError();
+        reportDepthError(errors);
         continue;
       }
       runCounts.set(scheduler, runs);
@@ -99,19 +115,18 @@ const flushScheduled = () => {
       }
     }
   } finally {
-    flushState.isScheduled = false;
-  }
-
-  if (errors.length > 0) {
-    if (errors.length === 1) {
-      throw errors[0];
-    } else {
-      for (const error of errors) {
-        console.error(error);
-      }
-      throw new AggregateError(errors, "Errors occurred during flushSync");
+    if (defer) {
+      flushState.isScheduled = false;
     }
   }
+
+  return taskCount;
+};
+
+const flushAndThrow = () => {
+  const errors: CollectedErrors = [];
+  flushScheduled(errors);
+  throwCollectedErrors(errors);
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
@@ -130,7 +145,7 @@ const scheduleMacrotask = (() => {
         const channel = new MessageChannel();
         channel.port1.onmessage = () => {
           port1?.unref?.();
-          flushScheduled();
+          flushAndThrow();
         };
         port1 = channel.port1;
         port2 = channel.port2;
@@ -140,7 +155,7 @@ const scheduleMacrotask = (() => {
     };
   }
   // Fallback for environments without MessageChannel
-  return () => setTimeout(flushScheduled, 0);
+  return () => setTimeout(flushAndThrow, 0);
 })();
 
 export const flushTapSync = <T>(callback: () => T): T => {
@@ -150,7 +165,20 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
   try {
     const value = callback();
-    flushScheduled();
+    // Synchronous callers rely on every notification having landed by the
+    // time this returns, so drain across passes until the queue is empty;
+    // a runaway is bounded by the same task ceiling (checked before each
+    // pass, so finite batches always finish first).
+    const errors: CollectedErrors = [];
+    let total = 0;
+    while (flushState.schedulers.size > 0) {
+      if (total > MAX_TASKS_PER_FLUSH) {
+        reportDepthError(errors);
+        break;
+      }
+      total += flushScheduled(errors, false);
+    }
+    throwCollectedErrors(errors);
 
     return value;
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,23 +2,29 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  // How often each scheduler has run since the queue last drained. A
+  // scheduler re-run MAX_TASK_RUNS_PER_BURST times within one burst is an
+  // infinite update loop; finite batches (even huge ones) never re-run a
+  // scheduler, so they are never subject to a total-size ceiling.
+  runCounts: Map<UpdateScheduler, number>;
   isScheduled: boolean;
 };
 
-// Maximum number of tasks a single flush pass may run. Large legitimate
-// batches (e.g. hundreds of resources mounting in one update) exceed this
-// easily, so overflowing work is deferred to follow-up passes instead of
-// being dropped.
-const MAX_FLUSH_LIMIT = 50;
-// Guard against true infinite update loops (a resource that re-dirties
-// itself on every run): if this many consecutive passes stay saturated
-// without the queue ever draining, give up and throw.
-const MAX_SATURATED_FLUSH_PASSES = 100;
-let flushState: GlobalFlushState = {
+const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  runCounts: new Map(),
   isScheduled: false,
-};
-let saturatedFlushPasses = 0;
+});
+
+// Maximum number of tasks a single flush pass may run. Bounds the work done
+// in one macrotask and, because Set iteration also visits schedulers
+// re-added mid-pass, prevents an infinite loop from hanging a single pass.
+const MAX_FLUSH_LIMIT = 50;
+// Guard against true infinite update loops: a resource that keeps
+// re-dirtying itself (or a cycle of resources re-dirtying each other)
+// re-runs the same scheduler over and over within one burst.
+const MAX_TASK_RUNS_PER_BURST = 50;
+let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
   private _isDirty = false;
@@ -52,7 +58,9 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-const flushScheduled = () => {
+// Runs at most MAX_FLUSH_LIMIT tasks from flushState.schedulers. Throws on
+// task errors (discarding the rest of the batch) and on infinite loops.
+const runFlushPass = () => {
   const errors = [];
   let flushDepth = 0;
 
@@ -63,6 +71,16 @@ const flushScheduled = () => {
 
     flushDepth++;
 
+    const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
+    flushState.runCounts.set(scheduler, runs);
+    if (runs > MAX_TASK_RUNS_PER_BURST) {
+      flushState.schedulers.clear();
+      throw new Error(
+        `Maximum update depth exceeded. This can happen when a resource ` +
+          `repeatedly calls setState inside useEffect.`,
+      );
+    }
+
     try {
       scheduler.runTask();
     } catch (error) {
@@ -72,8 +90,6 @@ const flushScheduled = () => {
 
   if (errors.length > 0) {
     flushState.schedulers.clear();
-    flushState.isScheduled = false;
-    saturatedFlushPasses = 0;
     if (errors.length === 1) {
       throw errors[0];
     } else {
@@ -83,27 +99,28 @@ const flushScheduled = () => {
       throw new AggregateError(errors, "Errors occurred during flushSync");
     }
   }
+};
 
-  if (flushState.schedulers.size > 0) {
-    saturatedFlushPasses += 1;
-    if (saturatedFlushPasses >= MAX_SATURATED_FLUSH_PASSES) {
-      flushState.schedulers.clear();
+const flushScheduled = () => {
+  try {
+    runFlushPass();
+
+    if (flushState.schedulers.size > 0) {
+      // Large batches (e.g. hundreds of resources mounting in one update)
+      // overflow a single pass; defer the rest to a follow-up pass instead
+      // of dropping them.
       flushState.isScheduled = false;
-      saturatedFlushPasses = 0;
-      throw new Error(
-        `Maximum update depth exceeded. This can happen when a resource ` +
-          `repeatedly calls setState inside useEffect.`,
-      );
+      scheduleFlush();
+      return;
     }
-    // More work remains: continue draining in the next pass instead of
-    // dropping the pending updates.
-    flushState.isScheduled = false;
-    scheduleFlush();
-    return;
-  }
 
-  saturatedFlushPasses = 0;
-  flushState.isScheduled = false;
+    flushState.runCounts.clear();
+    flushState.isScheduled = false;
+  } catch (error) {
+    flushState.runCounts.clear();
+    flushState.isScheduled = false;
+    throw error;
+  }
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
@@ -137,14 +154,17 @@ const scheduleMacrotask = (() => {
 
 export const flushTapSync = <T>(callback: () => T): T => {
   const prev = flushState;
-  flushState = {
-    schedulers: new Set([]),
-    isScheduled: true,
-  };
+  flushState = newFlushState();
+  flushState.isScheduled = true;
 
   try {
     const value = callback();
-    flushScheduled();
+    // Synchronous callers rely on every notification having landed by the
+    // time this returns, so drain across passes until the queue is empty
+    // (or the loop guard fires) instead of deferring to a macrotask.
+    while (flushState.schedulers.size > 0) {
+      runFlushPass();
+    }
 
     return value;
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -19,8 +19,8 @@ const MAX_TASK_RUNS_PER_BURST = 50;
 // per-scheduler guard never trips); sized far above realistic bulk updates.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
 // Cap-aborts reschedule so oversized batches keep draining; after this many
-// consecutive saturated flushes the queue is dropped so a runaway cascade
-// terminates instead of chunking an infinite loop into macrotasks forever.
+// consecutive saturated flushes, auto-continuing stops so a runaway cascade
+// terminates (the queue is kept, never dropped).
 const MAX_CAP_STREAK = 10;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -94,12 +94,12 @@ const flushScheduled = () => {
     flushState.isScheduled = false;
     if (abort === "cap") {
       flushState.capStreak += 1;
-      if (flushState.capStreak > MAX_CAP_STREAK) {
-        flushState.schedulers.clear();
-        flushState.capStreak = 0;
-      } else {
+      if (flushState.capStreak <= MAX_CAP_STREAK) {
         scheduleFlush();
       }
+      // Past the streak: stop auto-continuing so a runaway cascade
+      // terminates — but keep the queue; the remainder drains on the next
+      // externally triggered flush instead of being dropped.
     } else {
       flushState.capStreak = 0;
       if (abort === "loop") {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,34 +2,18 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  // Queue size at the previous cap abort (Infinity before the first one).
-  lastCapQueueSize: number;
-  capStreak: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
-  lastCapQueueSize: Number.POSITIVE_INFINITY,
-  capStreak: 0,
   isScheduled: false,
 });
 
-// Per-scheduler re-runs catch resources that re-dirty themselves or each
-// other in a loop; a finite batch never re-runs one scheduler this often.
-// (createTapRoot allocates a fresh UpdateScheduler per dispatch, so this
-// never fires for that root type - the burst cap is the guard there.)
-const MAX_TASK_RUNS_PER_BURST = 50;
-// A flush yields silently at this many tasks and continues on the next
-// macrotask, so oversized batches drain across flushes with no error. It is
-// also the hard ceiling for a single flushTapSync call, where there is no
-// next macrotask to yield to.
-const MAX_TOTAL_TASKS_PER_BURST = 10000;
-// "The queue did not shrink between cap aborts" is what cascade means for
-// the burst cap (a finite batch's queue always shrinks; a runaway's never
-// does). This many non-shrinking aborts in a row throws and stops
-// auto-continuing. Legitimate batches of any size never hit it.
-const MAX_CAP_STREAK = 3;
+// A scheduler re-run more than this many times in one flush is a resource
+// that keeps re-dirtying itself (or a cycle of resources re-dirtying each
+// other); the offender is dropped so the rest of the queue keeps flushing.
+const MAX_TASK_RUNS_PER_FLUSH = 50;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -64,33 +48,34 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Guards never lose queued work silently: the burst cap yields and
-// reschedules, so oversized batches drain across macrotasks with no error;
-// a cascade (queue not shrinking between cap aborts) throws after
-// MAX_CAP_STREAK and stops auto-continuing; a loop abort clears the queue,
-// which is the only way a mutually re-dirtying ring terminates.
-const flushScheduled = (defer = true): number => {
+// Drains flushState.schedulers completely. Set iteration also visits
+// schedulers re-added mid-pass, so bulk updates of any size land in a
+// single batch. Termination is guaranteed by the per-scheduler run guard:
+// every scheduler runs at most MAX_TASK_RUNS_PER_FLUSH times per flush.
+const flushScheduled = () => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
-  let taskCount = 0;
-  let abort: "cap" | "loop" | null = null;
+  let loopErrorReported = false;
 
   try {
     for (const scheduler of flushState.schedulers) {
-      if (taskCount >= MAX_TOTAL_TASKS_PER_BURST) {
-        abort = "cap";
-        break;
-      }
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
-      if (runs > MAX_TASK_RUNS_PER_BURST) {
-        abort = "loop";
-        break;
+      if (runs > MAX_TASK_RUNS_PER_FLUSH) {
+        if (!loopErrorReported) {
+          loopErrorReported = true;
+          errors.push(
+            new Error(
+              `Maximum update depth exceeded. This can happen when a resource ` +
+                `repeatedly calls setState inside useEffect.`,
+            ),
+          );
+        }
+        continue;
       }
       runCounts.set(scheduler, runs);
-      taskCount += 1;
 
       try {
         scheduler.runTask();
@@ -100,36 +85,6 @@ const flushScheduled = (defer = true): number => {
     }
   } finally {
     flushState.isScheduled = false;
-  }
-
-  if (abort === "cap") {
-    const remaining = flushState.schedulers.size;
-    flushState.capStreak =
-      remaining >= flushState.lastCapQueueSize ? flushState.capStreak + 1 : 0;
-    flushState.lastCapQueueSize = remaining;
-    if (flushState.capStreak > MAX_CAP_STREAK) {
-      // Runaway cascade: report once and stop auto-continuing, but keep the
-      // queue and judge the next burst fresh (no latched streak).
-      flushState.capStreak = 0;
-      flushState.lastCapQueueSize = Number.POSITIVE_INFINITY;
-      throw new Error(
-        `Maximum update depth exceeded. This can happen when a resource ` +
-          `repeatedly calls setState inside useEffect.`,
-      );
-    }
-    if (defer) {
-      scheduleFlush();
-    }
-  } else {
-    flushState.capStreak = 0;
-    flushState.lastCapQueueSize = Number.POSITIVE_INFINITY;
-    if (abort === "loop") {
-      flushState.schedulers.clear();
-      throw new Error(
-        `Maximum update depth exceeded. This can happen when a resource ` +
-          `repeatedly calls setState inside useEffect.`,
-      );
-    }
   }
 
   if (errors.length > 0) {
@@ -142,8 +97,6 @@ const flushScheduled = (defer = true): number => {
       throw new AggregateError(errors, "Errors occurred during flushSync");
     }
   }
-
-  return taskCount;
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
@@ -182,20 +135,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
   try {
     const value = callback();
-    // Synchronous callers rely on every notification having landed by the
-    // time this returns, so drain across passes until the queue is empty.
-    // There is no next macrotask to yield to here, so the burst cap is a
-    // hard ceiling instead of a yield boundary.
-    let total = 0;
-    while (flushState.schedulers.size > 0) {
-      total += flushScheduled(false);
-      if (total > MAX_TOTAL_TASKS_PER_BURST) {
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
-      }
-    }
+    flushScheduled();
 
     return value;
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,9 +2,6 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  // How often each scheduler has run, and how many tasks have run in total,
-  // since the queue last drained. Cleared whenever a flush finishes, whether
-  // it drained or aborted on a guard.
   runCounts: Map<UpdateScheduler, number>;
   taskCount: number;
   isScheduled: boolean;
@@ -17,19 +14,11 @@ const newFlushState = (): GlobalFlushState => ({
   isScheduled: false,
 });
 
-// Per-scheduler loop guard: a scheduler re-run more than this many times
-// within a single burst (before the queue ever drains) is a resource that
-// keeps re-dirtying itself, or a cycle of resources re-dirtying each other.
-// Finite batches never hit this regardless of size, because every scheduler
-// in them runs a bounded number of times. The bound is real, though: a
-// genuinely self-dependent cascade deeper than this many re-runs in one
-// burst (each run queueing the same scheduler again) is indistinguishable
-// from a loop and will also throw.
+// Per-scheduler re-runs catch resources that re-dirty themselves or each
+// other in a loop; a finite batch never re-runs one scheduler this often.
 const MAX_TASK_RUNS_PER_BURST = 50;
-// Burst-wide backstop: a cascade that keeps queueing NEW schedulers never
-// trips the per-scheduler guard (each instance runs once), so without a
-// total cap it would monopolize the macrotask forever. Sized far above any
-// realistic bulk update; only a genuinely unbounded cascade reaches it.
+// Backstop for cascades of FRESH schedulers (each runs once, so the
+// per-scheduler guard never trips); sized far above realistic bulk updates.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -65,36 +54,32 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Drains flushState.schedulers completely. Set iteration also visits
-// schedulers re-added mid-pass, so bulk updates of any size land in a
-// single batch (one React commit, no intermediate paints). A pass always
-// terminates: the per-scheduler guard bounds re-runs of one scheduler, and
-// the burst-wide task cap bounds cascades of fresh ones, so a pass executes
-// at most MAX_TOTAL_TASKS_PER_BURST tasks.
+// Guards throw loudly but never drop queued work: the remainder stays
+// queued and continues on the next flush.
 const flushScheduled = () => {
   const errors: unknown[] = [];
 
   try {
     for (const scheduler of flushState.schedulers) {
+      if (flushState.taskCount >= MAX_TOTAL_TASKS_PER_BURST) {
+        throw new Error(
+          `Maximum update depth exceeded. This can happen when a resource ` +
+            `repeatedly calls setState inside useEffect.`,
+        );
+      }
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
-      flushState.taskCount += 1;
-      if (flushState.taskCount > MAX_TOTAL_TASKS_PER_BURST) {
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
-      }
-
       const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
-      flushState.runCounts.set(scheduler, runs);
       if (runs > MAX_TASK_RUNS_PER_BURST) {
+        flushState.schedulers.add(scheduler);
         throw new Error(
           `Maximum update depth exceeded. This can happen when a resource ` +
             `repeatedly calls setState inside useEffect.`,
         );
       }
+      flushState.runCounts.set(scheduler, runs);
+      flushState.taskCount += 1;
 
       try {
         scheduler.runTask();
@@ -102,9 +87,12 @@ const flushScheduled = () => {
         errors.push(error);
       }
     }
-  } finally {
-    flushState.schedulers.clear();
+
     flushState.runCounts.clear();
+    if (errors.length > 0) {
+      flushState.schedulers.clear();
+    }
+  } finally {
     flushState.taskCount = 0;
     flushState.isScheduled = false;
   }

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -4,12 +4,14 @@ type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
   // Tasks run since the queue last drained, across chunked passes.
   burstTaskTotal: number;
+  burstDepthReported: boolean;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
   burstTaskTotal: 0,
+  burstDepthReported: false,
   isScheduled: false,
 });
 
@@ -21,13 +23,14 @@ const MAX_TASK_RUNS_PER_FLUSH = 50;
 // oversized batches chunk across macrotasks instead of blocking. ~1.5x
 // the motivating repro (one 200-message history page ~= 600 resources).
 const MAX_TASKS_PER_FLUSH = 1000;
-// Last-resort termination, documented as the real bound: nothing can
-// distinguish a huge finite cascade from an infinite one, so a burst that
-// runs more than this many tasks in total (~80x the repro, ~= 16000
-// messages in one update) is declared a loop and reported. The queue is
-// never dropped; a stalled remainder continues on the next triggered
-// flush.
-const MAX_BURST_TASKS = 50000;
+// Last-resort bound, documented as the real line: nothing can distinguish
+// a huge finite cascade from an infinite one, so a burst running more
+// than this many tasks total (~8x the 600-resource repro, ~= 1600
+// messages in one update) is REPORTED once as a likely loop - and then
+// keeps chunking anyway: a finite batch that large still completes, an
+// infinite one degrades to background work with a loud error in the
+// console. The queue is never dropped and never stalled.
+const MAX_BURST_TASKS = 5000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -48,6 +51,11 @@ export class UpdateScheduler {
 
     flushState.schedulers.add(this);
     scheduleFlush();
+  }
+
+  /** @internal Called when the run guard drops a scheduler, so the root is not left permanently dirty (which would suppress its own publishing). */
+  clearDirty() {
+    this._isDirty = false;
   }
 
   runTask() {
@@ -95,12 +103,10 @@ export const throwCollectedErrors = (
 // re-added mid-pass, so bulk updates of any size land in a single batch)
 // and appends failures to `errors` instead of throwing.
 //
-// The re-run guard has two modes by necessity: on the macrotask path the
-// offender is SKIPPED and retried next pass (a deep-but-finite cascade
-// still finishes; a true loop burns MAX_TASK_RUNS_PER_FLUSH runs and
-// reports once per pass); inside flushTapSync there is no next pass, so
-// the caller shares one runCounts map across passes and the offender is
-// DROPPED at the limit, terminating the drain at ~50 runs like main.
+// The re-run guard DROPS a scheduler that exceeds MAX_TASK_RUNS_PER_FLUSH
+// runs in one burst (a genuine update loop), on every path; inside
+// flushTapSync the caller shares one runCounts map across passes so the
+// budget is per logical flush, not per call.
 const flushScheduled = (
   errors: CollectedErrors,
   defer = true,
@@ -124,10 +130,12 @@ const flushScheduled = (
       }
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
+        // Dropped on every path (and left clean, not dirty): a resource
+        // re-dirtying itself this often in one burst is a genuine loop,
+        // and keeping it queued taxes every future flush.
         reportDepthError(errors);
-        if (shared) {
-          flushState.schedulers.delete(scheduler);
-        }
+        flushState.schedulers.delete(scheduler);
+        scheduler.clearDirty();
         continue;
       }
       flushState.schedulers.delete(scheduler);
@@ -155,16 +163,17 @@ const flushScheduled = (
       flushState.isScheduled = false;
       if (!hitCeiling) {
         flushState.burstTaskTotal = 0;
+        flushState.burstDepthReported = false;
       } else {
         flushState.burstTaskTotal += taskCount;
-        if (flushState.burstTaskTotal > MAX_BURST_TASKS) {
-          // Runaway: report and stop auto-continuing. The queue is kept.
-          flushState.burstTaskTotal = 0;
+        if (
+          flushState.burstTaskTotal > MAX_BURST_TASKS &&
+          !flushState.burstDepthReported
+        ) {
+          flushState.burstDepthReported = true;
           reportDepthError(errors);
-        } else {
-          // Oversized but under the bound: chunk on, silently.
-          scheduleFlush();
         }
+        scheduleFlush();
       }
     }
   }

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,12 +2,15 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  // Queue size at the previous cap abort (Infinity before the first one).
+  lastCapQueueSize: number;
   capStreak: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  lastCapQueueSize: Number.POSITIVE_INFINITY,
   capStreak: 0,
   isScheduled: false,
 });
@@ -15,15 +18,14 @@ const newFlushState = (): GlobalFlushState => ({
 // Per-scheduler re-runs catch resources that re-dirty themselves or each
 // other in a loop; a finite batch never re-runs one scheduler this often.
 const MAX_TASK_RUNS_PER_BURST = 50;
-// Backstop for cascades of FRESH schedulers (each runs once, so the
-// per-scheduler guard never trips). A flush yields silently at this many
-// tasks and continues on the next macrotask, so oversized batches drain
-// without errors; only MAX_CAP_STREAK consecutive saturated flushes are
-// treated as a runaway.
+// A flush yields silently at this many tasks and continues on the next
+// macrotask, so oversized batches drain across flushes with no error.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
-// "Saturated this many flushes in a row" is what loop means for the burst
-// cap: stop auto-continuing and throw. The queue is kept — never dropped.
-const MAX_CAP_STREAK = 10;
+// "The queue did not shrink between cap aborts" is what cascade means for
+// the burst cap (a finite batch's queue always shrinks; a runaway's never
+// does). This many non-shrinking aborts in a row throws and stops
+// auto-continuing. Legitimate batches of any size never hit it.
+const MAX_CAP_STREAK = 3;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -58,11 +60,11 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Guards never drop queued work. The burst-wide cap yields silently and
+// Guards never lose queued work silently: the burst cap yields and
 // reschedules, so oversized batches drain across macrotasks with no error;
-// only MAX_CAP_STREAK saturated flushes in a row (a runaway) throws and
-// stops auto-continuing. A looping scheduler is dropped so the rest of the
-// app keeps flushing.
+// a cascade (queue not shrinking between cap aborts) throws after
+// MAX_CAP_STREAK and stops auto-continuing; a loop abort clears the queue,
+// which is the only way a mutually re-dirtying ring terminates.
 const flushScheduled = () => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
@@ -97,19 +99,26 @@ const flushScheduled = () => {
   }
 
   if (abort === "cap") {
-    flushState.capStreak += 1;
-    if (flushState.capStreak <= MAX_CAP_STREAK) {
-      scheduleFlush();
-    } else {
+    const remaining = flushState.schedulers.size;
+    flushState.capStreak =
+      remaining >= flushState.lastCapQueueSize ? flushState.capStreak + 1 : 0;
+    flushState.lastCapQueueSize = remaining;
+    if (flushState.capStreak > MAX_CAP_STREAK) {
+      // Runaway cascade: report once and stop auto-continuing, but keep the
+      // queue and judge the next burst fresh (no latched streak).
+      flushState.capStreak = 0;
+      flushState.lastCapQueueSize = Number.POSITIVE_INFINITY;
       throw new Error(
         `Maximum update depth exceeded. This can happen when a resource ` +
           `repeatedly calls setState inside useEffect.`,
       );
     }
+    scheduleFlush();
   } else {
     flushState.capStreak = 0;
+    flushState.lastCapQueueSize = Number.POSITIVE_INFINITY;
     if (abort === "loop") {
-      scheduleFlush();
+      flushState.schedulers.clear();
       throw new Error(
         `Maximum update depth exceeded. This can happen when a resource ` +
           `repeatedly calls setState inside useEffect.`,
@@ -165,7 +174,13 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
   try {
     const value = callback();
-    flushScheduled();
+    // Synchronous callers rely on every notification having landed by the
+    // time this returns, so drain across passes until the queue is empty.
+    // A cascade still throws via the guards above rather than deferring to
+    // a macrotask that would outlive this temporary flushState.
+    while (flushState.schedulers.size > 0) {
+      flushScheduled();
+    }
 
     return value;
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -102,9 +102,14 @@ export const throwCollectedErrors = (
 const flushScheduled = (
   errors: CollectedErrors,
   defer = true,
-  sharedRunCounts?: Map<UpdateScheduler, number>,
+  shared?: {
+    runCounts: Map<UpdateScheduler, number>;
+    seenErrors: Map<UpdateScheduler, Set<string>>;
+  },
 ): number => {
-  const runCounts = sharedRunCounts ?? new Map<UpdateScheduler, number>();
+  const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
+  const seenErrors =
+    shared?.seenErrors ?? new Map<UpdateScheduler, Set<string>>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -132,7 +137,15 @@ const flushScheduled = (
       try {
         scheduler.runTask();
       } catch (error) {
-        errors.push(error);
+        // A deterministically re-throwing task can't flood the batch with
+        // copies of the same failure.
+        const message = error instanceof Error ? error.message : String(error);
+        const seen = seenErrors.get(scheduler) ?? new Set<string>();
+        if (!seen.has(message)) {
+          seen.add(message);
+          seenErrors.set(scheduler, seen);
+          errors.push(error);
+        }
       }
     }
   } finally {
@@ -141,10 +154,13 @@ const flushScheduled = (
       if (hitCeiling) {
         flushState.saturatedStreak += 1;
         if (flushState.saturatedStreak === MAX_SATURATED_STREAK + 1) {
-          // Likely a loop: report ONCE, then keep chunking anyway - a
-          // finite batch this large still completes, an infinite one
-          // degrades to background work with the error in the console.
-          reportDepthError(errors);
+          // Likely a loop - but saturation can't prove it, so this is a
+          // diagnostic, not an exception: a finite batch this large must
+          // still complete with zero thrown errors.
+          console.warn(
+            "Maximum update depth exceeded. This can happen when a resource " +
+              "repeatedly calls setState inside useEffect.",
+          );
         }
         scheduleFlush();
       } else {
@@ -201,21 +217,26 @@ export const flushTapSync = <T>(callback: () => T): T => {
     const value = callback();
     // Synchronous callers rely on every notification having landed by the
     // time this returns, so drain across passes until the queue is empty.
-    // sharedRunCounts makes the re-run budget per logical flush, not per
-    // pass (a looping scheduler is dropped at ~MAX_TASK_RUNS_PER_FLUSH
-    // total runs, like main).
+    // shared runCounts/seenErrors make the re-run budget and error dedupe
+    // per logical flush, not per pass (a looping scheduler is dropped at
+    // ~MAX_TASK_RUNS_PER_FLUSH total runs, like main).
     const errors: CollectedErrors = [];
-    const sharedRunCounts = new Map<UpdateScheduler, number>();
+    const shared = {
+      runCounts: new Map<UpdateScheduler, number>(),
+      seenErrors: new Map<UpdateScheduler, Set<string>>(),
+    };
     let total = 0;
     while (flushState.schedulers.size > 0) {
       if (total > MAX_SYNC_TASKS) {
-        reportDepthError(errors);
+        // A sync batch this large defers the remainder to the outer state
+        // instead of blocking (or erroring - the work is fine, it just
+        // can't all land synchronously).
         for (const scheduler of flushState.schedulers) {
           leftover.push(scheduler);
         }
         break;
       }
-      total += flushScheduled(errors, false, sharedRunCounts);
+      total += flushScheduled(errors, false, shared);
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -18,14 +18,16 @@ const newFlushState = (): GlobalFlushState => ({
 // other); the offender is dropped so the rest of the queue keeps flushing.
 const MAX_TASK_RUNS_PER_FLUSH = 50;
 // A pass yields at this many tasks and continues on the next flush, so
-// oversized batches chunk across macrotasks instead of blocking.
-const MAX_TASKS_PER_FLUSH = 50000;
+// oversized batches chunk across macrotasks instead of blocking. ~1.5x
+// the motivating repro (one 200-message history page ~= 600 resources).
+const MAX_TASKS_PER_FLUSH = 1000;
 // Last-resort termination, documented as the real bound: nothing can
 // distinguish a huge finite cascade from an infinite one, so a burst that
-// runs more than this many tasks in total (~100x any realistic bulk
-// update) is declared a loop and reported. The queue is never dropped; a
-// stalled remainder continues on the next triggered flush.
-const MAX_BURST_TASKS = 500000;
+// runs more than this many tasks in total (~33x the repro, ~= 6600
+// messages in one update) is declared a loop and reported. The queue is
+// never dropped; a stalled remainder continues on the next triggered
+// flush.
+const MAX_BURST_TASKS = 20000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -46,11 +48,6 @@ export class UpdateScheduler {
 
     flushState.schedulers.add(this);
     scheduleFlush();
-  }
-
-  /** @internal Called when the run guard drops a scheduler, so the root is not left permanently dirty (which would stall its own publishing). */
-  clearDirty() {
-    this._isDirty = false;
   }
 
   runTask() {
@@ -79,7 +76,10 @@ const reportDepthError = (errors: CollectedErrors) => {
   errors.push(newDepthError());
 };
 
-export const throwCollectedErrors = (errors: unknown[]): void => {
+export const throwCollectedErrors = (
+  errors: unknown[],
+  context = "Errors occurred during flushSync",
+): void => {
   if (errors.length === 1) {
     throw errors[0];
   }
@@ -87,7 +87,7 @@ export const throwCollectedErrors = (errors: unknown[]): void => {
     for (const error of errors) {
       console.error(error);
     }
-    throw new AggregateError(errors, "Errors occurred during flushSync");
+    throw new AggregateError(errors, context);
   }
 };
 
@@ -99,7 +99,7 @@ export const throwCollectedErrors = (errors: unknown[]): void => {
 // tasks, keeping the remainder queued for the next triggered flush.
 const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   const runCounts = new Map<UpdateScheduler, number>();
-  const errorContributors = new Set<UpdateScheduler>();
+  const errorContributors = new Map<UpdateScheduler, Set<string>>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -110,28 +110,31 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
         hitCeiling = true;
         break;
       }
-      flushState.schedulers.delete(scheduler);
-      if (!scheduler.isDirty) continue;
-
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
+        // Skipped, not dropped: the offender stays queued and is retried
+        // next pass, so a deep-but-finite cascade still finishes while a
+        // true loop just burns MAX_TASK_RUNS_PER_FLUSH runs per pass and
+        // reports each time.
         reportDepthError(errors);
-        // Dropped, but not left dirty: a stale isDirty would stall the
-        // root's own publishing and re-burn 50 runs on every later
-        // markDirty.
-        scheduler.clearDirty();
         continue;
       }
+      flushState.schedulers.delete(scheduler);
+      if (!scheduler.isDirty) continue;
       runCounts.set(scheduler, runs);
       taskCount += 1;
 
       try {
         scheduler.runTask();
       } catch (error) {
-        // A task that throws deterministically on every re-run contributes
-        // one entry, without hiding a different scheduler's failure.
-        if (!errorContributors.has(scheduler)) {
-          errorContributors.add(scheduler);
+        // One entry per (scheduler, message): a deterministically
+        // re-throwing task can't flood the batch, and two different
+        // failures - even with the same message - both surface.
+        const message = error instanceof Error ? error.message : String(error);
+        const seen = errorContributors.get(scheduler) ?? new Set<string>();
+        if (!seen.has(message)) {
+          seen.add(message);
+          errorContributors.set(scheduler, seen);
           errors.push(error);
         }
       }
@@ -198,17 +201,19 @@ export const flushTapSync = <T>(callback: () => T): T => {
   flushState = newFlushState();
   flushState.isScheduled = true;
 
+  const leftover: UpdateScheduler[] = [];
   try {
     const value = callback();
     // Synchronous callers rely on every notification having landed by the
     // time this returns, so drain across passes until the queue is empty;
-    // a runaway is bounded by the same task ceiling (checked before each
-    // pass, so finite batches always finish first).
+    // the burst bound only fires for a runaway, whose remainder is handed
+    // back to the outer state (see finally) rather than orphaned.
     const errors: CollectedErrors = [];
     let total = 0;
     while (flushState.schedulers.size > 0) {
       if (total > MAX_BURST_TASKS) {
         reportDepthError(errors);
+        leftover.push(...flushState.schedulers);
         break;
       }
       total += flushScheduled(errors, false);
@@ -218,5 +223,11 @@ export const flushTapSync = <T>(callback: () => T): T => {
     return value;
   } finally {
     flushState = prev;
+    for (const scheduler of leftover) {
+      prev.schedulers.add(scheduler);
+    }
+    if (leftover.length > 0) {
+      scheduleFlush();
+    }
   }
 };

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -3,9 +3,10 @@ type Task = () => void;
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
   // How often each scheduler has run since the queue last drained. A
-  // scheduler re-run MAX_TASK_RUNS_PER_BURST times within one burst is an
-  // infinite update loop; finite batches (even huge ones) never re-run a
-  // scheduler, so they are never subject to a total-size ceiling.
+  // scheduler re-run more than MAX_TASK_RUNS_PER_BURST times within one
+  // burst is an infinite update loop; finite batches (even huge ones)
+  // never re-run a scheduler, so they are never subject to a total-size
+  // ceiling.
   runCounts: Map<UpdateScheduler, number>;
   isScheduled: boolean;
 };
@@ -22,7 +23,7 @@ const newFlushState = (): GlobalFlushState => ({
 const MAX_FLUSH_LIMIT = 50;
 // Guard against true infinite update loops: a resource that keeps
 // re-dirtying itself (or a cycle of resources re-dirtying each other)
-// re-runs the same scheduler over and over within one burst.
+// re-runs the same scheduler more than this many times within one burst.
 const MAX_TASK_RUNS_PER_BURST = 50;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -61,7 +62,7 @@ const scheduleFlush = () => {
 // Runs at most MAX_FLUSH_LIMIT tasks from flushState.schedulers. Throws on
 // task errors (discarding the rest of the batch) and on infinite loops.
 const runFlushPass = () => {
-  const errors = [];
+  const errors: unknown[] = [];
   let flushDepth = 0;
 
   for (const scheduler of flushState.schedulers) {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,11 +2,8 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  // How often each scheduler has run since the queue last drained. A
-  // scheduler re-run more than MAX_TASK_RUNS_PER_BURST times within one
-  // burst is an infinite update loop; finite batches (even huge ones)
-  // never re-run a scheduler, so they are never subject to a total-size
-  // ceiling.
+  // How often each scheduler has run since the queue last drained.
+  // Reset whenever a flush fully drains.
   runCounts: Map<UpdateScheduler, number>;
   isScheduled: boolean;
 };
@@ -17,13 +14,14 @@ const newFlushState = (): GlobalFlushState => ({
   isScheduled: false,
 });
 
-// Maximum number of tasks a single flush pass may run. Bounds the work done
-// in one macrotask and, because Set iteration also visits schedulers
-// re-added mid-pass, prevents an infinite loop from hanging a single pass.
-const MAX_FLUSH_LIMIT = 50;
-// Guard against true infinite update loops: a resource that keeps
-// re-dirtying itself (or a cycle of resources re-dirtying each other)
-// re-runs the same scheduler more than this many times within one burst.
+// Infinite-loop guard: a scheduler re-run more than this many times within
+// a single burst (before the queue ever drains) is a resource that keeps
+// re-dirtying itself, or a cycle of resources re-dirtying each other.
+// Finite batches never hit this regardless of size, because every scheduler
+// in them runs a bounded number of times. The bound is real, though: a
+// genuinely self-dependent cascade deeper than this many re-runs in one
+// burst (each run queueing the same scheduler again) is indistinguishable
+// from a loop and will also throw.
 const MAX_TASK_RUNS_PER_BURST = 50;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -59,38 +57,42 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Runs at most MAX_FLUSH_LIMIT tasks from flushState.schedulers. Throws on
-// task errors (discarding the rest of the batch) and on infinite loops.
-const runFlushPass = () => {
+// Drains flushState.schedulers completely. Set iteration also visits
+// schedulers re-added mid-pass, so bulk updates of any size land in a
+// single batch (one React commit, no intermediate paints). Termination is
+// guaranteed by the per-scheduler run guard: every scheduler runs at most
+// MAX_TASK_RUNS_PER_BURST times, so a pass executes at most
+// (distinct schedulers) x MAX_TASK_RUNS_PER_BURST tasks.
+const flushScheduled = () => {
   const errors: unknown[] = [];
-  let flushDepth = 0;
 
-  for (const scheduler of flushState.schedulers) {
-    if (flushDepth >= MAX_FLUSH_LIMIT) break;
-    flushState.schedulers.delete(scheduler);
-    if (!scheduler.isDirty) continue;
+  try {
+    for (const scheduler of flushState.schedulers) {
+      flushState.schedulers.delete(scheduler);
+      if (!scheduler.isDirty) continue;
 
-    flushDepth++;
+      const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
+      flushState.runCounts.set(scheduler, runs);
+      if (runs > MAX_TASK_RUNS_PER_BURST) {
+        throw new Error(
+          `Maximum update depth exceeded. This can happen when a resource ` +
+            `repeatedly calls setState inside useEffect.`,
+        );
+      }
 
-    const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
-    flushState.runCounts.set(scheduler, runs);
-    if (runs > MAX_TASK_RUNS_PER_BURST) {
-      flushState.schedulers.clear();
-      throw new Error(
-        `Maximum update depth exceeded. This can happen when a resource ` +
-          `repeatedly calls setState inside useEffect.`,
-      );
+      try {
+        scheduler.runTask();
+      } catch (error) {
+        errors.push(error);
+      }
     }
-
-    try {
-      scheduler.runTask();
-    } catch (error) {
-      errors.push(error);
-    }
+  } finally {
+    flushState.schedulers.clear();
+    flushState.runCounts.clear();
+    flushState.isScheduled = false;
   }
 
   if (errors.length > 0) {
-    flushState.schedulers.clear();
     if (errors.length === 1) {
       throw errors[0];
     } else {
@@ -99,28 +101,6 @@ const runFlushPass = () => {
       }
       throw new AggregateError(errors, "Errors occurred during flushSync");
     }
-  }
-};
-
-const flushScheduled = () => {
-  try {
-    runFlushPass();
-
-    if (flushState.schedulers.size > 0) {
-      // Large batches (e.g. hundreds of resources mounting in one update)
-      // overflow a single pass; defer the rest to a follow-up pass instead
-      // of dropping them.
-      flushState.isScheduled = false;
-      scheduleFlush();
-      return;
-    }
-
-    flushState.runCounts.clear();
-    flushState.isScheduled = false;
-  } catch (error) {
-    flushState.runCounts.clear();
-    flushState.isScheduled = false;
-    throw error;
   }
 };
 
@@ -160,12 +140,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
 
   try {
     const value = callback();
-    // Synchronous callers rely on every notification having landed by the
-    // time this returns, so drain across passes until the queue is empty
-    // (or the loop guard fires) instead of deferring to a macrotask.
-    while (flushState.schedulers.size > 0) {
-      runFlushPass();
-    }
+    flushScheduled();
 
     return value;
   } finally {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,27 +2,35 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  // How often each scheduler has run since the queue last drained.
-  // Reset whenever a flush fully drains.
+  // How often each scheduler has run, and how many tasks have run in total,
+  // since the queue last drained. Cleared whenever a flush finishes, whether
+  // it drained or aborted on a guard.
   runCounts: Map<UpdateScheduler, number>;
+  taskCount: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
   runCounts: new Map(),
+  taskCount: 0,
   isScheduled: false,
 });
 
-// Infinite-loop guard: a scheduler re-run more than this many times within
-// a single burst (before the queue ever drains) is a resource that keeps
-// re-dirtying itself, or a cycle of resources re-dirtying each other.
+// Per-scheduler loop guard: a scheduler re-run more than this many times
+// within a single burst (before the queue ever drains) is a resource that
+// keeps re-dirtying itself, or a cycle of resources re-dirtying each other.
 // Finite batches never hit this regardless of size, because every scheduler
 // in them runs a bounded number of times. The bound is real, though: a
 // genuinely self-dependent cascade deeper than this many re-runs in one
 // burst (each run queueing the same scheduler again) is indistinguishable
 // from a loop and will also throw.
 const MAX_TASK_RUNS_PER_BURST = 50;
+// Burst-wide backstop: a cascade that keeps queueing NEW schedulers never
+// trips the per-scheduler guard (each instance runs once), so without a
+// total cap it would monopolize the macrotask forever. Sized far above any
+// realistic bulk update; only a genuinely unbounded cascade reaches it.
+const MAX_TOTAL_TASKS_PER_BURST = 10000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -59,10 +67,10 @@ const scheduleFlush = () => {
 
 // Drains flushState.schedulers completely. Set iteration also visits
 // schedulers re-added mid-pass, so bulk updates of any size land in a
-// single batch (one React commit, no intermediate paints). Termination is
-// guaranteed by the per-scheduler run guard: every scheduler runs at most
-// MAX_TASK_RUNS_PER_BURST times, so a pass executes at most
-// (distinct schedulers) x MAX_TASK_RUNS_PER_BURST tasks.
+// single batch (one React commit, no intermediate paints). A pass always
+// terminates: the per-scheduler guard bounds re-runs of one scheduler, and
+// the burst-wide task cap bounds cascades of fresh ones, so a pass executes
+// at most MAX_TOTAL_TASKS_PER_BURST tasks.
 const flushScheduled = () => {
   const errors: unknown[] = [];
 
@@ -70,6 +78,14 @@ const flushScheduled = () => {
     for (const scheduler of flushState.schedulers) {
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
+
+      flushState.taskCount += 1;
+      if (flushState.taskCount > MAX_TOTAL_TASKS_PER_BURST) {
+        throw new Error(
+          `Maximum update depth exceeded. This can happen when a resource ` +
+            `repeatedly calls setState inside useEffect.`,
+        );
+      }
 
       const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
       flushState.runCounts.set(scheduler, runs);
@@ -89,6 +105,7 @@ const flushScheduled = () => {
   } finally {
     flushState.schedulers.clear();
     flushState.runCounts.clear();
+    flushState.taskCount = 0;
     flushState.isScheduled = false;
   }
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -126,7 +126,10 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
         // it so its task drains the stranded queue consistently.
         reportDepthError(errors);
         flushState.schedulers.delete(scheduler);
-        runCounts.delete(scheduler);
+        // The count is kept (not deleted): re-queueing the offender later
+        // in the same burst must not hand it a fresh budget - it is
+        // dropped again immediately, without burning another 50 runs.
+        // Counts reset only when a pass drains the queue.
         continue;
       }
       flushState.schedulers.delete(scheduler);

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,6 +2,11 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  // Per-scheduler run counts and reported errors for the CURRENT burst
+  // (between two drained passes), so the re-run budget and error dedupe
+  // are per logical flush on every path - not per pass.
+  runCounts: Map<UpdateScheduler, number>;
+  seenErrors: Map<UpdateScheduler, Set<string>>;
   // Consecutive saturated (ceiling-hitting) passes; reset when a pass
   // drains the queue.
   saturatedStreak: number;
@@ -10,6 +15,8 @@ type GlobalFlushState = {
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  runCounts: new Map(),
+  seenErrors: new Map(),
   saturatedStreak: 0,
   isScheduled: false,
 });
@@ -17,22 +24,22 @@ const newFlushState = (): GlobalFlushState => ({
 // A scheduler re-run more than this many times in one flush is a resource
 // that keeps re-dirtying itself (or a cycle of resources re-dirtying each
 // other); the offender is dropped so the rest of the queue keeps flushing.
-const MAX_TASK_RUNS_PER_FLUSH = 50;
+export const MAX_TASK_RUNS_PER_FLUSH = 50;
 // A pass yields at this many tasks and continues on the next flush, so
 // oversized batches chunk across macrotasks instead of blocking. ~1.5x
 // the motivating repro (one 200-message history page ~= 600 resources).
-const MAX_TASKS_PER_FLUSH = 1000;
+export const MAX_TASKS_PER_FLUSH = 1000;
 // flushTapSync-only hard bound: a synchronous drain cannot defer, so an
 // unbounded batch (e.g. fresh schedulers minted mid-drain, which the
 // re-run guard cannot see) must be cut somewhere. ~8x the repro; the
 // remainder is handed to the outer state and continues there.
-const MAX_SYNC_TASKS = 5000;
+export const MAX_SYNC_TASKS = 5000;
 // A runaway minting fresh schedulers saturates EVERY pass, while a finite
 // batch's last pass is always partial. After this many saturated passes
 // in a row (x MAX_TASKS_PER_FLUSH tasks) the burst is reported once as a
 // likely loop - and keeps chunking anyway, so even oversized finite
 // batches complete. The queue is never dropped or stalled.
-const MAX_SATURATED_STREAK = 20;
+export const MAX_SATURATED_STREAK = 20;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -99,17 +106,9 @@ export const throwCollectedErrors = (
 // One flush pass over flushState.schedulers. Set iteration also visits
 // schedulers re-added mid-pass, so a batch of any size drains across
 // passes; failures are appended to `errors` for the caller to aggregate.
-const flushScheduled = (
-  errors: CollectedErrors,
-  defer = true,
-  shared?: {
-    runCounts: Map<UpdateScheduler, number>;
-    seenErrors: Map<UpdateScheduler, Set<string>>;
-  },
-): number => {
-  const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
-  const seenErrors =
-    shared?.seenErrors ?? new Map<UpdateScheduler, Set<string>>();
+const flushScheduled = (errors: CollectedErrors, defer = true): number => {
+  const runCounts = flushState.runCounts;
+  const seenErrors = flushState.seenErrors;
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -127,6 +126,7 @@ const flushScheduled = (
         // it so its task drains the stranded queue consistently.
         reportDepthError(errors);
         flushState.schedulers.delete(scheduler);
+        runCounts.delete(scheduler);
         continue;
       }
       flushState.schedulers.delete(scheduler);
@@ -164,6 +164,8 @@ const flushScheduled = (
         }
         scheduleFlush();
       } else {
+        flushState.runCounts.clear();
+        flushState.seenErrors.clear();
         flushState.saturatedStreak = 0;
       }
     }
@@ -217,14 +219,9 @@ export const flushTapSync = <T>(callback: () => T): T => {
     const value = callback();
     // Synchronous callers rely on every notification having landed by the
     // time this returns, so drain across passes until the queue is empty.
-    // shared runCounts/seenErrors make the re-run budget and error dedupe
-    // per logical flush, not per pass (a looping scheduler is dropped at
-    // ~MAX_TASK_RUNS_PER_FLUSH total runs, like main).
+    // The temporary flushState carries fresh run counts, so the re-run
+    // budget is per logical flush, like main.
     const errors: CollectedErrors = [];
-    const shared = {
-      runCounts: new Map<UpdateScheduler, number>(),
-      seenErrors: new Map<UpdateScheduler, Set<string>>(),
-    };
     let total = 0;
     while (flushState.schedulers.size > 0) {
       if (total > MAX_SYNC_TASKS) {
@@ -236,7 +233,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
         }
         break;
       }
-      total += flushScheduled(errors, false, shared);
+      total += flushScheduled(errors, false);
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -28,9 +28,10 @@ const MAX_TASKS_PER_FLUSH = 1000;
 // remainder is handed to the outer state and continues there.
 const MAX_SYNC_TASKS = 5000;
 // A runaway minting fresh schedulers saturates EVERY pass, while a finite
-// batch's last pass is always partial. This many saturated passes in a
-// row (x MAX_TASKS_PER_FLUSH tasks) declares a loop: report and stop
-// auto-continuing. The queue is kept, never dropped.
+// batch's last pass is always partial. After this many saturated passes
+// in a row (x MAX_TASKS_PER_FLUSH tasks) the burst is reported once as a
+// likely loop - and keeps chunking anyway, so even oversized finite
+// batches complete. The queue is never dropped or stalled.
 const MAX_SATURATED_STREAK = 20;
 let flushState: GlobalFlushState = newFlushState();
 
@@ -95,25 +96,15 @@ export const throwCollectedErrors = (
   }
 };
 
-// Drains flushState.schedulers (Set iteration also visits schedulers
-// re-added mid-pass, so bulk updates of any size land in a single batch)
-// and appends failures to `errors` instead of throwing.
-//
-// The re-run guard DROPS a scheduler that exceeds MAX_TASK_RUNS_PER_FLUSH
-// runs in one burst (a genuine update loop), on every path; inside
-// flushTapSync the caller shares one runCounts map across passes so the
-// budget is per logical flush, not per call.
+// One flush pass over flushState.schedulers. Set iteration also visits
+// schedulers re-added mid-pass, so a batch of any size drains across
+// passes; failures are appended to `errors` for the caller to aggregate.
 const flushScheduled = (
   errors: CollectedErrors,
   defer = true,
-  shared?: {
-    runCounts: Map<UpdateScheduler, number>;
-    errorContributors: Map<UpdateScheduler, Set<string>>;
-  },
+  sharedRunCounts?: Map<UpdateScheduler, number>,
 ): number => {
-  const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
-  const errorContributors =
-    shared?.errorContributors ?? new Map<UpdateScheduler, Set<string>>();
+  const runCounts = sharedRunCounts ?? new Map<UpdateScheduler, number>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -141,15 +132,7 @@ const flushScheduled = (
       try {
         scheduler.runTask();
       } catch (error) {
-        // A deterministically re-throwing task can't flood the batch with
-        // copies; a different failure (different message) still surfaces.
-        const message = error instanceof Error ? error.message : String(error);
-        const seen = errorContributors.get(scheduler) ?? new Set<string>();
-        if (!seen.has(message)) {
-          seen.add(message);
-          errorContributors.set(scheduler, seen);
-          errors.push(error);
-        }
+        errors.push(error);
       }
     }
   } finally {
@@ -157,12 +140,13 @@ const flushScheduled = (
       flushState.isScheduled = false;
       if (hitCeiling) {
         flushState.saturatedStreak += 1;
-        if (flushState.saturatedStreak > MAX_SATURATED_STREAK) {
-          flushState.saturatedStreak = 0;
+        if (flushState.saturatedStreak === MAX_SATURATED_STREAK + 1) {
+          // Likely a loop: report ONCE, then keep chunking anyway - a
+          // finite batch this large still completes, an infinite one
+          // degrades to background work with the error in the console.
           reportDepthError(errors);
-        } else {
-          scheduleFlush();
         }
+        scheduleFlush();
       } else {
         flushState.saturatedStreak = 0;
       }
@@ -216,18 +200,12 @@ export const flushTapSync = <T>(callback: () => T): T => {
   try {
     const value = callback();
     // Synchronous callers rely on every notification having landed by the
-    // time this returns, so drain across passes until the queue is empty;
-    // the burst bound only fires for a runaway, whose remainder is handed
-    // back to the outer state (see finally) rather than orphaned.
+    // time this returns, so drain across passes until the queue is empty.
+    // sharedRunCounts makes the re-run budget per logical flush, not per
+    // pass (a looping scheduler is dropped at ~MAX_TASK_RUNS_PER_FLUSH
+    // total runs, like main).
     const errors: CollectedErrors = [];
-    // One run budget for the whole sync drain: a looping scheduler is
-    // dropped at ~MAX_TASK_RUNS_PER_FLUSH total runs (like main), and the
-    // burst bound only fires for a runaway, whose remainder is handed
-    // back to the outer state (see finally) rather than orphaned.
-    const shared = {
-      runCounts: new Map<UpdateScheduler, number>(),
-      errorContributors: new Map<UpdateScheduler, Set<string>>(),
-    };
+    const sharedRunCounts = new Map<UpdateScheduler, number>();
     let total = 0;
     while (flushState.schedulers.size > 0) {
       if (total > MAX_SYNC_TASKS) {
@@ -237,7 +215,7 @@ export const flushTapSync = <T>(callback: () => T): T => {
         }
         break;
       }
-      total += flushScheduled(errors, false, shared);
+      total += flushScheduled(errors, false, sharedRunCounts);
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,11 +2,13 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
+  capStreak: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
+  capStreak: 0,
   isScheduled: false,
 });
 
@@ -16,6 +18,10 @@ const MAX_TASK_RUNS_PER_BURST = 50;
 // Backstop for cascades of FRESH schedulers (each runs once, so the
 // per-scheduler guard never trips); sized far above realistic bulk updates.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
+// Cap-aborts reschedule so oversized batches keep draining; after this many
+// consecutive saturated flushes the queue is dropped so a runaway cascade
+// terminates instead of chunking an infinite loop into macrotasks forever.
+const MAX_CAP_STREAK = 10;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -50,34 +56,30 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Guards throw loudly but never stall the queue: the burst-wide cap
-// reschedules so the remainder continues next flush; a looping scheduler
-// is dropped so the rest of the app keeps flushing.
+// Guards throw loudly but never stall the queue: a looping scheduler is
+// dropped so the rest of the app keeps flushing; the burst-wide cap
+// reschedules so oversized batches continue next flush, but gives up after
+// MAX_CAP_STREAK consecutive saturated flushes so a runaway cascade
+// terminates instead of hanging the tab.
 const flushScheduled = () => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
   let taskCount = 0;
-  let continueLater = false;
+  let abort: "cap" | "loop" | null = null;
 
   try {
     for (const scheduler of flushState.schedulers) {
       if (taskCount >= MAX_TOTAL_TASKS_PER_BURST) {
-        continueLater = true;
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
+        abort = "cap";
+        break;
       }
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_BURST) {
-        continueLater = true;
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
+        abort = "loop";
+        break;
       }
       runCounts.set(scheduler, runs);
       taskCount += 1;
@@ -90,9 +92,27 @@ const flushScheduled = () => {
     }
   } finally {
     flushState.isScheduled = false;
-    if (continueLater) {
-      scheduleFlush();
+    if (abort === "cap") {
+      flushState.capStreak += 1;
+      if (flushState.capStreak > MAX_CAP_STREAK) {
+        flushState.schedulers.clear();
+        flushState.capStreak = 0;
+      } else {
+        scheduleFlush();
+      }
+    } else {
+      flushState.capStreak = 0;
+      if (abort === "loop") {
+        scheduleFlush();
+      }
     }
+  }
+
+  if (abort !== null) {
+    throw new Error(
+      `Maximum update depth exceeded. This can happen when a resource ` +
+        `repeatedly calls setState inside useEffect.`,
+    );
   }
 
   if (errors.length > 0) {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -21,6 +21,10 @@ const MAX_TASK_RUNS_PER_FLUSH = 50;
 // depth error; the remainder stays queued (never dropped) and the next
 // triggered flush continues it.
 const MAX_TASKS_PER_FLUSH = 50000;
+// "The queue did not shrink between sync passes" is what runaway means for
+// a flushTapSync drain; this many in a row throws (finite batches always
+// shrink, so they never hit it).
+const MAX_CAP_STREAK = 3;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -41,6 +45,11 @@ export class UpdateScheduler {
 
     flushState.schedulers.add(this);
     scheduleFlush();
+  }
+
+  /** @internal Called when the run guard drops a scheduler, so the root is not left permanently dirty (which would stall its own publishing). */
+  clearDirty() {
+    this._isDirty = false;
   }
 
   runTask() {
@@ -89,6 +98,7 @@ export const throwCollectedErrors = (errors: unknown[]): void => {
 // tasks, keeping the remainder queued for the next triggered flush.
 const flushScheduled = (errors: CollectedErrors, defer = true): number => {
   const runCounts = new Map<UpdateScheduler, number>();
+  const errorContributors = new Set<UpdateScheduler>();
   let taskCount = 0;
 
   try {
@@ -107,6 +117,10 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
         reportDepthError(errors);
+        // Dropped, but not left dirty: a stale isDirty would stall the
+        // root's own publishing and re-burn 50 runs on every later
+        // markDirty.
+        scheduler.clearDirty();
         continue;
       }
       runCounts.set(scheduler, runs);
@@ -115,13 +129,10 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
       try {
         scheduler.runTask();
       } catch (error) {
-        // A task that throws deterministically on every re-run would
-        // otherwise flood the batch with identical entries.
-        const message = error instanceof Error ? error.message : String(error);
-        const duplicate = errors.some(
-          (e) => (e instanceof Error ? e.message : String(e)) === message,
-        );
-        if (!duplicate) {
+        // A task that throws deterministically on every re-run contributes
+        // one entry, without hiding a different scheduler's failure.
+        if (!errorContributors.has(scheduler)) {
+          errorContributors.add(scheduler);
           errors.push(error);
         }
       }
@@ -182,13 +193,21 @@ export const flushTapSync = <T>(callback: () => T): T => {
     // a runaway is bounded by the same task ceiling (checked before each
     // pass, so finite batches always finish first).
     const errors: CollectedErrors = [];
-    let total = 0;
+    // A finite batch's queue always shrinks between passes; only a runaway
+    // (fresh schedulers minted mid-drain) fails to. The sync ceiling
+    // therefore counts non-shrinking passes, and finite batches of any
+    // size always finish first.
+    let lastQueueSize = Number.POSITIVE_INFINITY;
+    let streak = 0;
     while (flushState.schedulers.size > 0) {
-      if (total > MAX_TASKS_PER_FLUSH) {
+      if (streak > MAX_CAP_STREAK) {
         reportDepthError(errors);
         break;
       }
-      total += flushScheduled(errors, false);
+      flushScheduled(errors, false);
+      const size = flushState.schedulers.size;
+      streak = size >= lastQueueSize ? streak + 1 : 0;
+      lastQueueSize = size;
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -17,9 +17,13 @@ const newFlushState = (): GlobalFlushState => ({
 
 // Per-scheduler re-runs catch resources that re-dirty themselves or each
 // other in a loop; a finite batch never re-runs one scheduler this often.
+// (createTapRoot allocates a fresh UpdateScheduler per dispatch, so this
+// never fires for that root type - the burst cap is the guard there.)
 const MAX_TASK_RUNS_PER_BURST = 50;
 // A flush yields silently at this many tasks and continues on the next
-// macrotask, so oversized batches drain across flushes with no error.
+// macrotask, so oversized batches drain across flushes with no error. It is
+// also the hard ceiling for a single flushTapSync call, where there is no
+// next macrotask to yield to.
 const MAX_TOTAL_TASKS_PER_BURST = 10000;
 // "The queue did not shrink between cap aborts" is what cascade means for
 // the burst cap (a finite batch's queue always shrinks; a runaway's never
@@ -65,7 +69,7 @@ const scheduleFlush = () => {
 // a cascade (queue not shrinking between cap aborts) throws after
 // MAX_CAP_STREAK and stops auto-continuing; a loop abort clears the queue,
 // which is the only way a mutually re-dirtying ring terminates.
-const flushScheduled = () => {
+const flushScheduled = (defer = true): number => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
   let taskCount = 0;
@@ -113,7 +117,9 @@ const flushScheduled = () => {
           `repeatedly calls setState inside useEffect.`,
       );
     }
-    scheduleFlush();
+    if (defer) {
+      scheduleFlush();
+    }
   } else {
     flushState.capStreak = 0;
     flushState.lastCapQueueSize = Number.POSITIVE_INFINITY;
@@ -136,6 +142,8 @@ const flushScheduled = () => {
       throw new AggregateError(errors, "Errors occurred during flushSync");
     }
   }
+
+  return taskCount;
 };
 
 // Use MessageChannel to schedule flushes as macrotasks (like React's scheduler).
@@ -176,10 +184,17 @@ export const flushTapSync = <T>(callback: () => T): T => {
     const value = callback();
     // Synchronous callers rely on every notification having landed by the
     // time this returns, so drain across passes until the queue is empty.
-    // A cascade still throws via the guards above rather than deferring to
-    // a macrotask that would outlive this temporary flushState.
+    // There is no next macrotask to yield to here, so the burst cap is a
+    // hard ceiling instead of a yield boundary.
+    let total = 0;
     while (flushState.schedulers.size > 0) {
-      flushScheduled();
+      total += flushScheduled(false);
+      if (total > MAX_TOTAL_TASKS_PER_BURST) {
+        throw new Error(
+          `Maximum update depth exceeded. This can happen when a resource ` +
+            `repeatedly calls setState inside useEffect.`,
+        );
+      }
     }
 
     return value;

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -14,6 +14,13 @@ const newFlushState = (): GlobalFlushState => ({
 // that keeps re-dirtying itself (or a cycle of resources re-dirtying each
 // other); the offender is dropped so the rest of the queue keeps flushing.
 const MAX_TASK_RUNS_PER_FLUSH = 50;
+// Last-resort termination: a task that synchronously mints NEW schedulers
+// (e.g. mounts another root mid-flush) never trips the per-scheduler
+// guard, so an unbounded cascade of fresh instances would otherwise lock
+// the thread in one macrotask. Set far above any real workload; on hitting
+// it the pass aborts with the depth error, the remainder stays queued, and
+// the next triggered flush continues - nothing is ever dropped.
+const MAX_TASKS_PER_FLUSH = 50000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -55,27 +62,35 @@ const scheduleFlush = () => {
 const flushScheduled = () => {
   const errors: unknown[] = [];
   const runCounts = new Map<UpdateScheduler, number>();
-  let loopErrorReported = false;
+  let taskCount = 0;
+  let depthErrorReported = false;
+  const reportDepthError = () => {
+    if (depthErrorReported) return;
+    depthErrorReported = true;
+    errors.push(
+      new Error(
+        `Maximum update depth exceeded. This can happen when a resource ` +
+          `repeatedly calls setState inside useEffect.`,
+      ),
+    );
+  };
 
   try {
     for (const scheduler of flushState.schedulers) {
+      if (taskCount >= MAX_TASKS_PER_FLUSH) {
+        reportDepthError();
+        break;
+      }
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
-        if (!loopErrorReported) {
-          loopErrorReported = true;
-          errors.push(
-            new Error(
-              `Maximum update depth exceeded. This can happen when a resource ` +
-                `repeatedly calls setState inside useEffect.`,
-            ),
-          );
-        }
+        reportDepthError();
         continue;
       }
       runCounts.set(scheduler, runs);
+      taskCount += 1;
 
       try {
         scheduler.runTask();

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -23,11 +23,11 @@ const MAX_TASK_RUNS_PER_FLUSH = 50;
 const MAX_TASKS_PER_FLUSH = 1000;
 // Last-resort termination, documented as the real bound: nothing can
 // distinguish a huge finite cascade from an infinite one, so a burst that
-// runs more than this many tasks in total (~33x the repro, ~= 6600
+// runs more than this many tasks in total (~80x the repro, ~= 16000
 // messages in one update) is declared a loop and reported. The queue is
 // never dropped; a stalled remainder continues on the next triggered
 // flush.
-const MAX_BURST_TASKS = 20000;
+const MAX_BURST_TASKS = 50000;
 let flushState: GlobalFlushState = newFlushState();
 
 export class UpdateScheduler {
@@ -93,13 +93,25 @@ export const throwCollectedErrors = (
 
 // Drains flushState.schedulers (Set iteration also visits schedulers
 // re-added mid-pass, so bulk updates of any size land in a single batch)
-// and appends failures to `errors` instead of throwing. Termination is
-// guaranteed by the two guards: every scheduler runs at most
-// MAX_TASK_RUNS_PER_FLUSH times, and the pass aborts at MAX_TASKS_PER_FLUSH
-// tasks, keeping the remainder queued for the next triggered flush.
-const flushScheduled = (errors: CollectedErrors, defer = true): number => {
-  const runCounts = new Map<UpdateScheduler, number>();
-  const errorContributors = new Map<UpdateScheduler, Set<string>>();
+// and appends failures to `errors` instead of throwing.
+//
+// The re-run guard has two modes by necessity: on the macrotask path the
+// offender is SKIPPED and retried next pass (a deep-but-finite cascade
+// still finishes; a true loop burns MAX_TASK_RUNS_PER_FLUSH runs and
+// reports once per pass); inside flushTapSync there is no next pass, so
+// the caller shares one runCounts map across passes and the offender is
+// DROPPED at the limit, terminating the drain at ~50 runs like main.
+const flushScheduled = (
+  errors: CollectedErrors,
+  defer = true,
+  shared?: {
+    runCounts: Map<UpdateScheduler, number>;
+    errorContributors: Map<UpdateScheduler, Set<string>>;
+  },
+): number => {
+  const runCounts = shared?.runCounts ?? new Map<UpdateScheduler, number>();
+  const errorContributors =
+    shared?.errorContributors ?? new Map<UpdateScheduler, Set<string>>();
   let taskCount = 0;
 
   let hitCeiling = false;
@@ -112,11 +124,10 @@ const flushScheduled = (errors: CollectedErrors, defer = true): number => {
       }
       const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_FLUSH) {
-        // Skipped, not dropped: the offender stays queued and is retried
-        // next pass, so a deep-but-finite cascade still finishes while a
-        // true loop just burns MAX_TASK_RUNS_PER_FLUSH runs per pass and
-        // reports each time.
         reportDepthError(errors);
+        if (shared) {
+          flushState.schedulers.delete(scheduler);
+        }
         continue;
       }
       flushState.schedulers.delete(scheduler);
@@ -209,14 +220,24 @@ export const flushTapSync = <T>(callback: () => T): T => {
     // the burst bound only fires for a runaway, whose remainder is handed
     // back to the outer state (see finally) rather than orphaned.
     const errors: CollectedErrors = [];
+    // One run budget for the whole sync drain: a looping scheduler is
+    // dropped at ~MAX_TASK_RUNS_PER_FLUSH total runs (like main), and the
+    // burst bound only fires for a runaway, whose remainder is handed
+    // back to the outer state (see finally) rather than orphaned.
+    const shared = {
+      runCounts: new Map<UpdateScheduler, number>(),
+      errorContributors: new Map<UpdateScheduler, Set<string>>(),
+    };
     let total = 0;
     while (flushState.schedulers.size > 0) {
       if (total > MAX_BURST_TASKS) {
         reportDepthError(errors);
-        leftover.push(...flushState.schedulers);
+        for (const scheduler of flushState.schedulers) {
+          leftover.push(scheduler);
+        }
         break;
       }
-      total += flushScheduled(errors, false);
+      total += flushScheduled(errors, false, shared);
     }
     throwCollectedErrors(errors);
 

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -2,15 +2,11 @@ type Task = () => void;
 
 type GlobalFlushState = {
   schedulers: Set<UpdateScheduler>;
-  runCounts: Map<UpdateScheduler, number>;
-  taskCount: number;
   isScheduled: boolean;
 };
 
 const newFlushState = (): GlobalFlushState => ({
   schedulers: new Set([]),
-  runCounts: new Map(),
-  taskCount: 0,
   isScheduled: false,
 });
 
@@ -54,14 +50,19 @@ const scheduleFlush = () => {
   scheduleMacrotask();
 };
 
-// Guards throw loudly but never drop queued work: the remainder stays
-// queued and continues on the next flush.
+// Guards throw loudly but never stall the queue: the burst-wide cap
+// reschedules so the remainder continues next flush; a looping scheduler
+// is dropped so the rest of the app keeps flushing.
 const flushScheduled = () => {
   const errors: unknown[] = [];
+  const runCounts = new Map<UpdateScheduler, number>();
+  let taskCount = 0;
+  let continueLater = false;
 
   try {
     for (const scheduler of flushState.schedulers) {
-      if (flushState.taskCount >= MAX_TOTAL_TASKS_PER_BURST) {
+      if (taskCount >= MAX_TOTAL_TASKS_PER_BURST) {
+        continueLater = true;
         throw new Error(
           `Maximum update depth exceeded. This can happen when a resource ` +
             `repeatedly calls setState inside useEffect.`,
@@ -70,16 +71,16 @@ const flushScheduled = () => {
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
-      const runs = (flushState.runCounts.get(scheduler) ?? 0) + 1;
+      const runs = (runCounts.get(scheduler) ?? 0) + 1;
       if (runs > MAX_TASK_RUNS_PER_BURST) {
-        flushState.schedulers.add(scheduler);
+        continueLater = true;
         throw new Error(
           `Maximum update depth exceeded. This can happen when a resource ` +
             `repeatedly calls setState inside useEffect.`,
         );
       }
-      flushState.runCounts.set(scheduler, runs);
-      flushState.taskCount += 1;
+      runCounts.set(scheduler, runs);
+      taskCount += 1;
 
       try {
         scheduler.runTask();
@@ -87,14 +88,11 @@ const flushScheduled = () => {
         errors.push(error);
       }
     }
-
-    flushState.runCounts.clear();
-    if (errors.length > 0) {
-      flushState.schedulers.clear();
-    }
   } finally {
-    flushState.taskCount = 0;
     flushState.isScheduled = false;
+    if (continueLater) {
+      scheduleFlush();
+    }
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
## Problem

`UpdateScheduler` batches dirty resources into macrotask flushes capped at `MAX_FLUSH_LIMIT` (50) tasks per pass. When a single flush contains more dirty schedulers than that, the pass threw `Maximum update depth exceeded` — and the `finally` block cleared the scheduler set, **permanently discarding every dirty scheduler that hadn't run yet**.

50 is easy to exceed with legitimate bulk updates, not just infinite loops. Concrete case from a production app (HAPI, using `useExternalStoreRuntime`): prepending one page of older messages (200 items) into the external store mounts ~600 message/part/composer resources in one tap flush. The flush aborted, the thread never rendered the merged page even though the runtime core had already applied it, and the UI appeared stuck (or kept re-triggering loads). The same hazard exists for any large one-shot update (bulk thread switch, importing a big transcript, etc.).

The initial mount path doesn't hit this because resource creation there is driven by React's render, not by a dirty-scheduler cascade inside an already-running flush.

## Fix

A flush pass now runs at most `MAX_FLUSH_LIMIT` tasks and **defers the rest to a follow-up pass** (same macrotask scheduling), so large batches drain across several passes instead of being dropped:

- queue fully drained → reset, done (unchanged behavior for the common case)
- queue still non-empty → schedule another pass
- queue saturated for `MAX_SATURATED_FLUSH_PASSES` (100) **consecutive** passes → a resource is re-dirtying itself on every run, i.e. a true infinite update loop → keep throwing `Maximum update depth exceeded` (same message as before)

The loop guard therefore still fires, just without false-positiving on large finite batches. Error handling for tasks that throw is unchanged: the batch is discarded and the error propagates.

## Tests

Added `scheduler.batched-drain.test.ts` with a manually-pumped MessageChannel so passes can be stepped synchronously:

- 120 dirty schedulers all run across passes, no throw (previously threw + dropped)
- a self-re-dirtying scheduler still throws `Maximum update depth exceeded`
- the saturated-pass counter resets after a fully drained pass (back-to-back 75-scheduler bursts don't accumulate)

Full `@assistant-ui/tap` suite: 457 tests passing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.0KS9rIkoIcaXg2G_NnNw-sfGZON2fp1X0NWvd_YvCe4SNdHj-DwbDQw8JIk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->