### PR TITLE
refactor(tap): drop the server snapshot branch in useSyncExternalStore

### DIFF
--- a/.changeset/tap-uses-no-server-snapshot.md
+++ b/.changeset/tap-uses-no-server-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+useSyncExternalStore: ignore getServerSnapshot — tap never hydrates, so the first render reads the client snapshot directly

--- a/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
+++ b/packages/tap/src/__tests__/basic/useSyncExternalStore.test.ts
@@ -75,21 +75,23 @@ describe("useSyncExternalStore", () => {
     expect(renders).toBe(rendersAfterMount);
   });
 
-  it("uses getServerSnapshot for the first render and corrects to getSnapshot on mount", async () => {
+  it("ignores getServerSnapshot; the first render uses the client snapshot", async () => {
     const store = createStore("client");
-    const testFiber = createTestResource(() =>
-      useSyncExternalStore(
+    let renders = 0;
+    const testFiber = createTestResource(() => {
+      renders++;
+      return useSyncExternalStore(
         (cb) => store.subscribe(cb),
         () => store.getState(),
         () => "server",
-      ),
-    );
+      );
+    });
 
-    // the first render itself returns the server snapshot
-    expect(renderTest(testFiber)).toBe("server");
-    // the mount effect detects the mismatch and re-renders with the client read
+    // tap never hydrates, so there is no server pass and no correction render
+    expect(renderTest(testFiber)).toBe("client");
     await waitForNextTick();
     expect(getCommittedValue(testFiber)).toBe("client");
+    expect(renders).toBe(1);
   });
 
   it("does not re-render when server and client snapshots match", async () => {

--- a/packages/tap/src/react-hooks/useSyncExternalStore.ts
+++ b/packages/tap/src/react-hooks/useSyncExternalStore.ts
@@ -1,16 +1,14 @@
 import { useState } from "./useState";
 import { useEffect } from "./useEffect";
 import { useEffectEvent } from "./useEffectEvent";
-import { useRef } from "./useRef";
 
 export const useSyncExternalStore = <T>(
   subscribe: (onStoreChange: () => void) => () => void,
   getSnapshot: () => T,
-  getServerSnapshot: () => T = getSnapshot,
+  // Signature parity with React; tap never hydrates, so it is ignored
+  _getServerSnapshot?: () => T,
 ): T => {
-  const isFirstRender = useRef(true);
-  const value = isFirstRender.current ? getServerSnapshot() : getSnapshot();
-  isFirstRender.current = false;
+  const value = getSnapshot();
 
   const [, forceUpdate] = useState(0);
 


### PR DESCRIPTION
## Summary

tap resources never hydrate server-rendered output, so the first-render getServerSnapshot() read plus the mount-time correction re-render were dead complexity.

- First render now calls getSnapshot() directly; the isFirstRender ref is gone.
- The third parameter remains for signature parity with React's useSyncExternalStore but is ignored.
- The contract test that pinned server-snapshot-first behavior now pins the new contract: client snapshot on first render, no correction re-render.

Verified: @assistant-ui/tap tests (459 passed) and typecheck (one pre-existing, unrelated tsc error in an upstream test file: concurrent-version-replay.test.tsx passes {} to a zero-arg resource).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.j9qx7hSgZlSR5TzVqk1-zCGfu-uXG6tMihZSxhjobdek9_spQC7eRpzYiTA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->