### PR TITLE
fix(core): isolate dictation listener error

### DIFF
--- a/.changeset/calm-dictation-listeners.md
+++ b/.changeset/calm-dictation-listeners.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate WebSpeech dictation listener errors

--- a/.changeset/calm-dictation-listeners.md
+++ b/.changeset/calm-dictation-listeners.md
@@ -2,4 +2,4 @@
 "@assistant-ui/core": patch
 ---
 
-fix: isolate WebSpeech dictation listener errors
+fix: isolate WebSpeech dictation listener errors and report async listener rejections from speech synthesis and voice sessions

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -88,7 +88,7 @@ describe("WebSpeechSynthesisAdapter", () => {
 });
 
 describe("WebSpeechDictationAdapter", () => {
-  it("continues notifying dictation listeners when one throws", () => {
+  const stubSpeechRecognition = () => {
     const listeners = new Map<string, EventListener>();
     class MockSpeechRecognition {
       lang = "";
@@ -106,6 +106,11 @@ describe("WebSpeechDictationAdapter", () => {
     vi.stubGlobal("window", {
       SpeechRecognition: MockSpeechRecognition,
     });
+    return listeners;
+  };
+
+  it("continues notifying dictation listeners when one throws", () => {
+    const listeners = stubSpeechRecognition();
     const listenerError = new Error("listener failed");
     const consoleError = vi
       .spyOn(console, "error")
@@ -160,23 +165,7 @@ describe("WebSpeechDictationAdapter", () => {
   });
 
   it("isolates async failures and payload mutations", async () => {
-    const listeners = new Map<string, EventListener>();
-    class MockSpeechRecognition {
-      lang = "";
-      continuous = false;
-      interimResults = false;
-
-      addEventListener(type: string, listener: EventListener) {
-        listeners.set(type, listener);
-      }
-
-      start() {}
-      stop() {}
-      abort() {}
-    }
-    vi.stubGlobal("window", {
-      SpeechRecognition: MockSpeechRecognition,
-    });
+    const listeners = stubSpeechRecognition();
     const listenerError = new Error("async listener failed");
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -158,4 +158,59 @@ describe("WebSpeechDictationAdapter", () => {
       listenerError,
     );
   });
+
+  it("isolates async failures and payload mutations", async () => {
+    const listeners = new Map<string, EventListener>();
+    class MockSpeechRecognition {
+      lang = "";
+      continuous = false;
+      interimResults = false;
+
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      }
+
+      start() {}
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal("window", {
+      SpeechRecognition: MockSpeechRecognition,
+    });
+    const listenerError = new Error("async listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const session = new WebSpeechDictationAdapter().listen();
+    const laterListener = vi.fn();
+
+    session.onSpeech(async (result) => {
+      result.transcript = "Changed";
+      result.isFinal = false;
+      throw listenerError;
+    });
+    session.onSpeech(laterListener);
+
+    const event = {
+      resultIndex: 0,
+      results: [
+        {
+          0: { transcript: "Hello" },
+          isFinal: true,
+        },
+      ],
+    } as unknown as Event;
+
+    expect(() => listeners.get("result")?.(event)).not.toThrow();
+    expect(laterListener).toHaveBeenCalledWith({
+      transcript: "Hello",
+      isFinal: true,
+    });
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Dictation listener threw an error",
+        listenerError,
+      );
+    });
+  });
 });

--- a/packages/core/src/adapters/speech.test.ts
+++ b/packages/core/src/adapters/speech.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSpeechSynthesisAdapter } from "./speech";
+import { WebSpeechDictationAdapter, WebSpeechSynthesisAdapter } from "./speech";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -82,6 +82,79 @@ describe("WebSpeechSynthesisAdapter", () => {
     });
     expect(consoleError).toHaveBeenCalledWith(
       "[assistant-ui] Speech synthesis listener threw an error",
+      listenerError,
+    );
+  });
+});
+
+describe("WebSpeechDictationAdapter", () => {
+  it("continues notifying dictation listeners when one throws", () => {
+    const listeners = new Map<string, EventListener>();
+    class MockSpeechRecognition {
+      lang = "";
+      continuous = false;
+      interimResults = false;
+
+      addEventListener(type: string, listener: EventListener) {
+        listeners.set(type, listener);
+      }
+
+      start() {}
+      stop() {}
+      abort() {}
+    }
+    vi.stubGlobal("window", {
+      SpeechRecognition: MockSpeechRecognition,
+    });
+    const listenerError = new Error("listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const session = new WebSpeechDictationAdapter().listen();
+    const laterStartListener = vi.fn();
+    const laterSpeechListener = vi.fn();
+    const laterEndListener = vi.fn();
+
+    session.onSpeechStart(() => {
+      throw listenerError;
+    });
+    session.onSpeechStart(laterStartListener);
+    session.onSpeech(() => {
+      throw listenerError;
+    });
+    session.onSpeech(laterSpeechListener);
+    session.onSpeechEnd(() => {
+      throw listenerError;
+    });
+    session.onSpeechEnd(laterEndListener);
+
+    const event = {
+      resultIndex: 0,
+      results: [
+        {
+          0: { transcript: "Hello" },
+          isFinal: true,
+        },
+      ],
+    } as unknown as Event;
+
+    expect(() =>
+      listeners.get("speechstart")?.(new Event("speechstart")),
+    ).not.toThrow();
+    expect(() => listeners.get("result")?.(event)).not.toThrow();
+    expect(() => listeners.get("end")?.(new Event("end"))).not.toThrow();
+
+    expect(laterStartListener).toHaveBeenCalledOnce();
+    expect(laterSpeechListener).toHaveBeenCalledWith({
+      transcript: "Hello",
+      isFinal: true,
+    });
+    expect(laterEndListener).toHaveBeenCalledWith({
+      transcript: "Hello",
+    });
+    expect(consoleError).toHaveBeenCalledTimes(3);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] Dictation listener threw an error",
       listenerError,
     );
   });

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -280,21 +280,17 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
         if (result.isFinal) {
           finalTranscript += transcript;
-          const payload: DictationAdapter.Result = {
-            transcript,
-            isFinal: true,
-          };
-          notifyEventListeners(speechCallbacks, payload, "Dictation", () => ({
-            ...payload,
-          }));
+          notifyEventListeners(
+            speechCallbacks,
+            () => ({ transcript, isFinal: true }),
+            "Dictation",
+          );
         } else {
-          const payload: DictationAdapter.Result = {
-            transcript,
-            isFinal: false,
-          };
-          notifyEventListeners(speechCallbacks, payload, "Dictation", () => ({
-            ...payload,
-          }));
+          notifyEventListeners(
+            speechCallbacks,
+            () => ({ transcript, isFinal: false }),
+            "Dictation",
+          );
         }
       }
     });
