### PR TITLE
fix(react-langgraph): route the values-path reconcile through appendMessage

### DIFF
--- a/.changeset/langgraph-accumulator-single-writer.md
+++ b/.changeset/langgraph-accumulator-single-writer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: route the values-path message reconcile through appendMessage

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1007,6 +1007,7 @@ declare class LangGraphMessageAccumulator<TMessage extends {
   private appendMessage;
   constructor(_param0?: LangGraphStateAccumulatorConfig<TMessage>);
   private ensureMessageId;
+  private upsertMessage;
   private applyRemove;
   addMessages(newMessages: TMessage[]): TMessage[];
   addMessageWithMetadata(message: TMessage, metadata: LangGraphTupleMetadata): TMessage[];

--- a/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
+++ b/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { appendLangChainChunk } from "./appendLangChainChunk";
 import { LangGraphMessageAccumulator } from "./LangGraphMessageAccumulator";
-import type { LangChainMessage, UIMessage } from "./types";
+import type {
+  LangChainMessage,
+  LangChainMessageChunk,
+  UIMessage,
+} from "./types";
 
 const makeUIMessage = (
   id: string,
@@ -356,5 +361,132 @@ describe("LangGraphMessageAccumulator reconcileMessages", () => {
     const result = acc.reconcileMessages([]);
     expect(result).toHaveLength(1);
     expect(result[0]!.id).toBe("ai-1");
+  });
+});
+
+describe("LangGraphMessageAccumulator values-path appendMessage", () => {
+  const partialJson = '{"city":';
+
+  const streamedChunk = (): LangChainMessageChunk => ({
+    id: "ai-1",
+    type: "AIMessageChunk",
+    content: "",
+    tool_call_chunks: [
+      {
+        id: "call-1",
+        index: 0,
+        name: "weather",
+        args_json: partialJson,
+      },
+    ],
+  });
+
+  const fullAiMessage = (): Extract<LangChainMessage, { type: "ai" }> => ({
+    id: "ai-1",
+    type: "ai",
+    content: "",
+    tool_calls: [
+      {
+        id: "call-1",
+        index: 0,
+        name: "weather",
+        args: { city: "Tokyo" },
+      },
+    ],
+  });
+
+  const createAccumulator = () =>
+    new LangGraphMessageAccumulator<LangChainMessage>({
+      appendMessage: appendLangChainChunk,
+    });
+
+  it("carries streamed partial_json through replaceMessages", () => {
+    const acc = createAccumulator();
+    acc.addMessages([streamedChunk() as unknown as LangChainMessage]);
+
+    const result = acc.replaceMessages([fullAiMessage()]);
+
+    expect(result[0]).toMatchObject({
+      type: "ai",
+      tool_calls: [
+        {
+          args: { city: "Tokyo" },
+          partial_json: partialJson,
+        },
+      ],
+    });
+  });
+
+  it("carries streamed partial_json through reconcileMessages", () => {
+    const acc = createAccumulator();
+    acc.addMessages([streamedChunk() as unknown as LangChainMessage]);
+
+    const result = acc.reconcileMessages([fullAiMessage()]);
+
+    expect(result[0]).toMatchObject({
+      type: "ai",
+      tool_calls: [
+        {
+          args: { city: "Tokyo" },
+          partial_json: partialJson,
+        },
+      ],
+    });
+  });
+
+  it("drops ids absent from a replaceMessages snapshot", () => {
+    const acc = createAccumulator();
+    acc.addMessages([
+      { id: "ai-1", type: "ai", content: "first" },
+      { id: "ai-2", type: "ai", content: "second" },
+    ]);
+
+    const result = acc.replaceMessages([
+      { id: "ai-1", type: "ai", content: "replacement" },
+    ]);
+
+    expect(result).toEqual([
+      { id: "ai-1", type: "ai", content: "replacement" },
+    ]);
+  });
+
+  it("preserves accumulator-only messages through reconcileMessages", () => {
+    const acc = createAccumulator();
+    acc.addMessages([
+      { id: "ai-1", type: "ai", content: "first" },
+      { id: "ai-2", type: "ai", content: "accumulator only" },
+    ]);
+
+    const result = acc.reconcileMessages([
+      { id: "ai-1", type: "ai", content: "server" },
+    ]);
+
+    expect(result).toEqual([
+      { id: "ai-1", type: "ai", content: "server" },
+      { id: "ai-2", type: "ai", content: "accumulator only" },
+    ]);
+  });
+
+  it("passes new and non-ai messages through unchanged on both values paths", () => {
+    const aiMessage: LangChainMessage = {
+      id: "ai-1",
+      type: "ai",
+      content: "new",
+    };
+    const humanMessage: LangChainMessage = {
+      id: "human-1",
+      type: "human",
+      content: "hello",
+    };
+
+    const replaceAccumulator = createAccumulator();
+    expect(
+      replaceAccumulator.replaceMessages([aiMessage, humanMessage]),
+    ).toEqual([aiMessage, humanMessage]);
+
+    const reconcileAccumulator = createAccumulator();
+    expect(
+      reconcileAccumulator.reconcileMessages([aiMessage, humanMessage]),
+    ).toEqual([aiMessage, humanMessage]);
   });
 });

--- a/packages/react-langgraph/src/LangGraphMessageAccumulator.ts
+++ b/packages/react-langgraph/src/LangGraphMessageAccumulator.ts
@@ -44,6 +44,17 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
     return message.id ? message : { ...message, id: uuidv4() };
   }
 
