### PR TITLE
fix: case-insensitive data: scheme in ui kit and devtools preview parsing

### DIFF
--- a/.changeset/data-url-case-ui-devtools.md
+++ b/.changeset/data-url-case-ui-devtools.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-devtools": patch
+---
+
+fix: case-insensitive data: and http(s) scheme checks in preview parsing

--- a/packages/react-devtools/src/views/attachments/formatBytes.ts
+++ b/packages/react-devtools/src/views/attachments/formatBytes.ts
@@ -10,6 +10,4 @@ export const estimateBase64Bytes = (data: string): number =>
   Math.max(0, Math.floor((data.length * 3) / 4));
 
 export const isSafeImagePreviewUrl = (url: string): boolean =>
-  url.startsWith("data:image/") ||
-  url.startsWith("https://") ||
-  url.startsWith("http://");
+  /^data:image\//i.test(url) || /^https?:\/\//i.test(url);

--- a/packages/react-devtools/src/views/attachments/parseAttachment.test.ts
+++ b/packages/react-devtools/src/views/attachments/parseAttachment.test.ts
@@ -34,4 +34,29 @@ describe("parseAttachment", () => {
     expect(result?.previewUrl).toBe("data:image/png;base64,abcd");
     expect(result?.sizeBytes).toBeGreaterThan(0);
   });
+
+  it("extracts preview and size for an uppercase data: scheme", () => {
+    const result = parseAttachment({
+      name: "shot.png",
+      type: "image",
+      content: [
+        {
+          type: "image",
+          image: "DATA:IMAGE/PNG;base64,abcd",
+        },
+      ],
+    });
+    expect(result?.previewUrl).toBe("DATA:IMAGE/PNG;base64,abcd");
+    expect(result?.sizeBytes).toBeGreaterThan(0);
+  });
+
+  it("accepts an uppercase HTTPS preview URL without a size estimate", () => {
+    const result = parseAttachment({
+      name: "remote.png",
+      type: "image",
+      image: "HTTPS://example.com/pic.png",
+    });
+    expect(result?.previewUrl).toBe("HTTPS://example.com/pic.png");
+    expect(result?.sizeBytes).toBeUndefined();
+  });
 });

