### PR TITLE
refactor(tap): hoist createTapRoot's scheduler out of dispatch

### DIFF
--- a/.changeset/tap-root-single-scheduler.md
+++ b/.changeset/tap-root-single-scheduler.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+createTapRoot: reuse a single per-root UpdateScheduler across dispatches and assert without applying first

--- a/packages/tap/src/core/createTapRoot.ts
+++ b/packages/tap/src/core/createTapRoot.ts
@@ -12,16 +12,20 @@ import { createResourceFiberRoot } from "./helpers/root";
 export const createTapRoot = <R>(
   render: () => R,
 ): useTapRoot.Root<R> & { unmount: () => void } => {
+  const pendingEvaluates: (() => boolean)[] = [];
+  const scheduler = new UpdateScheduler(() => {
+    for (const evaluate of pendingEvaluates.splice(0)) {
+      if (evaluate()) {
+        throw new Error("Unexpected rerender of createTapRoot outer fiber");
+      }
+    }
+  });
+
   const fiber = createResourceFiber(
     useTapRoot,
-    createResourceFiberRoot((evaluate, apply) => {
-      new UpdateScheduler(() => {
-        if (evaluate()) {
-          apply();
-          throw new Error("Unexpected rerender of createTapRoot outer fiber");
-        }
-        return false;
-      }).markDirty();
+    createResourceFiberRoot((evaluate) => {
+      pendingEvaluates.push(evaluate);
+      scheduler.markDirty();
     }),
     undefined,
     isDevelopment ? "root" : null,


### PR DESCRIPTION
## Summary

createTapRoot allocated a new UpdateScheduler on every dispatch, whose task called apply() and then threw as an impossible-branch assertion — mutating root state before failing.

- One UpdateScheduler is now created per root; dispatches push their evaluate closure onto a queue and mark the shared scheduler dirty.
- The impossible branch (an evaluate reporting pending work for the outer fiber, which never re-renders) now throws without applying first.

Verified: @assistant-ui/tap tests (454 passed) and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7IhnDf64yCweWXLQlqjRPQSlQfStPPAQ1NkCp9WuI0mg4aWy95DHWkWfcmY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->