### PR TITLE
refactor(store): drop redundant keys memo in useClientLookup

### DIFF
--- a/.changeset/client-lookup-cleanup.md
+++ b/.changeset/client-lookup-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+useClientLookup: derive the key-to-index map from the validated element keys and drop the redundant keys memo

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -29,18 +29,15 @@ export function useClientLookup<TMethods extends ClientMethods>(
     ),
   );
 
-  const keys = useMemo(() => Object.keys(resources), [resources]);
-
-  // For arrays, track element key -> index mapping
   const keyToIndex = useMemo(() => {
-    return resources.reduce(
-      (acc, resource, index) => {
-        acc[resource.key!] = index;
+    return elements.reduce(
+      (acc, element, index) => {
+        acc[getElementKey(element)] = index;
         return acc;
       },
       {} as Record<string, number>,
     );
-  }, [resources]);
+  }, [elements]);
 
   const state = useMemo(() => {
     return resources.map((r) => r.state);
@@ -50,9 +47,9 @@ export function useClientLookup<TMethods extends ClientMethods>(
     state,
     get: (lookup: { index: number } | { key: string }) => {
       if ("index" in lookup) {
-        if (lookup.index < 0 || lookup.index >= keys.length) {
+        if (lookup.index < 0 || lookup.index >= resources.length) {
           throw new Error(
-            `useClientLookup: index ${lookup.index} out of bounds (length: ${keys.length}) (ignore if recovered)`,
+            `useClientLookup: index ${lookup.index} out of bounds (length: ${resources.length}) (ignore if recovered)`,
           );
         }
         return resources[lookup.index]!.methods;


### PR DESCRIPTION
## Summary

Pure cleanup, no behavior change:

- The useMemo(Object.keys(resources)) array existed only for a length check; the index bounds check now uses resources.length directly.
- The key-to-index map is built from the elements via the existing getElementKey validator, removing the resource.key! non-null assertion. Its memo now also depends on elements, which is the only input it reads.

Verified: @assistant-ui/store tests (30 passed) and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FUoPm7h7bW4ZeoGxe6JPycwd7wXUHoLXKfqEQKBKcHutTp-mXW_PfEGLHe0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->