--- a/packages/react-devtools/src/views/attachments/parseAttachment.ts
+++ b/packages/react-devtools/src/views/attachments/parseAttachment.ts
@@ -26,7 +26,7 @@ const mediaFromContent = (
     if (type === "image") {
       const image = asString(part.image);
       if (image && isSafeImagePreviewUrl(image)) {
-        const sizeBytes = image.startsWith("data:")
+        const sizeBytes = /^data:/i.test(image)
           ? estimateBase64Bytes(image.split(",", 2)[1] ?? image)
           : undefined;
         return {

--- a/packages/react-devtools/src/views/message/parse.test.ts
+++ b/packages/react-devtools/src/views/message/parse.test.ts
@@ -99,6 +99,21 @@ describe("parsePart", () => {
     expect(part.subMessageCount).toBe(2);
   });
 
+  it("parses an image part with an uppercase data: scheme", () => {
+    const part = parsePart({
+      type: "image",
+      image: "DATA:IMAGE/PNG;base64,abcd",
+      filename: "shot.png",
+    });
+    expect(part).toMatchObject({
+      type: "image",
+      filename: "shot.png",
+      previewUrl: "DATA:IMAGE/PNG;base64,abcd",
+    });
+    if (part.type !== "image") return;
+    expect(part.sizeBytes).toBeGreaterThan(0);
+  });
+
   it("falls back to unknown for unrecognized part types", () => {
     const part = parsePart({ type: "mystery", foo: 1 });
     expect(part.type).toBe("unknown");

--- a/packages/react-devtools/src/views/message/parse.ts
+++ b/packages/react-devtools/src/views/message/parse.ts
@@ -128,9 +128,10 @@ export const parsePart = (value: unknown): PartPreview => {
       const image = asString(value.image);
       const previewUrl =
         image && isSafeImagePreviewUrl(image) ? image : undefined;
-      const sizeBytes = previewUrl?.startsWith("data:")
-        ? estimateBase64Bytes(previewUrl.split(",", 2)[1] ?? previewUrl)
-        : undefined;
+      const sizeBytes =
+        previewUrl && /^data:/i.test(previewUrl)
+          ? estimateBase64Bytes(previewUrl.split(",", 2)[1] ?? previewUrl)
+          : undefined;
       return {
         type: "image",
         ...(filename ? { filename } : {}),

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -37,22 +37,23 @@ const fileVariants = cva(
 );
 
 function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
-  if (mimeType.startsWith("image/")) {
+  const type = mimeType.toLowerCase();
+  if (type.startsWith("image/")) {
     return ImageIcon;
   }
-  if (mimeType === "application/pdf") {
+  if (type === "application/pdf") {
     return FileTextIcon;
   }
-  if (mimeType === "application/json") {
+  if (type === "application/json") {
     return BracesIcon;
   }
-  if (mimeType.startsWith("text/")) {
+  if (type.startsWith("text/")) {
     return FileTextIcon;
   }
-  if (mimeType.startsWith("audio/")) {
+  if (type.startsWith("audio/")) {
     return MusicIcon;
   }
-  if (mimeType.startsWith("video/")) {
+  if (type.startsWith("video/")) {
     return VideoIcon;
   }
   return FileIcon;
@@ -167,9 +168,7 @@ function FileDownload({
   children,
   ...props
 }: FileDownloadProps) {
-  const href = data.startsWith("data:")
-    ? data
-    : `data:${mimeType};base64,${data}`;
+  const href = /^data:/i.test(data) ? data : `data:${mimeType};base64,${data}`;
 
   return (
     <a

--- a/packages/ui/src/components/assistant-ui/image.tsx
+++ b/packages/ui/src/components/assistant-ui/image.tsx
@@ -44,7 +44,9 @@ const extensionForMimeType = (mimeType?: string): string => {
 
 const dataUriToBlob = (dataUri: string): Blob => {
   const [meta, data] = dataUri.split(",");
-  const mime = meta?.match(/data:([^;]+)/)?.[1] ?? "application/octet-stream";
+  const mime =
+    meta?.match(/data:([^;]+)/i)?.[1]?.toLowerCase() ??
+    "application/octet-stream";
   if (!/;base64/i.test(meta ?? "")) {
     return new Blob([decodeURIComponent(data ?? "")], { type: mime });
   }
@@ -55,7 +57,7 @@ const dataUriToBlob = (dataUri: string): Blob => {
 };
 
 const mimeFromImage = (image: string): string | undefined =>
-  image.match(/^data:([^;,]+)/)?.[1];
+  image.match(/^data:([^;,]+)/i)?.[1]?.toLowerCase();
 
 const downloadImagePart = (
   part: Pick<ImageMessagePart, "image" | "filename">,
@@ -63,7 +65,7 @@ const downloadImagePart = (
   if (typeof document === "undefined") return;
   const ext = extensionForMimeType(mimeFromImage(part.image));
   const filename = part.filename ?? `image.${ext}`;
-  const isDataUri = part.image.startsWith("data:");
+  const isDataUri = /^data:/i.test(part.image);
   const objectUrl = isDataUri
     ? URL.createObjectURL(dataUriToBlob(part.image))
     : null;
@@ -88,7 +90,7 @@ const copyImagePart = async (
   ) {
     throw new Error("Clipboard API is not available in this environment.");
   }
-  const blob = part.image.startsWith("data:")
+  const blob = /^data:/i.test(part.image)
     ? dataUriToBlob(part.image)
     : await fetch(part.image).then((r) => r.blob());
   const mime = mimeFromImage(part.image) ?? blob.type ?? "image/png";


### PR DESCRIPTION
## What
Finishes the case-insensitive `data:` scheme sweep that #5318 deferred: the ui kit's `file.tsx`/`image.tsx` and react-devtools' preview parsing now use `/^data:/i` gates and lowercase captured mimes, matching the pattern #5318 established.

## Why
While tracing an uppercase `DATA:application/pdf;base64,...` URL through the kit, FileDownload re-wrapped it into `href="data:...;base64,DATA:..."`, a dead download link, and devtools rendered no preview at all because `isSafeImagePreviewUrl` only accepts lowercase schemes. These are the exact sites enumerated in [the #5318 review](https://github.com/assistant-ui/assistant-ui/pull/5318#issuecomment-5114853691). Closes #5322.

## Impact
- Uppercase or mixed-case data URLs now download, copy, and preview correctly in the kit components and devtools; lowercase inputs are byte-identical.
- `dataUriToBlob`/`mimeFromImage` now lowercase the captured mime, so a `data:IMAGE/PNG` blob is typed `image/png` and no longer rejects in `ClipboardItem`.

## Scope & caveats
- `isSafeImagePreviewUrl` widening is case-only: `/^data:image\//i` and `/^https?:\/\//i` admit no new scheme, and the http pattern matches core's `httpUrlPattern` from #5318.
- The two `startsWith("data:")` sizeBytes gates in devtools sit behind `isSafeImagePreviewUrl`, so fixing the front gate alone would leave them dead for uppercase; all three are changed together.
- `getBase64Size` in file.tsx already splits on the first comma and is case-agnostic, so it is untouched.
- Mime lowercasing also normalizes the previously accepted mixed-case `data:IMAGE/PNG` case; deliberate, same contract as #5318.
- file.tsx and image.tsx are single-flavor (no `.radix` sibling) with no template copies; `pnpm sync-templates` confirms no drift.
- Tests: uppercase scheme pinned through both devtools parsers (preview accepted, sizeBytes computed) plus an uppercase HTTPS preview URL; not covered: the ui components, since `packages/ui` has no test infrastructure.
- Additive only, no exports removed or reshaped.
- Changeset: patch (`@assistant-ui/react-devtools`); `@assistant-ui/ui` is private.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ECaDKUSW8wXCCuSQYqJ7mDbpv85kxMqGBLdVGGOhhRElgLNwta55raQrCpM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->