### PR TITLE
fix: case-insensitive data: URL scheme in parseDataUrl and passthrough gates

### DIFF
--- a/.changeset/data-url-scheme-case-insensitive.md
+++ b/.changeset/data-url-scheme-case-insensitive.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-a2a": patch
+"assistant-stream": patch
+"@assistant-ui/react-pi": patch
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: accept case-insensitive `data:` URL schemes and normalize parsed mime types to lowercase

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -189,6 +189,23 @@ describe("toGenericMessages", () => {
       expect((content[0] as { data: unknown }).data).toBeInstanceOf(URL);
     });
 
+    it("infers a lowercase media type from an uppercase-scheme data URL", () => {
+      const dataUrl =
+        "DATA:IMAGE/PNG;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [{ type: "image", image: dataUrl }],
+        },
+      ]);
+
+      const content = (result[0] as { content: unknown[] }).content;
+      expect(content[0]).toMatchObject({
+        type: "file",
+        mediaType: "image/png",
+      });
+    });
+
     it("handles relative/invalid URL as string", () => {
       const result = toGenericMessages([
         {

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -97,9 +97,9 @@ const IMAGE_MEDIA_TYPES: Record<string, string> = {
 
 function inferImageMediaType(url: string): string {
   // Handle data URLs: data:[<mediatype>][;base64],<data>
-  if (url.startsWith("data:")) {
-    const match = url.match(/^data:([^;,]+)/);
-    if (match?.[1]) return match[1];
+  if (/^data:/i.test(url)) {
+    const match = url.match(/^data:([^;,]+)/i);
+    if (match?.[1]) return match[1].toLowerCase();
   }
 
   // Extract extension from URL path, ignoring query string and hash

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -131,12 +131,12 @@ export const fromThreadMessageLike = (
   }: ImageMessagePart): ImageMessagePart | null => {
     if (typeof image !== "string") return null;
     const dataUri = image.match(
-      /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,(.*)$/,
+      /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,(.*)$/i,
     );
     if (dataUri) {
       return { ...rest, image };
     }
-    if (/^(https:\/\/|blob:)/.test(image)) {
+    if (/^(https:\/\/|blob:)/i.test(image)) {
       return { ...rest, image };
     }
     console.warn(`Invalid image data format detected`);

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -159,6 +159,21 @@ describe("fromThreadMessageLike", () => {
 
       expect(result.content).toEqual([]);
     });
+
+    it("keeps an image part with an uppercase-scheme data URL", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "image", image: "DATA:IMAGE/PNG;base64,AAAA" }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([
+        { type: "image", image: "DATA:IMAGE/PNG;base64,AAAA" },
+      ]);
+    });
   });
 
   describe("providerMetadata passthrough", () => {

--- a/packages/core/src/utils/data-url.test.ts
+++ b/packages/core/src/utils/data-url.test.ts
@@ -27,6 +27,27 @@ describe("parseDataUrl", () => {
     });
   });
 
+  it("parses an uppercase scheme", () => {
+    expect(parseDataUrl("DATA:image/png;base64,aGVsbG8=")).toEqual({
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+  });
+
+  it("parses a mixed-case scheme and base64 token", () => {
+    expect(parseDataUrl("Data:image/png;Base64,aGVsbG8=")).toEqual({
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+  });
+
+  it("lowercases the captured mime type", () => {
+    expect(parseDataUrl("data:IMAGE/PNG;base64,aGVsbG8=")).toEqual({
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+  });
+
   it("returns null for plain strings", () => {
     expect(parseDataUrl("aGVsbG8=")).toBeNull();
   });

--- a/packages/core/src/utils/data-url.ts
+++ b/packages/core/src/utils/data-url.ts
@@ -3,7 +3,7 @@ export const httpUrlPattern = /^https?:\/\//i;
 export function parseDataUrl(
   value: string,
 ): { mimeType: string; data: string } | null {
-  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.*)$/);
+  const match = value.match(/^data:([^;,]+)(?:;[^;,]+)*;base64,(.*)$/i);
   if (!match) return null;
-  return { mimeType: match[1]!, data: match[2]! };
+  return { mimeType: match[1]!.toLowerCase(), data: match[2]! };
 }

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -382,6 +382,15 @@ describe("contentPartsToA2AParts", () => {
     ]);
   });
 
+  it("passes uppercase-scheme non-base64 data URLs through as URLs for file parts", () => {
+    const result = contentPartsToA2AParts([
+      { type: "file", data: "DATA:text/plain,hello", mimeType: "text/plain" },
+    ]);
+    expect(result).toEqual([
+      { url: "DATA:text/plain,hello", mediaType: "text/plain" },
+    ]);
+  });
+
   it("converts zero-byte data URLs in file parts to empty raw bytes", () => {
     const result = contentPartsToA2AParts([
       { type: "file", data: "data:application/pdf;base64,", mimeType: "" },

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -138,7 +138,7 @@ export function contentPartsToA2AParts(
               ...(part.filename && { filename: part.filename }),
             };
           }
-          if (part.data.startsWith("data:")) {
+          if (/^data:/i.test(part.data)) {
             return {
               url: part.data,
               ...(declaredMimeType && { mediaType: declaredMimeType }),

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -93,6 +93,30 @@ describe("toCreateMessage", () => {
     ]);
   });
 
+  it("infers a lowercase media type from uppercase-scheme image data URLs", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "image",
+          image: "DATA:IMAGE/JPEG;base64,/9j/4AAQSkZJRg==",
+          filename: "photo.jpg",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "DATA:IMAGE/JPEG;base64,/9j/4AAQSkZJRg==",
+        filename: "photo.jpg",
+        mediaType: "image/jpeg",
+      },
+    ]);
+  });
+
   it("uses attachment contentType for image attachments", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -13,8 +13,8 @@ type InputPart = AppendMessage["content"][number] & {
 };
 
 const getDataUrlMediaType = (url: string) => {
-  const match = /^data:([^;,]+)(?:[;,])/.exec(url);
-  return match?.[1];
+  const match = /^data:([^;,]+)(?:[;,])/i.exec(url);
+  return match?.[1]?.toLowerCase();
 };
 
 const getImageMediaType = (part: {

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -258,6 +258,22 @@ describe("PiThreadController", () => {
     ]);
   });
 
+  it("maps uppercase-scheme data URLs to Pi image content with a lowercase mime", async () => {
+    const client = createFakeClient();
+    const controller = new PiThreadController(client, THREAD);
+    await controller.sendMessage(
+      userMessage("look", {
+        content: [
+          { type: "text", text: "look" },
+          { type: "image", image: "DATA:IMAGE/PNG;base64,AAAA" },
+        ],
+      } as Partial<AppendMessage>),
+    );
+    expect(client.sent[0]!.input.attachments).toEqual([
+      { type: "image", mimeType: "image/png", data: "AAAA" },
+    ]);
+  });
+
   it("cancels the run via the client", async () => {
     const client = createFakeClient();
     const controller = new PiThreadController(client, THREAD);

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -134,9 +134,13 @@ const KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set([
 /** Parse a `data:<mime>;base64,<data>` URL into Pi `ImageContent`. Non-data-URL
  * strings pass through as opaque base64 with a generic image mime. */
 const toImageContent = (image: string): PiImageContent => {
-  const match = /^data:([^;,]+)(?:;base64)?,(.*)$/s.exec(image);
+  const match = /^data:([^;,]+)(?:;base64)?,(.*)$/is.exec(image);
   if (match) {
-    return { type: "image", mimeType: match[1]!, data: match[2]! };
+    return {
+      type: "image",
+      mimeType: match[1]!.toLowerCase(),
+      data: match[2]!,
+    };
   }
   return { type: "image", mimeType: "image/png", data: image };
 };

--- a/packages/react-pi/src/runtime/messageProjection.test.ts
+++ b/packages/react-pi/src/runtime/messageProjection.test.ts
@@ -79,6 +79,28 @@ describe("messageProjection", () => {
     });
   });
 
+  it("does not re-wrap image data that is already an uppercase-scheme data URL", () => {
+    const out = projectPiThreadMessages(
+      input([
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              data: "DATA:image/png;base64,abc",
+              mimeType: "image/png",
+            },
+          ],
+          timestamp: 1,
+        },
+      ]),
+    );
+    expect(contentParts(out[0]!)[0]).toEqual({
+      type: "image",
+      image: "DATA:image/png;base64,abc",
+    });
+  });
+
   it("projects assistant text vs thinking vs tool-call distinctly with parentId", () => {
     const out = projectPiThreadMessages(
       input([

--- a/packages/react-pi/src/runtime/messageProjection.ts
+++ b/packages/react-pi/src/runtime/messageProjection.ts
@@ -57,7 +57,7 @@ const messageId = (index: number) => `pi-msg:${index}`;
 const stepId = (index: number) => `pi-step:${index}`;
 
 const toDataUrl = (data: string, mimeType: string) =>
-  data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
+  /^data:/i.test(data) ? data : `data:${mimeType};base64,${data}`;
 
 const createdAtOf = (message: { timestamp?: number }): Date =>
   new Date(typeof message.timestamp === "number" ? message.timestamp : 0);


### PR DESCRIPTION
## What
`parseDataUrl` now matches the `data:` scheme and `;base64` token case-insensitively and returns the mime type lowercased. The three passthrough sites with their own scheme checks get the same treatment: react-a2a's url arm gate, assistant-stream's `inferImageMediaType`, and react-pi's `toDataUrl` wrap guard.

## Why
Parked item on #5222 during the #5220 review: the scheme check is case-sensitive in core and the adapter passthroughs, so a legal uppercase `DATA:` URL falls through to the raw/base64 arms ([sketch on the issue](https://github.com/assistant-ui/assistant-ui/issues/5222#issuecomment-5114594127), an `/i` on the core regex in one pass). While auditing the sites I found the `/i` alone still misroutes: a verbatim uppercase mime makes ag-ui's `mediaTypeForMime` classify an image as `document`, so the parse boundary also lowercases the captured mime (RFC 2045 mime types are case-insensitive, matching browser canonicalization).

## Impact
- Uppercase or mixed-case data URLs, legal per RFC 3986/2397, now parse everywhere instead of being re-encoded, double-wrapped, or mis-typed.
- The 8 delegating call sites (langchain, langgraph, ag-ui, a2a) are fixed by the core change with no edits.
- Behavior change is strictly widening plus mime lowercasing; previously accepted lowercase URLs with lowercase mimes are byte-identical.

## Scope & caveats
- No false-accept risk from `/i`: a raw base64 payload can never contain `:`, so only genuine data URLs match the widened checks.
- Mime lowercasing also normalizes the pre-existing `data:IMAGE/PNG` case, which previously parsed but misrouted downstream; this is deliberate.
- `packages/ui` (file.tsx, image.tsx) and react-devtools carry the same case-sensitive checks but are private rendering paths with template-sync ripple; deferred as a follow-up.
- Inline `/^data:/i` literals instead of a shared exported pattern: assistant-stream cannot import core (dependency direction), so a shared export could never cover all sites.
- Tests: uppercase/mixed scheme, uppercase `;BASE64` token, and mime lowercasing pinned in core; each edited gate pinned in its own package. The delegating sites are not re-tested per package since they exercise core's contract.
- Additive only, no exports removed or reshaped.
- Expect a trivial rebase against #5315 (touches adk parseDataUrl call sites); built on main per the roadmap sequencing note.
- Review round folded in claude-bot's two findings (core `sanitizeImageContent`, react-pi `toImageContent`) plus one more site a re-sweep surfaced (react-ai-sdk `getDataUrlMediaType`), each pinned with a test.
- Changeset: patch (`@assistant-ui/core`, `@assistant-ui/react-a2a`, `assistant-stream`, `@assistant-ui/react-pi`, `@assistant-ui/react-ai-sdk`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nbNJAKDMWif06OwmTDa8Y440I-l7Y1geeTIMerPDmjySiBRtUPAdfiwo_H4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->