### PR TITLE
fix(core): preserve messages sent after cancellation

### DIFF
--- a/.changeset/external-store-cancel-resync.md
+++ b/.changeset/external-store-cancel-resync.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve messages appended immediately after cancelling a run

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1777,6 +1777,7 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   extras: unknown;
   private _converter;
   private _store;
+  private _cancelResyncRevision;
   private _toolInvocations;
   beginEdit(messageId: string): void;
   constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1777,7 +1777,6 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   extras: unknown;
   private _converter;
   private _store;
-  private _cancelResyncRevision;
   private _toolInvocations;
   beginEdit(messageId: string): void;
   constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1777,6 +1777,7 @@ declare class ExternalStoreThreadRuntimeCore extends BaseThreadRuntimeCore imple
   extras: unknown;
   private _converter;
   private _store;
+  private _optimisticMessageId;
   private _toolInvocations;
   beginEdit(messageId: string): void;
   constructor(contextProvider: ModelContextProvider, store: ExternalStoreAdapter<any>);

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -571,10 +571,9 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
-    const messageIdsBeforeCancel = new Set([
-      ...this.repository.export().messages.map(({ message }) => message.id),
-      ...this.repository.getMessages().map((message) => message.id),
-    ]);
+    const messageIdsBeforeCancel = new Set(
+      this.repository.export().messages.map(({ message }) => message.id),
+    );
 
     this._store.queue?.clear("cancel-run");
 
@@ -613,7 +612,11 @@ export class ExternalStoreThreadRuntimeCore
       if (
         this.repository
           .getMessages()
-          .some((message) => !messageIdsBeforeCancel.has(message.id))
+          .some(
+            (message) =>
+              !message.metadata.isOptimistic &&
+              !messageIdsBeforeCancel.has(message.id),
+          )
       )
         return;
       this.updateMessages(messages);

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -108,6 +108,7 @@ export class ExternalStoreThreadRuntimeCore
   private _converter = new ThreadMessageConverter();
 
   private _store!: ExternalStoreAdapter<any>;
+  private _cancelResyncRevision = 0;
 
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
@@ -457,6 +458,8 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public async append(message: AppendMessage): Promise<void> {
+    this._cancelResyncRevision++;
+
     const isEdit = message.parentId !== (this.messages.at(-1)?.id ?? null);
 
     // Buffering does not start a run, so the tool-abort below must wait until
@@ -571,6 +574,8 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
+    const resyncRevision = ++this._cancelResyncRevision;
+
     this._store.queue?.clear("cancel-run");
 
     // Abort any in-flight client-side tool executions. Fire-and-forget —
@@ -605,6 +610,7 @@ export class ExternalStoreThreadRuntimeCore
 
     // resync messages (for reloading, to restore the previous branch)
     setTimeout(() => {
+      if (this._cancelResyncRevision !== resyncRevision) return;
       this.updateMessages(messages);
     }, 0);
   }

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -108,7 +108,6 @@ export class ExternalStoreThreadRuntimeCore
   private _converter = new ThreadMessageConverter();
 
   private _store!: ExternalStoreAdapter<any>;
-  private _cancelResyncRevision = 0;
 
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
@@ -458,8 +457,6 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public async append(message: AppendMessage): Promise<void> {
-    this._cancelResyncRevision++;
-
     const isEdit = message.parentId !== (this.messages.at(-1)?.id ?? null);
 
     // Buffering does not start a run, so the tool-abort below must wait until
@@ -574,7 +571,10 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
-    const resyncRevision = ++this._cancelResyncRevision;
+    const messageIdsBeforeCancel = new Set([
+      ...this.repository.export().messages.map(({ message }) => message.id),
+      ...this.repository.getMessages().map((message) => message.id),
+    ]);
 
     this._store.queue?.clear("cancel-run");
 
@@ -610,7 +610,12 @@ export class ExternalStoreThreadRuntimeCore
 
     // resync messages (for reloading, to restore the previous branch)
     setTimeout(() => {
-      if (this._cancelResyncRevision !== resyncRevision) return;
+      if (
+        this.repository
+          .getMessages()
+          .some((message) => !messageIdsBeforeCancel.has(message.id))
+      )
+        return;
       this.updateMessages(messages);
     }, 0);
   }

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -109,6 +109,8 @@ export class ExternalStoreThreadRuntimeCore
 
   private _store!: ExternalStoreAdapter<any>;
 
