### PR TITLE
fix(docs): use bot icon for coding agent prompt

### DIFF
--- a/apps/docs/components/home/copy-command-button.tsx
+++ b/apps/docs/components/home/copy-command-button.tsx
@@ -2,7 +2,7 @@
 
 import { analytics, type AnalyticsProperties } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
-import { CheckIcon, CopyIcon, SparklesIcon, TerminalIcon } from "lucide-react";
+import { BotIcon, CheckIcon, CopyIcon, TerminalIcon } from "lucide-react";
 import { useState } from "react";
 import { Menu } from "@base-ui/react/menu";
 import {
@@ -93,7 +93,7 @@ export function CopyCommandButton({
           Copy CLI command
         </DropdownMenuItem>
         <DropdownMenuItem onClick={copyPrompt}>
-          <SparklesIcon className="size-3.5" />
+          <BotIcon className="size-3.5" />
           Copy coding agent prompt
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary

- replace the sparkle icon in the home page copy menu with Lucide's bot icon
- keep the existing copy behavior and menu layout unchanged

## Why

The sparkle icon makes the "Copy coding agent prompt" action visually ambiguous. A bot icon more directly communicates that the copied text is intended for a coding agent.

## Testing

- `oxfmt --check apps/docs/components/home/copy-command-button.tsx`
- `oxlint apps/docs/components/home/copy-command-button.tsx`
- verified that `BotIcon` is exported by the installed `lucide-react` package

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.y7nAoVmwI_HPpSp_j6CZYDRdP-pazHdm1gQZHUa_JM35vv08rrd06EkXfUk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->