### PR TITLE
feat(docs): step-based code slideshow for the tap tutorial

### DIFF
--- a/apps/docs/components/docs/code-slideshow/changed-lines.ts
+++ b/apps/docs/components/docs/code-slideshow/changed-lines.ts
@@ -1,0 +1,68 @@
+import type { BlockAnnotation } from "codehike/code";
+
+export const changedLineAnnotations = (
+  previous: string,
+  next: string,
+): BlockAnnotation[] => {
+  const a = previous.split("\n");
+  const b = next.split("\n");
+
+  const lcs: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array(b.length + 1).fill(0),
+  );
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i]![j] =
+        a[i] === b[j]
+          ? lcs[i + 1]![j + 1]! + 1
+          : Math.max(lcs[i + 1]![j]!, lcs[i]![j + 1]!);
+    }
+  }
+
+  const changed: number[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      i++;
+      j++;
+    } else if (lcs[i + 1]![j]! >= lcs[i]![j + 1]!) {
+      i++;
+    } else {
+      changed.push(j++);
+    }
+  }
+  while (j < b.length) changed.push(j++);
+
+  const marked = new Set(changed.filter((line) => b[line]!.trim() !== ""));
+  let k = 0;
+  while (k < b.length) {
+    if (b[k]!.trim() !== "") {
+      k++;
+      continue;
+    }
+    let end = k;
+    while (end < b.length && b[end]!.trim() === "") end++;
+    if (k > 0 && end < b.length && marked.has(k - 1) && marked.has(end)) {
+      for (let blank = k; blank < end; blank++) marked.add(blank);
+    }
+    k = end;
+  }
+
+  return [...marked]
+    .sort((x, y) => x - y)
+    .reduce<BlockAnnotation[]>((annotations, line) => {
+      const last = annotations.at(-1);
+      if (last && last.toLineNumber === line) {
+        last.toLineNumber = line + 1;
+      } else {
+        annotations.push({
+          name: "mark",
+          query: "",
+          fromLineNumber: line + 1,
+          toLineNumber: line + 1,
+        });
+      }
+      return annotations;
+    }, []);
+};

