### PR TITLE
fix(react-mcp): handle custom storage failures

### DIFF
--- a/.changeset/handle-react-mcp-storage-failures.md
+++ b/.changeset/handle-react-mcp-storage-failures.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: handle custom MCP server storage failures

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -4,7 +4,9 @@ import { defineConnector } from "../connector";
 import type { MCPConnector } from "../mcp-scope";
 import { assertUniqueServerIds } from "../utils/serverId";
 import { McpManagerResource } from "./McpManagerResource";
+import { McpCustomStorage } from "./storage/McpCustomStorage";
 import { McpMemoryStorage } from "./storage/McpMemoryStorage";
+import type { MCPStorageElement } from "./storage/types";
 
 const mocks = vi.hoisted(() => {
   const Client = vi.fn().mockImplementation(function Client(this: any) {
@@ -41,12 +43,15 @@ const connector = (id: string, name = id): MCPConnector =>
     auth: { type: "none" },
   });
 
-const mount = (connectors: MCPConnector[]) =>
+const mount = (
+  connectors: MCPConnector[],
+  storage: MCPStorageElement = McpMemoryStorage(),
+) =>
   createTapRoot(function Root() {
     return useResource(
       McpManagerResource({
         connectors,
-        storage: McpMemoryStorage(),
+        storage,
         autoConnect: false,
       }),
     );
@@ -118,6 +123,88 @@ describe("McpManagerResource server ids", () => {
       );
     } finally {
       root.unmount();
+    }
+  });
+});
+
+describe("McpManagerResource storage failures", () => {
+  it("handles custom server load failures", async () => {
+    const error = new Error("load failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const root = mount(
+      [],
+      McpCustomStorage({
+        loadCustomServers: vi.fn(async () => {
+          throw error;
+        }),
+        saveCustomServers: vi.fn(async () => {}),
+        loadAuthState: vi.fn(async () => null),
+        saveAuthState: vi.fn(async () => {}),
+        clearAuthState: vi.fn(async () => {}),
+      }),
+    );
+
+    try {
+      await vi.waitFor(() =>
+        expect(root.getValue().getState().isHydrated).toBe(true),
+      );
+      expect(root.getValue().getState().customServers).toHaveLength(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui/react-mcp] failed to load custom servers:",
+        error,
+      );
+    } finally {
+      root.unmount();
+      consoleError.mockRestore();
+    }
+  });
+
+  it("handles custom server save failures", async () => {
+    const error = new Error("save failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const saveCustomServers = vi.fn(async () => {});
+    const root = mount(
+      [],
+      McpCustomStorage({
+        loadCustomServers: vi.fn(async () => []),
+        saveCustomServers,
+        loadAuthState: vi.fn(async () => null),
+        saveAuthState: vi.fn(async () => {}),
+        clearAuthState: vi.fn(async () => {}),
+      }),
+    );
+
+    try {
+      await vi.waitFor(() =>
+        expect(root.getValue().getState().isHydrated).toBe(true),
+      );
+      await vi.waitFor(() => expect(saveCustomServers).toHaveBeenCalled());
+      saveCustomServers.mockClear();
+      saveCustomServers.mockRejectedValue(error);
+
+      await root.getValue().addCustomServer({
+        name: "Docs",
+        url: "https://example.com/docs/mcp",
+        auth: { type: "none" },
+      });
+
+      await vi.waitFor(() => {
+        expect(saveCustomServers).toHaveBeenCalledWith([
+          expect.objectContaining({ name: "Docs" }),
+        ]);
+        expect(root.getValue().getState().customServers).toHaveLength(1);
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui/react-mcp] failed to save custom servers:",
+        error,
+      );
+    } finally {
+      root.unmount();
+      consoleError.mockRestore();
     }
   });
 });

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -39,6 +39,16 @@ function defaultRedirectUri(): string {
 // array each render (which would invalidate the serverElements memo below).
 const NO_CONNECTORS: MCPConnector[] = [];
 
+const reportCustomStorageFailure = (
+  operation: "load" | "save",
+  error: unknown,
+) => {
+  console.error(
+    `[assistant-ui/react-mcp] failed to ${operation} custom servers:`,
+    error,
+  );
+};
+
 const useMcpManagerResource = (
   props: McpManagerResourceProps,
 ): ClientOutput<"mcp"> => {
@@ -69,8 +79,11 @@ const useMcpManagerResource = (
     try {
       records = await storage.loadCustomServers();
     } catch (error) {
+      if (!signal.cancelled) {
+        reportCustomStorageFailure("load", error);
+      }
       markHydrated();
-      throw error;
+      return;
     }
 
     if (signal.cancelled) return;
@@ -96,7 +109,11 @@ const useMcpManagerResource = (
   const persistCustomServers = useEffectEvent(
     async (records: MCPCustomServerRecord[]) => {
       if (!hydratedRef.current) return;
-      await storage.saveCustomServers(records);
+      try {
+        await storage.saveCustomServers(records);
+      } catch (error) {
+        reportCustomStorageFailure("save", error);
+      }
     },
   );
 


### PR DESCRIPTION
## Summary

- handle rejected custom MCP server load and save operations inside `McpManagerResource`
- report failures with operation-specific React MCP context instead of producing global unhandled rejections
- verify failed loads hydrate without persisted servers and failed saves preserve in-memory state
- add regression coverage for custom storage implementations and a patch changeset

## Why

Custom `McpCustomStorage` implementations may use IndexedDB or remote persistence, where reads and writes can reject because the database is unavailable, access is blocked, or the network fails. The manager started both operations as fire-and-forget promises, so those expected infrastructure failures escaped as global `unhandledrejection` events.

The load path now logs the failure and returns after the existing hydration-completion step, leaving no persisted custom servers. The save path logs the failure while preserving the existing in-memory server state. Successful storage behavior is unchanged.

## Verification

- reproduced both failures before the fix; Vitest reported unhandled `load failed` and `save failed` rejections
- `packages/react-mcp/node_modules/.bin/vitest run packages/react-mcp/src` (90 tests)
- `oxlint packages/react-mcp/src/resources/McpManagerResource.ts packages/react-mcp/src/resources/McpManagerResource.test.ts`
- `oxfmt --check packages/react-mcp/src/resources/McpManagerResource.ts packages/react-mcp/src/resources/McpManagerResource.test.ts .changeset/handle-react-mcp-storage-failures.md`
- `aui-build` in `packages/react-mcp`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5mdT_0_z15lDDjUcGYHzVzSiPtKxD3mWDiVooMblNZ_5IrdTZYa9yGUKRkk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->