### PR TITLE
fix(react-opencode): wire permissions to standard tool approvals

### DIFF
--- a/.changeset/clean-tools-approve.md
+++ b/.changeset/clean-tools-approve.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: connect OpenCode permissions to standard tool approvals

--- a/apps/docs/content/docs/runtimes/opencode/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/hooks.mdx
@@ -9,7 +9,9 @@ OpenCode-specific React hooks for interacting with the running session. All hook
 
 ## Permissions
 
-OpenCode pauses tool execution to ask the user for permission (e.g. running shell commands, writing files). `useOpenCodePermissions` returns the pending permission requests and a reply function:
+OpenCode pauses tool execution to ask the user for permission (e.g. running shell commands, writing files). Permissions linked to a tool call are projected into assistant-ui's standard tool approval contract, so the default `ToolFallback` renders working **Allow once**, **Always allow**, and **Reject** actions without a custom permission component.
+
+`useOpenCodePermissions` remains available for custom tool renderers and permission requests that are not linked to a tool call. It returns the pending permission requests and a reply function:
 
 ```tsx
 import { useOpenCodePermissions } from "@assistant-ui/react-opencode";

--- a/apps/docs/content/docs/runtimes/opencode/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/hooks.mdx
@@ -9,7 +9,7 @@ OpenCode-specific React hooks for interacting with the running session. All hook
 
 ## Permissions
 
-OpenCode pauses tool execution to ask the user for permission (e.g. running shell commands, writing files). Permissions linked to a tool call are projected into assistant-ui's standard tool approval contract, so the default `ToolFallback` renders working **Allow once**, **Always allow**, and **Reject** actions without a custom permission component.
+OpenCode pauses tool execution to ask the user for permission (e.g. running shell commands, writing files). Permissions linked to a tool call are projected into assistant-ui's standard tool approval contract, so the default `ToolFallback` renders working **Allow**, **Always allow**, and **Deny** actions without a custom permission component. The always option only appears when OpenCode offers patterns to persist.
 
 `useOpenCodePermissions` remains available for custom tool renderers and permission requests that are not linked to a tool call. It returns the pending permission requests and a reply function:
 

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -234,6 +234,34 @@ describe("OpenCodeThreadController", () => {
     });
   });
 
+  it("normalizes permission requests missing the always list", () => {
+    const eventSource = createEventSource();
+    const controller = new OpenCodeThreadController(
+      {} as never,
+      () => eventSource,
+      "ses_1",
+    );
+    controller.subscribe(vi.fn());
+
+    eventSource.emit({
+      type: "permission.asked",
+      sessionId: "ses_1",
+      properties: {
+        id: "permission_1",
+        sessionID: "ses_1",
+        permission: "bash",
+        patterns: [],
+        metadata: {},
+        tool: { messageID: "assistant-1", callID: "call-1" },
+      },
+      raw: {},
+    });
+
+    expect(
+      controller.getState().interactions.permissions.pending["permission_1"],
+    ).toMatchObject({ id: "permission_1", always: [] });
+  });
+
   it("detaches from OpenCode events when the last state listener unsubscribes", () => {
     const eventSource = createEventSource();
     const controller = new OpenCodeThreadController(

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -115,7 +115,7 @@ const toPermissionRequest = (
     permission: request.permission,
     patterns: request.patterns,
     metadata,
-    always: request.always,
+    always: Array.isArray(request.always) ? request.always : [],
     tool: request.tool,
     toolName:
       typeof toolNameValue === "string" ? toolNameValue : request.permission,

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -155,7 +155,7 @@ describe("projectOpenCodeThreadMessages", () => {
               permission: "bash",
               patterns: [],
               metadata: {},
-              always: [],
+              always: ["git *"],
               askedAt: 1000,
               raw: {} as never,
               tool: {
@@ -220,6 +220,25 @@ describe("projectOpenCodeThreadMessages", () => {
       type: "requires-action",
       reason: "tool-calls",
     });
+    expect(messages[0]?.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        approval: {
+          id: "permission_1",
+          options: [
+            { id: "once", kind: "allow-once" },
+            {
+              id: "always",
+              kind: "allow-always",
+              grants: ["git *"],
+              confirm: true,
+            },
+            { id: "reject", kind: "reject-once" },
+          ],
+        },
+      },
+    ]);
   });
 
   it("marks assistant messages with pending question requests as requires-action", () => {

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -241,6 +241,93 @@ describe("projectOpenCodeThreadMessages", () => {
     ]);
   });
 
+  it("projects resolved permissions as recorded approval decisions", () => {
+    const base = createOpenCodeThreadState("ses_1");
+    const state: OpenCodeThreadState = {
+      ...base,
+      interactions: {
+        ...base.interactions,
+        permissions: {
+          pending: {},
+          resolved: {
+            permission_1: {
+              request: {
+                id: "permission_1",
+                sessionId: "ses_1",
+                permission: "bash",
+                patterns: [],
+                metadata: {},
+                always: ["git *"],
+                askedAt: 1000,
+                raw: {} as never,
+                tool: {
+                  messageID: "assistant-1",
+                  callID: "call-1",
+                },
+              },
+              reply: "once",
+              respondedAt: 2000,
+            },
+          },
+        },
+      },
+      messageOrder: ["assistant-1"],
+      messagesById: {
+        "assistant-1": {
+          id: "assistant-1",
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+            sessionID: "ses_1",
+            parentID: "user-1",
+            modelID: "model",
+            providerID: "provider",
+            mode: "primary",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 1 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "tool-1",
+              callID: "call-1",
+              sessionID: "ses_1",
+              messageID: "assistant-1",
+              type: "tool",
+              tool: "bash",
+              state: {
+                status: "pending",
+                input: { command: "ls" },
+                raw: "ls",
+              },
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+
+    const messages = projectOpenCodeThreadMessages(state);
+    expect(messages[0]?.content).toMatchObject([
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        approval: {
+          id: "permission_1",
+          approved: true,
+          optionId: "once",
+        },
+      },
+    ]);
+  });
+
   it("marks assistant messages with pending question requests as requires-action", () => {
     const state: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_1"),

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -123,21 +123,47 @@ const getPartToolCallId = (part: Part) => {
   return typeof part.callID === "string" ? part.callID : undefined;
 };
 
+type PermissionState = OpenCodeThreadState["interactions"]["permissions"];
+type PendingPermission = PermissionState["pending"][string];
+type ResolvedPermission = PermissionState["resolved"][string];
+
+type PermissionIndex = {
+  pendingByCallId: ReadonlyMap<string, PendingPermission>;
+  resolvedByCallId: ReadonlyMap<string, ResolvedPermission>;
+};
+
+const permissionIndexCache = new WeakMap<PermissionState, PermissionIndex>();
+
+const getPermissionIndex = (state: OpenCodeThreadState): PermissionIndex => {
+  const permissions = state.interactions.permissions;
+  const cached = permissionIndexCache.get(permissions);
+  if (cached) return cached;
+
+  const pendingByCallId = new Map<string, PendingPermission>();
+  for (const request of Object.values(permissions.pending)) {
+    if (request.tool?.callID) pendingByCallId.set(request.tool.callID, request);
+  }
+
+  const resolvedByCallId = new Map<string, ResolvedPermission>();
+  for (const entry of Object.values(permissions.resolved)) {
+    const callId = entry.request.tool?.callID;
+    if (callId) resolvedByCallId.set(callId, entry);
+  }
+
+  const index: PermissionIndex = { pendingByCallId, resolvedByCallId };
+  permissionIndexCache.set(permissions, index);
+  return index;
+};
+
 const getPendingPermissionForToolCall = (
   state: OpenCodeThreadState,
   toolCallId: string,
-) =>
-  Object.values(state.interactions.permissions.pending).find(
-    (request) => request.tool?.callID === toolCallId,
-  );
+) => getPermissionIndex(state).pendingByCallId.get(toolCallId);
 
 const getResolvedPermissionForToolCall = (
   state: OpenCodeThreadState,
   toolCallId: string,
-) =>
-  Object.values(state.interactions.permissions.resolved).find(
-    (entry) => entry.request.tool?.callID === toolCallId,
-  );
+) => getPermissionIndex(state).resolvedByCallId.get(toolCallId);
 
 const hasPendingInteractionForToolCall = (
   state: OpenCodeThreadState,
@@ -145,10 +171,8 @@ const hasPendingInteractionForToolCall = (
 ) => {
   if (!toolCallId) return false;
 
-  for (const request of Object.values(state.interactions.permissions.pending)) {
-    if (request.tool?.callID === toolCallId) {
-      return true;
-    }
+  if (getPermissionIndex(state).pendingByCallId.has(toolCallId)) {
+    return true;
   }
 
   for (const request of Object.values(state.interactions.questions.pending)) {

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -11,7 +11,10 @@ import {
   ExportedMessageRepository,
   type MessageTiming,
 } from "@assistant-ui/react";
-import { projectOpenCodePermissionApproval } from "./openCodePermissionApproval";
+import {
+  projectOpenCodePermissionApproval,
+  projectResolvedOpenCodePermissionApproval,
+} from "./openCodePermissionApproval";
 
 type ProjectedContentPart = Exclude<
   OpenCodeProjectedThreadMessage["content"],
@@ -126,6 +129,14 @@ const getPendingPermissionForToolCall = (
 ) =>
   Object.values(state.interactions.permissions.pending).find(
     (request) => request.tool?.callID === toolCallId,
+  );
+
+const getResolvedPermissionForToolCall = (
+  state: OpenCodeThreadState,
+  toolCallId: string,
+) =>
+  Object.values(state.interactions.permissions.resolved).find(
+    (entry) => entry.request.tool?.callID === toolCallId,
   );
 
 const hasPendingInteractionForToolCall = (
@@ -247,6 +258,9 @@ const projectAssistantContent = (
         const toolState = mapToolState(part.state);
         const toolCallId = part.callID ?? part.id ?? `tool-${index}`;
         const permission = getPendingPermissionForToolCall(state, toolCallId);
+        const resolvedPermission = permission
+          ? undefined
+          : getResolvedPermissionForToolCall(state, toolCallId);
         content.push({
           type: "tool-call",
           toolCallId,
@@ -259,7 +273,14 @@ const projectAssistantContent = (
           ...(toolState.isError ? { isError: true } : {}),
           ...(permission
             ? { approval: projectOpenCodePermissionApproval(permission) }
-            : {}),
+            : resolvedPermission
+              ? {
+                  approval:
+                    projectResolvedOpenCodePermissionApproval(
+                      resolvedPermission,
+                    ),
+                }
+              : {}),
           ...(currentStepId() ? { parentId: currentStepId() } : {}),
         });
         break;

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -11,6 +11,7 @@ import {
   ExportedMessageRepository,
   type MessageTiming,
 } from "@assistant-ui/react";
+import { projectOpenCodePermissionApproval } from "./openCodePermissionApproval";
 
 type ProjectedContentPart = Exclude<
   OpenCodeProjectedThreadMessage["content"],
@@ -119,6 +120,14 @@ const getPartToolCallId = (part: Part) => {
   return typeof part.callID === "string" ? part.callID : undefined;
 };
 
+const getPendingPermissionForToolCall = (
+  state: OpenCodeThreadState,
+  toolCallId: string,
+) =>
+  Object.values(state.interactions.permissions.pending).find(
+    (request) => request.tool?.callID === toolCallId,
+  );
+
 const hasPendingInteractionForToolCall = (
   state: OpenCodeThreadState,
   toolCallId: string | undefined,
@@ -201,6 +210,7 @@ const convertFilePart = (part: Extract<Part, { type: "file" }>) => {
 };
 
 const projectAssistantContent = (
+  state: OpenCodeThreadState,
   message: OpenCodeServerMessage,
 ): ProjectedContentPart[] => {
   const content: ProjectedContentPart[] = [];
@@ -235,9 +245,11 @@ const projectAssistantContent = (
 
       case "tool": {
         const toolState = mapToolState(part.state);
+        const toolCallId = part.callID ?? part.id ?? `tool-${index}`;
+        const permission = getPendingPermissionForToolCall(state, toolCallId);
         content.push({
           type: "tool-call",
-          toolCallId: part.callID ?? part.id ?? `tool-${index}`,
+          toolCallId,
           toolName: part.tool ?? "tool",
           args: toolState.args as never,
           argsText: toolState.argsText,
@@ -245,6 +257,9 @@ const projectAssistantContent = (
             ? { result: toolState.result }
             : {}),
           ...(toolState.isError ? { isError: true } : {}),
+          ...(permission
+            ? { approval: projectOpenCodePermissionApproval(permission) }
+            : {}),
           ...(currentStepId() ? { parentId: currentStepId() } : {}),
         });
         break;
@@ -480,7 +495,7 @@ const projectServerMessage = (
       id: message.info.id,
       role: "assistant",
       createdAt: new Date(message.info.time?.created ?? Date.now()),
-      content: projectAssistantContent(message),
+      content: projectAssistantContent(state, message),
       status: getMessageStatus(state, message),
       metadata: {
         custom: {

--- a/packages/react-opencode/src/openCodePermissionApproval.test.ts
+++ b/packages/react-opencode/src/openCodePermissionApproval.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  projectOpenCodePermissionApproval,
+  toOpenCodePermissionResponse,
+} from "./openCodePermissionApproval";
+import type { OpenCodePermissionRequest } from "./types";
+
+const request: OpenCodePermissionRequest = {
+  id: "permission-1",
+  sessionId: "session-1",
+  permission: "bash",
+  patterns: ["git status"],
+  metadata: {},
+  always: ["git *"],
+  tool: {
+    messageID: "message-1",
+    callID: "call-1",
+  },
+  askedAt: 1,
+  raw: {} as never,
+};
+
+describe("OpenCode permission approvals", () => {
+  it("projects OpenCode replies as standard approval options", () => {
+    expect(projectOpenCodePermissionApproval(request)).toEqual({
+      id: "permission-1",
+      options: [
+        {
+          id: "once",
+          kind: "allow-once",
+          label: "Allow once",
+        },
+        {
+          id: "always",
+          kind: "allow-always",
+          label: "Always allow",
+          description: "Allow these patterns until OpenCode is restarted.",
+          grants: ["git *"],
+          confirm: true,
+        },
+        {
+          id: "reject",
+          kind: "reject-once",
+          label: "Reject",
+        },
+      ],
+    });
+  });
+
+  it.each([
+    [{ approvalId: "p", approved: true }, "once"],
+    [{ approvalId: "p", approved: false }, "reject"],
+    [{ approvalId: "p", approved: true, optionId: "once" }, "once"],
+    [{ approvalId: "p", approved: true, optionId: "always" }, "always"],
+    [{ approvalId: "p", approved: false, optionId: "reject" }, "reject"],
+  ] as const)("maps the standard decision %o to %s", (response, expected) => {
+    expect(toOpenCodePermissionResponse(response)).toBe(expected);
+  });
+
+  it.each([
+    { approvalId: "p", approved: false, optionId: "once" },
+    { approvalId: "p", approved: false, optionId: "always" },
+    { approvalId: "p", approved: true, optionId: "reject" },
+    { approvalId: "p", approved: true, optionId: "unknown" },
+  ])("rejects an invalid standard decision %o", (response) => {
+    expect(() => toOpenCodePermissionResponse(response)).toThrow();
+  });
+});

--- a/packages/react-opencode/src/openCodePermissionApproval.test.ts
+++ b/packages/react-opencode/src/openCodePermissionApproval.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   projectOpenCodePermissionApproval,
+  projectResolvedOpenCodePermissionApproval,
   toOpenCodePermissionResponse,
 } from "./openCodePermissionApproval";
 import type { OpenCodePermissionRequest } from "./types";
@@ -28,12 +29,10 @@ describe("OpenCode permission approvals", () => {
         {
           id: "once",
           kind: "allow-once",
-          label: "Allow once",
         },
         {
           id: "always",
           kind: "allow-always",
-          label: "Always allow",
           description: "Allow these patterns until OpenCode is restarted.",
           grants: ["git *"],
           confirm: true,
@@ -41,10 +40,27 @@ describe("OpenCode permission approvals", () => {
         {
           id: "reject",
           kind: "reject-once",
-          label: "Reject",
         },
       ],
     });
+  });
+
+  it("omits the always option when the request grants nothing", () => {
+    expect(
+      projectOpenCodePermissionApproval({ ...request, always: [] }).options,
+    ).toEqual([
+      { id: "once", kind: "allow-once" },
+      { id: "reject", kind: "reject-once" },
+    ]);
+  });
+
+  it("projects resolved replies with the recorded decision", () => {
+    expect(
+      projectResolvedOpenCodePermissionApproval({ request, reply: "always" }),
+    ).toEqual({ id: "permission-1", approved: true, optionId: "always" });
+    expect(
+      projectResolvedOpenCodePermissionApproval({ request, reply: "reject" }),
+    ).toEqual({ id: "permission-1", approved: false, optionId: "reject" });
   });
 
   it.each([

--- a/packages/react-opencode/src/openCodePermissionApproval.ts
+++ b/packages/react-opencode/src/openCodePermissionApproval.ts
@@ -7,30 +7,42 @@ import type {
   OpenCodePermissionResponse,
 } from "./types";
 
+type ToolCallApproval = NonNullable<ToolCallMessagePart["approval"]>;
+
 export const projectOpenCodePermissionApproval = (
   request: OpenCodePermissionRequest,
-): NonNullable<ToolCallMessagePart["approval"]> => ({
+): ToolCallApproval => ({
   id: request.id,
   options: [
     {
       id: "once",
       kind: "allow-once",
-      label: "Allow once",
     },
-    {
-      id: "always",
-      kind: "allow-always",
-      label: "Always allow",
-      description: "Allow these patterns until OpenCode is restarted.",
-      ...(request.always.length > 0 ? { grants: request.always } : {}),
-      confirm: true,
-    },
+    ...(request.always.length > 0
+      ? [
+          {
+            id: "always",
+            kind: "allow-always",
+            description: "Allow these patterns until OpenCode is restarted.",
+            grants: request.always,
+            confirm: true,
+          },
+        ]
+      : []),
     {
       id: "reject",
       kind: "reject-once",
-      label: "Reject",
     },
   ],
+});
+
+export const projectResolvedOpenCodePermissionApproval = (entry: {
+  request: OpenCodePermissionRequest;
+  reply: OpenCodePermissionResponse;
+}): ToolCallApproval => ({
+  id: entry.request.id,
+  approved: entry.reply !== "reject",
+  optionId: entry.reply,
 });
 
 export const toOpenCodePermissionResponse = ({

--- a/packages/react-opencode/src/openCodePermissionApproval.ts
+++ b/packages/react-opencode/src/openCodePermissionApproval.ts
@@ -1,0 +1,57 @@
+import type {
+  RespondToToolApprovalOptions,
+  ToolCallMessagePart,
+} from "@assistant-ui/react";
+import type {
+  OpenCodePermissionRequest,
+  OpenCodePermissionResponse,
+} from "./types";
+
+export const projectOpenCodePermissionApproval = (
+  request: OpenCodePermissionRequest,
+): NonNullable<ToolCallMessagePart["approval"]> => ({
+  id: request.id,
+  options: [
+    {
+      id: "once",
+      kind: "allow-once",
+      label: "Allow once",
+    },
+    {
+      id: "always",
+      kind: "allow-always",
+      label: "Always allow",
+      description: "Allow these patterns until OpenCode is restarted.",
+      ...(request.always.length > 0 ? { grants: request.always } : {}),
+      confirm: true,
+    },
+    {
+      id: "reject",
+      kind: "reject-once",
+      label: "Reject",
+    },
+  ],
+});
+
+export const toOpenCodePermissionResponse = ({
+  approved,
+  optionId,
+}: RespondToToolApprovalOptions): OpenCodePermissionResponse => {
+  if (optionId === undefined) return approved ? "once" : "reject";
+
+  if (optionId === "once" || optionId === "always") {
+    if (!approved) {
+      throw new Error(`OpenCode permission option "${optionId}" must approve`);
+    }
+    return optionId;
+  }
+
+  if (optionId === "reject") {
+    if (approved) {
+      throw new Error('OpenCode permission option "reject" must reject');
+    }
+    return "reject";
+  }
+
+  throw new Error(`Unknown OpenCode permission option "${optionId}"`);
+};

--- a/packages/react-opencode/src/useOpenCodeRuntime.ts
+++ b/packages/react-opencode/src/useOpenCodeRuntime.ts
@@ -23,6 +23,7 @@ import type {
   OpenCodeThreadState,
 } from "./types";
 import { OpenCodeEventSource } from "./OpenCodeEventSource";
+import { toOpenCodePermissionResponse } from "./openCodePermissionApproval";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
 import { projectOpenCodeThreadRepository } from "./openCodeMessageProjection";
 import { EMPTY_OPENCODE_THREAD_STATE } from "./openCodeThreadState";
@@ -182,6 +183,17 @@ const useOpenCodeThreadRuntime = (
     onCancel: async () => {
       try {
         await controller.cancel();
+      } catch (error) {
+        options.onError?.(error);
+        throw error;
+      }
+    },
+    onRespondToToolApproval: async (response) => {
+      try {
+        await controller.replyToPermission(
+          response.approvalId,
+          toOpenCodePermissionResponse(response),
+        );
       } catch (error) {
         options.onError?.(error);
         throw error;

--- a/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
+++ b/packages/react-opencode/src/useOpenCodeRuntimeApproval.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RespondToToolApprovalOptions } from "@assistant-ui/react";
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+
+const mocks = vi.hoisted(() => ({
+  adapters: [] as unknown[],
+  controller: {
+    load: vi.fn().mockResolvedValue(undefined),
+    replyToPermission: vi.fn().mockResolvedValue(undefined),
+  },
+  state: undefined as unknown,
+}));
+
+vi.mock("@assistant-ui/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@assistant-ui/react")>()),
+  useAuiState: () => "session-1",
+  useExternalStoreRuntime: (adapter: unknown) => {
+    mocks.adapters.push(adapter);
+    return {};
+  },
+  useRemoteThreadListRuntime: (options: { runtimeHook: () => unknown }) =>
+    options.runtimeHook(),
+}));
+
+vi.mock("./OpenCodeThreadController", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./OpenCodeThreadController")>();
+
+  class OpenCodeThreadController {
+    getState = () => mocks.state;
+    subscribe = () => () => {};
+    load = mocks.controller.load;
+    refresh = vi.fn().mockResolvedValue(undefined);
+    sendMessage = vi.fn().mockResolvedValue(undefined);
+    stageMessage = vi.fn().mockResolvedValue(undefined);
+    sendStagedMessage = vi.fn().mockResolvedValue(false);
+    cancel = vi.fn().mockResolvedValue(undefined);
+    revert = vi.fn().mockResolvedValue(undefined);
+    unrevert = vi.fn().mockResolvedValue(undefined);
+    fork = vi.fn().mockResolvedValue("");
+    replyToPermission = mocks.controller.replyToPermission;
+    replyToQuestion = vi.fn().mockResolvedValue(undefined);
+    rejectQuestion = vi.fn().mockResolvedValue(undefined);
+    dispose = vi.fn();
+  }
+
+  return { ...original, OpenCodeThreadController };
+});
+
+import { createOpenCodeThreadState } from "./openCodeThreadState";
+import { useOpenCodeRuntime } from "./useOpenCodeRuntime";
+
+type ApprovalAdapter = {
+  onRespondToToolApproval?: (
+    response: RespondToToolApprovalOptions,
+  ) => Promise<void> | void;
+};
+
+const stubClient = {} as ReturnType<typeof createOpencodeClient>;
+
+let root: Root | undefined;
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  mocks.adapters.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("useOpenCodeRuntime tool approvals", () => {
+  it("replies to standard approvals through the OpenCode permission API", async () => {
+    mocks.state = createOpenCodeThreadState("session-1");
+
+    const App = () => {
+      useOpenCodeRuntime({ client: stubClient });
+      return null;
+    };
+
+    root = createRoot(document.createElement("div"));
+    await act(async () => root!.render(createElement(App)));
+
+    const adapter = mocks.adapters.find(
+      (candidate): candidate is ApprovalAdapter =>
+        typeof (candidate as ApprovalAdapter).onRespondToToolApproval ===
+        "function",
+    );
+
+    await adapter!.onRespondToToolApproval!({
+      approvalId: "permission-1",
+      approved: true,
+      optionId: "always",
+    });
+
+    expect(mocks.controller.replyToPermission).toHaveBeenCalledWith(
+      "permission-1",
+      "always",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- project pending OpenCode permissions with a stable tool call correlation into the standard assistant-ui tool approval contract
- expose OpenCode once, always, and reject decisions as standard approval options, including grants and confirmation for always-allow decisions
- wire onRespondToToolApproval to the existing OpenCode permission reply path
- document the default ToolFallback behavior and add projection, response mapping, and runtime wiring regressions

Fixes #5324.

## Why

The adapter already marked a correlated assistant message as requires-action, but the tool-call part had no approval data and the external-store runtime had no approval response callback. The default ToolFallback therefore rendered controls that could only throw Runtime does not support tool approvals.

This change completes the existing owner chain instead of adding a second permission UI or state model. OpenCode remains the permission authority, react-opencode owns the projection, and assistant-ui owns the standard approval UI.

The mapping follows the approval option vocabulary introduced in #4378:

- once to allow-once
- always to allow-always
- reject to reject-once

The OpenCode request ID remains the approval ID, and tool.callID remains the exact tool-part correlation. Unknown or inconsistent option responses fail closed.

## Test plan

- pnpm --filter @assistant-ui/react-opencode test — 62/62 passed
- pnpm --filter @assistant-ui/react-opencode build — passed
- focused oxlint — passed
- focused oxfmt check — passed
- pnpm exec changeset status --since origin/main — reports only @assistant-ui/react-opencode patch

A package-wide tsc --noEmit additionally reaches an existing main-branch TS2352 in useOpenCodeRuntime.test.tsx around the React 18 useEffectEvent ponyfill cast; the source build and the changed test suites are clean.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.g3HeJqygR6jDw45GB3CVh8wftQuUHqxsm2O2oSGhQV_UBbb0yeRxE6zmjM0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

