### PR TITLE
fix(core): derive group status from member statuses instead of the last member

### DIFF
--- a/.changeset/status-readers-honour-part-status.md
+++ b/.changeset/status-readers-honour-part-status.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: keep grouped and detached part statuses in sync

--- a/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageGroupedParts.tsx
@@ -8,6 +8,7 @@ import type {
   MessagePartStatus,
   ToolCallMessagePartStatus,
 } from "../../../types/message";
+import { getGroupStatus } from "../../../utils/getGroupStatus";
 import {
   buildGroupTree,
   GROUPBY_MEMO_KEY,
@@ -21,7 +22,8 @@ export namespace MessagePrimitiveGroupedParts {
    * A coalesced group of adjacent parts. Surfaced through the same
    * `{ part }` channel as a leaf {@link EnrichedPartState} so consumers
    * dispatch on a single `switch (part.type)`. `type` is the group key
-   * (always `"group-…"`); `status` mirrors the last contained part.
+   * (always `"group-…"`); `status` is running when any contained part runs,
+   * otherwise it mirrors the last contained part.
    */
   export type GroupPart<TKey extends `group-${string}` = `group-${string}`> = {
     readonly type: TKey;
@@ -133,8 +135,6 @@ export namespace MessagePrimitiveGroupedParts {
   };
 }
 
-const COMPLETE_STATUS: MessagePartStatus = Object.freeze({ type: "complete" });
-
 const shouldShowIndicator = (
   mode: MessagePrimitiveGroupedParts.IndicatorMode,
   parts: readonly PartState[],
@@ -194,7 +194,7 @@ const renderNode = <TKey extends `group-${string}`>(
     );
   }
 
-  const status = parts[node.indices.at(-1)!]?.status ?? COMPLETE_STATUS;
+  const status = getGroupStatus(parts, node.indices);
   const groupPart: MessagePrimitiveGroupedParts.GroupPart<TKey> = {
     type: node.key as TKey,
     status,

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -7,11 +7,11 @@ import type {
   ThreadUserMessagePart,
 } from "../../types/message";
 import type { Unsubscribe } from "../../types/unsubscribe";
-import type {
-  MessagePartStatus,
-  MessagePartStreamStatus,
-  RunConfig,
-} from "../../types/message";
+import type { MessagePartStatus, RunConfig } from "../../types/message";
+import {
+  COMPLETE_STATUS,
+  normalizePartStatus,
+} from "../../utils/normalizePartStatus";
 import { getThreadMessageText } from "../../utils/text";
 import { NestedSubscriptionSubject } from "../../subscribable/subscribable";
 import {
@@ -35,55 +35,6 @@ import {
 import type { MessageRuntimePath } from "./paths";
 import type { ThreadRuntimeCoreBinding } from "./thread-runtime";
 import type { MessageStateBinding } from "./bindings";
-
-const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
-  type: "complete",
-});
-const RUNNING_STATUS: MessagePartStatus = Object.freeze({
-  type: "running",
-});
-type IncompleteMessagePartStatus = Extract<
-  MessagePartStreamStatus,
-  { readonly type: "incomplete" }
->;
-const INCOMPLETE_STATUSES: Readonly<
-  Record<IncompleteMessagePartStatus["reason"], IncompleteMessagePartStatus>
-> = Object.freeze({
-  cancelled: Object.freeze({ type: "incomplete", reason: "cancelled" }),
-  length: Object.freeze({ type: "incomplete", reason: "length" }),
-  "content-filter": Object.freeze({
-    type: "incomplete",
-    reason: "content-filter",
-  }),
-  other: Object.freeze({ type: "incomplete", reason: "other" }),
-  error: Object.freeze({ type: "incomplete", reason: "error" }),
-});
-
-const normalizePartStatus = (
-  part: ThreadUserMessagePart | ThreadAssistantMessagePart,
-): MessagePartStatus | undefined => {
-  const status = (part as { readonly status?: unknown }).status;
-  if (!status || typeof status !== "object") return undefined;
-
-  const { type } = status as { readonly type?: unknown };
-  if (type === "running") return RUNNING_STATUS;
-  if (type === "complete") return COMPLETE_STATUS;
-  if (type !== "incomplete") return undefined;
-
-  const { reason } = status as {
-    readonly reason?: unknown;
-  };
-  const normalizedReason: IncompleteMessagePartStatus["reason"] =
-    reason === "cancelled" ||
-    reason === "length" ||
-    reason === "content-filter" ||
-    reason === "other" ||
-    reason === "error"
-      ? reason
-      : "other";
-
-  return INCOMPLETE_STATUSES[normalizedReason];
-};
 
 export const toMessagePartStatus = (
   message: ThreadMessage,

--- a/packages/core/src/store/clients/chain-of-thought-client.ts
+++ b/packages/core/src/store/clients/chain-of-thought-client.ts
@@ -5,12 +5,8 @@ import type {
   ChainOfThoughtState,
   ChainOfThoughtPart,
 } from "../scopes/chain-of-thought";
-import type { MessagePartStatus } from "../../types/message";
 import type { PartMethods } from "../scopes/part";
-
-const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
-  type: "complete",
-});
+import { getGroupStatus } from "../../utils/getGroupStatus";
 
 const useChainOfThoughtClient = ({
   parts,
@@ -22,8 +18,7 @@ const useChainOfThoughtClient = ({
   const [collapsed, setCollapsed] = useState(true);
 
   const status = useMemo(() => {
-    const lastPart = parts[parts.length - 1];
-    return lastPart?.status ?? COMPLETE_STATUS;
+    return getGroupStatus(parts);
   }, [parts]);
 
   const state = useMemo<ChainOfThoughtState>(

--- a/packages/core/src/store/clients/thread-message-client.test.ts
+++ b/packages/core/src/store/clients/thread-message-client.test.ts
@@ -1,0 +1,39 @@
+import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { describe, expect, it } from "vitest";
+import type { ThreadAssistantMessage } from "../../types/message";
+import { ThreadMessageClient } from "./thread-message-client";
+
+describe("ThreadMessageClient", () => {
+  it("normalizes an upstream complete reason on a running detached message", () => {
+    const part = {
+      type: "text",
+      text: "done",
+      status: { type: "complete", reason: "unknown" },
+    } as unknown as ThreadAssistantMessage["content"][number];
+    const message: ThreadAssistantMessage = {
+      id: "message-1",
+      role: "assistant",
+      createdAt: new Date(0),
+      content: [part],
+      status: { type: "running" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+    };
+    const root = createTapRoot(function ThreadMessageRoot() {
+      return useResource(ThreadMessageClient({ message, index: 0 }));
+    });
+
+    try {
+      expect(root.getValue().getState().parts[0]?.status).toEqual({
+        type: "complete",
+      });
+    } finally {
+      root.unmount();
+    }
+  });
+});

--- a/packages/core/src/store/clients/thread-message-client.test.ts
+++ b/packages/core/src/store/clients/thread-message-client.test.ts
@@ -4,18 +4,16 @@ import type { ThreadAssistantMessage } from "../../types/message";
 import { ThreadMessageClient } from "./thread-message-client";
 
 describe("ThreadMessageClient", () => {
-  it("normalizes an upstream complete reason on a running detached message", () => {
-    const part = {
-      type: "text",
-      text: "done",
-      status: { type: "complete", reason: "unknown" },
-    } as unknown as ThreadAssistantMessage["content"][number];
+  const getPartStatus = (
+    part: ThreadAssistantMessage["content"][number],
+    status: ThreadAssistantMessage["status"],
+  ) => {
     const message: ThreadAssistantMessage = {
       id: "message-1",
       role: "assistant",
       createdAt: new Date(0),
       content: [part],
-      status: { type: "running" },
+      status,
       metadata: {
         unstable_state: null,
         unstable_annotations: [],
@@ -29,11 +27,58 @@ describe("ThreadMessageClient", () => {
     });
 
     try {
-      expect(root.getValue().getState().parts[0]?.status).toEqual({
-        type: "complete",
-      });
+      return root.getValue().getState().parts[0]?.status;
     } finally {
       root.unmount();
     }
+  };
+
+  it("preserves a running part status on a running detached message", () => {
+    const part = {
+      type: "text",
+      text: "done",
+      status: { type: "running" },
+    } as unknown as ThreadAssistantMessage["content"][number];
+
+    expect(getPartStatus(part, { type: "running" })).toEqual({
+      type: "running",
+    });
+  });
+
+  it("normalizes an unknown incomplete reason on a running detached message", () => {
+    const part = {
+      type: "text",
+      text: "done",
+      status: { type: "incomplete", reason: "unknown" },
+    } as unknown as ThreadAssistantMessage["content"][number];
+
+    expect(getPartStatus(part, { type: "running" })).toEqual({
+      type: "incomplete",
+      reason: "other",
+    });
+  });
+
+  it("normalizes an upstream complete reason on a running detached message", () => {
+    const part = {
+      type: "text",
+      text: "done",
+      status: { type: "complete", reason: "unknown" },
+    } as unknown as ThreadAssistantMessage["content"][number];
+
+    expect(getPartStatus(part, { type: "running" })).toEqual({
+      type: "complete",
+    });
+  });
+
+  it("marks parts complete on a non-running detached message", () => {
+    const part = {
+      type: "text",
+      text: "done",
+      status: { type: "running" },
+    } as unknown as ThreadAssistantMessage["content"][number];
+
+    expect(getPartStatus(part, { type: "complete", reason: "stop" })).toEqual({
+      type: "complete",
+    });
   });
 });

--- a/packages/core/src/store/clients/thread-message-client.ts
+++ b/packages/core/src/store/clients/thread-message-client.ts
@@ -27,10 +27,9 @@ const useThreadMessagePartClient = ({
   const state = useMemo<PartState>(() => {
     return {
       ...part,
-      status:
-        isMessageRunning && "status" in part
-          ? (normalizePartStatus(part) ?? COMPLETE_STATUS)
-          : COMPLETE_STATUS,
+      status: isMessageRunning
+        ? (normalizePartStatus(part) ?? COMPLETE_STATUS)
+        : COMPLETE_STATUS,
     };
   }, [part, isMessageRunning]);
 

--- a/packages/core/src/store/clients/thread-message-client.ts
+++ b/packages/core/src/store/clients/thread-message-client.ts
@@ -13,17 +13,24 @@ import type { PartState } from "../scopes/part";
 import { NoOpComposerClient } from "./no-op-composer-client";
 import { getThreadMessageText } from "../../utils/text";
 
+const COMPLETE_STATUS = Object.freeze({ type: "complete" } as const);
+
 const useThreadMessagePartClient = ({
   part,
+  isMessageRunning,
 }: {
   part: ThreadAssistantMessagePart | ThreadUserMessagePart;
+  isMessageRunning: boolean;
 }): ClientOutput<"part"> => {
   const state = useMemo<PartState>(() => {
     return {
       ...part,
-      status: { type: "complete" },
+      status:
+        isMessageRunning && "status" in part
+          ? (part.status ?? COMPLETE_STATUS)
+          : COMPLETE_STATUS,
     };
-  }, [part]);
+  }, [part, isMessageRunning]);
 
   return {
     getState: () => state,
@@ -74,6 +81,8 @@ const useThreadMessageClient = ({
 }: ThreadMessageClientProps): ClientOutput<"message"> => {
   const [isCopiedState, setIsCopied] = useState(false);
   const [isHoveringState, setIsHovering] = useState(false);
+  const isMessageRunning =
+    message.role === "assistant" && message.status.type === "running";
 
   const parts = useClientLookup(
     message.content.map((part, idx) =>
@@ -81,8 +90,8 @@ const useThreadMessageClient = ({
         "toolCallId" in part && part.toolCallId != null
           ? `toolCallId-${part.toolCallId}`
           : `index-${idx}`,
-        ThreadMessagePartClient({ part }),
-        [part],
+        ThreadMessagePartClient({ part, isMessageRunning }),
+        [part, isMessageRunning],
       ),
     ),
   );

--- a/packages/core/src/store/clients/thread-message-client.ts
+++ b/packages/core/src/store/clients/thread-message-client.ts
@@ -11,9 +11,11 @@ import { useClientLookup } from "@assistant-ui/store";
 import type { MessageState } from "../scopes/message";
 import type { PartState } from "../scopes/part";
 import { NoOpComposerClient } from "./no-op-composer-client";
+import {
+  COMPLETE_STATUS,
+  normalizePartStatus,
+} from "../../utils/normalizePartStatus";
 import { getThreadMessageText } from "../../utils/text";
-
-const COMPLETE_STATUS = Object.freeze({ type: "complete" } as const);
 
 const useThreadMessagePartClient = ({
   part,
@@ -27,7 +29,7 @@ const useThreadMessagePartClient = ({
       ...part,
       status:
         isMessageRunning && "status" in part
-          ? (part.status ?? COMPLETE_STATUS)
+          ? (normalizePartStatus(part) ?? COMPLETE_STATUS)
           : COMPLETE_STATUS,
     };
   }, [part, isMessageRunning]);

--- a/packages/core/src/utils/getGroupStatus.test.ts
+++ b/packages/core/src/utils/getGroupStatus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getGroupStatus } from "./getGroupStatus";
+
+describe("getGroupStatus", () => {
+  it("reports running when the first member is running and the last is complete", () => {
+    const parts = [
+      { status: { type: "running" as const } },
+      { status: { type: "complete" as const } },
+    ];
+    const status = getGroupStatus(parts);
+
+    expect(status).toEqual({ type: "running" });
+    expect(getGroupStatus(parts, [0, 1])).toBe(status);
+    expect(status).toBe(getGroupStatus([{ status: { type: "running" } }]));
+    expect(Object.isFrozen(status)).toBe(true);
+  });
+
+  it("reports the last status when every member is complete", () => {
+    const status = { type: "complete" } as const;
+
+    expect(getGroupStatus([{ status }, { status }])).toBe(status);
+  });
+
+  it("reports complete for an empty group", () => {
+    expect(getGroupStatus([])).toEqual({ type: "complete" });
+  });
+
+  it("matches the positional outcome for statusless adapters", () => {
+    expect(
+      getGroupStatus(
+        [{ status: { type: "complete" } }, { status: { type: "running" } }],
+        [0, 1],
+      ),
+    ).toEqual({ type: "running" });
+  });
+});

--- a/packages/core/src/utils/getGroupStatus.ts
+++ b/packages/core/src/utils/getGroupStatus.ts
@@ -2,17 +2,11 @@ import type {
   MessagePartStatus,
   ToolCallMessagePartStatus,
 } from "../types/message";
+import { COMPLETE_STATUS, RUNNING_STATUS } from "./normalizePartStatus";
 
 type PartWithStatus = {
   readonly status: MessagePartStatus | ToolCallMessagePartStatus;
 };
-
-const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
-  type: "complete",
-});
-const RUNNING_STATUS: MessagePartStatus = Object.freeze({
-  type: "running",
-});
 
 export const getGroupStatus = (
   parts: readonly (PartWithStatus | undefined)[],

--- a/packages/core/src/utils/getGroupStatus.ts
+++ b/packages/core/src/utils/getGroupStatus.ts
@@ -1,0 +1,37 @@
+import type {
+  MessagePartStatus,
+  ToolCallMessagePartStatus,
+} from "../types/message";
+
+type PartWithStatus = {
+  readonly status: MessagePartStatus | ToolCallMessagePartStatus;
+};
+
+const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
+  type: "complete",
+});
+const RUNNING_STATUS: MessagePartStatus = Object.freeze({
+  type: "running",
+});
+
+export const getGroupStatus = (
+  parts: readonly (PartWithStatus | undefined)[],
+  indices?: readonly number[],
+): MessagePartStatus | ToolCallMessagePartStatus => {
+  if (indices) {
+    for (const index of indices) {
+      if (parts[index]?.status.type === "running") return RUNNING_STATUS;
+    }
+
+    const lastIndex = indices.at(-1);
+    return lastIndex === undefined
+      ? COMPLETE_STATUS
+      : (parts[lastIndex]?.status ?? COMPLETE_STATUS);
+  }
+
+  for (const part of parts) {
+    if (part?.status.type === "running") return RUNNING_STATUS;
+  }
+
+  return parts.at(-1)?.status ?? COMPLETE_STATUS;
+};

--- a/packages/core/src/utils/normalizePartStatus.test.ts
+++ b/packages/core/src/utils/normalizePartStatus.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadAssistantMessagePart } from "../types/message";
+import { normalizePartStatus } from "./normalizePartStatus";
+
+const partWithStatus = (status: unknown): ThreadAssistantMessagePart =>
+  ({
+    type: "text",
+    text: "text",
+    status,
+  }) as unknown as ThreadAssistantMessagePart;
+
+describe("normalizePartStatus", () => {
+  it("returns a frozen running status", () => {
+    const status = normalizePartStatus(partWithStatus({ type: "running" }));
+
+    expect(status).toEqual({ type: "running" });
+    expect(status).toBe(
+      normalizePartStatus(partWithStatus({ type: "running" })),
+    );
+    expect(Object.isFrozen(status)).toBe(true);
+  });
+
+  it("normalizes a complete status without a reason", () => {
+    expect(normalizePartStatus(partWithStatus({ type: "complete" }))).toEqual({
+      type: "complete",
+    });
+  });
+
+  it("drops an upstream complete reason", () => {
+    expect(
+      normalizePartStatus(
+        partWithStatus({ type: "complete", reason: "unknown" }),
+      ),
+    ).toEqual({ type: "complete" });
+  });
+
+  it.each(["cancelled", "length", "content-filter", "other", "error"] as const)(
+    "preserves the incomplete reason %s",
+    (reason) => {
+      expect(
+        normalizePartStatus(partWithStatus({ type: "incomplete", reason })),
+      ).toEqual({ type: "incomplete", reason });
+    },
+  );
+
+  it("coerces an unrecognized incomplete reason to other", () => {
+    expect(
+      normalizePartStatus(
+        partWithStatus({ type: "incomplete", reason: "unknown" }),
+      ),
+    ).toEqual({ type: "incomplete", reason: "other" });
+  });
+
+  it("returns undefined for an unknown status type", () => {
+    expect(
+      normalizePartStatus(partWithStatus({ type: "unknown" })),
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/normalizePartStatus.ts
+++ b/packages/core/src/utils/normalizePartStatus.ts
@@ -8,7 +8,7 @@ import type {
 export const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
   type: "complete",
 });
-const RUNNING_STATUS: MessagePartStatus = Object.freeze({
+export const RUNNING_STATUS: MessagePartStatus = Object.freeze({
   type: "running",
 });
 type IncompleteMessagePartStatus = Extract<

--- a/packages/core/src/utils/normalizePartStatus.ts
+++ b/packages/core/src/utils/normalizePartStatus.ts
@@ -1,0 +1,55 @@
+import type {
+  MessagePartStatus,
+  MessagePartStreamStatus,
+  ThreadAssistantMessagePart,
+  ThreadUserMessagePart,
+} from "../types/message";
+
+export const COMPLETE_STATUS: MessagePartStatus = Object.freeze({
+  type: "complete",
+});
+const RUNNING_STATUS: MessagePartStatus = Object.freeze({
+  type: "running",
+});
+type IncompleteMessagePartStatus = Extract<
+  MessagePartStreamStatus,
+  { readonly type: "incomplete" }
+>;
+const INCOMPLETE_STATUSES: Readonly<
+  Record<IncompleteMessagePartStatus["reason"], IncompleteMessagePartStatus>
+> = Object.freeze({
+  cancelled: Object.freeze({ type: "incomplete", reason: "cancelled" }),
+  length: Object.freeze({ type: "incomplete", reason: "length" }),
+  "content-filter": Object.freeze({
+    type: "incomplete",
+    reason: "content-filter",
+  }),
+  other: Object.freeze({ type: "incomplete", reason: "other" }),
+  error: Object.freeze({ type: "incomplete", reason: "error" }),
+});
+
+export const normalizePartStatus = (
+  part: ThreadUserMessagePart | ThreadAssistantMessagePart,
+): MessagePartStatus | undefined => {
+  const status = (part as { readonly status?: unknown }).status;
+  if (!status || typeof status !== "object") return undefined;
+
+  const { type } = status as { readonly type?: unknown };
+  if (type === "running") return RUNNING_STATUS;
+  if (type === "complete") return COMPLETE_STATUS;
+  if (type !== "incomplete") return undefined;
+
+  const { reason } = status as {
+    readonly reason?: unknown;
+  };
+  const normalizedReason: IncompleteMessagePartStatus["reason"] =
+    reason === "cancelled" ||
+    reason === "length" ||
+    reason === "content-filter" ||
+    reason === "other" ||
+    reason === "error"
+      ? reason
+      : "other";
+
+  return INCOMPLETE_STATUSES[normalizedReason];
+};

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -343,11 +343,10 @@ const ReasoningGroupImpl: ReasoningGroupComponent = ({
 }) => {
   const isReasoningStreaming = useAuiState((s) => {
     if (s.message.status?.type !== "running") return false;
-    const lastIndex = s.message.parts.length - 1;
-    if (lastIndex < 0) return false;
-    const lastType = s.message.parts[lastIndex]?.type;
-    if (lastType !== "reasoning") return false;
-    return lastIndex >= startIndex && lastIndex <= endIndex;
+    for (let index = startIndex; index <= endIndex; index++) {
+      if (s.message.parts[index]?.status.type === "running") return true;
+    }
+    return false;
   });
 
   return (


### PR DESCRIPTION
closes #5407

## summary

- a part group reported the status of its physical last member, so a group whose earlier member was still streaming read as complete. that is #5166's footgun seen from the group side, and #5403 made it observable by letting a part carry its own status
- the rule is now: any member running makes the group running, otherwise the last member's status as before. deliberately minimal, so a statusless adapter keeps exactly today's outcome
- the two readers that implemented this were independent hand-copies of each other (`chain-of-thought-client.ts` and `MessageGroupedParts.tsx`, the second being what feeds the shipped reasoning and tool groups through `packages/ui/.../thread.tsx`). they now share one `getGroupStatus` helper rather than gaining a third copy
- `reasoning.tsx`'s `isReasoningStreaming` checked that the message's last part was of type reasoning and fell inside the group; it now scans the group's own range for a running status
- `ThreadMessageClient` hardcoded `{ type: "complete" }` for every part. it keeps that default, but no longer discards a status the caller supplied, under the same running gate core uses

## equivalence for statusless adapters

with no supplied status the derivation makes only the message's last part running, so the group scan can only fire when the group contains that part. for `reasoning.tsx` the old and new conditions coincide because a reasoning group's range contains only reasoning parts by construction, which is what made the old last-part-TYPE check work in the first place.

## test plan

### already verified

- [x] `packages/core` 781 passed (up from 773 with four new cases on the group rule), `packages/react` 375 passed, `packages/ui` typechecks clean, repo lint clean
- [x] the group-rule test that matters, `reports running when the first member is running and the last is complete`, is the case this issue is about and fails without the change
- [x] `tsc --noEmit` unchanged against the current baseline: core 6, react 5, both measured on a pristine tree at this commit rather than from an older run. the sixth core error predates this branch, it appeared in `useActionBarCopy.test.ts` upstream while this work was in flight

### reviewer should verify

- [ ] a live thread streaming a reasoning group followed by text keeps the reasoning disclosure open and pinned while reasoning streams, and the tool group indicator resolves the same way

## notes

- `getGroupStatus` returns shared frozen instances, since these values feed memoized state whose `shallowEqual` compares `status` by reference. returning a fresh object per call was the re-render regression caught during #5403
- deferred, tracked separately: #5408 for whether status joins the persisted shape and the attachment encoder that returns parts by reference, #5409 for the first converter to actually supply a status

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.vJvUNraV1-frymG3-Ux--BuSukQD9kV8ZYmkcl2pyQthdHNlpoGC1NJptd4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->