### PR TITLE
feat(react-ag-ui): render A2UI surfaces from a2ui-surface activity snapshots

### DIFF
--- a/.changeset/olive-lions-invent.md
+++ b/.changeset/olive-lions-invent.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: consume a2ui-surface activity snapshots and render A2UI surfaces as present tool-call parts

--- a/apps/docs/content/docs/tools/a2ui.mdx
+++ b/apps/docs/content/docs/tools/a2ui.mdx
@@ -40,7 +40,7 @@ A backend paints or updates a surface by emitting an activity snapshot on the AG
 }
 ```
 
-- A snapshot with `replace: true` (the schema default) rebuilds that `messageId`'s surface state from the operations it carries; `replace: false` applies the operations incrementally on top of the previous snapshot with the same `messageId`.
+- A snapshot with `replace: true` (the schema default) rebuilds that `messageId`'s surface state from the operations it carries. `replace: false` means the snapshot is ignored when that `messageId` has already been seen, matching the AG-UI event spec. The middleware always emits `replace: true`.
 - Surfaces are keyed by the `surfaceId` inside the operations, not by `messageId`. Multiple snapshots that share a `messageId` update their surfaces in place, and the synthesized part keeps its `toolCallId`, so the rendered surface updates without duplicating parts.
 - Component trees use the A2UI adjacency-list model: nodes reference children by id, the root node has id `root`, and props of shape `{ "path": "/x/y" }` are JSON Pointer bindings resolved against the surface data model. Both v0.9 and v1.0 operation payloads are accepted, including the v1.0 inline `components` and `dataModel` on `createSurface`.
 - Lifecycle snapshots that carry a `status` (such as `"building"`) but no `a2ui_operations` are tolerated and produce no part until operations arrive. A `deleteSurface` operation removes the surface's part.

--- a/apps/docs/content/docs/tools/a2ui.mdx
+++ b/apps/docs/content/docs/tools/a2ui.mdx
@@ -44,6 +44,7 @@ A backend paints or updates a surface by emitting an activity snapshot on the AG
 - Surfaces are keyed by the `surfaceId` inside the operations, not by `messageId`. Multiple snapshots that share a `messageId` update their surfaces in place, and the synthesized part keeps its `toolCallId`, so the rendered surface updates without duplicating parts.
 - Component trees use the A2UI adjacency-list model: nodes reference children by id, the root node has id `root`, and props of shape `{ "path": "/x/y" }` are JSON Pointer bindings resolved against the surface data model. Both v0.9 and v1.0 operation payloads are accepted, including the v1.0 inline `components` and `dataModel` on `createSurface`.
 - Lifecycle snapshots that carry a `status` (such as `"building"`) but no `a2ui_operations` are tolerated and produce no part until operations arrive. A `deleteSurface` operation removes the surface's part.
+- The `a2ui:` tool-call id prefix is reserved for synthesized surface parts: they are client-side render artifacts and are excluded from the history sent back to the agent, so genuine agent tool calls must not use ids starting with `a2ui:`.
 
 ## Quick start
 

--- a/apps/docs/content/docs/tools/a2ui.mdx
+++ b/apps/docs/content/docs/tools/a2ui.mdx
@@ -1,0 +1,83 @@
+---
+title: A2UI over AG-UI
+description: Render A2UI surfaces from AG-UI activity snapshots as generative UI, using the community a2ui-surface convention.
+platforms: ["react"]
+---
+
+[A2UI](https://a2ui.org/) is a declarative generative UI protocol: the agent streams surface operations (create a surface, upsert components, update a data model) and the host renders them from a pre-approved component catalog, with no code over the wire. The AG-UI ecosystem carries A2UI as `ACTIVITY_SNAPSHOT` events with `activityType: "a2ui-surface"` and the operations under `content.a2ui_operations`; this is the convention emitted by [`@ag-ui/a2ui-middleware`](https://github.com/ag-ui-protocol/ag-ui/tree/main/middlewares/a2ui-middleware).
+
+`useAgUiRuntime` consumes these snapshots natively. Each surface becomes one tool-call part with `toolCallId` `a2ui:<surfaceId>` and `toolName` `"present"`, whose args are the converted generative UI spec, so surfaces render through the same path as the [`present` frontend tool](/docs/tools/generative-ui). Snapshots with any other `activityType` are ignored, and the MCP Apps activity path is unaffected.
+
+## Wire contract
+
+A backend paints or updates a surface by emitting an activity snapshot on the AG-UI stream:
+
+```json
+{
+  "type": "ACTIVITY_SNAPSHOT",
+  "messageId": "a2ui-surface-call_1",
+  "activityType": "a2ui-surface",
+  "replace": true,
+  "content": {
+    "a2ui_operations": [
+      { "version": "v0.9", "createSurface": { "surfaceId": "s1" } },
+      {
+        "version": "v0.9",
+        "updateComponents": {
+          "surfaceId": "s1",
+          "components": [
+            { "id": "root", "component": "Card", "title": "Order", "children": ["total"] },
+            { "id": "total", "component": "Text", "text": { "path": "/total" } }
+          ]
+        }
+      },
+      {
+        "version": "v0.9",
+        "updateDataModel": { "surfaceId": "s1", "path": "/", "contents": { "total": "$42" } }
+      }
+    ]
+  }
+}
+```
+
+- A snapshot with `replace: true` (the schema default) rebuilds that `messageId`'s surface state from the operations it carries; `replace: false` applies the operations incrementally on top of the previous snapshot with the same `messageId`.
+- Surfaces are keyed by the `surfaceId` inside the operations, not by `messageId`. Multiple snapshots that share a `messageId` update their surfaces in place, and the synthesized part keeps its `toolCallId`, so the rendered surface updates without duplicating parts.
+- Component trees use the A2UI adjacency-list model: nodes reference children by id, the root node has id `root`, and props of shape `{ "path": "/x/y" }` are JSON Pointer bindings resolved against the surface data model. Both v0.9 and v1.0 operation payloads are accepted, including the v1.0 inline `components` and `dataModel` on `createSurface`.
+- Lifecycle snapshots that carry a `status` (such as `"building"`) but no `a2ui_operations` are tolerated and produce no part until operations arrive. A `deleteSurface` operation removes the surface's part.
+
+## Quick start
+
+Register the `present` frontend tool from `@assistant-ui/react-generative-ui`; incoming surfaces then render with the default vocabulary:
+
+```tsx
+import {
+  JSONGenerativeUI,
+  createActionRegistry,
+  defaultGenerativeUILibrary,
+} from "@assistant-ui/react-generative-ui";
+
+const generative = new JSONGenerativeUI({
+  library: defaultGenerativeUILibrary,
+  actions: createActionRegistry({
+    "a2ui:action": async ({ payload }) => {
+      // forward the A2UI action to your backend
+    },
+  }),
+});
+
+const toolkit = {
+  present: generative.present({ display: "standalone" }),
+};
+```
+
+Pass the toolkit to your assistant as on the [Generative UI](/docs/tools/generative-ui) page; no other configuration is needed on `useAgUiRuntime`.
+
+## Component mapping
+
+The converter maps the A2UI basic catalog onto the default generative UI vocabulary: `Text` becomes `Markdown` (`h1` to `h6` variants become `Header`, `caption` becomes `Caption`), `Column` becomes `Col`, `TextField` becomes `Input` (the control name is derived from the last segment of its binding path), `CheckBox` becomes `Checkbox`, and `Image`, `Row`, `Card`, `Divider`, `Button` map one to one. A node with template children expands into a `ListView` over the bound list. `Button` actions become `$action` objects with type `"a2ui:action"` carrying the action name, `surfaceId`, and `sourceComponentId`, which is how your action registry receives them. Unknown components and operations are skipped with a debug warning, and conversion is bounded (depth 32, 100 template items, 5000 nodes) so a malformed stream cannot hang the client.
+
+## Limitations
+
+- Forwarding an `"a2ui:action"` back to the agent is host code today: send it on the next run as `forwardedProps.a2uiAction.userAction`, the convention `@ag-ui/a2ui-middleware` consumes. A first-class round-trip helper is planned.
+- Surfaces are not yet rehydrated when a thread is restored from history.
+- The upstream middleware currently emits v0.9 operation payloads; the renderer accepts v0.9 and v1.0 shapes.

--- a/apps/docs/content/docs/tools/meta.json
+++ b/apps/docs/content/docs/tools/meta.json
@@ -14,6 +14,7 @@
     "tool-ui",
     "generative-ui",
     "interactables",
+    "a2ui",
     "interactables-legacy",
     "---MCP---",
     "mcp",

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@ag-ui/client": "^0.0.57",
     "@assistant-ui/core": "^0.3.0",
+    "@assistant-ui/react-generative-ui": "^0.0.10",
     "@assistant-ui/store": "^0.3.0",
     "assistant-stream": "^0.3.29",
     "fast-json-patch": "^3.1.1"

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -717,7 +717,12 @@ function convertAssistantMessage(
   const contentArray = Array.isArray(message.content) ? message.content : [];
 
   const toolCallParts = contentArray.filter(
-    (part): part is ToolCallPart => part?.type === "tool-call",
+    (part): part is ToolCallPart =>
+      part?.type === "tool-call" &&
+      !(
+        typeof part.toolCallId === "string" &&
+        part.toolCallId.startsWith("a2ui:")
+      ),
   );
 
   const toolCalls = toolCallParts.map((part) => ({

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -328,11 +328,9 @@ export class RunAggregator {
     if (!Array.isArray(operations)) return;
 
     const messageId = event.messageId ?? "a2ui:anonymous";
-    const previousState =
-      event.replace === false
-        ? (this.a2uiBuckets.get(messageId) ?? new Map())
-        : new Map();
-    const { state, warnings } = applyA2uiOperations(previousState, operations);
+    if (event.replace === false && this.a2uiBuckets.has(messageId)) return;
+
+    const { state, warnings } = applyA2uiOperations(new Map(), operations);
     for (const warning of warnings) {
       this.logger.debug("[agui] a2ui operation warning", warning);
     }
@@ -354,12 +352,13 @@ export class RunAggregator {
     const activeToolCallIds = new Set<string>();
     for (const [surfaceId, surface] of surfaces) {
       const toolCallId = `a2ui:${surfaceId}`;
-      activeToolCallIds.add(toolCallId);
       const { spec, warnings } = convertSurfaceToUISpec(surface);
       for (const warning of warnings) {
         this.logger.debug("[agui] a2ui surface conversion warning", warning);
       }
       if (!spec) continue;
+
+      activeToolCallIds.add(toolCallId);
 
       const entry: ToolCallState = {
         toolCallId,

--- a/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/run-aggregator.ts
@@ -8,6 +8,12 @@ import {
   type ToolCallMessagePart,
   type ToolModelContentPart,
 } from "@assistant-ui/core";
+import {
+  applyA2uiOperations,
+  convertSurfaceToUISpec,
+  type A2uiState,
+  type A2uiSurfaceState,
+} from "@assistant-ui/react-generative-ui/a2ui";
 import { readMcpAppResourceUri } from "../mcp-tool-result";
 import type { AgUiEvent, AgUiInterrupt } from "../types";
 import type { Logger } from "../logger";
@@ -36,6 +42,8 @@ type ToolCallState = {
 };
 
 export const MCP_APPS_ACTIVITY_TYPE = "mcp-apps";
+
+export const A2UI_SURFACE_ACTIVITY_TYPE = "a2ui-surface";
 
 export const isPlainObject = (
   value: unknown,
@@ -72,6 +80,8 @@ export class RunAggregator {
   private activeReasoningKey: string | undefined;
   private reasoningPartCounter = 0;
   private readonly toolCalls = new Map<string, ToolCallState>();
+  private readonly a2uiBuckets = new Map<string, A2uiState>();
+  private readonly a2uiToolCallIds = new Set<string>();
   private lastResolvedToolCallId: string | undefined;
   private readonly partOrder: (
     | { kind: "text"; key: string }
@@ -104,6 +114,8 @@ export class RunAggregator {
         this.activeReasoningKey = undefined;
         this.reasoningPartCounter = 0;
         this.toolCalls.clear();
+        this.a2uiBuckets.clear();
+        this.a2uiToolCallIds.clear();
         this.lastResolvedToolCallId = undefined;
         this.partOrder.length = 0;
         this.textPartCounter = 0;
@@ -250,6 +262,10 @@ export class RunAggregator {
         break;
       }
       case "ACTIVITY_SNAPSHOT": {
+        if (event.activityType === A2UI_SURFACE_ACTIVITY_TYPE) {
+          this.handleA2uiActivitySnapshot(event);
+          break;
+        }
         if (event.activityType !== MCP_APPS_ACTIVITY_TYPE) break;
         const toolCallId = event.content.toolCallId;
         const entry =
@@ -302,6 +318,73 @@ export class RunAggregator {
       default: {
         this.logger.debug?.("[agui] aggregator ignored event", event);
       }
+    }
+  }
+
+  private handleA2uiActivitySnapshot(
+    event: Extract<AgUiEvent, { type: "ACTIVITY_SNAPSHOT" }>,
+  ): void {
+    const operations = event.content["a2ui_operations"];
+    if (!Array.isArray(operations)) return;
+
+    const messageId = event.messageId ?? "a2ui:anonymous";
+    const previousState =
+      event.replace === false
+        ? (this.a2uiBuckets.get(messageId) ?? new Map())
+        : new Map();
+    const { state, warnings } = applyA2uiOperations(previousState, operations);
+    for (const warning of warnings) {
+      this.logger.debug("[agui] a2ui operation warning", warning);
+    }
+    this.a2uiBuckets.delete(messageId);
+    this.a2uiBuckets.set(messageId, state);
+    this.synthesizeA2uiToolCalls();
+    this.emit();
+  }
+
+  private synthesizeA2uiToolCalls(): void {
+    const surfaces = new Map<string, A2uiSurfaceState>();
+
+    for (const bucket of this.a2uiBuckets.values()) {
+      for (const [surfaceId, surface] of bucket) {
+        surfaces.set(surfaceId, surface);
+      }
+    }
+
+    const activeToolCallIds = new Set<string>();
+    for (const [surfaceId, surface] of surfaces) {
+      const toolCallId = `a2ui:${surfaceId}`;
+      activeToolCallIds.add(toolCallId);
+      const { spec, warnings } = convertSurfaceToUISpec(surface);
+      for (const warning of warnings) {
+        this.logger.debug("[agui] a2ui surface conversion warning", warning);
+      }
+      if (!spec) continue;
+
+      const entry: ToolCallState = {
+        toolCallId,
+        toolCallName: "present",
+        argsText: JSON.stringify(spec),
+        parsedArgs: spec,
+        result: {},
+        isError: undefined,
+        snapshotResultApplied: false,
+      };
+      if (!this.toolCalls.has(toolCallId)) {
+        this.partOrder.push({ kind: "tool-call", toolCallId });
+      }
+      this.toolCalls.set(toolCallId, entry);
+      this.a2uiToolCallIds.add(toolCallId);
+    }
+
+    for (const toolCallId of this.a2uiToolCallIds) {
+      if (activeToolCallIds.has(toolCallId)) continue;
+      this.toolCalls.delete(toolCallId);
+      const partIndex = this.partOrder.findIndex(
+        (part) => part.kind === "tool-call" && part.toolCallId === toolCallId,
+      );
+      if (partIndex !== -1) this.partOrder.splice(partIndex, 1);
+      this.a2uiToolCallIds.delete(toolCallId);
     }
   }
 

--- a/packages/react-ag-ui/src/runtime/event-parser.ts
+++ b/packages/react-ag-ui/src/runtime/event-parser.ts
@@ -241,11 +241,18 @@ export const parseAgUiEvent = (
     case "ACTIVITY_SNAPSHOT": {
       const activityType = getString("activityType");
       if (!activityType || !isPlainObject(payload.content)) return null;
-      return {
-        type: "ACTIVITY_SNAPSHOT" as const,
-        activityType,
-        content: payload.content,
-      };
+      return withOptional(
+        {
+          type: "ACTIVITY_SNAPSHOT" as const,
+          activityType,
+          content: payload.content,
+        },
+        {
+          messageId: getString("messageId"),
+          replace:
+            typeof payload.replace === "boolean" ? payload.replace : undefined,
+        },
+      );
     }
     case "RAW":
       return withOptional(

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -169,6 +169,8 @@ export type AgUiEvent =
       type: "ACTIVITY_SNAPSHOT";
       activityType: string;
       content: Record<string, unknown>;
+      messageId?: string;
+      replace?: boolean;
     }
   | { type: "RAW"; event: any; source?: string }
   | { type: "CUSTOM"; name: string; value: any }

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -106,6 +106,90 @@ describe("adapter conversions", () => {
     });
   });
 
+  it("excludes synthesized a2ui tool calls and results from outbound messages", () => {
+    const result = toAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-42",
+            toolName: "search",
+            argsText: '{"query":"x"}',
+            result: { ok: true },
+          },
+          {
+            type: "tool-call",
+            toolCallId: "a2ui:surface-1",
+            toolName: "present",
+            argsText: '{"$type":"Markdown","value":"Welcome"}',
+            result: {},
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result).toHaveLength(2);
+    const assistantMessage = result[0] as any;
+    expect(assistantMessage.role).toBe("assistant");
+    expect(assistantMessage.toolCalls).toHaveLength(1);
+    expect(assistantMessage.toolCalls[0]).toMatchObject({
+      id: "call-42",
+      function: { name: "search", arguments: '{"query":"x"}' },
+    });
+    const toolMessages = result.filter((message) => message.role === "tool");
+    expect(toolMessages).toHaveLength(1);
+    expect(toolMessages[0]).toMatchObject({
+      role: "tool",
+      toolCallId: "call-42",
+      content: '{"ok":true}',
+    });
+  });
+
+  it("drops an assistant message with only a synthesized a2ui tool call", () => {
+    const withoutText = toAgUiMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "a2ui:surface-1",
+            toolName: "present",
+            argsText: "{}",
+            result: {},
+          },
+        ],
+      },
+    ] as any);
+    const withText = toAgUiMessages([
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: [
+          { type: "text", text: "Here is the surface" },
+          {
+            type: "tool-call",
+            toolCallId: "a2ui:surface-1",
+            toolName: "present",
+            argsText: "{}",
+            result: {},
+          },
+        ],
+      },
+    ] as any);
+
+    expect(withoutText).toEqual([]);
+    expect(withText).toEqual([
+      {
+        id: "assistant-2",
+        role: "assistant",
+        content: "Here is the surface",
+      },
+    ]);
+  });
+
   it("does not serialize Host-only data when modelContent is empty", () => {
     const result = toAgUiMessages([
       {

--- a/packages/react-ag-ui/test/event-parser.spec.ts
+++ b/packages/react-ag-ui/test/event-parser.spec.ts
@@ -57,11 +57,13 @@ describe("parseAgUiEvent", () => {
     });
     expect(event).toEqual({
       type: "ACTIVITY_SNAPSHOT",
+      messageId: "m1",
       activityType: "mcp-apps",
       content: {
         resourceUri: "ui://srv/mcp-app.html",
         toolInput: { city: "sf" },
       },
+      replace: true,
     });
   });
 
@@ -72,6 +74,47 @@ describe("parseAgUiEvent", () => {
     expect(
       parseAgUiEvent({ type: "ACTIVITY_SNAPSHOT", activityType: "mcp-apps" }),
     ).toBeNull();
+  });
+
+  it("omits non-string messageId from ACTIVITY_SNAPSHOT", () => {
+    const event = parseAgUiEvent({
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: 42,
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+    expect(event).toEqual({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+  });
+
+  it("omits non-boolean replace from ACTIVITY_SNAPSHOT", () => {
+    const event = parseAgUiEvent({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+      replace: "yes",
+    });
+    expect(event).toEqual({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+  });
+
+  it("parses ACTIVITY_SNAPSHOT without messageId or replace", () => {
+    const event = parseAgUiEvent({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    });
+    expect(event).toEqual({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "mcp-apps",
+      content: { resourceUri: "ui://srv/mcp-app.html" },
+    });
   });
 
   it("passes RUN_FINISHED through with no outcome (legacy)", () => {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1765,7 +1765,7 @@ describe("RunAggregator", () => {
     expect(toolParts[0].args.children).toBeUndefined();
   });
 
-  it("applies incremental a2ui snapshots to the same message bucket", () => {
+  it("ignores replace-false a2ui snapshots for an existing message bucket", () => {
     const aggregator = createAggregator(false);
 
     aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
@@ -1774,25 +1774,7 @@ describe("RunAggregator", () => {
       activityType: "a2ui-surface",
       messageId: "message-1",
       content: {
-        a2ui_operations: [
-          {
-            version: "v0.9",
-            createSurface: { surfaceId: "surface-1" },
-          },
-          {
-            version: "v0.9",
-            updateComponents: {
-              surfaceId: "surface-1",
-              components: [
-                {
-                  id: "root",
-                  component: "Text",
-                  text: { path: "/title" },
-                },
-              ],
-            },
-          },
-        ],
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Original"),
       },
     } as AgUiEvent);
     aggregator.handle({
@@ -1816,7 +1798,81 @@ describe("RunAggregator", () => {
     const toolPart = results
       .at(-1)
       ?.content?.find((part) => part.type === "tool-call") as any;
-    expect(toolPart.args).toEqual({ $type: "Markdown", value: "Incremental" });
+    expect(toolPart.args).toMatchObject({
+      $type: "Col",
+      children: [
+        { $type: "Header", text: "Original" },
+        { $type: "Markdown", value: "Original body" },
+      ],
+    });
+  });
+
+  it("applies a replace-false a2ui snapshot for an unseen message bucket", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: false,
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.args).toMatchObject({
+      $type: "Col",
+      children: [
+        { $type: "Header", text: "Welcome" },
+        { $type: "Markdown", value: "Welcome body" },
+      ],
+    });
+  });
+
+  it("removes an a2ui tool call when a replacement surface has no root component", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: true,
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "surface-1" },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "surface-1",
+              components: [{ id: "child", component: "Text", text: "No root" }],
+            },
+          },
+        ],
+      },
+    } as AgUiEvent);
+
+    expect(
+      (results.at(-1)?.content ?? []).some(
+        (part) =>
+          part.type === "tool-call" && part.toolCallId === "a2ui:surface-1",
+      ),
+    ).toBe(false);
   });
 
   it("ignores status-only a2ui snapshots", () => {
@@ -1851,7 +1907,7 @@ describe("RunAggregator", () => {
       type: "ACTIVITY_SNAPSHOT",
       activityType: "a2ui-surface",
       messageId: "message-1",
-      replace: false,
+      replace: true,
       content: {
         a2ui_operations: [
           {

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1648,4 +1648,261 @@ describe("RunAggregator", () => {
     expect((parts[0] as any).text).toBe("intro");
     expect((parts[2] as any).text).toBe("followup");
   });
+
+  const a2uiSurfaceOperations = (surfaceId: string, title: string) => [
+    {
+      version: "v0.9",
+      createSurface: { surfaceId },
+    },
+    {
+      version: "v0.9",
+      updateComponents: {
+        surfaceId,
+        components: [
+          {
+            id: "root",
+            component: "Column",
+            children: ["heading", "body"],
+          },
+          {
+            id: "heading",
+            component: "Text",
+            variant: "h1",
+            text: { path: "/title" },
+          },
+          {
+            id: "body",
+            component: "Text",
+            text: { path: "/body" },
+          },
+        ],
+      },
+    },
+    {
+      version: "v0.9",
+      updateDataModel: {
+        surfaceId,
+        data: { title, body: `${title} body` },
+      },
+    },
+  ];
+
+  it("maps an a2ui surface snapshot to a present tool call", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart).toMatchObject({
+      toolCallId: "a2ui:surface-1",
+      toolName: "present",
+      args: {
+        $type: "Col",
+        children: [
+          { $type: "Header", text: "Welcome" },
+          { $type: "Markdown", value: "Welcome body" },
+        ],
+      },
+    });
+    expect(toolPart.result).toBeDefined();
+  });
+
+  it("replaces an a2ui surface snapshot without duplicating its tool call", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Original"),
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: true,
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "surface-1" },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "surface-1",
+              components: [
+                { id: "root", component: "Text", text: "Replacement" },
+              ],
+            },
+          },
+        ],
+      },
+    } as AgUiEvent);
+
+    const toolParts = (results.at(-1)?.content ?? []).filter(
+      (part) => part.type === "tool-call",
+    ) as any[];
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]).toMatchObject({
+      toolCallId: "a2ui:surface-1",
+      args: { $type: "Markdown", value: "Replacement" },
+      argsText: '{"$type":"Markdown","value":"Replacement"}',
+    });
+    expect(toolParts[0].args.children).toBeUndefined();
+  });
+
+  it("applies incremental a2ui snapshots to the same message bucket", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "surface-1" },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "surface-1",
+              components: [
+                {
+                  id: "root",
+                  component: "Text",
+                  text: { path: "/title" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: false,
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            updateDataModel: {
+              surfaceId: "surface-1",
+              data: { title: "Incremental" },
+            },
+          },
+        ],
+      },
+    } as AgUiEvent);
+
+    const toolPart = results
+      .at(-1)
+      ?.content?.find((part) => part.type === "tool-call") as any;
+    expect(toolPart.args).toEqual({ $type: "Markdown", value: "Incremental" });
+  });
+
+  it("ignores status-only a2ui snapshots", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    expect(() =>
+      aggregator.handle({
+        type: "ACTIVITY_SNAPSHOT",
+        activityType: "a2ui-surface",
+        messageId: "message-1",
+        content: { status: "building" },
+      } as AgUiEvent),
+    ).not.toThrow();
+
+    expect(results.at(-1)?.content).toEqual([]);
+  });
+
+  it("removes an a2ui tool call when its surface is deleted", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: false,
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            deleteSurface: { surfaceId: "surface-1" },
+          },
+        ],
+      },
+    } as AgUiEvent);
+
+    expect(
+      (results.at(-1)?.content ?? []).some(
+        (part) =>
+          part.type === "tool-call" && part.toolCallId === "a2ui:surface-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("completes an a2ui-only run", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_FINISHED", runId: "r1" } as AgUiEvent);
+
+    expect(results.at(-1)?.status?.type).toBe("complete");
+  });
+
+  it("clears a2ui surfaces on RUN_STARTED", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      content: {
+        a2ui_operations: a2uiSurfaceOperations("surface-1", "Welcome"),
+      },
+    } as AgUiEvent);
+    aggregator.handle({ type: "RUN_STARTED", runId: "r2" } as AgUiEvent);
+
+    expect(
+      (results.at(-1)?.content ?? []).some((part) => part.type === "tool-call"),
+    ).toBe(false);
+  });
 });

--- a/packages/react-ag-ui/test/run-aggregator.spec.ts
+++ b/packages/react-ag-ui/test/run-aggregator.spec.ts
@@ -1961,4 +1961,73 @@ describe("RunAggregator", () => {
       (results.at(-1)?.content ?? []).some((part) => part.type === "tool-call"),
     ).toBe(false);
   });
+
+  it("maps multiple a2ui surfaces in one snapshot to present tool calls", () => {
+    const aggregator = createAggregator(false);
+
+    aggregator.handle({ type: "RUN_STARTED", runId: "r1" } as AgUiEvent);
+    aggregator.handle({
+      type: "ACTIVITY_SNAPSHOT",
+      activityType: "a2ui-surface",
+      messageId: "message-1",
+      replace: true,
+      content: {
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "s1" },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "s1",
+              components: [
+                { id: "root", component: "Text", text: "First surface" },
+              ],
+            },
+          },
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: "s2" },
+          },
+          {
+            version: "v0.9",
+            updateComponents: {
+              surfaceId: "s2",
+              components: [
+                { id: "root", component: "Text", text: "Second surface" },
+              ],
+            },
+          },
+        ],
+      },
+    } as AgUiEvent);
+
+    const toolParts = (results.at(-1)?.content ?? []).filter(
+      (part) => part.type === "tool-call",
+    ) as any[];
+    expect(toolParts).toHaveLength(2);
+    expect(toolParts.map((part) => part.toolCallId).sort()).toEqual([
+      "a2ui:s1",
+      "a2ui:s2",
+    ]);
+
+    const firstSurface = toolParts.find(
+      (part) => part.toolCallId === "a2ui:s1",
+    );
+    expect(firstSurface).toMatchObject({
+      toolName: "present",
+      args: { $type: "Markdown", value: "First surface" },
+    });
+    expect(firstSurface.result).toBeDefined();
+
+    const secondSurface = toolParts.find(
+      (part) => part.toolCallId === "a2ui:s2",
+    );
+    expect(secondSurface).toMatchObject({
+      toolName: "present",
+      args: { $type: "Markdown", value: "Second surface" },
+    });
+    expect(secondSurface.result).toBeDefined();
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3861,6 +3861,9 @@ importers:
       '@assistant-ui/core':
         specifier: ^0.3.0
         version: link:../core
+      '@assistant-ui/react-generative-ui':
+        specifier: ^0.0.10
+        version: link:../react-generative-ui
       '@assistant-ui/store':
         specifier: ^0.3.0
         version: link:../store


### PR DESCRIPTION
closes #5156

stacked on #5344 (merged), which added the transport-agnostic A2UI to UISpec converter this PR consumes.

## summary

- `RunAggregator` now consumes AG-UI `ACTIVITY_SNAPSHOT` events with `activityType: "a2ui-surface"` (the `@ag-ui/a2ui-middleware` convention): operations from `content.a2ui_operations` are reduced per snapshot `messageId` with `replace` semantics (rebuild on `replace: true`, the schema default; incremental on `replace: false`), and each surface is synthesized as a tool-call part with `toolCallId` `a2ui:<surfaceId>`, `toolName "present"`, args set to the converted spec, so surfaces render through the existing `present` frontend tool path with zero core changes
- the event parser and `AgUiEvent` type now pass `messageId` and `replace` through on ACTIVITY_SNAPSHOT (previously stripped); unknown `activityType` values are still ignored and the mcp-apps path is untouched
- updates replace args wholesale on the same `toolCallId` (no duplicate parts), `deleteSurface` removes the part, status-only lifecycle snapshots (`{ status: "building" }`) are tolerated, and synthesized parts carry a result so a2ui-only runs finish `complete` instead of `requires-action`
- new docs page `tools/a2ui` documents the wire contract, quick start, component mapping, and current limitations

## test plan

### already verified

- [x] `pnpm -C packages/react-ag-ui exec vitest run` -> 8 files, 268/268 green (7 new aggregator cases: paint, wholesale replace, incremental replace, status-only, deleteSurface, run completion, run reset; existing mcp-apps and ignore-unknown tests unmodified)
- [x] `pnpm -C packages/react-ag-ui build` -> clean
- [x] `pnpm lint` -> clean

### reviewer should verify

- [ ] an AG-UI stream emitting the documented snapshot shape paints and live-updates a surface in a thread with `present` registered (docs quick start)

## notes

- follow-ups tracked separately: history rehydration of surfaces (mirrors the mcp-apps restored-history work in #5110/#5225) and a first-class action round-trip helper (`forwardedProps.a2uiAction.userAction` is host code today, as documented)
- changeset: patch on `@assistant-ui/react-ag-ui`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.TzInXcHiIG0wGOpcs-EwxKzZaBNZ7kz1hC20SrQwx9O5RRDGMYB7EMkwqLE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->