### PR TITLE
refactor(tap): shared throwAggregated error helper

### DIFF
--- a/.changeset/tap-throw-aggregated.md
+++ b/.changeset/tap-throw-aggregated.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+Deduplicate the rethrow-or-AggregateError error handling into a shared internal helper

--- a/packages/tap/src/core/helpers/commit.ts
+++ b/packages/tap/src/core/helpers/commit.ts
@@ -1,4 +1,5 @@
 import type { CommitCallbacks, ResourceFiber } from "../types";
+import { throwAggregated } from "./throwAggregated";
 
 export const CommitPriority = {
   HookState: 0,
@@ -34,16 +35,7 @@ export function commitAllCallbacks(callbacks: CommitCallbacks): void {
     }
   }
 
-  if (errors.length > 0) {
-    if (errors.length === 1) {
-      throw errors[0];
-    } else {
-      for (const error of errors) {
-        console.error(error);
-      }
-      throw new AggregateError(errors, "Errors during commit");
-    }
-  }
+  throwAggregated(errors, "Errors during commit");
 }
 
 export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {
@@ -63,14 +55,5 @@ export function cleanupAllEffects<R>(executionContext: ResourceFiber<R>) {
       }
     }
   }
-  if (errors.length > 0) {
-    if (errors.length === 1) {
-      throw errors[0];
-    } else {
-      for (const error of errors) {
-        console.error(error);
-      }
-      throw new AggregateError(errors, "Errors during cleanup");
-    }
-  }
+  throwAggregated(errors, "Errors during cleanup");
 }

--- a/packages/tap/src/core/helpers/throwAggregated.ts
+++ b/packages/tap/src/core/helpers/throwAggregated.ts
@@ -1,0 +1,8 @@
+export const throwAggregated = (errors: unknown[], message: string): void => {
+  if (errors.length === 0) return;
+  if (errors.length === 1) throw errors[0];
+  for (const error of errors) {
+    console.error(error);
+  }
+  throw new AggregateError(errors, message);
+};

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -1,3 +1,5 @@
+import { throwAggregated } from "./helpers/throwAggregated";
+
 type Task = () => void;
 
 type GlobalFlushState = {
@@ -68,16 +70,7 @@ const flushScheduled = () => {
       }
     }
 
-    if (errors.length > 0) {
-      if (errors.length === 1) {
-        throw errors[0];
-      } else {
-        for (const error of errors) {
-          console.error(error);
-        }
-        throw new AggregateError(errors, "Errors occurred during flushSync");
-      }
-    }
+    throwAggregated(errors, "Errors occurred during flushSync");
   } finally {
     flushState.schedulers.clear();
     flushState.isScheduled = false;


### PR DESCRIPTION
## Summary

tap carried three identical error-aggregation blocks (scheduler flush, commit callbacks, effect cleanup): rethrow a single error as-is; for several, console.error each and throw an AggregateError.

- New internal helper throwAggregated(errors, message) in core/helpers/throwAggregated.ts; not exported from the package entrypoint.
- scheduler.ts and the two commit.ts sites now call it. Behavior, messages, and logging are byte-for-byte unchanged.
- Per review direction, store's NotificationManager keeps its own copy; the helper is tap-internal.

Verified: @assistant-ui/tap tests (454 passed) and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eQdH3PRfQFxhBWfF6afewJsR5XSOIiPdHleaa6V2kgqtCOZtW53NrMJVND8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

