### PR TITLE
test(docs): pin the mcp header-leniency shim contract

### DIFF
--- a/apps/docs/app/api/mcp/normalize-mcp-headers.integration.test.ts
+++ b/apps/docs/app/api/mcp/normalize-mcp-headers.integration.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  McpServer,
+  WebStandardStreamableHTTPServerTransport,
+} from "@modelcontextprotocol/server";
+import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
+
+const encoder = new TextEncoder();
+
+const initializeBody = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "sentinel-client", version: "1.0.0" },
+  },
+});
+
+const makeLenientRequest = () =>
+  new Request("https://example.com/api/mcp", {
+    method: "POST",
+    headers: { Accept: "application/json" },
+    body: encoder.encode(initializeBody),
+  });
+
+describe("normalizeMcpRequestHeaders against a live transport", () => {
+  let server: McpServer;
+  let transport: WebStandardStreamableHTTPServerTransport;
+
+  beforeEach(async () => {
+    server = new McpServer({ name: "sentinel-server", version: "1.0.0" });
+    transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    });
+    await server.connect(transport);
+  });
+
+  afterEach(async () => {
+    await transport.close().catch(() => {});
+    await server.close().catch(() => {});
+  });
+
+  it("lets a lenient request through once normalizeMcpRequestHeaders rewrites it", async () => {
+    const normalized = await normalizeMcpRequestHeaders(makeLenientRequest());
+    const response = await transport.handleRequest(normalized);
+    expect(response.status).toBe(200);
+  });
+
+  it("rejects the same raw lenient request with 406 when the shim is skipped", async () => {
+    // If this assertion fails, the SDK's Accept header gate moved and normalizeMcpRequestHeaders must be re-evaluated against the new behavior.
+    const response = await transport.handleRequest(makeLenientRequest());
+    expect(response.status).toBe(406);
+  });
+
+  it("rejects a form encoded Content-Type with 415", async () => {
+    const request = new Request("https://example.com/api/mcp", {
+      method: "POST",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: encoder.encode(initializeBody),
+    });
+    const response = await transport.handleRequest(request);
+    expect(response.status).toBe(415);
+  });
+});

--- a/apps/docs/app/api/mcp/normalize-mcp-headers.test.ts
+++ b/apps/docs/app/api/mcp/normalize-mcp-headers.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
+
+const encoder = new TextEncoder();
+
+const makeRequest = (headers: Record<string, string>, body = "{}") =>
+  new Request("https://example.com/api/mcp", {
+    method: "POST",
+    headers,
+    body: encoder.encode(body),
+  });
+
+describe("normalizeMcpRequestHeaders", () => {
+  it("rewrites Accept when only application/json is present", async () => {
+    const request = makeRequest({
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result.headers.get("accept")).toBe(
+      "application/json, text/event-stream",
+    );
+  });
+
+  it("rewrites Accept when only text/event-stream is present", async () => {
+    const request = makeRequest({
+      Accept: "text/event-stream",
+      "Content-Type": "application/json",
+    });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result.headers.get("accept")).toBe(
+      "application/json, text/event-stream",
+    );
+  });
+
+  it("rewrites Accept when the header is absent", async () => {
+    const request = makeRequest({ "Content-Type": "application/json" });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result.headers.get("accept")).toBe(
+      "application/json, text/event-stream",
+    );
+  });
+
+  it("rewrites Accept when it is a bare wildcard", async () => {
+    const request = makeRequest({
+      Accept: "*/*",
+      "Content-Type": "application/json",
+    });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result.headers.get("accept")).toBe(
+      "application/json, text/event-stream",
+    );
+  });
+
+  it("returns the original request unchanged when Accept already contains both", async () => {
+    const request = makeRequest({
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result).toBe(request);
+  });
+
+  it("defaults Content-Type to application/json when absent and preserves the body", async () => {
+    const payload = '{"jsonrpc":"2.0","id":1,"method":"ping"}';
+    const request = makeRequest(
+      { Accept: "application/json, text/event-stream" },
+      payload,
+    );
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result.headers.get("content-type")).toBe("application/json");
+    await expect(result.text()).resolves.toBe(payload);
+  });
+
+  it("leaves a present but incorrect Content-Type unchanged while still fixing Accept", async () => {
+    const request = makeRequest({
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    });
+    const result = await normalizeMcpRequestHeaders(request);
+    expect(result).not.toBe(request);
+    expect(result.headers.get("accept")).toBe(
+      "application/json, text/event-stream",
+    );
+    expect(result.headers.get("content-type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+  });
+
+  it("preserves the body when rewriting Accept", async () => {
+    const payload = '{"jsonrpc":"2.0","id":2,"method":"tools/list"}';
+    const request = makeRequest({ Accept: "application/json" }, payload);
+    const result = await normalizeMcpRequestHeaders(request);
+    await expect(result.text()).resolves.toBe(payload);
+  });
+});

--- a/apps/docs/app/api/mcp/normalize-mcp-headers.ts
+++ b/apps/docs/app/api/mcp/normalize-mcp-headers.ts
@@ -1,0 +1,24 @@
+// The public docs endpoint keeps accepting pre-SDK lenient clients that omit the SSE half of Accept or the Content-Type header.
+export async function normalizeMcpRequestHeaders(
+  request: Request,
+): Promise<Request> {
+  const accept = request.headers.get("accept");
+  const needsAcceptFix =
+    !accept?.includes("application/json") ||
+    !accept.includes("text/event-stream");
+  const needsContentTypeFix = request.headers.get("content-type") === null;
+  if (!needsAcceptFix && !needsContentTypeFix) return request;
+
+  const headers = new Headers(request.headers);
+  if (needsAcceptFix) {
+    headers.set("Accept", "application/json, text/event-stream");
+  }
+  if (needsContentTypeFix) {
+    headers.set("Content-Type", "application/json");
+  }
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body: await request.text(),
+  });
+}

