### PR TITLE
perf(store): simplify useAui notification plumbing

### DIFF
--- a/.changeset/bright-cats-call.md
+++ b/.changeset/bright-cats-call.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+perf: simplify useAui notification and effect plumbing

--- a/packages/store/src/__tests__/useAuiHost.test.tsx
+++ b/packages/store/src/__tests__/useAuiHost.test.tsx
@@ -83,6 +83,21 @@ describe("useAui tap host", () => {
     expect(log).toEqual(["tap effect"]);
   });
 
+  it("keeps tap effect metadata outside the client object", () => {
+    const TestClient = makeTestClient([]);
+    let aui!: ReturnType<typeof useAui>;
+
+    function Host() {
+      aui = useAui({
+        thread: TestClient(),
+      } as unknown as useAui.Props);
+      return null;
+    }
+
+    render(<Host />);
+    expect(Object.getOwnPropertySymbols(aui)).toEqual([]);
+  });
+
   it("updates flow through to useAuiState consumers", () => {
     const log: string[] = [];
     const TestClient = makeTestClient(log);

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -31,7 +31,7 @@ import {
   useAssistantContextProvider,
   DefaultAssistantClient,
   createRootAssistantClient,
-  AUI_USE_EFFECTS_SYMBOL,
+  setTapEffects,
 } from "./utils/react-assistant-context";
 import { getTransformScopes, type ScopesConfig } from "./attachTransformScopes";
 import {
@@ -40,7 +40,10 @@ import {
   type AssistantEventCallback,
   type AssistantEventSelector,
 } from "./types/events";
-import { NotificationManager } from "./utils/NotificationManager";
+import {
+  useNotificationManager,
+  type NotificationManager,
+} from "./utils/NotificationManager";
 import { useAssistantTapContextProvider } from "./utils/tap-assistant-context";
 import { ClientResource } from "./useClientResource";
 import { useShallowStable } from "./utils/useShallowStable";
@@ -272,8 +275,6 @@ const useAuiRoot = ({
   };
 };
 
-const useNotifications = () => useResource(NotificationManager());
-
 const useHostedAssistantClient = ({
   parent,
   entries,
@@ -283,7 +284,7 @@ const useHostedAssistantClient = ({
 }): AssistantClient => {
   const { value: client, effects } = useTapHost(function AssistantClientHost() {
     const clientRef = useRef<ClientRef>({ parent, current: null }).current;
-    const notifications = useNotifications();
+    const notifications = useNotificationManager();
 
     const store = useTapRoot(function AuiRoot() {
       return useAuiRoot({ parent, entries, clientRef, notifications });
@@ -297,17 +298,16 @@ const useHostedAssistantClient = ({
 
     // flushTapSync makes structural rebinds triggered by a notification land
     // before the notification returns
-    useEffect(
-      () =>
-        store.subscribe(() => flushTapSync(notifications.notifySubscribers)),
-      [store, notifications],
-    );
-    useEffect(
-      () =>
-        parent.subscribe(() => flushTapSync(notifications.notifySubscribers)),
+    useEffect(() => {
+      const notify = () => flushTapSync(notifications.notifySubscribers);
+      const unsubscribeStore = store.subscribe(notify);
+      const unsubscribeParent = parent.subscribe(notify);
+      return () => {
+        unsubscribeStore();
+        unsubscribeParent();
+      };
       // oxlint-disable-next-line react-hooks/exhaustive-deps -- parent is a prop of the outer hook; the host re-renders with a fresh closure when it changes
-      [parent, notifications],
-    );
+    }, [store, parent, notifications]);
 
     useEffect(() => {
       clientRef.parent = parent;
@@ -321,7 +321,7 @@ const useHostedAssistantClient = ({
     return client;
   });
 
-  (client as Record<symbol, unknown>)[AUI_USE_EFFECTS_SYMBOL] = effects;
+  setTapEffects(client, effects);
 
   return client;
 };

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -1,5 +1,4 @@
 import { useMemo } from "react";
-import { resource } from "@assistant-ui/tap";
 import type { ClientStack } from "./tap-client-stack-context";
 import type {
   AssistantEventName,
@@ -26,7 +25,7 @@ export type NotificationManager = {
   notifySubscribers(): void;
 };
 
-const useNotificationManager = (): NotificationManager => {
+export const useNotificationManager = (): NotificationManager => {
   return useMemo(() => {
     const listeners = new Map<string, Set<InternalCallback>>();
     const wildcardListeners = new Set<InternalCallback>();
@@ -112,5 +111,3 @@ const useNotificationManager = (): NotificationManager => {
     };
   }, []);
 };
-
-export const NotificationManager = resource(useNotificationManager);

--- a/packages/store/src/utils/react-assistant-context.tsx
+++ b/packages/store/src/utils/react-assistant-context.tsx
@@ -78,18 +78,22 @@ export const createRootAssistantClient = (): AssistantClient =>
  */
 const AssistantContext = createContext<AssistantClient>(DefaultAssistantClient);
 
-/**
- * Carries the tap host's effects callback on the client so AuiProvider can
- * mount the host's commit ahead of its children's effects.
- */
-export const AUI_USE_EFFECTS_SYMBOL = Symbol("assistant-ui.store.useEffects");
-
 const NOOP_EFFECT = () => {};
+const tapEffects = new WeakMap<AssistantClient, () => void>();
 
 const getTapEffects = (client: AssistantClient): (() => void) => {
-  return (
-    (client as Record<symbol, never>)[AUI_USE_EFFECTS_SYMBOL] ?? NOOP_EFFECT
-  );
+  return tapEffects.get(client) ?? NOOP_EFFECT;
+};
+
+/**
+ * Records the tap host's effects callback so AuiProvider can mount the host's
+ * commit ahead of its children's effects.
+ */
+export const setTapEffects = (
+  client: AssistantClient,
+  effects: () => void,
+): void => {
+  tapEffects.set(client, effects);
 };
 
 const UseTapEffects = () => {


### PR DESCRIPTION
## Summary

- construct NotificationManager directly in the existing tap host instead of mounting a nested resource
- combine the store and parent notification bridges into one effect
- store tap effect callbacks in a WeakMap instead of mutating AssistantClient objects during render
- verify tap metadata is not exposed as an own client symbol

## Why

The notification manager is private to useAui and already runs inside a tap host, so wrapping it in another resource adds a fiber without adding lifecycle behavior. Keeping tap effects outside the client also removes render-time mutation and prevents derived clients from inheriting parent effect metadata through the prototype chain.

## Size and validation

Built output decreases by about 230 bytes across useAui, NotificationManager, and the React context modules.

- pnpm --filter @assistant-ui/store test
- pnpm --filter @assistant-ui/store build
- pnpm lint
- focused useAui benchmark remains within run-to-run noise

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._RLeVjJEncOsUUle019_az4cBxvV33cKQ3yFP6hI6n-fkWZK4m7RBsSP2hg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->