### PR TITLE
fix: proxy invariant violation in store client/state proxies

### DIFF
--- a/.changeset/proxy-invariant-configurable.md
+++ b/.changeset/proxy-invariant-configurable.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: report proxy properties as configurable so `Object.keys`, spread, and `Object.getOwnPropertyDescriptor` on clients and the proxied assistant state no longer throw the proxy invariant TypeError

--- a/packages/store/src/__tests__/proxy-invariants.test.tsx
+++ b/packages/store/src/__tests__/proxy-invariants.test.tsx
@@ -62,6 +62,16 @@ describe("proxy invariants", () => {
     ).toBe(true);
   });
 
+  it("keeps method identity and a callable descriptor value across descriptor reads", () => {
+    render(<App />);
+    const client = probe.aui.thread().item({ index: 0 });
+
+    const echo = client.echo;
+    const descriptor = Object.getOwnPropertyDescriptor(client, "echo");
+    expect(descriptor!.value("hi")).toBe("hi");
+    expect(client.echo).toBe(echo);
+  });
+
   it("supports Object.keys and spread on the proxied state", () => {
     render(<App />);
 

--- a/packages/store/src/__tests__/proxy-invariants.test.tsx
+++ b/packages/store/src/__tests__/proxy-invariants.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import type { FC } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { resource, withKey } from "@assistant-ui/tap";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { useClientLookup } from "../useClientLookup";
+
+const useItem = ({ id }: { id: string }) => ({
+  getState: () => ({ id }),
+  echo: (text: string) => text,
+});
+const Item = resource(useItem);
+
+const useThread = () => {
+  const items = useClientLookup([withKey("a", Item({ id: "a" }))]);
+  return {
+    getState: () => ({ count: 1 }),
+    item: (lookup: { index: number }) => items.get(lookup),
+  };
+};
+const Thread = resource(useThread);
+
+const probe: { aui: any; state: any } = { aui: null, state: null };
+
+const App: FC = () => {
+  const aui = useAui({ thread: Thread() } as unknown as useAui.Props);
+  probe.aui = aui;
+  return (
+    <AuiProvider value={aui}>
+      <Leaf />
+    </AuiProvider>
+  );
+};
+
+const Leaf: FC = () => {
+  useAuiState((s) => {
+    probe.state = s;
+    return null;
+  });
+  return null;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("proxy invariants", () => {
+  it("supports Object.keys and spread on a client", () => {
+    render(<App />);
+    const client = probe.aui.thread().item({ index: 0 });
+
+    expect(Object.keys(client)).toEqual(["getState", "echo"]);
+    const spread = { ...client };
+    expect(Object.keys(spread)).toEqual(["getState", "echo"]);
+    expect(spread.echo("hi")).toBe("hi");
+    expect(
+      Object.getOwnPropertyDescriptor(client, "getState")?.configurable,
+    ).toBe(true);
+  });
+
+  it("supports Object.keys and spread on the proxied state", () => {
+    render(<App />);
+
+    expect(Object.keys(probe.state)).toEqual(["thread", "optional"]);
+    const spread = { ...probe.state };
+    expect(spread.thread).toEqual({ count: 1 });
+    expect(
+      Object.getOwnPropertyDescriptor(probe.state, "thread")?.configurable,
+    ).toBe(true);
+  });
+});

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -101,7 +101,7 @@ class ClientProxyHandler
     if (introspection !== false) return introspection;
     const value = this.outputRef.current[prop];
     if (typeof value === "function") {
-      if (this.cachedReceiver !== receiver) {
+      if (!this.boundFns || this.cachedReceiver !== receiver) {
         this.boundFns = new Map();
         this.cachedReceiver = receiver;
       }

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -101,6 +101,9 @@ class ClientProxyHandler
     if (introspection !== false) return introspection;
     const value = this.outputRef.current[prop];
     if (typeof value === "function") {
+      // receiver-less reads (getOwnPropertyDescriptor) get the raw method so
+      // the bound-fn cache stays keyed on the real receiver
+      if (receiver === undefined) return value;
       if (!this.boundFns || this.cachedReceiver !== receiver) {
         this.boundFns = new Map();
         this.cachedReceiver = receiver;

--- a/packages/store/src/utils/BaseProxyHandler.ts
+++ b/packages/store/src/utils/BaseProxyHandler.ts
@@ -28,7 +28,8 @@ export abstract class BaseProxyHandler implements ProxyHandler<object> {
       value,
       writable: false,
       enumerable: true,
-      configurable: false,
+      // must be configurable: the invariant forbids non-configurable props absent from the empty target
+      configurable: true,
     };
   }
 


### PR DESCRIPTION
## Bug

`BaseProxyHandler.getOwnPropertyDescriptor` reported `{ writable: false, configurable: false }` descriptors, but the proxy targets are empty `{}` objects. The JS proxy invariant forbids reporting a non-configurable own property that does not exist on the target, so `Object.keys(...)`, spread (`{...client}`), and `Object.getOwnPropertyDescriptor` threw `TypeError: proxy can't report a non-configurable own property` on the proxied `AssistantState` (e.g. `Object.keys(s)` inside a `useAuiState` selector) and on raw client proxies. On client proxies the descriptor path additionally crashed with `TypeError: Cannot read properties of undefined (reading 'get')` because `ClientProxyHandler.get` never initialized its bound-function cache when invoked without a receiver.

## Fix

- `BaseProxyHandler` now reports `configurable: true` (mirroring `client-accessor.ts`).
- `ClientProxyHandler.get` initializes `boundFns` when the cache is absent, not only on receiver change.

## Contract test

`packages/store/src/__tests__/proxy-invariants.test.tsx` covers `Object.keys`, spread, and `Object.getOwnPropertyDescriptor` on a real client (via `useClientLookup` item) and on the proxied state (via a `useAuiState` selector), rendered through `useAui`.

Refs sw-102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Wx9bSyd2fNai6zgX0lXY6DVh2CjRaujBylfIE8txLP7uWIaVx0DqdHIefGc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->