### PR TITLE
refactor(docs): serve /api/mcp through the v2 web-standard MCP transport

### DIFF
--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -402,7 +402,9 @@ async function normalizeMcpRequestHeaders(
   request: NextRequest,
 ): Promise<Request> {
   const accept = request.headers.get("accept");
-  const needsAcceptFix = !accept?.includes("text/event-stream");
+  const needsAcceptFix =
+    !accept?.includes("application/json") ||
+    !accept.includes("text/event-stream");
   const needsContentTypeFix = request.headers.get("content-type") === null;
   if (!needsAcceptFix && !needsContentTypeFix) return request;
 

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -1,18 +1,15 @@
 import type * as PageTree from "fumadocs-core/page-tree";
 import { NextResponse, type NextRequest } from "next/server";
+import {
+  McpServer,
+  ResourceTemplate,
+  WebStandardStreamableHTTPServerTransport,
+} from "@modelcontextprotocol/server";
+import { z } from "zod";
 import { getLLMText } from "@/lib/get-llm-text";
 import { examples, getTapDocsPage, source, tapDocs } from "@/lib/source";
 
 export const revalidate = false;
-
-type JsonRpcRequest = {
-  jsonrpc?: string;
-  id?: string | number | null;
-  method?: string;
-  params?: unknown;
-};
-
-const PROTOCOL_VERSION = "2025-06-18";
 
 const toolDefinitions = [
   {
@@ -74,12 +71,10 @@ const toolDefinitions = [
   },
 ];
 
-function getStringParam(params: unknown, key: string) {
-  if (params && typeof params === "object" && key in params) {
-    const value = (params as Record<string, unknown>)[key];
-    if (typeof value === "string") return value;
-  }
-  return undefined;
+function toolDescription(name: string): string {
+  const tool = toolDefinitions.find((definition) => definition.name === name);
+  if (!tool) throw new Error(`Unknown tool: ${name}`);
+  return tool.description;
 }
 
 function pageSummary(page: {
@@ -275,146 +270,150 @@ async function readPage(path: string | undefined, requestUrl: string) {
   };
 }
 
-async function callTool(
-  name: string | undefined,
-  params: unknown,
-  requestUrl: string,
-) {
-  const args =
-    params && typeof params === "object" && "arguments" in params
-      ? (params as { arguments?: unknown }).arguments
-      : undefined;
-
-  switch (name) {
-    case "list_pages":
-      return listPages(getStringParam(args, "path"));
-    case "get_navigation":
-      return getNavigation();
-    case "search_docs":
-      return searchDocs(getStringParam(args, "query") ?? "");
-    case "read_page":
-      return readPage(getStringParam(args, "path"), requestUrl);
-    default:
-      throw new Error(`Unknown tool: ${name ?? "missing"}`);
-  }
+function toolTextResult(text: string) {
+  return { content: [{ type: "text" as const, text }] };
 }
 
-function jsonRpcResult(id: JsonRpcRequest["id"], result: unknown) {
-  return { jsonrpc: "2.0", id, result };
+function stringifyToolResult(result: unknown) {
+  return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
-function jsonRpcError(id: JsonRpcRequest["id"], code: number, message: string) {
-  return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
-}
-
-async function handleJsonRpcMessage(
-  message: JsonRpcRequest,
-  requestUrl: string,
-) {
-  if (message.id === undefined) return null;
-
+async function toolResult(fn: () => unknown | Promise<unknown>) {
   try {
-    switch (message.method) {
-      case "initialize": {
-        return jsonRpcResult(message.id, {
-          protocolVersion: PROTOCOL_VERSION,
-          capabilities: {
-            tools: { listChanged: false },
-            resources: { subscribe: false, listChanged: false },
-          },
-          serverInfo: {
-            name: "assistant-ui-docs",
-            version: "1.0.0",
-          },
-        });
-      }
-      case "tools/list":
-        return jsonRpcResult(message.id, { tools: toolDefinitions });
-      case "tools/call": {
-        const name = getStringParam(message.params, "name");
-        let result: unknown;
-        try {
-          result = await callTool(name, message.params, requestUrl);
-        } catch (error) {
-          return jsonRpcResult(message.id, {
-            content: [
-              {
-                type: "text",
-                text: error instanceof Error ? error.message : String(error),
-              },
-            ],
-            isError: true,
-          });
-        }
-        return jsonRpcResult(message.id, {
-          content: [
-            {
-              type: "text",
-              text:
-                typeof result === "string"
-                  ? result
-                  : JSON.stringify(result, null, 2),
-            },
-          ],
-        });
-      }
-      case "resources/list":
-        return jsonRpcResult(message.id, {
-          resources: [
-            {
-              uri: "assistant-ui://navigation",
-              name: "assistant-ui docs navigation",
-              mimeType: "application/json",
-            },
-            ...allPages().map(({ page }) => ({
-              uri: `assistant-ui://${stripLeadingSlashes(page.url)}`,
-              name: page.data.title,
-              mimeType: "text/markdown",
-            })),
-          ],
-        });
-      case "resources/read": {
-        const uri = getStringParam(message.params, "uri");
-        if (uri === "assistant-ui://navigation") {
-          return jsonRpcResult(message.id, {
-            contents: [
-              {
-                uri,
-                mimeType: "application/json",
-                text: JSON.stringify(getNavigation(), null, 2),
-              },
-            ],
-          });
-        }
-        if (!uri?.startsWith("assistant-ui://")) {
-          return jsonRpcError(message.id, -32602, "Unsupported resource URI");
-        }
-        const path = uri.slice("assistant-ui://".length);
-        const page = await readPage(path, requestUrl);
-        return jsonRpcResult(message.id, {
-          contents: [
-            {
-              uri,
-              mimeType: "text/markdown",
-              text: page.content,
-            },
-          ],
-        });
-      }
-      default:
-        return jsonRpcError(
-          message.id,
-          -32601,
-          `Method not found: ${message.method ?? "missing"}`,
-        );
-    }
+    return toolTextResult(stringifyToolResult(await fn()));
   } catch (error) {
-    return jsonRpcError(
-      message.id,
-      -32000,
-      error instanceof Error ? error.message : String(error),
-    );
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: error instanceof Error ? error.message : String(error),
+        },
+      ],
+      isError: true as const,
+    };
   }
+}
+
+const listPagesInputSchema = z
+  .object({
+    path: z
+      .string()
+      .describe("Optional docs path or prefix to filter by.")
+      .optional(),
+  })
+  .strict();
+
+const getNavigationInputSchema = z.object({}).strict();
+
+const searchDocsInputSchema = z
+  .object({
+    query: z.string().describe("Search query."),
+  })
+  .strict();
+
+const readPageInputSchema = z
+  .object({
+    path: z
+      .string()
+      .describe(
+        "Page path such as /docs/installation, /docs/installation.md, examples/ai-sdk, tap/docs/store/state, or a same-origin URL.",
+      ),
+  })
+  .strict();
+
+function templateVarToPath(value: string | string[] | undefined): string {
+  return Array.isArray(value) ? value.join("/") : (value ?? "");
+}
+
+function registerResources(server: McpServer, requestUrl: string) {
+  server.registerResource(
+    "assistant-ui docs navigation",
+    "assistant-ui://navigation",
+    { mimeType: "application/json" },
+    async (uri) => ({
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: JSON.stringify(getNavigation(), null, 2),
+        },
+      ],
+    }),
+  );
+
+  server.registerResource(
+    "assistant-ui docs pages",
+    new ResourceTemplate("assistant-ui://{+path}", {
+      list: async () => ({
+        resources: allPages().map(({ page }) => ({
+          uri: `assistant-ui://${stripLeadingSlashes(page.url)}`,
+          name: page.data.title,
+          mimeType: "text/markdown",
+        })),
+      }),
+    }),
+    { mimeType: "text/markdown" },
+    async (uri, variables) => {
+      const path = templateVarToPath(variables["path"]);
+      const page = await readPage(path, requestUrl);
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "text/markdown",
+            text: page.content,
+          },
+        ],
+      };
+    },
+  );
+}
+
+function buildMcpServer(requestUrl: string) {
+  const server = new McpServer({
+    name: "assistant-ui-docs",
+    version: "1.0.0",
+  });
+
+  server.registerTool(
+    "list_pages",
+    {
+      description: toolDescription("list_pages"),
+      inputSchema: listPagesInputSchema,
+    },
+    ({ path }) => toolResult(() => listPages(path)),
+  );
+
+  server.registerTool(
+    "get_navigation",
+    {
+      description: toolDescription("get_navigation"),
+      inputSchema: getNavigationInputSchema,
+    },
+    () => toolResult(() => getNavigation()),
+  );
+
+  server.registerTool(
+    "search_docs",
+    {
+      description: toolDescription("search_docs"),
+      inputSchema: searchDocsInputSchema,
+    },
+    ({ query }) => toolResult(() => searchDocs(query)),
+  );
+
+  server.registerTool(
+    "read_page",
+    {
+      description: toolDescription("read_page"),
+      inputSchema: readPageInputSchema,
+    },
+    ({ path }) => toolResult(() => readPage(path, requestUrl)),
+  );
+
+  registerResources(server, requestUrl);
+
+  return server;
 }
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
@@ -440,43 +439,13 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  let payload: unknown;
-  try {
-    payload = await request.json();
-  } catch {
-    return jsonResponse(jsonRpcError(null, -32700, "Parse error"), {
-      status: 400,
-    });
-  }
-
-  if (Array.isArray(payload)) {
-    if (payload.length === 0) {
-      return jsonResponse(jsonRpcError(null, -32600, "Invalid Request"), {
-        status: 400,
-      });
-    }
-
-    const results = (
-      await Promise.all(
-        payload.map((message) =>
-          handleJsonRpcMessage(message as JsonRpcRequest, request.url),
-        ),
-      )
-    ).filter((result) => result !== null);
-
-    return results.length > 0
-      ? jsonResponse(results)
-      : new NextResponse(null, { status: 202 });
-  }
-
-  const result = await handleJsonRpcMessage(
-    payload as JsonRpcRequest,
-    request.url,
-  );
-
-  return result
-    ? jsonResponse(result)
-    : new NextResponse(null, { status: 202 });
+  const server = buildMcpServer(request.url);
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+  });
+  await server.connect(transport);
+  return transport.handleRequest(request);
 }
 
 export function OPTIONS() {

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -16,66 +16,25 @@ const toolDefinitions = [
     name: "list_pages",
     description:
       "List assistant-ui documentation pages. Optionally filter by a URL path prefix such as /docs/tools, /examples, or /tap/docs.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        path: {
-          type: "string",
-          description: "Optional docs path or prefix to filter by.",
-        },
-      },
-      additionalProperties: false,
-    },
   },
   {
     name: "get_navigation",
     description: "Return the assistant-ui docs navigation tree.",
-    inputSchema: {
-      type: "object",
-      properties: {},
-      additionalProperties: false,
-    },
   },
   {
     name: "search_docs",
     description:
       "Search assistant-ui docs, examples, and Tap docs by title, description, or URL.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        query: {
-          type: "string",
-          description: "Search query.",
-        },
-      },
-      required: ["query"],
-      additionalProperties: false,
-    },
   },
   {
     name: "read_page",
     description:
       "Read one assistant-ui docs, examples, or Tap docs page as markdown. Accepts a slug, path, .md URL, or same-origin URL.",
-    inputSchema: {
-      type: "object",
-      properties: {
-        path: {
-          type: "string",
-          description:
-            "Page path such as /docs/installation, /docs/installation.md, examples/ai-sdk, tap/docs/store/state, or a same-origin URL.",
-        },
-      },
-      required: ["path"],
-      additionalProperties: false,
-    },
   },
