### PR TITLE
fix(react): isolate mcp app error callbacks

### DIFF
--- a/.changeset/isolate-mcp-app-error-callbacks.md
+++ b/.changeset/isolate-mcp-app-error-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: keep MCP App error replies reliable when error callbacks throw

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -475,4 +475,35 @@ describe("createMcpAppBridge", () => {
     expect(onRequestTeardown).toHaveBeenCalledWith({ reason: "done" });
     bridge.dispose();
   });
+
+  it("isolates a throwing onError from widget error notifications", () => {
+    const { frame } = makeFrame();
+    const callbackError = new Error("error callback failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onError = vi.fn(() => {
+      throw callbackError;
+    });
+    const bridge = createMcpAppBridge({
+      frame,
+      handlers: { callTool: vi.fn(), onError },
+    });
+
+    expect(() =>
+      deliver(bridge, {
+        jsonrpc: "2.0",
+        method: "notifications/error",
+        params: { message: "kaboom" },
+      }),
+    ).not.toThrow();
+
+    expect(onError).toHaveBeenCalledWith(new Error("kaboom"));
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] MCP App onError callback threw an error",
+      callbackError,
+    );
+    consoleError.mockRestore();
+    bridge.dispose();
+  });
 });

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -124,43 +124,52 @@ describe("createMcpAppBridge", () => {
     bridge.dispose();
   });
 
