### PR TITLE
fix(tap): re-add deprecated useMemoCache export

### DIFF
--- a/.changeset/tap-usememocache-export.md
+++ b/.changeset/tap-usememocache-export.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+re-add the deprecated useMemoCache export for older @assistant-ui/store versions

--- a/api-surface/assistant-ui__tap.ts
+++ b/api-surface/assistant-ui__tap.ts
@@ -18,12 +18,14 @@ declare const createTapRoot: <R>(render: () => R) => useTapRoot.Root<R> & {
 declare const flushTapSync: <T>(callback: () => T) => T;
 
 declare namespace entry_root_exports {
-  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useResource, useResources, useTapHost, useTapRoot, withKey };
+  export { Resource, ResourceElement, createTapRoot, flushTapSync, resource, useContextProvider, useMemoCache, useResource, useResources, useTapHost, useTapRoot, withKey };
 }
 
 declare function resource<R, A extends readonly unknown[]>(hook: (...args: A) => R): Resource<R, A>;
 
 declare const useContextProvider: <T, TResult>(context: Context<T>, value: T, fn: () => TResult) => TResult;
+
+declare const useMemoCache: (size: number) => unknown[];
 
 declare function useResource<E extends ResourceElement<any>>(element: E): ExtractResourceReturnType<E>;
 

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -9,7 +9,11 @@ export { flushTapSync } from "./core/scheduler";
 export { useContextProvider } from "./core/context";
 
 // hooks
-export { useMemoCache } from "./react-hooks/useMemoCache";
+import { useMemoCache as useMemoCacheInternal } from "./react-hooks/useMemoCache";
+/**
+ * @deprecated Internal API kept for older @assistant-ui/store versions; do not use.
+ */
+export const useMemoCache = useMemoCacheInternal;
 export { useResource } from "./hooks/useResource";
 export { useResources } from "./hooks/useResources";
 export { useTapRoot } from "./hooks/useTapRoot";

--- a/packages/tap/src/index.ts
+++ b/packages/tap/src/index.ts
@@ -9,6 +9,7 @@ export { flushTapSync } from "./core/scheduler";
 export { useContextProvider } from "./core/context";
 
 // hooks
+export { useMemoCache } from "./react-hooks/useMemoCache";
 export { useResource } from "./hooks/useResource";
 export { useResources } from "./hooks/useResources";
 export { useTapRoot } from "./hooks/useTapRoot";

--- a/packages/tap/src/react-hooks/useMemoCache.ts
+++ b/packages/tap/src/react-hooks/useMemoCache.ts
@@ -36,5 +36,8 @@ const nextFiberMemoCache = (
   return cache;
 };
 
+/**
+ * @deprecated Internal API kept for older @assistant-ui/store versions; do not use.
+ */
 export const useMemoCache = (size: number): unknown[] =>
   nextFiberMemoCache(getCurrentResourceFiber(), size);

--- a/packages/tap/src/react-hooks/useMemoCache.ts
+++ b/packages/tap/src/react-hooks/useMemoCache.ts
@@ -36,8 +36,5 @@ const nextFiberMemoCache = (
   return cache;
 };
 
-/**
- * @deprecated Internal API kept for older @assistant-ui/store versions; do not use.
- */
 export const useMemoCache = (size: number): unknown[] =>
   nextFiberMemoCache(getCurrentResourceFiber(), size);


### PR DESCRIPTION
The published @assistant-ui/store 0.3.1 imports `useMemoCache` from @assistant-ui/tap's public surface; tap 0.9.8 dropped the export (#5368), breaking it. This restores the export, marked `@deprecated` (internal API kept for older @assistant-ui/store versions).

Note: `@internal` could not be used because the shared tsconfig sets `stripInternal: true`, which removes the declaration from the d.ts entirely. The api-surface generator strips comments from all surface files, so the JSDoc lives on the declaration and ships in the built d.ts.

- Re-added export in `packages/tap/src/index.ts` (original spot in the hooks group)
- `@deprecated` JSDoc on the declaration in `react-hooks/useMemoCache.ts`
- Regenerated `api-surface/assistant-ui__tap.ts`
- Changeset: patch bump for @assistant-ui/tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Omna2NZBxhl9qHZFS38Ei1n90vTW2bEkD-cROmtet760w2EdzSVivjE-E00?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->