### PR TITLE
feat(react-ag-ui): send A2UI actions back over forwardedProps

### DIFF
--- a/.changeset/a2ui-actions-forwarded-props.md
+++ b/.changeset/a2ui-actions-forwarded-props.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: send A2UI actions back to the agent as forwardedProps.a2uiAction on the next run

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1572,12 +1572,14 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AgUiAssistantRuntime, AgUiInterrupt, AgUiInterruptReason, AgUiResumeEntry, AgUiRunFinishedOutcome, FromAgUiMessagesOptions, UseAgUiRuntimeAdapters, UseAgUiRuntimeOptions, UseAgUiThreadListAdapter, fromAgUiMessages, useAgUiInterrupts, useAgUiRuntime, useAgUiSetState, useAgUiState, useAgUiSteerAway, useAgUiSubmitInterruptResponses };
+  export { AgUiAssistantRuntime, AgUiInterrupt, AgUiInterruptReason, AgUiResumeEntry, AgUiRunFinishedOutcome, FromAgUiMessagesOptions, UseAgUiRuntimeAdapters, UseAgUiRuntimeOptions, UseAgUiThreadListAdapter, fromAgUiMessages, useAgUiInterrupts, useAgUiRuntime, useAgUiSendA2uiAction, useAgUiSetState, useAgUiState, useAgUiSteerAway, useAgUiSubmitInterruptResponses };
 }
 
 declare const useAgUiInterrupts: () => readonly AgUiInterrupt[];
 
 declare function useAgUiRuntime(options: UseAgUiRuntimeOptions): AgUiAssistantRuntime;
+
+declare const useAgUiSendA2uiAction: () => (action: Record<string, unknown>) => void;
 
 declare const useAgUiSetState: <TState = ReadonlyJSONValue>() => (next: TState | ((prev: TState | undefined) => TState)) => void;
 

