### PR TITLE
fix(store): replay-safe initial-data handles in useClientList

### DIFF
--- a/.changeset/client-list-replay-safe.md
+++ b/.changeset/client-list-replay-safe.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+useClientList: clear initial-data handles on commit instead of during render so discarded renders can replay

--- a/packages/store/src/__tests__/useClientList.test.tsx
+++ b/packages/store/src/__tests__/useClientList.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { StrictMode, Suspense, useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { resource } from "@assistant-ui/tap";
+import { useClientList } from "../useClientList";
+
+type ItemData = { id: string; label: string };
+
+const ItemResource = resource(
+  ({ key, getInitialData, remove }: useClientList.ResourceProps<ItemData>) => {
+    const [data, setData] = useState(getInitialData);
+    return {
+      getState: () => ({ key, label: data.label }),
+      setLabel: (label: string) => setData((d) => ({ ...d, label })),
+      remove,
+    };
+  },
+);
+
+type ListApi = ReturnType<typeof useClientList<ItemData, any>>;
+
+const setup = (initialValues: ItemData[]) => {
+  let api!: ListApi;
+  const List = () => {
+    api = useClientList<ItemData, any>({
+      initialValues,
+      getKey: (data) => data.id,
+      resource: ItemResource,
+    });
+    return null;
+  };
+  const view = render(
+    <StrictMode>
+      <List />
+    </StrictMode>,
+  );
+  return { getApi: () => api, view };
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useClientList", () => {
+  it("mounts initial items under StrictMode double-rendering", () => {
+    const { getApi } = setup([
+      { id: "a", label: "first" },
+      { id: "b", label: "second" },
+    ]);
+
+    expect(getApi().state).toEqual([
+      { key: "a", label: "first" },
+      { key: "b", label: "second" },
+    ]);
+    expect(getApi().get({ key: "b" }).getState()).toEqual({
+      key: "b",
+      label: "second",
+    });
+  });
+
+  it("adds items whose initial data survives replayed renders", () => {
+    const { getApi } = setup([{ id: "a", label: "first" }]);
+
+    act(() => {
+      getApi().add({ id: "b", label: "added" });
+    });
+
+    expect(getApi().state).toEqual([
+      { key: "a", label: "first" },
+      { key: "b", label: "added" },
+    ]);
+  });
+
+  it("removes items via the resource's remove prop", () => {
+    const { getApi } = setup([
+      { id: "a", label: "first" },
+      { id: "b", label: "second" },
+    ]);
+
+    act(() => {
+      getApi().get({ key: "a" }).remove();
+    });
+
+    expect(getApi().state).toEqual([{ key: "b", label: "second" }]);
+    expect(() => getApi().get({ key: "a" })).toThrow(/not found/);
+  });
+
+  it("replays getInitialData after a discarded render (suspended sibling)", async () => {
+    let resolve!: () => void;
+    let done = false;
+    const promise = new Promise<void>((r) => (resolve = r)).then(() => {
+      done = true;
+    });
+    const Suspender = () => {
+      if (!done) throw promise;
+      return null;
+    };
+
+    let api!: ListApi;
+    const List = () => {
+      api = useClientList<ItemData, any>({
+        initialValues: [{ id: "a", label: "first" }],
+        getKey: (data) => data.id,
+        resource: ItemResource,
+      });
+      return null;
+    };
+
+    render(
+      <Suspense fallback={null}>
+        <List />
+        <Suspender />
+      </Suspense>,
+    );
+
+    await act(async () => {
+      resolve();
+      await promise;
+    });
+
+    expect(api.state).toEqual([{ key: "a", label: "first" }]);
+  });
+
+  it("rejects adding a duplicate key", () => {
+    const { getApi } = setup([{ id: "a", label: "first" }]);
+
+    expect(() =>
+      act(() => {
+        getApi().add({ id: "a", label: "dupe" });
+      }),
+    ).toThrow(/already exists/);
+  });
+});

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { withKey, type Resource } from "@assistant-ui/tap";
 
 import { useClientLookup } from "./useClientLookup";
@@ -42,7 +42,7 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
 
   type Props = useClientList.ResourceProps<TData>;
 
-  const initialDataHandles: DataHandle<TData>[] = useMemo(() => [], []);
+  const initialDataHandles = useRef<DataHandle<TData>[]>([]).current;
 
   const [items, setItems] = useState<Record<string, Props>>(() => {
     const entries: [string, Props][] = [];
@@ -71,9 +71,13 @@ export const useClientList = <TData, TMethods extends ClientMethods>(
     ),
   );
 
-  initialDataHandles.forEach((handle) => {
-    handle.data = undefined;
-    handle.hasData = false;
+  // Clear on commit, not during render, so discarded renders can replay
+  useEffect(() => {
+    for (const handle of initialDataHandles) {
+      handle.data = undefined;
+      handle.hasData = false;
+    }
+    initialDataHandles.length = 0;
   });
 
   const add = (data: TData) => {


### PR DESCRIPTION
## Summary

useClientList kept its initial-data handles in a deps-less useMemo and cleared them during render. Render-phase mutation is unsafe under discarded/replayed renders: a discarded pass that already cleared the handles can leave a replayed child's getInitialData() with no data.

- Hold the handle list in a useRef instead of useMemo(() => [], []) (it was a ref in disguise).
- Clear the handles in a commit effect instead of during render, keeping renders pure and replay-safe.
- Add contract tests for useClientList: StrictMode mount, add/remove lifecycle, duplicate-key rejection, and a discard+replay pass via a suspended sibling in the same Suspense boundary.

Note on reproducibility: neither StrictMode double-rendering nor a suspended-sibling discard reproduces a failure on the previous code in a test (both vehicles pass before and after). The change is motivated by render purity — the clearing was a render-phase side effect — and the tests pin the intended contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.h6W1StNwt0xVy_AIdq_RBgE55laPqWOqlZacrhMXD8klgXYk088UXOza1Dg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->