### PR TITLE
perf(store): reduce useAui allocation overhead

### DIFF
--- a/.changeset/quiet-dogs-smile.md
+++ b/.changeset/quiet-dogs-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+perf: reduce allocations while building assistant clients

--- a/packages/store/src/__tests__/accessor-properties.test.tsx
+++ b/packages/store/src/__tests__/accessor-properties.test.tsx
@@ -148,6 +148,7 @@ describe("accessor property API", () => {
     expect(() => accessor()).toThrow(/AuiProvider/);
     expect(() => accessor.getState()).toThrow(/AuiProvider/);
     expect(accessor.source).toBeNull();
+    expect(accessor).toBe((aui as AnyClient).thread);
   });
 
   it("undefined scopes never throw at selection time, only on use", () => {
@@ -160,5 +161,12 @@ describe("accessor property API", () => {
     expect(aui.composer.name).toBe("composer");
     expect(() => aui.composer()).toThrow(/"composer"/);
     expect(() => aui.composer.send()).toThrow(/"composer"/);
+  });
+
+  it("reuses unavailable scope accessors", () => {
+    const { getAui } = setup();
+    const aui = getAui();
+
+    expect(aui.composer).toBe(aui.composer);
   });
 });

--- a/packages/store/src/__tests__/attachTransformScopes.test.tsx
+++ b/packages/store/src/__tests__/attachTransformScopes.test.tsx
@@ -65,6 +65,23 @@ describe("attachTransformScopes", () => {
     expect(getAui().c.getState()).toEqual({ name: "c" });
   });
 