--- a/apps/docs/app/api/mcp/normalize-mcp-headers.ts
+++ b/apps/docs/app/api/mcp/normalize-mcp-headers.ts
@@ -1,4 +1,5 @@
 // The public docs endpoint keeps accepting pre-SDK lenient clients that omit the SSE half of Accept or the Content-Type header.
+// The substring checks deliberately mirror the SDK gate's own matching; do not tighten them independently of the gate.
 export async function normalizeMcpRequestHeaders(
   request: Request,
 ): Promise<Request> {

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -8,6 +8,7 @@ import {
 import { z } from "zod";
 import { getLLMText } from "@/lib/get-llm-text";
 import { examples, getTapDocsPage, source, tapDocs } from "@/lib/source";
+import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
 
 export const revalidate = false;
 
@@ -394,31 +395,6 @@ export async function GET() {
       name: tool.name,
       description: tool.description,
     })),
-  });
-}
-
-// The public docs endpoint keeps accepting pre-SDK lenient clients that omit the SSE half of Accept or the Content-Type header.
-async function normalizeMcpRequestHeaders(
-  request: NextRequest,
-): Promise<Request> {
-  const accept = request.headers.get("accept");
-  const needsAcceptFix =
-    !accept?.includes("application/json") ||
-    !accept.includes("text/event-stream");
-  const needsContentTypeFix = request.headers.get("content-type") === null;
-  if (!needsAcceptFix && !needsContentTypeFix) return request;
-
-  const headers = new Headers(request.headers);
-  if (needsAcceptFix) {
-    headers.set("Accept", "application/json, text/event-stream");
-  }
-  if (needsContentTypeFix) {
-    headers.set("Content-Type", "application/json");
-  }
-  return new Request(request.url, {
-    method: request.method,
-    headers,
-    body: await request.text(),
   });
 }
 


### PR DESCRIPTION
## summary

- extracts `normalizeMcpRequestHeaders` from the docs `/api/mcp` route into a pure sibling module (type widened from `NextRequest` to `Request`; the body only touches standard members, and the pure signature is what makes the module testable without the route's fumadocs import graph)
- adds a colocated vitest matrix pinning the shim's contract: json-only, sse-only, absent, and `*/*` Accept headers are rewritten to the full pair; a compliant Accept passes the original request through by identity (no body re-read); a truly absent `Content-Type` is defaulted while a present-but-wrong one stays untouched; body preservation asserted on both paths
- the shim compensates for a private gate inside `@modelcontextprotocol/server` and already regressed once during #5320 review; this makes an SDK bump that moves the gate loud instead of silently 4xx-ing lenient clients (follow-up promised on the #5320 review thread)
- test bodies are encoded as `Uint8Array`: the fetch spec auto-fills `text/plain` on string bodies, which would have silently defeated the absent-Content-Type case

## test plan

### already verified

- [x] `vitest run app/api/mcp/normalize-mcp-headers.test.ts` -> 8/8 green
- [x] `tsc --noEmit` in apps/docs clean; `oxlint` and `oxfmt --check` clean on the three files
- [x] no changeset needed, apps/docs is private

### reviewer should verify

- [ ] nothing beyond CI; test-only change with a mechanical extraction

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.s0GwwdyAPpFVIuOZAZ_HyZIFmAMt-WUwE-I1UV5Y059ekhvK3Ju59pVLIug?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->