### PR TITLE
fix(ui): let defaultOpen decide the reasoning resting state

### DIFF
--- a/apps/docs/content/docs/ui/reasoning.mdx
+++ b/apps/docs/content/docs/ui/reasoning.mdx
@@ -28,7 +28,7 @@ Previously, reasoning parts were rendered via `components.Reasoning` and grouped
 
 Render reasoning parts through `MessagePrimitive.GroupedParts`. Group consecutive reasoning parts with `"group-reasoning"`, then compose `ReasoningRoot`, `ReasoningTrigger`, `ReasoningContent`, and `ReasoningText` around the grouped children.
 
-While reasoning is streaming, `part.status.type === "running"`. Pass that to `streaming` so the accordion auto-opens during streaming with a bottom-pinned live preview of the newest tokens, auto-collapses when the model moves on, and permanently defers to the first manual toggle. When `streaming` is provided it supersedes `defaultOpen`.
+While reasoning is streaming, `part.status.type === "running"`. Pass that to `streaming` so the accordion auto-opens during streaming with a bottom-pinned live preview of the newest tokens, and permanently defers to the first manual toggle. `streaming` only holds the disclosure open; when it ends the accordion returns to `defaultOpen`, which is `false` by default and therefore collapses. Pass `defaultOpen` to keep reasoning expanded once the run finishes.
 
 ```tsx title="/app/components/assistant-ui/thread.tsx"
 import { MessagePrimitive, groupPartByType } from "@assistant-ui/react";

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -52,13 +52,13 @@ export type ReasoningRootProps = Omit<
     onOpenChange?: (open: boolean) => void;
     defaultOpen?: boolean;
     /**
-     * Whether the reasoning is currently streaming. When provided, it
-     * supersedes `defaultOpen`: the disclosure auto-opens while streaming
-     * with a bottom-pinned live preview, auto-collapses when streaming
-     * ends, and the first manual toggle takes over the open/close state
-     * permanently. The live preview keeps following the newest tokens while
-     * the disclosure is open during streaming, even after a manual toggle,
-     * and pauses while the reader is scrolled up.
+     * Whether the reasoning is currently streaming. While `true` the
+     * disclosure is held open with a bottom-pinned live preview; when
+     * streaming ends it returns to `defaultOpen`, and the first manual
+     * toggle takes over the open/close state permanently. The live preview
+     * keeps following the newest tokens while the disclosure is open during
+     * streaming, even after a manual toggle, and pauses while the reader is
+     * scrolled up.
      */
     streaming?: boolean;
   };
@@ -81,14 +81,18 @@ function ReasoningRoot({
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled
     ? controlledOpen
-    : (userOpen ?? streaming ?? initialOpenRef.current);
+    : (userOpen ?? (streaming || initialOpenRef.current));
   const isPreview = streaming === true && isOpen;
 
   const prevStreamingRef = useRef(streaming);
   useLayoutEffect(() => {
     if (prevStreamingRef.current === streaming) return;
     prevStreamingRef.current = streaming;
-    if (!isControlled && userOpen === null) lockScroll();
+    // A streaming transition only animates the panel when the resting state
+    // is collapsed; with `defaultOpen` the disclosure stays open across it.
+    if (!isControlled && userOpen === null && !initialOpenRef.current) {
+      lockScroll();
+    }
   }, [streaming, isControlled, userOpen, lockScroll]);
 
   const handleOpenChange = useCallback(


### PR DESCRIPTION
closes #5165

## summary

- `ReasoningRoot` resolved its uncontrolled open state as `userOpen ?? streaming ?? initialOpenRef.current`, so any boolean `streaming` short-circuited `defaultOpen` and passing both silently did nothing (`defaultOpen` is destructured out of props, so it never reached `Collapsible` either). the resolution is now `userOpen ?? (streaming || initialOpenRef.current)`: `streaming` only holds the disclosure open, and `defaultOpen` decides the resting state
- behavior is unchanged for every configuration that works today. with `defaultOpen` left at its `false` default the disclosure still goes closed, open while streaming, closed again, so the documented auto-collapse is intact; the only difference is the previously dead `defaultOpen={true}` combination, which now stays open after the run instead of being ignored
- the `streaming={running || undefined}` idiom that used to be required for that is no longer needed (it still works)
- guards the scroll lock behind the resting state: `lockScroll` pins the thread's scroll position for the 200ms collapse animation, and without the guard a `defaultOpen` disclosure (which no longer animates across a streaming transition) would freeze scroll follow right as the answer starts streaming

## test plan

### already verified

- [x] resolution truth table over the three lifecycle phases (before run, streaming, after run) for both `defaultOpen` values: default path is cell-for-cell identical to today, `defaultOpen={true}` becomes open/open/open
- [x] `pnpm -C packages/ui exec tsc --noEmit` -> zero errors
- [x] repo lint -> clean

### reviewer should verify

- [ ] in a live thread, a `<ReasoningRoot defaultOpen streaming={running}>` stays expanded after the run ends, and the default `<ReasoningRoot streaming={running}>` still collapses with no scroll jump

## notes

- `packages/ui` is private, so no changeset (per AGENTS.md); the registry dist and the docs source snapshot are generated artifacts, and no template or example carries a forked copy of this component
- no in-repo consumer passes both props today (`thread.tsx` and the docs example pass `streaming` only), so the blast radius is external users, for whom the changed combination is currently inert
- `packages/ui` has no test setup, so this carries no unit test; worth its own issue rather than growing this fix

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DEOvZf0lwsmX2oc1y7RJOsR-pjBGmQaUnABQLKatDsxZdOREKjo8z1Uv0gg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->