### PR TITLE
fix(react-ag-ui,react-google-adk): forward audio parts and skip data parts

### DIFF
--- a/.changeset/shiny-parrots-listen.md
+++ b/.changeset/shiny-parrots-listen.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: forward audio message parts and skip data parts instead of dropping or throwing

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -217,7 +217,13 @@ function toInputContent(
     const data = getString(audio, "data");
     const format = getString(audio, "format");
     if (data === undefined || format === undefined) return null;
-    return { type: "audio", source: buildInputSource(data, `audio/${format}`) };
+    return {
+      type: "audio",
+      source: buildInputSource(
+        parseDataUrl(data)?.data ?? data,
+        `audio/${format}`,
+      ),
+    };
   }
 
   return null;

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -211,6 +211,15 @@ function toInputContent(
     }
   }
 
+  if (type === "audio") {
+    const audio = part.audio;
+    if (!isObject(audio)) return null;
+    const data = getString(audio, "data");
+    const format = getString(audio, "format");
+    if (data === undefined || format === undefined) return null;
+    return { type: "audio", source: buildInputSource(data, `audio/${format}`) };
+  }
+
   return null;
 }
 

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -1163,6 +1163,125 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(roundTripped[0])).not.toThrow();
   });
 
+  it("converts a native audio content part to an AG-UI audio source", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "listen to this" },
+          { type: "audio", audio: { data: "QUJD", format: "mp3" } },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "listen to this" },
+        {
+          type: "audio",
+          source: { type: "data", value: "QUJD", mimeType: "audio/mp3" },
+        },
+      ],
+    });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("derives the audio mime type from the wav format", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "audio", audio: { data: "QUJD", format: "wav" } }],
+      },
+    ] as any);
+
+    expect(result[0]!.content).toMatchObject([
+      {
+        type: "audio",
+        source: { type: "data", value: "QUJD", mimeType: "audio/wav" },
+      },
+    ]);
+  });
+
+  it("strips a data URL envelope from audio data, preferring the embedded mime type", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "audio",
+            audio: { data: "data:audio/ogg;base64,QUJD", format: "mp3" },
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]!.content).toMatchObject([
+      {
+        type: "audio",
+        source: { type: "data", value: "QUJD", mimeType: "audio/ogg" },
+      },
+    ]);
+  });
+
+  it("drops an audio part with a malformed payload without failing the send", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "hi" },
+          { type: "audio", audio: { format: "mp3" } },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({ role: "user", content: "hi" });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("drops data parts while keeping surrounding text", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "hi" },
+          { type: "data", name: "chart", data: { x: 1 } },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({ role: "user", content: "hi" });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("round-trips a native audio part through the attachment channel back to a wire audio block", () => {
+    const sent = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+      },
+    ] as any);
+
+    const restored = fromAgUiMessages(sent);
+    const resent = toAgUiMessages(
+      restored as Parameters<typeof toAgUiMessages>[0],
+    );
+
+    expect(resent[0]!.content).toMatchObject([
+      {
+        type: "audio",
+        source: { type: "data", value: "QUJD", mimeType: "audio/mp3" },
+      },
+    ]);
+    expect(() => UserMessageSchema.parse(resent[0])).not.toThrow();
+  });
+
   it("restores a legacy binary input part and re-sends it as a modern part", () => {
     const restored = fromAgUiMessages([
       {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -1205,7 +1205,7 @@ describe("adapter conversions", () => {
     ]);
   });
 
-  it("strips a data URL envelope from audio data, preferring the embedded mime type", () => {
+  it("strips a data URL envelope from audio data and keeps the format-derived mime type", () => {
     const result = toAgUiMessages([
       {
         id: "u-1",
@@ -1213,7 +1213,7 @@ describe("adapter conversions", () => {
         content: [
           {
             type: "audio",
-            audio: { data: "data:audio/ogg;base64,QUJD", format: "mp3" },
+            audio: { data: "data:audio/mpeg;base64,QUJD", format: "mp3" },
           },
         ],
       },
@@ -1222,7 +1222,7 @@ describe("adapter conversions", () => {
     expect(result[0]!.content).toMatchObject([
       {
         type: "audio",
-        source: { type: "data", value: "QUJD", mimeType: "audio/ogg" },
+        source: { type: "data", value: "QUJD", mimeType: "audio/mp3" },
       },
     ]);
   });

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -52,6 +52,33 @@ describe("convertAdkMessage - human messages", () => {
     });
   });
 
+  it("keeps attachment-derived audio file parts (with filename) as file parts", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [
+        {
+          type: "file",
+          mimeType: "audio/wav",
+          data: "QUJD",
+          filename: "memo.wav",
+        },
+      ],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          mimeType: "audio/wav",
+          data: "QUJD",
+          filename: "memo.wav",
+        },
+      ],
+    });
+  });
+
   it("keeps file parts with other audio mime types as file parts", () => {
     const msg: AdkMessage = {
       id: "m1",

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -25,6 +25,45 @@ describe("convertAdkMessage - human messages", () => {
       content: [{ type: "text", text: "Hello" }],
     });
   });
+
+  it("restores an audio/mp3 file part as an audio message part", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+    });
+  });
+
+  it("restores an audio/wav file part as an audio message part", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [{ type: "file", mimeType: "audio/wav", data: "QUJD" }],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "audio", audio: { data: "QUJD", format: "wav" } }],
+    });
+  });
+
+  it("keeps file parts with other audio mime types as file parts", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [{ type: "file", mimeType: "audio/ogg", data: "QUJD" }],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "file", mimeType: "audio/ogg", data: "QUJD" }],
+    });
+  });
 });
 
 describe("convertAdkMessage - ai messages", () => {
@@ -75,6 +114,19 @@ describe("convertAdkMessage - ai messages", () => {
     const result = convertAdkMessage(msg, {});
     expect(result).toMatchObject({
       content: [{ type: "image", image: "https://example.com/img.png" }],
+    });
+  });
+
+  it("keeps audio/mp3 file parts as file parts on assistant messages", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "ai",
+      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
     });
   });
 

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -35,11 +35,13 @@ const contentToParts = (
           return { type: "image", image: part.url };
         case "file": {
           const format =
-            role === "user" && part.mimeType === "audio/wav"
-              ? ("wav" as const)
-              : role === "user" && part.mimeType === "audio/mp3"
-                ? ("mp3" as const)
-                : null;
+            role === "user" && part.filename == null
+              ? part.mimeType === "audio/wav"
+                ? ("wav" as const)
+                : part.mimeType === "audio/mp3"
+                  ? ("mp3" as const)
+                  : null
+              : null;
           if (format) {
             return { type: "audio", audio: { data: part.data, format } };
           }

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -9,9 +9,13 @@ type ContentPart =
   | { type: "reasoning"; text: string }
   | { type: "image"; image: string }
   | { type: "file"; data: string; mimeType: string; filename?: string }
+  | { type: "audio"; audio: { data: string; format: "mp3" | "wav" } }
   | { type: "data"; name: string; data: unknown };
 
-const contentToParts = (content: AdkMessage["content"]): ContentPart[] => {
+const contentToParts = (
+  content: AdkMessage["content"],
+  role: "user" | "assistant",
+): ContentPart[] => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
 
@@ -29,13 +33,23 @@ const contentToParts = (content: AdkMessage["content"]): ContentPart[] => {
           };
         case "image_url":
           return { type: "image", image: part.url };
-        case "file":
+        case "file": {
+          const format =
+            role === "user" && part.mimeType === "audio/wav"
+              ? ("wav" as const)
+              : role === "user" && part.mimeType === "audio/mp3"
+                ? ("mp3" as const)
+                : null;
+          if (format) {
+            return { type: "audio", audio: { data: part.data, format } };
+          }
           return {
             type: "file",
             data: part.data,
             mimeType: part.mimeType,
             ...(part.filename != null && { filename: part.filename }),
           };
+        }
         case "file_url":
           return {
             type: "data",
@@ -72,7 +86,7 @@ export const convertAdkMessage: useExternalMessageConverter.Callback<
       return {
         role: "user",
         id: message.id,
-        content: contentToParts(message.content),
+        content: contentToParts(message.content, "user"),
       };
 
     case "ai": {
@@ -88,7 +102,10 @@ export const convertAdkMessage: useExternalMessageConverter.Callback<
       return {
         role: "assistant",
         id: message.id,
-        content: [...contentToParts(message.content), ...toolCallParts],
+        content: [
+          ...contentToParts(message.content, "assistant"),
+          ...toolCallParts,
+        ],
         ...(message.status && { status: message.status }),
         ...(message.author && {
           metadata: {

--- a/packages/react-google-adk/src/useAdkRuntime.test.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.test.ts
@@ -208,4 +208,65 @@ describe("getMessageContent", () => {
       { type: "file", mimeType: "application/pdf", data: "AAAA" },
     ]);
   });
+
+  it("forwards an audio part as a file block with the format-derived mime type", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        { type: "audio", audio: { data: "QUJD", format: "mp3" } },
+      ]),
+    );
+    expect(result).toEqual([
+      { type: "file", mimeType: "audio/mp3", data: "QUJD" },
+    ]);
+  });
+
+  it("forwards a wav audio part with the audio/wav mime type", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        { type: "audio", audio: { data: "QUJD", format: "wav" } },
+      ]),
+    );
+    expect(result).toEqual([
+      { type: "file", mimeType: "audio/wav", data: "QUJD" },
+    ]);
+  });
+
+  it("strips a data URL envelope from audio data", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "audio",
+          audio: { data: "data:audio/mp3;base64,QUJD", format: "mp3" },
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      { type: "file", mimeType: "audio/mp3", data: "QUJD" },
+    ]);
+  });
+
+  it("skips data parts while keeping surrounding text", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        { type: "text", text: "hi" },
+        { type: "data", name: "chart", data: { x: 1 } },
+      ]),
+    );
+    expect(result).toBe("hi");
+  });
+
+  it("returns empty content for a data-only message", () => {
+    const result = getMessageContent(
+      makeAppendMessage([{ type: "data", name: "chart", data: { x: 1 } }]),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("still throws on assistant-only part types", () => {
+    expect(() =>
+      getMessageContent(
+        makeAppendMessage([{ type: "reasoning", text: "thinking" }]),
+      ),
+    ).toThrow("Unsupported append message part type: reasoning");
+  });
 });

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -13,6 +13,7 @@ import {
   type ToolExecutionStatus,
   generateId,
 } from "@assistant-ui/core";
+import { parseDataUrl } from "@assistant-ui/core/internal";
 import {
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
@@ -41,7 +42,7 @@ export const getMessageContent = (msg: AppendMessage) => {
     ...msg.content,
     ...(msg.attachments?.flatMap((a) => a.content) ?? []),
   ];
-  const content = allContent.map((part) => {
+  const content = allContent.flatMap((part) => {
     const type = part.type;
     switch (type) {
       case "text":
@@ -55,17 +56,22 @@ export const getMessageContent = (msg: AppendMessage) => {
           data: part.data,
           ...(part.filename != null && { filename: part.filename }),
         };
+      case "audio": {
+        const parsed = parseDataUrl(part.audio.data);
+        return {
+          type: "file" as const,
+          mimeType: `audio/${part.audio.format}`,
+          data: parsed?.data ?? part.audio.data,
+        };
+      }
+      case "data":
+        return [];
 
       case "tool-call":
         throw new Error("Tool call appends are not supported.");
 
       default: {
-        const _exhaustiveCheck:
-          | "reasoning"
-          | "source"
-          | "audio"
-          | "data"
-          | "generative-ui" = type;
+        const _exhaustiveCheck: "reasoning" | "source" | "generative-ui" = type;
         throw new Error(
           `Unsupported append message part type: ${_exhaustiveCheck}`,
         );


### PR DESCRIPTION
## What

react-ag-ui and react-google-adk now forward user `audio` parts and skip `data` parts, matching the shape #5223 settled for langchain and langgraph.

- ag-ui: `toInputContent` maps a native audio part onto the existing wire `{type: "audio", source}` block via `buildInputSource` with an `audio/<format>` mime; data parts keep being dropped, now test-pinned.
- adk outbound: `getMessageContent` forwards audio as a file block with the format-derived mime (after a `parseDataUrl` strip), skips data parts, and the exhaustive throw narrows to `reasoning | source | generative-ui`.
- adk inbound: `convertAdkMessage` restores `audio/mp3` and `audio/wav` file parts as audio parts on human messages, mirroring the inbound round trip okisdev added to #5223 (user role gated, format derived from mime).

## Why

Both part types are typed members of `ThreadUserMessagePart` reachable through public `append`, and these two adapters were the remaining legs: adk failed the entire send with a throw, ag-ui dropped the parts silently. Closes #5222, and ticks the adapter parity checkbox on #5309.

## Impact

- A user message carrying an audio part now reaches the agent instead of throwing (adk) or vanishing (ag-ui), and in adk it survives a session reload as an audio part.
- Data parts drop instead of throwing, so the rest of the message still sends.
- No regression surface: every changed path previously threw or returned null.

## Scope 

- Audio branches are ~10 lines and follow the union decision per #5309: they delete cleanly if Unstable_Audio is removed on a major line.
- ag-ui inbound is deliberately unchanged: audio already round-trips losslessly through the attachment channel (wire audio becomes a file attachment with the audio mime, and the file branch re-emits it as a wire audio block), and converting it to a content part instead would break the adapter's all-media-as-attachments snapshot design. A new round-trip test pins the losslessness.
- adk inbound reclassification only touches filename-less file parts: outbound audio blocks never set `filename` and attachment-derived file parts always do (`CloudFileAttachmentAdapter` includes `attachment.name`), so genuine audio file attachments stay file parts and keep their filename. This matches #5223, where inbound only converts wire parts already typed `audio`. Residual edge: a custom attachment adapter emitting filename-less mp3/wav file parts would reclassify.
- adk gets no `" "` text placeholder for media-only messages: that mechanism exists in langchain because its providers reject binary-only content, and Gemini accepts media-only parts.
- Data parts drop silently with no warning, matching #5223's rationale: a warn on every send would be noise for an app that knowingly uses data parts.
- Mime precedence differs by design: adk lets the declared format win (mirrors #5223), ag-ui lets an embedded data-URL mime win because that is how its `buildInputSource` already treats every other media type.
- The react-a2a leg is tracked separately in #5220.
- Additive only: no exports removed or reshaped, api-surface regen shows no drift.
- Tests: audio forwarding (raw base64, data-URL strip, wav), malformed-payload drop, data-skip with surviving text, data-only empty content, assistant-only parts still throwing, adk role gate, and the ag-ui attachment round trip; not covered: live provider acceptance, which needs a running server and is tracked as #5309 item 3.
- Changeset: patch (`@assistant-ui/react-ag-ui`, `@assistant-ui/react-google-adk`).



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mpWfk3bj8U6kDdqxPvI7bYoLSS4j04RisLtvZmCsFqVEqt9giGx3RGBL3xI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->