### PR TITLE
fix(react-pi): isolate event stream error callbacks

### DIFF
--- a/.changeset/react-pi-error-callbacks.md
+++ b/.changeset/react-pi-error-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: keep event streams reconnecting when error callbacks fail

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -321,6 +321,53 @@ describe("openPiEventStream", () => {
     expect(errors).toHaveLength(1);
   });
 
+  it.each(["throws", "rejects"] as const)(
+    "reconnects when the error callback %s",
+    async (failureMode) => {
+      let calls = 0;
+      const networkError = new Error("network drop");
+      const callbackError = new Error("telemetry failed");
+      const fetchImpl = (async () => {
+        calls += 1;
+        if (calls === 1) throw networkError;
+        return sseResponse([
+          sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+        ]);
+      }) as unknown as typeof fetch;
+      const onError = vi.fn(() => {
+        if (failureMode === "throws") throw callbackError;
+        return Promise.reject(callbackError);
+      });
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      try {
+        await new Promise<void>((resolve) => {
+          const close = openPiEventStream({
+            url: "/events",
+            fetchImpl,
+            reconnectDelay: () => Promise.resolve(),
+            onError,
+            onEvent: () => {
+              close();
+              resolve();
+            },
+          });
+        });
+
+        expect(calls).toBe(2);
+        expect(onError).toHaveBeenCalledWith(networkError);
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-pi] onError callback threw an error",
+          callbackError,
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    },
+  );
+
   it("reports a bad-JSON frame via onError without crashing the stream", async () => {
     const events: PiAnyClientEvent[] = [];
     const errors: unknown[] = [];

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -368,6 +368,37 @@ describe("openPiEventStream", () => {
     },
   );
 
+  it("reconnects when the reconnect delay rejects", async () => {
+    let calls = 0;
+    const networkError = new Error("network drop");
+    const delayError = new Error("delay failed");
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls === 1) throw networkError;
+      return sseResponse([
+        sseFrame({ type: "agent_start", threadId: "t1", seq: 1 }),
+      ]);
+    }) as unknown as typeof fetch;
+    const onError = vi.fn();
+
+    await new Promise<void>((resolve) => {
+      const close = openPiEventStream({
+        url: "/events",
+        fetchImpl,
+        reconnectDelay: () => Promise.reject(delayError),
+        onError,
+        onEvent: () => {
+          close();
+          resolve();
+        },
+      });
+    });
+
+    expect(calls).toBe(2);
+    expect(onError).toHaveBeenNthCalledWith(1, networkError);
+    expect(onError).toHaveBeenNthCalledWith(2, delayError);
+  });
+
   it("reports a bad-JSON frame via onError without crashing the stream", async () => {
     const events: PiAnyClientEvent[] = [];
     const errors: unknown[] = [];

--- a/packages/react-pi/src/client/eventSource.test.ts
+++ b/packages/react-pi/src/client/eventSource.test.ts
@@ -369,6 +369,7 @@ describe("openPiEventStream", () => {
   );
 
   it("reconnects when the reconnect delay rejects", async () => {
+    vi.useFakeTimers();
     let calls = 0;
     const networkError = new Error("network drop");
     const delayError = new Error("delay failed");
@@ -381,18 +382,28 @@ describe("openPiEventStream", () => {
     }) as unknown as typeof fetch;
     const onError = vi.fn();
 
-    await new Promise<void>((resolve) => {
-      const close = openPiEventStream({
-        url: "/events",
-        fetchImpl,
-        reconnectDelay: () => Promise.reject(delayError),
-        onError,
-        onEvent: () => {
-          close();
-          resolve();
-        },
+    try {
+      const event = new Promise<void>((resolve) => {
+        const close = openPiEventStream({
+          url: "/events",
+          fetchImpl,
+          reconnectDelay: () => Promise.reject(delayError),
+          onError,
+          onEvent: () => {
+            close();
+            resolve();
+          },
+        });
       });
-    });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toBe(1);
+      await vi.advanceTimersByTimeAsync(1000);
+      await event;
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(calls).toBe(2);
     expect(onError).toHaveBeenNthCalledWith(1, networkError);

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -226,6 +226,8 @@ export const openPiEventStream = (
       } catch (error) {
         if (closed) break;
         reportError(error);
+        await defaultReconnectDelay();
+        if (closed) break;
       }
     }
   };

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -221,7 +221,12 @@ export const openPiEventStream = (
       if (closed) break;
       // Snapshot-first: the next connect replaces local state, so we lose
       // nothing by not replaying. Back off, then retry.
-      await reconnectDelay();
+      try {
+        await reconnectDelay();
+      } catch (error) {
+        if (closed) break;
+        reportError(error);
+      }
     }
   };
 

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -119,16 +119,15 @@ export interface PiEventStreamOptions {
   url: string;
   /** Called with each decoded `PiClientEvent`. */
   onEvent: (event: PiAnyClientEvent) => void;
-  /** Non-fatal stream errors (network drop, bad JSON). The loop reconnects after
-   * each; surface these for logging, not control flow. */
+  /** Non-fatal stream errors (network drop, bad JSON, reconnect-delay failures).
+   * The loop reconnects after each; surface these for logging, not control flow. */
   onError?: (error: unknown) => void;
   /** Injected `fetch` (defaults to the global). */
   fetchImpl?: typeof fetch;
   /** Extra request headers (e.g. auth). */
   headers?: Record<string, string>;
-  /** Reconnect backoff between a dropped stream and the next attempt. Returns a
-   * promise that resolves when it's time to retry. Defaults to a ~1s timer;
-   * injectable for tests. */
+  /** Reconnect backoff between a dropped stream and the next attempt. Rejections
+   * are reported via `onError`, then followed by the default ~1s backoff. */
   reconnectDelay?: () => Promise<void>;
 }
 

--- a/packages/react-pi/src/client/eventSource.ts
+++ b/packages/react-pi/src/client/eventSource.ts
@@ -169,6 +169,17 @@ export const openPiEventStream = (
 
   let closed = false;
   const abort = new AbortController();
+  const reportCallbackError = (callbackError: unknown) => {
+    console.error("[react-pi] onError callback threw an error", callbackError);
+  };
+  const reportError = (error: unknown) => {
+    if (!onError) return;
+    try {
+      void Promise.resolve(onError(error)).catch(reportCallbackError);
+    } catch (callbackError) {
+      reportCallbackError(callbackError);
+    }
+  };
 
   const run = async () => {
     while (!closed) {
@@ -197,7 +208,7 @@ export const openPiEventStream = (
             try {
               parsed = JSON.parse(frame.data) as PiAnyClientEvent;
             } catch (error) {
-              onError?.(error);
+              reportError(error);
               continue;
             }
             if (!closed) onEvent(parsed);
@@ -205,7 +216,7 @@ export const openPiEventStream = (
         }
       } catch (error) {
         if (closed || abort.signal.aborted) break;
-        onError?.(error);
+        reportError(error);
       }
       if (closed) break;
       // Snapshot-first: the next connect replaces local state, so we lose


### PR DESCRIPTION
## Summary

- isolate failures thrown or rejected by React Pi event-stream `onError` callbacks
- keep the SSE reconnect loop running after callback failures
- cover synchronous throws and asynchronous rejections with regression tests

## Why

`openPiEventStream()` documents `onError` as a non-fatal logging/telemetry callback. However, a synchronous callback throw escaped the internal `run()` task, producing a global unhandled rejection and stopping all future reconnects. A rejected callback promise was also left unobserved.

The reproduction used a first request that failed with `network drop` and an `onError` callback that threw `telemetry failed`. On `main`, only one fetch occurred, reconnection never ran, and Vitest reported the unhandled rejection.

## Implementation

Both malformed-frame and transport errors now use an isolated reporter. The original stream error is still delivered to `onError`, while callback failures are reported separately through `console.error` and cannot alter stream control flow.

## Validation

- regression test failed on `main` with a timeout and unhandled rejection
- `eventSource.test.ts`: 23 tests passed
- `@assistant-ui/react-pi` package build passed
- oxlint passed
- oxfmt passed
- `git diff --check` passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qdy8OEdUCQ2Fdsk2QqRg8hm6XL9rrDLuEvuH0UpsxoPGYCVxmGowiJ2gDhc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->