### PR TITLE
feat: make assistant-ui installable in an eve app with eve add

### DIFF
--- a/apps/docs/content/docs/runtimes/eve/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/eve/quickstart.mdx
@@ -54,7 +54,9 @@ eve registry add @assistant-ui=https://r.assistant-ui.com/{name}.json
 eve add @assistant-ui/eve-chat --overwrite
 ```
 
-`eve registry add` records the namespace in your `package.json`. `eve add` then installs `@assistant-ui/react` and `@assistant-ui/eve`, writes `app/page.tsx`, and writes the thread component together with everything it imports into `components/assistant-ui` and `components/ui`. Pass `--overwrite` so it can replace the scaffold's own `app/page.tsx`; a plain `eve add` skips every file that already exists. Inspect an item before installing it with `eve registry view @assistant-ui/eve-chat`, and browse the rest of the registry with `eve registry list --registry @assistant-ui`.
+`eve registry add` records the namespace in your `package.json`. `eve add` then installs `@assistant-ui/react` and `@assistant-ui/eve`, writes `app/page.tsx`, and writes the thread component together with everything it imports into `components/assistant-ui` and `components/ui`. It expects an Eve app that carries the Next.js Web Chat scaffold, because the installed files import `@/lib/utils` through the `@/*` alias that `eve init --channel-web-nextjs` sets up.
+
+`--overwrite` is global rather than per file. It is what lets the item replace the scaffold's own `app/page.tsx`, and it also replaces any `components/assistant-ui` or `components/ui` file already in the project, including `avatar`, `button`, `collapsible`, `dialog`, and `tooltip`, so install on a clean tree and read the diff before keeping it. A plain `eve add` skips every pre-existing file instead, which leaves `app/page.tsx` untouched. Inspect an item before installing it with `eve registry view @assistant-ui/eve-chat`, and browse the rest of the registry with `eve registry list --registry @assistant-ui`.
 
 That namespace serves the Radix flavor, which matches the shadcn components in Eve's Next.js scaffold. Point it at `https://r.assistant-ui.com/base/{name}.json` instead for a Base UI project.
 

--- a/apps/docs/content/docs/runtimes/eve/quickstart.mdx
+++ b/apps/docs/content/docs/runtimes/eve/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: Quickstart
-description: From-template and manual setup paths to a working Eve agent chat in assistant-ui.
+description: Template, Eve CLI, and manual setup paths to a working Eve agent chat in assistant-ui.
 ---
 
-Two paths to a running Eve-powered assistant-ui app. The template is fastest; the manual path is what you adapt when integrating into an existing Next.js project.
+Three paths to a running Eve-powered assistant-ui app. The template is fastest, `eve add` drops assistant-ui into an Eve app you already have, and the manual path is what you adapt when integrating into an existing Next.js project.
 
 ## From the template
 
@@ -44,6 +44,53 @@ Use Eve's terminal UI directly for command-line agent sessions.
 
 </Tab>
 </PlatformTabs>
+
+## With the Eve CLI
+
+For an Eve app that already exists, register the assistant-ui registry once and install the chat page from it:
+
+```sh
+eve registry add @assistant-ui=https://r.assistant-ui.com/{name}.json
+eve add @assistant-ui/eve-chat --overwrite
+```
+
+`eve registry add` records the namespace in your `package.json`. `eve add` then installs `@assistant-ui/react` and `@assistant-ui/eve`, writes `app/page.tsx`, and writes the thread component together with everything it imports into `components/assistant-ui` and `components/ui`. Pass `--overwrite` so it can replace the scaffold's own `app/page.tsx`; a plain `eve add` skips every file that already exists. Inspect an item before installing it with `eve registry view @assistant-ui/eve-chat`, and browse the rest of the registry with `eve registry list --registry @assistant-ui`.
+
+That namespace serves the Radix flavor, which matches the shadcn components in Eve's Next.js scaffold. Point it at `https://r.assistant-ui.com/base/{name}.json` instead for a Base UI project.
+
+The Eve CLI writes registry files without editing CSS, so add the styles the reasoning and tool components animate with to `app/globals.css` yourself:
+
+```css title="app/globals.css"
+@import "tw-shimmer";
+
+@custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
+@custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));
+
+@theme inline {
+  @keyframes collapsible-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+  }
+  @keyframes collapsible-up {
+    from {
+      height: var(
+        --radix-collapsible-content-height,
+        var(--collapsible-panel-height, auto)
+      );
+    }
+    to {
+      height: 0;
+    }
+  }
+}
+```
 
 ## Manual setup in an existing app
 

--- a/apps/registry/package.json
+++ b/apps/registry/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@ai-sdk/openai": "^4.0.20",
+    "@assistant-ui/eve": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-ai-sdk": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -6,6 +6,7 @@ const {
   collectAttributeSelectorValues,
   createBaseRegistryItem,
   createRadixRegistryItem,
+  expandBundledRegistryDependencies,
   getRadixVariantSourcePath,
   validateBasePassDidNotReadRadixSources,
   validateBaseTreeRadixImports,
@@ -524,6 +525,144 @@ test("base registry item merges baseDependencies and drops radixDependencies", (
       type: "registry:ui",
       dependencies: ["lucide-react", "@base-ui/react", "clsx"],
     },
+  );
+});
+
+const bundleFixtures = () => {
+  const thread = {
+    name: "thread",
+    type: "registry:component",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/thread.tsx",
+        sourcePath: "../../packages/ui/src/components/assistant-ui/thread.tsx",
+      },
+    ],
+    dependencies: ["@assistant-ui/react"],
+    radixDependencies: ["radix-ui"],
+    registryDependencies: [
+      "button",
+      "https://r.assistant-ui.com/reasoning.json",
+    ],
+  };
+  const reasoning = {
+    name: "reasoning",
+    type: "registry:component",
+    files: [
+      {
+        type: "registry:component",
+        path: "components/assistant-ui/reasoning.tsx",
+      },
+    ],
+    dependencies: ["tw-shimmer"],
+    registryDependencies: ["collapsible"],
+    css: { '@import "tw-shimmer"': {} },
+  };
+
+  return {
+    item: {
+      name: "eve-chat",
+      type: "registry:item",
+      files: [
+        { type: "registry:file", path: "app/page.tsx", target: "app/page.tsx" },
+      ],
+      dependencies: ["@assistant-ui/eve"],
+      bundledRegistryDependencies: ["https://r.assistant-ui.com/thread.json"],
+    },
+    itemsByName: new Map(
+      [thread, reasoning].map((dependencyItem) => [
+        dependencyItem.name,
+        dependencyItem,
+      ]),
+    ),
+  };
+};
+
+test("bundling inlines the closure as targeted files and merges its dependencies and css", () => {
+  const { item, itemsByName } = bundleFixtures();
+
+  const expanded = expandBundledRegistryDependencies(
+    item,
+    itemsByName,
+    "radix",
+  );
+
+  assert.equal(expanded.bundledRegistryDependencies, undefined);
+  assert.equal(expanded.registryDependencies, undefined);
+  assert.deepEqual(
+    expanded.files.map((file) => [file.type, file.target, file.sourcePath]),
+    [
+      ["registry:file", "app/page.tsx", undefined],
+      [
+        "registry:file",
+        "components/assistant-ui/thread.tsx",
+        "../../packages/ui/src/components/assistant-ui/thread.tsx",
+      ],
+      ["registry:file", "components/assistant-ui/reasoning.tsx", undefined],
+      [
+        "registry:file",
+        "components/ui/button.tsx",
+        "../../packages/ui/src/components/ui/radix/button.tsx",
+      ],
+      [
+        "registry:file",
+        "components/ui/collapsible.tsx",
+        "../../packages/ui/src/components/ui/radix/collapsible.tsx",
+      ],
+    ],
+  );
+  assert.deepEqual(expanded.dependencies, [
+    "@assistant-ui/eve",
+    "@assistant-ui/react",
+    "tw-shimmer",
+  ]);
+  assert.deepEqual(expanded.radixDependencies, ["radix-ui"]);
+  assert.deepEqual(Object.keys(expanded.css), ['@import "tw-shimmer"']);
+});
+
+test("bundling sources ui primitives and their package from the requested flavor", () => {
+  const { item, itemsByName } = bundleFixtures();
+
+  const expanded = expandBundledRegistryDependencies(item, itemsByName, "base");
+
+  assert.deepEqual(
+    expanded.files
+      .filter((file) => file.target.startsWith("components/ui/"))
+      .map((file) => file.sourcePath),
+    [
+      "../../packages/ui/src/components/ui/base/button.tsx",
+      "../../packages/ui/src/components/ui/base/collapsible.tsx",
+    ],
+  );
+  assert.deepEqual(expanded.baseDependencies, ["@base-ui/react"]);
+});
+
+test("bundling leaves an item without bundled dependencies untouched and rejects an unknown target", () => {
+  const item = {
+    name: "thread",
+    type: "registry:component",
+    dependencies: ["@assistant-ui/react"],
+  };
+
+  assert.deepEqual(
+    expandBundledRegistryDependencies(item, new Map(), "radix"),
+    item,
+  );
+  assert.throws(
+    () =>
+      expandBundledRegistryDependencies(
+        {
+          name: "eve-chat",
+          type: "registry:item",
+          bundledRegistryDependencies: [
+            "https://r.assistant-ui.com/missing.json",
+          ],
+        },
+        new Map(),
+        "radix",
+      ),
+    /eve-chat: bundled registry dependency "https:\/\/r\.assistant-ui\.com\/missing\.json" does not match a local registry item/,
   );
 });
 

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -679,6 +679,7 @@ test("universal item validation rejects a bundled item a partial config cannot i
           path: "components/assistant-ui/thread.tsx",
         },
       ],
+      registryDependencies: ["button"],
     },
     {
       name: "thread",
@@ -701,6 +702,7 @@ test("universal item validation rejects a bundled item a partial config cannot i
       error.message.includes(
         "eve-chat: components/assistant-ui/thread.tsx needs an explicit target and a universal file type",
       ) &&
+      error.message.includes('eve-chat: registry dependency "button"') &&
       !error.message.includes("thread:"),
   );
   assert.doesNotThrow(() => validateUniversalItems(items, new Set()));

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -13,6 +13,7 @@ const {
   validateBaseVariantContent,
   validateEmittedSpecifierHygiene,
   validateStyleScopedDependencies,
+  validateUniversalItems,
   validateVariantExportParity,
   validateVariantSlotParity,
   validateVariantTreesDiffer,
@@ -664,6 +665,45 @@ test("bundling leaves an item without bundled dependencies untouched and rejects
       ),
     /eve-chat: bundled registry dependency "https:\/\/r\.assistant-ui\.com\/missing\.json" does not match a local registry item/,
   );
+});
+
+test("universal item validation rejects a bundled item a partial config cannot install", () => {
+  const items = [
+    {
+      name: "eve-chat",
+      type: "registry:page",
+      files: [
+        { type: "registry:page", path: "app/page.tsx", target: "app/page.tsx" },
+        {
+          type: "registry:component",
+          path: "components/assistant-ui/thread.tsx",
+        },
+      ],
+    },
+    {
+      name: "thread",
+      type: "registry:component",
+      files: [
+        {
+          type: "registry:component",
+          path: "components/assistant-ui/thread.tsx",
+        },
+      ],
+    },
+  ];
+
+  assert.throws(
+    () => validateUniversalItems(items, new Set(["eve-chat"])),
+    (error) =>
+      error.message.includes(
+        'eve-chat: type "registry:page" is not installable without a full project config',
+      ) &&
+      error.message.includes(
+        "eve-chat: components/assistant-ui/thread.tsx needs an explicit target and a universal file type",
+      ) &&
+      !error.message.includes("thread:"),
+  );
+  assert.doesNotThrow(() => validateUniversalItems(items, new Set()));
 });
 
 test("slot parity reports mismatched data-slot attributes", () => {

--- a/apps/registry/scripts/build-registry.test.mjs
+++ b/apps/registry/scripts/build-registry.test.mjs
@@ -667,6 +667,30 @@ test("bundling leaves an item without bundled dependencies untouched and rejects
   );
 });
 
+test("bundling rejects a foreign registry url inside the closure", () => {
+  const thread = {
+    name: "thread",
+    type: "registry:component",
+    registryDependencies: ["https://example.com/foreign.json"],
+  };
+
+  assert.throws(
+    () =>
+      expandBundledRegistryDependencies(
+        {
+          name: "eve-chat",
+          type: "registry:item",
+          bundledRegistryDependencies: [
+            "https://r.assistant-ui.com/thread.json",
+          ],
+        },
+        new Map([["thread", thread]]),
+        "radix",
+      ),
+    /eve-chat: bundled closure depends on foreign registry item "https:\/\/example\.com\/foreign\.json", which cannot be inlined/,
+  );
+});
+
 test("universal item validation rejects a bundled item a partial config cannot install", () => {
   const items = [
     {

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -623,7 +623,12 @@ export function expandBundledRegistryDependencies(
       }
 
       bundled.push(dependencyItem);
-      walk(dependencyItem.registryDependencies ?? []);
+      walk([
+        ...(dependencyItem.registryDependencies ?? []),
+        ...(flavor === "base"
+          ? (dependencyItem.baseRegistryDependencies ?? [])
+          : []),
+      ]);
     }
   };
 
@@ -986,6 +991,12 @@ export function validateUniversalItems(
           `${item.name}: ${file.path} needs an explicit target and a universal file type`,
         );
       }
+    }
+
+    for (const dependency of item.registryDependencies ?? []) {
+      findings.add(
+        `${item.name}: registry dependency "${dependency}" resolves to an item that cannot be installed without a full project config; bundle it instead`,
+      );
     }
   }
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -608,7 +608,12 @@ export function expandBundledRegistryDependencies(
       const name = getAssistantRegistryDependencyName(dependency);
 
       if (!name) {
-        if (!dependency.startsWith("http")) uiPrimitives.add(dependency);
+        if (dependency.startsWith("http")) {
+          throw new Error(
+            `${item.name}: bundled closure depends on foreign registry item "${dependency}", which cannot be inlined`,
+          );
+        }
+        uiPrimitives.add(dependency);
         continue;
       }
 
@@ -1008,7 +1013,10 @@ async function buildRegistry(registry: RegistryItem[]) {
 
   const universalNames = new Set(
     registry
-      .filter((item) => item.bundledRegistryDependencies)
+      .filter(
+        (item) =>
+          item.bundledRegistryDependencies || UNIVERSAL_TYPES.has(item.type),
+      )
       .map((item) => item.name),
   );
   const itemsByName = new Map(registry.map((item) => [item.name, item]));

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -29,6 +29,11 @@ const BASE_VARIANT_FORBIDDEN_PATTERNS = [
 const MARKED_UI_SPECIFIERS = ["radix", "base"].map(
   (flavor) => `@/components/ui/${flavor}/`,
 );
+const UI_PRIMITIVE_SOURCE_ROOT = "../../packages/ui/src/components/ui";
+const UI_PRIMITIVE_PACKAGE = {
+  radix: "radix-ui",
+  base: "@base-ui/react",
+} as const;
 const PROJECT_PACKAGE_IMPORTS = new Set([
   "next",
   "next-themes",
@@ -39,8 +44,12 @@ const PROJECT_PACKAGE_IMPORTS = new Set([
 type RegistryFile = NonNullable<RegistryItem["files"]>[number];
 type RegistryBuildItem = Omit<
   RegistryItem,
-  "baseRegistryDependencies" | "radixDependencies" | "baseDependencies"
+  | "bundledRegistryDependencies"
+  | "baseRegistryDependencies"
+  | "radixDependencies"
+  | "baseDependencies"
 >;
+type UiFlavor = "radix" | "base";
 type RegistryOutputFile = Omit<RegistryFile, "sourcePath"> & {
   content: string;
 };
@@ -572,6 +581,118 @@ function getAssistantRegistryDependencyName(dependency: string) {
   return ASSISTANT_REGISTRY_DEPENDENCY_RE.exec(dependency)?.[1] ?? null;
 }
 
+/**
+ * Inlines the files and dependencies of `bundledRegistryDependencies` into the item.
+ *
+ * A consumer that resolves items without a full shadcn project config, as the
+ * Eve CLI does when it passes only `package.json#registries`, rejects every
+ * item in the resolved tree that is not `registry:item` or `registry:file` with
+ * a target on each file. Referencing the shared component items is therefore
+ * unavailable to such an item, and bundling keeps one declaration in the
+ * manifest as the source of truth for both shapes.
+ */
+export function expandBundledRegistryDependencies(
+  item: RegistryItem,
+  itemsByName: Map<string, RegistryItem>,
+  flavor: UiFlavor,
+): RegistryItem {
+  const { bundledRegistryDependencies, ...rest } = item;
+  if (!bundledRegistryDependencies) return rest;
+
+  const bundled: RegistryItem[] = [];
+  const uiPrimitives = new Set<string>();
+  const seen = new Set<string>();
+
+  const walk = (dependencies: string[]) => {
+    for (const dependency of dependencies) {
+      const name = getAssistantRegistryDependencyName(dependency);
+
+      if (!name) {
+        if (!dependency.startsWith("http")) uiPrimitives.add(dependency);
+        continue;
+      }
+
+      if (seen.has(name)) continue;
+      seen.add(name);
+
+      const dependencyItem = itemsByName.get(name);
+      if (!dependencyItem) {
+        throw new Error(
+          `${item.name}: bundled registry dependency "${dependency}" does not match a local registry item`,
+        );
+      }
+
+      bundled.push(dependencyItem);
+      walk(dependencyItem.registryDependencies ?? []);
+    }
+  };
+
+  walk(bundledRegistryDependencies);
+
+  const files: RegistryFile[] = [
+    ...(rest.files ?? []),
+    ...bundled.flatMap((dependencyItem) =>
+      (dependencyItem.files ?? []).map((file) => ({
+        ...file,
+        type: "registry:file" as const,
+        target: file.target ?? file.path,
+      })),
+    ),
+    ...[...uiPrimitives].sort().map((name) => ({
+      type: "registry:file" as const,
+      path: `components/ui/${name}.tsx`,
+      sourcePath: `${UI_PRIMITIVE_SOURCE_ROOT}/${flavor}/${name}.tsx`,
+      target: `components/ui/${name}.tsx`,
+    })),
+  ];
+
+  const collectPackages = (
+    key: "dependencies" | "radixDependencies" | "baseDependencies",
+  ) => [
+    ...new Set([
+      ...(rest[key] ?? []),
+      ...bundled.flatMap((dependencyItem) => dependencyItem[key] ?? []),
+    ]),
+  ];
+
+  const dependencies = collectPackages("dependencies");
+  const radixDependencies = collectPackages("radixDependencies");
+  const baseDependencies = collectPackages("baseDependencies");
+
+  if (uiPrimitives.size > 0) {
+    const flavorDependencies =
+      flavor === "radix" ? radixDependencies : baseDependencies;
+    const flavorPackage = UI_PRIMITIVE_PACKAGE[flavor];
+    if (!flavorDependencies.includes(flavorPackage)) {
+      flavorDependencies.push(flavorPackage);
+    }
+  }
+
+  const css: Record<string, unknown> = {};
+  for (const dependencyItem of bundled) Object.assign(css, dependencyItem.css);
+  Object.assign(css, rest.css);
+
+  const cssVars: NonNullable<RegistryItem["cssVars"]> = {};
+  for (const scope of ["light", "dark", "theme"] as const) {
+    const scopeVars: Record<string, string> = {};
+    for (const dependencyItem of bundled) {
+      Object.assign(scopeVars, dependencyItem.cssVars?.[scope]);
+    }
+    Object.assign(scopeVars, rest.cssVars?.[scope]);
+    if (Object.keys(scopeVars).length > 0) cssVars[scope] = scopeVars;
+  }
+
+  return {
+    ...rest,
+    files,
+    ...(dependencies.length > 0 ? { dependencies } : {}),
+    ...(radixDependencies.length > 0 ? { radixDependencies } : {}),
+    ...(baseDependencies.length > 0 ? { baseDependencies } : {}),
+    ...(Object.keys(css).length > 0 ? { css } : {}),
+    ...(Object.keys(cssVars).length > 0 ? { cssVars } : {}),
+  };
+}
+
 export function createRadixRegistryItem(item: RegistryItem): RegistryBuildItem {
   const {
     baseRegistryDependencies: _,
@@ -838,8 +959,17 @@ function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
 async function buildRegistry(registry: RegistryItem[]) {
   validateRegistrySchema(registry);
 
-  const radixRegistry = registry.map(createRadixRegistryItem);
-  const baseRegistry = registry.map(createBaseRegistryItem);
+  const itemsByName = new Map(registry.map((item) => [item.name, item]));
+  const radixRegistry = registry.map((item) =>
+    createRadixRegistryItem(
+      expandBundledRegistryDependencies(item, itemsByName, "radix"),
+    ),
+  );
+  const baseRegistry = registry.map((item) =>
+    createBaseRegistryItem(
+      expandBundledRegistryDependencies(item, itemsByName, "base"),
+    ),
+  );
   validateRegistrySchema(radixRegistry);
   validateRegistrySchema(baseRegistry);
 

--- a/apps/registry/scripts/build-registry.ts
+++ b/apps/registry/scripts/build-registry.ts
@@ -956,9 +956,50 @@ function validateRegistryInstallMetadata(payloads: RegistryOutputItem[]) {
   throwIfFindings("Invalid registry install metadata:", findings);
 }
 
+const UNIVERSAL_TYPES = new Set(["registry:item", "registry:file"]);
+
+/**
+ * Holds bundled items to the shape a consumer without a full project config accepts.
+ *
+ * Bundling only exists to serve that consumer, so an item that bundles and then
+ * declares a type or an untargeted file it cannot install is inert. The failure
+ * surfaces at install time in the consumer, not here, unless the build rejects it.
+ */
+export function validateUniversalItems(
+  items: RegistryBuildItem[],
+  universalNames: Set<string>,
+) {
+  const findings = new Set<string>();
+
+  for (const item of items) {
+    if (!universalNames.has(item.name)) continue;
+
+    if (!UNIVERSAL_TYPES.has(item.type)) {
+      findings.add(
+        `${item.name}: type "${item.type}" is not installable without a full project config`,
+      );
+    }
+
+    for (const file of item.files ?? []) {
+      if (!file.target || !UNIVERSAL_TYPES.has(file.type)) {
+        findings.add(
+          `${item.name}: ${file.path} needs an explicit target and a universal file type`,
+        );
+      }
+    }
+  }
+
+  throwIfFindings("Invalid universal registry items:", findings);
+}
+
 async function buildRegistry(registry: RegistryItem[]) {
   validateRegistrySchema(registry);
 
+  const universalNames = new Set(
+    registry
+      .filter((item) => item.bundledRegistryDependencies)
+      .map((item) => item.name),
+  );
   const itemsByName = new Map(registry.map((item) => [item.name, item]));
   const radixRegistry = registry.map((item) =>
     createRadixRegistryItem(
@@ -972,6 +1013,8 @@ async function buildRegistry(registry: RegistryItem[]) {
   );
   validateRegistrySchema(radixRegistry);
   validateRegistrySchema(baseRegistry);
+  validateUniversalItems(radixRegistry, universalNames);
+  validateUniversalItems(baseRegistry, universalNames);
 
   const radixBuilt = radixRegistry.map((item) =>
     createRegistryPayload(item, true),

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -46,6 +46,9 @@ export const registry: RegistryItem[] = [
   {
     name: "shimmer-style",
     type: "registry:style",
+    title: "Shimmer Style",
+    description:
+      "Keyframes and theme variables for the streaming shimmer animation.",
     cssVars: {
       theme: {
         "--animate-shimmer":
@@ -66,6 +69,9 @@ export const registry: RegistryItem[] = [
   {
     name: "chat/b/ai-sdk-quick-start/json",
     type: "registry:page",
+    title: "AI SDK Quick Start",
+    description:
+      "Assistant page wired to the AI SDK chat route, with the thread component installed.",
     files: [
       {
         type: "registry:page",
@@ -87,6 +93,9 @@ export const registry: RegistryItem[] = [
   {
     name: "ai-sdk-backend",
     type: "registry:page",
+    title: "AI SDK Backend",
+    description:
+      "Next.js route handler that streams chat completions through the AI SDK.",
     files: [
       {
         type: "registry:page",
@@ -99,6 +108,9 @@ export const registry: RegistryItem[] = [
   {
     name: "ai-sdk-backend-resumable",
     type: "registry:page",
+    title: "AI SDK Resumable Backend",
+    description:
+      "AI SDK route handlers with resumable stream context, so a run survives a reload.",
     files: [
       {
         type: "registry:page",
@@ -130,8 +142,34 @@ export const registry: RegistryItem[] = [
     ],
   },
   {
+    name: "eve-chat",
+    type: "registry:item",
+    title: "Eve Chat",
+    description:
+      "Chat page for an Eve agent, rendering the session through an assistant-ui thread.",
+    files: [
+      {
+        type: "registry:file",
+        path: "app/page.tsx",
+        sourcePath: "templates/eve/app/page.tsx",
+        target: "app/page.tsx",
+      },
+    ],
+    dependencies: ["@assistant-ui/eve"],
+    bundledRegistryDependencies: ["https://r.assistant-ui.com/thread.json"],
+    docs: "Eve installs registry files without touching CSS, so add the reasoning and collapsible styles to app/globals.css, and replace the default auth policy in agent/channels/eve.ts before deploying: https://www.assistant-ui.com/docs/runtimes/eve/quickstart",
+    meta: {
+      eve: {
+        requires: ">=0.27.6",
+      },
+    },
+  },
+  {
     name: "thread",
     type: "registry:component",
+    title: "Thread",
+    description:
+      "Chat container with message list, composer, auto scroll, and accessibility built in.",
     files: [
       {
         type: "registry:component",
@@ -154,6 +192,9 @@ export const registry: RegistryItem[] = [
   {
     name: "voice",
     type: "registry:component",
+    title: "Voice",
+    description:
+      "Realtime voice session controls with connect, mute, and a status indicator.",
     files: [
       {
         type: "registry:component",
@@ -170,6 +211,9 @@ export const registry: RegistryItem[] = [
   {
     name: "markdown-text",
     type: "registry:component",
+    title: "Markdown Text",
+    description:
+      "Render assistant markdown with headings, lists, links, and code blocks.",
     files: [
       {
         type: "registry:component",
@@ -190,6 +234,9 @@ export const registry: RegistryItem[] = [
   {
     name: "reasoning",
     type: "registry:component",
+    title: "Reasoning",
+    description:
+      "Collapsible panel for assistant reasoning and thinking content.",
     files: [
       {
         type: "registry:component",
@@ -216,6 +263,9 @@ export const registry: RegistryItem[] = [
   {
     name: "message-timing",
     type: "registry:component",
+    title: "Message Timing",
+    description:
+      "Badge with streaming stats: time to first token, total time, and tokens per second.",
     files: [
       {
         type: "registry:component",
@@ -230,6 +280,9 @@ export const registry: RegistryItem[] = [
   {
     name: "context-display",
     type: "registry:component",
+    title: "Context Display",
+    description:
+      "Token usage against a model's context window as a ring, bar, or text, with a hover popover.",
     files: [
       {
         type: "registry:component",
@@ -244,6 +297,9 @@ export const registry: RegistryItem[] = [
   {
     name: "thread-list",
     type: "registry:component",
+    title: "Thread List",
+    description:
+      "Sidebar or dropdown for switching conversations, with search and active selection.",
     files: [
       {
         type: "registry:component",
@@ -263,6 +319,9 @@ export const registry: RegistryItem[] = [
   {
     name: "mcp-config",
     type: "registry:component",
+    title: "MCP Config Dialog",
+    description:
+      "Dialog listing MCP connectors and custom servers, with OAuth and bearer auth controls.",
     files: [
       {
         type: "registry:component",
@@ -288,6 +347,9 @@ export const registry: RegistryItem[] = [
   {
     name: "attachment",
     type: "registry:component",
+    title: "Attachment",
+    description:
+      "Attach files from the composer and view them inside messages.",
     files: [
       {
         type: "registry:component",
@@ -307,6 +369,9 @@ export const registry: RegistryItem[] = [
   {
     name: "follow-up-suggestions",
     type: "registry:component",
+    title: "Follow Up Suggestions",
+    description:
+      "Prompt chips rendered from runtime generated follow up suggestions.",
     files: [
       {
         type: "registry:component",
@@ -321,6 +386,9 @@ export const registry: RegistryItem[] = [
   {
     name: "tooltip-icon-button",
     type: "registry:component",
+    title: "Tooltip Icon Button",
+    description:
+      "Icon button with an accessible tooltip label, shared across the assistant UI components.",
     files: [
       {
         type: "registry:component",
@@ -335,6 +403,8 @@ export const registry: RegistryItem[] = [
   {
     name: "syntax-highlighter",
     type: "registry:component",
+    title: "Syntax Highlighter",
+    description: "Code block highlighting powered by react-syntax-highlighter.",
     files: [
       {
         type: "registry:component",
@@ -353,6 +423,8 @@ export const registry: RegistryItem[] = [
   {
     name: "assistant-modal",
     type: "registry:component",
+    title: "Assistant Modal",
+    description: "Floating chat bubble for support widgets and help desks.",
     files: [
       {
         type: "registry:component",
@@ -371,6 +443,9 @@ export const registry: RegistryItem[] = [
   {
     name: "assistant-sidebar",
     type: "registry:component",
+    title: "Assistant Sidebar",
+    description:
+      "Side panel chat for copilot experiences and inline assistance.",
     files: [
       {
         type: "registry:component",
@@ -388,6 +463,8 @@ export const registry: RegistryItem[] = [
   {
     name: "tool-fallback",
     type: "registry:component",
+    title: "Tool Fallback",
+    description: "Default renderer for tool calls that have no dedicated UI.",
     files: [
       {
         type: "registry:component",
@@ -406,6 +483,8 @@ export const registry: RegistryItem[] = [
   {
     name: "tool-group",
     type: "registry:component",
+    title: "Tool Group",
+    description: "Collapsible wrapper around consecutive tool calls.",
     files: [
       {
         type: "registry:component",
@@ -429,6 +508,8 @@ export const registry: RegistryItem[] = [
   {
     name: "shiki-highlighter",
     type: "registry:component",
+    title: "Shiki Highlighter",
+    description: "Code block highlighting powered by react-shiki.",
     files: [
       {
         type: "registry:component",
@@ -446,6 +527,9 @@ export const registry: RegistryItem[] = [
   {
     name: "mermaid-diagram",
     type: "registry:component",
+    title: "Mermaid Diagram",
+    description:
+      "Render Mermaid diagrams in messages, including while they stream.",
     files: [
       {
         type: "registry:component",
@@ -464,6 +548,8 @@ export const registry: RegistryItem[] = [
   {
     name: "diff-viewer",
     type: "registry:component",
+    title: "Diff Viewer",
+    description: "Render code diffs with highlighted additions and deletions.",
     files: [
       {
         type: "registry:component",
@@ -482,6 +568,8 @@ export const registry: RegistryItem[] = [
   {
     name: "threadlist-sidebar",
     type: "registry:component",
+    title: "Thread List Sidebar",
+    description: "Sidebar shell that hosts the thread list beside a thread.",
     files: [
       {
         type: "registry:component",
@@ -504,6 +592,9 @@ export const registry: RegistryItem[] = [
   {
     name: "quote",
     type: "registry:component",
+    title: "Quote",
+    description:
+      "Select and quote message text with a floating toolbar and a composer preview.",
     files: [
       {
         type: "registry:component",
@@ -517,6 +608,9 @@ export const registry: RegistryItem[] = [
   {
     name: "sources",
     type: "registry:component",
+    title: "Sources",
+    description:
+      "Display URL sources with favicon, title, and an external link.",
     files: [
       {
         type: "registry:component",
@@ -530,6 +624,9 @@ export const registry: RegistryItem[] = [
   {
     name: "image",
     type: "registry:component",
+    title: "Image",
+    description:
+      "Display image parts with preview, loading states, and a fullscreen dialog.",
     files: [
       {
         type: "registry:component",
@@ -547,6 +644,9 @@ export const registry: RegistryItem[] = [
   {
     name: "file",
     type: "registry:component",
+    title: "File",
+    description:
+      "Display file parts with icon, name, size, and a download button.",
     files: [
       {
         type: "registry:component",
@@ -563,6 +663,9 @@ export const registry: RegistryItem[] = [
   {
     name: "model-selector",
     type: "registry:component",
+    title: "Model Selector",
+    description:
+      "Model picker with reasoning effort levels, search, and runtime integration.",
     files: [
       {
         type: "registry:component",
@@ -583,6 +686,8 @@ export const registry: RegistryItem[] = [
   {
     name: "logos",
     type: "registry:component",
+    title: "Logos",
+    description: "Model provider logos as inline SVG components.",
     files: [
       {
         type: "registry:component",
@@ -596,6 +701,9 @@ export const registry: RegistryItem[] = [
   {
     name: "select",
     type: "registry:component",
+    title: "Select",
+    description:
+      "Dropdown select styled for the assistant UI, with composable sub components.",
     files: [
       {
         type: "registry:component",
@@ -611,6 +719,8 @@ export const registry: RegistryItem[] = [
   {
     name: "direction",
     type: "registry:ui",
+    title: "Direction Provider",
+    description: "Direction provider and hook for right to left layouts.",
     files: [
       {
         type: "registry:ui",
@@ -625,6 +735,8 @@ export const registry: RegistryItem[] = [
   {
     name: "badge",
     type: "registry:component",
+    title: "Badge",
+    description: "Small label for status, categories, and metadata.",
     files: [
       {
         type: "registry:component",
@@ -640,6 +752,8 @@ export const registry: RegistryItem[] = [
   {
     name: "tabs",
     type: "registry:component",
+    title: "Tabs",
+    description: "Tabs for organizing content into switchable panels.",
     files: [
       {
         type: "registry:component",
@@ -655,6 +769,8 @@ export const registry: RegistryItem[] = [
   {
     name: "accordion",
     type: "registry:component",
+    title: "Accordion",
+    description: "Stacked headings that reveal or hide content sections.",
     files: [
       {
         type: "registry:component",
@@ -672,6 +788,8 @@ export const registry: RegistryItem[] = [
   {
     name: "dot-matrix",
     type: "registry:component",
+    title: "Dot Matrix",
+    description: "5x5 dot matrix indicator with state specific blink patterns.",
     files: [
       {
         type: "registry:component",
@@ -686,6 +804,9 @@ export const registry: RegistryItem[] = [
   {
     name: "number-roll",
     type: "registry:component",
+    title: "Number Roll",
+    description:
+      "Animated number that rolls its digits odometer style when the value changes.",
     files: [
       {
         type: "registry:component",
@@ -700,6 +821,8 @@ export const registry: RegistryItem[] = [
   {
     name: "heat-graph",
     type: "registry:component",
+    title: "Heat Graph",
+    description: "Activity heat map with month and weekday labels.",
     files: [
       {
         type: "registry:component",
@@ -714,6 +837,9 @@ export const registry: RegistryItem[] = [
   {
     name: "composer-trigger-popover",
     type: "registry:component",
+    title: "Composer Trigger Popover",
+    description:
+      "Character triggered picker for @ mentions, / commands, and similar popovers.",
     files: [
       {
         type: "registry:component",
@@ -728,6 +854,8 @@ export const registry: RegistryItem[] = [
   {
     name: "directive-text",
     type: "registry:component",
+    title: "Directive Text",
+    description: "Render mention directives as inline chips in user messages.",
     files: [
       {
         type: "registry:component",
@@ -742,12 +870,16 @@ export const registry: RegistryItem[] = [
   {
     name: "generative-ui-style",
     type: "registry:style",
+    title: "Generative UI Style",
+    description: "Theme variables and vocabulary CSS for generative UI output.",
     cssVars: generativeUiThemeVars,
     css: generativeUiVocabularyCss,
   },
   {
     name: "generative-ui",
     type: "registry:component",
+    title: "Generative UI",
+    description: "Styled component library for rendering generative UI output.",
     files: [
       {
         type: "registry:component",

--- a/apps/registry/src/schema.ts
+++ b/apps/registry/src/schema.ts
@@ -10,6 +10,8 @@ export const registryItemTypeSchema = z.enum([
   "registry:hook",
   "registry:theme",
   "registry:page",
+  "registry:file",
+  "registry:item",
 ]);
 
 export const registryItemFileSchema = z.object({
@@ -39,10 +41,12 @@ export const registryItemCssVarsSchema = z.object({
 export const registryItemSchema = z.object({
   name: z.string(),
   type: registryItemTypeSchema,
+  title: z.string().optional(),
   description: z.string().optional(),
   dependencies: z.array(z.string()).optional(),
   devDependencies: z.array(z.string()).optional(),
   registryDependencies: z.array(z.string()).optional(),
+  bundledRegistryDependencies: z.array(z.string()).optional(),
   baseRegistryDependencies: z.array(z.string()).optional(),
   radixDependencies: z.array(z.string()).optional(),
   baseDependencies: z.array(z.string()).optional(),

--- a/apps/registry/templates/eve/app/page.tsx
+++ b/apps/registry/templates/eve/app/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Thread } from "@/components/assistant-ui/thread";
+import { AssistantRuntimeProvider } from "@assistant-ui/react";
+import { useEveAgentRuntime } from "@assistant-ui/eve";
+
+export default function Home() {
+  const runtime = useEveAgentRuntime();
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <div className="h-dvh">
+        <Thread />
+      </div>
+    </AssistantRuntimeProvider>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^4.0.20
         version: 4.0.20(zod@4.4.3)
+      '@assistant-ui/eve':
+        specifier: workspace:*
+        version: link:../../packages/eve
       '@assistant-ui/react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
## summary

- `eve add @assistant-ui/eve-chat` now installs an assistant-ui chat into an existing Eve app: the new `eve-chat` registry item writes an `app/page.tsx` built on `useEveAgentRuntime` and lands the thread component with it.
- the eve CLI passes shadcn only `package.json#registries`, so its resolver runs with `requireUniversal` and rejects every item in the resolved tree that is not `registry:item` or `registry:file` with a target on each file. that rules out referencing the shared component items, so a new `bundledRegistryDependencies` field keeps one declaration in the manifest and the build inlines the thread closure plus the `components/ui` primitives it imports, sourced per flavor.
- every catalog item now carries a title and a description, which is what `eve registry list` and `eve registry search` print for each entry.
- nothing else about the registry changes: diffing the emitted trees against a baseline build of `main` shows all 86 pre-existing files changed only by those two fields, 0 changed in any other way, and 2 new files (`eve-chat.json`, `base/eve-chat.json`).

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/shadcn-registry build` -> both trees emit `eve-chat` as `registry:item` with 14 targeted files, radix tree pulling `radix-ui` and base tree pulling `@base-ui/react`
- [x] `pnpm --filter @assistant-ui/shadcn-registry test` -> 30/30 green, including 3 new contract tests for the bundle expansion
- [x] `pnpm exec oxlint apps/registry` and `pnpm exec oxfmt --check` clean, and `apps/registry` typecheck back to its pre-existing baseline with no new errors
- [x] end to end against a real `eve init --channel-web-nextjs` app with `dist` served locally: `eve registry list --registry @aui` found 43 items with descriptions, `eve registry view @aui/eve-chat` printed the item, `eve add @aui/eve-chat --overwrite` wrote 14 files and installed the dependencies, then `tsc --noEmit` and `next build` both passed

### reviewer should verify

- [ ] once the registry redeploys, `eve registry add @assistant-ui=https://r.assistant-ui.com/{name}.json` followed by `eve add @assistant-ui/eve-chat --overwrite` in an Eve app renders a chat that streams
- [ ] a plain `eve add` with no `--overwrite` skips every pre-existing file, so `app/page.tsx` stays untouched by design

## notes

- eve's universal install path never edits CSS, so the reasoning shimmer and the collapsible keyframes are documented as a manual `app/globals.css` addition instead of being shipped by the item.
- no changeset: only private packages change (`apps/registry`, `apps/docs`).
- separately noticed and left alone: `templates/eve` has neither the `tw-shimmer` dependency nor its CSS import, and no template imports it even though the `reasoning` item declares both.
- follow-ups: a PR to `vercel/eve` to get listed in the official catalog at eve.dev/integrations, and raising the `@assistant-ui/eve` peer floor now that eve ships 0.27.13.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eMpTMck6ZptfHB_SOO_g38NW-zqmfMIy0RgTaKJ2lvtKgppY1Yj87IFGjGI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->