-];
+] as const;
 
-function toolDescription(name: string): string {
-  const tool = toolDefinitions.find((definition) => definition.name === name);
-  if (!tool) throw new Error(`Unknown tool: ${name}`);
-  return tool.description;
-}
+const [listPagesTool, getNavigationTool, searchDocsTool, readPageTool] =
+  toolDefinitions;
 
 function pageSummary(page: {
   url: string;
@@ -376,36 +335,36 @@ function buildMcpServer(requestUrl: string) {
   });
 
   server.registerTool(
-    "list_pages",
+    listPagesTool.name,
     {
-      description: toolDescription("list_pages"),
+      description: listPagesTool.description,
       inputSchema: listPagesInputSchema,
     },
     ({ path }) => toolResult(() => listPages(path)),
   );
 
   server.registerTool(
-    "get_navigation",
+    getNavigationTool.name,
     {
-      description: toolDescription("get_navigation"),
+      description: getNavigationTool.description,
       inputSchema: getNavigationInputSchema,
     },
     () => toolResult(() => getNavigation()),
   );
 
   server.registerTool(
-    "search_docs",
+    searchDocsTool.name,
     {
-      description: toolDescription("search_docs"),
+      description: searchDocsTool.description,
       inputSchema: searchDocsInputSchema,
     },
     ({ query }) => toolResult(() => searchDocs(query)),
   );
 
   server.registerTool(
-    "read_page",
+    readPageTool.name,
     {
-      description: toolDescription("read_page"),
+      description: readPageTool.description,
       inputSchema: readPageInputSchema,
     },
     ({ path }) => toolResult(() => readPage(path, requestUrl)),
@@ -438,6 +397,29 @@ export async function GET() {
   });
 }
 
