### PR TITLE
fix(react-generative-ui): narrow convertSurfaceToUISpec return to UIElement

### DIFF
--- a/.changeset/wild-moons-refine.md
+++ b/.changeset/wild-moons-refine.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-generative-ui": patch
+---
+
+fix: narrow the convertSurfaceToUISpec return type to UIElement, matching what the converter can produce

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -1545,7 +1545,7 @@ declare function applyA2uiOperations(state: A2uiState, operations: unknown): A2u
 declare function buildPresentParameters(library: GenerativeUILibrary): JSONSchema7$1;
 
 declare function convertSurfaceToUISpec(surface: A2uiSurfaceState): {
-  spec: UISpec | null;
+  spec: UIElement | null;
   warnings: string[];
 };
 

--- a/packages/react-generative-ui/src/a2ui/convert.ts
+++ b/packages/react-generative-ui/src/a2ui/convert.ts
@@ -1,4 +1,4 @@
-import type { UIElement, UISpec } from "../ir";
+import type { UIElement } from "../ir";
 import {
   A2UI_SURFACE_ID,
   type A2uiSurfaceState,
@@ -434,7 +434,7 @@ function convertComponent(
 }
 
 export function convertSurfaceToUISpec(surface: A2uiSurfaceState): {
-  spec: UISpec | null;
+  spec: UIElement | null;
   warnings: string[];
 } {
   const warnings: string[] = [];


### PR DESCRIPTION
closes #5379

## summary

- narrows the declared return of `convertSurfaceToUISpec` from `UISpec | null` to `UIElement | null`; the implementation already only produces `UIElement` roots (every mapped branch emits a `{ $type, ... }` object), the declaration was just wider than reality
- this dissolves the TS2322 at `run-aggregator.ts` (`parsedArgs: spec` vs `Record<string, unknown>`) with zero consumer edits: `UIElement` carries an explicit index signature (`ir.ts`), so it is structurally assignable where the old union's `string` / `number` arms were not
- return-type narrowing is a compatible refinement for consumers (`UIElement` is a member of `UISpec`); the public surface stays append-only

## test plan

### already verified

- [x] `pnpm -C packages/react-ag-ui exec tsc --noEmit` -> zero errors (previously failed with the tracked TS2322)
- [x] `pnpm -C packages/react-generative-ui build && exec vitest run` -> 26 files, 541/541
- [x] `pnpm -C packages/react-ag-ui exec vitest run` -> 8 files, 285/285
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` -> no drift (the rendered reference does not surface this signature, so no generated pages change)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6Odr5mVU8hmWOfjLrl3Qhry5Tvt0dueaJBGhHtWMTzHPAN_jGv4ODEPm8lA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->