### PR TITLE
fix(core): reset copied feedback timer

### DIFF
--- a/.changeset/reset-copy-feedback-timer.md
+++ b/.changeset/reset-copy-feedback-timer.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep copied feedback visible for the full duration after repeated copies

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { renderHook } from "@testing-library/react";
+import { cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -25,12 +25,18 @@ const mocks = vi.hoisted(() => {
         setIsCopied,
       },
     },
+    currentAui: {
+      message: {
+        getCopyText: () => "Hello",
+        setIsCopied,
+      },
+    },
   };
 });
 
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/store")>()),
-  useAui: () => mocks.aui,
+  useAui: () => mocks.currentAui,
   useAuiState: ((selector: (state: typeof mocks.state) => unknown) =>
     selector(mocks.state)) as typeof import("@assistant-ui/store").useAuiState,
 }));
@@ -38,8 +44,10 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 import { useActionBarCopy } from "./useActionBarCopy";
 
 afterEach(() => {
+  cleanup();
   vi.clearAllMocks();
   vi.useRealTimers();
+  mocks.currentAui = mocks.aui;
 });
 
 describe("useActionBarCopy", () => {
@@ -99,7 +107,7 @@ describe("useActionBarCopy", () => {
     expect(mocks.setIsCopied).toHaveBeenCalledWith(false);
   });
 
-  it("clears the copy feedback timer when unmounted", async () => {
+  it("resets copy feedback when unmounted", async () => {
     vi.useFakeTimers();
     const copyToClipboard = vi.fn();
     const { result, unmount } = renderHook(() =>
@@ -110,7 +118,57 @@ describe("useActionBarCopy", () => {
     await Promise.resolve();
     expect(vi.getTimerCount()).toBe(1);
 
+    mocks.setIsCopied.mockClear();
     unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(mocks.setIsCopied).toHaveBeenCalledWith(false);
+  });
+
+  it("ignores clipboard success after unmount", async () => {
+    vi.useFakeTimers();
+    let resolveCopy: (() => void) | undefined;
+    const copyToClipboard = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCopy = resolve;
+        }),
+    );
+    const { result, unmount } = renderHook(() =>
+      useActionBarCopy({ copyToClipboard }),
+    );
+
+    result.current.copy();
+    unmount();
+    resolveCopy?.();
+    await Promise.resolve();
+
+    expect(mocks.setIsCopied).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("resets feedback for the previous message scope", async () => {
+    vi.useFakeTimers();
+    const copyToClipboard = vi.fn();
+    const nextSetIsCopied = vi.fn();
+    const { result, rerender } = renderHook(() =>
+      useActionBarCopy({ copyToClipboard }),
+    );
+
+    result.current.copy();
+    await Promise.resolve();
+    mocks.setIsCopied.mockClear();
+
+    mocks.currentAui = {
+      message: {
+        getCopyText: () => "Next message",
+        setIsCopied: nextSetIsCopied,
+      },
+    };
+    rerender();
+
+    expect(mocks.setIsCopied).toHaveBeenCalledWith(false);
+    expect(nextSetIsCopied).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.test.ts
@@ -1,3 +1,5 @@
+/** @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -26,12 +28,6 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("react", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("react")>()),
-  useCallback: ((callback: unknown) =>
-    callback) as typeof import("react").useCallback,
-}));
-
 vi.mock("@assistant-ui/store", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@assistant-ui/store")>()),
   useAui: () => mocks.aui,
@@ -43,24 +39,25 @@ import { useActionBarCopy } from "./useActionBarCopy";
 
 afterEach(() => {
   vi.clearAllMocks();
+  vi.useRealTimers();
 });
 
 describe("useActionBarCopy", () => {
   it("does not report copy success without a clipboard handler", async () => {
-    const { copy, disabled } = useActionBarCopy();
+    const { result } = renderHook(() => useActionBarCopy());
 
-    copy();
+    result.current.copy();
     await Promise.resolve();
 
-    expect(disabled).toBe(true);
+    expect(result.current.disabled).toBe(true);
     expect(mocks.setIsCopied).not.toHaveBeenCalled();
   });
 
   it("reports copy success after the clipboard handler resolves", async () => {
     const copyToClipboard = vi.fn();
-    const { copy } = useActionBarCopy({ copyToClipboard });
+    const { result } = renderHook(() => useActionBarCopy({ copyToClipboard }));
 
-    copy();
+    result.current.copy();
     await Promise.resolve();
 
     expect(copyToClipboard).toHaveBeenCalledWith("Hello");
@@ -69,11 +66,51 @@ describe("useActionBarCopy", () => {
 
   it("does not report copy success when the clipboard handler rejects", async () => {
     const copyToClipboard = vi.fn().mockRejectedValue(new Error("denied"));
-    const { copy } = useActionBarCopy({ copyToClipboard });
+    const { result } = renderHook(() => useActionBarCopy({ copyToClipboard }));
 
-    copy();
+    result.current.copy();
     await Promise.resolve();
 
     expect(mocks.setIsCopied).not.toHaveBeenCalled();
+  });
+
+  it("keeps copy success visible for the full duration after copying again", async () => {
+    vi.useFakeTimers();
+    const copyToClipboard = vi.fn();
+    const { result } = renderHook(() =>
+      useActionBarCopy({
+        copiedDuration: 3000,
+        copyToClipboard,
+      }),
+    );
+
+    result.current.copy();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    result.current.copy();
+    await Promise.resolve();
+    mocks.setIsCopied.mockClear();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mocks.setIsCopied).not.toHaveBeenCalledWith(false);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mocks.setIsCopied).toHaveBeenCalledWith(false);
+  });
+
+  it("clears the copy feedback timer when unmounted", async () => {
+    vi.useFakeTimers();
+    const copyToClipboard = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useActionBarCopy({ copyToClipboard }),
+    );
+
+    result.current.copy();
+    await Promise.resolve();
+    expect(vi.getTimerCount()).toBe(1);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useAui, useAuiState } from "@assistant-ui/store";
 
 export type UseActionBarCopyOptions = {
@@ -21,6 +21,17 @@ export const useActionBarCopy = ({
   const isCopied = useAuiState((s) => s.message.isCopied);
   const isEditing = useAuiState((s) => s.composer.isEditing);
   const composerValue = useAuiState((s) => s.composer.text);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const clearCopiedTimer = useCallback(() => {
+    if (copiedTimerRef.current === undefined) return;
+    clearTimeout(copiedTimerRef.current);
+    copiedTimerRef.current = undefined;
+  }, []);
+
+  useEffect(() => clearCopiedTimer, [aui, clearCopiedTimer]);
 
   const copy = useCallback(() => {
     if (!copyToClipboard) return;
@@ -32,12 +43,23 @@ export const useActionBarCopy = ({
     // API unavailable) so they don't surface as unhandled promise rejections.
     Promise.resolve(copyToClipboard(valueToCopy)).then(
       () => {
+        clearCopiedTimer();
         aui.message.setIsCopied(true);
-        setTimeout(() => aui.message.setIsCopied(false), copiedDuration);
+        copiedTimerRef.current = setTimeout(() => {
+          copiedTimerRef.current = undefined;
+          aui.message.setIsCopied(false);
+        }, copiedDuration);
       },
       () => {},
     );
-  }, [aui, isEditing, composerValue, copiedDuration, copyToClipboard]);
+  }, [
+    aui,
+    isEditing,
+    composerValue,
+    copiedDuration,
+    copyToClipboard,
+    clearCopiedTimer,
+  ]);
 
   return { copy, disabled: disabled || !copyToClipboard, isCopied };
 };

--- a/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
+++ b/packages/core/src/react/primitive-hooks/useActionBarCopy.ts
@@ -24,26 +24,36 @@ export const useActionBarCopy = ({
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const scopeGenerationRef = useRef(0);
 
-  const clearCopiedTimer = useCallback(() => {
-    if (copiedTimerRef.current === undefined) return;
-    clearTimeout(copiedTimerRef.current);
-    copiedTimerRef.current = undefined;
-  }, []);
+  useEffect(
+    () => () => {
+      scopeGenerationRef.current += 1;
+      if (copiedTimerRef.current === undefined) return;
 
-  useEffect(() => clearCopiedTimer, [aui, clearCopiedTimer]);
+      clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = undefined;
+      aui.message.setIsCopied(false);
+    },
+    [aui],
+  );
 
   const copy = useCallback(() => {
     if (!copyToClipboard) return;
 
     const valueToCopy = isEditing ? composerValue : aui.message.getCopyText();
     if (!valueToCopy) return;
+    const scopeGeneration = scopeGenerationRef.current;
 
     // The rejection handler swallows clipboard write failures (permission denied,
     // API unavailable) so they don't surface as unhandled promise rejections.
     Promise.resolve(copyToClipboard(valueToCopy)).then(
       () => {
-        clearCopiedTimer();
+        if (scopeGeneration !== scopeGenerationRef.current) return;
+
+        if (copiedTimerRef.current !== undefined) {
+          clearTimeout(copiedTimerRef.current);
+        }
         aui.message.setIsCopied(true);
         copiedTimerRef.current = setTimeout(() => {
           copiedTimerRef.current = undefined;
@@ -52,14 +62,7 @@ export const useActionBarCopy = ({
       },
       () => {},
     );
-  }, [
-    aui,
-    isEditing,
-    composerValue,
-    copiedDuration,
-    copyToClipboard,
-    clearCopiedTimer,
-  ]);
+  }, [aui, isEditing, composerValue, copiedDuration, copyToClipboard]);
 
   return { copy, disabled: disabled || !copyToClipboard, isCopied };
 };


### PR DESCRIPTION
## Summary

- keep a single copy-feedback timeout per mounted action bar copy hook
- reset that timeout after each successful copy
- clear pending feedback timers when the message scope changes or unmounts

## Why

Copying the same message twice before `copiedDuration` elapsed created two independent timers. The first timer could set `isCopied` to `false` while the second copy was still inside its own feedback window, making the "Copied" state disappear early.

For example, with a 3-second duration, copying at `t=0` and again at `t=1` previously hid the feedback at `t=3`; it should remain visible until `t=4`.

## Testing

- added fake-timer coverage for repeated copies
- added cleanup coverage for unmounting with a pending timer
- `pnpm --filter @assistant-ui/core test` (80 files, 769 tests)
- `pnpm --filter @assistant-ui/core build`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.80Bl1PwxeAhpfNNfeW0mI-GZ2e2Z_OaBh9pWcQpAPiTz9L2wPrN9PcrMhX4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->