--- a/apps/docs/components/docs/code-slideshow/client.tsx
+++ b/apps/docs/components/docs/code-slideshow/client.tsx
@@ -41,9 +41,12 @@ const mark: AnnotationHandler = {
 const tooltip: AnnotationHandler = {
   name: "tooltip",
   Inline: ({ annotation, children }) => (
-    <span className="group/tooltip ch-tooltip border-fd-muted-foreground/60 relative cursor-help border-b border-dashed">
+    <span
+      tabIndex={0}
+      className="group/tooltip ch-tooltip border-fd-muted-foreground/60 relative cursor-help border-b border-dashed"
+    >
       {children}
-      <span className="border-fd-border bg-fd-popover text-fd-popover-foreground absolute bottom-full left-0 z-10 mb-1.5 hidden rounded-md border px-2.5 py-1.5 font-mono text-xs whitespace-nowrap shadow-md group-hover/tooltip:block">
+      <span className="border-fd-border bg-fd-popover text-fd-popover-foreground absolute bottom-full left-0 z-10 mb-1.5 hidden rounded-md border px-2.5 py-1.5 font-mono text-xs whitespace-nowrap shadow-md group-hover/tooltip:block group-focus-visible/tooltip:block">
         {annotation.query}
       </span>
     </span>

--- a/apps/docs/components/docs/code-slideshow/client.tsx
+++ b/apps/docs/components/docs/code-slideshow/client.tsx
@@ -50,6 +50,13 @@ const tooltip: AnnotationHandler = {
   ),
 };
 
+const TouchTarget = () => (
+  <span
+    className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+    aria-hidden="true"
+  />
+);
+
 export const CodeSlideshowClient = ({
   steps,
   testId,
@@ -58,10 +65,9 @@ export const CodeSlideshowClient = ({
   testId?: string | undefined;
 }) => {
   const [nav, setNav] = useState({ index: 0, prevIndex: -1, epoch: 0 });
-  const lastStepIndex = steps.length - 1;
   const step = steps[nav.index]!;
   const isFirst = nav.index === 0;
-  const isLast = nav.index === lastStepIndex;
+  const isLast = nav.index === steps.length - 1;
 
   const crossesCut = (from: number, to: number) =>
     steps
@@ -126,6 +132,10 @@ export const CodeSlideshowClient = ({
     [steps, nav, hardCut],
   );
 
+  const dimmed =
+    annotations.length > 0 ||
+    step.code.annotations.some((annotation) => annotation.name === "mark");
+
   const collapseSettled =
     nav.prevIndex < 0 ||
     hardCut ||
@@ -176,14 +186,7 @@ export const CodeSlideshowClient = ({
           </div>
           <div
             ref={scrollRef}
-            data-dimmed={
-              annotations.length ||
-              step.code.annotations.some(
-                (annotation) => annotation.name === "mark",
-              )
-                ? ""
-                : undefined
-            }
+            data-dimmed={dimmed ? "" : undefined}
             className="not-fumadocs-codeblock h-96 overflow-auto text-[0.8125rem]"
           >
             <CollapseSettledContext.Provider value={collapseSettled}>
@@ -219,10 +222,7 @@ export const CodeSlideshowClient = ({
               disabled={isFirst}
               className="text-fd-muted-foreground hover:text-fd-foreground relative"
             >
-              <span
-                className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                aria-hidden="true"
-              />
+              <TouchTarget />
               <ChevronLeftIcon />
               Back
             </Button>
@@ -231,10 +231,7 @@ export const CodeSlideshowClient = ({
               onClick={() => goTo(isLast ? 0 : nav.index + 1)}
               className="relative"
             >
-              <span
-                className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
-                aria-hidden="true"
-              />
+              <TouchTarget />
               {isLast ? (
                 <>
                   <RotateCcwIcon />

--- a/apps/docs/components/docs/code-slideshow/client.tsx
+++ b/apps/docs/components/docs/code-slideshow/client.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  InnerLine,
+  Pre,
+  type AnnotationHandler,
+  type HighlightedCode,
+} from "codehike/code";
+import { ChevronLeftIcon, ChevronRightIcon, RotateCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { changedLineAnnotations } from "./changed-lines";
+import { collapse, CollapseSettledContext } from "./collapse";
+import { tokenTransitions } from "./token-transitions";
+
+export type CodeSlideshowClientStep = {
+  title: string;
+  filename: string;
+  code: HighlightedCode;
+  cut?: boolean | undefined;
+};
+
+const mark: AnnotationHandler = {
+  name: "mark",
+  Line: ({ annotation, ...props }) => (
+    <InnerLine
+      merge={props}
+      data-line=""
+      data-changed={annotation ? "" : undefined}
+      className={cn(
+        "block border-l-2 px-4",
+        annotation
+          ? "border-l-fd-primary/60 bg-fd-primary/10"
+          : "border-l-transparent",
+      )}
+    />
+  ),
+};
+
+const tooltip: AnnotationHandler = {
+  name: "tooltip",
+  Inline: ({ annotation, children }) => (
+    <span className="group/tooltip ch-tooltip border-fd-muted-foreground/60 relative cursor-help border-b border-dashed">
+      {children}
+      <span className="border-fd-border bg-fd-popover text-fd-popover-foreground absolute bottom-full left-0 z-10 mb-1.5 hidden rounded-md border px-2.5 py-1.5 font-mono text-xs whitespace-nowrap shadow-md group-hover/tooltip:block">
+        {annotation.query}
+      </span>
+    </span>
+  ),
+};
+
+export const CodeSlideshowClient = ({
+  steps,
+  testId,
+}: {
+  steps: CodeSlideshowClientStep[];
+  testId?: string | undefined;
+}) => {
+  const [nav, setNav] = useState({ index: 0, prevIndex: -1, epoch: 0 });
+  const lastStepIndex = steps.length - 1;
+  const step = steps[nav.index]!;
+  const isFirst = nav.index === 0;
+  const isLast = nav.index === lastStepIndex;
+
+  const crossesCut = (from: number, to: number) =>
+    steps
+      .slice(Math.min(from, to) + 1, Math.max(from, to) + 1)
+      .some((item) => item.cut);
+
+  const goTo = (index: number) =>
+    setNav((current) =>
+      index === current.index
+        ? current
+        : {
+            index,
+            prevIndex: current.index,
+            epoch: current.epoch + (crossesCut(current.index, index) ? 1 : 0),
+          },
+    );
+
+  const hardCut = nav.prevIndex >= 0 && crossesCut(nav.prevIndex, nav.index);
+  const isNewFile =
+    nav.prevIndex >= 0 && steps[nav.prevIndex]!.filename !== step.filename;
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const changed = container.querySelectorAll("[data-changed]");
+    if (!changed.length) {
+      container.scrollTo({ top: 0, behavior: "auto" });
+      return;
+    }
+
+    const first = changed[0]!.getBoundingClientRect();
+    const last = changed[changed.length - 1]!.getBoundingClientRect();
+    const view = container.getBoundingClientRect();
+    const padding = 24;
+
+    let delta = 0;
+    if (last.bottom - first.top > view.height)
+      delta = first.top - view.top - padding;
+    else if (last.bottom > view.bottom)
+      delta = last.bottom - view.bottom + padding;
+    else if (first.top < view.top) delta = first.top - view.top - padding;
+    if (!delta) return;
+
+    const reduceMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    container.scrollTo({
+      top: container.scrollTop + delta,
+      behavior: reduceMotion ? "auto" : "smooth",
+    });
+  }, [nav]);
+
+  const annotations = useMemo(
+    () =>
+      nav.prevIndex < 0 || hardCut
+        ? []
+        : changedLineAnnotations(
+            steps[nav.prevIndex]!.code.code,
+            steps[nav.index]!.code.code,
+          ),
+    [steps, nav, hardCut],
+  );
+
+  const collapseSettled =
+    nav.prevIndex < 0 ||
+    hardCut ||
+    isNewFile ||
+    steps[nav.prevIndex]!.code.annotations.some(
+      (annotation) =>
+        annotation.name === "collapse" && annotation.query === "collapsed",
+    );
+
+  return (
+    <div
+      className="not-prose code-slideshow @container my-6"
+      data-testid={testId}
+    >
+      <div className="border-fd-border bg-fd-card overflow-hidden rounded-xl border">
+        <div className="border-fd-border/70 flex gap-1 border-b p-3">
+          {steps.map((item, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => goTo(index)}
+              aria-label={`Step ${index + 1}: ${item.title}`}
+              aria-current={index === nav.index ? "step" : undefined}
+              className="group min-w-0 flex-1 cursor-pointer py-1.5"
+            >
+              <div
+                className={cn(
+                  "h-1 rounded-full transition-colors",
+                  index <= nav.index
+                    ? "bg-fd-primary"
+                    : "bg-fd-muted group-hover:bg-fd-muted-foreground/40",
+                )}
+              />
+            </button>
+          ))}
+        </div>
+
+        <div className="border-fd-border/70 bg-fd-muted/20 min-w-0 border-b">
+          <div className="border-fd-border/70 flex items-center gap-3 border-b px-4 py-2.5">
+            <div className="flex gap-1.5" aria-hidden="true">
+              <div className="bg-fd-muted-foreground/25 size-2.5 rounded-full" />
+              <div className="bg-fd-muted-foreground/25 size-2.5 rounded-full" />
+              <div className="bg-fd-muted-foreground/25 size-2.5 rounded-full" />
+            </div>
+            <p className="text-fd-muted-foreground min-w-0 truncate font-mono text-sm">
+              {step.filename}
+            </p>
+          </div>
+          <div
+            ref={scrollRef}
+            data-dimmed={
+              annotations.length ||
+              step.code.annotations.some(
+                (annotation) => annotation.name === "mark",
+              )
+                ? ""
+                : undefined
+            }
+            className="not-fumadocs-codeblock h-96 overflow-auto text-[0.8125rem]"
+          >
+            <CollapseSettledContext.Provider value={collapseSettled}>
+              <Pre
+                key={nav.epoch}
+                code={{
+                  ...step.code,
+                  annotations: [...step.code.annotations, ...annotations],
+                }}
+                handlers={[tokenTransitions, mark, tooltip, ...collapse]}
+                className="m-0 min-w-max bg-transparent! py-4"
+              />
+            </CollapseSettledContext.Provider>
+          </div>
+        </div>
+
+        <div
+          className="flex min-w-0 flex-col gap-6 p-5 @2xl:flex-row @2xl:items-end @2xl:justify-between @2xl:gap-10 @2xl:p-6"
+          aria-live="polite"
+        >
+          <div className="flex max-w-2xl min-w-0 flex-col gap-1">
+            <p className="text-fd-muted-foreground text-sm font-medium tabular-nums">
+              Step {nav.index + 1} of {steps.length}
+            </p>
+            <h3 className="text-xl font-semibold text-balance">{step.title}</h3>
+          </div>
+
+          <div className="flex shrink-0 items-center justify-between gap-2 @2xl:justify-end">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => goTo(Math.max(0, nav.index - 1))}
+              disabled={isFirst}
+              className="text-fd-muted-foreground hover:text-fd-foreground relative"
+            >
+              <span
+                className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                aria-hidden="true"
+              />
+              <ChevronLeftIcon />
+              Back
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => goTo(isLast ? 0 : nav.index + 1)}
+              className="relative"
+            >
+              <span
+                className="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden"
+                aria-hidden="true"
+              />
+              {isLast ? (
+                <>
+                  <RotateCcwIcon />
+                  Start over
+                </>
+              ) : (
+                <>
+                  Next
+                  <ChevronRightIcon />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/docs/components/docs/code-slideshow/client.tsx
+++ b/apps/docs/components/docs/code-slideshow/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import {
   InnerLine,
   Pre,
@@ -40,17 +40,25 @@ const mark: AnnotationHandler = {
 
 const tooltip: AnnotationHandler = {
   name: "tooltip",
-  Inline: ({ annotation, children }) => (
-    <span
-      tabIndex={0}
-      className="group/tooltip ch-tooltip border-fd-muted-foreground/60 relative cursor-help border-b border-dashed"
-    >
-      {children}
-      <span className="border-fd-border bg-fd-popover text-fd-popover-foreground absolute bottom-full left-0 z-10 mb-1.5 hidden rounded-md border px-2.5 py-1.5 font-mono text-xs whitespace-nowrap shadow-md group-hover/tooltip:block group-focus-visible/tooltip:block">
-        {annotation.query}
+  Inline: ({ annotation, children }) => {
+    const id = useId();
+    return (
+      <span
+        tabIndex={0}
+        aria-describedby={id}
+        className="group/tooltip ch-tooltip border-fd-muted-foreground/60 relative cursor-help border-b border-dashed"
+      >
+        {children}
+        <span
+          id={id}
+          role="tooltip"
+          className="border-fd-border bg-fd-popover text-fd-popover-foreground absolute bottom-full left-0 z-10 mb-1.5 hidden rounded-md border px-2.5 py-1.5 font-mono text-xs whitespace-nowrap shadow-md group-hover/tooltip:block group-focus-visible/tooltip:block"
+        >
+          {annotation.query}
+        </span>
       </span>
-    </span>
-  ),
+    );
+  },
 };
 
 const TouchTarget = () => (
@@ -189,6 +197,9 @@ export const CodeSlideshowClient = ({
           </div>
           <div
             ref={scrollRef}
+            tabIndex={0}
+            role="region"
+            aria-label={step.filename}
             data-dimmed={dimmed ? "" : undefined}
             className="not-fumadocs-codeblock h-96 overflow-auto text-[0.8125rem]"
           >

--- a/apps/docs/components/docs/code-slideshow/collapse.tsx
+++ b/apps/docs/components/docs/code-slideshow/collapse.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { Collapsible } from "radix-ui";
+import {
+  InnerLine,
+  type AnnotationHandler,
+  type BlockAnnotation,
+} from "codehike/code";
+
+const AUTO_COLLAPSE_DELAY = 400;
+
+export const CollapseSettledContext = createContext(true);
+
+const CollapseRoot = ({
+  annotation,
+  children,
+}: {
+  annotation: BlockAnnotation;
+  children: ReactNode;
+}) => {
+  const settled = useContext(CollapseSettledContext);
+  const collapsed = annotation.query === "collapsed";
+  const [open, setOpen] = useState(!(collapsed && settled));
+
+  useEffect(() => {
+    if (!collapsed) return;
+    const timer = setTimeout(() => setOpen(false), AUTO_COLLAPSE_DELAY);
+    return () => clearTimeout(timer);
+  }, [collapsed]);
+
+  return (
+    <Collapsible.Root open={open} onOpenChange={setOpen}>
+      {children}
+    </Collapsible.Root>
+  );
+};
+
+export const collapse: AnnotationHandler[] = [
+  {
+    name: "collapse",
+    transform: (annotation: BlockAnnotation) => [
+      annotation,
+      {
+        ...annotation,
+        toLineNumber: annotation.fromLineNumber,
+        name: "CollapseTrigger",
+      },
+      {
+        ...annotation,
+        fromLineNumber: annotation.fromLineNumber + 1,
+        name: "CollapseContent",
+      },
+    ],
+    Block: CollapseRoot,
+  },
+  {
+    name: "CollapseTrigger",
+    onlyIfAnnotated: true,
+    AnnotatedLine: ({ annotation, ...props }) => (
+      <Collapsible.Trigger asChild>
+        <InnerLine
+          merge={props}
+          className="ch-collapse-trigger data-[state=closed]:after:text-fd-muted-foreground/60 cursor-pointer select-none data-[state=closed]:whitespace-nowrap data-[state=closed]:after:ml-2 data-[state=closed]:after:content-['⋯']"
+        />
+      </Collapsible.Trigger>
+    ),
+  },
+  {
+    name: "CollapseContent",
+    Block: ({ children }) => (
+      <Collapsible.Content className="ch-collapse-content">
+        {children}
+      </Collapsible.Content>
+    ),
+  },
+];

--- a/apps/docs/components/docs/code-slideshow/collapse.tsx
+++ b/apps/docs/components/docs/code-slideshow/collapse.tsx
@@ -30,10 +30,10 @@ const CollapseRoot = ({
   const [open, setOpen] = useState(!(collapsed && settled));
 
   useEffect(() => {
-    if (!collapsed) return;
+    if (!collapsed || settled) return;
     const timer = setTimeout(() => setOpen(false), AUTO_COLLAPSE_DELAY);
     return () => clearTimeout(timer);
-  }, [collapsed]);
+  }, [collapsed, settled]);
 
   return (
     <Collapsible.Root open={open} onOpenChange={setOpen}>

--- a/apps/docs/components/docs/code-slideshow/index.tsx
+++ b/apps/docs/components/docs/code-slideshow/index.tsx
@@ -1,0 +1,31 @@
+import { highlight } from "codehike/code";
+import { CodeSlideshowClient, type CodeSlideshowClientStep } from "./client";
+
+export type CodeSlideshowStep = {
+  title: string;
+  filename: string;
+  language: string;
+  code: string;
+  /** Hard-cut into this step instead of animating from the previous one. */
+  cut?: boolean;
+};
+
+export const CodeSlideshow = async ({
+  steps,
+  testId,
+}: {
+  steps: CodeSlideshowStep[];
+  testId?: string;
+}) => {
+  const highlighted: CodeSlideshowClientStep[] = await Promise.all(
+    steps.map(async ({ language, code, ...rest }) => ({
+      ...rest,
+      code: await highlight(
+        { value: code, lang: language, meta: "" },
+        "github-from-css",
+      ),
+    })),
+  );
+
+  return <CodeSlideshowClient steps={highlighted} testId={testId} />;
+};

--- a/apps/docs/components/docs/code-slideshow/token-transitions.tsx
+++ b/apps/docs/components/docs/code-slideshow/token-transitions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React from "react";
+import {
+  InnerPre,
+  InnerToken,
+  getPreRef,
+  type AnnotationHandler,
+  type CustomPreProps,
+} from "codehike/code";
+import {
+  calculateTransitions,
+  getStartingSnapshot,
+  type TokenTransitionsSnapshot,
+} from "codehike/utils/token-transitions";
+
+const MAX_TRANSITION_DURATION = 750;
+
+class SmoothPre extends React.Component<CustomPreProps> {
+  ref: React.RefObject<HTMLPreElement>;
+
+  constructor(props: CustomPreProps) {
+    super(props);
+    this.ref = getPreRef(this.props);
+  }
+
+  override render() {
+    return <InnerPre merge={this.props} style={{ position: "relative" }} />;
+  }
+
+  override getSnapshotBeforeUpdate() {
+    return getStartingSnapshot(this.ref.current!);
+  }
+
+  override componentDidUpdate(
+    _prevProps: unknown,
+    _prevState: unknown,
+    snapshot: TokenTransitionsSnapshot,
+  ) {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const transitions = calculateTransitions(this.ref.current!, snapshot);
+    for (const { element, keyframes, options } of transitions) {
+      const { translateX, translateY, ...rest } = keyframes;
+      const frames: PropertyIndexedKeyframes = { ...rest };
+      if (translateX && translateY) {
+        frames.translate = [
+          `${translateX[0]}px ${translateY[0]}px`,
+          `${translateX[1]}px ${translateY[1]}px`,
+        ];
+      }
+      element.animate(frames, {
+        duration: options.duration * MAX_TRANSITION_DURATION,
+        delay: options.delay * MAX_TRANSITION_DURATION,
+        easing: options.easing,
+        fill: options.fill,
+      });
+    }
+  }
+}
+
+export const tokenTransitions: AnnotationHandler = {
+  name: "token-transitions",
+  PreWithRef: SmoothPre,
+  Token: (props) => (
+    <InnerToken merge={props} style={{ display: "inline-block" }} />
+  ),
+};

--- a/apps/docs/components/docs/tap/tutorial-data.ts
+++ b/apps/docs/components/docs/tap/tutorial-data.ts
@@ -124,7 +124,7 @@ function CounterList({ ids }) {
     filename: "counter-root.js",
     language: "js",
     cut: true,
-    code: `import { createTapRoot } from "@assistant-ui/tap";
+    code: `import { createTapRoot, flushTapSync } from "@assistant-ui/tap";
 import { useCounter } from "./counter";
 
 const root = createTapRoot(function CounterRoot() {
@@ -132,10 +132,10 @@ const root = createTapRoot(function CounterRoot() {
 });
 
 const unsubscribe = root.subscribe(() => {
-  console.log(root.getValue().count);
+  console.log(root.getValue().count); // 1
 });
 
-root.getValue().increment();
+flushTapSync(() => root.getValue().increment());
 
 unsubscribe();
 root.unmount();`,

--- a/apps/docs/components/docs/tap/tutorial-data.ts
+++ b/apps/docs/components/docs/tap/tutorial-data.ts
@@ -127,7 +127,9 @@ function CounterList({ ids }) {
     code: `import { createTapRoot } from "@assistant-ui/tap";
 import { useCounter } from "./counter";
 
-const root = createTapRoot(() => useCounter());
+const root = createTapRoot(function CounterRoot() {
+  return useCounter();
+});
 
 const unsubscribe = root.subscribe(() => {
   console.log(root.getValue().count);

--- a/apps/docs/components/docs/tap/tutorial-data.ts
+++ b/apps/docs/components/docs/tap/tutorial-data.ts
@@ -1,0 +1,141 @@
+import type { CodeSlideshowStep } from "@/components/docs/code-slideshow";
+
+const useCounterFull = `const useCounter = () => {
+  const [count, setCount] = useState(0);
+  const increment = () => setCount((value) => value + 1);
+  return { count, increment };
+};`;
+
+const useCounterCollapsed = `// !collapse(1:5) collapsed
+${useCounterFull}`;
+
+export const tapTutorialSteps: CodeSlideshowStep[] = [
+  {
+    title: "Write a Hook",
+    filename: "counter.jsx",
+    language: "jsx",
+    code: `import { useState } from "react";
+
+${useCounterFull}`,
+  },
+  {
+    title: "Create a Resource",
+    filename: "counter.jsx",
+    language: "jsx",
+    code: `import { useState } from "react";
+import { resource } from "@assistant-ui/tap";
+
+${useCounterFull}
+
+// !tooltip[/resource/] Wraps a hook into a resource element factory.
+// !tooltip[/Counter/] () => ({ hook: useCounter, args: [] })
+const Counter = resource(useCounter);`,
+  },
+  {
+    title: "Use it in React",
+    filename: "counter.jsx",
+    language: "jsx",
+    code: `import { useState } from "react";
+import { resource, useResource } from "@assistant-ui/tap";
+
+${useCounterCollapsed}
+
+const Counter = resource(useCounter);
+
+function CounterButton() {
+  // !tooltip[/useResource/] Renders the resource as a child and returns its value.
+  // !tooltip[/Counter\\(\\)/] This returns a ResourceElement
+  const { count, increment } = useResource(Counter());
+
+  return <button onClick={increment}>{count}</button>;
+}`,
+  },
+  {
+    title: "Swap the implementation",
+    filename: "counter.jsx",
+    language: "jsx",
+    code: `import { useState } from "react";
+import { resource, useResource } from "@assistant-ui/tap";
+import { PersistentCounter } from "./persistent-counter";
+
+${useCounterCollapsed}
+
+const Counter = resource(useCounter);
+
+function CounterButton({ id }) {
+  const { count, increment } = useResource(
+    id ? PersistentCounter(id) : Counter(),
+  );
+
+  return <button onClick={increment}>{count}</button>;
+}`,
+  },
+  {
+    title: "Accept an implementation",
+    filename: "counter.jsx",
+    language: "jsx",
+    code: `import { useState } from "react";
+import { resource, useResource } from "@assistant-ui/tap";
+import { PersistentCounter } from "./persistent-counter";
+
+${useCounterCollapsed}
+
+const Counter = resource(useCounter);
+
+function CounterButton({ counter = Counter() }) {
+  const { count, increment } = useResource(counter);
+
+  return <button onClick={increment}>{count}</button>;
+}
+
+function App() {
+  return <CounterButton counter={PersistentCounter("main")} />;
+}`,
+  },
+  {
+    title: "Render a dynamic collection",
+    filename: "counter-list.jsx",
+    language: "jsx",
+    cut: true,
+    code: `// !mark(1:2)
+import { useResources, withKey } from "@assistant-ui/tap";
+import { Counter } from "./counter";
+
+function CounterList({ ids }) {
+  // !mark(1:3)
+  const counters = useResources(
+    ids.map((id) => withKey(id, Counter())),
+  );
+
+  // !mark(1:9)
+  return ids.map((id, index) => {
+    const { count, increment } = counters[index];
+
+    return (
+      <button key={id} onClick={increment}>
+        {id}: {count}
+      </button>
+    );
+  });
+}`,
+  },
+  {
+    title: "Run hooks outside React",
+    filename: "counter-root.js",
+    language: "js",
+    cut: true,
+    code: `import { createTapRoot } from "@assistant-ui/tap";
+import { useCounter } from "./counter";
+
+const root = createTapRoot(() => useCounter());
+
+const unsubscribe = root.subscribe(() => {
+  console.log(root.getValue().count);
+});
+
+root.getValue().increment();
+
+unsubscribe();
+root.unmount();`,
+  },
+];

--- a/apps/docs/components/docs/tap/tutorial-slideshow.llm.tsx
+++ b/apps/docs/components/docs/tap/tutorial-slideshow.llm.tsx
@@ -1,0 +1,18 @@
+import { tapTutorialSteps } from "./tutorial-data";
+
+export function TapTutorialSlideshowLLM() {
+  return (
+    <>
+      {tapTutorialSteps.map((step, index) => (
+        <section key={step.title}>
+          <h3>
+            {index + 1}. {step.title}
+          </h3>
+          <pre>
+            <code className={`language-${step.language}`}>{step.code}</code>
+          </pre>
+        </section>
+      ))}
+    </>
+  );
+}

--- a/apps/docs/components/docs/tap/tutorial-slideshow.llm.tsx
+++ b/apps/docs/components/docs/tap/tutorial-slideshow.llm.tsx
@@ -1,5 +1,11 @@
 import { tapTutorialSteps } from "./tutorial-data";
 
+const stripAnnotationComments = (code: string) =>
+  code
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("// !"))
+    .join("\n");
+
 export function TapTutorialSlideshowLLM() {
   return (
     <>
@@ -9,7 +15,9 @@ export function TapTutorialSlideshowLLM() {
             {index + 1}. {step.title}
           </h3>
           <pre>
-            <code className={`language-${step.language}`}>{step.code}</code>
+            <code className={`language-${step.language}`}>
+              {stripAnnotationComments(step.code)}
+            </code>
           </pre>
         </section>
       ))}

--- a/apps/docs/components/docs/tap/tutorial-slideshow.tsx
+++ b/apps/docs/components/docs/tap/tutorial-slideshow.tsx
@@ -1,0 +1,6 @@
+import { CodeSlideshow } from "@/components/docs/code-slideshow";
+import { tapTutorialSteps } from "./tutorial-data";
+
+export const TapTutorialSlideshow = () => (
+  <CodeSlideshow steps={tapTutorialSteps} testId="tap-tutorial-slideshow" />
+);

--- a/apps/docs/content/tap-docs/overview/introduction.mdx
+++ b/apps/docs/content/tap-docs/overview/introduction.mdx
@@ -1,55 +1,41 @@
 ---
 title: Introduction
-description: "tap: React hooks, headless"
+description: State management based on React Hooks.
 ---
 
-<div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] items-center rounded-xl bg-fd-secondary overflow-hidden">
-<div className="not-prose flex flex-col gap-1 pl-6 lg:pl-8 pt-4 lg:pt-0">
-  <p className="text-lg font-semibold">Quickstart</p>
-  <p className="text-fd-muted-foreground">Learn how to build your first resource with tap.</p>
-  <a href="/tap/docs/tap/quickstart" className="text-fd-primary font-medium mt-1 group inline-flex items-center gap-1">Get started <span className="inline-block transition-transform group-hover:translate-x-1">&rarr;</span></a>
-</div>
-<div className="mr-2 lg:mr-5 -my-5 lg:-my-2 lg:[&_pre]:pr-6">
+**tap is a state management library based on React Hooks.**
 
-```ts
-import { resource } from "@assistant-ui/tap";
-import { useState } from "react";
+It lets you build and manage your application state with the APIs and mental
+model you already use in React, organized around one new primitive: the
+**Resource**.
 
-const useCounter = () => {
-  const [count, setCount] = useState(0);
+A Resource does for state what a component does for UI. It turns stateful
+behavior into a reusable, composable building block—but returns state and methods
+instead of JSX.
 
-  return { count, increment: () => setCount((c) => c + 1) };
-};
+> **Resources organize like components, but execute like Hooks.**
 
-const Counter = resource(useCounter);
-```
+## Resources are the unit of state composition
 
-</div>
-</div>
+<TapTutorialSlideshow />
 
-**tap is React's hooks, headless.** You write a `resource` the same way you write a
-React component, with the same hooks (`useState`, `useEffect`, `useMemo`, ...)
-imported from `"react"` and the same rules. The only difference is that a resource
-has no UI: instead of returning JSX, it returns a plain value (state and methods),
-and it runs anywhere, inside a React component, inside another resource, or
-standalone with no React at all.
+`resource()` turns a Hook into a Resource. Use
+[`useResource`](/tap/docs/tap/resources#hosting-a-resource) to compose one Resource
+or [`useResources`](/tap/docs/tap/composition#useresources) to compose a keyed
+collection.
 
-If you know React hooks, you already know tap. There are only three new things:
-
-1. You write a `use`-prefixed hook and wrap it with `resource(useName)`; the unit
-   returns a value instead of JSX.
-2. You instantiate it by calling the factory (`Name(props)`) to get an element,
-   then host it with [`useResource`](/tap/docs/tap/resources#hosting-a-resource).
-3. A resource tree can run [outside React](/tap/docs/tap/outside-react) entirely.
+Nested Resources behave as if their Hook logic were inlined, so effects follow
+declaration order—not component-tree order. See
+[Differences from React](/tap/docs/tap/differences-from-react) for details.
 
 ## Next steps
 
 <Cards>
-  <Card title="Quickstart" href="/tap/docs/tap/quickstart">
-    Install tap and build your first resource.
-  </Card>
   <Card title="Resources" href="/tap/docs/tap/resources">
-    Author, compose, and host resources.
+    Package Hooks into reusable, configurable state.
+  </Card>
+  <Card title="Composition" href="/tap/docs/tap/composition">
+    Build Resource graphs and dynamic keyed collections.
   </Card>
   <Card title="API Reference" href="/tap/docs/tap/api-reference">
     Every export, in one place.

--- a/apps/docs/lib/llm-components.tsx
+++ b/apps/docs/lib/llm-components.tsx
@@ -13,6 +13,7 @@ import { InstallCommandLLM } from "@/components/docs/fumadocs/install/install-co
 import { ParametersTableLLM } from "@/components/docs/parameters-table";
 import { PrimitivesTypeTableLLM } from "@/components/docs/primitives-type-table";
 import { FlowLLM } from "@/components/assistant-ui/flow";
+import { TapTutorialSlideshowLLM } from "@/components/docs/tap/tutorial-slideshow.llm";
 
 /**
  * The single substitution point mapping MDX components to their text variants
@@ -62,4 +63,5 @@ export const LLM_COMPONENTS: MDXComponents = {
   ParametersTable: ParametersTableLLM,
   PrimitivesTypeTable: PrimitivesTypeTableLLM,
   Flow: FlowLLM,
+  TapTutorialSlideshow: TapTutorialSlideshowLLM,
 };

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -23,6 +23,7 @@ import { SourceLink } from "@/components/docs/source-link";
 import { DemoIframe } from "@/components/docs/demo-iframe";
 import { Flow } from "@/components/assistant-ui/flow";
 import { MermaidDiagram } from "@/components/docs/mermaid-diagram";
+import { TapTutorialSlideshow } from "@/components/docs/tap/tutorial-slideshow";
 
 function Kbd({ children, ...props }: ComponentProps<"kbd">) {
   return (
@@ -75,6 +76,7 @@ export function getMDXComponents(components: MDXComponents): MDXComponents {
     DemoIframe,
     Flow,
     MermaidDiagram,
+    TapTutorialSlideshow,
     Code,
     blockquote: (props) => <Callout>{props.children}</Callout>,
     ...components,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -48,6 +48,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "codehike": "^1.1.0",
     "date-fns": "^4.4.0",
     "dotenv": "^17.4.2",
     "embla-carousel-react": "^8.6.0",
@@ -112,10 +113,10 @@
     "tailwindcss": "^4.3.3",
     "ts-morph": "^28.0.0",
     "tsx": "^4.23.1",
-    "vitest": "^4.1.10",
     "tw-animate-css": "^1.4.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-7": "npm:typescript@^7.0.2",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/docs/styles/codehike.css
+++ b/apps/docs/styles/codehike.css
@@ -59,10 +59,6 @@
   --ch-26: #0d1117e6;
 }
 
-.code-slideshow [data-changed] {
-  animation: code-line-changed 400ms ease 250ms backwards;
-}
-
 .code-slideshow [data-line] {
   transition: opacity 300ms ease;
 }
@@ -71,8 +67,15 @@
   opacity: 0.5;
 }
 
-.ch-collapse-trigger[data-state="closed"]::after {
-  animation: ch-hint-in 200ms ease 400ms backwards;
+.code-slideshow [data-changed] {
+  animation: code-line-changed 400ms ease 250ms backwards;
+}
+
+@keyframes code-line-changed {
+  from {
+    background-color: transparent;
+    border-left-color: transparent;
+  }
 }
 
 .code-slideshow .ch-tooltip {
@@ -83,6 +86,10 @@
   from {
     border-color: transparent;
   }
+}
+
+.ch-collapse-trigger[data-state="closed"]::after {
+  animation: ch-hint-in 200ms ease 400ms backwards;
 }
 
 @keyframes ch-hint-in {
@@ -122,23 +129,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ch-collapse-content[data-state="open"],
-  .ch-collapse-content[data-state="closed"],
+  .code-slideshow [data-changed],
+  .code-slideshow .ch-tooltip,
   .ch-collapse-trigger[data-state="closed"]::after,
-  .code-slideshow .ch-tooltip {
-    animation: none;
-  }
-}
-
-@keyframes code-line-changed {
-  from {
-    background-color: transparent;
-    border-left-color: transparent;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .code-slideshow [data-changed] {
+  .ch-collapse-content[data-state="open"],
+  .ch-collapse-content[data-state="closed"] {
     animation: none;
   }
 }

--- a/apps/docs/styles/codehike.css
+++ b/apps/docs/styles/codehike.css
@@ -1,0 +1,144 @@
+/* github-from-css theme variables — https://github.com/code-hike/lighter/blob/main/lib/themes/github-from-css.css */
+:root {
+  --ch-0: light;
+  --ch-1: #6e7781;
+  --ch-2: #0550ae;
+  --ch-3: #953800;
+  --ch-4: #24292f;
+  --ch-5: #8250df;
+  --ch-6: #116329;
+  --ch-7: #cf222e;
+  --ch-8: #0a3069;
+  --ch-9: #82071e;
+  --ch-10: #f6f8fa;
+  --ch-11: #ffebe9;
+  --ch-12: #dafbe1;
+  --ch-13: #ffd8b5;
+  --ch-14: #eaeef2;
+  --ch-15: #57606a;
+  --ch-16: #ffffff;
+  --ch-17: #eaeef280;
+  --ch-18: #fdff0033;
+  --ch-19: #1a85ff;
+  --ch-20: #add6ff;
+  --ch-21: #0969da;
+  --ch-22: #f6f8fa;
+  --ch-23: #d0d7de;
+  --ch-24: #8c959f;
+  --ch-25: #afb8c133;
+  --ch-26: #ffffffe6;
+}
+
+.dark {
+  --ch-0: dark;
+  --ch-1: #8b949e;
+  --ch-2: #79c0ff;
+  --ch-3: #ffa657;
+  --ch-4: #c9d1d9;
+  --ch-5: #d2a8ff;
+  --ch-6: #7ee787;
+  --ch-7: #ff7b72;
+  --ch-8: #a5d6ff;
+  --ch-9: #ffa198;
+  --ch-10: #f0f6fc;
+  --ch-11: #490202;
+  --ch-12: #04260f;
+  --ch-13: #5a1e02;
+  --ch-14: #161b22;
+  --ch-15: #8b949e;
+  --ch-16: #0d1117;
+  --ch-17: #6e76811a;
+  --ch-18: #ffffff0b;
+  --ch-19: #3794ff;
+  --ch-20: #264f78;
+  --ch-21: #1f6feb;
+  --ch-22: #010409;
+  --ch-23: #30363d;
+  --ch-24: #6e7681;
+  --ch-25: #6e768166;
+  --ch-26: #0d1117e6;
+}
+
+.code-slideshow [data-changed] {
+  animation: code-line-changed 400ms ease 250ms backwards;
+}
+
+.code-slideshow [data-line] {
+  transition: opacity 300ms ease;
+}
+
+.code-slideshow [data-dimmed] [data-line]:not([data-changed]) {
+  opacity: 0.5;
+}
+
+.ch-collapse-trigger[data-state="closed"]::after {
+  animation: ch-hint-in 200ms ease 400ms backwards;
+}
+
+.code-slideshow .ch-tooltip {
+  animation: ch-underline-in 300ms ease 600ms backwards;
+}
+
+@keyframes ch-underline-in {
+  from {
+    border-color: transparent;
+  }
+}
+
+@keyframes ch-hint-in {
+  from {
+    opacity: 0;
+  }
+}
+
+.ch-collapse-content {
+  overflow: hidden;
+}
+
+.ch-collapse-content[data-state="open"] {
+  animation: ch-fold-open 200ms ease-out;
+}
+
+.ch-collapse-content[data-state="closed"] {
+  animation: ch-fold-close 200ms ease-out;
+}
+
+@keyframes ch-fold-open {
+  from {
+    height: 0;
+  }
+  to {
+    height: var(--radix-collapsible-content-height);
+  }
+}
+
+@keyframes ch-fold-close {
+  from {
+    height: var(--radix-collapsible-content-height);
+  }
+  to {
+    height: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ch-collapse-content[data-state="open"],
+  .ch-collapse-content[data-state="closed"],
+  .ch-collapse-trigger[data-state="closed"]::after,
+  .code-slideshow .ch-tooltip {
+    animation: none;
+  }
+}
+
+@keyframes code-line-changed {
+  from {
+    background-color: transparent;
+    border-left-color: transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .code-slideshow [data-changed] {
+    animation: none;
+  }
+}

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -8,6 +8,7 @@
 
 @import "./fumadocs.css";
 @import "./animate.css";
+@import "./codehike.css";
 
 @custom-variant data-open (&:where([data-state="open"], [data-open]:not([data-open="false"])));
 @custom-variant data-closed (&:where([data-state="closed"], [data-closed]:not([data-closed="false"])));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      codehike:
+        specifier: ^1.1.0
+        version: 1.1.0
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1985,7 +1988,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -4057,7 +4060,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -4082,7 +4085,7 @@ importers:
         version: 19.2.8
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/react-hook-form:
     dependencies:
@@ -6487,6 +6490,9 @@ packages:
   '@clerk/themes@2.4.57':
     resolution: {integrity: sha512-Nb3bO79rMTU/MPVTC/dde6LG27/IgOMKIYi5KSvAmO4ZUHlj0OWufu6CMvz5OYVZ0YdyMnTBU2aPGRUiRzO+2w==}
     engines: {node: '>=18.17.0'}
+
+  '@code-hike/lighter@1.0.1':
+    resolution: {integrity: sha512-mccvcsk5UTScRrE02oBz1/qzckyhD8YE3VQlQv++2bSVVZgNuCUX8MpokSCi5OmfRAAxbj6kmNiqq1Um8eXPrw==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -11157,6 +11163,9 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
+  ansi-sequence-parser@1.1.1:
+    resolution: {integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -11701,6 +11710,9 @@ packages:
   code-excerpt@4.0.0:
     resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  codehike@1.1.0:
+    resolution: {integrity: sha512-hOxqmTHjiOxhlcVEuDTCoAQ8TW358HVrNKlOwuKcnbwkuTpbGtwj5TnQ7AZjnZiQvJ3LeXohrd1E7qfYYN0Rdg==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -12301,6 +12313,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -19424,6 +19440,10 @@ snapshots:
       - react
       - react-dom
 
+  '@code-hike/lighter@1.0.1':
+    dependencies:
+      ansi-sequence-parser: 1.1.1
+
   '@colors/colors@1.6.0': {}
 
   '@commander-js/extra-typings@13.1.0(commander@13.1.0)':
@@ -24755,6 +24775,8 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
+  ansi-sequence-parser@1.1.1: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -25382,6 +25404,16 @@ snapshots:
     dependencies:
       convert-to-spaces: 2.0.1
 
+  codehike@1.1.0:
+    dependencies:
+      '@code-hike/lighter': 1.0.1
+      diff: 5.2.2
+      estree-util-visit: 2.0.0
+      mdast-util-mdx-jsx: 3.2.0
+      unist-util-visit: 5.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   collapse-white-space@2.1.0: {}
 
   color-convert@1.9.3:
@@ -25915,6 +25947,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@5.2.2: {}
 
   diff@8.0.4: {}
 
@@ -32481,6 +32515,37 @@ snapshots:
   vitefu@1.1.3(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 26.1.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Adds a `CodeSlideshow` component for the docs app, built on codehike, and uses it for the tap tutorial on the introduction page.

- **Step navigation** with progress bar, shadcn Back/Next buttons, and per-step titles.
- **Token-level transitions**: codehike token-transitions FLIP animation between steps; shared tokens move, new tokens fade in.
- **Changed-line highlighting**: LCS line diff against the previously shown step marks inserted lines (bridging interior blank lines), dims unchanged lines, and auto-scrolls the viewer to the changed region.
- **Hard cuts**: steps can opt out of transitioning from their predecessor via `cut: true` (used where the file changes entirely); the `Pre` is keyed by a cut-epoch so in-file transitions survive.
- **Collapse**: codehike `!collapse` annotations rendered with Radix Collapsible; first appearance mounts open and auto-folds so the FLIP matches body-to-body, subsequent steps mount collapsed.
- **Hover tooltips** via `!tooltip` inline annotations; authored `!mark` annotations for steps without a diff.
- Highlighting runs server-side (`github-from-css` theme, CSS variables for light/dark).

The tutorial content itself lives in `tutorial-data.ts` (7 steps), with a text variant for the LLM docs pipeline.

Needs judgment: public-ish component API for the docs app (`CodeSlideshowStep`), and the tutorial copy itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GC5C2qtuCdUV3S4sPTg3HY

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.a66pYSOZIhJlHgbJdLPqmBpEOPMEp7Stfm8dnMK-zFJTGzWUn_Wd0EXc8HU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->