### PR TITLE
fix(tap): per-scheduler update-depth limit in UpdateScheduler

### DIFF
--- a/.changeset/tap-per-scheduler-update-depth.md
+++ b/.changeset/tap-per-scheduler-update-depth.md
@@ -2,4 +2,4 @@
 "@assistant-ui/tap": patch
 ---
 
-UpdateScheduler: count update depth per scheduler and drop only the offending scheduler from a flush, so one looping root no longer starves or wedges unrelated roots
+fix: count update depth per scheduler in UpdateScheduler and drop only the offending scheduler from a flush, so one looping root no longer starves or wedges unrelated roots

--- a/.changeset/tap-per-scheduler-update-depth.md
+++ b/.changeset/tap-per-scheduler-update-depth.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+UpdateScheduler: count update depth per scheduler and drop only the offending scheduler from a flush, so one looping root no longer starves or wedges unrelated roots

--- a/packages/tap/src/__tests__/scheduler.update-depth.test.ts
+++ b/packages/tap/src/__tests__/scheduler.update-depth.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { UpdateScheduler, flushTapSync } from "../core/scheduler";
+
+describe("scheduler update depth", () => {
+  it("runs many independent schedulers in one flush without tripping the limit", async () => {
+    let runCount = 0;
+    const schedulers = Array.from(
+      { length: 60 },
+      () => new UpdateScheduler(() => runCount++),
+    );
+
+    for (const scheduler of schedulers) scheduler.markDirty();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runCount).toBe(60);
+    expect(schedulers.every((scheduler) => !scheduler.isDirty)).toBe(true);
+  });
+
+  it("stops a self-re-dirtying scheduler after the limit without starving others", () => {
+    let selfRuns = 0;
+    const self: UpdateScheduler = new UpdateScheduler(() => {
+      selfRuns++;
+      self.markDirty();
+    });
+    let otherRan = false;
+    const other = new UpdateScheduler(() => {
+      otherRan = true;
+    });
+
+    expect(() =>
+      flushTapSync(() => {
+        self.markDirty();
+        other.markDirty();
+      }),
+    ).toThrow(/Maximum update depth exceeded/);
+
+    expect(selfRuns).toBe(50);
+    expect(otherRan).toBe(true);
+  });
+
+  it("recovers the offending scheduler on the next flush", () => {
+    let looping = true;
+    let runCount = 0;
+    const scheduler: UpdateScheduler = new UpdateScheduler(() => {
+      runCount++;
+      if (looping) scheduler.markDirty();
+    });
+
+    expect(() => flushTapSync(() => scheduler.markDirty())).toThrow(
+      /Maximum update depth exceeded/,
+    );
+    expect(scheduler.isDirty).toBe(true);
+
+    looping = false;
+    const runsBefore = runCount;
+    flushTapSync(() => scheduler.markDirty());
+    expect(runCount).toBe(runsBefore + 1);
+    expect(scheduler.isDirty).toBe(false);
+  });
+});

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -48,19 +48,25 @@ const scheduleFlush = () => {
 const flushScheduled = () => {
   try {
     const errors = [];
-    let flushDepth = 0;
+    const runs = new Map<UpdateScheduler, number>();
 
     for (const scheduler of flushState.schedulers) {
       flushState.schedulers.delete(scheduler);
       if (!scheduler.isDirty) continue;
 
-      flushDepth++;
+      const count = (runs.get(scheduler) ?? 0) + 1;
+      runs.set(scheduler, count);
 
-      if (flushDepth > MAX_FLUSH_LIMIT) {
-        throw new Error(
-          `Maximum update depth exceeded. This can happen when a resource ` +
-            `repeatedly calls setState inside useEffect.`,
-        );
+      if (count > MAX_FLUSH_LIMIT) {
+        if (count === MAX_FLUSH_LIMIT + 1) {
+          errors.push(
+            new Error(
+              `Maximum update depth exceeded. This can happen when a resource ` +
+                `repeatedly calls setState inside useEffect.`,
+            ),
+          );
+        }
+        continue;
       }
 
       try {

--- a/packages/tap/src/core/scheduler.ts
+++ b/packages/tap/src/core/scheduler.ts
@@ -7,7 +7,7 @@ type GlobalFlushState = {
   isScheduled: boolean;
 };
 
-const MAX_FLUSH_LIMIT = 50;
+const MAX_UPDATE_DEPTH = 50;
 let flushState: GlobalFlushState = {
   schedulers: new Set([]),
   isScheduled: false,
@@ -49,6 +49,7 @@ const flushScheduled = () => {
   try {
     const errors = [];
     const runs = new Map<UpdateScheduler, number>();
+    let depthExceeded = false;
 
     for (const scheduler of flushState.schedulers) {
       flushState.schedulers.delete(scheduler);
@@ -57,8 +58,9 @@ const flushScheduled = () => {
       const count = (runs.get(scheduler) ?? 0) + 1;
       runs.set(scheduler, count);
 
-      if (count > MAX_FLUSH_LIMIT) {
-        if (count === MAX_FLUSH_LIMIT + 1) {
+      if (count > MAX_UPDATE_DEPTH) {
+        if (!depthExceeded) {
+          depthExceeded = true;
           errors.push(
             new Error(
               `Maximum update depth exceeded. This can happen when a resource ` +


### PR DESCRIPTION
`flushScheduled` counted total dirty-scheduler runs per flush, so 51 independent roots dispatching once in the same macrotask tripped a limit meant for infinite loops — and the throw aborted the flush, leaving unrelated schedulers dirty with no flush scheduled.

Now the update-depth limit is counted per scheduler within a flush. An offender exceeding the limit is dropped from the flush (staying dirty and recoverable on the next markDirty) while every other scheduler keeps draining; the error still throws via the existing aggregated throw.

Identified in #5308 by @tiann — thanks for the analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8zcoC7PXbh98rp_1UUhRSEmLvKdud8VUUEyvA5hodaDzO6xxlFQF_8VHy3Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->