-  it("returns an error response when onError throws", async () => {
-    const { frame, captured } = makeFrame();
-    const callTool = vi.fn().mockRejectedValue(new Error("tool failed"));
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const onError = vi.fn(() => {
-      throw new Error("error callback failed");
-    });
-    const bridge = createMcpAppBridge({
-      frame,
-      handlers: { callTool, onError },
-    });
+  it.each([
+    [
+      "throws",
+      () => {
+        throw new Error("error callback failed");
+      },
+    ],
+    ["rejects", () => Promise.reject(new Error("error callback failed"))],
+  ])(
+    "returns an error response when onError %s",
+    async (_behavior, onErrorCallback) => {
+      const { frame, captured } = makeFrame();
+      const callTool = vi.fn().mockRejectedValue(new Error("tool failed"));
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onError = vi.fn(onErrorCallback);
+      const bridge = createMcpAppBridge({
+        frame,
+        handlers: { callTool, onError },
+      });
 
-    deliver(bridge, {
-      jsonrpc: "2.0",
-      id: 8,
-      method: "tools/call",
-      params: { name: "search" },
-    });
-    await flush();
-
-    expect(onError).toHaveBeenCalledWith(new Error("tool failed"));
-    expect(captured).toEqual([
-      {
+      deliver(bridge, {
         jsonrpc: "2.0",
         id: 8,
-        error: { code: -32603, message: "tool failed" },
-      },
-    ]);
-    expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] MCP App onError callback threw an error",
-      new Error("error callback failed"),
-    );
-    consoleError.mockRestore();
-    bridge.dispose();
-  });
+        method: "tools/call",
+        params: { name: "search" },
+      });
+      await flush();
+
+      expect(onError).toHaveBeenCalledWith(new Error("tool failed"));
+      expect(captured).toEqual([
+        {
+          jsonrpc: "2.0",
+          id: 8,
+          error: { code: -32603, message: "tool failed" },
+        },
+      ]);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] MCP App onError callback threw an error",
+        new Error("error callback failed"),
+      );
+      consoleError.mockRestore();
+      bridge.dispose();
+    },
+  );
 
   it("rejects tools/call for disallowed tool with -32602", async () => {
     const { frame, captured } = makeFrame();
@@ -438,12 +447,7 @@ describe("createMcpAppBridge", () => {
   it("invokes onLog / onError / onRequestTeardown for notifications", () => {
     const { frame } = makeFrame();
     const onLog = vi.fn();
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const onError = vi.fn(() => {
-      throw new Error("error callback failed");
-    });
+    const onError = vi.fn();
     const onRequestTeardown = vi.fn();
     const bridge = createMcpAppBridge({
       frame,
@@ -469,11 +473,6 @@ describe("createMcpAppBridge", () => {
     expect(onLog).toHaveBeenCalledWith({ level: "info", message: "hello" });
     expect(onError).toHaveBeenCalled();
     expect(onRequestTeardown).toHaveBeenCalledWith({ reason: "done" });
-    expect(consoleError).toHaveBeenCalledWith(
-      "[assistant-ui] MCP App onError callback threw an error",
-      new Error("error callback failed"),
-    );
-    consoleError.mockRestore();
     bridge.dispose();
   });
 });

--- a/packages/react/src/mcp-apps/bridge.test.ts
+++ b/packages/react/src/mcp-apps/bridge.test.ts
@@ -124,6 +124,44 @@ describe("createMcpAppBridge", () => {
     bridge.dispose();
   });
 
+  it("returns an error response when onError throws", async () => {
+    const { frame, captured } = makeFrame();
+    const callTool = vi.fn().mockRejectedValue(new Error("tool failed"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onError = vi.fn(() => {
+      throw new Error("error callback failed");
+    });
+    const bridge = createMcpAppBridge({
+      frame,
+      handlers: { callTool, onError },
+    });
+
+    deliver(bridge, {
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: { name: "search" },
+    });
+    await flush();
+
+    expect(onError).toHaveBeenCalledWith(new Error("tool failed"));
+    expect(captured).toEqual([
+      {
+        jsonrpc: "2.0",
+        id: 8,
+        error: { code: -32603, message: "tool failed" },
+      },
+    ]);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] MCP App onError callback threw an error",
+      new Error("error callback failed"),
+    );
+    consoleError.mockRestore();
+    bridge.dispose();
+  });
+
   it("rejects tools/call for disallowed tool with -32602", async () => {
     const { frame, captured } = makeFrame();
     const callTool = vi.fn();
@@ -400,7 +438,12 @@ describe("createMcpAppBridge", () => {
   it("invokes onLog / onError / onRequestTeardown for notifications", () => {
     const { frame } = makeFrame();
     const onLog = vi.fn();
-    const onError = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onError = vi.fn(() => {
+      throw new Error("error callback failed");
+    });
     const onRequestTeardown = vi.fn();
     const bridge = createMcpAppBridge({
       frame,
@@ -426,6 +469,11 @@ describe("createMcpAppBridge", () => {
     expect(onLog).toHaveBeenCalledWith({ level: "info", message: "hello" });
     expect(onError).toHaveBeenCalled();
     expect(onRequestTeardown).toHaveBeenCalledWith({ reason: "done" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[assistant-ui] MCP App onError callback threw an error",
+      new Error("error callback failed"),
+    );
+    consoleError.mockRestore();
     bridge.dispose();
   });
 });

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -123,6 +123,17 @@ export function createMcpAppBridge(
     });
   };
 
+  const reportError = (error: Error) => {
+    try {
+      handlers.onError?.(error);
+    } catch (callbackError) {
+      console.error(
+        "[assistant-ui] MCP App onError callback threw an error",
+        callbackError,
+      );
+    }
+  };
+
   const handleRequest = async (req: McpAppJsonRpcRequest) => {
     try {
       const params = req.params;
@@ -376,7 +387,7 @@ export function createMcpAppBridge(
       }
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
-      handlers.onError?.(error);
+      reportError(error);
       errorResponse(req.id, JSONRPC_ERROR.internalError, error.message);
     }
   };
@@ -405,7 +416,7 @@ export function createMcpAppBridge(
       }
       case "notifications/error": {
         const p = (note.params ?? {}) as { message?: string };
-        handlers.onError?.(
+        reportError(
           new Error(typeof p.message === "string" ? p.message : "Widget error"),
         );
         return;

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -123,14 +123,20 @@ export function createMcpAppBridge(
     });
   };
 
+  const reportErrorCallbackFailure = (error: unknown) => {
+    console.error(
+      "[assistant-ui] MCP App onError callback threw an error",
+      error,
+    );
+  };
+
   const reportError = (error: Error) => {
     try {
-      handlers.onError?.(error);
-    } catch (callbackError) {
-      console.error(
-        "[assistant-ui] MCP App onError callback threw an error",
-        callbackError,
+      void Promise.resolve(handlers.onError?.(error)).catch(
+        reportErrorCallbackFailure,
       );
+    } catch (callbackError) {
+      reportErrorCallbackFailure(callbackError);
     }
   };
 
@@ -416,7 +422,7 @@ export function createMcpAppBridge(
       }
       case "notifications/error": {
         const p = (note.params ?? {}) as { message?: string };
-        reportError(
+        handlers.onError?.(
           new Error(typeof p.message === "string" ? p.message : "Widget error"),
         );
         return;

--- a/packages/react/src/mcp-apps/bridge.ts
+++ b/packages/react/src/mcp-apps/bridge.ts
@@ -422,7 +422,7 @@ export function createMcpAppBridge(
       }
       case "notifications/error": {
         const p = (note.params ?? {}) as { message?: string };
-        handlers.onError?.(
+        reportError(
           new Error(typeof p.message === "string" ? p.message : "Widget error"),
         );
         return;


### PR DESCRIPTION
## Summary

- isolate synchronous throws and asynchronous rejections from MCP App `onError` callbacks
- preserve the original JSON-RPC internal error response when a request handler fails
- keep notification callback behavior unchanged

## Why

While testing a host error path, I found that a failed request handler followed by a throwing `onError` callback left the widget waiting forever. The callback ran before the JSON-RPC error response, so its exception prevented the bridge from replying and also surfaced as an unhandled rejection.

Error reporting is an observer of the failure and should not control protocol settlement. This keeps the callback notification, logs callback failures, and still sends the original `-32603` response to the widget. Rejected promises from async callbacks are consumed and logged as well.

## Testing

- `pnpm exec vitest run src/mcp-apps/bridge.test.ts`
- `pnpm --filter @assistant-ui/react test`
- `pnpm --filter @assistant-ui/react build`
- `pnpm lint`