--- a/apps/docs/content/docs/tools/a2ui.mdx
+++ b/apps/docs/content/docs/tools/a2ui.mdx
@@ -53,17 +53,11 @@ Register the `present` frontend tool from `@assistant-ui/react-generative-ui`; i
 ```tsx
 import {
   JSONGenerativeUI,
-  createActionRegistry,
   defaultGenerativeUILibrary,
 } from "@assistant-ui/react-generative-ui";
 
 const generative = new JSONGenerativeUI({
   library: defaultGenerativeUILibrary,
-  actions: createActionRegistry({
-    "a2ui:action": async ({ payload }) => {
-      // forward the A2UI action to your backend
-    },
-  }),
 });
 
 const toolkit = {
@@ -73,12 +67,41 @@ const toolkit = {
 
 Pass the toolkit to your assistant as on the [Generative UI](/docs/tools/generative-ui) page; no other configuration is needed on `useAgUiRuntime`.
 
+## Actions
+
+`Button` nodes dispatch `$action` objects with type `"a2ui:action"` through the action registry. Wire the registry to `useAgUiSendA2uiAction` inside a component; the hook returns a stable function, so the toolkit can be memoized on it:
+
+```tsx
+import { useMemo } from "react";
+import { useAgUiSendA2uiAction } from "@assistant-ui/react-ag-ui";
+import {
+  JSONGenerativeUI,
+  createActionRegistry,
+  defaultGenerativeUILibrary,
+} from "@assistant-ui/react-generative-ui";
+
+function useA2uiToolkit() {
+  const sendA2uiAction = useAgUiSendA2uiAction();
+  return useMemo(() => {
+    const generative = new JSONGenerativeUI({
+      library: defaultGenerativeUILibrary,
+      actions: createActionRegistry({
+        "a2ui:action": ({ payload }) => sendA2uiAction(payload),
+      }),
+    });
+    return { present: generative.present({ display: "standalone" }) };
+  }, [sendA2uiAction]);
+}
+```
+
+Sending an action triggers a run with no new user message, and the agent receives it as `forwardedProps.a2uiAction.userAction`, the convention `@ag-ui/a2ui-middleware` consumes. The action rides exactly one run; the `type` field is stripped and a `timestamp` is added when absent.
+
+The middleware turns the action into a synthetic `log_a2ui_event` tool-call pair that is never declared in `input.tools`; a backend that validates tool calls against the declared tool list will reject it.
+
 ## Component mapping
 
 The converter maps the A2UI basic catalog onto the default generative UI vocabulary: `Text` becomes `Markdown` (`h1` to `h6` variants become `Header`, `caption` becomes `Caption`), `Column` becomes `Col`, `TextField` becomes `Input` (the control name is derived from the last segment of its binding path), `CheckBox` becomes `Checkbox`, and `Image`, `Row`, `Card`, `Divider`, `Button` map one to one. A node with template children expands into a `ListView` over the bound list. `Button` actions become `$action` objects with type `"a2ui:action"` carrying the action name, `surfaceId`, and `sourceComponentId`, which is how your action registry receives them. Unknown components and operations are skipped with a debug warning, and conversion is bounded (depth 32, 100 template items, 5000 nodes) so a malformed stream cannot hang the client.
 
 ## Limitations
 
-- Forwarding an `"a2ui:action"` back to the agent is host code today: send it on the next run as `forwardedProps.a2uiAction.userAction`, the convention `@ag-ui/a2ui-middleware` consumes. A first-class round-trip helper is planned.
-- Surfaces are not yet rehydrated when a thread is restored from history.
 - The upstream middleware currently emits v0.9 operation payloads; the renderer accepts v0.9 and v1.0 shapes.

--- a/packages/react-ag-ui/src/hooks.ts
+++ b/packages/react-ag-ui/src/hooks.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useCallback } from "react";
 import { useAui } from "@assistant-ui/store";
 import type { CreateAppendMessage } from "@assistant-ui/core";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -14,6 +15,19 @@ const EMPTY_INTERRUPTS: readonly AgUiInterrupt[] = [];
  */
 export const useAgUiInterrupts = (): readonly AgUiInterrupt[] =>
   agUiExtras.use((e) => e.interrupts, EMPTY_INTERRUPTS);
+
+/**
+ * Returns a stable function that sends an A2UI action back to the agent and
+ * resumes the run.
+ */
+export const useAgUiSendA2uiAction = () => {
+  const aui = useAui();
+  return useCallback(
+    (action: Record<string, unknown>): void =>
+      agUiExtras.get(aui).sendA2uiAction(action),
+    [aui],
+  );
+};
 
 /**
  * Returns a function that submits responses (each `resolved` or `cancelled`)

--- a/packages/react-ag-ui/src/index.ts
+++ b/packages/react-ag-ui/src/index.ts
@@ -2,6 +2,7 @@ export { useAgUiRuntime } from "./useAgUiRuntime";
 export type { AgUiAssistantRuntime } from "./useAgUiRuntime";
 export {
   useAgUiInterrupts,
+  useAgUiSendA2uiAction,
   useAgUiSubmitInterruptResponses,
   useAgUiSteerAway,
   useAgUiState,

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -692,6 +692,7 @@ export class AgUiThreadRuntimeCore {
 
   sendA2uiAction(action: Record<string, unknown>): void {
     this.assertNoPendingInterrupts();
+    this.maybeAutoCancelPendingToolCalls();
     const parentId = this.repository.headId;
     if (parentId === null) {
       this.logger.debug(

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1044,6 +1044,7 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       this.pendingResumeMessageId = null;
+      this.pendingA2uiAction = undefined;
       throw err;
     }
 
@@ -1054,6 +1055,8 @@ export class AgUiThreadRuntimeCore {
       this.pendingResumeMessageId = null;
       if (!abortSignal.aborted) {
         this.startResumeRun(resumeMessageId);
+      } else {
+        this.pendingA2uiAction = undefined;
       }
     }
   }

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1071,6 +1071,14 @@ export class AgUiThreadRuntimeCore {
     if (this.pendingA2uiResume) {
       this.pendingA2uiResume = false;
       if (!abortSignal.aborted && this.pendingA2uiAction !== undefined) {
+        if (this.getPendingInterrupts()) {
+          this.pendingA2uiAction = undefined;
+          this.logger.debug(
+            "[agui] sendA2uiAction: pending interrupts, dropping action",
+          );
+          return;
+        }
+        this.maybeAutoCancelPendingToolCalls();
         const parentId = this.repository.headId;
         if (parentId !== null) {
           this.startResumeRun(parentId);

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -99,6 +99,7 @@ export class AgUiThreadRuntimeCore {
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
   private pendingResumeMessageId: string | null = null;
+  private pendingA2uiAction: Record<string, unknown> | undefined;
 
   constructor(options: CoreOptions) {
     this.agent = options.agent;
@@ -688,6 +689,27 @@ export class AgUiThreadRuntimeCore {
     this.maybeResumeAfterToolResults(options.messageId);
   }
 
+  sendA2uiAction(action: Record<string, unknown>): void {
+    const parentId = this.repository.headId;
+    if (parentId === null) {
+      this.logger.debug(
+        "[agui] sendA2uiAction: no messages to resume, dropping action",
+      );
+      return;
+    }
+
+    const userAction = { ...action };
+    delete userAction.type;
+    if (!("timestamp" in userAction)) userAction.timestamp = Date.now();
+    this.pendingA2uiAction = userAction;
+
+    if (this.isRunningFlag) {
+      this.pendingResumeMessageId = parentId;
+      return;
+    }
+    this.startResumeRun(parentId);
+  }
+
   // The continuation fires whether the frontend result lands before
   // RUN_FINISHED (the status flips to requires-action only later, while the
   // run is still draining) or after it.
@@ -1105,7 +1127,7 @@ export class AgUiThreadRuntimeCore {
       historyMessages ?? this.repository.getMessages(),
     );
     const context = this.runtime?.thread.getModelContext();
-    return {
+    const input = {
       threadId,
       runId,
       state: this.stateSnapshot ?? null,
@@ -1118,9 +1140,14 @@ export class AgUiThreadRuntimeCore {
         ...(context?.callSettings ?? {}),
         ...(context?.config ?? {}),
         ...(runConfig?.custom ? { runConfig: runConfig.custom } : {}),
+        ...(this.pendingA2uiAction
+          ? { a2uiAction: { userAction: this.pendingA2uiAction } }
+          : {}),
       },
       ...(resume !== undefined ? { resume } : {}),
     };
+    this.pendingA2uiAction = undefined;
+    return input;
   }
 
   private installResumeShim(): void {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -99,6 +99,7 @@ export class AgUiThreadRuntimeCore {
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
   private pendingResumeMessageId: string | null = null;
+  private pendingA2uiResume: string | null = null;
   private pendingA2uiAction: Record<string, unknown> | undefined;
 
   constructor(options: CoreOptions) {
@@ -690,6 +691,7 @@ export class AgUiThreadRuntimeCore {
   }
 
   sendA2uiAction(action: Record<string, unknown>): void {
+    this.assertNoPendingInterrupts();
     const parentId = this.repository.headId;
     if (parentId === null) {
       this.logger.debug(
@@ -700,11 +702,13 @@ export class AgUiThreadRuntimeCore {
 
     const userAction = { ...action };
     delete userAction.type;
-    if (!("timestamp" in userAction)) userAction.timestamp = Date.now();
+    if (!("timestamp" in userAction)) {
+      userAction.timestamp = new Date().toISOString();
+    }
     this.pendingA2uiAction = userAction;
 
     if (this.isRunningFlag) {
-      this.pendingResumeMessageId = parentId;
+      this.pendingA2uiResume = parentId;
       return;
     }
     this.startResumeRun(parentId);
@@ -1044,6 +1048,7 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       this.pendingResumeMessageId = null;
+      this.pendingA2uiResume = null;
       this.pendingA2uiAction = undefined;
       throw err;
     }
@@ -1054,6 +1059,16 @@ export class AgUiThreadRuntimeCore {
       const resumeMessageId = this.pendingResumeMessageId;
       this.pendingResumeMessageId = null;
       if (!abortSignal.aborted) {
+        this.startResumeRun(resumeMessageId);
+      } else {
+        this.pendingA2uiAction = undefined;
+      }
+    }
+
+    if (this.pendingA2uiResume !== null) {
+      const resumeMessageId = this.pendingA2uiResume;
+      this.pendingA2uiResume = null;
+      if (!abortSignal.aborted && this.pendingA2uiAction !== undefined) {
         this.startResumeRun(resumeMessageId);
       } else {
         this.pendingA2uiAction = undefined;
@@ -1075,6 +1090,8 @@ export class AgUiThreadRuntimeCore {
       getAssistantMessageId: () => string | undefined;
     },
   ): Promise<void> {
+    this.pendingA2uiAction = undefined;
+    this.pendingA2uiResume = null;
     const assistantId = ctx.ensureAssistant();
     const currentId = () => ctx.getAssistantMessageId() ?? assistantId;
     const options: ChatModelRunOptions = {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -99,7 +99,7 @@ export class AgUiThreadRuntimeCore {
   private _isLoading = false;
   private _loadPromise: Promise<void> | undefined;
   private pendingResumeMessageId: string | null = null;
-  private pendingA2uiResume: string | null = null;
+  private pendingA2uiResume = false;
   private pendingA2uiAction: Record<string, unknown> | undefined;
 
   constructor(options: CoreOptions) {
@@ -708,7 +708,7 @@ export class AgUiThreadRuntimeCore {
     this.pendingA2uiAction = userAction;
 
     if (this.isRunningFlag) {
-      this.pendingA2uiResume = parentId;
+      this.pendingA2uiResume = true;
       return;
     }
     this.startResumeRun(parentId);
@@ -765,6 +765,8 @@ export class AgUiThreadRuntimeCore {
   }
 
   applyExternalMessages(messages: readonly ThreadMessage[]): void {
+    this.pendingA2uiResume = false;
+    this.pendingA2uiAction = undefined;
     this.assistantHistoryParents.clear();
 
     if (messages.length === 0) {
@@ -1048,7 +1050,7 @@ export class AgUiThreadRuntimeCore {
       const err = this.pendingError;
       this.pendingError = null;
       this.pendingResumeMessageId = null;
-      this.pendingA2uiResume = null;
+      this.pendingA2uiResume = false;
       this.pendingA2uiAction = undefined;
       throw err;
     }
@@ -1065,11 +1067,18 @@ export class AgUiThreadRuntimeCore {
       }
     }
 
-    if (this.pendingA2uiResume !== null) {
-      const resumeMessageId = this.pendingA2uiResume;
-      this.pendingA2uiResume = null;
+    if (this.pendingA2uiResume) {
+      this.pendingA2uiResume = false;
       if (!abortSignal.aborted && this.pendingA2uiAction !== undefined) {
-        this.startResumeRun(resumeMessageId);
+        const parentId = this.repository.headId;
+        if (parentId !== null) {
+          this.startResumeRun(parentId);
+        } else {
+          this.pendingA2uiAction = undefined;
+          this.logger.debug(
+            "[agui] sendA2uiAction: no messages to resume, dropping action",
+          );
+        }
       } else {
         this.pendingA2uiAction = undefined;
       }
@@ -1091,7 +1100,7 @@ export class AgUiThreadRuntimeCore {
     },
   ): Promise<void> {
     this.pendingA2uiAction = undefined;
-    this.pendingA2uiResume = null;
+    this.pendingA2uiResume = false;
     const assistantId = ctx.ensureAssistant();
     const currentId = () => ctx.getAssistantMessageId() ?? assistantId;
     const options: ChatModelRunOptions = {

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -100,6 +100,7 @@ export type AgUiResumeEntry = {
 
 export type AgUiRuntimeExtras = {
   interrupts: readonly AgUiInterrupt[];
+  sendA2uiAction: (action: Record<string, unknown>) => void;
   submitInterruptResponses: (
     responses: readonly AgUiResumeEntry[],
   ) => Promise<void>;

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -147,6 +147,7 @@ export function useAgUiRuntime(
         extras: agUiExtras.provide({
           interrupts:
             core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,
+          sendA2uiAction: (action) => core.sendA2uiAction(action),
           submitInterruptResponses: (responses) =>
             core.submitInterruptResponses(responses),
           steerAway: (message, responses) => core.steerAway(message, responses),

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -4966,4 +4966,35 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runInputs).toHaveLength(2);
     expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
   });
+
+  it("sendA2uiAction auto-cancels pending client-side tool calls", async () => {
+    const { runAgent, runInputs, getRunCount } = createPendingToolCallAgent();
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+    await core.append(createAppendMessage());
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(core.getPendingToolCalls()?.toolCallIds).toEqual(["call-1"]);
+
+    core.sendA2uiAction({ type: "a2ui:action", name: "submit" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getRunCount()).toBe(2);
+
+    const assistant = core
+      .getMessages()
+      .find((m) => m.role === "assistant") as ThreadAssistantMessage;
+    const call1 = assistant.content.find(
+      (p) => p.type === "tool-call" && p.toolCallId === "call-1",
+    ) as any;
+    expect(call1.result).toEqual({ error: "Tool call cancelled by user" });
+
+    const run2Messages = runInputs[1]?.messages ?? [];
+    const toolMsg = run2Messages.find(
+      (m: any) => m.role === "tool" && m.toolCallId === "call-1",
+    );
+    expect(toolMsg?.content).toContain("Tool call cancelled by user");
+    expect(runInputs[1].forwardedProps.a2uiAction.userAction.name).toBe(
+      "submit",
+    );
+  });
 });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -4708,4 +4708,67 @@ describe("AGUIThreadRuntimeCore", () => {
       },
     });
   });
+
+  it("clears deferred A2UI actions when the active run is cancelled", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn((input, subscriber, { signal }) => {
+        runInputs.push(input);
+        if (runInputs.length > 1) {
+          subscriber.onRunFinalized?.();
+          return Promise.resolve();
+        }
+        return new Promise((_, reject) => {
+          signal.addEventListener("abort", () => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          });
+        });
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+    await core.cancel();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runInputs).toHaveLength(1);
+
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("clears deferred A2UI actions when the active run errors", async () => {
+    const runInputs: any[] = [];
+    let failRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      failRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) {
+          await activeRun;
+          throw new Error("boom");
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+    failRun();
+    await expect(initialRun).rejects.toThrow("boom");
+
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
 });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2630,13 +2630,16 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runCount).toBe(1);
   });
 
-  const createPendingToolCallAgent = () => {
+  const createPendingToolCallAgent = (
+    beforeFirstRunFinalized?: () => Promise<void>,
+  ) => {
     const runInputs: any[] = [];
     let runCount = 0;
     const runAgent = vi.fn(async (input: any, subscriber: any) => {
       runInputs.push(JSON.parse(JSON.stringify(input)));
       runCount++;
       if (runCount === 1) {
+        await beforeFirstRunFinalized?.();
         subscriber.onToolCallStartEvent?.({
           event: {
             type: "TOOL_CALL_START",
@@ -4991,6 +4994,86 @@ describe("AGUIThreadRuntimeCore", () => {
     const run2Messages = runInputs[1]?.messages ?? [];
     const toolMsg = run2Messages.find(
       (m: any) => m.role === "tool" && m.toolCallId === "call-1",
+    );
+    expect(toolMsg?.content).toContain("Tool call cancelled by user");
+    expect(runInputs[1].forwardedProps.a2uiAction.userAction.name).toBe(
+      "submit",
+    );
+  });
+
+  it("drops deferred A2UI actions when the active run finishes with interrupts", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runInputs.push(JSON.parse(JSON.stringify(input)));
+        runCount++;
+        if (runCount === 1) {
+          await activeRun;
+          subscriber.onRunFinishedEvent?.({
+            event: {
+              type: "RUN_FINISHED",
+              runId: input.runId,
+              outcome: {
+                type: "interrupt",
+                interrupts: [{ id: "int-1", reason: "tool_call" }],
+              },
+            },
+          });
+        } else {
+          subscriber.onRunFinishedEvent?.({
+            event: {
+              type: "RUN_FINISHED",
+              runId: input.runId,
+              outcome: { type: "success" },
+            },
+          });
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runCount).toBe(1);
+
+    await core.submitInterruptResponses([
+      { interruptId: "int-1", status: "resolved", payload: { ok: true } },
+    ]);
+
+    expect(runCount).toBe(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("resumes deferred A2UI actions once after cancelling tool calls from the active run", async () => {
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const { runAgent, runInputs, getRunCount } = createPendingToolCallAgent(
+      () => activeRun,
+    );
+    const core = createCore({ runAgent } as unknown as HttpAgent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "submit" });
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getRunCount()).toBe(2);
+    const toolMsg = runInputs[1]?.messages.find(
+      (message: any) =>
+        message.role === "tool" && message.toolCallId === "call-1",
     );
     expect(toolMsg?.content).toContain("Tool call cancelled by user");
     expect(runInputs[1].forwardedProps.a2uiAction.userAction.name).toBe(

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -4616,4 +4616,96 @@ describe("AGUIThreadRuntimeCore", () => {
     await core.append(createAppendMessage());
     expect(observed).toEqual(["Hel", "Hello"]);
   });
+
+  it("sends A2UI actions in forwarded props without appending a user message", async () => {
+    const runInputs: any[] = [];
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    await core.append(
+      createAppendMessage({
+        runConfig: { custom: { source: "a2ui" } } as TestRunConfig,
+      }),
+    );
+    const userMessageCount = core
+      .getMessages()
+      .filter((message) => message.role === "user").length;
+
+    core.sendA2uiAction({
+      type: "a2ui:action",
+      name: "submit",
+      surfaceId: "s1",
+      sourceComponentId: "btn",
+      context: { total: 1 },
+      $input: "x",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runInputs).toHaveLength(2);
+    expect(
+      core.getMessages().filter((message) => message.role === "user"),
+    ).toHaveLength(userMessageCount);
+    expect(runInputs[1].forwardedProps).toMatchObject({
+      runConfig: { source: "a2ui" },
+      a2uiAction: {
+        userAction: {
+          name: "submit",
+          surfaceId: "s1",
+          sourceComponentId: "btn",
+          context: { total: 1 },
+          $input: "x",
+          timestamp: expect.any(Number),
+        },
+      },
+    });
+    expect(
+      runInputs[1].forwardedProps.a2uiAction.userAction.type,
+    ).toBeUndefined();
+    expect(runInputs[1].forwardedProps.runConfig.a2uiAction).toBeUndefined();
+
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(3);
+    expect(runInputs[2].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("defers A2UI action runs until the active run settles", async () => {
+    const runInputs: any[] = [];
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) await activeRun;
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    expect(agent.runAgent).toHaveBeenCalledTimes(1);
+
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    expect(agent.runAgent).toHaveBeenCalledTimes(1);
+
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(agent.runAgent).toHaveBeenCalledTimes(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toMatchObject({
+      userAction: {
+        name: "continue",
+        timestamp: expect.any(Number),
+      },
+    });
+  });
 });

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -4709,6 +4709,88 @@ describe("AGUIThreadRuntimeCore", () => {
     });
   });
 
+  it("clears deferred A2UI actions when external messages replace the thread", async () => {
+    const runInputs: any[] = [];
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) await activeRun;
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+    core.applyExternalMessages([]);
+
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runInputs).toHaveLength(1);
+
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("resumes deferred A2UI actions from the current head", async () => {
+    const runInputs: any[] = [];
+    let releaseRun!: () => void;
+    let postRunHead: string | undefined;
+    let core: AgUiThreadRuntimeCore;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) {
+          await activeRun;
+          subscriber.onTextMessageStartEvent?.({
+            event: { type: "TEXT_MESSAGE_START", messageId: "assistant-1" },
+          });
+          subscriber.onTextMessageContentEvent?.({
+            event: {
+              type: "TEXT_MESSAGE_CONTENT",
+              messageId: "assistant-1",
+              delta: "first response",
+            },
+          });
+          postRunHead = core.getMessages().at(-1)?.id;
+        }
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    const preRunHead = core.getMessages().at(-1)!.id;
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runInputs).toHaveLength(2);
+    expect(postRunHead).toBe("assistant-1");
+    expect(preRunHead).not.toBe(postRunHead);
+    expect(runInputs[1].messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: postRunHead, role: "assistant" }),
+      ]),
+    );
+    expect(runInputs[1].forwardedProps.a2uiAction).toMatchObject({
+      userAction: { name: "continue" },
+    });
+  });
+
   it("clears deferred A2UI actions when the active run is cancelled", async () => {
     const runInputs: any[] = [];
     const agent = {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -4659,7 +4659,7 @@ describe("AGUIThreadRuntimeCore", () => {
           sourceComponentId: "btn",
           context: { total: 1 },
           $input: "x",
-          timestamp: expect.any(Number),
+          timestamp: expect.any(String),
         },
       },
     });
@@ -4704,7 +4704,7 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(runInputs[1].forwardedProps.a2uiAction).toMatchObject({
       userAction: {
         name: "continue",
-        timestamp: expect.any(Number),
+        timestamp: expect.any(String),
       },
     });
   });
@@ -4766,6 +4766,119 @@ describe("AGUIThreadRuntimeCore", () => {
     failRun();
     await expect(initialRun).rejects.toThrow("boom");
 
+    await core.append(createAppendMessage());
+
+    expect(runInputs).toHaveLength(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("does not start an actionless run when an append consumes a deferred A2UI action", async () => {
+    const runInputs: any[] = [];
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) await activeRun;
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+    await core.append(createAppendMessage());
+
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(agent.runAgent).toHaveBeenCalledTimes(2);
+    expect(runInputs[1].forwardedProps.a2uiAction).toMatchObject({
+      userAction: { name: "continue" },
+    });
+  });
+
+  it("rejects A2UI actions while interrupts are pending without retaining them", async () => {
+    const runInputs: any[] = [];
+    let runCount = 0;
+    const agent = {
+      runAgent: vi.fn(async (input: any, subscriber: any) => {
+        runInputs.push(input);
+        runCount++;
+        subscriber.onRunFinishedEvent?.({
+          event: {
+            type: "RUN_FINISHED",
+            runId: input.runId,
+            outcome:
+              runCount === 1
+                ? {
+                    type: "interrupt",
+                    interrupts: [{ id: "int-1", reason: "tool_call" }],
+                  }
+                : { type: "success" },
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    await core.append(createAppendMessage());
+
+    expect(() =>
+      core.sendA2uiAction({ type: "a2ui:action", name: "continue" }),
+    ).toThrow(
+      "[agui] cannot start a new run while interrupts are pending; resolve them with submitInterruptResponses()",
+    );
+
+    await core.submitInterruptResponses([
+      { interruptId: "int-1", status: "resolved" },
+    ]);
+
+    expect(runInputs[1].forwardedProps.a2uiAction).toBeUndefined();
+  });
+
+  it("clears pending A2UI actions before replaying a resume stream", async () => {
+    const runInputs: any[] = [];
+    let releaseRun!: () => void;
+    const activeRun = new Promise<void>((resolve) => {
+      releaseRun = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (input, subscriber) => {
+        runInputs.push(input);
+        if (runInputs.length === 1) await activeRun;
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const core = createCore(agent);
+
+    const initialRun = core.append(createAppendMessage());
+    const userId = core.getMessages()[0]!.id;
+    core.sendA2uiAction({ type: "a2ui:action", name: "continue" });
+
+    await core.resume({
+      parentId: userId,
+      sourceId: null,
+      runConfig: {} as TestRunConfig,
+      stream: async function* (): AsyncGenerator<
+        ChatModelRunResult,
+        void,
+        unknown
+      > {
+        yield {
+          content: [{ type: "text", text: "resumed" }],
+          status: { type: "complete", reason: "unknown" },
+        };
+      },
+    });
+
+    releaseRun();
+    await initialRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
     await core.append(createAppendMessage());
 
     expect(runInputs).toHaveLength(2);

--- a/packages/react-ag-ui/test/hooks.spec.ts
+++ b/packages/react-ag-ui/test/hooks.spec.ts
@@ -14,10 +14,16 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
   useAui: (() => mockUseAui()) as typeof import("@assistant-ui/store").useAui,
 }));
 
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useCallback: (<T>(fn: T): T => fn) as typeof import("react").useCallback,
+}));
+
 import type { AppendMessage } from "@assistant-ui/core";
 import { agUiExtras } from "../src/agUiExtras";
 import {
   useAgUiInterrupts,
+  useAgUiSendA2uiAction,
   useAgUiSubmitInterruptResponses,
   useAgUiSteerAway,
 } from "../src/hooks";
@@ -87,6 +93,26 @@ describe("useAgUiSubmitInterruptResponses", () => {
     expect(() => useAgUiSubmitInterruptResponses()([])).toThrow(
       "useAgUiRuntime",
     );
+  });
+});
+
+describe("useAgUiSendA2uiAction", () => {
+  it("delegates to extras.sendA2uiAction with the given action", () => {
+    const sendA2uiAction = vi.fn();
+    const extras = agUiExtras.provide({
+      interrupts: [interrupt],
+      sendA2uiAction,
+      submitInterruptResponses: vi.fn(),
+      steerAway: vi.fn(),
+    });
+    mockUseAui.mockReturnValue({
+      thread: { getState: () => ({ extras }) },
+    });
+    const action = { type: "a2ui:action", name: "submit" };
+
+    useAgUiSendA2uiAction()(action);
+
+    expect(sendA2uiAction).toHaveBeenCalledWith(action);
   });
 });
 


### PR DESCRIPTION
closes #5349

completes the A2UI workstream (#5344 -> #5345 -> #5352): surfaces render and update, and with this PR their actions round-trip to the agent.

## summary

- new extras method `sendA2uiAction(action)` plus paired hook `useAgUiSendA2uiAction`, mirroring the package's resume rail: the action is stored pending, a run is triggered with no new user message (reusing the tool-result resume mechanics including the defer-while-draining behavior), and `buildRunInput` consumes it exactly once into a TOP-level `forwardedProps.a2uiAction.userAction`, the `@ag-ui/a2ui-middleware` convention; the installed `@ag-ui/client` forwards `forwardedProps` natively so no shim is involved
- payload mapping: `type` is stripped, `timestamp` is added when absent, everything else (`name`, `surfaceId`, `sourceComponentId`, `context`, `$input`) rides through verbatim; a second send before the run starts overwrites, and an action that races a user append rides that run instead (dedup by design)
- the hook returns a `useCallback`-stable function, diverging from the sibling hooks' fresh-closure shape on purpose: siblings feed event handlers where identity is irrelevant, this one feeds action-registry construction where a stable identity lets hosts memoize the toolkit (the docs example relies on it)
- docs: new "Actions" section with a compilable component-scoped wiring example, the exact wire shape, and the middleware's phantom `log_a2ui_event` caveat; also drops the rehydration bullet under Limitations that #5352 made stale
- new public hook sign-off: maintainer-directed in review of the design (hooks surface policy)
- cross-runtime parity note: the capability is transport-specific by nature (AG-UI's community forwardedProps convention); the future react-a2a leg maps the same extras shape onto its reverse action DataPart

## test plan

### already verified

- [x] `pnpm -C packages/react-ag-ui exec vitest run` -> 8 files, 288/288 (forwarded shape incl. type-strip/timestamp/$input passthrough and no appended user message, consume-once across following runs, top-level placement beside `forwardedProps.runConfig` nesting, defer until the active run settles, hook delegation)
- [x] `pnpm -C packages/react-ag-ui exec tsc --noEmit` -> zero errors
- [x] `pnpm -C packages/react-ag-ui build` + repo lint -> clean
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` -> no drift

### reviewer should verify

- [ ] against a backend running `@ag-ui/a2ui-middleware`, clicking a surface `Button` produces a run whose `RunAgentInput.forwardedProps.a2uiAction.userAction` carries the action and the middleware injects its synthetic tool-call pair

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JhBuhopateC6T4I_VvOPsuwirVvjHHX9m44bTUNwvzJAJjVMIU-t_WE-IvQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->