@@ -309,12 +305,11 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
         updateStatus({ type: "ended", reason: "stopped" });
       }
       if (finalTranscript) {
-        const payload: DictationAdapter.Result = {
-          transcript: finalTranscript,
-        };
-        notifyEventListeners(speechEndCallbacks, payload, "Dictation", () => ({
-          ...payload,
-        }));
+        notifyEventListeners(
+          speechEndCallbacks,
+          () => ({ transcript: finalTranscript }),
+          "Dictation",
+        );
         finalTranscript = "";
       }
     });

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -37,6 +37,19 @@ const notifySpeechSynthesisListeners = (
   }
 };
 
+const notifyDictationListeners = <T>(
+  listeners: Iterable<(value: T) => void>,
+  value: T,
+): void => {
+  for (const listener of listeners) {
+    try {
+      listener(value);
+    } catch (error) {
+      console.error("[assistant-ui] Dictation listener threw an error", error);
+    }
+  }
+};
+
 export namespace DictationAdapter {
   export type Status =
     | {
@@ -270,7 +283,7 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
     };
 
     recognition.addEventListener("speechstart", () => {
-      for (const cb of speechStartCallbacks) cb();
+      notifyDictationListeners(speechStartCallbacks, undefined);
     });
 
     recognition.addEventListener("start", () => {
@@ -292,9 +305,15 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
         if (result.isFinal) {
           finalTranscript += transcript;
-          for (const cb of speechCallbacks) cb({ transcript, isFinal: true });
+          notifyDictationListeners(speechCallbacks, {
+            transcript,
+            isFinal: true,
+          });
         } else {
-          for (const cb of speechCallbacks) cb({ transcript, isFinal: false });
+          notifyDictationListeners(speechCallbacks, {
+            transcript,
+            isFinal: false,
+          });
         }
       }
     });
@@ -309,8 +328,9 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
         updateStatus({ type: "ended", reason: "stopped" });
       }
       if (finalTranscript) {
-        for (const cb of speechEndCallbacks)
-          cb({ transcript: finalTranscript });
+        notifyDictationListeners(speechEndCallbacks, {
+          transcript: finalTranscript,
+        });
         finalTranscript = "";
       }
     });

--- a/packages/core/src/adapters/speech.ts
+++ b/packages/core/src/adapters/speech.ts
@@ -1,4 +1,5 @@
 import type { Unsubscribe } from "../types/unsubscribe";
