### PR TITLE
feat: read the nested _meta.ui.resourceUri MCP Apps pointer

### DIFF
--- a/.changeset/mcp-apps-nested-ui-meta.md
+++ b/.changeset/mcp-apps-nested-ui-meta.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+feat: read the canonical nested `_meta.ui.resourceUri` MCP Apps pointer, keeping the deprecated flat `"ui/resourceUri"` key as a fallback

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -184,7 +184,13 @@ const withTemplateUri = (tool: Tool, name: string): Tool => {
     ...tool,
     execute: async (args, options) => {
       const result = (await exec(args, options)) as { _meta?: Record<string, unknown> };
-      return { ...result, _meta: { ...result._meta, ui: { resourceUri: uri } } };
+      return {
+        ...result,
+        _meta: {
+          ...result._meta,
+          ui: { ...(result._meta?.["ui"] as Record<string, unknown>), resourceUri: uri },
+        },
+      };
     },
   } satisfies Tool;
 };

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -164,7 +164,7 @@ const result = streamText({
 
 [OpenAI Apps SDK](https://developers.openai.com/apps-sdk) servers carry the same `ui://` template under a different convention: the pointer is `_meta["openai/outputTemplate"]` on the tool definition (not `_meta.ui.resourceUri`), and the resource is served as `text/html+skybridge` rather than `text/html;profile=mcp-app`. `@ai-sdk/mcp` does not recognize `openai/outputTemplate`, so it never populates `callProviderMetadata.mcp.app` and the renderer stays idle.
 
-The renderer needs no change; you only have to surface the pointer. assistant-ui already reads `result._meta["ui/resourceUri"]` off tool results, so the smallest bridge is to copy the template onto the result by tool name. Build the map once from the tool listing, then stamp it inside each tool's `execute`:
+The renderer needs no change; you only have to surface the pointer. assistant-ui reads the canonical `result._meta.ui.resourceUri` off tool results (and still accepts the deprecated flat `result._meta["ui/resourceUri"]`), so the smallest bridge is to copy the template onto the result by tool name. Build the map once from the tool listing, then stamp it inside each tool's `execute`:
 
 ```ts
 import type { Tool } from "ai";
@@ -184,7 +184,7 @@ const withTemplateUri = (tool: Tool, name: string): Tool => {
     ...tool,
     execute: async (args, options) => {
       const result = (await exec(args, options)) as { _meta?: Record<string, unknown> };
-      return { ...result, _meta: { ...result._meta, "ui/resourceUri": uri } };
+      return { ...result, _meta: { ...result._meta, ui: { resourceUri: uri } } };
     },
   } satisfies Tool;
 };
@@ -253,7 +253,7 @@ Alternatively, AG-UI servers can place MCP host fields directly on `TOOL_CALL_RE
 }
 ```
 
-In this form, the runtime assembles a `CallToolResult`-shaped `part.result` from `content`, `structuredContent`, `_meta`, and `isError`. At least one of `structuredContent` or `_meta` must be present; when both are absent the enriched path does not activate and the result falls back to the plain `content` string. An `ACTIVITY_SNAPSHOT` is still required to provide the app's `resourceUri` and optional server identity, but it does not need to repeat `result`.
+In this form, the runtime assembles a `CallToolResult`-shaped `part.result` from `content`, `structuredContent`, `_meta`, and `isError`. At least one of `structuredContent` or `_meta` must be present; when both are absent the enriched path does not activate and the result falls back to the plain `content` string. The `_meta` can also carry the app pointer itself (canonical `ui.resourceUri`, or the deprecated flat `"ui/resourceUri"`), in which case no `ACTIVITY_SNAPSHOT` is needed to activate the widget. A snapshot remains the only carrier for server identity (`serverId`), and when both provide a `resourceUri` the snapshot wins.
 
 The visibility split follows the MCP Apps contract: `content` is model-visible; `structuredContent` and `_meta` are available only to the host and widget. When assistant-ui serializes history into a later AG-UI request, it sends the saved model-visible text and never includes `structuredContent` or `_meta`.
 

--- a/packages/react-ag-ui/src/runtime/mcp-tool-result.ts
+++ b/packages/react-ag-ui/src/runtime/mcp-tool-result.ts
@@ -26,12 +26,14 @@ export const parseMcpToolCallResult = (
   };
 };
 
-// _meta["ui/resourceUri"] is the MCP-UI pointer react-ai-sdk reads off
-// CallToolResult._meta; only ui:// URIs identify an MCP Apps widget. A
-// structured carrier is deliberately not read until upstream AG-UI settles
-// one (agno-agi/agno#9087).
+// The MCP Apps pointer on CallToolResult._meta: canonical nested `ui.resourceUri`
+// per the Apps spec (2026-01-26), with the deprecated flat `"ui/resourceUri"` kept
+// for legacy producers. Only ui:// URIs identify a widget.
 export const readMcpAppResourceUri = (meta: unknown): string | undefined => {
   if (!isRecord(meta)) return undefined;
-  const uri = meta["ui/resourceUri"];
-  return typeof uri === "string" && isMcpAppUri(uri) ? uri : undefined;
+  const ui = meta["ui"];
+  const nested = isRecord(ui) ? ui["resourceUri"] : undefined;
+  if (typeof nested === "string" && isMcpAppUri(nested)) return nested;
+  const flat = meta["ui/resourceUri"];
+  return typeof flat === "string" && isMcpAppUri(flat) ? flat : undefined;
 };

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -1347,6 +1347,99 @@ describe("mcp app rehydration from restored tool messages", () => {
     expect(part.mcp).toEqual({ app: { resourceUri: "ui://example/search" } });
   });
 
+  it("rehydrates mcp.app from the nested _meta ui.resourceUri carrier", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "a-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "search", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        id: "t-1",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: "ok",
+        _meta: { ui: { resourceUri: "ui://example/search" } },
+      },
+    ] as any);
+
+    const part = (result[0] as any).content.find(
+      (p: { type: string }) => p.type === "tool-call",
+    );
+    expect(part.mcp).toEqual({ app: { resourceUri: "ui://example/search" } });
+  });
+
+  it("prefers the nested _meta ui.resourceUri carrier over the flat carrier", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "a-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "search", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        id: "t-1",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: "ok",
+        _meta: {
+          ui: { resourceUri: "ui://example/nested" },
+          "ui/resourceUri": "ui://example/flat",
+        },
+      },
+    ] as any);
+
+    const part = (result[0] as any).content.find(
+      (p: { type: string }) => p.type === "tool-call",
+    );
+    expect(part.mcp).toEqual({ app: { resourceUri: "ui://example/nested" } });
+  });
+
+  it("falls back to the flat carrier when the nested resourceUri is not a ui:// app uri", () => {
+    const result = fromAgUiMessages([
+      {
+        id: "a-1",
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "function",
+            function: { name: "search", arguments: "{}" },
+          },
+        ],
+      },
+      {
+        id: "t-1",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: "ok",
+        _meta: {
+          ui: { resourceUri: "https://example.com/not-an-app" },
+          "ui/resourceUri": "ui://example/flat",
+        },
+      },
+    ] as any);
+
+    const part = (result[0] as any).content.find(
+      (p: { type: string }) => p.type === "tool-call",
+    );
+    expect(part.mcp).toEqual({ app: { resourceUri: "ui://example/flat" } });
+  });
+
   it("rehydrates mcp.app on a synthetic assistant tool-call for an orphan tool message", () => {
     const result = fromAgUiMessages([
       {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -665,6 +665,34 @@ describe("RunAggregator", () => {
     });
   });
 
+  it("stamps mcp app metadata from the nested tool result _meta ui.resourceUri carrier", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_START",
+      toolCallId: "tool1",
+      toolCallName: "show_map",
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "TOOL_CALL_RESULT",
+      toolCallId: "tool1",
+      content: "ok",
+      role: "tool",
+      mcpResult: {
+        content: [{ type: "text", text: "ok" }],
+        _meta: { ui: { resourceUri: "ui://example/widget" } },
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.mcp).toEqual({
+      app: { resourceUri: "ui://example/widget" },
+    });
+  });
+
   it("ignores a tool result _meta carrier whose resourceUri is not a ui:// uri", () => {
     const aggregator = createAggregator(false);
 

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -875,7 +875,7 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
-  it("extracts MCP app metadata from output._meta.ui.resourceUri", () => {
+  it("adopts only spec'd ui fields from output._meta.ui", () => {
     const converted = AISDKMessageConverter.toThreadMessages([
       {
         id: "a1",
@@ -891,6 +891,7 @@ describe("AISDKMessageConverter", () => {
                 ui: {
                   resourceUri: "ui://app/hello_ui.html",
                   serverId: "srv",
+                  visibility: ["model"],
                 },
               },
               content: [{ type: "text", text: "" }],
@@ -905,7 +906,7 @@ describe("AISDKMessageConverter", () => {
     );
     expect(call?.mcp?.app).toEqual({
       resourceUri: "ui://app/hello_ui.html",
-      serverId: "srv",
+      visibility: ["model"],
     });
   });
 

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.test.ts
@@ -875,6 +875,102 @@ describe("AISDKMessageConverter", () => {
     });
   });
 
+  it("extracts MCP app metadata from output._meta.ui.resourceUri", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-hello_ui",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: {},
+            output: {
+              _meta: {
+                ui: {
+                  resourceUri: "ui://app/hello_ui.html",
+                  serverId: "srv",
+                },
+              },
+              content: [{ type: "text", text: "" }],
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://app/hello_ui.html",
+      serverId: "srv",
+    });
+  });
+
+  it("prefers output._meta.ui.resourceUri over output._meta['ui/resourceUri']", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-hello_ui",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: {},
+            output: {
+              _meta: {
+                ui: { resourceUri: "ui://app/nested.html" },
+                "ui/resourceUri": "ui://app/flat.html",
+              },
+              content: [{ type: "text", text: "" }],
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://app/nested.html",
+    });
+  });
+
+  it("falls back to output._meta['ui/resourceUri'] when the nested resourceUri is not a ui:// app uri", () => {
+    const converted = AISDKMessageConverter.toThreadMessages([
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-hello_ui",
+            toolCallId: "tc-1",
+            state: "output-available",
+            input: {},
+            output: {
+              _meta: {
+                ui: { resourceUri: "https://example.com/not-an-app" },
+                "ui/resourceUri": "ui://app/flat.html",
+              },
+              content: [{ type: "text", text: "" }],
+            },
+          },
+        ],
+      } as any,
+    ]);
+
+    const call = converted[0]?.content.find(
+      (part): part is any => part.type === "tool-call",
+    );
+    expect(call?.mcp?.app).toEqual({
+      resourceUri: "ui://app/flat.html",
+    });
+  });
+
   it("memoizes MCP app metadata across conversions by serverId and resourceUri", () => {
     const metadata: AISDKMessageConverterMetadata = {
       mcpAppMetadataCache: new Map(),

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -62,19 +62,32 @@ function extractMcpAppMetadata(
   if (app && typeof app === "object") {
     a = app as Record<string, unknown>;
   } else {
-    // MCP-UI tools (e.g. xmcp) surface the UI pointer as
-    // result._meta["ui/resourceUri"] rather than in callProviderMetadata.
+    // MCP-UI tools surface the pointer on result._meta: canonical nested
+    // `ui.resourceUri`, or the deprecated flat `"ui/resourceUri"` key.
     const output = (part as { output?: unknown }).output;
     const outMeta =
       output && typeof output === "object"
         ? (output as { _meta?: unknown })._meta
         : undefined;
-    const uiResourceUri =
+    const ui =
       outMeta && typeof outMeta === "object"
-        ? (outMeta as Record<string, unknown>)["ui/resourceUri"]
+        ? (outMeta as Record<string, unknown>)["ui"]
         : undefined;
-    if (typeof uiResourceUri !== "string") return undefined;
-    a = { resourceUri: uiResourceUri };
+    if (
+      ui &&
+      typeof ui === "object" &&
+      typeof (ui as Record<string, unknown>)["resourceUri"] === "string" &&
+      isMcpAppUri((ui as Record<string, unknown>)["resourceUri"] as string)
+    ) {
+      a = ui as Record<string, unknown>;
+    } else {
+      const flat =
+        outMeta && typeof outMeta === "object"
+          ? (outMeta as Record<string, unknown>)["ui/resourceUri"]
+          : undefined;
+      if (typeof flat !== "string" || !isMcpAppUri(flat)) return undefined;
+      a = { resourceUri: flat };
+    }
   }
   if (typeof a["resourceUri"] !== "string") return undefined;
   if (!isMcpAppUri(a["resourceUri"])) return undefined;

--- a/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/convertMessage.ts
@@ -79,7 +79,15 @@ function extractMcpAppMetadata(
       typeof (ui as Record<string, unknown>)["resourceUri"] === "string" &&
       isMcpAppUri((ui as Record<string, unknown>)["resourceUri"] as string)
     ) {
-      a = ui as Record<string, unknown>;
+      // Only the spec'd ui fields cross from the result body; serverId is a
+      // routing key and stays transport-derived via callProviderMetadata.
+      const uiMeta = ui as Record<string, unknown>;
+      a = {
+        resourceUri: uiMeta["resourceUri"],
+        ...(Array.isArray(uiMeta["visibility"])
+          ? { visibility: uiMeta["visibility"] }
+          : {}),
+      };
     } else {
       const flat =
         outMeta && typeof outMeta === "object"


### PR DESCRIPTION
## summary

- the MCP Apps extension spec (Stable 2026-01-26) defines the tool-result UI pointer as nested `_meta.ui.resourceUri` and deprecates the flat `_meta["ui/resourceUri"]` key ("will be removed before GA"); both readers in this repo read only the flat key today
- `readMcpAppResourceUri` (react-ag-ui, shared by the restore, aggregator, and cross-run consumers) now prefers a valid nested key and falls back to the flat one; a nested value that is not a `ui://` URI falls through to the flat key
- the react-ai-sdk `convertMessage` fallback branch reads the spec'd fields off the nested `ui` object (`resourceUri`, plus `visibility` when present); `serverId` and `mimeType` stay sourced from `callProviderMetadata`, the transport-derived carrier, so a result body can never redirect host routing
- mcp-apps.mdx teaches the canonical nested key in the OpenAI Apps SDK bridge example and corrects the claim that an `ACTIVITY_SNAPSHOT` is required to provide `resourceUri` (the result `_meta` can carry the pointer itself; a snapshot remains the only `serverId` carrier and wins on conflict)

## test plan

### already verified

- [x] `pnpm -C packages/react-ag-ui test` -> 252/252 green (includes 4 new nested-carrier cases)
- [x] `pnpm -C packages/react-ai-sdk test` -> 168/168 green (includes 3 new nested-carrier cases)
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

### reviewer should verify

- [ ] a `TOOL_CALL_RESULT` whose `_meta` is `{ ui: { resourceUri: "ui://..." } }` (with no `ACTIVITY_SNAPSHOT`) renders the MCP app widget in an AG-UI thread

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.XE693FjT1Yr5v6iUN9XpM6GDcmNx6SxSAW6Bh4g2nybrj5pwQ-eMnlYQh2U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->