### PR TITLE
fix(ui): soften tooltip icon button press feedback

### DIFF
--- a/packages/ui/src/components/assistant-ui/tooltip-icon-button.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/tooltip-icon-button.radix.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
             size="icon"
             {...rest}
             className={cn(
-              "aui-button-icon size-6 p-1 active:scale-90",
+              "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
               className,
             )}
             ref={ref}

--- a/packages/ui/src/components/assistant-ui/tooltip-icon-button.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/tooltip-icon-button.radix.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
             size="icon"
             {...rest}
             className={cn(
-              "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
+              "aui-button-icon size-6 p-1 active:scale-[0.96]",
               className,
             )}
             ref={ref}

--- a/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
               size="icon"
               {...rest}
               className={cn(
-                "aui-button-icon size-6 p-1 active:scale-90",
+                "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
                 className,
               )}
               ref={ref}

--- a/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/packages/ui/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
               size="icon"
               {...rest}
               className={cn(
-                "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
+                "aui-button-icon size-6 p-1 active:scale-[0.96]",
                 className,
               )}
               ref={ref}

--- a/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
               size="icon"
               {...rest}
               className={cn(
-                "aui-button-icon size-6 p-1 active:scale-90",
+                "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
                 className,
               )}
               ref={ref}

--- a/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
+++ b/templates/minimal/components/assistant-ui/tooltip-icon-button.tsx
@@ -30,7 +30,7 @@ export const TooltipIconButton = forwardRef<
               size="icon"
               {...rest}
               className={cn(
-                "aui-button-icon size-6 p-1 transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none",
+                "aui-button-icon size-6 p-1 active:scale-[0.96]",
                 className,
               )}
               ref={ref}


### PR DESCRIPTION
## What

`TooltipIconButton` pressed to `active:scale-90` with no transition — an instant 10% snap. This replaces it with the kit's shared press recipe:

```
transition-[color,scale] active:scale-[0.98] motion-reduce:transition-none
```

One class-string change in both variants (`tooltip-icon-button.tsx`, `tooltip-icon-button.radix.tsx`), plus the byte-equal `templates/minimal` copy via `pnpm sync-templates`.

## Why

This is the kit's highest-frequency control (message copy/refresh, branch picker, composer dictate/send, scroll-to-bottom), and it was the only press interaction in the kit that snapped with no transition. The collapsible triggers in `reasoning.tsx`, `tool-group.tsx`, and `tool-fallback.tsx` all press to 98% with an eased `transition-[color,scale]` — this brings the icon button in line with that existing recipe rather than introducing a new opinion. The `motion-reduce:transition-none` gate follows the existing convention in `reasoning.tsx` (scale change becomes instant, color feedback remains).

No explicit `duration-*`/`ease-*`: Tailwind defaults (150ms) apply, same as the exemplar components.

## How verified

- `active:scale-90` no longer appears anywhere in the repo (including example forks)
- `pnpm sync-templates` green; `oxfmt --check` and `oxlint` clean on all three files
- `tsc --noEmit` on `templates/minimal` passes; the 4 pre-existing type errors in `packages/ui` reproduce identically on clean `main` (unrelated files)
- No changeset: `@assistant-ui/ui` is `private: true`

Deliberately untouched: `assistant-modal.tsx` (`active:scale-96` is intentional for the 44px floating button) and everything under `components/ui/**`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fDB6QvNgvwhfDxjLhsnxurx_aaNHMseVhOO_iRBwhmIdxFpKf88e_L-KRUY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->