### PR TITLE
feat(react-mcp): form-mode MCP elicitation, list-change refresh, cache config

### DIFF
--- a/.changeset/bright-badgers-ask.md
+++ b/.changeset/bright-badgers-ask.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+feat: form-mode MCP elicitation (pending state, `answerElicitation`, unstyled `McpElicitationPrimitive` namespace), tool list-change auto-refresh, and `cache.defaultTtlMs` response cache configuration

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -49,6 +49,13 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
 };
 
+type ElicitationFieldContextValue = {
+  name: string;
+  schema: unknown;
+  value: unknown;
+  setValue: (value: unknown) => void;
+};
+
 type MCPAuthConfig = {
   type: "none";
 } | {
@@ -73,6 +80,7 @@ type MCPConnector = {
   icon?: string | undefined;
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
+  readonly cache?: MCPResponseCacheConfig | undefined;
 };
 
 type MCPCustomServerRecord = {
@@ -81,7 +89,23 @@ type MCPCustomServerRecord = {
   url: string;
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
+  readonly cache?: MCPResponseCacheConfig | undefined;
   createdAt: number;
+};
+
+type MCPElicitation = {
+  readonly id: string;
+  readonly message: string;
+  readonly requestedSchema: unknown;
+};
+
+type MCPElicitationResponse = {
+  action: "accept";
+  content: Record<string, unknown>;
+} | {
+  action: "decline";
+} | {
+  action: "cancel";
 };
 
 type MCPManagerMethods = {
@@ -116,6 +140,10 @@ type MCPPersistedAuthState = {
   token?: string;
 };
 
+type MCPResponseCacheConfig = {
+  readonly defaultTtlMs?: number;
+};
+
 type MCPServerKind = "connector" | "custom";
 
 type MCPServerMethods = {
@@ -129,6 +157,7 @@ type MCPServerMethods = {
   }) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
   completeAuth: (callbackUrl: string) => Promise<void>;
+  answerElicitation(id: string, response: MCPElicitationResponse): void;
 };
 
 type MCPServerQuery = {
@@ -153,6 +182,7 @@ type MCPServerState = {
   } | null;
   tools: MCPToolInfo[];
   authorizationUrl: string | null;
+  readonly pendingElicitations: readonly MCPElicitation[];
 };
 
 type MCPStorage = {
@@ -255,6 +285,67 @@ declare const McpCustomServerByIndexProvider: FC<PropsWithChildren<{
 declare const McpCustomStorage: Resource<MCPStorage, [
   impl: MCPStorage
 ]>;
+
+declare namespace McpElicitationPrimitiveAccept {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+declare const McpElicitationPrimitiveAccept: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpElicitationPrimitiveCancel {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+declare const McpElicitationPrimitiveCancel: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpElicitationPrimitiveDecline {
+  type Element = ComponentRef<typeof Primitive.button>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+declare const McpElicitationPrimitiveDecline: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpElicitationPrimitiveFields {
+  type Props = {
+    children: (field: ElicitationFieldContextValue) => ReactNode;
+  };
+}
+
+declare const McpElicitationPrimitiveFields: FC<McpElicitationPrimitiveFields.Props>;
+
+declare namespace McpElicitationPrimitiveItems {
+  type Props = {
+    children: ReactNode | ((elicitation: MCPElicitation) => ReactNode);
+  };
+}
+
+declare const McpElicitationPrimitiveItems: FC<McpElicitationPrimitiveItems.Props>;
+
+declare namespace McpElicitationPrimitiveMessage {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+declare const McpElicitationPrimitiveMessage: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+
+declare namespace McpElicitationPrimitiveRoot {
+  type Element = ComponentRef<typeof Primitive.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+declare const McpElicitationPrimitiveRoot: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
 
 declare const McpLocalStorage: Resource<MCPStorage, [
   opts?: McpLocalStorageOptions | undefined
@@ -449,6 +540,9 @@ type McpServerResourceProps = {
   redirectUri: string;
   autoConnect: boolean;
   connectionTimeout?: number | undefined;
+  cache?: {
+    readonly defaultTtlMs?: number;
+  } | undefined;
   onRemove: () => Promise<void>;
 };
 
@@ -491,8 +585,12 @@ declare namespace addForm_d_exports {
 
 declare function defineConnector(connector: MCPConnector): MCPConnector;
 
+declare namespace elicitation_d_exports {
+  export { McpElicitationPrimitiveAccept as Accept, McpElicitationPrimitiveCancel as Cancel, McpElicitationPrimitiveDecline as Decline, McpElicitationPrimitiveFields as Fields, McpElicitationPrimitiveItems as Items, McpElicitationPrimitiveMessage as Message, McpElicitationPrimitiveRoot as Root, useMcpElicitation, useMcpElicitationField };
+}
+
 declare namespace entry_root_exports {
-  export { MCPAuthConfig, MCPConnectionState, MCPConnector, MCPCustomServerRecord, MCPManagerMethods, MCPManagerState, MCPPersistedAuthState, MCPServerKind, MCPServerMethods, MCPServerQuery, MCPServerState, MCPStorage, MCPStorageElement, MCPToolInfo, addForm_d_exports as McpAddFormPrimitive, McpConnectorByIndexProvider, McpCustomServerByIndexProvider, McpCustomStorage, McpLocalStorage, McpLocalStorageOptions, manager_d_exports as McpManagerPrimitive, McpManagerResource, McpManagerResourceProps, McpMemoryStorage, McpOAuthCallback, McpServerByIdProvider, server_d_exports as McpServerPrimitive, McpServerResource, McpServerResourceProps, UseMcpOAuthCallbackOptions, UseMcpOAuthCallbackResult, defineConnector, useMcpOAuthCallback };
+  export { MCPAuthConfig, MCPConnectionState, MCPConnector, MCPCustomServerRecord, MCPElicitation, MCPElicitationResponse, MCPManagerMethods, MCPManagerState, MCPPersistedAuthState, MCPServerKind, MCPServerMethods, MCPServerQuery, MCPServerState, MCPStorage, MCPStorageElement, MCPToolInfo, addForm_d_exports as McpAddFormPrimitive, McpConnectorByIndexProvider, McpCustomServerByIndexProvider, McpCustomStorage, elicitation_d_exports as McpElicitationPrimitive, McpLocalStorage, McpLocalStorageOptions, manager_d_exports as McpManagerPrimitive, McpManagerResource, McpManagerResourceProps, McpMemoryStorage, McpOAuthCallback, McpServerByIdProvider, server_d_exports as McpServerPrimitive, McpServerResource, McpServerResourceProps, UseMcpOAuthCallbackOptions, UseMcpOAuthCallbackResult, defineConnector, useMcpOAuthCallback };
 }
 
 declare namespace manager_d_exports {
@@ -502,6 +600,10 @@ declare namespace manager_d_exports {
 declare namespace server_d_exports {
   export { McpServerPrimitiveConnectButton as ConnectButton, McpServerPrimitiveDisconnectButton as DisconnectButton, McpServerPrimitiveError as Error, McpServerPrimitiveIcon as Icon, McpServerPrimitiveName as Name, McpServerPrimitiveOAuthLink as OAuthLink, McpServerPrimitiveRemoveButton as RemoveButton, McpServerPrimitiveRoot as Root, McpServerPrimitiveStatus as Status, McpServerPrimitiveToolName as ToolName, McpServerPrimitiveTools as Tools, useMcpServerTool };
 }
+
+declare const useMcpElicitation: () => MCPElicitation;
+
+declare const useMcpElicitationField: () => ElicitationFieldContextValue;
 
 declare function useMcpOAuthCallback(opts?: UseMcpOAuthCallbackOptions): UseMcpOAuthCallbackResult;
 

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -122,6 +122,7 @@ type MCPManagerMethods = {
     url: string;
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
+    readonly cache?: MCPResponseCacheConfig | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
@@ -590,7 +591,7 @@ declare namespace elicitation_d_exports {
 }
 
 declare namespace entry_root_exports {
-  export { MCPAuthConfig, MCPConnectionState, MCPConnector, MCPCustomServerRecord, MCPElicitation, MCPElicitationResponse, MCPManagerMethods, MCPManagerState, MCPPersistedAuthState, MCPServerKind, MCPServerMethods, MCPServerQuery, MCPServerState, MCPStorage, MCPStorageElement, MCPToolInfo, addForm_d_exports as McpAddFormPrimitive, McpConnectorByIndexProvider, McpCustomServerByIndexProvider, McpCustomStorage, elicitation_d_exports as McpElicitationPrimitive, McpLocalStorage, McpLocalStorageOptions, manager_d_exports as McpManagerPrimitive, McpManagerResource, McpManagerResourceProps, McpMemoryStorage, McpOAuthCallback, McpServerByIdProvider, server_d_exports as McpServerPrimitive, McpServerResource, McpServerResourceProps, UseMcpOAuthCallbackOptions, UseMcpOAuthCallbackResult, defineConnector, useMcpOAuthCallback };
+  export { MCPAuthConfig, MCPConnectionState, MCPConnector, MCPCustomServerRecord, MCPElicitation, MCPElicitationResponse, MCPManagerMethods, MCPManagerState, MCPPersistedAuthState, MCPResponseCacheConfig, MCPServerKind, MCPServerMethods, MCPServerQuery, MCPServerState, MCPStorage, MCPStorageElement, MCPToolInfo, addForm_d_exports as McpAddFormPrimitive, McpConnectorByIndexProvider, McpCustomServerByIndexProvider, McpCustomStorage, elicitation_d_exports as McpElicitationPrimitive, McpLocalStorage, McpLocalStorageOptions, manager_d_exports as McpManagerPrimitive, McpManagerResource, McpManagerResourceProps, McpMemoryStorage, McpOAuthCallback, McpServerByIdProvider, server_d_exports as McpServerPrimitive, McpServerResource, McpServerResourceProps, UseMcpOAuthCallbackOptions, UseMcpOAuthCallbackResult, defineConnector, useMcpOAuthCallback };
 }
 
 declare namespace manager_d_exports {

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -114,7 +114,7 @@ Pass children to override the trigger:
 </McpConfigDialog>
 ```
 
-**Compose your own from primitives** — three namespaces, all unstyled and `data-*`-driven. The iteration primitives take a **render function** so the body re-runs per server with the right scope:
+**Compose your own from primitives.** Four namespaces are available, all unstyled and `data-*`-driven. The iteration primitives take a **render function** so the body re-runs per server with the right scope:
 
 ```tsx title="app/mcp/page.tsx"
 "use client";
@@ -242,6 +242,34 @@ const out = await aui.mcp.server({ id: "linear" }).callTool("search", { q });
 </Step>
 </Steps>
 
+## Form elicitation
+
+Connected servers can request structured user input through form-mode elicitation. Render `McpElicitationPrimitive.Items` inside a server-scoped subtree, then compose fields and response actions from the unstyled primitives:
+
+```tsx
+import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
+
+<McpElicitationPrimitive.Items>
+  {() => (
+    <McpElicitationPrimitive.Root>
+      <McpElicitationPrimitive.Message />
+      <McpElicitationPrimitive.Fields>
+        {({ name, value, setValue }) => (
+          <input
+            name={name}
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        )}
+      </McpElicitationPrimitive.Fields>
+      <McpElicitationPrimitive.Accept>Submit</McpElicitationPrimitive.Accept>
+      <McpElicitationPrimitive.Decline>Decline</McpElicitationPrimitive.Decline>
+      <McpElicitationPrimitive.Cancel>Cancel</McpElicitationPrimitive.Cancel>
+    </McpElicitationPrimitive.Root>
+  )}
+</McpElicitationPrimitive.Items>
+```
+
 ## Storage
 
 All persisted state — custom server records, OAuth tokens, PKCE verifiers, DCR client info — goes through a single `MCPStorage` resource. Three built-ins:
@@ -346,6 +374,7 @@ What ships:
 
 - Tool listing and invocation, auto-registered as frontend tools
 - Resource listing and reads for app-built browsers or preview panes
+- Form-mode elicitation with app-composed fields and response actions
 - OAuth (PKCE + DCR), bearer, none
 - StreamableHTTP transport
 - Manual connect/disconnect

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -11,7 +11,7 @@ External API spec for the MCP integration package. Mirrors `@assistant-ui/react-
 
 Both share one connection lifecycle, one persisted state surface, and one tool registration path.
 
-**Tools and form elicitation.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Servers can also request structured user input through pending elicitations. Resources, prompts, sampling, server-pushed list updates, and resumable sessions are deferred.
+**Tools and form elicitation.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Servers can also request structured user input through pending elicitations. Server-pushed tool list updates refresh the registered tools automatically. Resources, prompts, sampling, and resumable sessions are deferred.
 
 **Three auth modes only:** OAuth (PKCE + RFC 7591 DCR), Bearer, None.
 
@@ -88,6 +88,7 @@ type MCPConnector = {
   icon?: string;
   auth: MCPAuthConfig;
   connectionTimeout?: number;
+  cache?: { defaultTtlMs?: number };
 };
 defineConnector(c: MCPConnector): MCPConnector;
 ```
@@ -101,6 +102,7 @@ type MCPCustomServerRecord = {
   url: string;
   auth: MCPAuthConfig;
   connectionTimeout?: number;
+  cache?: { defaultTtlMs?: number };
   createdAt: number;
 };
 ```
@@ -334,6 +336,8 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
 ```
 
 `useMcpElicitation()` reads the current request inside `Items`. `useMcpElicitationField()` reads the current field inside the element returned from the `Fields` render function.
+
+`Accept` does not submit while a required field is absent or empty, and exposes `data-missing-required` in that state. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -11,7 +11,7 @@ External API spec for the MCP integration package. Mirrors `@assistant-ui/react-
 
 Both share one connection lifecycle, one persisted state surface, and one tool registration path.
 
-**Tools and form elicitation.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Servers can also request structured user input through pending elicitations. Server-pushed tool list updates refresh the registered tools automatically. Resources, prompts, sampling, and resumable sessions are deferred.
+**Tools and form elicitation.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Servers can also request structured user input through pending elicitations. Server-pushed tool list updates refresh the registered tools automatically; update failures preserve the existing tool list and appear in the server error state. Resources, prompts, sampling, and resumable sessions are deferred.
 
 **Three auth modes only:** OAuth (PKCE + RFC 7591 DCR), Bearer, None.
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -11,7 +11,7 @@ External API spec for the MCP integration package. Mirrors `@assistant-ui/react-
 
 Both share one connection lifecycle, one persisted state surface, and one tool registration path.
 
-**Tools only.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Resources, prompts, sampling, server-pushed list updates, and resumable sessions are deferred.
+**Tools and form elicitation.** v1 lists and invokes tools, registering them as **frontend tools** with `modelContext` so a connected chat runtime sees them automatically. Servers can also request structured user input through pending elicitations. Resources, prompts, sampling, server-pushed list updates, and resumable sessions are deferred.
 
 **Three auth modes only:** OAuth (PKCE + RFC 7591 DCR), Bearer, None.
 
@@ -51,7 +51,9 @@ packages/react-mcp/
 │   │   ├── server.ts                           barrel (McpServerPrimitive.*)
 │   │   ├── server/{Root,Icon,Name,Status,Error,ConnectButton,DisconnectButton,RemoveButton,OAuthLink,Tools,ToolName}.tsx
 │   │   ├── addForm.ts                          barrel (McpAddFormPrimitive.*)
-│   │   └── addForm/{Root,NameField,UrlField,AuthSelect,AuthFields,Submit,Cancel,Error}.tsx
+│   │   ├── addForm/{Root,NameField,UrlField,AuthSelect,AuthFields,Submit,Cancel,Error}.tsx
+│   │   ├── elicitation.ts                       barrel (McpElicitationPrimitive.*)
+│   │   └── elicitation/{Items,Root,Message,Fields,Accept,Decline,Cancel}.tsx
 │   ├── hooks/
 │   │   └── useMcpOAuthCallback.tsx
 │   └── index.ts
@@ -68,7 +70,7 @@ After the v0.1 simplification, the package's runtime surface is:
 | `McpServerResource` | Per-server resource (advanced — used internally by `McpManagerResource`) |
 | `McpLocalStorage`, `McpMemoryStorage`, `McpCustomStorage` | Storage resource factories |
 | `defineConnector` | Identity-typed helper for `MCPConnector` objects |
-| `McpManagerPrimitive.*`, `McpServerPrimitive.*`, `McpAddFormPrimitive.*` | Unstyled UI primitives |
+| `McpManagerPrimitive.*`, `McpServerPrimitive.*`, `McpAddFormPrimitive.*`, `McpElicitationPrimitive.*` | Unstyled UI primitives |
 | `McpServerByIdProvider` | Scope a subtree to one server (used by iteration primitives; useful standalone) |
 | `useMcpOAuthCallback`, `McpOAuthCallback` | OAuth callback page handlers |
 
@@ -114,12 +116,24 @@ type MCPConnectionState =
 
 type MCPToolInfo = { name: string; description?: string; inputSchema: unknown };
 
+type MCPElicitation = {
+  readonly id: string;
+  readonly message: string;
+  readonly requestedSchema: unknown;
+};
+
+type MCPElicitationResponse =
+  | { action: "accept"; content: Record<string, unknown> }
+  | { action: "decline" }
+  | { action: "cancel" };
+
 type MCPServerState = {
   id: string; kind: MCPServerKind; name: string; url: string;
   icon?: string; connectionState: MCPConnectionState;
   lastError: { message: string } | null;
   tools: MCPToolInfo[];
   authorizationUrl: string | null;
+  readonly pendingElicitations: readonly MCPElicitation[];
 };
 
 type MCPManagerState = {
@@ -158,6 +172,7 @@ type MCPServerMethods = {
   callTool: (name: string, args: unknown) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
   completeAuth: (callbackUrl: string) => Promise<void>;
+  answerElicitation: (id: string, response: MCPElicitationResponse) => void;
 };
 ```
 
@@ -257,7 +272,7 @@ Flow:
 Same conventions as `SpanPrimitive`: `forwardRef`, Radix `Primitive.<tag>`, namespaced `Element`/`Props`, `data-*` rendering.
 
 ```tsx
-import { McpManagerPrimitive, McpServerPrimitive, McpAddFormPrimitive } from "@assistant-ui/react-mcp";
+import { McpManagerPrimitive, McpServerPrimitive, McpAddFormPrimitive, McpElicitationPrimitive } from "@assistant-ui/react-mcp";
 
 <McpManagerPrimitive.Root>
   <McpManagerPrimitive.Connectors>
@@ -293,6 +308,32 @@ The add form owns its own draft state and submits via `aui.mcp().addCustomServer
   <McpAddFormPrimitive.Cancel />
 </McpAddFormPrimitive.Root>
 ```
+
+Render form-mode elicitation inside a server-scoped subtree. Each item owns an isolated draft, and `Fields` renders nothing when the requested schema has no usable `properties` object:
+
+```tsx
+<McpElicitationPrimitive.Items>
+  {() => (
+    <McpElicitationPrimitive.Root>
+      <McpElicitationPrimitive.Message />
+      <McpElicitationPrimitive.Fields>
+        {({ name, value, setValue }) => (
+          <input
+            name={name}
+            value={typeof value === "string" ? value : ""}
+            onChange={(event) => setValue(event.target.value)}
+          />
+        )}
+      </McpElicitationPrimitive.Fields>
+      <McpElicitationPrimitive.Accept>Submit</McpElicitationPrimitive.Accept>
+      <McpElicitationPrimitive.Decline>Decline</McpElicitationPrimitive.Decline>
+      <McpElicitationPrimitive.Cancel>Cancel</McpElicitationPrimitive.Cancel>
+    </McpElicitationPrimitive.Root>
+  )}
+</McpElicitationPrimitive.Items>
+```
+
+`useMcpElicitation()` reads the current request inside `Items`. `useMcpElicitationField()` reads the current field inside the element returned from the `Fields` render function.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/src/index.ts
+++ b/packages/react-mcp/src/index.ts
@@ -53,6 +53,7 @@ export type { MCPPersistedAuthState } from "./auth/types";
 // Public types
 export type {
   MCPAuthConfig,
+  MCPResponseCacheConfig,
   MCPConnector,
   MCPCustomServerRecord,
   MCPServerKind,

--- a/packages/react-mcp/src/index.ts
+++ b/packages/react-mcp/src/index.ts
@@ -30,6 +30,7 @@ export type { MCPStorage, MCPStorageElement } from "./resources/storage/types";
 export * as McpManagerPrimitive from "./primitives/manager";
 export * as McpServerPrimitive from "./primitives/server";
 export * as McpAddFormPrimitive from "./primitives/addForm";
+export * as McpElicitationPrimitive from "./primitives/elicitation";
 
 // Per-server scope providers. The iteration primitives wrap each item in
 // the appropriate ByIndex provider. The ById provider is useful for
@@ -57,6 +58,8 @@ export type {
   MCPServerKind,
   MCPConnectionState,
   MCPToolInfo,
+  MCPElicitation,
+  MCPElicitationResponse,
   MCPServerState,
   MCPManagerState,
   MCPServerMethods,

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -13,6 +13,10 @@ export type MCPAuthConfig =
       clientSecret?: string | undefined;
     };
 
+export type MCPResponseCacheConfig = {
+  readonly defaultTtlMs?: number;
+};
+
 export type MCPConnector = {
   id: string;
   name: string;
@@ -20,6 +24,7 @@ export type MCPConnector = {
   icon?: string | undefined;
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
+  readonly cache?: MCPResponseCacheConfig | undefined;
 };
 
 export type MCPCustomServerRecord = {
@@ -28,6 +33,7 @@ export type MCPCustomServerRecord = {
   url: string;
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
+  readonly cache?: MCPResponseCacheConfig | undefined;
   createdAt: number;
 };
 
@@ -47,6 +53,17 @@ export type MCPToolInfo = {
   inputSchema: unknown;
 };
 
+export type MCPElicitation = {
+  readonly id: string;
+  readonly message: string;
+  readonly requestedSchema: unknown;
+};
+
+export type MCPElicitationResponse =
+  | { action: "accept"; content: Record<string, unknown> }
+  | { action: "decline" }
+  | { action: "cancel" };
+
 export type MCPServerState = {
   id: string;
   kind: MCPServerKind;
@@ -57,6 +74,7 @@ export type MCPServerState = {
   lastError: { message: string } | null;
   tools: MCPToolInfo[];
   authorizationUrl: string | null;
+  readonly pendingElicitations: readonly MCPElicitation[];
 };
 
 export type MCPManagerState = {
@@ -78,6 +96,7 @@ export type MCPServerMethods = {
   readResource: (uri: string) => Promise<unknown>;
   /** OAuth only: pass full callback URL (e.g. window.location.href) */
   completeAuth: (callbackUrl: string) => Promise<void>;
+  answerElicitation(id: string, response: MCPElicitationResponse): void;
 };
 
 export type MCPServerQuery =

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -117,6 +117,7 @@ export type MCPManagerMethods = {
     url: string;
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
+    readonly cache?: MCPResponseCacheConfig | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/primitives/elicitation.ts
+++ b/packages/react-mcp/src/primitives/elicitation.ts
@@ -1,0 +1,13 @@
+export {
+  McpElicitationPrimitiveItems as Items,
+  useMcpElicitation,
+} from "./elicitation/McpElicitationPrimitiveItems";
+export { McpElicitationPrimitiveRoot as Root } from "./elicitation/McpElicitationPrimitiveRoot";
+export { McpElicitationPrimitiveMessage as Message } from "./elicitation/McpElicitationPrimitiveMessage";
+export {
+  McpElicitationPrimitiveFields as Fields,
+  useMcpElicitationField,
+} from "./elicitation/McpElicitationPrimitiveFields";
+export { McpElicitationPrimitiveAccept as Accept } from "./elicitation/McpElicitationPrimitiveAccept";
+export { McpElicitationPrimitiveDecline as Decline } from "./elicitation/McpElicitationPrimitiveDecline";
+export { McpElicitationPrimitiveCancel as Cancel } from "./elicitation/McpElicitationPrimitiveCancel";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
@@ -6,6 +6,7 @@ import {
 import { Primitive } from "@radix-ui/react-primitive";
 import { useAui } from "@assistant-ui/store";
 import { useElicitationContext } from "./context";
+import { prepareElicitationContent } from "./prepareElicitationContent";
 
 export namespace McpElicitationPrimitiveAccept {
   export type Element = ComponentRef<typeof Primitive.button>;
@@ -18,17 +19,24 @@ export const McpElicitationPrimitiveAccept = forwardRef<
 >((props, ref) => {
   const { elicitation, draft } = useElicitationContext();
   const aui = useAui();
+  const { content, missingRequired } = prepareElicitationContent(
+    elicitation.requestedSchema,
+    draft,
+  );
+  const hasMissingRequired = missingRequired.length > 0;
   return (
     <Primitive.button
       {...props}
       type="button"
       ref={ref}
+      disabled={props.disabled || hasMissingRequired}
+      data-missing-required={hasMissingRequired ? "" : undefined}
       onClick={(event) => {
         props.onClick?.(event);
-        if (event.defaultPrevented) return;
+        if (event.defaultPrevented || hasMissingRequired) return;
         aui.mcpServer.answerElicitation(elicitation.id, {
           action: "accept",
-          content: draft,
+          content,
         });
       }}
     />

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
@@ -19,21 +19,23 @@ export const McpElicitationPrimitiveAccept = forwardRef<
 >((props, ref) => {
   const { elicitation, draft } = useElicitationContext();
   const aui = useAui();
-  const { content, missingRequired } = prepareElicitationContent(
+  const { content, missingRequired, invalid } = prepareElicitationContent(
     elicitation.requestedSchema,
     draft,
   );
   const hasMissingRequired = missingRequired.length > 0;
+  const hasInvalid = invalid.length > 0;
   return (
     <Primitive.button
       {...props}
       type="button"
       ref={ref}
-      disabled={props.disabled || hasMissingRequired}
+      disabled={props.disabled || hasMissingRequired || hasInvalid}
       data-missing-required={hasMissingRequired ? "" : undefined}
+      data-invalid={hasInvalid ? invalid.join(",") : undefined}
       onClick={(event) => {
         props.onClick?.(event);
-        if (event.defaultPrevented || hasMissingRequired) return;
+        if (event.defaultPrevented || hasMissingRequired || hasInvalid) return;
         aui.mcpServer.answerElicitation(elicitation.id, {
           action: "accept",
           content,

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveAccept.tsx
@@ -1,0 +1,38 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui } from "@assistant-ui/store";
+import { useElicitationContext } from "./context";
+
+export namespace McpElicitationPrimitiveAccept {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpElicitationPrimitiveAccept = forwardRef<
+  McpElicitationPrimitiveAccept.Element,
+  McpElicitationPrimitiveAccept.Props
+>((props, ref) => {
+  const { elicitation, draft } = useElicitationContext();
+  const aui = useAui();
+  return (
+    <Primitive.button
+      {...props}
+      type="button"
+      ref={ref}
+      onClick={(event) => {
+        props.onClick?.(event);
+        if (event.defaultPrevented) return;
+        aui.mcpServer.answerElicitation(elicitation.id, {
+          action: "accept",
+          content: draft,
+        });
+      }}
+    />
+  );
+});
+
+McpElicitationPrimitiveAccept.displayName = "McpElicitationPrimitive.Accept";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveCancel.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveCancel.tsx
@@ -1,0 +1,37 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui } from "@assistant-ui/store";
+import { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveCancel {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpElicitationPrimitiveCancel = forwardRef<
+  McpElicitationPrimitiveCancel.Element,
+  McpElicitationPrimitiveCancel.Props
+>((props, ref) => {
+  const elicitation = useMcpElicitation();
+  const aui = useAui();
+  return (
+    <Primitive.button
+      {...props}
+      type="button"
+      ref={ref}
+      onClick={(event) => {
+        props.onClick?.(event);
+        if (event.defaultPrevented) return;
+        aui.mcpServer.answerElicitation(elicitation.id, {
+          action: "cancel",
+        });
+      }}
+    />
+  );
+});
+
+McpElicitationPrimitiveCancel.displayName = "McpElicitationPrimitive.Cancel";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveDecline.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveDecline.tsx
@@ -1,0 +1,37 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useAui } from "@assistant-ui/store";
+import { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveDecline {
+  export type Element = ComponentRef<typeof Primitive.button>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.button>;
+}
+
+export const McpElicitationPrimitiveDecline = forwardRef<
+  McpElicitationPrimitiveDecline.Element,
+  McpElicitationPrimitiveDecline.Props
+>((props, ref) => {
+  const elicitation = useMcpElicitation();
+  const aui = useAui();
+  return (
+    <Primitive.button
+      {...props}
+      type="button"
+      ref={ref}
+      onClick={(event) => {
+        props.onClick?.(event);
+        if (event.defaultPrevented) return;
+        aui.mcpServer.answerElicitation(elicitation.id, {
+          action: "decline",
+        });
+      }}
+    />
+  );
+});
+
+McpElicitationPrimitiveDecline.displayName = "McpElicitationPrimitive.Decline";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveFields.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveFields.tsx
@@ -1,0 +1,56 @@
+import { type FC, type ReactNode } from "react";
+import {
+  ElicitationFieldContext,
+  type ElicitationFieldContextValue,
+  useElicitationContext,
+} from "./context";
+
+export { useMcpElicitationField } from "./context";
+
+export namespace McpElicitationPrimitiveFields {
+  export type Props = {
+    children: (field: ElicitationFieldContextValue) => ReactNode;
+  };
+}
+
+export const McpElicitationPrimitiveFields: FC<
+  McpElicitationPrimitiveFields.Props
+> = ({ children }) => {
+  const { elicitation, draft, setField } = useElicitationContext();
+  const properties = (
+    elicitation.requestedSchema as {
+      properties?: Record<string, unknown> | undefined;
+    } | null
+  )?.properties;
+
+  if (
+    properties === null ||
+    typeof properties !== "object" ||
+    Array.isArray(properties)
+  ) {
+    return null;
+  }
+
+  const fields = Object.entries(properties);
+  if (fields.length === 0) return null;
+
+  return (
+    <>
+      {fields.map(([name, schema]) => {
+        const field = {
+          name,
+          schema,
+          value: draft[name],
+          setValue: (value: unknown) => setField(name, value),
+        };
+        return (
+          <ElicitationFieldContext.Provider key={name} value={field}>
+            {children(field)}
+          </ElicitationFieldContext.Provider>
+        );
+      })}
+    </>
+  );
+};
+
+McpElicitationPrimitiveFields.displayName = "McpElicitationPrimitive.Fields";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveFields.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveFields.tsx
@@ -40,7 +40,7 @@ export const McpElicitationPrimitiveFields: FC<
         const field = {
           name,
           schema,
-          value: draft[name],
+          value: Object.hasOwn(draft, name) ? draft[name] : undefined,
           setValue: (value: unknown) => setField(name, value),
         };
         return (

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveItems.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveItems.tsx
@@ -1,0 +1,55 @@
+import { type FC, type ReactNode, useCallback, useMemo, useState } from "react";
+import { useAuiState } from "@assistant-ui/store";
+import type { MCPElicitation } from "../../mcp-scope";
+import { ElicitationContext } from "./context";
+
+export { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveItems {
+  export type Props = {
+    children: ReactNode | ((elicitation: MCPElicitation) => ReactNode);
+  };
+}
+
+const McpElicitationPrimitiveItem: FC<{
+  elicitation: MCPElicitation;
+  children: McpElicitationPrimitiveItems.Props["children"];
+}> = ({ elicitation, children }) => {
+  const [draft, setDraft] = useState<Record<string, unknown>>({});
+  const setField = useCallback((name: string, value: unknown) => {
+    setDraft((current) => ({ ...current, [name]: value }));
+  }, []);
+  const context = useMemo(
+    () => ({ elicitation, draft, setField }),
+    [elicitation, draft, setField],
+  );
+
+  return (
+    <ElicitationContext.Provider value={context}>
+      {typeof children === "function" ? children(elicitation) : children}
+    </ElicitationContext.Provider>
+  );
+};
+
+export const McpElicitationPrimitiveItems: FC<
+  McpElicitationPrimitiveItems.Props
+> = ({ children }) => {
+  const elicitations = useAuiState(
+    (state) => state.mcpServer.pendingElicitations,
+  );
+  if (elicitations.length === 0) return null;
+  return (
+    <>
+      {elicitations.map((elicitation) => (
+        <McpElicitationPrimitiveItem
+          key={elicitation.id}
+          elicitation={elicitation}
+        >
+          {children}
+        </McpElicitationPrimitiveItem>
+      ))}
+    </>
+  );
+};
+
+McpElicitationPrimitiveItems.displayName = "McpElicitationPrimitive.Items";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveMessage.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveMessage.tsx
@@ -1,0 +1,26 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveMessage {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+export const McpElicitationPrimitiveMessage = forwardRef<
+  McpElicitationPrimitiveMessage.Element,
+  McpElicitationPrimitiveMessage.Props
+>((props, ref) => {
+  const elicitation = useMcpElicitation();
+  return (
+    <Primitive.span {...props} ref={ref}>
+      {props.children ?? elicitation.message}
+    </Primitive.span>
+  );
+});
+
+McpElicitationPrimitiveMessage.displayName = "McpElicitationPrimitive.Message";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveRoot.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveRoot.tsx
@@ -1,0 +1,24 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveRoot {
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
+}
+
+export const McpElicitationPrimitiveRoot = forwardRef<
+  McpElicitationPrimitiveRoot.Element,
+  McpElicitationPrimitiveRoot.Props
+>((props, ref) => {
+  const elicitation = useMcpElicitation();
+  return (
+    <Primitive.div {...props} ref={ref} data-elicitation-id={elicitation.id} />
+  );
+});
+
+McpElicitationPrimitiveRoot.displayName = "McpElicitationPrimitive.Root";

--- a/packages/react-mcp/src/primitives/elicitation/context.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/context.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext } from "react";
+import type { MCPElicitation } from "../../mcp-scope";
+
+export type ElicitationContextValue = {
+  elicitation: MCPElicitation;
+  draft: Record<string, unknown>;
+  setField: (name: string, value: unknown) => void;
+};
+
+export type ElicitationFieldContextValue = {
+  name: string;
+  schema: unknown;
+  value: unknown;
+  setValue: (value: unknown) => void;
+};
+
+export const ElicitationContext = createContext<ElicitationContextValue | null>(
+  null,
+);
+
+export const ElicitationFieldContext =
+  createContext<ElicitationFieldContextValue | null>(null);
+
+export const useElicitationContext = (): ElicitationContextValue => {
+  const context = useContext(ElicitationContext);
+  if (!context) {
+    throw new Error(
+      "useMcpElicitation must be used inside <McpElicitationPrimitive.Items>",
+    );
+  }
+  return context;
+};
+
+export const useMcpElicitation = (): MCPElicitation =>
+  useElicitationContext().elicitation;
+
+export const useMcpElicitationField = (): ElicitationFieldContextValue => {
+  const context = useContext(ElicitationFieldContext);
+  if (!context) {
+    throw new Error(
+      "useMcpElicitationField must be used inside <McpElicitationPrimitive.Fields>",
+    );
+  }
+  return context;
+};

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { prepareElicitationContent } from "./prepareElicitationContent";
 
 describe("prepareElicitationContent", () => {
-  it("coerces parseable number and integer draft values", () => {
+  it("accepts parseable number and integer draft values", () => {
     expect(
       prepareElicitationContent(
         {
@@ -20,7 +20,7 @@ describe("prepareElicitationContent", () => {
     ).toEqual({ count: 42, ratio: 1.5, enabled: false });
   });
 
-  it("leaves an unparseable number value as a string", () => {
+  it("flags and excludes an unparseable number value", () => {
     expect(
       prepareElicitationContent(
         {
@@ -29,10 +29,19 @@ describe("prepareElicitationContent", () => {
         },
         { count: "not a number" },
       ).content,
-    ).toEqual({ count: "not a number" });
+    ).toEqual({});
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { count: { type: "number" } },
+        },
+        { count: "not a number" },
+      ).invalid,
+    ).toEqual(["count"]);
   });
 
-  it("leaves a fractional integer value as a string", () => {
+  it("flags and excludes a fractional integer value", () => {
     expect(
       prepareElicitationContent(
         {
@@ -41,7 +50,16 @@ describe("prepareElicitationContent", () => {
         },
         { count: "1.5" },
       ).content,
-    ).toEqual({ count: "1.5" });
+    ).toEqual({});
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { count: { type: "integer" } },
+        },
+        { count: "1.5" },
+      ).invalid,
+    ).toEqual(["count"]);
   });
 
   it("does not read inherited draft values", () => {
@@ -54,7 +72,11 @@ describe("prepareElicitationContent", () => {
         },
         {},
       ),
-    ).toEqual({ content: {}, missingRequired: ["toString"] });
+    ).toEqual({
+      content: {},
+      missingRequired: ["toString"],
+      invalid: [],
+    });
   });
 
   it("accepts missing required booleans as false", () => {
@@ -73,6 +95,39 @@ describe("prepareElicitationContent", () => {
     ).toEqual({
       content: { name: "Ada", enabled: false },
       missingRequired: [],
+      invalid: [],
+    });
+  });
+
+  it("omits absent optional booleans, including schema defaults", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            sendEmail: { type: "boolean", default: true },
+          },
+        },
+        {},
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: [] });
+  });
+
+  it("seeds required booleans with an empty draft value as false", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["enabled"],
+          properties: { enabled: { type: "boolean" } },
+        },
+        { enabled: "" },
+      ),
+    ).toEqual({
+      content: { enabled: false },
+      missingRequired: [],
+      invalid: [],
     });
   });
 

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -32,6 +32,50 @@ describe("prepareElicitationContent", () => {
     ).toEqual({ count: "not a number" });
   });
 
+  it("leaves a fractional integer value as a string", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { count: { type: "integer" } },
+        },
+        { count: "1.5" },
+      ).content,
+    ).toEqual({ count: "1.5" });
+  });
+
+  it("does not read inherited draft values", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["toString"],
+          properties: { toString: { type: "string" } },
+        },
+        {},
+      ),
+    ).toEqual({ content: {}, missingRequired: ["toString"] });
+  });
+
+  it("accepts missing required booleans as false", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["enabled", "name"],
+          properties: {
+            enabled: { type: "boolean" },
+            name: { type: "string" },
+          },
+        },
+        { name: "Ada" },
+      ),
+    ).toEqual({
+      content: { name: "Ada", enabled: false },
+      missingRequired: [],
+    });
+  });
+
   it("reports required draft values that are absent or empty", () => {
     expect(
       prepareElicitationContent(

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { prepareElicitationContent } from "./prepareElicitationContent";
+
+describe("prepareElicitationContent", () => {
+  it("coerces parseable number and integer draft values", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: {
+            count: { type: "integer" },
+            ratio: { type: "number" },
+            enabled: { type: "boolean" },
+          },
+        },
+        { count: "42", ratio: "1.5", enabled: false },
+      ).content,
+    ).toEqual({ count: 42, ratio: 1.5, enabled: false });
+  });
+
+  it("leaves an unparseable number value as a string", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { count: { type: "number" } },
+        },
+        { count: "not a number" },
+      ).content,
+    ).toEqual({ count: "not a number" });
+  });
+
+  it("reports required draft values that are absent or empty", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["name", "email", "ignored"],
+          properties: {},
+        },
+        { name: "", email: "ada@example.com" },
+      ).missingRequired,
+    ).toEqual(["name", "ignored"]);
+  });
+});

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -1,14 +1,24 @@
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const coerceValue = (schema: unknown, value: unknown): unknown => {
-  if (!isRecord(schema) || typeof value !== "string") return value;
-  if (schema.type !== "number" && schema.type !== "integer") return value;
+const coerceValue = (
+  schema: unknown,
+  value: unknown,
+): { value: unknown; invalid: boolean } => {
+  if (!isRecord(schema) || typeof value !== "string") {
+    return { value, invalid: false };
+  }
+  if (schema.type !== "number" && schema.type !== "integer") {
+    return { value, invalid: false };
+  }
 
   const number = Number(value);
-  if (value.trim() === "" || !Number.isFinite(number)) return value;
-  if (schema.type === "integer" && !Number.isInteger(number)) return value;
-  return number;
+  if (value.trim() === "") return { value, invalid: false };
+  if (!Number.isFinite(number)) return { value, invalid: true };
+  if (schema.type === "integer" && !Number.isInteger(number)) {
+    return { value, invalid: true };
+  }
+  return { value: number, invalid: false };
 };
 
 const isBooleanSchema = (schema: unknown) =>
@@ -17,12 +27,16 @@ const isBooleanSchema = (schema: unknown) =>
 const getDraftValue = (draft: Record<string, unknown>, name: string) =>
   Object.hasOwn(draft, name) ? draft[name] : undefined;
 
+const isAbsentBooleanDraftValue = (value: unknown) =>
+  value === undefined || value === "" || typeof value !== "boolean";
+
 export const prepareElicitationContent = (
   requestedSchema: unknown,
   draft: Record<string, unknown>,
 ): {
   content: Record<string, unknown>;
   missingRequired: readonly string[];
+  invalid: readonly string[];
 } => {
   const properties =
     isRecord(requestedSchema) && isRecord(requestedSchema.properties)
@@ -35,23 +49,31 @@ export const prepareElicitationContent = (
         )
       : [];
 
+  const preparedDraft = Object.entries(draft).flatMap(([name, value]) => {
+    const schema = properties[name];
+    if (isBooleanSchema(schema) && isAbsentBooleanDraftValue(value)) return [];
+
+    const coerced = coerceValue(schema, value);
+    return coerced.invalid ? [] : [[name, coerced.value]];
+  });
+  const invalid = Object.entries(draft).flatMap(([name, value]) =>
+    coerceValue(properties[name], value).invalid ? [name] : [],
+  );
+  const requiredBooleans = required.flatMap((name) =>
+    isBooleanSchema(properties[name]) &&
+    isAbsentBooleanDraftValue(getDraftValue(draft, name))
+      ? [[name, false]]
+      : [],
+  );
+
   return {
-    content: Object.fromEntries([
-      ...Object.entries(draft).map(([name, value]) => [
-        name,
-        coerceValue(properties[name], value),
-      ]),
-      ...Object.entries(properties).flatMap(([name, schema]) =>
-        isBooleanSchema(schema) && !Object.hasOwn(draft, name)
-          ? [[name, false]]
-          : [],
-      ),
-    ]),
+    content: Object.fromEntries([...preparedDraft, ...requiredBooleans]),
     missingRequired: required.filter(
       (name) =>
         !isBooleanSchema(properties[name]) &&
         (getDraftValue(draft, name) === undefined ||
           getDraftValue(draft, name) === ""),
     ),
+    invalid,
   };
 };

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -1,0 +1,42 @@
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const coerceValue = (schema: unknown, value: unknown): unknown => {
+  if (!isRecord(schema) || typeof value !== "string") return value;
+  if (schema.type !== "number" && schema.type !== "integer") return value;
+
+  const number = Number(value);
+  if (value.trim() === "" || !Number.isFinite(number)) return value;
+  return number;
+};
+
+export const prepareElicitationContent = (
+  requestedSchema: unknown,
+  draft: Record<string, unknown>,
+): {
+  content: Record<string, unknown>;
+  missingRequired: readonly string[];
+} => {
+  const properties =
+    isRecord(requestedSchema) && isRecord(requestedSchema.properties)
+      ? requestedSchema.properties
+      : {};
+  const required =
+    isRecord(requestedSchema) && Array.isArray(requestedSchema.required)
+      ? requestedSchema.required.filter(
+          (property): property is string => typeof property === "string",
+        )
+      : [];
+
+  return {
+    content: Object.fromEntries(
+      Object.entries(draft).map(([name, value]) => [
+        name,
+        coerceValue(properties[name], value),
+      ]),
+    ),
+    missingRequired: required.filter(
+      (name) => draft[name] === undefined || draft[name] === "",
+    ),
+  };
+};

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -7,8 +7,15 @@ const coerceValue = (schema: unknown, value: unknown): unknown => {
 
   const number = Number(value);
   if (value.trim() === "" || !Number.isFinite(number)) return value;
+  if (schema.type === "integer" && !Number.isInteger(number)) return value;
   return number;
 };
+
+const isBooleanSchema = (schema: unknown) =>
+  isRecord(schema) && schema.type === "boolean";
+
+const getDraftValue = (draft: Record<string, unknown>, name: string) =>
+  Object.hasOwn(draft, name) ? draft[name] : undefined;
 
 export const prepareElicitationContent = (
   requestedSchema: unknown,
@@ -29,14 +36,22 @@ export const prepareElicitationContent = (
       : [];
 
   return {
-    content: Object.fromEntries(
-      Object.entries(draft).map(([name, value]) => [
+    content: Object.fromEntries([
+      ...Object.entries(draft).map(([name, value]) => [
         name,
         coerceValue(properties[name], value),
       ]),
-    ),
+      ...Object.entries(properties).flatMap(([name, schema]) =>
+        isBooleanSchema(schema) && !Object.hasOwn(draft, name)
+          ? [[name, false]]
+          : [],
+      ),
+    ]),
     missingRequired: required.filter(
-      (name) => draft[name] === undefined || draft[name] === "",
+      (name) =>
+        !isBooleanSchema(properties[name]) &&
+        (getDraftValue(draft, name) === undefined ||
+          getDraftValue(draft, name) === ""),
     ),
   };
 };

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -91,4 +91,33 @@ describe("McpManagerResource server ids", () => {
       root.unmount();
     }
   });
+
+  it("passes custom server cache configuration to its client", async () => {
+    mocks.Client.mockClear();
+    const root = mount([]);
+
+    try {
+      const id = await root.getValue().addCustomServer({
+        name: "Docs",
+        url: "https://example.com/docs/mcp",
+        auth: { type: "none" },
+        cache: { defaultTtlMs: 5_000 },
+      });
+
+      await vi.waitFor(() =>
+        expect(root.getValue().getState().customServers).toHaveLength(1),
+      );
+      await root.getValue().server({ id }).connect();
+
+      expect(mocks.Client).toHaveBeenCalledWith(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        expect.objectContaining({ defaultCacheTtlMs: 5_000 }),
+      );
+    } finally {
+      root.unmount();
+    }
+  });
 });

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -1,10 +1,37 @@
 import { createTapRoot, useResource } from "@assistant-ui/tap";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { defineConnector } from "../connector";
 import type { MCPConnector } from "../mcp-scope";
 import { assertUniqueServerIds } from "../utils/serverId";
 import { McpManagerResource } from "./McpManagerResource";
 import { McpMemoryStorage } from "./storage/McpMemoryStorage";
+
+const mocks = vi.hoisted(() => {
+  const Client = vi.fn().mockImplementation(function Client(this: any) {
+    this.connect = vi.fn(async () => {});
+    this.listTools = vi.fn(async () => ({ tools: [] }));
+    this.setRequestHandler = vi.fn();
+    this.setNotificationHandler = vi.fn();
+  });
+  const StreamableHTTPClientTransport = vi
+    .fn()
+    .mockImplementation(function StreamableHTTPClientTransport(this: any) {
+      this.close = vi.fn(async () => {});
+    });
+
+  return { Client, StreamableHTTPClientTransport };
+});
+
+vi.mock("@modelcontextprotocol/client", async (importOriginal) => ({
+  ...(await importOriginal()),
+  Client: mocks.Client,
+  StreamableHTTPClientTransport: mocks.StreamableHTTPClientTransport,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAssistantClientRef: () => ({ current: null }),
+}));
 
 const connector = (id: string, name = id): MCPConnector =>
   defineConnector({
@@ -36,5 +63,32 @@ describe("McpManagerResource server ids", () => {
 
   it("allows distinct ids", () => {
     expect(() => assertUniqueServerIds(["docs", "linear"])).not.toThrow();
+  });
+
+  it("passes connector cache configuration to its client", async () => {
+    mocks.Client.mockClear();
+    const root = mount([
+      defineConnector({
+        id: "docs",
+        name: "Docs",
+        url: "https://example.com/docs/mcp",
+        auth: { type: "none" },
+        cache: { defaultTtlMs: 5_000 },
+      }),
+    ]);
+
+    try {
+      await root.getValue().connector({ index: 0 }).connect();
+
+      expect(mocks.Client).toHaveBeenCalledWith(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        expect.objectContaining({ defaultCacheTtlMs: 5_000 }),
+      );
+    } finally {
+      root.unmount();
+    }
   });
 });

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -228,7 +228,7 @@ const useMcpManagerResource = (
     },
     connector: ({ index }) => serverByKind("connector", index),
     customServer: ({ index }) => serverByKind("custom", index),
-    addCustomServer: async ({ name, url, auth, connectionTimeout }) => {
+    addCustomServer: async ({ name, url, auth, connectionTimeout, cache }) => {
       const record: MCPCustomServerRecord = {
         id:
           typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -238,6 +238,7 @@ const useMcpManagerResource = (
         url,
         auth: auth as MCPAuthConfig,
         connectionTimeout,
+        ...(cache !== undefined ? { cache } : {}),
         createdAt: Date.now(),
       };
       setCustomServers((prev) => [...prev, record]);

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -124,6 +124,7 @@ const useMcpManagerResource = (
           redirectUri,
           autoConnect,
           connectionTimeout: c.connectionTimeout ?? connectionTimeout,
+          ...(c.cache !== undefined ? { cache: c.cache } : {}),
           onRemove: async () => {
             // connectors cannot be removed
           },
@@ -143,6 +144,7 @@ const useMcpManagerResource = (
           redirectUri,
           autoConnect,
           connectionTimeout: s.connectionTimeout ?? connectionTimeout,
+          ...(s.cache !== undefined ? { cache: s.cache } : {}),
           onRemove: async () => {
             setCustomServers((prev) => prev.filter((x) => x.id !== s.id));
           },

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -935,6 +935,23 @@ describe("McpServerResource tools listChanged", () => {
           },
         ],
       });
+
+      onChanged(null, [
+        {
+          name: "summarize",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
+      await waitForResourceUpdate(
+        () => root.getValue().getState().lastError === null,
+      );
+
+      expect(root.getValue().getState().tools).toEqual([
+        {
+          name: "summarize",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
     } finally {
       root.unmount();
     }

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -110,13 +110,19 @@ const requestElicitation = (
   client: any,
   message: string,
   requestedSchema: unknown,
+  context: { signal: AbortSignal } = {
+    signal: new AbortController().signal,
+  },
 ) => {
   const handler = client.requestHandlers.get("elicitation/create");
   if (!handler) throw new Error("elicitation/create handler not registered");
-  return handler({
-    method: "elicitation/create",
-    params: { message, requestedSchema },
-  });
+  return handler(
+    {
+      method: "elicitation/create",
+      params: { message, requestedSchema },
+    },
+    context,
+  );
 };
 
 const createStorage = (): MCPStorage => ({
@@ -624,7 +630,7 @@ describe("McpServerResource elicitation", () => {
     }
   });
 
-  it("throws when answering an unknown elicitation", () => {
+  it("ignores answers for unknown elicitations", () => {
     const root = mount();
 
     try {
@@ -632,7 +638,8 @@ describe("McpServerResource elicitation", () => {
         root
           .getValue()
           .answerElicitation("missing-elicitation", { action: "cancel" }),
-      ).toThrow('Unknown MCP elicitation "missing-elicitation"');
+      ).not.toThrow();
+      expect(root.getValue().getState().pendingElicitations).toEqual([]);
     } finally {
       root.unmount();
     }
@@ -683,6 +690,36 @@ describe("McpServerResource elicitation", () => {
       );
 
       await root.getValue().disconnect();
+
+      await expect(response).resolves.toEqual({ action: "cancel" });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("cancels pending elicitations when the server aborts the request", async () => {
+    const root = mount();
+    const controller = new AbortController();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(
+        mocks.clients[0],
+        "Confirm access",
+        {
+          type: "object",
+          properties: {},
+        },
+        { signal: controller.signal },
+      );
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+
+      controller.abort();
 
       await expect(response).resolves.toEqual({ action: "cancel" });
       await waitForResourceUpdate(
@@ -753,7 +790,8 @@ describe("McpServerResource elicitation", () => {
           },
           listChanged: {
             tools: {
-              autoRefresh: false,
+              autoRefresh: true,
+              debounceMs: 300,
               onChanged: expect.any(Function),
             },
           },
@@ -768,7 +806,7 @@ describe("McpServerResource elicitation", () => {
 describe("McpServerResource tools listChanged", () => {
   beforeEach(resetMocks);
 
-  it("registers the list_changed notification handler and opts into listChanged tools", async () => {
+  it("opts into automatic listChanged tool refreshes", async () => {
     const root = mount();
 
     try {
@@ -785,22 +823,20 @@ describe("McpServerResource tools listChanged", () => {
           },
           listChanged: {
             tools: {
-              autoRefresh: false,
+              autoRefresh: true,
+              debounceMs: 300,
               onChanged: expect.any(Function),
             },
           },
         },
       );
-      expect(mocks.clients[0].setNotificationHandler).toHaveBeenCalledWith(
-        "notifications/tools/list_changed",
-        expect.any(Function),
-      );
+      expect(mocks.clients[0].setNotificationHandler).not.toHaveBeenCalled();
     } finally {
       root.unmount();
     }
   });
 
-  it("re-syncs tools when notifications/tools/list_changed fires after connect", async () => {
+  it("applies refreshed tools from the listChanged callback", async () => {
     mocks.listToolsResults.push(async () => ({
       tools: [
         {
@@ -825,30 +861,25 @@ describe("McpServerResource tools listChanged", () => {
         },
       ]);
 
-      mocks.clients[0].listTools.mockResolvedValueOnce({
-        tools: [
-          {
-            name: "search",
-            description: "Search docs",
-            inputSchema: { type: "object" },
-          },
-          {
-            name: "summarize",
-            inputSchema: { type: "object", properties: {} },
-          },
-        ],
-      });
-
-      const handler = mocks.clients[0].notificationHandlers.get(
-        "notifications/tools/list_changed",
-      );
-      expect(handler).toEqual(expect.any(Function));
-      await handler();
+      const onChanged =
+        mocks.Client.mock.calls[0]?.[1]?.listChanged?.tools?.onChanged;
+      if (!onChanged) throw new Error("Expected tools listChanged callback");
+      onChanged(null, [
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "summarize",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
       await waitForResourceUpdate(
         () => root.getValue().getState().tools.length === 2,
       );
 
-      expect(mocks.clients[0].listTools).toHaveBeenCalledTimes(2);
+      expect(mocks.clients[0].listTools).toHaveBeenCalledTimes(1);
       expect(root.getValue().getState().tools).toEqual([
         {
           name: "search",
@@ -865,7 +896,7 @@ describe("McpServerResource tools listChanged", () => {
     }
   });
 
-  it("ignores list_changed notifications from a stale connection generation", async () => {
+  it("ignores listChanged callbacks from a stale connection generation", async () => {
     mocks.listToolsResults.push(async () => ({
       tools: [
         {
@@ -886,9 +917,10 @@ describe("McpServerResource tools listChanged", () => {
 
     try {
       await root.getValue().connect();
-      const staleHandler = mocks.clients[0].notificationHandlers.get(
-        "notifications/tools/list_changed",
-      );
+      const staleOnChanged =
+        mocks.Client.mock.calls[0]?.[1]?.listChanged?.tools?.onChanged;
+      if (!staleOnChanged)
+        throw new Error("Expected tools listChanged callback");
       await root.getValue().connect();
       await waitForResourceUpdate(
         () => root.getValue().getState().tools[0]?.name === "second",
@@ -901,15 +933,12 @@ describe("McpServerResource tools listChanged", () => {
         },
       ]);
 
-      mocks.clients[0].listTools.mockResolvedValueOnce({
-        tools: [
-          {
-            name: "stale-tool",
-            inputSchema: { type: "object" },
-          },
-        ],
-      });
-      await staleHandler();
+      staleOnChanged(null, [
+        {
+          name: "stale-tool",
+          inputSchema: { type: "object" },
+        },
+      ]);
       await flushMacrotask();
 
       expect(root.getValue().getState().tools).toEqual([
@@ -918,7 +947,6 @@ describe("McpServerResource tools listChanged", () => {
           inputSchema: { type: "object" },
         },
       ]);
-      // Stale generation returns before listTools is invoked.
       expect(mocks.clients[0].listTools).toHaveBeenCalledTimes(1);
     } finally {
       root.unmount();
@@ -942,7 +970,8 @@ describe("McpServerResource tools listChanged", () => {
           },
           listChanged: {
             tools: {
-              autoRefresh: false,
+              autoRefresh: true,
+              debounceMs: 300,
               onChanged: expect.any(Function),
             },
           },

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -896,6 +896,50 @@ describe("McpServerResource tools listChanged", () => {
     }
   });
 
+  it("stores listChanged errors without replacing the current tools", async () => {
+    mocks.listToolsResults.push(async () => ({
+      tools: [
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object" },
+        },
+      ],
+    }));
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      await waitForResourceUpdate(
+        () => root.getValue().getState().tools.length === 1,
+      );
+      const onChanged =
+        mocks.Client.mock.calls[0]?.[1]?.listChanged?.tools?.onChanged;
+      if (!onChanged) throw new Error("Expected tools listChanged callback");
+
+      onChanged(new Error("tool update failed"), null);
+      await waitForResourceUpdate(
+        () =>
+          root.getValue().getState().lastError?.message ===
+          "tool update failed",
+      );
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "connected",
+        lastError: { message: "tool update failed" },
+        tools: [
+          {
+            name: "search",
+            description: "Search docs",
+            inputSchema: { type: "object" },
+          },
+        ],
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("ignores listChanged callbacks from a stale connection generation", async () => {
     mocks.listToolsResults.push(async () => ({
       tools: [

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -30,6 +30,14 @@ const mocks = vi.hoisted(() => {
     this.callTool = vi.fn();
     this.listResources = vi.fn(() => Promise.resolve({ resources: [] }));
     this.readResource = vi.fn();
+    this.requestHandlers = new Map();
+    this.notificationHandlers = new Map();
+    this.setRequestHandler = vi.fn((method, handler) => {
+      this.requestHandlers.set(method, handler);
+    });
+    this.setNotificationHandler = vi.fn((method, handler) => {
+      this.notificationHandlers.set(method, handler);
+    });
     clients.push(this);
   });
 
@@ -90,6 +98,27 @@ const waitFor = async (predicate: () => boolean) => {
   expect(predicate()).toBe(true);
 };
 
+const waitForResourceUpdate = async (predicate: () => boolean) => {
+  for (let i = 0; i < 20; i++) {
+    if (predicate()) return;
+    await flushMacrotask();
+  }
+  expect(predicate()).toBe(true);
+};
+
+const requestElicitation = (
+  client: any,
+  message: string,
+  requestedSchema: unknown,
+) => {
+  const handler = client.requestHandlers.get("elicitation/create");
+  if (!handler) throw new Error("elicitation/create handler not registered");
+  return handler({
+    method: "elicitation/create",
+    params: { message, requestedSchema },
+  });
+};
+
 const createStorage = (): MCPStorage => ({
   loadCustomServers: vi.fn(async () => []),
   saveCustomServers: vi.fn(async () => {}),
@@ -113,6 +142,7 @@ const mount = (
   props?: {
     auth?: MCPAuthConfig | undefined;
     connectionTimeout?: number | undefined;
+    cache?: { readonly defaultTtlMs?: number } | undefined;
   },
   onMount?: (server: ClientOutput<"mcpServer">) => void,
 ) => {
@@ -131,6 +161,7 @@ const mount = (
         redirectUri: "https://example.com/callback",
         autoConnect: false,
         connectionTimeout,
+        cache: props?.cache,
         onRemove: vi.fn(async () => {}),
       }),
     );
@@ -463,6 +494,476 @@ describe("McpServerResource completeAuth", () => {
       });
     } finally {
       if (!didUnmount) root.unmount();
+    }
+  });
+});
+
+describe("McpServerResource elicitation", () => {
+  beforeEach(resetMocks);
+
+  it("surfaces pending elicitation requests in server state", async () => {
+    const root = mount();
+    const requestedSchema = {
+      type: "object",
+      properties: {
+        answer: { type: "string" },
+      },
+    };
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(
+        mocks.clients[0],
+        "Provide an answer",
+        requestedSchema,
+      );
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+      expect(elicitation).toEqual({
+        id: expect.any(String),
+        message: "Provide an answer",
+        requestedSchema,
+      });
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "cancel",
+      });
+      await expect(response).resolves.toEqual({ action: "cancel" });
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("answers pending elicitations with accepted content", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Choose a color", {
+        type: "object",
+        properties: {
+          color: { type: "string" },
+        },
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+      const content = { color: "blue" };
+
+      root
+        .getValue()
+        .answerElicitation(elicitation!.id, { action: "accept", content });
+
+      await expect(response).resolves.toEqual({
+        action: "accept",
+        content,
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("declines pending elicitations", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Confirm access", {
+        type: "object",
+        properties: {},
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "decline",
+      });
+
+      await expect(response).resolves.toEqual({ action: "decline" });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("cancels pending elicitations", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Confirm access", {
+        type: "object",
+        properties: {},
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "cancel",
+      });
+
+      await expect(response).resolves.toEqual({ action: "cancel" });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("throws when answering an unknown elicitation", () => {
+    const root = mount();
+
+    try {
+      expect(() =>
+        root
+          .getValue()
+          .answerElicitation("missing-elicitation", { action: "cancel" }),
+      ).toThrow('Unknown MCP elicitation "missing-elicitation"');
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("rejects accepted elicitation content that is not an object", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Confirm access", {
+        type: "object",
+        properties: {},
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+
+      expect(() =>
+        root.getValue().answerElicitation(elicitation!.id, {
+          action: "accept",
+          content: null as never,
+        }),
+      ).toThrow(
+        `MCP elicitation "${elicitation!.id}" response content must be an object`,
+      );
+      expect(root.getValue().getState().pendingElicitations).toHaveLength(1);
+
+      await root.getValue().disconnect();
+      await expect(response).resolves.toEqual({ action: "cancel" });
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("cancels pending elicitations on disconnect", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Confirm access", {
+        type: "object",
+        properties: {},
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+
+      await root.getValue().disconnect();
+
+      await expect(response).resolves.toEqual({ action: "cancel" });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("cancels pending elicitations on unmount", async () => {
+    const root = mount();
+    let didUnmount = false;
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Confirm access", {
+        type: "object",
+        properties: {},
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+
+      root.unmount();
+      didUnmount = true;
+      await flushMacrotask();
+
+      await expect(response).resolves.toEqual({ action: "cancel" });
+    } finally {
+      if (!didUnmount) root.unmount();
+    }
+  });
+
+  it("cancels requests from stale connections without surfacing them", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      await root.getValue().connect();
+
+      await expect(
+        requestElicitation(mocks.clients[0], "Confirm access", {
+          type: "object",
+          properties: {},
+        }),
+      ).resolves.toEqual({ action: "cancel" });
+      expect(root.getValue().getState().pendingElicitations).toEqual([]);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("advertises form elicitation capability", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+
+      expect(mocks.Client).toHaveBeenCalledWith(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        {
+          capabilities: {
+            elicitation: {},
+          },
+          listChanged: {
+            tools: {
+              autoRefresh: false,
+              onChanged: expect.any(Function),
+            },
+          },
+        },
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+});
+
+describe("McpServerResource tools listChanged", () => {
+  beforeEach(resetMocks);
+
+  it("registers the list_changed notification handler and opts into listChanged tools", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+
+      expect(mocks.Client).toHaveBeenCalledWith(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        {
+          capabilities: {
+            elicitation: {},
+          },
+          listChanged: {
+            tools: {
+              autoRefresh: false,
+              onChanged: expect.any(Function),
+            },
+          },
+        },
+      );
+      expect(mocks.clients[0].setNotificationHandler).toHaveBeenCalledWith(
+        "notifications/tools/list_changed",
+        expect.any(Function),
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("re-syncs tools when notifications/tools/list_changed fires after connect", async () => {
+    mocks.listToolsResults.push(async () => ({
+      tools: [
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object" },
+        },
+      ],
+    }));
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      await waitForResourceUpdate(
+        () => root.getValue().getState().tools.length === 1,
+      );
+      expect(root.getValue().getState().tools).toEqual([
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object" },
+        },
+      ]);
+
+      mocks.clients[0].listTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: "search",
+            description: "Search docs",
+            inputSchema: { type: "object" },
+          },
+          {
+            name: "summarize",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      });
+
+      const handler = mocks.clients[0].notificationHandlers.get(
+        "notifications/tools/list_changed",
+      );
+      expect(handler).toEqual(expect.any(Function));
+      await handler();
+      await waitForResourceUpdate(
+        () => root.getValue().getState().tools.length === 2,
+      );
+
+      expect(mocks.clients[0].listTools).toHaveBeenCalledTimes(2);
+      expect(root.getValue().getState().tools).toEqual([
+        {
+          name: "search",
+          description: "Search docs",
+          inputSchema: { type: "object" },
+        },
+        {
+          name: "summarize",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("ignores list_changed notifications from a stale connection generation", async () => {
+    mocks.listToolsResults.push(async () => ({
+      tools: [
+        {
+          name: "first",
+          inputSchema: { type: "object" },
+        },
+      ],
+    }));
+    mocks.listToolsResults.push(async () => ({
+      tools: [
+        {
+          name: "second",
+          inputSchema: { type: "object" },
+        },
+      ],
+    }));
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const staleHandler = mocks.clients[0].notificationHandlers.get(
+        "notifications/tools/list_changed",
+      );
+      await root.getValue().connect();
+      await waitForResourceUpdate(
+        () => root.getValue().getState().tools[0]?.name === "second",
+      );
+
+      expect(root.getValue().getState().tools).toEqual([
+        {
+          name: "second",
+          inputSchema: { type: "object" },
+        },
+      ]);
+
+      mocks.clients[0].listTools.mockResolvedValueOnce({
+        tools: [
+          {
+            name: "stale-tool",
+            inputSchema: { type: "object" },
+          },
+        ],
+      });
+      await staleHandler();
+      await flushMacrotask();
+
+      expect(root.getValue().getState().tools).toEqual([
+        {
+          name: "second",
+          inputSchema: { type: "object" },
+        },
+      ]);
+      // Stale generation returns before listTools is invoked.
+      expect(mocks.clients[0].listTools).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("passes defaultCacheTtlMs when cache.defaultTtlMs is configured", async () => {
+    const root = mount({ cache: { defaultTtlMs: 5_000 } });
+
+    try {
+      await root.getValue().connect();
+
+      expect(mocks.Client).toHaveBeenCalledWith(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        {
+          capabilities: {
+            elicitation: {},
+          },
+          listChanged: {
+            tools: {
+              autoRefresh: false,
+              onChanged: expect.any(Function),
+            },
+          },
+          defaultCacheTtlMs: 5_000,
+        },
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("omits defaultCacheTtlMs when cache is not configured", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+
+      const options = mocks.Client.mock.calls[0]?.[1];
+      expect(options).not.toHaveProperty("defaultCacheTtlMs");
+    } finally {
+      root.unmount();
     }
   });
 });

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -5,6 +5,7 @@ import {
   Client,
   StreamableHTTPClientTransport,
   UnauthorizedError,
+  type ClientOptions,
   type ElicitRequest,
   type ElicitResult,
   type StreamableHTTPClientTransportOptions,
@@ -59,7 +60,14 @@ const useMcpServerResource = (
   const transportCloseQueueRef = useRef(Promise.resolve());
   const connectionGenerationRef = useRef(0);
   const elicitationResolversRef = useRef(
-    new Map<string, { resolve: (result: ElicitResult) => void }>(),
+    new Map<
+      string,
+      {
+        resolve: (result: ElicitResult) => void;
+        signal: AbortSignal;
+        onAbort: () => void;
+      }
+    >(),
   );
   const pendingDisposalRef = useRef<{ cancelled: boolean } | null>(null);
   const mountedRef = useRef(true);
@@ -90,12 +98,22 @@ const useMcpServerResource = (
     await closeQueuedTransports(transport ? [transport] : []);
   };
 
+  const resolvePendingElicitation = (id: string, result: ElicitResult) => {
+    const entry = elicitationResolversRef.current.get(id);
+    if (!entry) return false;
+    elicitationResolversRef.current.delete(id);
+    entry.signal.removeEventListener("abort", entry.onAbort);
+    setPendingElicitations((current) =>
+      current.filter((elicitation) => elicitation.id !== id),
+    );
+    entry.resolve(result);
+    return true;
+  };
+
   const cancelPendingElicitations = () => {
-    for (const { resolve } of elicitationResolversRef.current.values()) {
-      resolve({ action: "cancel" });
+    for (const [id] of elicitationResolversRef.current) {
+      resolvePendingElicitation(id, { action: "cancel" });
     }
-    elicitationResolversRef.current.clear();
-    setPendingElicitations([]);
   };
 
   const closeTransports = async () => {
@@ -228,32 +246,17 @@ const useMcpServerResource = (
       transport: StreamableHTTPClientTransport,
       generation: number,
     ): Promise<boolean> => {
-      const clientOptions: {
-        capabilities: { elicitation: Record<string, never> };
-        listChanged: {
-          tools: {
-            // false: the SDK invalidates its cached tool list on a
-            // listChanged notification instead of refetching it, so the
-            // notification handler below performs the single listTools()
-            // call.
-            autoRefresh?: boolean;
-            onChanged: () => void;
-          };
-        };
-        defaultCacheTtlMs?: number;
-      } = {
+      const clientOptions: ClientOptions = {
         capabilities: {
           elicitation: {},
         },
-        // Opt into tools listChanged so the client auto-opens modern-era
-        // subscriptions; react-mcp state is refreshed via the notification
-        // handler below (generation-guarded).
         listChanged: {
           tools: {
-            autoRefresh: false,
-            onChanged: () => {
-              // State updates are driven by setNotificationHandler so the
-              // connectionGenerationRef staleness guard stays in one place.
+            autoRefresh: true,
+            debounceMs: 300,
+            onChanged: (_error, items) => {
+              if (!isCurrentConnection(generation) || items === null) return;
+              applyToolsList({ tools: items });
             },
           },
         },
@@ -270,7 +273,7 @@ const useMcpServerResource = (
       );
       client.setRequestHandler(
         "elicitation/create",
-        (request: ElicitRequest): Promise<ElicitResult> => {
+        (request: ElicitRequest, context): Promise<ElicitResult> => {
           if (!isCurrentConnection(generation)) {
             return Promise.resolve({ action: "cancel" });
           }
@@ -284,7 +287,14 @@ const useMcpServerResource = (
               ? crypto.randomUUID()
               : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
           const promise = new Promise<ElicitResult>((resolve) => {
-            elicitationResolversRef.current.set(id, { resolve });
+            const onAbort = () => {
+              resolvePendingElicitation(id, { action: "cancel" });
+            };
+            elicitationResolversRef.current.set(id, {
+              resolve,
+              signal: context.signal,
+              onAbort,
+            });
           });
           setPendingElicitations((current) => [
             ...current,
@@ -294,15 +304,19 @@ const useMcpServerResource = (
               requestedSchema,
             },
           ]);
+          const entry = elicitationResolversRef.current.get(id);
+          if (entry) {
+            if (context.signal.aborted) {
+              entry.onAbort();
+            } else {
+              context.signal.addEventListener("abort", entry.onAbort, {
+                once: true,
+              });
+            }
+          }
           return promise;
         },
       );
-      client.setNotificationHandler("notifications/tools/list_changed", () => {
-        if (!isCurrentConnection(generation)) return;
-        void syncTools(client, generation).catch(() => {
-          // Ignore refresh failures from stale or closed connections.
-        });
-      });
       const startedAt = Date.now();
       await withConnectionTimeout(
         client.connect(transport),
@@ -529,10 +543,6 @@ const useMcpServerResource = (
     },
     completeAuth: doCompleteAuth,
     answerElicitation: (id: string, response: MCPElicitationResponse): void => {
-      const entry = elicitationResolversRef.current.get(id);
-      if (!entry) {
-        throw new Error(`Unknown MCP elicitation "${id}"`);
-      }
       if (
         response.action === "accept" &&
         (typeof response.content !== "object" ||
@@ -551,11 +561,7 @@ const useMcpServerResource = (
               content: response.content as ElicitResult["content"],
             }
           : { action: response.action };
-      elicitationResolversRef.current.delete(id);
-      setPendingElicitations((current) =>
-        current.filter((elicitation) => elicitation.id !== id),
-      );
-      entry.resolve(result);
+      resolvePendingElicitation(id, result);
     },
   };
 };

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -254,8 +254,13 @@ const useMcpServerResource = (
           tools: {
             autoRefresh: true,
             debounceMs: 300,
-            onChanged: (_error, items) => {
-              if (!isCurrentConnection(generation) || items === null) return;
+            onChanged: (error, items) => {
+              if (!isCurrentConnection(generation)) return;
+              if (error !== null) {
+                setLastError({ message: error.message });
+                return;
+              }
+              if (items === null) return;
               applyToolsList({ tools: items });
             },
           },

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -5,6 +5,8 @@ import {
   Client,
   StreamableHTTPClientTransport,
   UnauthorizedError,
+  type ElicitRequest,
+  type ElicitResult,
   type StreamableHTTPClientTransportOptions,
 } from "@modelcontextprotocol/client";
 import { createOAuthProvider } from "../auth/createOAuthProvider";
@@ -14,6 +16,8 @@ import type { MCPStorage } from "./storage/types";
 import type {
   MCPAuthConfig,
   MCPConnectionState,
+  MCPElicitation,
+  MCPElicitationResponse,
   MCPServerKind,
   MCPServerState,
   MCPToolInfo,
@@ -30,6 +34,7 @@ export type McpServerResourceProps = {
   redirectUri: string;
   autoConnect: boolean;
   connectionTimeout?: number | undefined;
+  cache?: { readonly defaultTtlMs?: number } | undefined;
   onRemove: () => Promise<void>;
 };
 
@@ -42,6 +47,9 @@ const useMcpServerResource = (
   const [tools, setTools] = useState<MCPToolInfo[]>([]);
   const [lastError, setLastError] = useState<{ message: string } | null>(null);
   const [authorizationUrl, setAuthorizationUrl] = useState<string | null>(null);
+  const [pendingElicitations, setPendingElicitations] = useState<
+    MCPElicitation[]
+  >([]);
 
   const clientRef = useRef<Client | null>(null);
   const transportRef = useRef<StreamableHTTPClientTransport | null>(null);
@@ -50,6 +58,9 @@ const useMcpServerResource = (
   );
   const transportCloseQueueRef = useRef(Promise.resolve());
   const connectionGenerationRef = useRef(0);
+  const elicitationResolversRef = useRef(
+    new Map<string, { resolve: (result: ElicitResult) => void }>(),
+  );
   const pendingDisposalRef = useRef<{ cancelled: boolean } | null>(null);
   const mountedRef = useRef(true);
 
@@ -79,7 +90,16 @@ const useMcpServerResource = (
     await closeQueuedTransports(transport ? [transport] : []);
   };
 
+  const cancelPendingElicitations = () => {
+    for (const { resolve } of elicitationResolversRef.current.values()) {
+      resolve({ action: "cancel" });
+    }
+    elicitationResolversRef.current.clear();
+    setPendingElicitations([]);
+  };
+
   const closeTransports = async () => {
+    cancelPendingElicitations();
     const pendingTransport = pendingTransportRef.current;
     const activeTransport = transportRef.current;
     pendingTransportRef.current = null;
@@ -161,14 +181,127 @@ const useMcpServerResource = (
     },
   );
 
+  const applyToolsList = useEffectEvent(
+    (list: {
+      tools: Array<{
+        name: string;
+        description?: string | undefined;
+        inputSchema: unknown;
+      }>;
+    }) => {
+      setTools(
+        list.tools.map((t) => {
+          const info: MCPToolInfo = {
+            name: t.name,
+            inputSchema: t.inputSchema,
+          };
+          if (t.description !== undefined) info.description = t.description;
+          return info;
+        }),
+      );
+    },
+  );
+
+  const syncTools = useEffectEvent(
+    async (
+      client: Client,
+      generation: number,
+      options?: { startedAt?: number | undefined },
+    ): Promise<boolean> => {
+      const listPromise = client.listTools();
+      const list =
+        options?.startedAt === undefined
+          ? await listPromise
+          : await withConnectionTimeout(
+              listPromise,
+              "listing tools",
+              options.startedAt,
+            );
+      if (!isCurrentConnection(generation)) return false;
+      applyToolsList(list);
+      return true;
+    },
+  );
+
   const finalizeConnect = useEffectEvent(
     async (
       transport: StreamableHTTPClientTransport,
       generation: number,
     ): Promise<boolean> => {
-      const client = new Client({
-        name: "assistant-ui-mcp",
-        version: "0.0.0",
+      const clientOptions: {
+        capabilities: { elicitation: Record<string, never> };
+        listChanged: {
+          tools: {
+            // false: the SDK invalidates its cached tool list on a
+            // listChanged notification instead of refetching it, so the
+            // notification handler below performs the single listTools()
+            // call.
+            autoRefresh?: boolean;
+            onChanged: () => void;
+          };
+        };
+        defaultCacheTtlMs?: number;
+      } = {
+        capabilities: {
+          elicitation: {},
+        },
+        // Opt into tools listChanged so the client auto-opens modern-era
+        // subscriptions; react-mcp state is refreshed via the notification
+        // handler below (generation-guarded).
+        listChanged: {
+          tools: {
+            autoRefresh: false,
+            onChanged: () => {
+              // State updates are driven by setNotificationHandler so the
+              // connectionGenerationRef staleness guard stays in one place.
+            },
+          },
+        },
+      };
+      if (props.cache?.defaultTtlMs !== undefined) {
+        clientOptions.defaultCacheTtlMs = props.cache.defaultTtlMs;
+      }
+      const client = new Client(
+        {
+          name: "assistant-ui-mcp",
+          version: "0.0.0",
+        },
+        clientOptions,
+      );
+      client.setRequestHandler(
+        "elicitation/create",
+        (request: ElicitRequest): Promise<ElicitResult> => {
+          if (!isCurrentConnection(generation)) {
+            return Promise.resolve({ action: "cancel" });
+          }
+          if (!("requestedSchema" in request.params)) {
+            return Promise.resolve({ action: "cancel" });
+          }
+          const { message, requestedSchema } = request.params;
+
+          const id =
+            typeof crypto !== "undefined" && "randomUUID" in crypto
+              ? crypto.randomUUID()
+              : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+          const promise = new Promise<ElicitResult>((resolve) => {
+            elicitationResolversRef.current.set(id, { resolve });
+          });
+          setPendingElicitations((current) => [
+            ...current,
+            {
+              id,
+              message,
+              requestedSchema,
+            },
+          ]);
+          return promise;
+        },
+      );
+      client.setNotificationHandler("notifications/tools/list_changed", () => {
+        if (!isCurrentConnection(generation)) return;
+        void syncTools(client, generation).catch(() => {
+          // Ignore refresh failures from stale or closed connections.
+        });
       });
       const startedAt = Date.now();
       await withConnectionTimeout(
@@ -181,26 +314,12 @@ const useMcpServerResource = (
       // post-connect failure leaves stale refs that `callTool()` would
       // happily walk into, producing confusing SDK errors instead of
       // "not connected".
-      const list = await withConnectionTimeout(
-        client.listTools(),
-        "listing tools",
-        startedAt,
-      );
-      if (!isCurrentConnection(generation)) return false;
+      const synced = await syncTools(client, generation, { startedAt });
+      if (!synced) return false;
 
       pendingTransportRef.current = null;
       clientRef.current = client;
       transportRef.current = transport;
-      setTools(
-        list.tools.map((t) => {
-          const info: MCPToolInfo = {
-            name: t.name,
-            inputSchema: t.inputSchema,
-          };
-          if (t.description !== undefined) info.description = t.description;
-          return info;
-        }),
-      );
       setConnectionState("connected");
       return true;
     },
@@ -241,6 +360,7 @@ const useMcpServerResource = (
         transportRef.current = transport;
         setConnectionState("authRequired");
       } else {
+        cancelPendingElicitations();
         if (transport) {
           pendingTransportRef.current = null;
           await closeQueuedTransports([transport]);
@@ -263,6 +383,7 @@ const useMcpServerResource = (
 
   const doCompleteAuth = useEffectEvent(async (callbackUrl: string) => {
     const generation = ++connectionGenerationRef.current;
+    cancelPendingElicitations();
     await closePendingTransport();
     if (!isCurrentConnection(generation)) throw createInterruptedAuthError();
 
@@ -357,6 +478,7 @@ const useMcpServerResource = (
       lastError,
       tools,
       authorizationUrl,
+      pendingElicitations,
     }),
     [
       props.id,
@@ -368,6 +490,7 @@ const useMcpServerResource = (
       lastError,
       tools,
       authorizationUrl,
+      pendingElicitations,
     ],
   );
 
@@ -405,6 +528,35 @@ const useMcpServerResource = (
       return await client.readResource({ uri });
     },
     completeAuth: doCompleteAuth,
+    answerElicitation: (id: string, response: MCPElicitationResponse): void => {
+      const entry = elicitationResolversRef.current.get(id);
+      if (!entry) {
+        throw new Error(`Unknown MCP elicitation "${id}"`);
+      }
+      if (
+        response.action === "accept" &&
+        (typeof response.content !== "object" ||
+          response.content === null ||
+          Array.isArray(response.content))
+      ) {
+        throw new Error(
+          `MCP elicitation "${id}" response content must be an object`,
+        );
+      }
+
+      const result: ElicitResult =
+        response.action === "accept"
+          ? {
+              action: "accept",
+              content: response.content as ElicitResult["content"],
+            }
+          : { action: response.action };
+      elicitationResolversRef.current.delete(id);
+      setPendingElicitations((current) =>
+        current.filter((elicitation) => elicitation.id !== id),
+      );
+      entry.resolve(result);
+    },
   };
 };
 

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -261,6 +261,7 @@ const useMcpServerResource = (
                 return;
               }
               if (items === null) return;
+              setLastError(null);
               applyToolsList({ tools: items });
             },
           },


### PR DESCRIPTION
## summary

- react-mcp registered no elicitation handler, so servers that ask the user mid-tool-call hit a dead end; this adds the form-mode bridge on the v2 SDK: the client declares `capabilities: { elicitation: {} }` and one `setRequestHandler("elicitation/create")` serves both protocol eras, because SDK v2 auto-fulfills modern MRTR requests through the same registered handler (its default `autoFulfill` retry loop), so callers never see `input_required`
- pending requests surface as `MCPServerState.pendingElicitations` with `answerElicitation(id, { action: "accept", content } | { action: "decline" } | { action: "cancel" })` beside `completeAuth` (the existing server-blocked-on-user slot); the park/resolve map mirrors the tracker discipline (teardown resolves everything as cancel, stale generations answer cancel immediately) without touching the internal `ToolInvocationTracker`; no new public hooks
- a new unstyled `McpElicitationPrimitive` namespace (`Items`, `Root`, `Message`, `Fields`, `Accept`, `Decline`, `Cancel`) follows the package's primitive conventions (Tools-style iteration, addForm-style per-item draft context, data-* only)
- tool lists now track server changes: the client opts into `listChanged.tools` with `autoRefresh: false` deliberately (the SDK only invalidates its cache; our generation-guarded `notifications/tools/list_changed` handler performs the single `listTools`, avoiding the double fetch `autoRefresh: true` would cause) and connectors accept `cache.defaultTtlMs`, threaded to the SDK's built-in response cache (`defaultCacheTtlMs`; no custom store)
- SPEC.md and user-managed-mcp.mdx move in lockstep; api-surface regenerated

## test plan

### already verified

- [x] `pnpm -C packages/react-mcp test` -> 45/45 green (elicitation surface/answer/teardown/stale-generation cases, list-change re-sync and stale-ignore cases, cache option pass-through)
- [x] `pnpm api-surface` regenerated + `pnpm api-surface:check` clean; `aui-build` green; `oxlint` and `oxfmt --check` clean
- [x] official MCP conformance suite (active) run against mcp-docs-server as a side check of the migrated stack: zero genuine failures (remaining fails are reference-fixture expectations and undeclared-capability rejections)

### reviewer should verify

- [ ] against an MCP server that issues `elicitation/create` (e.g. the SDK's example everything-server), the pending form renders through `McpElicitationPrimitive`, accept returns the typed content to the server, and the tool call completes

## notes

- URL-mode elicitation is deliberately out of scope (requires an explicit capability declaration and a popup flow); form mode only, matching the empty `elicitation: {}` declaration
- the changeset rides patch on the 0.x line per repo default

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VuG0UtMXbNT4mju0sRNW_PqJLI5OdLzTpnlkYrYdLAKkUUtZYZsl7lfrkBM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->