### PR TITLE
fix(react-mcp): elicitation seam follow-ups from #5339

### DIFF
--- a/.changeset/elicitation-seam-followups.md
+++ b/.changeset/elicitation-seam-followups.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: honor boolean schema defaults in elicitation seeding, flag mistyped boolean drafts as invalid, and add an `elicitation: false` opt-out

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -81,6 +81,7 @@ type MCPConnector = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
+  readonly elicitation?: boolean;
 };
 
 type MCPCustomServerRecord = {
@@ -90,6 +91,7 @@ type MCPCustomServerRecord = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
+  readonly elicitation?: boolean;
   createdAt: number;
 };
 
@@ -123,6 +125,7 @@ type MCPManagerMethods = {
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
     readonly cache?: MCPResponseCacheConfig | undefined;
+    readonly elicitation?: boolean;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
@@ -544,6 +547,7 @@ type McpServerResourceProps = {
   cache?: {
     readonly defaultTtlMs?: number;
   } | undefined;
+  readonly elicitation?: boolean;
   onRemove: () => Promise<void>;
 };
 

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -246,7 +246,7 @@ const out = await aui.mcp.server({ id: "linear" }).callTool("search", { q });
 
 Connected servers can request structured user input through form-mode elicitation. Render `McpElicitationPrimitive.Items` inside a server-scoped subtree, then compose fields and response actions from the unstyled primitives:
 
-Answering a request requires composing `McpElicitationPrimitive`, because the server waits for the form response otherwise. Set `elicitation: false` on a connector or custom server to opt it out of advertising the capability.
+Answering a request requires composing `McpElicitationPrimitive`, because the server waits for the form response otherwise. Set `elicitation: false` on a connector or custom server to opt it out of advertising the capability. Numeric fields can stay text inputs (parseable strings are coerced); boolean fields must compose a checkbox, because string drafts for booleans are flagged invalid rather than coerced.
 
 ```tsx
 import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
@@ -256,13 +256,24 @@ import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
     <McpElicitationPrimitive.Root>
       <McpElicitationPrimitive.Message />
       <McpElicitationPrimitive.Fields>
-        {({ name, value, setValue }) => (
-          <input
-            name={name}
-            value={typeof value === "string" ? value : ""}
-            onChange={(event) => setValue(event.target.value)}
-          />
-        )}
+        {({ name, schema, value, setValue }) =>
+          (schema as { type?: string } | undefined)?.type === "boolean" ? (
+            <label>
+              {name}
+              <input
+                type="checkbox"
+                checked={value === true}
+                onChange={(event) => setValue(event.target.checked)}
+              />
+            </label>
+          ) : (
+            <input
+              name={name}
+              value={typeof value === "string" ? value : ""}
+              onChange={(event) => setValue(event.target.value)}
+            />
+          )
+        }
       </McpElicitationPrimitive.Fields>
       <McpElicitationPrimitive.Accept>Submit</McpElicitationPrimitive.Accept>
       <McpElicitationPrimitive.Decline>Decline</McpElicitationPrimitive.Decline>

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -246,6 +246,8 @@ const out = await aui.mcp.server({ id: "linear" }).callTool("search", { q });
 
 Connected servers can request structured user input through form-mode elicitation. Render `McpElicitationPrimitive.Items` inside a server-scoped subtree, then compose fields and response actions from the unstyled primitives:
 
+Answering a request requires composing `McpElicitationPrimitive`, because the server waits for the form response otherwise. Set `elicitation: false` on a connector or custom server to opt it out of advertising the capability.
+
 ```tsx
 import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -89,6 +89,7 @@ type MCPConnector = {
   auth: MCPAuthConfig;
   connectionTimeout?: number;
   cache?: { defaultTtlMs?: number };
+  elicitation?: boolean;
 };
 defineConnector(c: MCPConnector): MCPConnector;
 ```
@@ -103,6 +104,7 @@ type MCPCustomServerRecord = {
   auth: MCPAuthConfig;
   connectionTimeout?: number;
   cache?: { defaultTtlMs?: number };
+  elicitation?: boolean;
   createdAt: number;
 };
 ```
@@ -162,7 +164,7 @@ declare module "@assistant-ui/store" {
 type MCPManagerMethods = {
   getState: () => MCPManagerState;
   server: (lookup: { id: string }) => MCPServerMethods;
-  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig; connectionTimeout?: number }) => Promise<string>;
+  addCustomServer: (input: { name: string; url: string; auth: MCPAuthConfig; connectionTimeout?: number; elicitation?: boolean }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
 
@@ -337,7 +339,7 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
 
 `useMcpElicitation()` reads the current request inside `Items`. `useMcpElicitationField()` reads the current field inside the element returned from the `Fields` render function.
 
-`Accept` does not submit while a required field is absent or empty, and exposes `data-missing-required` in that state. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content.
+`Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -339,7 +339,7 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
 
 `useMcpElicitation()` reads the current request inside `Items`. `useMcpElicitationField()` reads the current field inside the element returned from the `Fields` render function.
 
-`Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content.
+`Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content. Boolean drafts must be real booleans (compose a checkbox); string drafts are coerced only for `number` and `integer` properties and are flagged invalid for booleans. The `elicitation` flag defaults to advertising the capability; `false` skips both the capability declaration and the handler registration, and, like the rest of the capability set, a changed flag applies from the next connect rather than mid-connection.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -25,6 +25,7 @@ export type MCPConnector = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
+  readonly elicitation?: boolean;
 };
 
 export type MCPCustomServerRecord = {
@@ -34,6 +35,7 @@ export type MCPCustomServerRecord = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
+  readonly elicitation?: boolean;
   createdAt: number;
 };
 
@@ -118,6 +120,7 @@ export type MCPManagerMethods = {
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
     readonly cache?: MCPResponseCacheConfig | undefined;
+    readonly elicitation?: boolean;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -193,6 +193,39 @@ describe("prepareElicitationContent", () => {
     ).toEqual({ content: {}, missingRequired: [], invalid: ["enabled"] });
   });
 
+  it("flags a mistyped required boolean instead of seeding false", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { enabled: { type: "boolean" } },
+          required: ["enabled"],
+        },
+        { enabled: "true" },
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: ["enabled"] });
+  });
+
+  it("treats null drafts as absent for booleans and required fields", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            query: { type: "string" },
+          },
+          required: ["enabled", "query"],
+        },
+        { enabled: null, query: null },
+      ),
+    ).toEqual({
+      content: { enabled: false },
+      missingRequired: ["query"],
+      invalid: [],
+    });
+  });
+
   it("reports required draft values that are absent or empty", () => {
     expect(
       prepareElicitationContent(

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -79,21 +79,56 @@ describe("prepareElicitationContent", () => {
     });
   });
 
-  it("accepts missing required booleans as false", () => {
+  it("seeds required booleans with a true schema default", () => {
     expect(
       prepareElicitationContent(
         {
           type: "object",
-          required: ["enabled", "name"],
+          required: ["enabled"],
           properties: {
-            enabled: { type: "boolean" },
-            name: { type: "string" },
+            enabled: { type: "boolean", default: true },
           },
         },
-        { name: "Ada" },
+        {},
       ),
     ).toEqual({
-      content: { name: "Ada", enabled: false },
+      content: { enabled: true },
+      missingRequired: [],
+      invalid: [],
+    });
+  });
+
+  it("seeds required booleans with a false schema default", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["enabled"],
+          properties: {
+            enabled: { type: "boolean", default: false },
+          },
+        },
+        {},
+      ),
+    ).toEqual({
+      content: { enabled: false },
+      missingRequired: [],
+      invalid: [],
+    });
+  });
+
+  it("seeds required booleans without a schema default as false", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["enabled"],
+          properties: { enabled: { type: "boolean" } },
+        },
+        {},
+      ),
+    ).toEqual({
+      content: { enabled: false },
       missingRequired: [],
       invalid: [],
     });
@@ -129,6 +164,33 @@ describe("prepareElicitationContent", () => {
       missingRequired: [],
       invalid: [],
     });
+  });
+
+  it("treats undefined and empty optional boolean drafts as absent", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            sendEmail: { type: "boolean" },
+          },
+        },
+        { enabled: undefined, sendEmail: "" },
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: [] });
+  });
+
+  it("flags and excludes mistyped boolean draft values", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { enabled: { type: "boolean" } },
+        },
+        { enabled: "true" },
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: ["enabled"] });
   });
 
   it("reports required draft values that are absent or empty", () => {

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -21,14 +21,19 @@ const coerceValue = (
   return { value: number, invalid: false };
 };
 
-const isBooleanSchema = (schema: unknown) =>
+const isBooleanSchema = (schema: unknown): schema is Record<string, unknown> =>
   isRecord(schema) && schema.type === "boolean";
 
 const getDraftValue = (draft: Record<string, unknown>, name: string) =>
   Object.hasOwn(draft, name) ? draft[name] : undefined;
 
 const isAbsentBooleanDraftValue = (value: unknown) =>
-  value === undefined || value === "" || typeof value !== "boolean";
+  value === undefined || value === "";
+
+const isInvalidBooleanDraftValue = (schema: unknown, value: unknown) =>
+  isBooleanSchema(schema) &&
+  !isAbsentBooleanDraftValue(value) &&
+  typeof value !== "boolean";
 
 export const prepareElicitationContent = (
   requestedSchema: unknown,
@@ -51,18 +56,35 @@ export const prepareElicitationContent = (
 
   const preparedDraft = Object.entries(draft).flatMap(([name, value]) => {
     const schema = properties[name];
-    if (isBooleanSchema(schema) && isAbsentBooleanDraftValue(value)) return [];
+    if (
+      isBooleanSchema(schema) &&
+      (isAbsentBooleanDraftValue(value) ||
+        isInvalidBooleanDraftValue(schema, value))
+    ) {
+      return [];
+    }
 
     const coerced = coerceValue(schema, value);
     return coerced.invalid ? [] : [[name, coerced.value]];
   });
-  const invalid = Object.entries(draft).flatMap(([name, value]) =>
-    coerceValue(properties[name], value).invalid ? [name] : [],
-  );
+  const invalid = Object.entries(draft).flatMap(([name, value]) => {
+    const schema = properties[name];
+    return isInvalidBooleanDraftValue(schema, value) ||
+      coerceValue(schema, value).invalid
+      ? [name]
+      : [];
+  });
   const requiredBooleans = required.flatMap((name) =>
     isBooleanSchema(properties[name]) &&
     isAbsentBooleanDraftValue(getDraftValue(draft, name))
-      ? [[name, false]]
+      ? [
+          [
+            name,
+            typeof properties[name].default === "boolean"
+              ? properties[name].default
+              : false,
+          ],
+        ]
       : [],
   );
 

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -27,12 +27,12 @@ const isBooleanSchema = (schema: unknown): schema is Record<string, unknown> =>
 const getDraftValue = (draft: Record<string, unknown>, name: string) =>
   Object.hasOwn(draft, name) ? draft[name] : undefined;
 
-const isAbsentBooleanDraftValue = (value: unknown) =>
-  value === undefined || value === "";
+const isAbsentDraftValue = (value: unknown) =>
+  value === undefined || value === null || value === "";
 
 const isInvalidBooleanDraftValue = (schema: unknown, value: unknown) =>
   isBooleanSchema(schema) &&
-  !isAbsentBooleanDraftValue(value) &&
+  !isAbsentDraftValue(value) &&
   typeof value !== "boolean";
 
 export const prepareElicitationContent = (
@@ -56,10 +56,10 @@ export const prepareElicitationContent = (
 
   const preparedDraft = Object.entries(draft).flatMap(([name, value]) => {
     const schema = properties[name];
+    if (value === undefined || value === null) return [];
     if (
       isBooleanSchema(schema) &&
-      (isAbsentBooleanDraftValue(value) ||
-        isInvalidBooleanDraftValue(schema, value))
+      (isAbsentDraftValue(value) || isInvalidBooleanDraftValue(schema, value))
     ) {
       return [];
     }
@@ -76,7 +76,7 @@ export const prepareElicitationContent = (
   });
   const requiredBooleans = required.flatMap((name) =>
     isBooleanSchema(properties[name]) &&
-    isAbsentBooleanDraftValue(getDraftValue(draft, name))
+    isAbsentDraftValue(getDraftValue(draft, name))
       ? [
           [
             name,
@@ -93,8 +93,7 @@ export const prepareElicitationContent = (
     missingRequired: required.filter(
       (name) =>
         !isBooleanSchema(properties[name]) &&
-        (getDraftValue(draft, name) === undefined ||
-          getDraftValue(draft, name) === ""),
+        isAbsentDraftValue(getDraftValue(draft, name)),
     ),
     invalid,
   };

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -125,6 +125,9 @@ const useMcpManagerResource = (
           autoConnect,
           connectionTimeout: c.connectionTimeout ?? connectionTimeout,
           ...(c.cache !== undefined ? { cache: c.cache } : {}),
+          ...(c.elicitation !== undefined
+            ? { elicitation: c.elicitation }
+            : {}),
           onRemove: async () => {
             // connectors cannot be removed
           },
@@ -145,6 +148,9 @@ const useMcpManagerResource = (
           autoConnect,
           connectionTimeout: s.connectionTimeout ?? connectionTimeout,
           ...(s.cache !== undefined ? { cache: s.cache } : {}),
+          ...(s.elicitation !== undefined
+            ? { elicitation: s.elicitation }
+            : {}),
           onRemove: async () => {
             setCustomServers((prev) => prev.filter((x) => x.id !== s.id));
           },
@@ -228,7 +234,14 @@ const useMcpManagerResource = (
     },
     connector: ({ index }) => serverByKind("connector", index),
     customServer: ({ index }) => serverByKind("custom", index),
-    addCustomServer: async ({ name, url, auth, connectionTimeout, cache }) => {
+    addCustomServer: async ({
+      name,
+      url,
+      auth,
+      connectionTimeout,
+      cache,
+      elicitation,
+    }) => {
       const record: MCPCustomServerRecord = {
         id:
           typeof crypto !== "undefined" && "randomUUID" in crypto
@@ -239,6 +252,7 @@ const useMcpManagerResource = (
         auth: auth as MCPAuthConfig,
         connectionTimeout,
         ...(cache !== undefined ? { cache } : {}),
+        ...(elicitation !== undefined ? { elicitation } : {}),
         createdAt: Date.now(),
       };
       setCustomServers((prev) => [...prev, record]);

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -149,6 +149,7 @@ const mount = (
     auth?: MCPAuthConfig | undefined;
     connectionTimeout?: number | undefined;
     cache?: { readonly defaultTtlMs?: number } | undefined;
+    elicitation?: boolean | undefined;
   },
   onMount?: (server: ClientOutput<"mcpServer">) => void,
 ) => {
@@ -168,6 +169,9 @@ const mount = (
         autoConnect: false,
         connectionTimeout,
         cache: props?.cache,
+        ...(props?.elicitation !== undefined
+          ? { elicitation: props.elicitation }
+          : {}),
         onRemove: vi.fn(async () => {}),
       }),
     );
@@ -773,7 +777,7 @@ describe("McpServerResource elicitation", () => {
     }
   });
 
-  it("advertises form elicitation capability", async () => {
+  it("advertises form elicitation capability and registers its handler by default", async () => {
     const root = mount();
 
     try {
@@ -796,6 +800,27 @@ describe("McpServerResource elicitation", () => {
             },
           },
         },
+      );
+      expect(mocks.clients[0].setRequestHandler).toHaveBeenCalledWith(
+        "elicitation/create",
+        expect.any(Function),
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("does not advertise or handle elicitation when opted out", async () => {
+    const root = mount({ elicitation: false });
+
+    try {
+      await root.getValue().connect();
+
+      const clientOptions = mocks.Client.mock.calls[0]?.[1];
+      expect(clientOptions).not.toHaveProperty("capabilities.elicitation");
+      expect(mocks.clients[0].setRequestHandler).not.toHaveBeenCalledWith(
+        "elicitation/create",
+        expect.any(Function),
       );
     } finally {
       root.unmount();

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -36,6 +36,7 @@ export type McpServerResourceProps = {
   autoConnect: boolean;
   connectionTimeout?: number | undefined;
   cache?: { readonly defaultTtlMs?: number } | undefined;
+  readonly elicitation?: boolean;
   onRemove: () => Promise<void>;
 };
 
@@ -247,9 +248,9 @@ const useMcpServerResource = (
       generation: number,
     ): Promise<boolean> => {
       const clientOptions: ClientOptions = {
-        capabilities: {
-          elicitation: {},
-        },
+        ...(props.elicitation === false
+          ? {}
+          : { capabilities: { elicitation: {} } }),
         listChanged: {
           tools: {
             autoRefresh: true,
@@ -277,52 +278,54 @@ const useMcpServerResource = (
         },
         clientOptions,
       );
-      client.setRequestHandler(
-        "elicitation/create",
-        (request: ElicitRequest, context): Promise<ElicitResult> => {
-          if (!isCurrentConnection(generation)) {
-            return Promise.resolve({ action: "cancel" });
-          }
-          if (!("requestedSchema" in request.params)) {
-            return Promise.resolve({ action: "cancel" });
-          }
-          const { message, requestedSchema } = request.params;
-
-          const id =
-            typeof crypto !== "undefined" && "randomUUID" in crypto
-              ? crypto.randomUUID()
-              : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-          const promise = new Promise<ElicitResult>((resolve) => {
-            const onAbort = () => {
-              resolvePendingElicitation(id, { action: "cancel" });
-            };
-            elicitationResolversRef.current.set(id, {
-              resolve,
-              signal: context.signal,
-              onAbort,
-            });
-          });
-          setPendingElicitations((current) => [
-            ...current,
-            {
-              id,
-              message,
-              requestedSchema,
-            },
-          ]);
-          const entry = elicitationResolversRef.current.get(id);
-          if (entry) {
-            if (context.signal.aborted) {
-              entry.onAbort();
-            } else {
-              context.signal.addEventListener("abort", entry.onAbort, {
-                once: true,
-              });
+      if (props.elicitation !== false) {
+        client.setRequestHandler(
+          "elicitation/create",
+          (request: ElicitRequest, context): Promise<ElicitResult> => {
+            if (!isCurrentConnection(generation)) {
+              return Promise.resolve({ action: "cancel" });
             }
-          }
-          return promise;
-        },
-      );
+            if (!("requestedSchema" in request.params)) {
+              return Promise.resolve({ action: "cancel" });
+            }
+            const { message, requestedSchema } = request.params;
+
+            const id =
+              typeof crypto !== "undefined" && "randomUUID" in crypto
+                ? crypto.randomUUID()
+                : `mcp-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            const promise = new Promise<ElicitResult>((resolve) => {
+              const onAbort = () => {
+                resolvePendingElicitation(id, { action: "cancel" });
+              };
+              elicitationResolversRef.current.set(id, {
+                resolve,
+                signal: context.signal,
+                onAbort,
+              });
+            });
+            setPendingElicitations((current) => [
+              ...current,
+              {
+                id,
+                message,
+                requestedSchema,
+              },
+            ]);
+            const entry = elicitationResolversRef.current.get(id);
+            if (entry) {
+              if (context.signal.aborted) {
+                entry.onAbort();
+              } else {
+                context.signal.addEventListener("abort", entry.onAbort, {
+                  once: true,
+                });
+              }
+            }
+            return promise;
+          },
+        );
+      }
       const startedAt = Date.now();
       await withConnectionTimeout(
         client.connect(transport),


### PR DESCRIPTION
references #5339 (items 1-4; item 5, validation surfacing through `answerElicitation`, deliberately stays open)

## summary

- required boolean elicitation fields now seed from the property schema's boolean `default` when present (falling back to `false`), so `{ type: "boolean", default: true }` is no longer silently inverted for untouched controls
- a boolean draft value that is present but not a real boolean (for example the string `"true"`) now lands in the `invalid` list and disables `Accept` with `data-invalid`, instead of being treated as absent and submitted as `false`; `undefined` and empty string keep the absent semantics
- SPEC.md now states the Accept-gate contract (`data-missing-required`, `data-invalid`, disabled until both clear) and the required-boolean seeding rule including default honoring
- connectors, custom-server records, and `addCustomServer` gain an append-only `elicitation?: boolean` opt-out (`false` skips both the capability declaration and the handler registration); user-managed-mcp.mdx documents that answering requires composing `McpElicitationPrimitive` and how to opt a server out

## test plan

### already verified

- [x] `pnpm -C packages/react-mcp test` -> 62/62 green (new cases: default-true/false/absent seeding, mistyped boolean invalid, opt-out constructor/handler assertions)
- [x] `pnpm api-surface` + `pnpm api-surface:check` clean; `aui-build`, `oxlint`, `oxfmt --check` clean

### reviewer should verify

- [ ] a server opted out with `elicitation: false` connects without advertising the capability and never receives `elicitation/create`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8ZE0uMKuJgx_6K6aZ2kE2loCs7ys3Fiqqj4TZyJzD6EhDdvWAn3VExLKF3Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->