### PR TITLE
docs(store): trim AuiIf JSDoc and add a mount/unmount contract test

### DIFF
--- a/.changeset/aui-if-contract-test.md
+++ b/.changeset/aui-if-contract-test.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+AuiIf: trim JSDoc and add a mount/unmount contract test

--- a/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/primitives/assistant-if.mdx
@@ -202,24 +202,7 @@ const isThreadEmpty: AuiIf.Condition = (s) => s.thread.isEmpty;
 
 ### AuiIf
 
-Conditionally renders children based on a slice of assistant state.
-
-A thin wrapper around [useAuiState](/docs/api-reference/hooks/state#useauistate) that renders its children
-when `condition` returns `true` and unmounts them when it returns
-`false`. Keeps render logic declarative without mounting unused
-subtrees.
-
-```tsx
-<AuiIf condition={(s) => s.thread.isRunning}>
-  <CancelButton />
-</AuiIf>
-```
-
-```tsx
-<AuiIf condition={(s) => s.thread.messages.length === 0}>
-  <EmptyState />
-</AuiIf>
-```
+Renders `children` while `condition` selects `true` from the assistant state.
 
 <ParametersTable {...AuiIf} />
 {/* api-reference:end */}

--- a/packages/store/src/AuiIf.ts
+++ b/packages/store/src/AuiIf.ts
@@ -7,42 +7,15 @@ import type { AssistantState } from "./types/client";
 export namespace AuiIf {
   /** Props for `AuiIf`. */
   export type Props = PropsWithChildren<{
-    /**
-     * Selector that decides whether to render `children`. Children render
-     * when this returns `true` and unmount when it returns `false`.
-     */
+    /** Selector deciding whether `children` render. */
     condition: AuiIf.Condition;
   }>;
 
-  /**
-   * Selector passed to `AuiIf`. Receives the assistant state and must
-   * return a boolean.
-   */
+  /** Boolean selector over the assistant state. */
   export type Condition = (state: AssistantState) => boolean;
 }
 
-/**
- * Conditionally renders children based on a slice of assistant state.
- *
- * A thin wrapper around {@link useAuiState} that renders its children
- * when `condition` returns `true` and unmounts them when it returns
- * `false`. Keeps render logic declarative without mounting unused
- * subtrees.
- *
- * @example
- * ```tsx
- * <AuiIf condition={(s) => s.thread.isRunning}>
- *   <CancelButton />
- * </AuiIf>
- * ```
- *
- * @example
- * ```tsx
- * <AuiIf condition={(s) => s.thread.messages.length === 0}>
- *   <EmptyState />
- * </AuiIf>
- * ```
- */
+/** Renders `children` while `condition` selects `true` from the assistant state. */
 export const AuiIf: FC<AuiIf.Props> = ({ children, condition }) => {
   const result = useAuiState(condition);
   return result ? children : null;

--- a/packages/store/src/__tests__/AuiIf.test.tsx
+++ b/packages/store/src/__tests__/AuiIf.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { useEffect, useState, type ReactNode } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { flushTapSync, resource } from "@assistant-ui/tap";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { useAui } from "../useAui";
+import { AuiIf } from "../AuiIf";
+
+afterEach(() => {
+  cleanup();
+});
+
+const useCounterClient = () => {
+  const [count, setCount] = useState(0);
+  return {
+    getState: () => ({ count }),
+    setCount: (value: number) => setCount(value),
+  };
+};
+const CounterClient = resource(useCounterClient);
+
+const setup = (children: ReactNode) => {
+  let aui!: Record<string, any>;
+  const Harness = ({ children }: { children: ReactNode }) => {
+    const client = useAui({
+      counter: CounterClient(),
+    } as unknown as useAui.Props);
+    aui = client;
+    return <AuiProvider value={client}>{children}</AuiProvider>;
+  };
+  const view = render(<Harness>{children}</Harness>);
+  return { view, getAui: () => aui };
+};
+
+describe("AuiIf", () => {
+  it("mounts children when the condition is true and unmounts when false", () => {
+    const mounted = vi.fn();
+    const unmounted = vi.fn();
+    const Probe = () => {
+      useEffect(() => {
+        mounted();
+        return unmounted;
+      }, []);
+      return <div>visible</div>;
+    };
+
+    const { view, getAui } = setup(
+      <AuiIf condition={(s: any) => s.counter.count > 0}>
+        <Probe />
+      </AuiIf>,
+    );
+
+    expect(view.container.textContent).toBe("");
+    expect(mounted).not.toHaveBeenCalled();
+
+    act(() => {
+      flushTapSync(() => getAui().counter.setCount(1));
+    });
+    expect(view.container.textContent).toBe("visible");
+    expect(mounted).toHaveBeenCalledTimes(1);
+    expect(unmounted).not.toHaveBeenCalled();
+
+    act(() => {
+      flushTapSync(() => getAui().counter.setCount(0));
+    });
+    expect(view.container.textContent).toBe("");
+    expect(unmounted).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Per the decision to keep the AuiIf export:

- JSDoc trimmed to one line per public symbol (component, Props.condition, Condition).
- New contract test exercises the component through the real client machinery: children mount (effect fires) when the condition selects true and unmount (cleanup fires) when it flips false.
- No runtime change; removal of the export was explicitly out of scope for this PR.

Verified: @assistant-ui/store tests (48 passed) and typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pfXjTu49Lp-0YI8eAS6kQfS_YxcCIAarDS6VYuK-PEkK3WOrDR0c_bqJ5Qw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->