### PR TITLE
fix(tap): accept reducer replays below the committed version instead of throwing

### DIFF
--- a/.changeset/tap-version-replay.md
+++ b/.changeset/tap-version-replay.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix: accept reducer replays below the committed version instead of throwing

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -3,11 +3,26 @@ import { StrictMode, startTransition } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { act } from "@testing-library/react";
+import type { TapRoot } from "../../core/types";
 import { resource } from "../../core/resource";
 import { useResource } from "../../index";
 import { useReducer as useResourceReducer } from "../../react-hooks/useReducer";
 import { useMemo as useResourceMemo } from "../../react-hooks/useMemo";
 import { cleanupAllResources } from "../test-utils";
+
+const probes = vi.hoisted(() => ({ belowCommitted: 0 }));
+
+vi.mock("../../core/helpers/root", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("../../core/helpers/root")>();
+  return {
+    ...original,
+    setRootVersion: (root: TapRoot, version: number) => {
+      if (version < root.committedVersion) probes.belowCommitted++;
+      return original.setRootVersion(root, version);
+    },
+  };
+});
 
 let reactRoot: Root | undefined;
 let container: HTMLElement | undefined;
@@ -77,5 +92,6 @@ describe("React-hosted reducer replay below the committed version", () => {
 
     expect(container.textContent).toContain("after");
     expect(recoverable).not.toHaveBeenCalled();
+    expect(probes.belowCommitted).toBeGreaterThan(0);
   });
 });

