### PR TITLE
refactor(store): evaluate Derived scopes at React level, tap root only for build scopes

### DIFF
--- a/.changeset/derived-scopes-react-level.md
+++ b/.changeset/derived-scopes-react-level.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+refactor: evaluate Derived scopes at React level; useAui's tap root hosts only build scopes, so Derived-only mounts no longer re-render a tap root per update

--- a/packages/store/src/__tests__/useAui.derived-split.repro.bench.test.tsx
+++ b/packages/store/src/__tests__/useAui.derived-split.repro.bench.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+// repro: temporary benchmark for sw-120 (Derived scopes at React level).
+// Logs wall-clock medians; no timing assertions.
+
+import type { FC, ReactNode } from "react";
+import { useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { resource, withKey } from "@assistant-ui/tap";
+import { AuiProvider } from "../utils/react-assistant-context";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { useClientLookup } from "../useClientLookup";
+import { Derived } from "../Derived";
+
+const MESSAGE_COUNT = 500;
+const ITERATIONS = 5;
+
+const useItem = ({ id }: { id: string }) => {
+  return {
+    getState: () => ({ id, text: `text-${id}` }),
+  };
+};
+const Item = resource(useItem);
+
+const useThread = ({ ids }: { ids: string[] }) => {
+  const items = useClientLookup(ids.map((id) => withKey(id, Item({ id }))));
+  return {
+    getState: () => ({ count: ids.length }),
+    item: (lookup: { index: number }) => items.get(lookup),
+  };
+};
+const Thread = resource(useThread);
+
+const ThreadProvider: FC<{ ids: string[]; children: ReactNode }> = ({
+  ids,
+  children,
+}) => {
+  const aui = useAui({ thread: Thread({ ids }) } as unknown as useAui.Props);
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+// Mirrors core's MessageByIndexProvider: Derived-only useAui mount
+const MessageProvider: FC<{ index: number; children: ReactNode }> = ({
+  index,
+  children,
+}) => {
+  const aui = useAui({
+    message: Derived({
+      source: "thread",
+      query: { type: "index", index },
+      get: (aui: any) => aui.thread().item({ index }),
+    } as any),
+    composer: Derived({
+      source: "message",
+      query: {},
+      get: (aui: any) => aui.thread().item({ index }),
+    } as any),
+  } as unknown as useAui.Props);
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+const texts: string[] = [];
+const Leaf: FC<{ index: number }> = ({ index }) => {
+  texts[index] = useAuiState((s: any) => s.message.text);
+  return null;
+};
+
+const harness: { setIds: ((ids: string[]) => void) | null } = { setIds: null };
+
+const App: FC<{ initialIds: string[] }> = ({ initialIds }) => {
+  const [ids, setIds] = useState(initialIds);
+  harness.setIds = setIds;
+  return (
+    <ThreadProvider ids={ids}>
+      {ids.map((id, index) => (
+        <MessageProvider key={id} index={index}>
+          <Leaf index={index} />
+        </MessageProvider>
+      ))}
+    </ThreadProvider>
+  );
+};
+
+const makeIds = () => Array.from({ length: MESSAGE_COUNT }, (_, i) => `m${i}`);
+
+const median = (samples: number[]) =>
+  [...samples].sort((a, b) => a - b)[samples.length >> 1]!;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("repro sw-120: derived-only useAui benchmark", () => {
+  it(`mount, first-message delete, remount with ${MESSAGE_COUNT} messages`, () => {
+    const mount: number[] = [];
+    const update: number[] = [];
+    const remount: number[] = [];
+
+    for (let i = 0; i < ITERATIONS; i++) {
+      const ids = makeIds();
+
+      let t0 = performance.now();
+      const view = render(<App initialIds={ids} />);
+      mount.push(performance.now() - t0);
+      expect(texts[0]).toBe("text-m0");
+      expect(texts[MESSAGE_COUNT - 1]).toBe(`text-m${MESSAGE_COUNT - 1}`);
+
+      t0 = performance.now();
+      act(() => harness.setIds!(ids.slice(1)));
+      update.push(performance.now() - t0);
+      expect(texts[0]).toBe("text-m1");
+
+      t0 = performance.now();
+      view.unmount();
+      render(<App initialIds={makeIds()} />);
+      remount.push(performance.now() - t0);
+      expect(texts[0]).toBe("text-m0");
+
+      cleanup();
+    }
+
+    console.log(
+      `[sw-120 bench] messages=${MESSAGE_COUNT} iterations=${ITERATIONS}\n` +
+        `  mount           median ${median(mount).toFixed(1)}ms  (${mount.map((s) => s.toFixed(1)).join(", ")})\n` +
+        `  delete-first    median ${median(update).toFixed(1)}ms  (${update.map((s) => s.toFixed(1)).join(", ")})\n` +
+        `  unmount+remount median ${median(remount).toFixed(1)}ms  (${remount.map((s) => s.toFixed(1)).join(", ")})`,
+    );
+  });
+});

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -19,7 +19,7 @@ import type {
   ClientElement,
   ClientMethods,
 } from "./types/client";
-import { useDerived, type DerivedElement } from "./Derived";
+import { useDerived, type Derived, type DerivedElement } from "./Derived";
 import {
   useAssistantContextValue,
   DefaultAssistantClient,
@@ -54,11 +54,6 @@ type ScopeMeta = {
   source: ClientNames | "root";
   query: Record<string, unknown>;
 };
-type ScopeResult = {
-  name: ClientNames;
-  accessor: AssistantClientAccessor<ClientNames>;
-  state: unknown;
-};
 
 const applyTransformScopes = (
   clients: useAui.Props,
@@ -89,11 +84,12 @@ const applyTransformScopes = (
 const isDerivedElement = (element: ScopeElement) =>
   element.hook === (useDerived as unknown);
 
-const metaOf = (element: ScopeElement): ScopeMeta => {
-  if (!isDerivedElement(element)) return { source: "root", query: {} };
-  const props = element.args[0] as ScopeMeta;
-  return { source: props.source, query: props.query ?? {} };
-};
+const derivedPropsOf = (element: ScopeElement) =>
+  element.args[0] as Derived.Props<ClientNames> & {
+    query?: Record<string, unknown>;
+  };
+
+const ROOT_META: ScopeMeta = { source: "root", query: {} };
 
 const toScopeEntries = (scopes: Record<string, ScopeElement>): ScopeEntry[] =>
   (Object.entries(scopes) as [ClientNames, ScopeElement][]).map(
@@ -193,32 +189,19 @@ const useClientFields = ({
   );
 };
 
-const useScopeMeta = (element: ScopeElement): ScopeMeta => {
-  const { source, query } = metaOf(element);
-  return useShallowStable({ source, query: useShallowStable(query) });
-};
+const useScopeValue = (element: ScopeElement) =>
+  useResource(ClientResource(element));
 
-const useScopeValue = (element: ScopeElement, derived: boolean) =>
-  useResource(derived ? element : ClientResource(element));
-
-const useScopeMount = ({ name, element }: ScopeEntry): ScopeResult => {
+const useScopeMount = ({
+  name,
+  element,
+}: ScopeEntry): AssistantClientAccessor<ClientNames> => {
   const client = useBuildingClient();
+  const { methods } = useScopeValue(element);
 
-  // A derived element resolves to an existing client; mount it directly
-  const derived = isDerivedElement(element);
-  const value = useScopeValue(element, derived);
-
-  const methods = derived
-    ? (value as ClientMethods)
-    : (value as { methods: ClientMethods }).methods;
-  const state = derived
-    ? (value as { getState?: () => unknown }).getState?.()
-    : (value as { state: unknown }).state;
-
-  const meta = useScopeMeta(element);
   const accessor = useMemo(
-    () => createAccessor(name, meta, () => methods),
-    [name, meta, methods],
+    () => createAccessor(name, ROOT_META, () => methods),
+    [name, methods],
   );
 
   // Only fill vacant slots so a re-render never mutates an already-built client
@@ -226,12 +209,14 @@ const useScopeMount = ({ name, element }: ScopeEntry): ScopeResult => {
     (client as Record<ClientNames, unknown>)[name] = accessor;
   }
 
-  return useMemo(() => ({ name, accessor, state }), [name, accessor, state]);
+  return accessor;
 };
 
 const ScopeMount = resource(useScopeMount);
 
-const useScopeMounts = (entries: ScopeEntry[]): ScopeResult[] =>
+const useScopeMounts = (
+  entries: ScopeEntry[],
+): AssistantClientAccessor<ClientNames>[] =>
   useResources(entries.map((entry) => withKey(entry.name, ScopeMount(entry))));
 
 const useCommittedClient = ({
@@ -257,38 +242,26 @@ const useCommittedClient = ({
   return cell.client!;
 };
 
-const useAuiRoot = ({
-  parent,
-  clients,
-  clientRef,
-  notifications,
-}: {
-  parent: AssistantClient;
-  clients: useAui.Props;
-  clientRef: ClientRef;
-  notifications: NotificationManager;
-}): { client: AssistantClient } => {
-  const entries = toScopeEntries(applyTransformScopes(clients, parent));
+const useDerivedMount = ({
+  name,
+  element,
+}: ScopeEntry): AssistantClientAccessor<ClientNames> => {
+  const client = useBuildingClient();
+  const { source, query = {} } = derivedPropsOf(element);
+  const instance = useDerived(derivedPropsOf(element)) as ClientMethods;
 
-  const fields = useClientFields({ notifications, clientRef });
-  const building = createClientObject(parent, fields);
-
-  const results = useAssistantTapContextProvider(
-    { clientRef, emit: notifications.emit },
-    function WithTapContext() {
-      return useBuildingClientProvider(building, function WithBuildingClient() {
-        return useScopeMounts(entries);
-      });
-    },
+  const meta = useShallowStable({ source, query: useShallowStable(query) });
+  const accessor = useMemo(
+    () => createAccessor(name, meta, () => instance),
+    [name, meta, instance],
   );
 
-  const accessors = useShallowStable(results.map((r) => r.accessor));
+  // Only fill vacant slots so a re-render never mutates an already-built client
+  if (!Object.hasOwn(client, name)) {
+    (client as Record<ClientNames, unknown>)[name] = accessor;
+  }
 
-  // Fresh envelope per commit so value-only updates reach the store's
-  // subscribers; the client inside keeps its identity
-  return {
-    client: useCommittedClient({ building, parent, fields, accessors }),
-  };
+  return accessor;
 };
 
 const useNotifications = () => useResource(NotificationManager());
@@ -303,15 +276,56 @@ const useAssistantClient = ({
   const clientRef = useRef<ClientRef>({ parent, current: null }).current;
   const notifications = useNotifications();
 
+  const entries = toScopeEntries(applyTransformScopes(clients, parent));
+  const buildEntries = entries.filter((e) => !isDerivedElement(e.element));
+  const derivedEntries = entries.filter((e) => isDerivedElement(e.element));
+
+  const fields = useClientFields({ notifications, clientRef });
+  const building = createClientObject(parent, fields);
+
   const store = useTapRoot(function AuiRoot() {
-    return useAuiRoot({ parent, clients, clientRef, notifications });
+    const results = useAssistantTapContextProvider(
+      { clientRef, emit: notifications.emit },
+      function WithTapContext() {
+        return useBuildingClientProvider(
+          building,
+          function WithBuildingClient() {
+            return useScopeMounts(buildEntries);
+          },
+        );
+      },
+    );
+    // Fresh envelope per render so value-only updates reach the store's
+    // subscribers; the accessors inside keep their identity
+    return { accessors: useShallowStable(results) };
   });
 
-  const client = useSyncExternalStore(
+  const readBuildAccessors = () => store.getValue().accessors;
+  const buildAccessors = useSyncExternalStore(
     store.subscribe,
-    () => store.getValue().client,
-    () => store.getValue().client,
+    readBuildAccessors,
+    readBuildAccessors,
   );
+
+  const derivedAccessors = useBuildingClientProvider(
+    building,
+    function WithBuildingClient() {
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- scope maps are static per call site
+      return derivedEntries.map((entry) => useDerivedMount(entry));
+    },
+  );
+
+  let buildIndex = 0;
+  let derivedIndex = 0;
+  const accessors = useShallowStable(
+    entries.map(({ element }) =>
+      isDerivedElement(element)
+        ? derivedAccessors[derivedIndex++]!
+        : buildAccessors[buildIndex++]!,
+    ),
+  );
+
+  const client = useCommittedClient({ building, parent, fields, accessors });
 
   // flushTapSync makes structural rebinds triggered by a notification land
   // before the notification returns


### PR DESCRIPTION
Restructures `useAui` so Derived-only mounts (per-message providers) no longer pay for a tap root's scheduler, per-scope fibers, and root re-renders on every store update.

## What changed

- **Derived scopes** now run at the React level: `useAui` calls `useDerived` directly (internals unchanged, including its per-scope `useSyncExternalStore`) inside a `useBuildingClientProvider` wrapper on the host fiber, instead of mounting each Derived scope as a fiber inside a tap root. Per-scope hooks are fine because scope maps are static per call site; entries are iterated in a stable order.
- **Build scopes** keep the single `useTapRoot`, still always called (the hook sequence does not depend on scope count/kind), but it now hosts only the non-Derived scopes. In a Derived-only mount nothing subscribes to or dirties this root, so it renders once at mount and stays inert; its output is the shallow-stable build-accessor list, read through one `useSyncExternalStore`.
- The client envelope (accessors + committed identity) is composed at the React level from both groups in original scope order via `useShallowStable`/`useCommittedClient` (rebased on top of #5367's fixed hook count and #5368's `useShallowStable`/mutable-cell machinery, both preserved).
- Semantics preserved: same envelope identity behavior (value-only updates keep `aui` identity, structural swaps produce a new one), same notification routing, same missing-scope error accessors, and a Derived `get()` that throws on re-selection still keeps the committed value while a throw at mount still propagates.

## Benchmark

500 Derived-only `useAui` mounts (MessageByIndexProvider-shaped, 2 Derived scopes each) under one thread provider; jsdom, `performance.now()` around `act()`, median of 5 iterations, two runs shown as a range. Baseline is current main (ecd7c87, includes #5367/#5368). Benchmark file is a temporary "repro" test on this branch (`packages/store/src/__tests__/useAui.derived-split.repro.bench.test.tsx`), to be deleted at merge.

| Scenario | main | this PR | delta |
| --- | ---: | ---: | ---: |
| Mount 500-message thread | 23.7–25.6 ms | 20.2–21.0 ms | ~1.2x faster |
| Delete first message (bulk identity shift) | 92.3–106.2 ms | 42.5–46.5 ms | ~2.2x faster |
| Unmount + remount (thread switch) | 30.2–31.0 ms | 16.2–17.2 ms | ~1.8x faster |

## Verification

- `@assistant-ui/store`: all pre-existing tests pass unmodified (84 incl. the repro bench)
- `@assistant-ui/core`: 767/767 tests pass unmodified
- `pnpm -F @assistant-ui/store build`, `pnpm -F @assistant-ui/core build` pass
- `node scripts/generate-api-surface.mjs`: no api-surface changes
- `pnpm check:resource-memo`: clean

Refs: sw-120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