+import { notifyEventListeners } from "../utils/notify-event-listeners";
 
 export namespace SpeechSynthesisAdapter {
   export type Status =
@@ -20,34 +21,6 @@ export namespace SpeechSynthesisAdapter {
 
 export type SpeechSynthesisAdapter = {
   speak: (text: string) => SpeechSynthesisAdapter.Utterance;
-};
-
-const notifySpeechSynthesisListeners = (
-  listeners: Iterable<() => void>,
-): void => {
-  for (const listener of listeners) {
-    try {
-      listener();
-    } catch (error) {
-      console.error(
-        "[assistant-ui] Speech synthesis listener threw an error",
-        error,
-      );
-    }
-  }
-};
-
-const notifyDictationListeners = <T>(
-  listeners: Iterable<(value: T) => void>,
-  value: T,
-): void => {
-  for (const listener of listeners) {
-    try {
-      listener(value);
-    } catch (error) {
-      console.error("[assistant-ui] Dictation listener threw an error", error);
-    }
-  }
 };
 
 export namespace DictationAdapter {
@@ -92,7 +65,7 @@ export class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
       if (res.status.type === "ended") return;
 
       res.status = { type: "ended", reason, error };
-      notifySpeechSynthesisListeners(subscribers);
+      notifyEventListeners(subscribers, undefined, "Speech synthesis");
     };
 
     utterance.addEventListener("end", () => handleEnd("finished"));
@@ -110,7 +83,9 @@ export class WebSpeechSynthesisAdapter implements SpeechSynthesisAdapter {
         if (res.status.type === "ended") {
           let cancelled = false;
           queueMicrotask(() => {
-            if (!cancelled) notifySpeechSynthesisListeners([callback]);
+            if (!cancelled) {
+              notifyEventListeners([callback], undefined, "Speech synthesis");
+            }
           });
           return () => {
             cancelled = true;
@@ -283,7 +258,7 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
     };
 
     recognition.addEventListener("speechstart", () => {
-      notifyDictationListeners(speechStartCallbacks, undefined);
+      notifyEventListeners(speechStartCallbacks, undefined, "Dictation");
     });
 
     recognition.addEventListener("start", () => {
@@ -305,15 +280,21 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
 
         if (result.isFinal) {
           finalTranscript += transcript;
-          notifyDictationListeners(speechCallbacks, {
+          const payload: DictationAdapter.Result = {
             transcript,
             isFinal: true,
-          });
+          };
+          notifyEventListeners(speechCallbacks, payload, "Dictation", () => ({
+            ...payload,
+          }));
         } else {
-          notifyDictationListeners(speechCallbacks, {
+          const payload: DictationAdapter.Result = {
             transcript,
             isFinal: false,
-          });
+          };
+          notifyEventListeners(speechCallbacks, payload, "Dictation", () => ({
+            ...payload,
+          }));
         }
       }
     });
@@ -328,9 +309,12 @@ export class WebSpeechDictationAdapter implements DictationAdapter {
         updateStatus({ type: "ended", reason: "stopped" });
       }
       if (finalTranscript) {
-        notifyDictationListeners(speechEndCallbacks, {
+        const payload: DictationAdapter.Result = {
           transcript: finalTranscript,
-        });
+        };
+        notifyEventListeners(speechEndCallbacks, payload, "Dictation", () => ({
+          ...payload,
+        }));
         finalTranscript = "";
       }
     });

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -1,4 +1,5 @@
 import type { Unsubscribe } from "../types/unsubscribe";
+import { notifyEventListeners } from "../utils/notify-event-listeners";
 
 export namespace RealtimeVoiceAdapter {
   export type Status =
@@ -57,22 +58,6 @@ export type VoiceSessionHelpers = {
   isDisposed: () => boolean;
 };
 
-const notifyListeners = <T>(
-  listeners: ReadonlySet<(value: T) => void>,
-  value: T,
-) => {
-  for (const listener of listeners) {
-    try {
-      listener(value);
-    } catch (error) {
-      console.error(
-        "[assistant-ui] Voice session listener threw an error",
-        error,
-      );
-    }
-  }
-};
-
 export function createVoiceSession(
   options: { abortSignal?: AbortSignal },
   setup: (helpers: VoiceSessionHelpers) => Promise<VoiceSessionControls>,
@@ -101,25 +86,25 @@ export function createVoiceSession(
     setStatus: (status) => {
       if (disposed) return;
       currentStatus = status;
-      notifyListeners(statusCbs, status);
+      notifyEventListeners(statusCbs, status, "Voice session");
     },
     end: (reason, error?) => {
       if (disposed) return;
       currentStatus = { type: "ended", reason, error };
-      notifyListeners(statusCbs, currentStatus);
+      notifyEventListeners(statusCbs, currentStatus, "Voice session");
       cleanup();
     },
     emitTranscript: (item) => {
       if (disposed) return;
-      notifyListeners(transcriptCbs, item);
+      notifyEventListeners(transcriptCbs, item, "Voice session");
     },
     emitMode: (mode) => {
       if (disposed) return;
-      notifyListeners(modeCbs, mode);
+      notifyEventListeners(modeCbs, mode, "Voice session");
     },
     emitVolume: (volume) => {
       if (disposed) return;
-      notifyListeners(volumeCbs, volume);
+      notifyEventListeners(volumeCbs, volume, "Voice session");
     },
     isDisposed: () => disposed,
   };

--- a/packages/core/src/utils/notify-event-listeners.ts
+++ b/packages/core/src/utils/notify-event-listeners.ts
@@ -2,9 +2,8 @@ type EventListener<T> = (payload: T) => unknown;
 
 export const notifyEventListeners = <T>(
   listeners: Iterable<EventListener<T>>,
-  payload: T,
+  payloadOrFactory: T | (() => T),
   errorContext: string,
-  createPayload: (() => T) | undefined = undefined,
 ) => {
   const reportError = (error: unknown) => {
     console.error(
@@ -15,7 +14,11 @@ export const notifyEventListeners = <T>(
 
   for (const listener of listeners) {
     try {
-      const result = listener(createPayload ? createPayload() : payload);
+      const result = listener(
+        typeof payloadOrFactory === "function"
+          ? (payloadOrFactory as () => T)()
+          : payloadOrFactory,
+      );
       if (
         result !== null &&
         (typeof result === "object" || typeof result === "function") &&

--- a/packages/core/src/utils/notify-event-listeners.ts
+++ b/packages/core/src/utils/notify-event-listeners.ts
@@ -1,9 +1,10 @@
-type EventListener = (payload?: unknown) => void;
+type EventListener<T> = (payload: T) => unknown;
 
-export const notifyEventListeners = (
-  listeners: Iterable<EventListener>,
-  payload: unknown,
+export const notifyEventListeners = <T>(
+  listeners: Iterable<EventListener<T>>,
+  payload: T,
   errorContext: string,
+  createPayload: (() => T) | undefined = undefined,
 ) => {
   const reportError = (error: unknown) => {
     console.error(
@@ -14,7 +15,7 @@ export const notifyEventListeners = (
 
   for (const listener of listeners) {
     try {
-      const result = listener(payload) as unknown;
+      const result = listener(createPayload ? createPayload() : payload);
       if (
         result !== null &&
         (typeof result === "object" || typeof result === "function") &&

--- a/packages/core/src/utils/notify-event-listeners.ts
+++ b/packages/core/src/utils/notify-event-listeners.ts
@@ -1,5 +1,6 @@
 type EventListener<T> = (payload: T) => unknown;
 
+// A function payload is indistinguishable from a factory and gets invoked; wrap a function-typed payload in a factory.
 export const notifyEventListeners = <T>(
   listeners: Iterable<EventListener<T>>,
   payloadOrFactory: T | (() => T),


### PR DESCRIPTION
## Summary

- isolate WebSpeech dictation start, transcript, and end subscribers
- move speech synthesis and voice session notification onto the shared `notifyEventListeners` primitive, deleting both local copies
- report subscriber failures without interrupting remaining listeners; async listener rejections are now reported for dictation, synthesis, and voice sessions
- add regression coverage for all dictation callback types

## Why

`WebSpeechDictationAdapter` invoked subscribers directly. If one callback threw, the error escaped the recognition event handler and prevented every later callback from receiving that event. Speech synthesis and realtime voice already isolate listener failures, so dictation behaved inconsistently.

Rather than adding a third local notify loop, this change routes `speech.ts` and `voice.ts` through the shared `notifyEventListeners` primitive, which also reports async listener rejections the local copies discarded. The primitive resolves an optional payload factory per listener, so every subscriber keeps receiving its own result object, and a comment documents that a function-typed payload must be wrapped in a factory.

A focused fake `SpeechRecognition` reproduction confirmed that a throwing listener prevented the next subscriber from receiving the transcript before this change.

## Testing

- core adapter tests: 22 passed
- `@assistant-ui/core` build
- targeted oxlint and formatting checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.p_90zOKvRzVHXu8GBnRw5s0wm9tj6EFchq-V2R1WtAeeg9TalNVMFOQNZfc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
