### PR TITLE
refactor(store): local useShallowStable helper, drop tap useMemoCache export

### DIFF
--- a/.changeset/sw118-use-shallow-stable.md
+++ b/.changeset/sw118-use-shallow-stable.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/store": patch
+"@assistant-ui/tap": patch
+---
+
+refactor(store): local useShallowStable helper replaces tap useMemoCache; drop useMemoCache from tap's public entrypoint

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -18,14 +18,12 @@ declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
 
 declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn: () => TResult) => TResult;
-
-declare const useMemoCache: (size: number) => unknown[];
 
 declare function useResource<E extends ResourceElement<any>>(element: E): ExtractResourceReturnType<E>;
 

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -2,7 +2,6 @@
 
 import {
   flushTapSync,
-  useMemoCache,
   useResource,
   useResources,
   useTapHost,
@@ -41,6 +40,7 @@ import {
   useBuildingClient,
 } from "./utils/tap-assistant-context";
 import { ClientResource } from "./useClientResource";
+import { useShallowStable } from "./utils/useShallowStable";
 import { createClientAccessor, getClientId } from "./utils/client-accessor";
 import { getClientIndex } from "./utils/tap-client-stack-context";
 
@@ -187,31 +187,9 @@ const useClientFields = ({
   );
 };
 
-const shallowEqualRecord = (
-  a: Record<string, unknown>,
-  b: Record<string, unknown>,
-) => {
-  const aKeys = Object.keys(a);
-  return (
-    aKeys.length === Object.keys(b).length &&
-    aKeys.every((key) => Object.hasOwn(b, key) && Object.is(a[key], b[key]))
-  );
-};
-
 const useScopeMeta = (element: ScopeElement): ScopeMeta => {
   const { source, query } = metaOf(element);
-  const cache = useMemoCache(1) as [ScopeMeta | typeof MEMO_CACHE_UNFILLED];
-  const prev = cache[0];
-  if (
-    prev !== MEMO_CACHE_UNFILLED &&
-    prev.source === source &&
-    shallowEqualRecord(prev.query, query)
-  ) {
-    return prev;
-  }
-  const meta = { source, query };
-  cache[0] = meta;
-  return meta;
+  return useShallowStable({ source, query: useShallowStable(query) });
 };
 
 const useScopeValue = (element: ScopeElement, derived: boolean) =>
@@ -250,22 +228,6 @@ const ScopeMount = resource(useScopeMount);
 const useScopeMounts = (entries: ScopeEntry[]): ScopeResult[] =>
   useResources(entries.map((entry) => withKey(entry.name, ScopeMount(entry))));
 
-const MEMO_CACHE_UNFILLED = Symbol.for("react.memo_cache_sentinel");
-
-const useStableArray = <T>(values: readonly T[]): readonly T[] => {
-  const cache = useMemoCache(1) as [readonly T[] | typeof MEMO_CACHE_UNFILLED];
-  const prev = cache[0];
-  if (
-    prev !== MEMO_CACHE_UNFILLED &&
-    prev.length === values.length &&
-    values.every((value, i) => Object.is(value, prev[i]))
-  ) {
-    return prev;
-  }
-  cache[0] = values;
-  return values;
-};
-
 const useCommittedClient = ({
   building,
   parent,
@@ -277,16 +239,16 @@ const useCommittedClient = ({
   fields: ClientFields;
   accessors: readonly AssistantClientAccessor<ClientNames>[];
 }): AssistantClient => {
-  const deps = useStableArray([parent, fields, accessors]);
-  const cache = useMemoCache(2) as [
-    readonly unknown[] | typeof MEMO_CACHE_UNFILLED,
-    AssistantClient,
-  ];
-  if (cache[0] !== deps) {
-    cache[0] = deps;
-    cache[1] = building;
+  const deps = useShallowStable([parent, fields, accessors]);
+  const cell = useMemo(
+    () => ({}) as { deps?: unknown; client?: AssistantClient },
+    [],
+  );
+  if (cell.deps !== deps) {
+    cell.deps = deps;
+    cell.client = building;
   }
-  return cache[1];
+  return cell.client!;
 };
 
 const useAuiRoot = ({
@@ -314,7 +276,7 @@ const useAuiRoot = ({
     },
   );
 
-  const accessors = useStableArray(results.map((r) => r.accessor));
+  const accessors = useShallowStable(results.map((r) => r.accessor));
 
   // Fresh envelope per commit so value-only updates reach the store's
   // subscribers; the client inside keeps its identity

--- a/packages/store/src/utils/useShallowStable.ts
+++ b/packages/store/src/utils/useShallowStable.ts
@@ -1,11 +1,10 @@
 import { useMemo } from "react";
 
 const shallowEqual = (a: object, b: object): boolean => {
-  if (Array.isArray(a)) {
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
     return (
-      Array.isArray(b) &&
-      a.length === b.length &&
-      a.every((value, i) => Object.is(value, b[i]))
+      a.length === b.length && a.every((value, i) => Object.is(value, b[i]))
     );
   }
   const aKeys = Object.keys(a);

--- a/packages/store/src/utils/useShallowStable.ts
+++ b/packages/store/src/utils/useShallowStable.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+
+const shallowEqual = (a: object, b: object): boolean => {
+  if (Array.isArray(a)) {
+    return (
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((value, i) => Object.is(value, b[i]))
+    );
+  }
+  const aKeys = Object.keys(a);
+  return (
+    aKeys.length === Object.keys(b).length &&
+    aKeys.every(
+      (key) =>
+        Object.hasOwn(b, key) &&
+        Object.is(
+          (a as Record<string, unknown>)[key],
+          (b as Record<string, unknown>)[key],
+        ),
+    )
+  );
+};
+
+export const useShallowStable = <T extends object>(value: T): T => {
+  const cell = useMemo(() => ({}) as { v?: T }, []);
+  if (cell.v !== undefined && shallowEqual(cell.v, value)) return cell.v;
+  cell.v = value;
+  return value;
+};

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -9,7 +9,6 @@ export { flushTapSync } from "./core/scheduler";
 export { useContextProvider } from "./core/context";
 
 // hooks
-export { useMemoCache } from "./react-hooks/useMemoCache";
 export { useResource } from "./hooks/useResource";
 export { useResources } from "./hooks/useResources";
 export { useTapRoot } from "./hooks/useTapRoot";


### PR DESCRIPTION
Replaces @assistant-ui/store's uses of tap's `useMemoCache` (`useScopeMeta`, `useStableArray`, `useCommittedClient`) with a single store-internal `useShallowStable` helper, then removes the `useMemoCache` export from tap's public entrypoint (tap internals unchanged).

`useCommittedClient` keeps a plain once-per-mount cell rather than `useMemo(() => building, [deps])`: tap's `useMemo` schedules dirty-marking/commits, which self-sustains an update cycle with the fresh-envelope-per-commit root (hangs the react suite).

API surface regenerated; patch changesets for store and tap. No observable behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)