+  private _optimisticMessageId: string | null = null;
+
   /**
    * Client-side tool-invocations pipeline. Constructed lazily on first
    * snapshot — only when `adapter.unstable_enableToolInvocations === true`.
@@ -291,20 +293,22 @@ export class ExternalStoreThreadRuntimeCore
     // Append an optimistic placeholder while running but before a trailing
     // assistant message exists. resetHead evicts off-branch optimistic messages
     // (prior placeholders, mid-run id-swap siblings); export() never persists them.
-    let optimisticId: string | null = null;
+    this._optimisticMessageId = null;
     if (hasUpcomingMessage(isRunning, messages)) {
-      optimisticId = generateId();
+      this._optimisticMessageId = generateId();
       this.repository.addOrUpdateMessage(
         messages.at(-1)?.id ?? null,
         fromThreadMessageLike(
           { role: "assistant", content: [], metadata: { isOptimistic: true } },
-          optimisticId,
+          this._optimisticMessageId,
           { type: "running" },
         ),
       );
     }
 
-    this.repository.resetHead(optimisticId ?? messages.at(-1)?.id ?? null);
+    this.repository.resetHead(
+      this._optimisticMessageId ?? messages.at(-1)?.id ?? null,
+    );
 
     this._messages = this.repository.getMessages();
 
@@ -571,9 +575,13 @@ export class ExternalStoreThreadRuntimeCore
     if (!this._store.onCancel)
       throw new Error("Runtime does not support cancelling runs.");
 
-    const messageIdsBeforeCancel = new Set(
-      this.repository.export().messages.map(({ message }) => message.id),
-    );
+    // export() covers off-branch messages but omits optimistic ones; getMessages()
+    // contributes optimistic messages from the current branch.
+    const messageIdsBeforeCancel = new Set([
+      ...this.repository.export().messages.map(({ message }) => message.id),
+      ...this.repository.getMessages().map((message) => message.id),
+    ]);
+    const removedMessageIds = new Set<string>();
 
     this._store.queue?.clear("cancel-run");
 
@@ -588,6 +596,7 @@ export class ExternalStoreThreadRuntimeCore
     // partially-streamed one is kept and re-supplied by the store on resync.
     const head = this.repository.getMessages().at(-1);
     if (head && head.metadata.isOptimistic && head.content.length === 0) {
+      removedMessageIds.add(head.id);
       this.repository.deleteMessage(head.id);
     }
 
@@ -597,6 +606,7 @@ export class ExternalStoreThreadRuntimeCore
       previousMessage?.role === "user" &&
       previousMessage.id === messages.at(-1)?.id // ensure the previous message is a leaf node
     ) {
+      removedMessageIds.add(previousMessage.id);
       this.repository.deleteMessage(previousMessage.id);
       if (!this.composer.text.trim()) {
         this.composer.setText(getThreadMessageText(previousMessage));
@@ -609,17 +619,21 @@ export class ExternalStoreThreadRuntimeCore
 
     // resync messages (for reloading, to restore the previous branch)
     setTimeout(() => {
-      if (
-        this.repository
-          .getMessages()
-          .some(
-            (message) =>
-              !message.metadata.isOptimistic &&
-              !messageIdsBeforeCancel.has(message.id),
-          )
-      )
-        return;
-      this.updateMessages(messages);
+      const latestMessages = this.repository.getMessages();
+      const hasNewMessage = latestMessages.some(
+        (message) =>
+          message.id !== this._optimisticMessageId &&
+          !messageIdsBeforeCancel.has(message.id),
+      );
+      this.updateMessages(
+        hasNewMessage
+          ? latestMessages.filter(
+              (message) =>
+                message.id !== this._optimisticMessageId &&
+                !removedMessageIds.has(message.id),
+            )
+          : messages,
+      );
     }, 0);
   }
 

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -312,6 +312,76 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(setMessages).not.toHaveBeenCalled();
       expect(core.messages.map((message) => message.id)).toContain("u2");
     });
+
+    it("resyncs messages when an append is only queued", async () => {
+      const setMessages = vi.fn();
+      const queue = {
+        items: [],
+        enqueue: vi.fn(),
+        steer: vi.fn(),
+        remove: vi.fn(),
+        clear: vi.fn(),
+      };
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [createUserMessage("u1"), createAssistantMessage("a1")],
+          isRunning: true,
+          onCancel: vi.fn(),
+          setMessages,
+          queue,
+        }),
+      );
+
+      core.cancelRun();
+      await core.append({
+        role: "user",
+        content: [{ type: "text", text: "Follow up" }],
+        attachments: [],
+        createdAt: new Date(),
+        parentId: "a1",
+        sourceId: null,
+        runConfig: undefined,
+        metadata: { custom: {} },
+      } as AppendMessage);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(queue.enqueue).toHaveBeenCalledOnce();
+      expect(setMessages).toHaveBeenCalledOnce();
+    });
+
+    it("resyncs messages when an append fails", async () => {
+      const setMessages = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [createUserMessage("u1"), createAssistantMessage("a1")],
+          isRunning: true,
+          onCancel: vi.fn(),
+          onNew: vi.fn(async () => {
+            throw new Error("send failed");
+          }),
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      await expect(
+        core.append({
+          role: "user",
+          content: [{ type: "text", text: "Follow up" }],
+          attachments: [],
+          createdAt: new Date(),
+          parentId: "a1",
+          sourceId: null,
+          runConfig: undefined,
+          metadata: { custom: {} },
+        } as AppendMessage),
+      ).rejects.toThrow("send failed");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).toHaveBeenCalledOnce();
+    });
   });
 
   describe("optimistic assistant message", () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -264,6 +264,54 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       const lastCall = setMessages.mock.lastCall?.[0] as ThreadMessage[];
       expect(lastCall.map((m) => m.id)).not.toContain("server-msg");
     });
+
+    it("does not overwrite messages appended after cancel", async () => {
+      const initialMessages = [
+        createUserMessage("u1"),
+        createAssistantMessage("a1"),
+      ];
+      const appendedMessage = createUserMessage("u2", "Follow up");
+      const setMessages = vi.fn();
+      const onCancel = vi.fn();
+      let core!: ExternalStoreThreadRuntimeCore;
+      const onNew = vi.fn(async () => {
+        core.__internal_setAdapter(
+          createBaseAdapter({
+            messages: [...initialMessages, appendedMessage],
+            isRunning: true,
+            onCancel,
+            onNew,
+            setMessages,
+          }),
+        );
+      });
+      core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: initialMessages,
+          isRunning: true,
+          onCancel,
+          onNew,
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      await core.append({
+        role: "user",
+        content: appendedMessage.content,
+        attachments: [],
+        createdAt: appendedMessage.createdAt,
+        parentId: "a1",
+        sourceId: null,
+        runConfig: undefined,
+        metadata: appendedMessage.metadata,
+      } as AppendMessage);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).not.toHaveBeenCalled();
+      expect(core.messages.map((message) => message.id)).toContain("u2");
+    });
   });
 
   describe("optimistic assistant message", () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -309,7 +309,12 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       } as AppendMessage);
       await new Promise((resolve) => setTimeout(resolve, 0));
 
-      expect(setMessages).not.toHaveBeenCalled();
+      expect(setMessages).toHaveBeenCalledOnce();
+      expect(
+        (setMessages.mock.lastCall?.[0] as ThreadMessage[] | undefined)?.map(
+          (message) => message.id,
+        ),
+      ).toEqual(["u1", "a1", "u2"]);
       expect(core.messages.map((message) => message.id)).toContain("u2");
     });
 
@@ -377,6 +382,129 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
 
       expect(setMessages).toHaveBeenCalledOnce();
       expect(setMessages).toHaveBeenCalledWith([]);
+    });
+
+    it("preserves adapter-owned optimistic messages appended after cancel", async () => {
+      const initialMessages = [
+        createUserMessage("u1"),
+        createAssistantMessage("a1"),
+      ];
+      const optimisticMessage = {
+        ...createUserMessage("u2", "Follow up"),
+        metadata: { custom: {}, isOptimistic: true },
+      } as ThreadMessage;
+      const setMessages = vi.fn();
+      const onCancel = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: initialMessages,
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [...initialMessages, optimisticMessage],
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).toHaveBeenCalledOnce();
+      expect(
+        (setMessages.mock.lastCall?.[0] as ThreadMessage[] | undefined)?.map(
+          (message) => message.id,
+        ),
+      ).toEqual(["u1", "a1", "u2"]);
+    });
+
+    it("resyncs when a pre-existing optimistic user message settles", async () => {
+      const initialMessages = [
+        createUserMessage("u1"),
+        createAssistantMessage("a1"),
+      ];
+      const optimisticMessage = {
+        ...createUserMessage("u2", "Pending"),
+        metadata: { custom: {}, isOptimistic: true },
+      } as ThreadMessage;
+      const settledMessage = {
+        ...optimisticMessage,
+        metadata: { custom: {}, isOptimistic: false },
+      } as ThreadMessage;
+      const setMessages = vi.fn();
+      const onCancel = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [...initialMessages, optimisticMessage],
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [...initialMessages, settledMessage],
+          isRunning: false,
+          onCancel,
+          setMessages,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).toHaveBeenCalledOnce();
+      expect(
+        (setMessages.mock.lastCall?.[0] as ThreadMessage[] | undefined)?.map(
+          (message) => message.id,
+        ),
+      ).toEqual(["u1", "a1"]);
+    });
+
+    it("preserves new messages while removing the cancelled user message", async () => {
+      const initialMessages = [
+        createUserMessage("u1"),
+        createAssistantMessage("a1"),
+      ];
+      const cancelledMessage = createUserMessage("u2", "Cancelled");
+      const appendedMessage = createUserMessage("u3", "Replacement");
+      const setMessages = vi.fn();
+      const onCancel = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: [...initialMessages, cancelledMessage],
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [...initialMessages, cancelledMessage, appendedMessage],
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).toHaveBeenCalledOnce();
+      expect(
+        (setMessages.mock.lastCall?.[0] as ThreadMessage[] | undefined)?.map(
+          (message) => message.id,
+        ),
+      ).toEqual(["u1", "a1", "u3"]);
+      expect(core.composer.text).toBe("Cancelled");
     });
 
     it("resyncs messages when an append fails", async () => {

--- a/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core-adapter.test.ts
@@ -350,6 +350,35 @@ describe("ExternalStoreThreadRuntimeCore adapter contract", () => {
       expect(setMessages).toHaveBeenCalledOnce();
     });
 
+    it("does not treat a regenerated optimistic message as a new append", async () => {
+      const initialMessages = [createUserMessage("u1")];
+      const setMessages = vi.fn();
+      const onCancel = vi.fn();
+      const core = new ExternalStoreThreadRuntimeCore(
+        contextProvider,
+        createBaseAdapter({
+          messages: initialMessages,
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+
+      core.cancelRun();
+      core.__internal_setAdapter(
+        createBaseAdapter({
+          messages: [...initialMessages],
+          isRunning: true,
+          onCancel,
+          setMessages,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(setMessages).toHaveBeenCalledOnce();
+      expect(setMessages).toHaveBeenCalledWith([]);
+    });
+
     it("resyncs messages when an append fails", async () => {
       const setMessages = vi.fn();
       const core = new ExternalStoreThreadRuntimeCore(


### PR DESCRIPTION
## Summary

- reconcile deferred cancellation resyncs with messages delivered afterward
- preserve adapter-owned optimistic messages while excluding only the placeholder generated by core
- retain cancellation deletions and branch restoration for queued, failed, or overlapping sends

## Problem

`cancelRun()` captures the current message snapshot and writes it through `setMessages()` on the next task so branch state can resync after cancellation. If another message arrives before that task runs, replaying the captured snapshot can overwrite the newer message. Simply skipping the replay also loses cancellation changes, including removal of a cancelled trailing user message.

## Fix

The deferred resync now records the messages known before cancellation and the exact IDs cancellation removes. If no new message arrives, it restores the captured branch as before. If a new message arrives, it writes the latest repository state after removing only the cancelled IDs and the exact optimistic placeholder generated by core. Adapter-owned optimistic messages remain intact.

## Verification

- reproduced the original overwrite on fresh `main`
- added regressions for successful, queued, failed, and adapter-optimistic sends
- added coverage for optimistic settlement and cancellation deletion during replacement sends
- external-store runtime tests: 81 passed
- changed-file lint and formatting: passed
- `@assistant-ui/core` build: passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qGrHBdJQpEji99nXo6JMNwJulkoTDWy0xUF8LkpSEYpvCTV_qevfGGgWb5A?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->