### PR TITLE
fix(react-google-adk): cancel streams on early exit

### DIFF
--- a/.changeset/tidy-adk-streams-cancel.md
+++ b/.changeset/tidy-adk-streams-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: cancel Google ADK streams when iteration stops early

--- a/packages/react-google-adk/src/AdkClient.test.ts
+++ b/packages/react-google-adk/src/AdkClient.test.ts
@@ -630,6 +630,61 @@ describe("createAdkStream - SSE parsing", () => {
     expect(collected).toHaveLength(1);
     expect(collected[0]!.id).toBe("e1");
   });
+
+  it("cancels the response body when iteration stops early", async () => {
+    const cancel = vi.fn();
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ id: "e1" })}\n\n`),
+        );
+      },
+      cancel,
+    });
+    mockFetch.mockResolvedValueOnce(sseResponse(body));
+
+    const stream = createAdkStream({ api: "/api/adk" });
+    const gen = await stream(
+      [{ id: "m1", type: "human", content: "Hi" }],
+      makeConfig(),
+    );
+
+    for await (const _event of gen) {
+      break;
+    }
+
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("does not surface cancellation errors on early exit", async () => {
+    const encoder = new TextEncoder();
+    let controller!: ReadableStreamDefaultController<Uint8Array>;
+    const body = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController;
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify({ id: "e1" })}\n\n`),
+        );
+      },
+    });
+    mockFetch.mockResolvedValueOnce(sseResponse(body));
+
+    const stream = createAdkStream({ api: "/api/adk" });
+    const gen = await stream(
+      [{ id: "m1", type: "human", content: "Hi" }],
+      makeConfig(),
+    );
+
+    const consume = async () => {
+      for await (const _event of gen) {
+        controller.error(new Error("stream failed"));
+        break;
+      }
+    };
+
+    await expect(consume()).resolves.toBeUndefined();
+  });
 });
 
 // ── Error handling ──

--- a/packages/react-google-adk/src/AdkClient.ts
+++ b/packages/react-google-adk/src/AdkClient.ts
@@ -243,10 +243,20 @@ async function* parseSSEResponse(response: Response): AsyncGenerator<AdkEvent> {
   const decoder = new TextDecoder();
   const sseDecoder = new SSEEventDecoder({ trailing: "dispatch" });
 
+  let shouldCancel = true;
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      let result: ReadableStreamReadResult<Uint8Array>;
+      try {
+        result = await reader.read();
+      } catch (error) {
+        shouldCancel = false;
+        throw error;
+      }
+
+      const { done, value } = result;
       if (done) {
+        shouldCancel = false;
         for (const event of sseDecoder.push(decoder.decode())) {
           yield JSON.parse(event.data) as AdkEvent;
         }
@@ -263,6 +273,10 @@ async function* parseSSEResponse(response: Response): AsyncGenerator<AdkEvent> {
     const trailing = sseDecoder.flush();
     if (trailing !== null) yield JSON.parse(trailing.data) as AdkEvent;
   } finally {
-    reader.releaseLock();
+    try {
+      if (shouldCancel) await reader.cancel().catch(() => undefined);
+    } finally {
+      reader.releaseLock();
+    }
   }
 }


### PR DESCRIPTION
## Summary

- cancel the Google ADK response body when an SSE consumer stops iteration early
- preserve normal completion and stream read error behavior
- suppress cancellation failures while always releasing the reader lock

## Why

Breaking from `for await` previously only released the response reader lock. Releasing the lock does not cancel the HTTP body, so the ADK server or model could continue generating after the caller stopped consuming events.

A focused `ReadableStream` reproduction confirmed its `cancel()` hook was called zero times before this change. The parser now follows the same guarded cancellation behavior used by the A2A adapter: early exits cancel, natural completion does not, and cancellation failures do not replace the consumer outcome.

## Testing

- `vitest run packages/react-google-adk/src/AdkClient.test.ts` (41 tests)
- `aui-build` for `@assistant-ui/react-google-adk`
- `oxlint packages/react-google-adk/src/AdkClient.ts packages/react-google-adk/src/AdkClient.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MQk298LA9a1fx6ldz0Pb-u-DLXmKTzsEWbnEpmL-RIIMmarRlunHrMn88h0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->