### PR TITLE
fix(store): preserve notification state in StrictMode

### DIFF
--- a/.changeset/fresh-composers-listen.md
+++ b/.changeset/fresh-composers-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: prevent Composer updates from being lost under React StrictMode

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format:fix": "pnpm exec oxfmt",
     "sync-templates": "bash scripts/sync-templates.sh",
     "test": "turbo test && pnpm test:react-compiler && pnpm test:types",
-    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core",
+    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core --filter=@assistant-ui/store",
     "test:types": "pnpm -r --workspace-concurrency=4 --no-bail exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
     "prepare": "husky && pnpm --filter @assistant-ui/react-devtools run build:css",
     "deps:check": "npx taze major -f -r",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "aui-build",
     "test": "vitest run",
+    "test:react-compiler": "vitest run --config vitest.react-compiler.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {

--- a/packages/store/src/utils/NotificationManager.react-compiler.test.tsx
+++ b/packages/store/src/utils/NotificationManager.react-compiler.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { StrictMode } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTapHost } from "@assistant-ui/tap";
+import {
+  useNotificationManager,
+  type NotificationManager,
+} from "./NotificationManager";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("compiled useNotificationManager", () => {
+  it("keeps one state owner across a StrictMode render replay", () => {
+    const instances: NotificationManager[] = [];
+
+    function Harness() {
+      useTapHost(function NotificationHost() {
+        instances.push(useNotificationManager());
+        return null;
+      });
+      return null;
+    }
+
+    render(
+      <StrictMode>
+        <Harness />
+      </StrictMode>,
+    );
+
+    expect(instances.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(instances)).toHaveLength(1);
+  });
+});

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useState } from "react";
 import type { ClientStack } from "./tap-client-stack-context";
 import type {
   AssistantEventName,
@@ -26,7 +26,7 @@ export type NotificationManager = {
 };
 
 export const useNotificationManager = (): NotificationManager => {
-  return useMemo(() => {
+  return useState<NotificationManager>(() => {
     const listeners = new Map<string, Set<InternalCallback>>();
     const wildcardListeners = new Set<InternalCallback>();
     const subscribers = new Set<() => void>();
@@ -109,5 +109,5 @@ export const useNotificationManager = (): NotificationManager => {
         }
       },
     };
-  }, []);
+  })[0];
 };

--- a/packages/store/vitest.react-compiler.config.ts
+++ b/packages/store/vitest.react-compiler.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const compiledNotificationManager = fileURLToPath(
+  new URL("./dist/utils/NotificationManager.js", import.meta.url),
+);
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^\.\/NotificationManager$/,
+        replacement: compiledNotificationManager,
+      },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/utils/NotificationManager.react-compiler.test.tsx"],
+  },
+});


### PR DESCRIPTION
Fixes #5422.

## What

Hold `NotificationManager` in lazy `useState` rather than `useMemo`, so its listener registry remains the same state owner across React StrictMode render replays.

This supersedes the PR's earlier `fields` dependency workaround. The committed-client dependency list is no longer changed.

## Root cause

The source-level lifecycle is not the published lifecycle:

1. `@assistant-ui/store` is built with React Compiler.
2. React Compiler replaces `useNotificationManager`'s `useMemo` with a `c()` compiler memo cache.
3. The hook runs inside a Tap host. During the initial StrictMode double render, Tap starts the second uncommitted render from an empty current compiler cache, so the two renders receive different `NotificationManager` instances.
4. The `clientRef`, Tap fibers, and accessors survive that replay. The committed client can therefore retain notification methods from the first manager while the live host effects notify the second manager.
5. Composer state changes, but the UI subscriber attached to the first manager is never notified, so the controlled input resets to the stale empty value.

Instrumentation of the official example showed the same `clientRef` with notification manager identity changing from `1` to `13` between the StrictMode renders. This is the lifecycle detail missed by the prior source-only analysis.

`NotificationManager` owns mutable listener/subscriber state, so its lifetime must be represented as hook state. A memo cache is intentionally disposable and is not an appropriate state owner. Lazy `useState` expresses that invariant directly and compiles to a real hook rather than `c()` cache entries.

## Deterministic regression test

The new store compiler test imports the actual built `dist/utils/NotificationManager.js`, executes it inside `useTapHost` under `<StrictMode>`, and asserts that every replay observes the same manager.

The exact test was run against both implementations after a fresh store build:

- original `useMemo`: fails deterministically, `Set` size is `2`;
- fixed `useState`: passes, `Set` size is `1`.

The test is wired into the repository's existing `test:react-compiler` phase, alongside the core compiler test.

## End-to-end verification

The red/green browser comparison was established on upstream `main` at `052ce90d8` using the official `examples/with-external-store` app in fresh Chromium pages:

- before: 5/5 runs reset the textarea to `""`; no user message and no response;
- after: 5/5 runs retained the typed value, submitted the user message, and rendered `Hello, world!`;
- no console or page errors in either comparison.

After rebasing the fixed branch onto current upstream `main` (`1df2939a7`), the official example was force-built again and the passing Chromium probe was repeated 5/5 with zero console or page errors.

Additional checks on commit `09dbfb7bd`:

- forced `with-external-store...` build: 17/17 tasks passed;
- `@assistant-ui/store`: 16 files, 84 tests passed;
- compiled StrictMode regression: 1/1 passed;
- formatting, oxlint, and `git diff --check` passed.