+  private upsertMessage(
+    message: TMessage,
+    previousSource: ReadonlyMap<string, TMessage> = this.messagesMap,
+  ): void {
+    const id = message.id!;
+    this.messagesMap.set(
+      id,
+      this.appendMessage(previousSource.get(id), message),
+    );
+  }
+
   private applyRemove(messageId: string) {
     if (messageId === REMOVE_ALL_MESSAGES) {
       this.messagesMap.clear();
@@ -63,8 +74,7 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
         this.applyRemove(messageId);
         continue;
       }
-      const previous = this.messagesMap.get(messageId);
-      this.messagesMap.set(messageId, this.appendMessage(previous, message));
+      this.upsertMessage(message);
     }
     return this.getMessages();
   }
@@ -81,11 +91,7 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
       return this.getMessages();
     }
 
-    const previous = this.messagesMap.get(messageId);
-    this.messagesMap.set(
-      messageId,
-      this.appendMessage(previous, messageWithId),
-    );
+    this.upsertMessage(messageWithId);
 
     const existingMetadata = this.metadataMap.get(messageId);
     this.metadataMap.set(messageId, { ...existingMetadata, ...metadata });
@@ -102,11 +108,12 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
   }
 
   public replaceMessages(newMessages: TMessage[]): TMessage[] {
-    this.messagesMap.clear();
+    const previous = this.messagesMap;
+    this.messagesMap = new Map();
     this.metadataMap.clear();
 
     for (const message of newMessages.map(this.ensureMessageId)) {
-      this.messagesMap.set(message.id!, message);
+      this.upsertMessage(message, previous);
     }
     return this.getMessages();
   }
@@ -114,7 +121,7 @@ export class LangGraphMessageAccumulator<TMessage extends { id?: string }> {
   // upsert-only: tuple-only messages (e.g. subgraph internals absent from parent `values`) are preserved
   public reconcileMessages(serverMessages: TMessage[]): TMessage[] {
     for (const message of serverMessages.map(this.ensureMessageId)) {
-      this.messagesMap.set(message.id!, message);
+      this.upsertMessage(message);
     }
     return this.getMessages();
   }


### PR DESCRIPTION
closes #5389

## summary

- `LangGraphMessageAccumulator` had two ways a message reached `messagesMap`: the chunk path went through `this.appendMessage(previous, curr)`, while `replaceMessages` and `reconcileMessages` set the entry directly. `appendMessage` is where carry-forward logic lives (#5099 put the streamed `partial_json` carry there), so anything written into that hook applied on the chunk path and silently did not apply on the values path
- makes the hook the single reconciliation point by construction rather than by remembering: one private `upsertMessage(message, previousSource = this.messagesMap)` is now the only writer into `messagesMap`, and all four call sites go through it
- `replaceMessages` swaps in a fresh map instead of clearing the existing one, so the pre-replacement entries are still available as the hook's `previous`; its drop-what-is-absent semantics and `reconcileMessages`' upsert-only semantics are unchanged, as are the `RemoveMessage` branches and the metadata merge

## why the blast radius is small

for a values message (`type: "ai"`, not `AIMessageChunk`) `appendLangChainChunk` does exactly one thing, `mergeStreamedToolCallArgs`, which returns `curr` untouched unless both sides carry tool calls and the incoming one lacks `partial_json`. content, metadata and ordering are byte-identical to before. the pre-existing accumulator tests construct with the default identity `appendMessage`, so they are unaffected either way and all still pass unmodified.

known trade, inherited rather than introduced: if a graph rewrites a tool call's args in place under the same id, the carried `partial_json` is the older streamed text while `args` is the new parsed value. that is the same trade #5099 already made on the chunk path; this change makes the two paths consistent instead of adding a new one.

## test plan

### already verified

- [x] `pnpm -C packages/react-langgraph exec vitest run` -> 10 files, 214/214, including a new describe constructed with the real `appendLangChainChunk` (the existing describes use the default identity hook and cannot observe a carry)
- [x] red/green counterfactual: with only the accumulator source reverted and the new tests kept, exactly `carries streamed partial_json through replaceMessages` and `carries streamed partial_json through reconcileMessages` fail, and the three regression guards (absent ids still dropped, accumulator-only messages still preserved, pass-through unchanged) stay green
- [x] repo lint clean; `tsc --noEmit` on this package reports 4 errors in `convertLangChainMessages.test.ts` and `useLangGraphRuntime.test.tsx`, confirmed pre-existing by re-running against the HEAD versions of both changed files

## notes

- scope: this fixes the structural asymmetry and pins the carry at unit level. it does not claim to resolve the end-to-end values-mode divergence symptom, which has never been reproduced dynamically and may need render batching that is not reachable in practice (see #5389)
- deliberately not added: `RemoveMessage` handling on the values paths. a values snapshot is state rather than a reducer instruction, so `type: "remove"` does not appear in it

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FeI2FIPTHHm8IVSkU7Y7bW81XjxfOoSNFVyxy3bPJbkig1rG0zHlt6-9Elk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

- review surfaced that the carried text outranks the server args in `resolveToolCallArgs`, so the trade above is a correctness hazard rather than a display one; pre-existing on the chunk path since #5099 and tracked for both paths in #5391
