### PR TITLE
feat(react-mcp): surface elicitation validation and seed drafts from schema defaults

### DIFF
--- a/.changeset/elicitation-validation-surfacing.md
+++ b/.changeset/elicitation-validation-surfacing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: surface elicitation validation on the pending item (stay-pending accept errors and `McpElicitationPrimitive.Error`), seed drafts from schema defaults

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -81,7 +81,7 @@ type MCPConnector = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
-  readonly elicitation?: boolean;
+  readonly elicitation?: boolean | undefined;
 };
 
 type MCPCustomServerRecord = {
@@ -91,7 +91,7 @@ type MCPCustomServerRecord = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
-  readonly elicitation?: boolean;
+  readonly elicitation?: boolean | undefined;
   createdAt: number;
 };
 
@@ -99,6 +99,10 @@ type MCPElicitation = {
   readonly id: string;
   readonly message: string;
   readonly requestedSchema: unknown;
+  readonly error?: {
+    readonly message: string;
+    readonly properties?: readonly string[] | undefined;
+  } | undefined;
 };
 
 type MCPElicitationResponse = {
@@ -125,7 +129,7 @@ type MCPManagerMethods = {
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
     readonly cache?: MCPResponseCacheConfig | undefined;
-    readonly elicitation?: boolean;
+    readonly elicitation?: boolean | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };
@@ -316,6 +320,15 @@ declare namespace McpElicitationPrimitiveDecline {
 declare const McpElicitationPrimitiveDecline: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLButtonElement> & import("react").ButtonHTMLAttributes<HTMLButtonElement> & {
   asChild?: boolean;
 }, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
+
+declare namespace McpElicitationPrimitiveError {
+  type Element = ComponentRef<typeof Primitive.span>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+declare const McpElicitationPrimitiveError: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+  asChild?: boolean;
+}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
 
 declare namespace McpElicitationPrimitiveFields {
   type Props = {
@@ -591,7 +604,7 @@ declare namespace addForm_d_exports {
 declare function defineConnector(connector: MCPConnector): MCPConnector;
 
 declare namespace elicitation_d_exports {
-  export { McpElicitationPrimitiveAccept as Accept, McpElicitationPrimitiveCancel as Cancel, McpElicitationPrimitiveDecline as Decline, McpElicitationPrimitiveFields as Fields, McpElicitationPrimitiveItems as Items, McpElicitationPrimitiveMessage as Message, McpElicitationPrimitiveRoot as Root, useMcpElicitation, useMcpElicitationField };
+  export { McpElicitationPrimitiveAccept as Accept, McpElicitationPrimitiveCancel as Cancel, McpElicitationPrimitiveDecline as Decline, McpElicitationPrimitiveError as Error, McpElicitationPrimitiveFields as Fields, McpElicitationPrimitiveItems as Items, McpElicitationPrimitiveMessage as Message, McpElicitationPrimitiveRoot as Root, useMcpElicitation, useMcpElicitationField };
 }
 
 declare namespace entry_root_exports {

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -165,7 +165,10 @@ type MCPServerMethods = {
   }) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
   completeAuth: (callbackUrl: string) => Promise<void>;
-  answerElicitation(id: string, response: MCPElicitationResponse): void;
+  answerElicitation(id: string, response: MCPElicitationResponse): readonly {
+    property: string;
+    message: string;
+  }[] | undefined;
 };
 
 type MCPServerQuery = {

--- a/api-surface/assistant-ui__react-mcp.ts
+++ b/api-surface/assistant-ui__react-mcp.ts
@@ -325,13 +325,13 @@ declare const McpElicitationPrimitiveDecline: import("react").ForwardRefExoticCo
 }, "ref"> & import("react").RefAttributes<HTMLButtonElement>>;
 
 declare namespace McpElicitationPrimitiveError {
-  type Element = ComponentRef<typeof Primitive.span>;
-  type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+  type Element = ComponentRef<typeof Primitive.div>;
+  type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
 }
 
-declare const McpElicitationPrimitiveError: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLSpanElement> & import("react").HTMLAttributes<HTMLSpanElement> & {
+declare const McpElicitationPrimitiveError: import("react").ForwardRefExoticComponent<Omit<import("react").ClassAttributes<HTMLDivElement> & import("react").HTMLAttributes<HTMLDivElement> & {
   asChild?: boolean;
-}, "ref"> & import("react").RefAttributes<HTMLSpanElement>>;
+}, "ref"> & import("react").RefAttributes<HTMLDivElement>>;
 
 declare namespace McpElicitationPrimitiveFields {
   type Props = {

--- a/apps/docs/content/docs/tools/user-managed-mcp.mdx
+++ b/apps/docs/content/docs/tools/user-managed-mcp.mdx
@@ -255,6 +255,7 @@ import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
   {() => (
     <McpElicitationPrimitive.Root>
       <McpElicitationPrimitive.Message />
+      <McpElicitationPrimitive.Error />
       <McpElicitationPrimitive.Fields>
         {({ name, schema, value, setValue }) =>
           (schema as { type?: string } | undefined)?.type === "boolean" ? (
@@ -282,6 +283,8 @@ import { McpElicitationPrimitive } from "@assistant-ui/react-mcp";
   )}
 </McpElicitationPrimitive.Items>
 ```
+
+Client-side validation errors keep the elicitation pending so the user can correct the form, and `McpElicitationPrimitive.Error` renders the resulting message.
 
 ## Storage
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -35,6 +35,7 @@ packages/react-mcp/
 │   ├── resources/
 │   │   ├── McpManagerResource.ts               root; auto-mounts modelContext
 │   │   ├── McpServerResource.ts                per-server
+│   │   ├── validateElicitationContent.ts       flat client-side validation
 │   │   └── storage/
 │   │       ├── McpLocalStorage.ts
 │   │       ├── McpMemoryStorage.ts
@@ -53,7 +54,7 @@ packages/react-mcp/
 │   │   ├── addForm.ts                          barrel (McpAddFormPrimitive.*)
 │   │   ├── addForm/{Root,NameField,UrlField,AuthSelect,AuthFields,Submit,Cancel,Error}.tsx
 │   │   ├── elicitation.ts                       barrel (McpElicitationPrimitive.*)
-│   │   └── elicitation/{Items,Root,Message,Fields,Accept,Decline,Cancel}.tsx
+│   │   └── elicitation/{Items,Root,Message,Error,Fields,Accept,Decline,Cancel,initialElicitationDraft}.tsx
 │   ├── hooks/
 │   │   └── useMcpOAuthCallback.tsx
 │   └── index.ts
@@ -124,6 +125,10 @@ type MCPElicitation = {
   readonly id: string;
   readonly message: string;
   readonly requestedSchema: unknown;
+  readonly error?: {
+    readonly message: string;
+    readonly properties?: readonly string[];
+  } | undefined;
 };
 
 type MCPElicitationResponse =
@@ -320,6 +325,7 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
   {() => (
     <McpElicitationPrimitive.Root>
       <McpElicitationPrimitive.Message />
+      <McpElicitationPrimitive.Error />
       <McpElicitationPrimitive.Fields>
         {({ name, value, setValue }) => (
           <input
@@ -339,7 +345,9 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
 
 `useMcpElicitation()` reads the current request inside `Items`. `useMcpElicitationField()` reads the current field inside the element returned from the `Fields` render function.
 
-`Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content. Boolean drafts must be real booleans (compose a checkbox); string drafts are coerced only for `number` and `integer` properties and are flagged invalid for booleans. The `elicitation` flag defaults to advertising the capability; `false` skips both the capability declaration and the handler registration, and, like the rest of the capability set, a changed flag applies from the next connect rather than mid-connection.
+`Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Each item seeds its draft from flat schema defaults when the default matches a declared `string`, `number`, `integer`, or `boolean` type. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content. Boolean drafts must be real booleans (compose a checkbox); string drafts are coerced only for `number` and `integer` properties and are flagged invalid for booleans. The `elicitation` flag defaults to advertising the capability; `false` skips both the capability declaration and the handler registration, and, like the rest of the capability set, a changed flag applies from the next connect rather than mid-connection.
+
+An accepted response is client-side validated for required-property presence, `string`, `number`, `integer`, and `boolean` types, and declared enum membership. Constraints outside that flat subset, such as `minLength` and `format`, pass through for the server to judge. A failed validation keeps the elicitation pending, sets its `error`, and leaves the server request unresolved so the user can correct the draft. `McpElicitationPrimitive.Error` renders the error message and exposes its property names as comma-joined `data-properties` when available.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -181,7 +181,7 @@ type MCPServerMethods = {
   callTool: (name: string, args: unknown) => Promise<unknown>;
   readResource: (uri: string) => Promise<unknown>;
   completeAuth: (callbackUrl: string) => Promise<void>;
-  answerElicitation: (id: string, response: MCPElicitationResponse) => void;
+  answerElicitation: (id: string, response: MCPElicitationResponse) => readonly { property: string; message: string }[] | undefined;
 };
 ```
 
@@ -347,7 +347,7 @@ Render form-mode elicitation inside a server-scoped subtree. Each item owns an i
 
 `Accept` sets `data-missing-required` when required fields are absent or empty and `data-invalid` to comma-joined invalid property names when validation fails. It is disabled until both conditions are empty. Each item seeds its draft from flat schema defaults when the default matches a declared `string`, `number`, `integer`, or `boolean` type. Absent required boolean properties are submitted with the schema's boolean `default` when one is present, otherwise `false`; optional booleans remain omitted. It converts parseable string values from flat `number` and `integer` properties to numbers before submitting the response content. Boolean drafts must be real booleans (compose a checkbox); string drafts are coerced only for `number` and `integer` properties and are flagged invalid for booleans. The `elicitation` flag defaults to advertising the capability; `false` skips both the capability declaration and the handler registration, and, like the rest of the capability set, a changed flag applies from the next connect rather than mid-connection.
 
-An accepted response is client-side validated for required-property presence, `string`, `number`, `integer`, and `boolean` types, and declared enum membership. Constraints outside that flat subset, such as `minLength` and `format`, pass through for the server to judge. A failed validation keeps the elicitation pending, sets its `error`, and leaves the server request unresolved so the user can correct the draft. `McpElicitationPrimitive.Error` renders the error message and exposes its property names as comma-joined `data-properties` when available.
+An accepted response is client-side validated for required-property presence, `string`, `number`, `integer`, and `boolean` types, and declared enum membership. Constraints outside that flat subset, such as `minLength` and `format`, pass through for the server to judge. `answerElicitation` returns `undefined` when it applies an answer or the id is unknown. On validation failure, it keeps the elicitation pending, sets its `error`, leaves the server request unresolved, and returns the validation errors so the caller can correct the draft. `McpElicitationPrimitive.Error` renders the error message and exposes its property names as comma-joined `data-properties` when available.
 
 ## 6. Lifecycle
 

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -104,7 +104,10 @@ export type MCPServerMethods = {
   readResource: (uri: string) => Promise<unknown>;
   /** OAuth only: pass full callback URL (e.g. window.location.href) */
   completeAuth: (callbackUrl: string) => Promise<void>;
-  answerElicitation(id: string, response: MCPElicitationResponse): void;
+  answerElicitation(
+    id: string,
+    response: MCPElicitationResponse,
+  ): readonly { property: string; message: string }[] | undefined;
 };
 
 export type MCPServerQuery =

--- a/packages/react-mcp/src/mcp-scope.ts
+++ b/packages/react-mcp/src/mcp-scope.ts
@@ -25,7 +25,7 @@ export type MCPConnector = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
-  readonly elicitation?: boolean;
+  readonly elicitation?: boolean | undefined;
 };
 
 export type MCPCustomServerRecord = {
@@ -35,7 +35,7 @@ export type MCPCustomServerRecord = {
   auth: MCPAuthConfig;
   connectionTimeout?: number | undefined;
   readonly cache?: MCPResponseCacheConfig | undefined;
-  readonly elicitation?: boolean;
+  readonly elicitation?: boolean | undefined;
   createdAt: number;
 };
 
@@ -59,6 +59,12 @@ export type MCPElicitation = {
   readonly id: string;
   readonly message: string;
   readonly requestedSchema: unknown;
+  readonly error?:
+    | {
+        readonly message: string;
+        readonly properties?: readonly string[] | undefined;
+      }
+    | undefined;
 };
 
 export type MCPElicitationResponse =
@@ -120,7 +126,7 @@ export type MCPManagerMethods = {
     auth: MCPAuthConfig;
     connectionTimeout?: number | undefined;
     readonly cache?: MCPResponseCacheConfig | undefined;
-    readonly elicitation?: boolean;
+    readonly elicitation?: boolean | undefined;
   }) => Promise<string>;
   removeServer: (id: string) => Promise<void>;
 };

--- a/packages/react-mcp/src/primitives/elicitation.ts
+++ b/packages/react-mcp/src/primitives/elicitation.ts
@@ -4,6 +4,7 @@ export {
 } from "./elicitation/McpElicitationPrimitiveItems";
 export { McpElicitationPrimitiveRoot as Root } from "./elicitation/McpElicitationPrimitiveRoot";
 export { McpElicitationPrimitiveMessage as Message } from "./elicitation/McpElicitationPrimitiveMessage";
+export { McpElicitationPrimitiveError as Error } from "./elicitation/McpElicitationPrimitiveError";
 export {
   McpElicitationPrimitiveFields as Fields,
   useMcpElicitationField,

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveError.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveError.tsx
@@ -1,0 +1,31 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from "react";
+import { Primitive } from "@radix-ui/react-primitive";
+import { useMcpElicitation } from "./context";
+
+export namespace McpElicitationPrimitiveError {
+  export type Element = ComponentRef<typeof Primitive.span>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+}
+
+export const McpElicitationPrimitiveError = forwardRef<
+  McpElicitationPrimitiveError.Element,
+  McpElicitationPrimitiveError.Props
+>((props, ref) => {
+  const error = useMcpElicitation().error;
+  if (!error) return null;
+  return (
+    <Primitive.span
+      {...props}
+      ref={ref}
+      data-properties={error.properties?.join(",")}
+    >
+      {props.children ?? error.message}
+    </Primitive.span>
+  );
+});
+
+McpElicitationPrimitiveError.displayName = "McpElicitationPrimitive.Error";

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveError.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveError.tsx
@@ -7,8 +7,8 @@ import { Primitive } from "@radix-ui/react-primitive";
 import { useMcpElicitation } from "./context";
 
 export namespace McpElicitationPrimitiveError {
-  export type Element = ComponentRef<typeof Primitive.span>;
-  export type Props = ComponentPropsWithoutRef<typeof Primitive.span>;
+  export type Element = ComponentRef<typeof Primitive.div>;
+  export type Props = ComponentPropsWithoutRef<typeof Primitive.div>;
 }
 
 export const McpElicitationPrimitiveError = forwardRef<
@@ -18,13 +18,13 @@ export const McpElicitationPrimitiveError = forwardRef<
   const error = useMcpElicitation().error;
   if (!error) return null;
   return (
-    <Primitive.span
+    <Primitive.div
       {...props}
       ref={ref}
       data-properties={error.properties?.join(",")}
     >
       {props.children ?? error.message}
-    </Primitive.span>
+    </Primitive.div>
   );
 });
 

--- a/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveItems.tsx
+++ b/packages/react-mcp/src/primitives/elicitation/McpElicitationPrimitiveItems.tsx
@@ -2,6 +2,7 @@ import { type FC, type ReactNode, useCallback, useMemo, useState } from "react";
 import { useAuiState } from "@assistant-ui/store";
 import type { MCPElicitation } from "../../mcp-scope";
 import { ElicitationContext } from "./context";
+import { initialElicitationDraft } from "./initialElicitationDraft";
 
 export { useMcpElicitation } from "./context";
 
@@ -15,7 +16,9 @@ const McpElicitationPrimitiveItem: FC<{
   elicitation: MCPElicitation;
   children: McpElicitationPrimitiveItems.Props["children"];
 }> = ({ elicitation, children }) => {
-  const [draft, setDraft] = useState<Record<string, unknown>>({});
+  const [draft, setDraft] = useState<Record<string, unknown>>(() =>
+    initialElicitationDraft(elicitation.requestedSchema),
+  );
   const setField = useCallback((name: string, value: unknown) => {
     setDraft((current) => ({ ...current, [name]: value }));
   }, []);

--- a/packages/react-mcp/src/primitives/elicitation/initialElicitationDraft.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/initialElicitationDraft.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { initialElicitationDraft } from "./initialElicitationDraft";
+
+describe("initialElicitationDraft", () => {
+  it("seeds defaults that match their declared types", () => {
+    expect(
+      initialElicitationDraft({
+        type: "object",
+        properties: {
+          enabled: { type: "boolean", default: true },
+          name: { type: "string", default: "Ada" },
+          ratio: { type: "number", default: 1.5 },
+          count: { type: "integer", default: 2 },
+        },
+      }),
+    ).toEqual({ enabled: true, name: "Ada", ratio: 1.5, count: 2 });
+  });
+
+  it("skips defaults that do not match their declared types", () => {
+    expect(
+      initialElicitationDraft({
+        type: "object",
+        properties: {
+          enabled: { type: "boolean", default: "true" },
+          name: { type: "string", default: 1 },
+          ratio: { type: "number", default: "1.5" },
+          count: { type: "integer", default: 1.5 },
+        },
+      }),
+    ).toEqual({});
+  });
+});

--- a/packages/react-mcp/src/primitives/elicitation/initialElicitationDraft.ts
+++ b/packages/react-mcp/src/primitives/elicitation/initialElicitationDraft.ts
@@ -1,0 +1,39 @@
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getOwn = (value: Record<string, unknown>, key: string): unknown =>
+  Object.hasOwn(value, key) ? value[key] : undefined;
+
+const matchesType = (type: unknown, value: unknown): boolean => {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    default:
+      return false;
+  }
+};
+
+export const initialElicitationDraft = (
+  requestedSchema: unknown,
+): Record<string, unknown> => {
+  if (!isRecord(requestedSchema)) return {};
+
+  const properties = getOwn(requestedSchema, "properties");
+  if (!isRecord(properties)) return {};
+
+  return Object.fromEntries(
+    Object.keys(properties).flatMap((name) => {
+      const schema = properties[name];
+      if (!isRecord(schema) || !Object.hasOwn(schema, "default")) return [];
+
+      const value = schema.default;
+      return matchesType(getOwn(schema, "type"), value) ? [[name, value]] : [];
+    }),
+  );
+};

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -279,6 +279,26 @@ describe("prepareElicitationContent", () => {
     });
   });
 
+  it("treats a cleared numeric draft as absent instead of invalid", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: {
+            limit: { type: "number" },
+            count: { type: "integer" },
+          },
+          required: ["limit"],
+        },
+        { limit: "", count: "" },
+      ),
+    ).toEqual({
+      content: {},
+      missingRequired: ["limit"],
+      invalid: [],
+    });
+  });
+
   it("reports required draft values that are absent or empty", () => {
     expect(
       prepareElicitationContent(

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -178,6 +178,47 @@ describe("prepareElicitationContent", () => {
     });
   });
 
+  it("submits an empty optional string draft", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { query: { type: "string" } },
+        },
+        { query: "" },
+      ),
+    ).toEqual({ content: { query: "" }, missingRequired: [], invalid: [] });
+  });
+
+  it("keeps an empty required string draft in content while reporting it missing", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          required: ["query"],
+          properties: { query: { type: "string" } },
+        },
+        { query: "" },
+      ),
+    ).toEqual({
+      content: { query: "" },
+      missingRequired: ["query"],
+      invalid: [],
+    });
+  });
+
+  it("treats an empty optional boolean draft as absent", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { enabled: { type: "boolean" } },
+        },
+        { enabled: "" },
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: [] });
+  });
+
   it("treats undefined and empty optional boolean drafts as absent", () => {
     expect(
       prepareElicitationContent(

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.test.ts
@@ -62,6 +62,18 @@ describe("prepareElicitationContent", () => {
     ).toEqual(["count"]);
   });
 
+  it("flags enum values outside the allowed values for the Accept gate", () => {
+    expect(
+      prepareElicitationContent(
+        {
+          type: "object",
+          properties: { color: { enum: ["red", "blue"] } },
+        },
+        { color: "green" },
+      ),
+    ).toEqual({ content: {}, missingRequired: [], invalid: ["color"] });
+  });
+
   it("does not read inherited draft values", () => {
     expect(
       prepareElicitationContent(

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -26,10 +26,16 @@ const isBooleanSchema = (schema: unknown): schema is Record<string, unknown> =>
 const getDraftValue = (draft: Record<string, unknown>, name: string) =>
   Object.hasOwn(draft, name) ? draft[name] : undefined;
 
+const isNonStringTypedSchema = (schema: unknown): boolean =>
+  isRecord(schema) &&
+  (schema.type === "boolean" ||
+    schema.type === "number" ||
+    schema.type === "integer");
+
 const isAbsentDraftValue = (schema: unknown, value: unknown) =>
   value === undefined ||
   value === null ||
-  (value === "" && isBooleanSchema(schema));
+  (value === "" && isNonStringTypedSchema(schema));
 
 export const prepareElicitationContent = (
   requestedSchema: unknown,

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -23,8 +23,13 @@ const coerceValue = (schema: unknown, value: unknown): unknown => {
 const isBooleanSchema = (schema: unknown): schema is Record<string, unknown> =>
   isRecord(schema) && schema.type === "boolean";
 
-const isAbsentDraftValue = (value: unknown) =>
-  value === undefined || value === null || value === "";
+const getDraftValue = (draft: Record<string, unknown>, name: string) =>
+  Object.hasOwn(draft, name) ? draft[name] : undefined;
+
+const isAbsentDraftValue = (schema: unknown, value: unknown) =>
+  value === undefined ||
+  value === null ||
+  (value === "" && isBooleanSchema(schema));
 
 export const prepareElicitationContent = (
   requestedSchema: unknown,
@@ -38,10 +43,17 @@ export const prepareElicitationContent = (
     isRecord(requestedSchema) && isRecord(requestedSchema.properties)
       ? requestedSchema.properties
       : {};
+  const required =
+    isRecord(requestedSchema) && Array.isArray(requestedSchema.required)
+      ? requestedSchema.required.filter(
+          (property): property is string => typeof property === "string",
+        )
+      : [];
   const candidateContent = Object.fromEntries(
     Object.entries(draft).flatMap(([name, value]) => {
-      if (isAbsentDraftValue(value)) return [];
-      return [[name, coerceValue(properties[name], value)]];
+      const schema = properties[name];
+      if (isAbsentDraftValue(schema, value)) return [];
+      return [[name, coerceValue(schema, value)]];
     }),
   );
   const missingRequiredBooleans = validateElicitationContent(
@@ -72,6 +84,7 @@ export const prepareElicitationContent = (
       ({ property }) => !Object.hasOwn(contentWithBooleanDefaults, property),
     )
     .map(({ property }) => property);
+  const missingRequiredProperties = new Set(missingRequired);
   const invalid = [
     ...new Set(
       validationErrors
@@ -88,7 +101,12 @@ export const prepareElicitationContent = (
         ([property]) => !invalid.includes(property),
       ),
     ),
-    missingRequired,
+    missingRequired: required.filter(
+      (property) =>
+        missingRequiredProperties.has(property) ||
+        (!isBooleanSchema(properties[property]) &&
+          getDraftValue(draft, property) === ""),
+    ),
     invalid,
   };
 };

--- a/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
+++ b/packages/react-mcp/src/primitives/elicitation/prepareElicitationContent.ts
@@ -1,39 +1,30 @@
+import { validateElicitationContent } from "../../resources/validateElicitationContent";
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const coerceValue = (
-  schema: unknown,
-  value: unknown,
-): { value: unknown; invalid: boolean } => {
+const coerceValue = (schema: unknown, value: unknown): unknown => {
   if (!isRecord(schema) || typeof value !== "string") {
-    return { value, invalid: false };
+    return value;
   }
   if (schema.type !== "number" && schema.type !== "integer") {
-    return { value, invalid: false };
+    return value;
   }
 
   const number = Number(value);
-  if (value.trim() === "") return { value, invalid: false };
-  if (!Number.isFinite(number)) return { value, invalid: true };
+  if (value.trim() === "") return value;
+  if (!Number.isFinite(number)) return value;
   if (schema.type === "integer" && !Number.isInteger(number)) {
-    return { value, invalid: true };
+    return value;
   }
-  return { value: number, invalid: false };
+  return number;
 };
 
 const isBooleanSchema = (schema: unknown): schema is Record<string, unknown> =>
   isRecord(schema) && schema.type === "boolean";
 
-const getDraftValue = (draft: Record<string, unknown>, name: string) =>
-  Object.hasOwn(draft, name) ? draft[name] : undefined;
-
 const isAbsentDraftValue = (value: unknown) =>
   value === undefined || value === null || value === "";
-
-const isInvalidBooleanDraftValue = (schema: unknown, value: unknown) =>
-  isBooleanSchema(schema) &&
-  !isAbsentDraftValue(value) &&
-  typeof value !== "boolean";
 
 export const prepareElicitationContent = (
   requestedSchema: unknown,
@@ -47,54 +38,57 @@ export const prepareElicitationContent = (
     isRecord(requestedSchema) && isRecord(requestedSchema.properties)
       ? requestedSchema.properties
       : {};
-  const required =
-    isRecord(requestedSchema) && Array.isArray(requestedSchema.required)
-      ? requestedSchema.required.filter(
-          (property): property is string => typeof property === "string",
-        )
-      : [];
-
-  const preparedDraft = Object.entries(draft).flatMap(([name, value]) => {
-    const schema = properties[name];
-    if (value === undefined || value === null) return [];
-    if (
-      isBooleanSchema(schema) &&
-      (isAbsentDraftValue(value) || isInvalidBooleanDraftValue(schema, value))
-    ) {
-      return [];
-    }
-
-    const coerced = coerceValue(schema, value);
-    return coerced.invalid ? [] : [[name, coerced.value]];
-  });
-  const invalid = Object.entries(draft).flatMap(([name, value]) => {
-    const schema = properties[name];
-    return isInvalidBooleanDraftValue(schema, value) ||
-      coerceValue(schema, value).invalid
-      ? [name]
-      : [];
-  });
-  const requiredBooleans = required.flatMap((name) =>
-    isBooleanSchema(properties[name]) &&
-    isAbsentDraftValue(getDraftValue(draft, name))
-      ? [
-          [
-            name,
-            typeof properties[name].default === "boolean"
-              ? properties[name].default
-              : false,
-          ],
-        ]
-      : [],
+  const candidateContent = Object.fromEntries(
+    Object.entries(draft).flatMap(([name, value]) => {
+      if (isAbsentDraftValue(value)) return [];
+      return [[name, coerceValue(properties[name], value)]];
+    }),
   );
+  const missingRequiredBooleans = validateElicitationContent(
+    requestedSchema,
+    candidateContent,
+  ).filter(
+    ({ property }) =>
+      isBooleanSchema(properties[property]) &&
+      !Object.hasOwn(candidateContent, property),
+  );
+  const contentWithBooleanDefaults = {
+    ...candidateContent,
+    ...Object.fromEntries(
+      missingRequiredBooleans.map(({ property }) => [
+        property,
+        typeof properties[property].default === "boolean"
+          ? properties[property].default
+          : false,
+      ]),
+    ),
+  };
+  const validationErrors = validateElicitationContent(
+    requestedSchema,
+    contentWithBooleanDefaults,
+  );
+  const missingRequired = validationErrors
+    .filter(
+      ({ property }) => !Object.hasOwn(contentWithBooleanDefaults, property),
+    )
+    .map(({ property }) => property);
+  const invalid = [
+    ...new Set(
+      validationErrors
+        .filter(({ property }) =>
+          Object.hasOwn(contentWithBooleanDefaults, property),
+        )
+        .map(({ property }) => property),
+    ),
+  ];
 
   return {
-    content: Object.fromEntries([...preparedDraft, ...requiredBooleans]),
-    missingRequired: required.filter(
-      (name) =>
-        !isBooleanSchema(properties[name]) &&
-        isAbsentDraftValue(getDraftValue(draft, name)),
+    content: Object.fromEntries(
+      Object.entries(contentWithBooleanDefaults).filter(
+        ([property]) => !invalid.includes(property),
+      ),
     ),
+    missingRequired,
     invalid,
   };
 };

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -580,6 +580,104 @@ describe("McpServerResource elicitation", () => {
     }
   });
 
+  it("keeps invalid accepted content pending until a valid response arrives", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Choose a color", {
+        type: "object",
+        required: ["color"],
+        properties: {
+          color: { type: "string" },
+        },
+      });
+      let resolved = false;
+      void response.then(() => {
+        resolved = true;
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "accept",
+        content: { color: 1 },
+      });
+
+      await waitForResourceUpdate(
+        () =>
+          root.getValue().getState().pendingElicitations[0]?.error?.message ===
+          "Invalid elicitation content: color.",
+      );
+      expect(root.getValue().getState().pendingElicitations).toEqual([
+        expect.objectContaining({
+          id: elicitation!.id,
+          error: {
+            message: "Invalid elicitation content: color.",
+            properties: ["color"],
+          },
+        }),
+      ]);
+      await tick();
+      expect(resolved).toBe(false);
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "accept",
+        content: { color: "blue" },
+      });
+
+      await expect(response).resolves.toEqual({
+        action: "accept",
+        content: { color: "blue" },
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("declines an elicitation that carries a validation error", async () => {
+    const root = mount();
+
+    try {
+      await root.getValue().connect();
+      const response = requestElicitation(mocks.clients[0], "Choose a color", {
+        type: "object",
+        required: ["color"],
+        properties: {
+          color: { type: "string" },
+        },
+      });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 1,
+      );
+      const [elicitation] = root.getValue().getState().pendingElicitations;
+
+      root.getValue().answerElicitation(elicitation!.id, {
+        action: "accept",
+        content: {},
+      });
+      await waitForResourceUpdate(
+        () =>
+          root.getValue().getState().pendingElicitations[0]?.error !==
+          undefined,
+      );
+
+      root.getValue().answerElicitation(elicitation!.id, { action: "decline" });
+
+      await expect(response).resolves.toEqual({ action: "decline" });
+      await waitForResourceUpdate(
+        () => root.getValue().getState().pendingElicitations.length === 0,
+      );
+    } finally {
+      root.unmount();
+    }
+  });
+
   it("declines pending elicitations", async () => {
     const root = mount();
 

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -564,9 +564,11 @@ describe("McpServerResource elicitation", () => {
       const [elicitation] = root.getValue().getState().pendingElicitations;
       const content = { color: "blue" };
 
-      root
-        .getValue()
-        .answerElicitation(elicitation!.id, { action: "accept", content });
+      expect(
+        root
+          .getValue()
+          .answerElicitation(elicitation!.id, { action: "accept", content }),
+      ).toBeUndefined();
 
       await expect(response).resolves.toEqual({
         action: "accept",
@@ -601,10 +603,12 @@ describe("McpServerResource elicitation", () => {
       );
       const [elicitation] = root.getValue().getState().pendingElicitations;
 
-      root.getValue().answerElicitation(elicitation!.id, {
-        action: "accept",
-        content: { color: 1 },
-      });
+      expect(
+        root.getValue().answerElicitation(elicitation!.id, {
+          action: "accept",
+          content: { color: 1 },
+        }),
+      ).toEqual([{ property: "color", message: "Expected a string." }]);
 
       await waitForResourceUpdate(
         () =>
@@ -623,10 +627,12 @@ describe("McpServerResource elicitation", () => {
       await tick();
       expect(resolved).toBe(false);
 
-      root.getValue().answerElicitation(elicitation!.id, {
-        action: "accept",
-        content: { color: "blue" },
-      });
+      expect(
+        root.getValue().answerElicitation(elicitation!.id, {
+          action: "accept",
+          content: { color: "blue" },
+        }),
+      ).toBeUndefined();
 
       await expect(response).resolves.toEqual({
         action: "accept",
@@ -736,18 +742,18 @@ describe("McpServerResource elicitation", () => {
     const root = mount();
 
     try {
-      expect(() =>
+      expect(
         root
           .getValue()
           .answerElicitation("missing-elicitation", { action: "cancel" }),
-      ).not.toThrow();
+      ).toBeUndefined();
       expect(root.getValue().getState().pendingElicitations).toEqual([]);
     } finally {
       root.unmount();
     }
   });
 
-  it("rejects accepted elicitation content that is not an object", async () => {
+  it("returns validation errors for accepted elicitation content that is not an object", async () => {
     const root = mount();
 
     try {
@@ -761,15 +767,28 @@ describe("McpServerResource elicitation", () => {
       );
       const [elicitation] = root.getValue().getState().pendingElicitations;
 
-      expect(() =>
+      expect(
         root.getValue().answerElicitation(elicitation!.id, {
           action: "accept",
           content: null as never,
         }),
-      ).toThrow(
-        `MCP elicitation "${elicitation!.id}" response content must be an object`,
+      ).toEqual([
+        { property: "content", message: "Response content must be an object." },
+      ]);
+      await waitForResourceUpdate(
+        () =>
+          root.getValue().getState().pendingElicitations[0]?.error?.message ===
+          "Invalid elicitation content: content.",
       );
-      expect(root.getValue().getState().pendingElicitations).toHaveLength(1);
+      expect(root.getValue().getState().pendingElicitations).toEqual([
+        expect.objectContaining({
+          id: elicitation!.id,
+          error: {
+            message: "Invalid elicitation content: content.",
+            properties: ["content"],
+          },
+        }),
+      ]);
 
       await root.getValue().disconnect();
       await expect(response).resolves.toEqual({ action: "cancel" });

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo, useEffectEvent } from "react";
 import { resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
+import { ElicitResultSchema } from "@modelcontextprotocol/core";
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -13,6 +14,7 @@ import {
 import { createOAuthProvider } from "../auth/createOAuthProvider";
 import { buildHeaders } from "../auth/buildHeaders";
 import { assertValidServerId } from "../utils/serverId";
+import { validateElicitationContent } from "./validateElicitationContent";
 import type { MCPStorage } from "./storage/types";
 import type {
   MCPAuthConfig,
@@ -67,6 +69,7 @@ const useMcpServerResource = (
         resolve: (result: ElicitResult) => void;
         signal: AbortSignal;
         onAbort: () => void;
+        requestedSchema: unknown;
       }
     >(),
   );
@@ -109,6 +112,31 @@ const useMcpServerResource = (
     );
     entry.resolve(result);
     return true;
+  };
+
+  const setPendingElicitationError = (
+    id: string,
+    error: NonNullable<MCPElicitation["error"]>,
+  ) => {
+    if (!elicitationResolversRef.current.has(id)) return false;
+    setPendingElicitations((current) =>
+      current.map((elicitation) =>
+        elicitation.id === id ? { ...elicitation, error } : elicitation,
+      ),
+    );
+    return true;
+  };
+
+  const clearPendingElicitationError = (id: string) => {
+    setPendingElicitations((current) =>
+      current.map((elicitation) => {
+        if (elicitation.id !== id || elicitation.error === undefined) {
+          return elicitation;
+        }
+        const { error: _, ...next } = elicitation;
+        return next;
+      }),
+    );
   };
 
   const cancelPendingElicitations = () => {
@@ -302,6 +330,7 @@ const useMcpServerResource = (
                 resolve,
                 signal: context.signal,
                 onAbort,
+                requestedSchema,
               });
             });
             setPendingElicitations((current) => [
@@ -563,14 +592,42 @@ const useMcpServerResource = (
         );
       }
 
-      const result: ElicitResult =
-        response.action === "accept"
-          ? {
-              action: "accept",
-              content: response.content as ElicitResult["content"],
-            }
-          : { action: response.action };
-      resolvePendingElicitation(id, result);
+      if (response.action === "accept") {
+        const entry = elicitationResolversRef.current.get(id);
+        if (!entry) return;
+
+        const errors = validateElicitationContent(
+          entry.requestedSchema,
+          response.content,
+        );
+        if (errors.length > 0) {
+          const properties = [
+            ...new Set(errors.map((error) => error.property)),
+          ];
+          setPendingElicitationError(id, {
+            message: `Invalid elicitation content: ${properties.join(", ")}.`,
+            properties,
+          });
+          return;
+        }
+
+        const result: ElicitResult = {
+          action: "accept",
+          content: response.content as ElicitResult["content"],
+        };
+        if (!ElicitResultSchema.safeParse(result).success) {
+          setPendingElicitationError(id, {
+            message: "Invalid elicitation response.",
+          });
+          return;
+        }
+
+        clearPendingElicitationError(id);
+        resolvePendingElicitation(id, result);
+        return;
+      }
+
+      resolvePendingElicitation(id, { action: response.action });
     },
   };
 };

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect, useMemo, useEffectEvent } from "react";
 import { resource } from "@assistant-ui/tap";
 import type { ClientOutput } from "@assistant-ui/store";
-import { ElicitResultSchema } from "@modelcontextprotocol/core";
 import {
   Client,
   StreamableHTTPClientTransport,
@@ -125,18 +124,6 @@ const useMcpServerResource = (
       ),
     );
     return true;
-  };
-
-  const clearPendingElicitationError = (id: string) => {
-    setPendingElicitations((current) =>
-      current.map((elicitation) => {
-        if (elicitation.id !== id || elicitation.error === undefined) {
-          return elicitation;
-        }
-        const { error: _, ...next } = elicitation;
-        return next;
-      }),
-    );
   };
 
   const cancelPendingElicitations = () => {
@@ -580,21 +567,31 @@ const useMcpServerResource = (
       return await client.readResource({ uri });
     },
     completeAuth: doCompleteAuth,
-    answerElicitation: (id: string, response: MCPElicitationResponse): void => {
-      if (
-        response.action === "accept" &&
-        (typeof response.content !== "object" ||
-          response.content === null ||
-          Array.isArray(response.content))
-      ) {
-        throw new Error(
-          `MCP elicitation "${id}" response content must be an object`,
-        );
-      }
-
+    answerElicitation: (
+      id: string,
+      response: MCPElicitationResponse,
+    ): readonly { property: string; message: string }[] | undefined => {
       if (response.action === "accept") {
         const entry = elicitationResolversRef.current.get(id);
         if (!entry) return;
+
+        if (
+          typeof response.content !== "object" ||
+          response.content === null ||
+          Array.isArray(response.content)
+        ) {
+          const errors = [
+            {
+              property: "content",
+              message: "Response content must be an object.",
+            },
+          ];
+          setPendingElicitationError(id, {
+            message: "Invalid elicitation content: content.",
+            properties: ["content"],
+          });
+          return errors;
+        }
 
         const errors = validateElicitationContent(
           entry.requestedSchema,
@@ -608,21 +605,13 @@ const useMcpServerResource = (
             message: `Invalid elicitation content: ${properties.join(", ")}.`,
             properties,
           });
-          return;
+          return errors;
         }
 
         const result: ElicitResult = {
           action: "accept",
           content: response.content as ElicitResult["content"],
         };
-        if (!ElicitResultSchema.safeParse(result).success) {
-          setPendingElicitationError(id, {
-            message: "Invalid elicitation response.",
-          });
-          return;
-        }
-
-        clearPendingElicitationError(id);
         resolvePendingElicitation(id, result);
         return;
       }

--- a/packages/react-mcp/src/resources/validateElicitationContent.test.ts
+++ b/packages/react-mcp/src/resources/validateElicitationContent.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { validateElicitationContent } from "./validateElicitationContent";
+
+describe("validateElicitationContent", () => {
+  it.each([
+    ["string", 1, "Expected a string."],
+    ["number", "1", "Expected a number."],
+    ["integer", "1", "Expected an integer."],
+    ["boolean", "true", "Expected a boolean."],
+  ])("rejects a %s type mismatch", (type, value, message) => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: { value: { type } },
+        },
+        { value },
+      ),
+    ).toEqual([{ property: "value", message }]);
+  });
+
+  it("rejects a fractional integer", () => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: { count: { type: "integer" } },
+        },
+        { count: 1.5 },
+      ),
+    ).toEqual([{ property: "count", message: "Expected an integer." }]);
+  });
+
+  it("rejects a value outside an enum", () => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: { color: { enum: ["red", "blue"] } },
+        },
+        { color: "green" },
+      ),
+    ).toEqual([
+      {
+        property: "color",
+        message: "Must be one of the allowed values.",
+      },
+    ]);
+  });
+
+  it("rejects an absent required property", () => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          required: ["answer"],
+          properties: { answer: { type: "string" } },
+        },
+        {},
+      ),
+    ).toEqual([{ property: "answer", message: "This property is required." }]);
+  });
+
+  it("allows unknown content properties", () => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: { answer: { type: "string" } },
+        },
+        { extra: true },
+      ),
+    ).toEqual([]);
+  });
+
+  it("leaves constraints beyond the flat validation subset for the server", () => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: {
+            answer: { type: "string", minLength: 5, format: "email" },
+          },
+        },
+        { answer: "x" },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/packages/react-mcp/src/resources/validateElicitationContent.test.ts
+++ b/packages/react-mcp/src/resources/validateElicitationContent.test.ts
@@ -33,6 +33,25 @@ describe("validateElicitationContent", () => {
     ).toEqual([{ property: "count", message: "Expected an integer." }]);
   });
 
+  it.each([
+    ["number", NaN, "Expected a number."],
+    ["number", Infinity, "Expected a number."],
+    ["number", -Infinity, "Expected a number."],
+    ["integer", NaN, "Expected an integer."],
+    ["integer", Infinity, "Expected an integer."],
+    ["integer", -Infinity, "Expected an integer."],
+  ])("rejects a non-finite %s", (type, value, message) => {
+    expect(
+      validateElicitationContent(
+        {
+          type: "object",
+          properties: { value: { type } },
+        },
+        { value },
+      ),
+    ).toEqual([{ property: "value", message }]);
+  });
+
   it("rejects a value outside an enum", () => {
     expect(
       validateElicitationContent(

--- a/packages/react-mcp/src/resources/validateElicitationContent.ts
+++ b/packages/react-mcp/src/resources/validateElicitationContent.ts
@@ -14,9 +14,13 @@ const matchesType = (type: unknown, value: unknown): boolean => {
     case "string":
       return typeof value === "string";
     case "number":
-      return typeof value === "number";
+      return typeof value === "number" && Number.isFinite(value);
     case "integer":
-      return typeof value === "number" && Number.isInteger(value);
+      return (
+        typeof value === "number" &&
+        Number.isFinite(value) &&
+        Number.isInteger(value)
+      );
     case "boolean":
       return typeof value === "boolean";
     default:

--- a/packages/react-mcp/src/resources/validateElicitationContent.ts
+++ b/packages/react-mcp/src/resources/validateElicitationContent.ts
@@ -1,0 +1,75 @@
+type ValidationError = {
+  property: string;
+  message: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const getOwn = (value: Record<string, unknown>, key: string): unknown =>
+  Object.hasOwn(value, key) ? value[key] : undefined;
+
+const matchesType = (type: unknown, value: unknown): boolean => {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number";
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    default:
+      return true;
+  }
+};
+
+const typeMessage = (type: string) =>
+  `Expected ${type === "integer" ? "an" : "a"} ${type}.`;
+
+export const validateElicitationContent = (
+  requestedSchema: unknown,
+  content: Record<string, unknown>,
+): readonly ValidationError[] => {
+  if (!isRecord(requestedSchema)) return [];
+
+  const errors: ValidationError[] = [];
+  const properties = getOwn(requestedSchema, "properties");
+  if (isRecord(properties)) {
+    for (const property of Object.keys(properties)) {
+      if (!Object.hasOwn(content, property)) continue;
+
+      const schema = properties[property];
+      if (!isRecord(schema)) continue;
+
+      const value = content[property];
+      const type = getOwn(schema, "type");
+      if (typeof type === "string" && !matchesType(type, value)) {
+        errors.push({ property, message: typeMessage(type) });
+      }
+
+      const values = getOwn(schema, "enum");
+      if (
+        Array.isArray(values) &&
+        !values.some((enumValue) => Object.is(enumValue, value))
+      ) {
+        errors.push({
+          property,
+          message: "Must be one of the allowed values.",
+        });
+      }
+    }
+  }
+
+  const required = getOwn(requestedSchema, "required");
+  if (Array.isArray(required)) {
+    for (const property of required) {
+      if (typeof property !== "string" || Object.hasOwn(content, property)) {
+        continue;
+      }
+      errors.push({ property, message: "This property is required." });
+    }
+  }
+
+  return errors;
+};


### PR DESCRIPTION
closes #5339

## summary

- invalid accepts no longer vanish into a server-side protocol error: `answerElicitation` validates the content against the flat elicitation subset (property types with integer strictness, `required` presence, `enum` membership) before resolving, and on failure the entry STAYS pending with a structured `error` on `MCPElicitation` instead of being removed; a later valid accept clears it, and `ElicitResultSchema` from `@modelcontextprotocol/core` runs as the envelope backstop. constraints beyond the subset (minLength, format, ...) deliberately pass through for the server to judge, and SPEC states that boundary
- new `McpElicitationPrimitive.Error` renders the entry error (null when none, `data-properties` with the failing names), completing the unstyled composition
- drafts now initialize from schema property defaults via a pure `initialElicitationDraft` helper (matching-type defaults only), so the rendered form equals what submit would send; the untouched `default: true` checkbox renders checked, killing the render-vs-submit divergence flagged on #5341, with submit-side seeding kept as the backstop for custom compositions
- the three `elicitation?: boolean` optionals gain `| undefined` to match sibling optional style under `exactOptionalPropertyTypes`

## test plan

### already verified

- [x] `pnpm -C packages/react-mcp test` -> 77/77 green (new: 9 validator cases, stay-pending/clear/retry resource flows, draft seeding helper cases)
- [x] `pnpm api-surface` + `pnpm api-surface:check` clean; `aui-build`, scoped `oxlint`, `oxfmt --check` clean

### reviewer should verify

- [ ] against a server issuing a form elicitation with a `required` enum property, submitting a non-member value keeps the form open with `McpElicitationPrimitive.Error` populated, and correcting it completes the tool call

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AeghE-M22XKe4YAooPti2QmloVqnexe52vkNTmNVExNJnNKoKKvKxlwW170?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->