+// The public docs endpoint keeps accepting pre-SDK lenient clients that omit the SSE half of Accept or the Content-Type header.
+async function normalizeMcpRequestHeaders(
+  request: NextRequest,
+): Promise<Request> {
+  const accept = request.headers.get("accept");
+  const needsAcceptFix = !accept?.includes("text/event-stream");
+  const needsContentTypeFix = request.headers.get("content-type") === null;
+  if (!needsAcceptFix && !needsContentTypeFix) return request;
+
+  const headers = new Headers(request.headers);
+  if (needsAcceptFix) {
+    headers.set("Accept", "application/json, text/event-stream");
+  }
+  if (needsContentTypeFix) {
+    headers.set("Content-Type", "application/json");
+  }
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: await request.text(),
+  });
+}
+
 export async function POST(request: NextRequest) {
   const server = buildMcpServer(request.url);
   const transport = new WebStandardStreamableHTTPServerTransport({
@@ -445,7 +427,13 @@ export async function POST(request: NextRequest) {
     enableJsonResponse: true,
   });
   await server.connect(transport);
-  return transport.handleRequest(request);
+  try {
+    const normalizedRequest = await normalizeMcpRequestHeaders(request);
+    return await transport.handleRequest(normalizedRequest);
+  } finally {
+    await transport.close().catch(() => {});
+    await server.close().catch(() => {});
+  }
 }
 
 export function OPTIONS() {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -35,6 +35,7 @@
     "@blaxel/core": "^0.3.8",
     "@hookform/resolvers": "^5.4.2",
     "@langchain/langgraph-sdk": "^1.9.28",
+    "@modelcontextprotocol/server": "^2.0.0",
     "@posthog/ai": "^8.4.0",
     "@shikijs/transformers": "^4.3.1",
     "@upstash/ratelimit": "^2.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
         version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@posthog/ai':
         specifier: ^8.4.0
         version: 8.4.0(@ai-sdk/provider@3.0.14)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)))(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-http@0.205.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(posthog-node@5.46.1(rxjs@7.8.2))


### PR DESCRIPTION
## summary

- the docs site's `/api/mcp` route was a hand-rolled JSON-RPC implementation pinned to protocol `2025-06-18`; it now builds a per-request `McpServer` and answers through `@modelcontextprotocol/server`'s `WebStandardStreamableHTTPServerTransport` (`sessionIdGenerator: undefined`, `enableJsonResponse: true`), which matches Next.js route handlers' web-standard `Request`/`Response` and deletes the protocol layer
- the wire contract is preserved: same four tools with identical names, descriptions, and schema shapes (single-sourced `{name, description}` metadata feeding both the GET discovery payload and the registrations; zod v4 schemas with `.strict()` are the only schema source), same `assistant-ui://` resources, same tool-error and stringification conventions, and the bespoke GET discovery JSON and OPTIONS handlers are untouched (GET verified byte-identical)
- per-request server construction carries the request URL into `read_page`'s same-origin check with no module-level state, and both transport and server are closed in a `try/finally` after every request, mirroring the SDK's own stateless-fallback teardown order
- header leniency is preserved deliberately: the v2 transport strictly requires `Accept: application/json, text/event-stream` and a JSON `Content-Type` (probed 406/415), so POST normalizes a missing SSE half of `Accept` and a truly absent `Content-Type` before handing the request to the transport; a present-but-wrong `Content-Type` still rejects, and lenient clients receive genuine JSON bodies
- era scope, stated precisely: the endpoint still speaks the 2025 era only (2024-10-07 through 2025-11-25 negotiation via the SDK; a `2025-06-18` client works unchanged). `createMcpHandler`, which would add the `2026-07-28` era with a legacy fallback, was evaluated and deferred: its legacy leg exposes no JSON-response option and answers 2025-era POSTs as SSE, which would break exactly the lenient clients above; adopting it is a follow-up gated on upstream exposing that knob

## test plan

### already verified

- [x] live smoke against `next dev`: initialize as a `2025-06-18` client, `notifications/initialized`, `tools/list` (exactly four tools), `tools/call` for all four tools with real content, `resources/read assistant-ui://navigation` and a page resource, GET discovery byte-identical, JSON-RPC array batching still answered
- [x] leniency probes: `Accept: application/json` only, absent `Accept`, absent `Content-Type`, and both-absent all serve 200 with JSON bodies (each was 4xx before the fix commit); present-but-wrong `Content-Type` still 415
- [x] era probes: modern `server/discover` answers method-not-found, an `MCP-Protocol-Version: 2026-07-28` header is cleanly rejected with the supported-version list, and a modern `_meta` envelope on initialize degrades to a legacy handshake
- [x] 15x rapid `tools/list` soak clean; `tsc --noEmit`, `oxlint`, `oxfmt --check` all clean
- [x] no changeset needed, apps/docs is private

### reviewer should verify

- [ ] connect an MCP client (e.g. Claude Code `claude mcp add --transport http`) to the deployed `/mcp` rewrite and confirm `tools/list` and a `read_page` call return docs content

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Nt6xydAL5nrXNm-0Pmny_rTe-WIe4U5TiXl3q7uH22Qahzpv0j6UeU0uZ0I?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->