--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { StrictMode, startTransition } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "@testing-library/react";
+import { resource } from "../../core/resource";
+import { useResource } from "../../index";
+import { useReducer as useResourceReducer } from "../../react-hooks/useReducer";
+import { useMemo as useResourceMemo } from "../../react-hooks/useMemo";
+import { cleanupAllResources } from "../test-utils";
+
+let reactRoot: Root | undefined;
+let container: HTMLElement | undefined;
+
+afterEach(async () => {
+  await act(async () => reactRoot?.unmount());
+  container?.remove();
+  reactRoot = undefined;
+  container = undefined;
+  cleanupAllResources();
+});
+
+const useStream = () => {
+  const [chunks, push] = useResourceReducer(
+    (s: readonly string[], c: string) => [...s, c],
+    [] as readonly string[],
+  );
+  return useResourceMemo(() => ({ chunks, push }), [chunks]);
+};
+const Stream = resource(useStream);
+
+/**
+ * A flushSync commit against a pending transition makes React replay the
+ * reducer chain from a base below the committed version, which previously
+ * threw "Version is less than committed version" as a recoverable error on
+ * every replay. The assertions check delivery (every update present) rather
+ * than exact equality: the React-hosted bridge applies replayed updates onto
+ * already-committed cell state, so cross-lane replays duplicate committed
+ * entries. That rebase-fidelity gap predates the version handling and is
+ * tracked separately.
+ */
+describe("React-hosted reducer replay below the committed version", () => {
+  it("delivers a transition update rebased across a sync commit without recoverable errors", async () => {
+    const recoverable = vi.fn();
+    let api!: { chunks: readonly string[]; push: (c: string) => void };
+
+    function App() {
+      const value = useResource(Stream({}));
+      api = value;
+      return <div>{value.chunks.join(",")}</div>;
+    }
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    reactRoot = createRoot(container, { onRecoverableError: recoverable });
+
+    await act(async () => {
+      reactRoot!.render(
+        <StrictMode>
+          <App />
+        </StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      startTransition(() => api.push("t1"));
+      flushSync(() => api.push("s1"));
+    });
+
+    const delivered = container.textContent!.split(",");
+    expect(delivered).toContain("t1");
+    expect(delivered).toContain("s1");
+
+    await act(async () => {
+      api.push("after");
+    });
+
+    expect(container.textContent).toContain("after");
+    expect(recoverable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  commitRoot,
+  createResourceFiberRoot,
+  setRootVersion,
+} from "../core/helpers/root";
+
+const makeRoot = () => createResourceFiberRoot(() => {});
+
+describe("setRootVersion", () => {
+  it("clears the changelog when rolling back to the committed version", () => {
+    const root = makeRoot();
+    setRootVersion(root, 5);
+    expect(root.version).toBe(5);
+    expect(root.committedVersion).toBe(0);
+
+    setRootVersion(root, 0);
+    expect(root.version).toBe(0);
+    expect(root.changelog.length).toBe(0);
+  });
+
+  it("accepts a version below the committed version and keeps it", () => {
+    const root = makeRoot();
+    setRootVersion(root, 3);
+    commitRoot(root);
+    expect(root.committedVersion).toBe(3);
+
+    expect(() => setRootVersion(root, 1)).not.toThrow();
+    expect(root.version).toBe(1);
+    expect(root.committedVersion).toBe(3);
+    expect(root.changelog.length).toBe(0);
+  });
+
+  it("runs rollback callbacks when replaying below the committed version", () => {
+    const root = makeRoot();
+    setRootVersion(root, 3);
+    commitRoot(root);
+
+    let rolledBack = false;
+    root.rollbackCallbacks.push(() => {
+      rolledBack = true;
+    });
+
+    setRootVersion(root, 1);
+    expect(rolledBack).toBe(true);
+    expect(root.rollbackCallbacks.length).toBe(0);
+  });
+});

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -4,8 +4,13 @@ import {
   createResourceFiberRoot,
   setRootVersion,
 } from "../core/helpers/root";
+import type { ChangelogRecord } from "../core/types";
 
 const makeRoot = () => createResourceFiberRoot(() => {});
+
+const pushRecord = (root: ReturnType<typeof makeRoot>) => {
+  root.changelog.push({} as ChangelogRecord);
+};
 
 describe("setRootVersion", () => {
   it("clears the changelog when rolling back to the committed version", () => {
@@ -14,6 +19,7 @@ describe("setRootVersion", () => {
     expect(root.version).toBe(5);
     expect(root.committedVersion).toBe(0);
 
+    pushRecord(root);
     setRootVersion(root, 0);
     expect(root.version).toBe(0);
     expect(root.changelog.length).toBe(0);
@@ -25,6 +31,7 @@ describe("setRootVersion", () => {
     commitRoot(root);
     expect(root.committedVersion).toBe(3);
 
+    pushRecord(root);
     expect(() => setRootVersion(root, 1)).not.toThrow();
     expect(root.version).toBe(1);
     expect(root.committedVersion).toBe(3);

--- a/packages/tap/src/__tests__/root.test.ts
+++ b/packages/tap/src/__tests__/root.test.ts
@@ -25,7 +25,7 @@ describe("setRootVersion", () => {
     expect(root.changelog.length).toBe(0);
   });
 
-  it("accepts a version below the committed version and keeps it", () => {
+  it("re-bases to a version below the committed version instead of throwing", () => {
     const root = makeRoot();
     setRootVersion(root, 3);
     commitRoot(root);
@@ -34,7 +34,41 @@ describe("setRootVersion", () => {
     pushRecord(root);
     expect(() => setRootVersion(root, 1)).not.toThrow();
     expect(root.version).toBe(1);
+    expect(root.committedVersion).toBe(1);
+    expect(root.changelog.length).toBe(0);
+  });
+
+  it("keeps changelog records relative to the re-based version on a partial rollback", () => {
+    const root = makeRoot();
+    setRootVersion(root, 5);
+    commitRoot(root);
+
+    setRootVersion(root, 3);
     expect(root.committedVersion).toBe(3);
+
+    setRootVersion(root, 7);
+    const marked: number[] = [];
+    const trackedRecord = (index: number): ChangelogRecord =>
+      ({
+        fiber: {
+          root,
+          markDirty: () => {
+            marked.push(index);
+          },
+        },
+        cell: { isDirty: false, queue: null },
+        queued: true,
+      }) as unknown as ChangelogRecord;
+    root.changelog.push(
+      trackedRecord(1),
+      trackedRecord(2),
+      trackedRecord(3),
+      trackedRecord(4),
+    );
+
+    setRootVersion(root, 6);
+    expect(marked).toEqual([1, 2, 3]);
+    expect(root.committedVersion).toBe(6);
     expect(root.changelog.length).toBe(0);
   });
 

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -35,13 +35,12 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
     }
     root.rollbackCallbacks.length = 0;
 
-    if (version === root.committedVersion) {
+    if (version <= root.committedVersion) {
+      // A version below the last commit is a React concurrent reducer replay
+      // from an older base; the replayed chain re-supplies its updates.
       root.changelog.length = 0;
     } else {
       // commit happened without a useEffect update (offscreen API)
-
-      if (root.committedVersion > version)
-        throw new Error("Version is less than committed version");
 
       while (root.committedVersion + root.changelog.length > version) {
         root.changelog.pop();

--- a/packages/tap/src/core/helpers/root.ts
+++ b/packages/tap/src/core/helpers/root.ts
@@ -37,7 +37,10 @@ export const setRootVersion = (root: TapRoot, version: number): void => {
 
     if (version <= root.committedVersion) {
       // A version below the last commit is a React concurrent reducer replay
-      // from an older base; the replayed chain re-supplies its updates.
+      // from an older base; the replayed chain re-supplies its updates. The
+      // committed version re-bases to keep the changelog's base derivation in
+      // the branch below correct; the next commit overwrites it.
+      root.committedVersion = version;
       root.changelog.length = 0;
     } else {
       // commit happened without a useEffect update (offscreen API)


### PR DESCRIPTION
## Problem

`setRootVersion` threw `Version is less than committed version` whenever React 19 concurrent rendering replayed the reducer bridge from a base below the last commit (pending transition rebased across a sync commit, the exact interleave agent streaming produces). React treats the throw as a recoverable error and retries, so the app kept working, but the error fired on every replay and flooded the console/overlay. #5317 reports it.

## Why not the clamp (#5321)

the rollback branch already lands on a consistent snapshot: `root.version = version` runs before the guard, rollback callbacks reset every dirty cell, and clearing the changelog is exactly what the `version === committedVersion` branch does. the throw added nothing on top of that except aborting the render React was going to retry anyway. #5321 proposed clamping `root.version` up to `committedVersion` instead; empirically (same bridge test, deficit >= 2 traces) the upward clamp makes later reducer calls in the same replayed chain re-trigger the rollback and wipe the records their predecessors just applied, and leaves React's counter stranded below the committed version where subsequently dispatched updates are applied and then rolled back before render. keeping the low version is the loss-free shape: the replayed chain ascends from its own base and re-supplies every update, which is how the accidental throw-and-retry path already behaved, minus the error.

## Approach

widen the `version === root.committedVersion` branch to `version <= root.committedVersion` and delete the throw. the widened branch also re-bases `committedVersion` to the replayed version: the between-versions branch derives the changelog base from `committedVersion`, and a stale-high value there over-drops records on a later partial rollback (review-traced arithmetic, pinned by a unit test). `committedVersion` is read nowhere outside tap and the next `commitRoot` overwrites it. no logging: after the change a below-committed version is an expected concurrent replay state, not an anomaly, and erroring on it would recreate the console noise half of #5317. `commitRoot` may subsequently move `committedVersion` downward on a partial-lane commit, which commits the replayed chain's snapshot and stays internally consistent. blast radius: only the React-hosted root can hold `version < committedVersion`; `useTapRoot`'s scheduler calls `setRootVersion` with `committedVersion` or `committedVersion + changelog.length`, never below, so the `committedVersion + changelog.length` consumers at `useTapRoot.ts:49` and `:92` never observe the widened state.

## Verification

- new root-level unit tests pin the contract: below-committed input keeps the given version, clears the changelog, runs rollback callbacks, re-bases `committedVersion` to the given version, does not throw.
- new bridge-level test (`concurrent-version-replay.test.tsx`) drives the real `useResource` React host through `startTransition` + `flushSync` with an `onRecoverableError` probe: on current main it fails (the version error surfaces as a recoverable error), with this change it passes with zero recoverable errors and both updates delivered.
- full tap suite: 33 files / 458 tests green. `oxfmt` clean; package `tsc` shows only the pre-existing bench-file dist-resolution errors of an unbuilt worktree.

## Scope

the bridge test asserts delivery containment rather than exact ordering equality: cross-lane replays duplicate already-committed updates because tap cells have no per-hook base snapshot to rewind to. that rebase-fidelity gap predates this change (the throw path double-applies identically after React's retry) and is tracked in #5330 together with the related `eagerState` memoization hazard.

fixes #5317. supersedes #5321.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.F3uvGhIrg9n5sXO7pInIbCV1HYFIdmSOZeif4ZMMGtUACodJtwJ3dQJudWQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

