### PR TITLE
refactor(store): single shared InferClientState type

### DIFF
--- a/.changeset/shared-infer-client-state.md
+++ b/.changeset/shared-infer-client-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+Share a single InferClientState type across useClientResource, useClientLookup, and useClientList

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -120,14 +120,6 @@ type Hook = (...args: any[]) => any;
 
 type InferClientState<TMethods> = TMethods extends {
   getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$1<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$2<TMethods> = TMethods extends {
-  getState: () => infer S;
 } ? S : undefined;
 
 type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
@@ -257,7 +249,7 @@ declare namespace useClientList {
 }
 
 declare function useClientLookup<TMethods extends ClientMethods>(elements: readonly ResourceElement<TMethods>[]): {
-  state: InferClientState$1<TMethods>[];
+  state: InferClientState<TMethods>[];
   get: (lookup: {
     index: number;
   } | {
@@ -266,7 +258,7 @@ declare function useClientLookup<TMethods extends ClientMethods>(elements: reado
 };
 
 declare const useClientResource: <TMethods extends ClientMethods>(element: ResourceElement<TMethods>) => {
-  state: InferClientState$2<TMethods>;
+  state: InferClientState<TMethods>;
   methods: TMethods;
   key: string | number | undefined;
 };

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -154,6 +154,12 @@ export type ClientElement<K extends ClientNames> = ResourceElement<
  */
 export type Unsubscribe = () => void;
 
+export type InferClientState<TMethods> = TMethods extends {
+  getState: () => infer S;
+}
+  ? S
+  : undefined;
+
 type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -2,13 +2,7 @@ import { useMemo, useState } from "react";
 import { withKey, type Resource } from "@assistant-ui/tap";
 
 import { useClientLookup } from "./useClientLookup";
-import type { ClientMethods } from "./types/client";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
+import type { ClientMethods, InferClientState } from "./types/client";
 
 type DataHandle<TData> = { data: TData | undefined; hasData: boolean };
 

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -1,13 +1,7 @@
 import { useMemo } from "react";
 import { useResources, withKey, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import { ClientResource } from "./useClientResource";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
 
 const getElementKey = (el: ResourceElement<unknown>) => {
   if (el.key === undefined) {

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { resource, useResource, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import {
   useClientStack,
   useClientStackProvider,
@@ -125,12 +125,6 @@ class ClientProxyHandler
     return prop in this.outputRef.current;
   }
 }
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : undefined;
 
 export const useClientResource = <TMethods extends ClientMethods>(
   element: ResourceElement<TMethods>,


### PR DESCRIPTION
## Summary

InferClientState was defined three times with divergent fallbacks: useClientList.ts and useClientLookup.ts fell back to unknown, useClientResource.ts to undefined. All three now import a single shared type from types/client.ts (internal export, not re-exported from the package entrypoint).

## Fallback choice: undefined

When a client's methods lack getState(), all three call sites compute the state as (value as any).getState?.() — the runtime value is literally undefined. The undefined fallback is therefore both sound and precise at every site; the unknown fallback at the list/lookup sites merely hid the same undefined behind an unusable type. Narrowing unknown to undefined cannot make a previously well-typed consumer unsound (undefined is assignable wherever the unknown-typed value was already usable only after narrowing).

Verified: @assistant-ui/store tests (30 passed) and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.68Mjb9z2uSZE68FKA2Sq1NJs7H9Q3VVOJZyQORvrfhcpAczf-698EOwxpeQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5365
- <kbd>&nbsp;2&nbsp;</kbd> #5360
- <kbd>&nbsp;1&nbsp;</kbd> #5356 👈 
<!-- GitButler Footer Boundary Bottom -->