### PR TITLE
fix: let the tracker rebase a divergent argsText instead of carrying stale partial_json

### DIFF
--- a/.changeset/assistant-stream-text-replace.md
+++ b/.changeset/assistant-stream-text-replace.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/assistant-stream": patch
+---
+
+feat: add a client-internal text-replace chunk and TextStreamController.replace

--- a/.changeset/assistant-stream-text-replace.md
+++ b/.changeset/assistant-stream-text-replace.md
@@ -1,5 +1,5 @@
 ---
-"@assistant-ui/assistant-stream": patch
+"assistant-stream": patch
 ---
 
 feat: add a client-internal text-replace chunk and TextStreamController.replace

--- a/.changeset/react-langgraph-drop-partial-json-carry.md
+++ b/.changeset/react-langgraph-drop-partial-json-carry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: drop the partial_json carry now that the tracker rebases a divergent argsText

--- a/.changeset/tracker-adopt-divergent-snapshot.md
+++ b/.changeset/tracker-adopt-divergent-snapshot.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: adopt a divergent complete argsText snapshot instead of keeping the stale prefix

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -244,6 +244,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -117,7 +117,7 @@ type AssistantMessageTiming = {
 };
 
 type AssistantMetaStreamChunk = (AssistantStreamChunk & {
-  type: "part-finish" | "text-delta";
+  type: "part-finish" | "text-delta" | "text-replace";
   meta: PartInit;
 }) | (AssistantStreamChunk & {
   type: "result" | "tool-call-args-text-finish";
@@ -125,7 +125,7 @@ type AssistantMetaStreamChunk = (AssistantStreamChunk & {
     type: "tool-call";
   };
 }) | (AssistantStreamChunk & {
-  type: Exclude<AssistantStreamChunk["type"], "part-finish" | "result" | "text-delta" | "tool-call-args-text-finish">;
+  type: Exclude<AssistantStreamChunk["type"], "part-finish" | "result" | "text-delta" | "text-replace" | "tool-call-args-text-finish">;
 });
 
 declare class AssistantMetaTransformStream extends TransformStream<AssistantStreamChunk, AssistantMetaStreamChunk> {
@@ -153,6 +153,9 @@ type AssistantStreamChunk = {
 } | {
   readonly type: "text-delta";
   readonly textDelta: string;
+} | {
+  readonly type: "text-replace";
+  readonly text: string;
 } | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
@@ -11594,6 +11597,7 @@ type TextStatus = {
 
 type TextStreamController = {
   append(textDelta: string): void;
+  replace(text: string): void;
   close(): void;
 };
 

--- a/api-surface/assistant-ui__cloud-ai-sdk.ts
+++ b/api-surface/assistant-ui__cloud-ai-sdk.ts
@@ -248,6 +248,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -442,6 +442,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -323,6 +323,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -262,6 +262,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -638,6 +638,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -404,6 +404,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -274,6 +274,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -278,6 +278,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -402,6 +402,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -643,6 +643,9 @@ type AssistantStreamChunk = {
   readonly type: "text-delta";
   readonly textDelta: string;
 } | {
+  readonly type: "text-replace";
+  readonly text: string;
+} | {
   readonly type: "annotations";
   readonly annotations: ReadonlyJSONValue[];
 } | {

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -67,7 +67,13 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       readonly textDelta: string;
     }
   | {
-      /** Replaces accumulated text in a text, reasoning, or tool-call argument part. */
+      /**
+       * Replaces accumulated text in a text, reasoning, or tool-call argument
+       * part. Client-internal: it is produced locally to correct a controller
+       * whose streamed text diverged from an authoritative snapshot, and the
+       * wire transports do not carry it (the data stream drops it and the
+       * assistant transport rejects it as an unknown type).
+       */
       readonly type: "text-replace";
       readonly text: string;
     }

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -67,6 +67,11 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
       readonly textDelta: string;
     }
   | {
+      /** Replaces accumulated text in a text, reasoning, or tool-call argument part. */
+      readonly type: "text-replace";
+      readonly text: string;
+    }
+  | {
       /** Appends provider or application annotations to the current message. */
       readonly type: "annotations";
       readonly annotations: ReadonlyJSONValue[];

--- a/packages/assistant-stream/src/core/AssistantStreamChunk.ts
+++ b/packages/assistant-stream/src/core/AssistantStreamChunk.ts
@@ -69,10 +69,11 @@ export type AssistantStreamChunk = { readonly path: readonly number[] } & (
   | {
       /**
        * Replaces accumulated text in a text, reasoning, or tool-call argument
-       * part. Client-internal: it is produced locally to correct a controller
-       * whose streamed text diverged from an authoritative snapshot, and the
-       * wire transports do not carry it (the data stream drops it and the
-       * assistant transport rejects it as an unknown type).
+       * part. Values already delivered to consumers are not rewritten.
+       * Client-internal: it is produced locally to correct a controller whose
+       * streamed text diverged from an authoritative snapshot, and the wire
+       * transports do not carry it (the data stream drops it and the assistant
+       * transport rejects it as an unknown type).
        */
       readonly type: "text-replace";
       readonly text: string;

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.test.ts
@@ -29,6 +29,47 @@ const collectStream = async (
   return messages;
 };
 
+describe("AssistantMessageAccumulator text-replace", () => {
+  it("replaces accumulated text", async () => {
+    const messages = await collectStream([
+      { type: "part-start", path: [0], part: { type: "text" } },
+      { type: "text-delta", path: [0], textDelta: "longer text" },
+      { type: "text-replace", path: [0], text: "short" },
+    ]);
+
+    expect(messages.at(-1)!.parts[0]).toMatchObject({
+      type: "text",
+      text: "short",
+    });
+  });
+
+  it("replaces tool-call argsText and recomputes args", async () => {
+    const messages = await collectStream([
+      {
+        type: "part-start",
+        path: [0],
+        part: {
+          type: "tool-call",
+          toolCallId: "tc-1",
+          toolName: "search",
+        },
+      },
+      {
+        type: "text-delta",
+        path: [0],
+        textDelta: '{"query":"a much longer query","limit":10}',
+      },
+      { type: "text-replace", path: [0], text: '{"query":"Oslo"}' },
+    ]);
+
+    expect(messages.at(-1)!.parts[0]).toMatchObject({
+      type: "tool-call",
+      argsText: '{"query":"Oslo"}',
+      args: { query: "Oslo" },
+    });
+  });
+});
+
 describe("AssistantMessageAccumulator timing", () => {
   it("should include timing on message-finish", async () => {
     const chunks: AssistantStreamChunk[] = [

--- a/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
+++ b/packages/assistant-stream/src/core/accumulators/assistant-message-accumulator.ts
@@ -241,6 +241,29 @@ const handleTextDelta = (
   });
 };
 
+const handleTextReplace = (
+  message: AssistantMessage,
+  chunk: AssistantStreamChunk & { type: "text-replace" },
+  warnOnce: WarnOnce,
+): AssistantMessage => {
+  return updatePartForPath(message, chunk, warnOnce, (part) => {
+    if (part.type === "text" || part.type === "reasoning") {
+      return { ...part, text: chunk.text };
+    } else if (part.type === "tool-call") {
+      const newArgsText = chunk.text;
+      const newArgs = parsePartialJsonObject(newArgsText) ?? part.args;
+
+      return { ...part, argsText: newArgsText, args: newArgs };
+    } else {
+      warnOnce(
+        "wrong-part:text-replace",
+        "Dropped text-replace chunk: part is neither text nor tool-call",
+      );
+      return part;
+    }
+  });
+};
+
 const handleResult = (
   message: AssistantMessage,
   chunk: AssistantStreamChunk & { type: "result" },
@@ -533,6 +556,12 @@ export class AssistantMessageAccumulator extends TransformStream<
 
           case "text-delta": {
             const next = handleTextDelta(message, chunk, warnOnce);
+            if (next !== message) tracker.recordFirstToken();
+            message = next;
+            break;
+          }
+          case "text-replace": {
+            const next = handleTextReplace(message, chunk, warnOnce);
             if (next !== message) tracker.recordFirstToken();
             message = next;
             break;

--- a/packages/assistant-stream/src/core/modules/text.test.ts
+++ b/packages/assistant-stream/src/core/modules/text.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { createTextStreamController } from "./text";
+
+describe("TextStreamController", () => {
+  it("enqueues text-replace chunks", async () => {
+    const [stream, controller] = createTextStreamController();
+    const chunks: unknown[] = [];
+    const drain = stream.pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      }),
+    );
+
+    controller.replace("replacement");
+    controller.close();
+
+    await drain;
+    expect(chunks).toEqual([
+      { type: "text-replace", path: [], text: "replacement" },
+      { type: "part-finish", path: [] },
+    ]);
+  });
+});

--- a/packages/assistant-stream/src/core/modules/text.ts
+++ b/packages/assistant-stream/src/core/modules/text.ts
@@ -4,6 +4,7 @@ import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 
 export type TextStreamController = {
   append(textDelta: string): void;
+  replace(text: string): void;
   close(): void; // TODO reason? error?
 };
 
@@ -22,6 +23,15 @@ class TextStreamControllerImpl implements TextStreamController {
       type: "text-delta",
       path: [],
       textDelta,
+    });
+    return this;
+  }
+
+  replace(text: string) {
+    this._controller.enqueue({
+      type: "text-replace",
+      path: [],
+      text,
     });
     return this;
   }

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -38,6 +38,7 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
         write: (chunk) => {
           switch (chunk.type) {
             case "text-delta":
+            case "text-replace":
               hasArgsText = true;
               this._controller.enqueue(chunk);
               break;

--- a/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
+++ b/packages/assistant-stream/src/core/serialization/assistant-transport/AssistantTransport.ts
@@ -26,7 +26,10 @@ const requiredArray = (key: string) => (c: ChunkFields) =>
 const optionalBoolean = (key: string) => (c: ChunkFields) =>
   c[key] === undefined || typeof c[key] === "boolean";
 
-const KNOWN_CHUNK_TYPES: Record<AssistantStreamChunk["type"], ChunkRule> = {
+const KNOWN_CHUNK_TYPES: Record<
+  Exclude<AssistantStreamChunk["type"], "text-replace">,
+  ChunkRule
+> = {
   "part-start": { kind: "message", valid: requiredObject("part") },
   "part-finish": { kind: "part-addressed", valid: noFields },
   "tool-call-args-text-finish": { kind: "part-addressed", valid: noFields },
@@ -56,7 +59,10 @@ const parseChunk = (data: string): AssistantStreamChunk | string => {
     !Object.prototype.hasOwnProperty.call(KNOWN_CHUNK_TYPES, type)
   )
     return "unknown-type";
-  const rule = KNOWN_CHUNK_TYPES[type as AssistantStreamChunk["type"]];
+  const rule =
+    KNOWN_CHUNK_TYPES[
+      type as Exclude<AssistantStreamChunk["type"], "text-replace">
+    ];
   if (!rule.valid(value as Record<string, unknown>))
     return `invalid-fields:${type}`;
   if (path === undefined) {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -187,6 +187,7 @@ export class DataStreamEncoder
 
             // TODO ignore for now
             // in the future, we should create a handler that waits for text parts to finish before continuing
+            case "text-replace":
             case "tool-call-args-text-finish":
             case "part-finish":
               break;

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -17,6 +17,10 @@ import type {
   ReadonlyJSONValue,
 } from "../../utils";
 
+type ArgsTextEvent =
+  | { type: "delta"; text: string }
+  | { type: "replace"; text: string };
+
 // TODO: remove dispose
 
 function getField<T>(obj: T, fieldPath: (string | number)[]): unknown {
@@ -267,26 +271,30 @@ class ForEachHandle<T> implements Handle {
 export class ToolCallArgsReaderImpl<
   T extends ReadonlyJSONObject,
 > implements ToolCallArgsReader<T> {
-  private argTextDeltas: ReadableStream<string>;
+  private argTextEvents: ReadableStream<ArgsTextEvent>;
   private handles: Set<Handle> = new Set();
   private args: unknown = parsePartialJsonObject("");
   private finished = false;
 
-  constructor(argTextDeltas: ReadableStream<string>) {
-    this.argTextDeltas = argTextDeltas;
+  constructor(argTextEvents: ReadableStream<ArgsTextEvent>) {
+    this.argTextEvents = argTextEvents;
     this.processStream();
   }
 
   private async processStream(): Promise<void> {
     try {
       let accumulatedText = "";
-      const reader = this.argTextDeltas.getReader();
+      const reader = this.argTextEvents.getReader();
 
       while (true) {
         const { value, done } = await reader.read();
         if (done) break;
 
-        accumulatedText += value;
+        if (value.type === "delta") {
+          accumulatedText += value.text;
+        } else {
+          accumulatedText = value.text;
+        }
         const parsedArgs = parsePartialJsonObject(accumulatedText);
 
         if (parsedArgs !== undefined) {
@@ -458,13 +466,13 @@ export class ToolCallReaderImpl<
 > implements ToolCallReader<TArgs, TResult> {
   public readonly args: ToolCallArgsReaderImpl<TArgs>;
   public readonly response: ToolCallResponseReaderImpl<TResult>;
-  private readonly writable: WritableStream<string>;
+  private readonly writable: WritableStream<ArgsTextEvent>;
   private readonly resolve: (value: ToolResponse<TResult>) => void;
 
   public argsText: string = "";
 
   constructor() {
-    const stream = new TransformStream<string, string>();
+    const stream = new TransformStream<ArgsTextEvent, ArgsTextEvent>();
     this.writable = stream.writable;
     this.args = new ToolCallArgsReaderImpl<TArgs>(stream.readable);
 
@@ -476,7 +484,7 @@ export class ToolCallReaderImpl<
   async appendArgsTextDelta(text: string): Promise<void> {
     const writer = this.writable.getWriter();
     try {
-      await writer.write(text);
+      await writer.write({ type: "delta", text });
     } catch (err) {
       console.warn(err);
     } finally {
@@ -487,7 +495,15 @@ export class ToolCallReaderImpl<
   }
 
   async replaceArgsText(text: string): Promise<void> {
-    // The already-consumed preview stream cannot be rewound.
+    const writer = this.writable.getWriter();
+    try {
+      await writer.write({ type: "replace", text });
+    } catch (err) {
+      console.warn(err);
+    } finally {
+      writer.releaseLock();
+    }
+
     this.argsText = text;
   }
 

--- a/packages/assistant-stream/src/core/tool/ToolCallReader.ts
+++ b/packages/assistant-stream/src/core/tool/ToolCallReader.ts
@@ -486,6 +486,11 @@ export class ToolCallReaderImpl<
     this.argsText += text;
   }
 
+  async replaceArgsText(text: string): Promise<void> {
+    // The already-consumed preview stream cannot be rewound.
+    this.argsText = text;
+  }
+
   async finishArgsText(): Promise<void> {
     const writer = this.writable.getWriter();
     try {

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -82,7 +82,8 @@ export class ToolExecutionStream extends PipeableTransformStream<
                 });
               }
               break;
-            case "text-delta": {
+            case "text-delta":
+            case "text-replace": {
               if (chunk.meta.type === "tool-call") {
                 const toolCallId = chunk.meta.toolCallId;
 
@@ -91,7 +92,9 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   throw new Error("No controller found for tool call");
                 // Awaited so the writer lock is released (and argsText updated)
                 // before the next chunk acquires the writer.
-                await controller.appendArgsTextDelta(chunk.textDelta);
+                await (type === "text-delta"
+                  ? controller.appendArgsTextDelta(chunk.textDelta)
+                  : controller.replaceArgsText(chunk.text));
               }
               break;
             }

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -742,6 +742,64 @@ describe("unstable_runPendingTools", () => {
       expect(executedArgs).toEqual({ query: "Oslo" });
     });
 
+    it("propagates shorter replacement args to streamCall readers", async () => {
+      const observedQueries: unknown[] = [];
+      const observedQueriesDone: Promise<void>[] = [];
+      const terminalQueries: Promise<unknown>[] = [];
+      const tool: Tool = {
+        parameters: { type: "object", properties: {} },
+        streamCall: (reader) => {
+          terminalQueries.push(reader.args.get("query"));
+          observedQueriesDone.push(
+            (async () => {
+              for await (const query of reader.args.streamValues("query")) {
+                observedQueries.push(query);
+              }
+            })(),
+          );
+        },
+      };
+      const inputChunks: AssistantStreamChunk[] = [
+        {
+          type: "part-start",
+          path: [],
+          part: {
+            type: "tool-call",
+            toolCallId: "tc-stream-replace",
+            toolName: "search",
+          },
+        },
+        {
+          type: "text-delta",
+          path: [0],
+          textDelta: '{"query":"a much longer query',
+        },
+        { type: "text-replace", path: [0], text: '{"query":"Oslo' },
+        { type: "tool-call-args-text-finish", path: [0] },
+        { type: "part-finish", path: [0] },
+      ];
+      const inputStream = new ReadableStream<AssistantStreamChunk>({
+        start(controller) {
+          for (const chunk of inputChunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+
+      await inputStream
+        .pipeThrough(
+          unstable_toolResultStream(
+            { search: tool },
+            new AbortController().signal,
+            async () => {},
+          ),
+        )
+        .pipeTo(new WritableStream());
+      await Promise.all(observedQueriesDone);
+
+      expect(observedQueries.at(-1)).toBe("Oslo");
+      expect(await terminalQueries[0]!).toBe("Oslo");
+    });
+
     it("falls back to the plain result when toModelOutput throws in the streaming path", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const tool: Tool = {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -694,6 +694,54 @@ describe("unstable_runPendingTools", () => {
       ]);
     });
 
+    it("executes a tool with replacement argsText", async () => {
+      let executedArgs: unknown;
+      const tool: Tool = {
+        parameters: { type: "object", properties: {} },
+        execute: async (args) => {
+          executedArgs = args;
+          return "done";
+        },
+      };
+      const inputChunks: AssistantStreamChunk[] = [
+        {
+          type: "part-start",
+          path: [],
+          part: {
+            type: "tool-call",
+            toolCallId: "tc-replace",
+            toolName: "search",
+          },
+        },
+        {
+          type: "text-delta",
+          path: [0],
+          textDelta: '{"query":"a much longer query","limit":10}',
+        },
+        { type: "text-replace", path: [0], text: '{"query":"Oslo"}' },
+        { type: "tool-call-args-text-finish", path: [0] },
+        { type: "part-finish", path: [0] },
+      ];
+      const inputStream = new ReadableStream<AssistantStreamChunk>({
+        start(controller) {
+          for (const chunk of inputChunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+
+      await inputStream
+        .pipeThrough(
+          unstable_toolResultStream(
+            { search: tool },
+            new AbortController().signal,
+            async () => {},
+          ),
+        )
+        .pipeTo(new WritableStream());
+
+      expect(executedArgs).toEqual({ query: "Oslo" });
+    });
+
     it("falls back to the plain result when toModelOutput throws in the streaming path", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const tool: Tool = {

--- a/packages/assistant-stream/src/core/utils/stream/AssistantMetaTransformStream.ts
+++ b/packages/assistant-stream/src/core/utils/stream/AssistantMetaTransformStream.ts
@@ -9,7 +9,7 @@ import type {
  */
 export type AssistantMetaStreamChunk =
   | (AssistantStreamChunk & {
-      type: "text-delta" | "part-finish";
+      type: "text-delta" | "text-replace" | "part-finish";
       meta: PartInit;
     })
   | (AssistantStreamChunk & {
@@ -19,7 +19,11 @@ export type AssistantMetaStreamChunk =
   | (AssistantStreamChunk & {
       type: Exclude<
         AssistantStreamChunk["type"],
-        "text-delta" | "result" | "tool-call-args-text-finish" | "part-finish"
+        | "text-delta"
+        | "text-replace"
+        | "result"
+        | "tool-call-args-text-finish"
+        | "part-finish"
       >;
     });
 export class AssistantMetaTransformStream extends TransformStream<
@@ -46,6 +50,7 @@ export class AssistantMetaTransformStream extends TransformStream<
         // For chunks that expect an associated part.
         if (
           chunk.type === "text-delta" ||
+          chunk.type === "text-replace" ||
           chunk.type === "result" ||
           chunk.type === "part-finish" ||
           chunk.type === "tool-call-args-text-finish"

--- a/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
+++ b/packages/core/src/runtimes/tool-invocations/EDGE_CASES.md
@@ -31,24 +31,9 @@ tracker appends the delta into the active controller's `argsText`
 stream. No re-fire.
 
 ### A.2. Args regress mid-stream (snapshot regression)
-A later snapshot's `argsText` is shorter than what we already streamed,
-or otherwise *not* a prefix of it. Under the exactly-once contract, the
-tracker does **not** restart the stream. The controller keeps whatever
-prefix already streamed. The regression is logged in non-prod. The
-host's view diverges from the snapshot until `reader.events()` ships.
+A later snapshot's `argsText` is shorter than what we already streamed, or otherwise *not* a prefix of it. A complete divergent snapshot is authoritative: the tracker replaces the controller's streamed args text with the snapshot, then closes the stream when the normal close rules allow it. This lets execution parse the complete snapshot without re-firing `streamCall` or `execute`.
 
-Subsequent snapshots that *are* prefixes of the new (regressed) snapshot
-also won't be appended, because `entry.argsText` still points at the
-pre-regression value used for delta calculation.
-
-The args stream closes only when the controller's *streamed* content
-(`entry.argsText`) is complete, not when a later snapshot is. A divergent
-snapshot can be complete while the controller still holds an incomplete
-stale prefix; closing on the snapshot would parse that stale prefix and
-auto-submit a bogus parse-error result (resuming the host graph and
-abandoning a pending interrupt). Gating the close on the streamed content
-leaves the stream open until the prefix itself completes, so no stale
-parse runs and no error result is fabricated from divergent args.
+An incomplete divergent snapshot is not authoritative-final. The tracker keeps the existing streamed prefix and logs the regression in non-prod. Subsequent snapshots are compared against that prefix until a complete divergent snapshot arrives or the stream reconverges, so a snapshot that extends the *regressed* text is still not appended: `entry.argsText` remains the pre-regression value the delta is computed from.
 
 ### A.3. Args complete then equivalent-JSON key reorder
 Both old and new `argsText` parse to equivalent JSON values (e.g. keys
@@ -182,7 +167,7 @@ keep the tracker dead with a visible error to avoid restart loops.
 catch and log. The tracker continues to function; the host's bad
 callback is isolated.
 
-### Args-stream divergence after A.2 / A.4
+### Args-stream divergence after incomplete A.2 / A.4
 Documented in the corresponding sections. The host's `streamCall` may
 operate on stale args. The `reader.events()` follow-up gives consumers
 a way to observe and react to these post-completion transitions.

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -151,13 +151,58 @@ describe("ToolInvocationTracker", () => {
     }
   });
 
+  it("executes with a complete divergent argsText snapshot", async () => {
+    const execute = vi.fn(async () => ({ forecast: "ok" }));
+    const getTools = () => ({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    const onStatusesChange = () => {};
+    const tracker = new ToolInvocationTracker(getTools, {
+      onResult,
+      onStatusesChange,
+    });
+    tracker.setState(createState([]));
+
+    tracker.setState(
+      createState([
+        createAssistantMessage('{"question": "What?", "options":', {
+          question: "What?",
+          options: ["a", "b"],
+          allow_multiple: false,
+        }),
+      ]),
+    );
+
+    tracker.setState(
+      createState([
+        createAssistantMessage(
+          '{"question":"What?","options":["a","b"],"allow_multiple":false}',
+          {
+            question: "What?",
+            options: ["a", "b"],
+            allow_multiple: false,
+          },
+        ),
+      ]),
+    );
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenCalledWith(
+        {
+          question: "What?",
+          options: ["a", "b"],
+          allow_multiple: false,
+        },
+        expect.objectContaining({ toolCallId: "tool-1" }),
+      );
+    });
+  });
+
   it("does not auto-submit a parse-error result when divergent argsText closes without a backend result", async () => {
-    // A human-in-the-loop tool whose argsText diverges mid-stream and never
-    // re-converges, with no backend result at close time. The args stream must
-    // not close on the divergent snapshot (which holds a stale prefix the
-    // execution path would parse), so no bogus parse-error result is
-    // auto-submitted to resume the host graph and abandon the pending
-    // interrupt.
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const streamCall = vi.fn((_reader, { human }) => {
       // Request human input immediately — sets up the pending interrupt.
@@ -208,9 +253,6 @@ describe("ToolInvocationTracker", () => {
         ]),
       );
 
-      // Complete valid JSON, divergent from the streamed prefix, no backend
-      // result. Previously this closed the args stream on the snapshot's
-      // completeness, parsed the stale prefix, and auto-submitted an error.
       tracker.setState(
         createState([
           createAssistantMessage(
@@ -224,12 +266,19 @@ describe("ToolInvocationTracker", () => {
         await new Promise((r) => setTimeout(r, 0));
       }
 
-      // No bogus parse-error result is auto-submitted, so the host graph is
-      // not resumed with a fake tool failure and the pending interrupt is
-      // preserved.
-      expect(onResult).not.toHaveBeenCalled();
-      // The frontend execute never ran: the stale prefix was never parsed.
-      expect(execute).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(execute).toHaveBeenCalledWith(
+          {
+            query: "London",
+            longitude: -0.125,
+            latitude: 51.5072,
+          },
+          expect.objectContaining({ toolCallId: "tool-1" }),
+        );
+      });
+      expect(onResult).toHaveBeenCalledWith(
+        expect.objectContaining({ result: { forecast: "ok" }, isError: false }),
+      );
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.test.ts
@@ -202,10 +202,10 @@ describe("ToolInvocationTracker", () => {
     });
   });
 
-  it("does not auto-submit a parse-error result when divergent argsText closes without a backend result", async () => {
+  it("adopts a complete divergent argsText snapshot and executes with the authoritative args", async () => {
+    // A complete divergent snapshot is authoritative. The controller text is replaced before closing, so execution parses no stale prefix and its result is legitimate despite the pending human interrupt.
     const execute = vi.fn(async () => ({ forecast: "ok" }));
     const streamCall = vi.fn((_reader, { human }) => {
-      // Request human input immediately — sets up the pending interrupt.
       void human({ request: "approve" });
     });
     const getTools = () => ({
@@ -238,12 +238,10 @@ describe("ToolInvocationTracker", () => {
         ]),
       );
 
-      // The pending interrupt is set up via streamCall → human().
       await waitFor(() => {
         expect(statuses["tool-1"]?.type).toBe("interrupt");
       });
 
-      // Divergent regression (not a prefix of the streamed text).
       tracker.setState(
         createState([
           createAssistantMessage('{"query":"London","longitude":-0.125', {
@@ -279,6 +277,72 @@ describe("ToolInvocationTracker", () => {
       expect(onResult).toHaveBeenCalledWith(
         expect.objectContaining({ result: { forecast: "ok" }, isError: false }),
       );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("keeps the pending human interrupt when incomplete divergent argsText never reconverges", async () => {
+    // An incomplete divergent snapshot is not authoritative. The controller retains its prefix and does not close, so it neither executes nor submits a bogus result and the pending human interrupt survives.
+    let responseSettled = false;
+    const execute = vi.fn(async () => ({ forecast: "ok" }));
+    const streamCall = vi.fn((reader, { human }) => {
+      void reader.response.get().then(() => {
+        responseSettled = true;
+      });
+      void human({ request: "approve" });
+    });
+    const getTools = () => ({
+      weatherSearch: {
+        parameters: { type: "object", properties: {} },
+        execute,
+        streamCall,
+      } satisfies Tool,
+    });
+    const onResult = vi.fn();
+    let statuses: Record<string, ToolExecutionStatus> = {};
+    const onStatusesChange = (s: ReadonlyMap<string, ToolExecutionStatus>) => {
+      statuses = Object.fromEntries(s);
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const tracker = new ToolInvocationTracker(getTools, {
+        onResult,
+        onStatusesChange,
+      });
+      tracker.setState(createState([]));
+
+      tracker.setState(
+        createState([
+          createAssistantMessage('{"query":"London","longitude":0', {
+            query: "London",
+            longitude: 0,
+          }),
+        ]),
+      );
+
+      await waitFor(() => {
+        expect(statuses["tool-1"]?.type).toBe("interrupt");
+      });
+
+      tracker.setState(
+        createState([
+          createAssistantMessage('{"query":"London","longitude":-0.125', {
+            query: "London",
+            longitude: -0.125,
+          }),
+        ]),
+      );
+
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      expect(responseSettled).toBe(false);
+      expect(statuses["tool-1"]?.type).toBe("interrupt");
+      expect(execute).not.toHaveBeenCalled();
+      expect(onResult).not.toHaveBeenCalled();
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -610,11 +610,8 @@ export class ToolInvocationTracker {
           shouldWriteArgsText = false;
         }
       } else if (!content.argsText.startsWith(entry.argsText)) {
-        if (
-          isArgsTextComplete(entry.argsText) &&
-          isArgsTextComplete(content.argsText) &&
-          isEquivalentCompleteArgsText(entry.argsText, content.argsText)
-        ) {
+        if (isArgsTextComplete(content.argsText)) {
+          entry.controller.argsText.replace(content.argsText);
           const shouldClose = this._shouldCloseArgsStream({
             toolName: content.toolName,
             argsText: content.argsText,
@@ -625,31 +622,17 @@ export class ToolInvocationTracker {
           entry.argsComplete = shouldClose;
           shouldWriteArgsText = false;
         } else {
-          if (isArgsTextComplete(content.argsText)) {
-            entry.controller.argsText.replace(content.argsText);
-            const shouldClose = this._shouldCloseArgsStream({
-              toolName: content.toolName,
-              argsText: content.argsText,
-              hasResult,
-            });
-            if (shouldClose) entry.controller.argsText.close();
-            entry.argsText = content.argsText;
-            entry.argsComplete = shouldClose;
-            shouldWriteArgsText = false;
-          } else {
-            // A.2: a complete divergent snapshot replaces the streamed text. An incomplete divergent snapshot is not authoritative, so the controller keeps its current prefix until a complete snapshot arrives.
-            if (process.env.NODE_ENV !== "production") {
-              console.warn(
-                "[ToolInvocationTracker] argsText regressed mid-stream; not restarting (see EDGE_CASES.md A.2)",
-                {
-                  previous: entry.argsText,
-                  next: content.argsText,
-                  toolCallId: content.toolCallId,
-                },
-              );
-            }
-            shouldWriteArgsText = false;
+          if (process.env.NODE_ENV !== "production") {
+            console.warn(
+              "[ToolInvocationTracker] argsText regressed mid-stream; not restarting (see EDGE_CASES.md A.2)",
+              {
+                previous: entry.argsText,
+                next: content.argsText,
+                toolCallId: content.toolCallId,
+              },
+            );
           }
+          shouldWriteArgsText = false;
         }
       }
 

--- a/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
+++ b/packages/core/src/runtimes/tool-invocations/ToolInvocationTracker.ts
@@ -625,24 +625,31 @@ export class ToolInvocationTracker {
           entry.argsComplete = shouldClose;
           shouldWriteArgsText = false;
         } else {
-          // A.2 — args regressed mid-stream. Under the "exactly once"
-          // contract we do not restart. The controller keeps whatever
-          // prefix we already streamed; subsequent prefix-respecting
-          // updates can still flow against it. Snapshots that never
-          // re-converge to a prefix will leave the controller's args
-          // view stale relative to the snapshot. Events API in a
-          // follow-up will expose this to consumers that opt in.
-          if (process.env.NODE_ENV !== "production") {
-            console.warn(
-              "[ToolInvocationTracker] argsText regressed mid-stream; not restarting (see EDGE_CASES.md A.2)",
-              {
-                previous: entry.argsText,
-                next: content.argsText,
-                toolCallId: content.toolCallId,
-              },
-            );
+          if (isArgsTextComplete(content.argsText)) {
+            entry.controller.argsText.replace(content.argsText);
+            const shouldClose = this._shouldCloseArgsStream({
+              toolName: content.toolName,
+              argsText: content.argsText,
+              hasResult,
+            });
+            if (shouldClose) entry.controller.argsText.close();
+            entry.argsText = content.argsText;
+            entry.argsComplete = shouldClose;
+            shouldWriteArgsText = false;
+          } else {
+            // A.2: a complete divergent snapshot replaces the streamed text. An incomplete divergent snapshot is not authoritative, so the controller keeps its current prefix until a complete snapshot arrives.
+            if (process.env.NODE_ENV !== "production") {
+              console.warn(
+                "[ToolInvocationTracker] argsText regressed mid-stream; not restarting (see EDGE_CASES.md A.2)",
+                {
+                  previous: entry.argsText,
+                  next: content.argsText,
+                  toolCallId: content.toolCallId,
+                },
+              );
+            }
+            shouldWriteArgsText = false;
           }
-          shouldWriteArgsText = false;
         }
       }
 
@@ -661,9 +668,6 @@ export class ToolInvocationTracker {
     }
 
     if (!entry.argsComplete && entry.controller) {
-      // ToolExecutionStream parses the streamed prefix on close, so the close
-      // gates on the streamed content; a divergent snapshot (A.2) can be
-      // complete while the controller still holds an incomplete stale prefix.
       const shouldClose = this._shouldCloseArgsStream({
         toolName: content.toolName,
         argsText: entry.argsText,

--- a/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
+++ b/packages/react-langgraph/src/LangGraphMessageAccumulator.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { appendLangChainChunk } from "./appendLangChainChunk";
 import { LangGraphMessageAccumulator } from "./LangGraphMessageAccumulator";
@@ -400,38 +400,56 @@ describe("LangGraphMessageAccumulator values-path appendMessage", () => {
       appendMessage: appendLangChainChunk,
     });
 
-  it("carries streamed partial_json through replaceMessages", () => {
-    const acc = createAccumulator();
-    acc.addMessages([streamedChunk() as unknown as LangChainMessage]);
-
-    const result = acc.replaceMessages([fullAiMessage()]);
-
-    expect(result[0]).toMatchObject({
+  it("routes replaceMessages through appendMessage with the pre-replacement entry", () => {
+    const seeded: LangChainMessage = {
+      id: "ai-1",
       type: "ai",
-      tool_calls: [
-        {
-          args: { city: "Tokyo" },
-          partial_json: partialJson,
-        },
-      ],
+      content: "seeded",
+    };
+    const incoming: LangChainMessage = {
+      id: "ai-1",
+      type: "ai",
+      content: "incoming",
+    };
+    const appendMessage = vi.fn(
+      (prev: LangChainMessage | undefined, curr: LangChainMessage) => curr,
+    );
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>({
+      appendMessage,
     });
+    acc.addMessages([seeded]);
+    appendMessage.mockClear();
+
+    acc.replaceMessages([incoming]);
+
+    expect(appendMessage).toHaveBeenCalledTimes(1);
+    expect(appendMessage).toHaveBeenCalledWith(seeded, incoming);
   });
 
-  it("carries streamed partial_json through reconcileMessages", () => {
-    const acc = createAccumulator();
-    acc.addMessages([streamedChunk() as unknown as LangChainMessage]);
-
-    const result = acc.reconcileMessages([fullAiMessage()]);
-
-    expect(result[0]).toMatchObject({
+  it("routes reconcileMessages through appendMessage with the existing entry", () => {
+    const seeded: LangChainMessage = {
+      id: "ai-1",
       type: "ai",
-      tool_calls: [
-        {
-          args: { city: "Tokyo" },
-          partial_json: partialJson,
-        },
-      ],
+      content: "seeded",
+    };
+    const incoming: LangChainMessage = {
+      id: "ai-1",
+      type: "ai",
+      content: "incoming",
+    };
+    const appendMessage = vi.fn(
+      (prev: LangChainMessage | undefined, curr: LangChainMessage) => curr,
+    );
+    const acc = new LangGraphMessageAccumulator<LangChainMessage>({
+      appendMessage,
     });
+    acc.addMessages([seeded]);
+    appendMessage.mockClear();
+
+    acc.reconcileMessages([incoming]);
+
+    expect(appendMessage).toHaveBeenCalledTimes(1);
+    expect(appendMessage).toHaveBeenCalledWith(seeded, incoming);
   });
 
   it("drops ids absent from a replaceMessages snapshot", () => {

--- a/packages/react-langgraph/src/appendLangChainChunk.test.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { appendLangChainChunk } from "./appendLangChainChunk";
-import { convertLangChainMessages } from "./convertLangChainMessages";
 import type { LangChainMessage, LangChainMessageChunk } from "./types";
 
 type AiMessage = Extract<LangChainMessage, { type: "ai" }>;
@@ -14,23 +13,6 @@ const appendAi = appendLangChainChunk as unknown as (
   prev: AiMessage | undefined,
   curr: AiMessage | LangChainMessageChunk,
 ) => AiMessage;
-
-const convert = convertLangChainMessages as unknown as (
-  message: LangChainMessage,
-  metadata: Record<string, unknown>,
-) => {
-  content: ReadonlyArray<{
-    type: string;
-    argsText?: string;
-    toolCallId?: string;
-  }>;
-};
-
-const toolCallArgsText = (result: ReturnType<typeof convert>): string => {
-  const part = result.content.find((p) => p.type === "tool-call");
-  if (!part?.argsText) throw new Error("Expected tool-call argsText");
-  return part.argsText;
-};
 
 const aiChunk = (
   toolCallChunks: LangChainMessageChunk["tool_call_chunks"],
@@ -137,164 +119,17 @@ describe("appendLangChainChunk tool_call id merging", () => {
 });
 
 describe("appendLangChainChunk updates-event partial_json", () => {
-  // Anthropic streams input_json_delta with its own whitespace; the `messages`
-  // stream-mode chunks accumulate that text as partial_json. When the node
-  // completes, the `updates` event delivers the full AIMessage with parsed
-  // tool_calls and no partial_json. The streamed partial_json must be carried
-  // forward so the converter does not re-stringify the parsed args into
-  // compact JSON that diverges from the streamed text the tracker already
-  // observed (which freezes args mid-prefix and throws a parse error).
-  const streamed =
-    '{"question": "What?", "options": ["a", "b"], "allow_multiple": false}';
-
-  const streamPrefix = (): AiMessage =>
-    appendAi(undefined, {
-      type: "AIMessageChunk",
-      id: "ai-1",
-      content: "",
-      tool_call_chunks: [
-        {
-          id: "call-1",
-          index: 0,
-          name: "ask_question",
-          args_json: '{"question": "What?", "options":',
-        },
-      ],
-    });
-
-  const streamTail = (acc: AiMessage): AiMessage =>
-    appendAi(acc, {
-      type: "AIMessageChunk",
-      id: "ai-1",
-      content: "",
-      tool_call_chunks: [
-        {
-          id: "call-1",
-          index: 0,
-          name: "ask_question",
-          args_json: ' ["a", "b"], "allow_multiple": false}',
-        },
-      ],
-    });
-
-  const fullAiMessage = (): AiMessage => ({
-    type: "ai",
-    id: "ai-1",
-    content: "",
-    tool_calls: [
-      {
-        id: "call-1",
-        index: 0,
-        name: "ask_question",
-        args: {
-          question: "What?",
-          options: ["a", "b"],
-          allow_multiple: false,
-        },
-      },
-    ],
-  });
-
-  it("carries streamed partial_json onto the full AIMessage that replaces the chunk sequence", () => {
-    const acc = streamTail(streamPrefix());
-    expect(acc.tool_calls?.[0]?.partial_json).toBe(streamed);
-
-    const final = appendAi(acc, fullAiMessage());
-    expect(final.type).toBe("ai");
-    expect(final.tool_calls?.[0]?.partial_json).toBe(streamed);
-  });
-
-  it("final argsText stays a byte-extension of the streamed prefix after the updates event", () => {
-    const metadata = {
-      toolArgsKeyOrderCache: new Map<string, Map<string, string[]>>(),
-    };
-
-    const prefixArgsText = toolCallArgsText(convert(streamPrefix(), metadata));
-
-    const final = appendAi(streamTail(streamPrefix()), fullAiMessage());
-    const finalArgsText = toolCallArgsText(convert(final, metadata));
-
-    expect(finalArgsText).toBe(streamed);
-    expect(finalArgsText.startsWith(prefixArgsText)).toBe(true);
-  });
-
-  it("does not synthesize partial_json when the prior message has none to carry", () => {
-    const final = appendAi(
-      {
-        type: "ai",
-        id: "ai-1",
-        content: "",
-        tool_calls: [
-          { id: "call-1", index: 0, name: "ask_question", args: { q: "x" } },
-        ],
-      },
-      {
-        type: "ai",
-        id: "ai-1",
-        content: "",
-        tool_calls: [
-          { id: "call-1", index: 0, name: "ask_question", args: { q: "x" } },
-        ],
-      },
-    );
-
-    expect(final.tool_calls?.[0]?.partial_json).toBeUndefined();
-  });
-
-  it("keeps the updates event's own partial_json when present", () => {
-    const final = appendAi(
-      {
-        type: "ai",
-        id: "ai-1",
-        content: "",
-        tool_calls: [
-          {
-            id: "call-1",
-            index: 0,
-            name: "ask_question",
-            args: { q: "x" },
-            partial_json: '{"q":"prev"}',
-          },
-        ],
-      },
-      {
-        type: "ai",
-        id: "ai-1",
-        content: "",
-        tool_calls: [
-          {
-            id: "call-1",
-            index: 0,
-            name: "ask_question",
-            args: { q: "x" },
-            partial_json: '{"q": "x"}',
-          },
-        ],
-      },
-    );
-
-    expect(final.tool_calls?.[0]?.partial_json).toBe('{"q": "x"}');
-  });
-
-  it("matches tool calls by index when the updates event carries an empty id", () => {
-    const acc = appendAi(undefined, {
-      type: "AIMessageChunk",
-      id: "ai-1",
-      content: "",
-      tool_call_chunks: [
-        { id: "", index: 0, name: "ask_question", args_json: '{"q": "x"}' },
-      ],
-    });
-    const final = appendAi(acc, {
+  it("returns an updates event with an empty tool call id unchanged", () => {
+    const final: AiMessage = {
       type: "ai",
       id: "ai-1",
       content: "",
       tool_calls: [
         { id: "", index: 0, name: "ask_question", args: { q: "x" } },
       ],
-    });
+    };
 
-    expect(final.tool_calls?.[0]?.partial_json).toBe('{"q": "x"}');
+    expect(appendAi(undefined, final)).toBe(final);
   });
 
   it("returns a non-ai message unchanged", () => {

--- a/packages/react-langgraph/src/appendLangChainChunk.ts
+++ b/packages/react-langgraph/src/appendLangChainChunk.ts
@@ -1,13 +1,10 @@
 import type {
   LangChainMessage,
   LangChainMessageChunk,
-  LangChainToolCall,
   LangChainToolCallChunk,
   MessageContentText,
 } from "./types";
 import { parsePartialJsonObject } from "assistant-stream/utils";
-
-type AiMessage = Extract<LangChainMessage, { type: "ai" }>;
 
 const chunkToToolCall = (chunk: LangChainToolCallChunk) => {
   const partialJson = chunk.args ?? chunk.args_json ?? "";
@@ -16,51 +13,6 @@ const chunkToToolCall = (chunk: LangChainToolCallChunk) => {
     partial_json: partialJson,
     args: parsePartialJsonObject(partialJson) ?? {},
   };
-};
-
-const findMatchingToolCall = (
-  prevToolCalls: readonly LangChainToolCall[],
-  toolCall: LangChainToolCall,
-): LangChainToolCall | undefined => {
-  if (toolCall.id != null && toolCall.id !== "") {
-    const byId = prevToolCalls.find(
-      (p) => p.id != null && p.id !== "" && p.id === toolCall.id,
-    );
-    if (byId) return byId;
-  }
-  if (toolCall.index != null) {
-    return prevToolCalls.find(
-      (p) => p.index === toolCall.index && (!p.id || !toolCall.id),
-    );
-  }
-  return undefined;
-};
-
-// The full AIMessage a LangGraph `updates` event delivers on node completion
-// carries parsed tool_calls with no partial_json. Carry over the partial_json
-// already streamed on matching tool calls so argsText stays a byte-prefix of
-// what the tracker already observed, instead of re-stringifying parsed args.
-const mergeStreamedToolCallArgs = (
-  prev: AiMessage,
-  curr: AiMessage,
-): AiMessage => {
-  const prevToolCalls = prev.tool_calls ?? [];
-  const currToolCalls = curr.tool_calls ?? [];
-  if (prevToolCalls.length === 0 || currToolCalls.length === 0) return curr;
-
-  let changed = false;
-  const mergedToolCalls = currToolCalls.map((toolCall) => {
-    if (toolCall.partial_json) return toolCall;
-    const streamedPartialJson = findMatchingToolCall(
-      prevToolCalls,
-      toolCall,
-    )?.partial_json;
-    if (!streamedPartialJson) return toolCall;
-    changed = true;
-    return { ...toolCall, partial_json: streamedPartialJson };
-  });
-
-  return changed ? { ...curr, tool_calls: mergedToolCalls } : curr;
 };
 
 /**
@@ -73,9 +25,6 @@ export const appendLangChainChunk = (
   curr: LangChainMessage | LangChainMessageChunk,
 ): LangChainMessage => {
   if (curr.type !== "AIMessageChunk") {
-    if (prev?.type === "ai" && curr.type === "ai") {
-      return mergeStreamedToolCallArgs(prev, curr);
-    }
     return curr;
   }
 


### PR DESCRIPTION
closes #5391, and resolves direction 1 of #5130

## summary

`ToolInvocationTracker` could not adopt a snapshot whose `argsText` was not an extension of what it had already streamed: the args controller is append-only, so the A.2 branch could only keep the stale prefix. `mergeStreamedToolCallArgs` in react-langgraph existed to work around that, carrying already-streamed `partial_json` forward so the converter never emitted a text the tracker could not take. that workaround costs correctness, because `resolveToolCallArgs` gives `partial_json` top precedence and derives `args` from it, so a carried text discards the server's own parsed args.

this replaces the workaround with the missing capability:

- **assistant-stream**: a `text-replace` chunk and `TextStreamController.replace(text)`, with accumulator, `ToolCallReader`, and `ToolExecutionStream` support. deliberately client-internal: it is produced locally to correct a controller, never by a backend, so it is excluded from `AssistantTransport`'s `KNOWN_CHUNK_TYPES` via `Exclude<AssistantStreamChunk["type"], "text-replace">` and a frame carrying it is rejected as `unknown-type`. the Python mirror is untouched
- **core**: a divergent snapshot whose `argsText` is complete is authoritative, so the tracker replaces the controller's text and closes under the normal rules. an incomplete divergent snapshot is not authoritative-final and keeps today's behavior (retain the prefix, warn). `EDGE_CASES.md` A.2 updated
- **react-langgraph**: `mergeStreamedToolCallArgs` and `findMatchingToolCall` deleted

replace propagates through the private args event stream, so the accumulated text, `reader.args`, its handles, and the terminal value handed to `handle.end` all converge on the replacement. only intermediate values a consumer already read remain stale, since a consumed stream cannot be un-written.

## why one PR

the parts are strictly sequential (the deletion needs the tracker change, which needs the primitive) and the intermediate states are never exercised. more importantly `TextStreamController` is exported and tracked in `api-surface/assistant-stream.ts`, and this repo's public surface is append-only: shipping the primitive in its own PR would risk permanently adding an unremovable method whose only consumer never lands.

## test plan

### already verified

- [x] `assistant-stream` 364 passed / 20 skipped, `core` 768 passed, `react-langgraph` 210 passed; repo lint clean
- [x] #5099's four converter tests pinned a mechanism this PR deletes, so the scenario they protected (#5098: an updates event delivers a complete re-serialized args text over an incomplete streamed prefix) is re-pinned at the tracker level as `executes with a complete divergent argsText snapshot`. red/green counterfactual: with only the tracker change reverted, that test fails on zero `execute` calls
- [x] the two values-path tests added in #5390 were rewritten as `appendMessage` spy contracts. their previous form asserted a carry that no longer exists, and the naive replacement (`expect(result[0]).toBe(full)`) passes with or without the routing, so they now assert the hook is invoked once with the pre-replacement entry, which is red without #5390's fix
- [x] `tsc --noEmit` on `packages/core` reports 5 errors in unrelated test files, confirmed pre-existing by re-running against the HEAD versions of both changed files

### reviewer should verify

- [ ] against a live LangGraph backend that streams tool args and then emits an `updates` event, the tool executes with the server's args and no `Function parameter parsing failed` result appears

## notes

- the rewrite case (a node rewriting tool args in place after the stream completed) stays unfixed and is unfixable at this layer: the stream closed and the tool already executed before the rewrite existed
- the guard originally proposed on #5391 (carry only when the parsed text deep-equals the incoming args) is refuted in that issue: it declines exactly the incomplete-prefix case #5099 needs, so it would regress #5098

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.igRAJuMbkaY_3-rGaRbt5N51v7xBZF6xrrjCQq0gzIEX8IvtqvPtjODQIIQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
