### PR TITLE
fix(cloud-ai-sdk): handle finish callback failures

### DIFF
--- a/.changeset/handle-cloud-finish-callback-errors.md
+++ b/.changeset/handle-cloud-finish-callback-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: preserve AI SDK finish callback error handling

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.test.ts
@@ -85,4 +85,45 @@ describe("CloudChatCore", () => {
     expect(onToolCall).toHaveBeenCalledWith({ toolCall: {} });
     expect(result).toBe(completion);
   });
+
+  it("preserves synchronous finish callback failures", () => {
+    const error = new Error("finish failed");
+    const onFinish = vi.fn(() => {
+      throw error;
+    });
+    const core = createCore({ chatConfig: { onFinish } });
+    const persistChatMessages = vi
+      .spyOn(core, "persistChatMessages")
+      .mockResolvedValue(undefined);
+
+    core.createChat("chat-1", {} as never);
+
+    const wrappedOnFinish = chatOptionsRef.current?.onFinish;
+    expect(wrappedOnFinish).toBeTypeOf("function");
+
+    expect(() => (wrappedOnFinish as (event: unknown) => unknown)({})).toThrow(
+      error,
+    );
+    expect(persistChatMessages).toHaveBeenCalledWith(
+      "chat-1",
+      expect.anything(),
+      {},
+    );
+  });
+
+  it("reports finish persistence failures", async () => {
+    const error = new Error("persistence failed");
+    const onSyncError = vi.fn();
+    const core = createCore({ onSyncError });
+    vi.spyOn(core, "persistChatMessages").mockRejectedValue(error);
+
+    core.createChat("chat-1", {} as never);
+
+    const wrappedOnFinish = chatOptionsRef.current?.onFinish;
+    expect(wrappedOnFinish).toBeTypeOf("function");
+    const result = (wrappedOnFinish as (event: unknown) => unknown)({});
+
+    expect(result).toBeUndefined();
+    await vi.waitFor(() => expect(onSyncError).toHaveBeenCalledWith(error));
+  });
 });

--- a/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
+++ b/packages/cloud-ai-sdk/src/core/CloudChatCore.ts
@@ -194,11 +194,15 @@ export class CloudChatCore {
       ...chatInit,
       id: chatKey,
       transport: this.createTransport(chatKey, registry),
-      onFinish: async (event) => {
+      onFinish: (event) => {
         try {
           this.options.chatConfig.onFinish?.(event);
         } finally {
-          await this.persistChatMessages(chatKey, registry, event);
+          void this.persistChatMessages(chatKey, registry, event).catch(
+            (error) => {
+              this.handleSyncError(error);
+            },
+          );
         }
       },
       onError: (error) => {


### PR DESCRIPTION
## Summary

- keep the Cloud `onFinish` wrapper synchronous so user callback failures remain visible to AI SDK's error handling
- continue Cloud message persistence from `finally`, even when the user callback throws
- route detached persistence failures through the existing `onSyncError` callback
- add v6/v7 regression coverage and a patch changeset

## Why

AI SDK's `Chat` invokes `onFinish` inside a synchronous `try/catch` and does not await its return value. Cloud wrapped that callback in an `async` function, so a synchronous exception from an app's `onFinish` became a rejected Promise after Cloud persistence completed. AI SDK could not catch that rejection, leaving the callback failure ignored or reported as an unhandled rejection.

The wrapper now returns `void`, matching AI SDK's contract. User callback errors are thrown synchronously, while Cloud persistence still starts in `finally` and reports its own asynchronous failures through `onSyncError`.

## Verification

- reproduced the old wrapper returning a rejected Promise instead of throwing synchronously
- AI SDK v7 suite: 68 tests passed
- AI SDK v6 peer suite: 68 tests passed
- peer-v6 TypeScript check passed
- focused lint and formatting checks passed
- `aui-build` passed for `@assistant-ui/cloud-ai-sdk`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.k22eRNPI16twi3E0azyD5HOjwVjSDfiFxw5CXxmWrPxFPnM2Yp2RNcFZr2U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->