### PR TITLE
docs: explain that only the last message part reports running

### DIFF
--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -372,6 +372,32 @@ const MyModelAdapter: ChatModelAdapter = {
 
 Each yield replaces the previous content. Yield the full state every time, not deltas.
 
+### Only the last part streams
+
+A part reports `status.type === "running"` only while it is the last part of the message. Every earlier part reads as complete, and the components that react to streaming follow that status: the reasoning disclosure auto-opens and pins its live preview while its part is running, and part status indicators resolve the same way.
+
+That makes an empty trailing part destructive. Yielding `[reasoning, text("")]` to reserve the text slot marks the reasoning part complete the moment the empty text part appears, even though reasoning is still streaming, and nothing in the UI signals why. Add a part on its first token instead of reserving it:
+
+```tsx
+let reasoning = "";
+let text = "";
+
+for await (const part of stream) {
+  reasoning += part.reasoningDelta ?? "";
+  text += part.textDelta ?? "";
+
+  yield {
+    content: [
+      { type: "reasoning" as const, text: reasoning },
+      // Only include the text part once it has content
+      ...(text ? [{ type: "text" as const, text }] : []),
+    ],
+  };
+}
+```
+
+The same applies to any part type: an empty placeholder at the end of the content array completes everything before it.
+
 ### Streaming with tool calls
 
 Accumulate tool calls in a `Map` outside the streaming loop so they persist across chunks:

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -382,9 +382,11 @@ That makes an empty trailing part destructive. Yielding `[reasoning, text("")]` 
 let reasoning = "";
 let text = "";
 
-for await (const part of stream) {
-  reasoning += part.reasoningDelta ?? "";
-  text += part.textDelta ?? "";
+for await (const chunk of stream) {
+  const delta = chunk.choices[0]?.delta;
+  text += delta?.content ?? "";
+  // Reasoning deltas are provider-specific; read whichever field yours sends
+  reasoning += (delta as { reasoning?: string })?.reasoning ?? "";
 
   // Include each part only once it has content
   yield {

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -374,7 +374,7 @@ Each yield replaces the previous content. Yield the full state every time, not d
 
 ### Only the last part streams
 
-A part reports `status.type === "running"` only while it is the last part of the message. Every earlier part reads as complete, and the components that react to streaming follow that status: the reasoning disclosure auto-opens and pins its live preview while its part is running, and part status indicators resolve the same way.
+A text or reasoning part reports `status.type === "running"` only while it is the last part of the message. Every earlier one reads as complete, and the components that react to streaming follow that status: the reasoning disclosure auto-opens and pins its live preview while its part is running, and part status indicators resolve the same way. Tool-call parts are exempt, since their status comes from whether they have a result.
 
 That makes an empty trailing part destructive. Yielding `[reasoning, text("")]` to reserve the text slot marks the reasoning part complete the moment the empty text part appears, even though reasoning is still streaming, and nothing in the UI signals why. Add a part on its first token instead of reserving it:
 
@@ -386,17 +386,17 @@ for await (const part of stream) {
   reasoning += part.reasoningDelta ?? "";
   text += part.textDelta ?? "";
 
+  // Include each part only once it has content
   yield {
     content: [
-      { type: "reasoning" as const, text: reasoning },
-      // Only include the text part once it has content
+      ...(reasoning ? [{ type: "reasoning" as const, text: reasoning }] : []),
       ...(text ? [{ type: "text" as const, text }] : []),
     ],
   };
 }
 ```
 
-The same applies to any part type: an empty placeholder at the end of the content array completes everything before it.
+Guard every text or reasoning part this way, not just the trailing one. An empty part that is never filled also renders as an empty block, and whichever part ends up last is the only one that can report `running`.
 
 ### Streaming with tool calls
 


### PR DESCRIPTION
addresses direction 3 of #5166

## summary

- documents the last-part-only `running` semantics in the `ChatModelAdapter` streaming guide, where an adapter author is reading about what to yield, and states the actionable rule: add a part on its first token rather than reserving an empty slot for it
- the example is the exact shape that cost the reporter in #5162 a debugging session: yielding `[reasoning, text("")]` marks the reasoning part complete while reasoning is still streaming, so the disclosure stops auto-opening and its live preview stops following, and nothing in the UI signals why

## why documentation rather than a code fix

the two code directions in #5166 were implemented and both are empirically dead:

- a dev-mode warning in the accumulator (#5218, closed): the merge stream reorders chunks relative to producer calls at every granularity, so the accumulator cannot separate producer intent from transport interleaving. two of the three predicates fired on every first-party stream (400/400, 3000/3000), and the race-immune third is orthogonal to the symptom
- skipping trailing empty parts in the positional derivation (#5214, closed): a trailing `text("")` is byte-identical between the footgun and a normal part boundary, so every boundary transiently mislabels which part is streaming, and `[tool-call(with result), text("")]` ends up with no part reporting running at all, killing the loading indicator

the sound successor is to honour supplied per-part status with a positional fallback, which needs `status` to exist on core's `TextMessagePart` and `ReasoningMessagePart` first (it does not today) plus the plumbing and audit list collected on #5166. that is a design change and stays out of this PR.

deliberately not documented as guidance: emitting a `part-finish` for the earlier part. the derivation never consults it, so that advice would silence a symptom without changing anything observable.

no test plan, docs only. `apps/docs` is private, so no changeset.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.REYv-kaGRIlzWeIzq5bXDFlTDQfKDXtuWCW7rJW-ScbC9XxRLgrC5925uiw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->