### PR TITLE
fix(store): shallow-compare scope meta query instead of spreading deps

### DIFF
--- a/.changeset/scope-meta-shallow-equal.md
+++ b/.changeset/scope-meta-shallow-equal.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+useAui: memoize scope meta via shallow equality on the query object instead of a spread deps array, so query key-count changes are detected reliably

--- a/.changeset/shared-infer-client-state.md
+++ b/.changeset/shared-infer-client-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+Share a single InferClientState type across useClientResource, useClientLookup, and useClientList

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -120,14 +120,6 @@ type Hook = (...args: any[]) => any;
 
 type InferClientState<TMethods> = TMethods extends {
   getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$1<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$2<TMethods> = TMethods extends {
-  getState: () => infer S;
 } ? S : undefined;
 
 type ParentOf<K extends ClientNames> = ClientMeta<K> extends {
@@ -257,7 +249,7 @@ declare namespace useClientList {
 }
 
 declare function useClientLookup<TMethods extends ClientMethods>(elements: readonly ResourceElement<TMethods>[]): {
-  state: InferClientState$1<TMethods>[];
+  state: InferClientState<TMethods>[];
   get: (lookup: {
     index: number;
   } | {
@@ -266,7 +258,7 @@ declare function useClientLookup<TMethods extends ClientMethods>(elements: reado
 };
 
 declare const useClientResource: <TMethods extends ClientMethods>(element: ResourceElement<TMethods>) => {
-  state: InferClientState$2<TMethods>;
+  state: InferClientState<TMethods>;
   methods: TMethods;
   key: string | number | undefined;
 };

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -154,6 +154,12 @@ export type ClientElement<K extends ClientNames> = ResourceElement<
  */
 export type Unsubscribe = () => void;
 
+export type InferClientState<TMethods> = TMethods extends {
+  getState: () => infer S;
+}
+  ? S
+  : undefined;
+
 type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -194,13 +194,31 @@ const useClientFields = ({
   );
 };
 
+const shallowEqualRecord = (
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+) => {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length &&
+    aKeys.every((key) => Object.hasOwn(b, key) && Object.is(a[key], b[key]))
+  );
+};
+
 const useScopeMeta = (element: ScopeElement): ScopeMeta => {
   const { source, query } = metaOf(element);
-  // oxlint-disable-next-line react-hooks/exhaustive-deps -- shallow memo over the query's entries
-  return useMemo(
-    () => ({ source, query }),
-    [source, ...Object.entries(query).flat()],
-  );
+  const cache = useMemoCache(1) as [ScopeMeta | typeof MEMO_CACHE_UNFILLED];
+  const prev = cache[0];
+  if (
+    prev !== MEMO_CACHE_UNFILLED &&
+    prev.source === source &&
+    shallowEqualRecord(prev.query, query)
+  ) {
+    return prev;
+  }
+  const meta = { source, query };
+  cache[0] = meta;
+  return meta;
 };
 
 const useScopeValue = (element: ScopeElement, derived: boolean) =>

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -2,13 +2,7 @@ import { useMemo, useState } from "react";
 import { withKey, type Resource } from "@assistant-ui/tap";
 
 import { useClientLookup } from "./useClientLookup";
-import type { ClientMethods } from "./types/client";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
+import type { ClientMethods, InferClientState } from "./types/client";
 
 type DataHandle<TData> = { data: TData | undefined; hasData: boolean };
 

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -1,13 +1,7 @@
 import { useMemo } from "react";
 import { useResources, withKey, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import { ClientResource } from "./useClientResource";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
 
 const getElementKey = (el: ResourceElement<unknown>) => {
   if (el.key === undefined) {

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { resource, useResource, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import {
   useClientStack,
   useClientStackProvider,
@@ -125,12 +125,6 @@ class ClientProxyHandler
     return prop in this.outputRef.current;
   }
 }
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : undefined;
 
 export const useClientResource = <TMethods extends ClientMethods>(
   element: ResourceElement<TMethods>,


### PR DESCRIPTION
## Summary

useScopeMeta memoized { source, query } with a deps array spread from Object.entries(query).flat(). Deps arrays whose length changes between renders are prefix-compared in production (a key-count change could go undetected) and console.error in development.

- Cache the meta with useMemoCache and an explicit shallow-equality check over the query record (key count, Object.hasOwn, Object.is per key), mirroring the existing useStableArray idiom in the same file.
- A change in the set of query keys now always produces a fresh meta object.

Verified: @assistant-ui/store tests (30 passed) and typecheck.

Note: stacked textually independent of, but in the same file as, the upcoming sw-116/sw-106 changes; those PRs will be based on separate lanes touching different regions of useAui.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QsGF-d80zwZvxOGjCDIpkbvwbkQuLTVXFahmukvQhlOBfrAfxw9C_utR-34?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5365
- <kbd>&nbsp;2&nbsp;</kbd> #5360 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5356
<!-- GitButler Footer Boundary Bottom -->