### PR TITLE
refactor(store): resolve Derived to a client+meta envelope

### DIFF
--- a/.changeset/derived-meta-envelope.md
+++ b/.changeset/derived-meta-envelope.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+Derived resolves to a `{ client, source, query }` envelope; scope machinery discriminates the resolved value instead of sniffing elements

--- a/.changeset/scope-meta-shallow-equal.md
+++ b/.changeset/scope-meta-shallow-equal.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+useAui: memoize scope meta via shallow equality on the query object instead of a spread deps array, so query key-count changes are detected reliably

--- a/.changeset/shared-infer-client-state.md
+++ b/.changeset/shared-infer-client-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+Share a single InferClientState type across useClientResource, useClientLookup, and useClientList

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1467,7 +1467,20 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<DerivedInstance<K>>;
+declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
+  type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
+}
+
+type DerivedElement<K extends ClientNames> = ResourceElement<Derived.Output<K>>;
 
 type DerivedInstance<K extends ClientNames> = ReturnType<AssistantClientAccessor<K>>;
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1302,7 +1302,20 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<DerivedInstance<K>>;
+declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
+  type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
+}
+
+type DerivedElement<K extends ClientNames> = ResourceElement<Derived.Output<K>>;
 
 type DerivedInstance<K extends ClientNames> = ReturnType<AssistantClientAccessor<K>>;
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1213,7 +1213,20 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<DerivedInstance<K>>;
+declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
+  type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
+}
+
+type DerivedElement<K extends ClientNames> = ResourceElement<Derived.Output<K>>;
 
 type DerivedInstance<K extends ClientNames> = ReturnType<AssistantClientAccessor<K>>;
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -1857,7 +1857,20 @@ declare class DefaultThreadComposerRuntimeCore extends BaseComposerRuntimeCore i
   handleCancel(): Promise<void>;
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<DerivedInstance<K>>;
+declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
+
+declare namespace Derived {
+  type Props<K extends ClientNames> = {
+    get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
+  } & ClientMeta<K>;
+  type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
+}
+
+type DerivedElement<K extends ClientNames> = ResourceElement<Derived.Output<K>>;
 
 type DerivedInstance<K extends ClientNames> = ReturnType<AssistantClientAccessor<K>>;
 

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -174,15 +174,9 @@ type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) exten
 
 type Unsubscribe = () => void;
 