+  it("transforms resources that replace an existing scope", () => {
+    const [useA, A] = makeClient("a");
+    const [useB, B] = makeClient("b");
+    const [, C] = makeClient("c");
+    attachTransformScopes(useA, (scopes) => {
+      (scopes as AnyScopes).a = B();
+    });
+    attachTransformScopes(useB, (scopes) => {
+      (scopes as AnyScopes).c = C();
+    });
+
+    const getAui = mount({ a: A() });
+
+    expect(getAui().a.getState()).toEqual({ name: "b" });
+    expect(getAui().c.getState()).toEqual({ name: "c" });
+  });
+
   it("each transform runs once per pass, even when it always writes", () => {
     const [useA, A] = makeClient("a");
     const [, B] = makeClient("b");
@@ -73,10 +90,28 @@ describe("attachTransformScopes", () => {
     });
     attachTransformScopes(useA, transform);
 
-    const getAui = mount({ a: A() });
+    const getAui = mount({ a: A(), composer: A() });
 
     expect(transform).toHaveBeenCalledTimes(1);
     expect(getAui().b.getState()).toEqual({ name: "b" });
+  });
+
+  it("does not transform a scope replaced before its turn", () => {
+    const [useA, A] = makeClient("a");
+    const [useB, B] = makeClient("b");
+    const [, Replacement] = makeClient("replacement");
+    const [, C] = makeClient("c");
+    attachTransformScopes(useA, (scopes) => {
+      (scopes as AnyScopes).b = Replacement();
+    });
+    attachTransformScopes(useB, (scopes) => {
+      (scopes as AnyScopes).c = C();
+    });
+
+    const getAui = mount({ a: A(), b: B() });
+
+    expect(getAui().b.getState()).toEqual({ name: "replacement" });
+    expect(Object.hasOwn(getAui(), "c")).toBe(false);
   });
 
   it("a transform can inspect the parent client to add scopes conditionally", () => {

--- a/packages/store/src/__tests__/useAui.bench.tsx
+++ b/packages/store/src/__tests__/useAui.bench.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+/**
+ * Focused useAui benchmark. Run:
+ *
+ *   pnpm --filter @assistant-ui/store exec vitest bench --run src/__tests__/useAui.bench.tsx
+ */
+import type { ReactNode } from "react";
+import { useState } from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { bench, describe } from "vitest";
+import { flushTapSync, resource } from "@assistant-ui/tap";
+import { Derived } from "../Derived";
+import { useAui } from "../useAui";
+import { useClientResource } from "../useClientResource";
+import { AuiProvider } from "../utils/react-assistant-context";
+
+const PROVIDER_COUNT = 100;
+
+const useItem = () => ({
+  getState: () => ({}),
+});
+const Item = resource(useItem);
+
+let bumpThread!: () => void;
+
+const useThread = () => {
+  const [, setVersion] = useState(0);
+  const item = useClientResource(Item());
+  bumpThread = () => setVersion((version) => version + 1);
+  return {
+    getState: () => ({}),
+    item: () => item.methods,
+  };
+};
+const Thread = resource(useThread);
+
+const Root = ({ children }: { children: ReactNode }) => {
+  const aui = useAui({
+    thread: Thread(),
+  } as unknown as useAui.Props);
+  return <AuiProvider value={aui}>{children}</AuiProvider>;
+};
+
+const DerivedScopes = ({ count }: { count: 1 | 2 }) => {
+  const aui = useAui({
+    message: Derived({
+      source: "thread",
+      query: {},
+      get: (parent) => parent.thread.item(),
+    } as never),
+    ...(count === 2
+      ? {
+          composer: Derived({
+            source: "thread",
+            query: {},
+            get: (parent) => parent.thread.item(),
+          } as never),
+        }
+      : {}),
+  } as unknown as useAui.Props);
+  return <AuiProvider value={aui}>{null}</AuiProvider>;
+};
+
+const DerivedTree = ({ count }: { count: 1 | 2 }) => (
+  <Root>
+    {Array.from({ length: PROVIDER_COUNT }, (_, index) => (
+      <DerivedScopes key={index} count={count} />
+    ))}
+  </Root>
+);
+
+describe(`useAui with ${PROVIDER_COUNT} derived providers`, () => {
+  for (const count of [1, 2] as const) {
+    bench(`mount and unmount, ${count} scope(s)`, () => {
+      const view = render(<DerivedTree count={count} />);
+      view.unmount();
+    });
+
+    bench(
+      `parent update, ${count} scope(s)`,
+      () => {
+        act(() => flushTapSync(bumpThread));
+      },
+      {
+        setup: () => {
+          render(<DerivedTree count={count} />);
+        },
+        teardown: cleanup,
+      },
+    );
+  }
+});

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -65,22 +65,36 @@ const applyTransformScopes = (
   clients: useAui.Props,
   parent: AssistantClient,
 ): Record<string, ScopeElement> => {
+  const initialElements = Object.values(clients) as ScopeElement[];
+  if (
+    !initialElements.some((element) => getTransformScopes(element.hook) != null)
+  ) {
+    return clients as Record<string, ScopeElement>;
+  }
+
   const scopes = { ...clients } as Record<string, ScopeElement>;
-  const visited = new Set<ScopeElement["hook"]>();
+  const pending: ScopeElement["hook"][] = [];
+  const queued = new Set<ScopeElement["hook"]>();
+  for (const element of initialElements) {
+    if (queued.has(element.hook)) continue;
+    queued.add(element.hook);
+    pending.push(element.hook);
+  }
 
-  let changed = true;
-  while (changed) {
-    changed = false;
+  for (let index = 0; index < pending.length; index++) {
+    const hook = pending[index]!;
+    if (!Object.values(scopes).some((element) => element.hook === hook)) {
+      continue;
+    }
+
+    const transform = getTransformScopes(hook);
+    if (!transform) continue;
+
+    transform(scopes as ScopesConfig, parent);
     for (const element of Object.values(scopes)) {
-      if (visited.has(element.hook)) continue;
-      visited.add(element.hook);
-
-      const transform = getTransformScopes(element.hook);
-      if (transform) {
-        transform(scopes as ScopesConfig, parent);
-        changed = true;
-        break;
-      }
+      if (queued.has(element.hook)) continue;
+      queued.add(element.hook);
+      pending.push(element.hook);
     }
   }
 

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -1,11 +1,35 @@
 import type React from "react";
 import { createContext, useContext, useEffect } from "react";
 import { useContextProvider } from "@assistant-ui/tap";
-import type { AssistantClient } from "../types/client";
+import type {
+  AssistantClient,
+  AssistantClientAccessor,
+  ClientNames,
+} from "../types/client";
 import { BaseProxyHandler, handleIntrospectionProp } from "./BaseProxyHandler";
 import { createErrorClientAccessor } from "./client-accessor";
 
 const NO_OP_SUBSCRIBE = () => () => {};
+const MAX_CACHED_ACCESSORS = 64;
+
+type ErrorAccessor = AssistantClientAccessor<ClientNames>;
+type ErrorAccessorCache = Map<string, ErrorAccessor>;
+
+const getCachedErrorAccessor = (
+  cache: ErrorAccessorCache,
+  name: string,
+  message: string,
+): ErrorAccessor => {
+  let accessor = cache.get(name);
+  if (accessor) return accessor;
+
+  if (cache.size >= MAX_CACHED_ACCESSORS) {
+    cache.delete(cache.keys().next().value!);
+  }
+  accessor = createErrorClientAccessor(message, name);
+  cache.set(name, accessor);
+  return accessor;
+};
 
 const MISSING_PROVIDER_MESSAGE =
   "You are using a component or hook that requires an AuiProvider. Wrap your component in an <AuiProvider> component.";
@@ -16,6 +40,7 @@ class EmptyAssistantClientProxyHandler
 {
   readonly #displayName: string;
   readonly #messageOf: (prop: string) => string;
+  readonly #accessors: ErrorAccessorCache = new Map();
 
   constructor(displayName: string, messageOf: (prop: string) => string) {
     super();
@@ -28,10 +53,8 @@ class EmptyAssistantClientProxyHandler
     if (prop === "on") return NO_OP_SUBSCRIBE;
     const introspection = handleIntrospectionProp(prop, this.#displayName);
     if (introspection !== false) return introspection;
-    return createErrorClientAccessor(
-      this.#messageOf(String(prop)),
-      String(prop),
-    );
+    const name = String(prop);
+    return getCachedErrorAccessor(this.#accessors, name, this.#messageOf(name));
   }
 
   ownKeys(): ArrayLike<string | symbol> {
@@ -59,19 +82,25 @@ export const DefaultAssistantClient: AssistantClient =
     () => MISSING_PROVIDER_MESSAGE,
   );
 
-/** Root prototype for created clients - throws "scope not defined" error */
-export const createRootAssistantClient = (): AssistantClient =>
-  new Proxy<AssistantClient>({} as AssistantClient, {
-    get(_: AssistantClient, prop: string | symbol) {
-      const introspection = handleIntrospectionProp(prop, "AssistantClient");
-      if (introspection !== false) return introspection;
+const rootAccessors: ErrorAccessorCache = new Map();
 
-      return createErrorClientAccessor(
-        `The current scope does not have a "${String(prop)}" property.`,
-        String(prop),
-      );
-    },
-  });
+/** Root prototype for created clients - throws "scope not defined" error */
+const RootAssistantClient = new Proxy<AssistantClient>({} as AssistantClient, {
+  get(_: AssistantClient, prop: string | symbol) {
+    const introspection = handleIntrospectionProp(prop, "AssistantClient");
+    if (introspection !== false) return introspection;
+
+    const name = String(prop);
+    return getCachedErrorAccessor(
+      rootAccessors,
+      name,
+      `The current scope does not have a "${name}" property.`,
+    );
+  },
+});
+
+export const createRootAssistantClient = (): AssistantClient =>
+  RootAssistantClient;
 
 /**
  * React Context for the AssistantClient


### PR DESCRIPTION
## Summary

- skip cloning and transform bookkeeping for the common no-transform scope config
- process transformed scopes with a work queue while preserving replacement behavior
- reuse root and unavailable-scope proxies instead of allocating them on every lookup/render
- add a focused benchmark for derived-provider mount and parent-update fan-out

## Why

Derived-only useAui providers appear once per message, part, attachment, and suggestion. Most contain no scope transforms, so avoiding repeated config/proxy allocation reduces work in these high-cardinality paths without changing the public API.

## Validation

- pnpm --filter @assistant-ui/store test
- pnpm --filter @assistant-ui/store build
- pnpm lint
- pnpm --filter @assistant-ui/store exec vitest bench --run src/__tests__/useAui.bench.tsx

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.YJcKzkVT1H0TfaEk_kpvnVUKKQBrkeU4PrI-MNWf_892De4guRT5ikAhN58?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->