### PR TITLE
perf(store): avoid derived-only useAui client allocations

### DIFF
--- a/.changeset/soft-apes-juggle.md
+++ b/.changeset/soft-apes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+perf: skip per-render throwaway client allocation in derived-only useAui

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -225,11 +225,11 @@ const useScopeMounts = (entries: ScopeEntry[]): ScopeAccessor[] =>
     entries.map(([name, element]) => withKey(name, ScopeMount(name, element))),
   );
 
-// Commits the freshly built client only when its identity-relevant inputs
-// changed: value-only updates keep the committed client's identity, a
-// structural change produces a new one
+// Creates and commits a client only when its identity-relevant inputs change:
+// value-only updates keep the committed client's identity, while a structural
+// change produces a new one
 const useCommittedClient = (
-  building: AssistantClient,
+  create: () => AssistantClient,
   deps: readonly unknown[],
 ): AssistantClient => {
   const stableDeps = useShallowStable(deps);
@@ -239,7 +239,7 @@ const useCommittedClient = (
   );
   if (cell.deps !== stableDeps) {
     cell.deps = stableDeps;
-    cell.client = building;
+    cell.client = create();
   }
   return cell.client!;
 };
@@ -273,7 +273,7 @@ const useAuiRoot = ({
   // Fresh envelope per commit so value-only updates reach the store's
   // subscribers; the client inside keeps its identity
   return {
-    client: useCommittedClient(building, [parent, ...accessors]),
+    client: useCommittedClient(() => building, [parent, ...accessors]),
   };
 };
 
@@ -336,7 +336,6 @@ const useHostedAssistantClient = (props: {
 };
 
 const useDerivedScopeMount = (
-  building: AssistantClient,
   name: ClientNames,
   element: ScopeElement,
 ): ScopeAccessor => {
@@ -347,8 +346,6 @@ const useDerivedScopeMount = (
     () => createAccessor(name, meta, () => value),
     [name, meta, value],
   );
-
-  (building as Record<ClientNames, unknown>)[name] = accessor;
 
   return accessor;
 };
@@ -371,16 +368,23 @@ const useDerivedOnlyClient = (
     }
   }
 
-  const building = createClientObject(parent, {
-    subscribe: parent.subscribe,
-    on: parent.on,
-  });
-
   const accessors = entries.map(([name, element]) =>
-    // oxlint-disable-next-line react-hooks/rules-of-hooks -- fixed per call site; React throws on a count change
-    useDerivedScopeMount(building, name, element),
+    // oxlint-disable-next-line react-hooks/rules-of-hooks -- useAui scope shape is fixed per call site
+    useDerivedScopeMount(name, element),
   );
-  return useCommittedClient(building, [parent, ...accessors]);
+  // Accessor identity includes the scope name, so renaming a scope invalidates
+  // these dependencies before the factory reads the new entries.
+  return useCommittedClient(() => {
+    const client = createClientObject(parent, {
+      subscribe: parent.subscribe,
+      on: parent.on,
+    });
+    const scopes = client as unknown as Record<ClientNames, ScopeAccessor>;
+    for (let index = 0; index < entries.length; index++) {
+      scopes[entries[index]![0]] = accessors[index]!;
+    }
+    return client;
+  }, [parent, ...accessors]);
 };
 
 const useScopedClient = (


### PR DESCRIPTION
## Summary

- preserve keyed dynamic scope mounting for rooted `useAui` calls, including scopes produced by `attachTransformScopes`
- create derived-only client objects only when parent or accessor identity changes
- stop mutating a throwaway derived client before deciding whether its identity changed

## Why

Derived-only providers are high-cardinality and receive frequent parent updates. The previous implementation allocated and populated a new client object on every render, then discarded it whenever the structural dependencies were unchanged. Deferring creation removes that wasted object without narrowing root scope behavior.

Rooted `useAui` calls intentionally retain `ScopeMount`/`useResources`: `attachTransformScopes` can legitimately add or remove scopes as the parent changes, so those scope lists are not fixed.

## Benchmark

Paired median of three runs with 100 derived providers; baseline is #5382 + #5385, comparison adds this PR:

- mount/unmount, 1 scope: 0.9117 ms -> 0.8901 ms (-2.4%)
- parent update, 1 scope: 0.0240 ms -> 0.0243 ms (+1.3%)
- mount/unmount, 2 scopes: 1.0499 ms -> 1.0490 ms (-0.1%)
- parent update, 2 scopes: 0.0350 ms -> 0.0347 ms (-0.9%)

These differences are within the benchmark RME (roughly 2.5-4%). The benchmark therefore shows no measurable wall-clock change; the benefit is the mechanically removed client allocation on value-only updates.

## Validation

- `pnpm --filter @assistant-ui/store test` (86 tests)
- `pnpm --filter @assistant-ui/store build`
- `pnpm lint`
- `pnpm build` (85/85 tasks, before the root-path reversion; the revised root path matches main)
- paired focused `useAui` benchmark from #5382

## Review note

Please judge whether the allocation reduction is worthwhile on its own. The earlier fixed-root-scope tradeoff has been removed.