-type ValidateClient<K extends string, TClient> = K extends ReservedScopeNames ? ClientError<`ERROR: ${K} is a reserved scope name`> : unknown extends ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient> ? TClient : ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient>;
-
-type ValidateEvents<K extends string, TClient> = "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? unknown : ClientError<`ERROR: ${K} has invalid events type`> : unknown;
-
-type ValidateMeta<K extends string, TClient> = "meta" extends keyof TClient ? TClient["meta"] extends ClientMetaType ? unknown : ClientError<`ERROR: ${K} has invalid meta type`> : unknown;
-
-type ValidateMethods<K extends string, TClient> = TClient extends {
+type ValidateClient<K extends string, TClient> = K extends ReservedScopeNames ? ClientError<`ERROR: ${K} is a reserved scope name`> : TClient extends {
   methods: ClientMethods;
-} ? keyof TClient["methods"] & ReservedAccessorProps extends never ? unknown : ClientError<`ERROR: ${K} methods declare a reserved accessor property (source/query/name)`> : ClientError<`ERROR: ${K} has invalid methods type`>;
+} ? keyof TClient["methods"] & ReservedAccessorProps extends never ? "meta" extends keyof TClient ? TClient["meta"] extends ClientMetaType ? "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? TClient : ClientError<`ERROR: ${K} has invalid events type`> : TClient : ClientError<`ERROR: ${K} has invalid meta type`> : "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? TClient : ClientError<`ERROR: ${K} has invalid events type`> : TClient : ClientError<`ERROR: ${K} methods declare a reserved accessor property (source/query/name)`> : ClientError<`ERROR: ${K} has invalid methods type`>;
 
 type WildcardPayload = {
   [K in keyof ClientEventMap]: {

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -108,9 +108,14 @@ declare namespace Derived {
   type Props<K extends ClientNames> = {
     get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
   } & ClientMeta<K>;
+  type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
 }
 
-type DerivedElement<K extends ClientNames> = ResourceElement<DerivedInstance<K>>;
+type DerivedElement<K extends ClientNames> = ResourceElement<Derived.Output<K>>;
 
 type DerivedInstance<K extends ClientNames> = ReturnType<AssistantClientAccessor<K>>;
 
@@ -119,14 +124,6 @@ type EventSource<T extends AssistantEventName> = T extends `${infer Source}.${st
 type Hook = (...args: any[]) => any;
 
 type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$1<TMethods> = TMethods extends {
-  getState: () => infer S;
-} ? S : unknown;
-
-type InferClientState$2<TMethods> = TMethods extends {
   getState: () => infer S;
 } ? S : undefined;
 
@@ -152,6 +149,11 @@ type ResourceElement<V> = {
   readonly deps?: readonly unknown[];
 };
 
+type ScopeMeta = {
+  source: ClientNames | "root";
+  query: Record<string, unknown>;
+};
+
 interface ScopeRegistry {
   [key: string]: { methods: any; meta?: any; events?: any };
 }
@@ -172,9 +174,15 @@ type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) exten
 
 type Unsubscribe = () => void;
 
-type ValidateClient<K extends string, TClient> = K extends ReservedScopeNames ? ClientError<`ERROR: ${K} is a reserved scope name`> : TClient extends {
+type ValidateClient<K extends string, TClient> = K extends ReservedScopeNames ? ClientError<`ERROR: ${K} is a reserved scope name`> : unknown extends ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient> ? TClient : ValidateMethods<K, TClient> & ValidateMeta<K, TClient> & ValidateEvents<K, TClient>;
+
+type ValidateEvents<K extends string, TClient> = "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? unknown : ClientError<`ERROR: ${K} has invalid events type`> : unknown;
+
+type ValidateMeta<K extends string, TClient> = "meta" extends keyof TClient ? TClient["meta"] extends ClientMetaType ? unknown : ClientError<`ERROR: ${K} has invalid meta type`> : unknown;
+
+type ValidateMethods<K extends string, TClient> = TClient extends {
   methods: ClientMethods;
-} ? keyof TClient["methods"] & ReservedAccessorProps extends never ? "meta" extends keyof TClient ? TClient["meta"] extends ClientMetaType ? "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? TClient : ClientError<`ERROR: ${K} has invalid events type`> : TClient : ClientError<`ERROR: ${K} has invalid meta type`> : "events" extends keyof TClient ? TClient["events"] extends ClientEventsType<K> ? TClient : ClientError<`ERROR: ${K} has invalid events type`> : TClient : ClientError<`ERROR: ${K} methods declare a reserved accessor property (source/query/name)`> : ClientError<`ERROR: ${K} has invalid methods type`>;
+} ? keyof TClient["methods"] & ReservedAccessorProps extends never ? unknown : ClientError<`ERROR: ${K} methods declare a reserved accessor property (source/query/name)`> : ClientError<`ERROR: ${K} has invalid methods type`>;
 
 type WildcardPayload = {
   [K in keyof ClientEventMap]: {
@@ -257,7 +265,7 @@ declare namespace useClientList {
 }
 
 declare function useClientLookup<TMethods extends ClientMethods>(elements: readonly ResourceElement<TMethods>[]): {
-  state: InferClientState$1<TMethods>[];
+  state: InferClientState<TMethods>[];
   get: (lookup: {
     index: number;
   } | {
@@ -266,9 +274,10 @@ declare function useClientLookup<TMethods extends ClientMethods>(elements: reado
 };
 
 declare const useClientResource: <TMethods extends ClientMethods>(element: ResourceElement<TMethods>) => {
-  state: InferClientState$2<TMethods>;
+  state: InferClientState<TMethods>;
   methods: TMethods;
   key: string | number | undefined;
+  meta: ScopeMeta;
 };
 
 export { entry_root_exports as entry_root };

--- a/packages/store/src/Derived.ts
+++ b/packages/store/src/Derived.ts
@@ -1,4 +1,8 @@
-import { resource, type ResourceElement } from "@assistant-ui/tap";
+import {
+  resource,
+  useMemoCache,
+  type ResourceElement,
+} from "@assistant-ui/tap";
 import { useSyncExternalStore } from "react";
 import type {
   AssistantClient,
@@ -12,12 +16,46 @@ type DerivedInstance<K extends ClientNames> = ReturnType<
   AssistantClientAccessor<K>
 >;
 
-export const useDerived = <K extends ClientNames>({
-  get,
-}: Derived.Props<K>): DerivedInstance<K> => {
-  const client = useBuildingClient();
-  const select = () => get(client) as DerivedInstance<K>;
-  return useSyncExternalStore(client.subscribe, select, select);
+const MEMO_CACHE_UNFILLED = Symbol.for("react.memo_cache_sentinel");
+
+const shallowEqualRecord = (
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+) => {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length &&
+    aKeys.every((key) => Object.hasOwn(b, key) && Object.is(a[key], b[key]))
+  );
+};
+
+export const useDerived = <K extends ClientNames>(
+  props: Derived.Props<K>,
+): Derived.Output<K> => {
+  const buildingClient = useBuildingClient();
+  const select = () => props.get(buildingClient) as DerivedInstance<K>;
+  const client = useSyncExternalStore(buildingClient.subscribe, select, select);
+
+  const { source, query = {} } = props as unknown as {
+    source: ClientNames;
+    query?: Record<string, unknown>;
+  };
+
+  const cache = useMemoCache(1) as [
+    Derived.Output<K> | typeof MEMO_CACHE_UNFILLED,
+  ];
+  const prev = cache[0];
+  if (
+    prev !== MEMO_CACHE_UNFILLED &&
+    prev.client === client &&
+    prev.source === source &&
+    shallowEqualRecord(prev.query, query)
+  ) {
+    return prev;
+  }
+  const output = { client, source, query };
+  cache[0] = output;
+  return output;
 };
 
 /**
@@ -42,7 +80,7 @@ export const Derived = resource(useDerived) as <K extends ClientNames>(
 ) => DerivedElement<K>;
 
 export type DerivedElement<K extends ClientNames> = ResourceElement<
-  DerivedInstance<K>
+  Derived.Output<K>
 >;
 
 export namespace Derived {
@@ -52,4 +90,13 @@ export namespace Derived {
   export type Props<K extends ClientNames> = {
     get: (client: AssistantClient) => ReturnType<AssistantClientAccessor<K>>;
   } & ClientMeta<K>;
+
+  /**
+   * The resolved bound instance plus its selection metadata.
+   */
+  export type Output<K extends ClientNames> = {
+    client: DerivedInstance<K>;
+    source: ClientNames;
+    query: Record<string, unknown>;
+  };
 }

--- a/packages/store/src/types/client.ts
+++ b/packages/store/src/types/client.ts
@@ -154,6 +154,12 @@ export type ClientElement<K extends ClientNames> = ResourceElement<
  */
 export type Unsubscribe = () => void;
 
+export type InferClientState<TMethods> = TMethods extends {
+  getState: () => infer S;
+}
+  ? S
+  : undefined;
+
 type ScopeStates = {
   [K in ClientNames]: ClientSchemas[K]["methods"] extends {
     getState: () => infer S;

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -194,13 +194,31 @@ const useClientFields = ({
   );
 };
 
+const shallowEqualRecord = (
+  a: Record<string, unknown>,
+  b: Record<string, unknown>,
+) => {
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length &&
+    aKeys.every((key) => Object.hasOwn(b, key) && Object.is(a[key], b[key]))
+  );
+};
+
 const useScopeMeta = (element: ScopeElement): ScopeMeta => {
   const { source, query } = metaOf(element);
-  // oxlint-disable-next-line react-hooks/exhaustive-deps -- shallow memo over the query's entries
-  return useMemo(
-    () => ({ source, query }),
-    [source, ...Object.entries(query).flat()],
-  );
+  const cache = useMemoCache(1) as [ScopeMeta | typeof MEMO_CACHE_UNFILLED];
+  const prev = cache[0];
+  if (
+    prev !== MEMO_CACHE_UNFILLED &&
+    prev.source === source &&
+    shallowEqualRecord(prev.query, query)
+  ) {
+    return prev;
+  }
+  const meta = { source, query };
+  cache[0] = meta;
+  return meta;
 };
 
 const useScopeValue = (element: ScopeElement, derived: boolean) =>

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -20,7 +20,7 @@ import type {
   ClientElement,
   ClientMethods,
 } from "./types/client";
-import { useDerived, type DerivedElement } from "./Derived";
+import type { DerivedElement } from "./Derived";
 import {
   useAssistantContextValue,
   DefaultAssistantClient,
@@ -88,15 +88,6 @@ const applyTransformScopes = (
   return scopes;
 };
 
-const isDerivedElement = (element: ScopeElement) =>
-  element.hook === (useDerived as unknown);
-
-const metaOf = (element: ScopeElement): ScopeMeta => {
-  if (!isDerivedElement(element)) return { source: "root", query: {} };
-  const props = element.args[0] as ScopeMeta;
-  return { source: props.source, query: props.query ?? {} };
-};
-
 const toScopeEntries = (scopes: Record<string, ScopeElement>): ScopeEntry[] =>
   (Object.entries(scopes) as [ClientNames, ScopeElement][]).map(
     ([name, element]) => ({ name, element }),
@@ -107,7 +98,10 @@ const createAccessor = <K extends ClientNames>(
   meta: ScopeMeta,
   read: () => ClientMethods,
 ): AssistantClientAccessor<K> =>
-  createClientAccessor<K>({ name, ...meta }, read);
+  createClientAccessor<K>(
+    { name, source: meta.source, query: meta.query },
+    read,
+  );
 
 type ClientFields = {
   subscribe: AssistantClient["subscribe"];
@@ -194,51 +188,11 @@ const useClientFields = ({
   );
 };
 
-const shallowEqualRecord = (
-  a: Record<string, unknown>,
-  b: Record<string, unknown>,
-) => {
-  const aKeys = Object.keys(a);
-  return (
-    aKeys.length === Object.keys(b).length &&
-    aKeys.every((key) => Object.hasOwn(b, key) && Object.is(a[key], b[key]))
-  );
-};
-
-const useScopeMeta = (element: ScopeElement): ScopeMeta => {
-  const { source, query } = metaOf(element);
-  const cache = useMemoCache(1) as [ScopeMeta | typeof MEMO_CACHE_UNFILLED];
-  const prev = cache[0];
-  if (
-    prev !== MEMO_CACHE_UNFILLED &&
-    prev.source === source &&
-    shallowEqualRecord(prev.query, query)
-  ) {
-    return prev;
-  }
-  const meta = { source, query };
-  cache[0] = meta;
-  return meta;
-};
-
-const useScopeValue = (element: ScopeElement, derived: boolean) =>
-  useResource(derived ? element : ClientResource(element));
-
 const useScopeMount = ({ name, element }: ScopeEntry): ScopeResult => {
   const client = useBuildingClient();
 
-  // A derived element resolves to an existing client; mount it directly
-  const derived = isDerivedElement(element);
-  const value = useScopeValue(element, derived);
+  const { methods, state, meta } = useResource(ClientResource(element));
 
-  const methods = derived
-    ? (value as ClientMethods)
-    : (value as { methods: ClientMethods }).methods;
-  const state = derived
-    ? (value as { getState?: () => unknown }).getState?.()
-    : (value as { state: unknown }).state;
-
-  const meta = useScopeMeta(element);
   const accessor = useMemo(
     () => createAccessor(name, meta, () => methods),
     [name, meta, methods],

--- a/packages/store/src/useClientList.ts
+++ b/packages/store/src/useClientList.ts
@@ -2,13 +2,7 @@ import { useMemo, useState } from "react";
 import { withKey, type Resource } from "@assistant-ui/tap";
 
 import { useClientLookup } from "./useClientLookup";
-import type { ClientMethods } from "./types/client";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
+import type { ClientMethods, InferClientState } from "./types/client";
 
 type DataHandle<TData> = { data: TData | undefined; hasData: boolean };
 

--- a/packages/store/src/useClientLookup.ts
+++ b/packages/store/src/useClientLookup.ts
@@ -1,13 +1,7 @@
 import { useMemo } from "react";
 import { useResources, withKey, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import { ClientResource } from "./useClientResource";
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : unknown;
 
 const getElementKey = (el: ResourceElement<unknown>) => {
   if (el.key === undefined) {

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { resource, useResource, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods } from "./types/client";
+import type { ClientMethods, InferClientState } from "./types/client";
 import {
   useClientStack,
   useClientStackProvider,
@@ -125,12 +125,6 @@ class ClientProxyHandler
     return prop in this.outputRef.current;
   }
 }
-
-type InferClientState<TMethods> = TMethods extends {
-  getState: () => infer S;
-}
-  ? S
-  : undefined;
 
 export const useClientResource = <TMethods extends ClientMethods>(
   element: ResourceElement<TMethods>,

--- a/packages/store/src/useClientResource.ts
+++ b/packages/store/src/useClientResource.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef } from "react";
 import { resource, useResource, type ResourceElement } from "@assistant-ui/tap";
-import type { ClientMethods, InferClientState } from "./types/client";
+import type {
+  ClientMethods,
+  ClientNames,
+  InferClientState,
+} from "./types/client";
+import type { Derived } from "./Derived";
 import {
   useClientStack,
   useClientStackProvider,
@@ -126,12 +131,29 @@ class ClientProxyHandler
   }
 }
 
+type ScopeMeta = {
+  source: ClientNames | "root";
+  query: Record<string, unknown>;
+};
+
+const ROOT_META: ScopeMeta = { source: "root", query: {} };
+
+// Unambiguous: ValidateClient bans source/query/name in client methods
+const isDerivedOutput = (
+  value: unknown,
+): value is Derived.Output<ClientNames> =>
+  typeof value === "object" &&
+  value !== null &&
+  "client" in value &&
+  "source" in value;
+
 export const useClientResource = <TMethods extends ClientMethods>(
   element: ResourceElement<TMethods>,
 ): {
   state: InferClientState<TMethods>;
   methods: TMethods;
   key: string | number | undefined;
+  meta: ScopeMeta;
 } => {
   const valueRef = useRef(null as unknown as TMethods);
 
@@ -157,8 +179,18 @@ export const useClientResource = <TMethods extends ClientMethods>(
     valueRef.current = value;
   });
 
+  if (isDerivedOutput(value)) {
+    const bound = value.client as unknown as TMethods;
+    return {
+      methods: bound,
+      state: (bound as any).getState?.(),
+      key: element.key,
+      meta: value,
+    };
+  }
+
   const state = (value as any).getState?.();
-  return { methods, state, key: element.key };
+  return { methods, state, key: element.key, meta: ROOT_META };
 };
 
 export const ClientResource = resource(useClientResource);


### PR DESCRIPTION
## What

- `useDerived` now returns `{ client, source, query }` — the resolved bound instance plus the meta from its props — memoized as one object (identity is stable while the client, source, and query contents are unchanged).
- `useClientResource` unwraps the envelope after resolution and returns a `meta` field alongside `state`/`methods`/`key`: envelopes carry their own `source`/`query`; every other resolved value is a bare client with `{ source: "root", query: {} }`.
- The scope machinery in `useAui` discriminates the resolved value instead of the element: `isDerivedElement`, `metaOf`'s element sniffing, and the `args[0]` blind cast are deleted. The discrimination is unambiguous because `ValidateClient` bans `source`/`query`/`name` in scope methods.
- `useScopeMeta`'s shallow-compare memoization moved to `useDerived` (the envelope is the meta carrier now); accessor meta derives directly from the resolved object.
- `DerivedElement<K>` is now `ResourceElement<Derived.Output<K>>`; the consumer-visible surface of `aui.<scope>` is unchanged (all accessor-properties tests pass unmodified).

## Notes

- Stacked on #5360 (scope meta shallow-compare) and the shared `InferClientState` PR — the edits build directly on those hunks in `useAui.ts` / `useClientResource.ts`.
- `api-surface/assistant-ui__store.ts` is regenerated; it also absorbs surface drift left to autofix.ci by the ValidateClient and InferClientState PRs.
- Derived scope elements now mount through `ClientResource` like every other scope; the wrapper proxy it pushes on the client stack is inert for envelopes (never read, never emitted through).

## Tests

- `pnpm exec vitest run` in packages/store: 48 passed.
- `pnpm exec tsc --noEmit`: clean.

Refs sw-116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #5365 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #5360
- <kbd>&nbsp;1&nbsp;</kbd> #5356
<!-- GitButler Footer Boundary Bottom -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZjnUU98HjkmLV70Utgc5sqdRprOd6cQ3MVHYOYc8fSUW61ibqbNCSdr6MmM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->