### PR TITLE
feat(react-opencode): project Task child sessions

### DIFF
--- a/.changeset/tidy-tasks-nest.md
+++ b/.changeset/tidy-tasks-nest.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+feat: project OpenCode Task child sessions as nested messages

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1068,10 +1068,18 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private unsubscribeFromEvents;
   private loadPromise;
   private reconnectSyncToken;
+  private readonly childControllersById;
+  private ancestorSessionIds;
   private readonly stagedMessages;
   private readonly client;
   private readonly sessionId;
   constructor(client: OpencodeClient, getEventSource: OpenCodeEventSourceProvider, sessionId: string);
+  private notifyListeners;
+  private updateChildSnapshot;
+  private attachChildController;
+  private detachChildControllers;
+  private discard;
+  private syncChildControllers;
   private ensureEventSubscription;
   private handleStreamReconnect;
   dispose(): void;
@@ -1123,6 +1131,7 @@ type OpenCodeThreadState = {
   runState: OpenCodeRunState;
   messageOrder: readonly string[];
   messagesById: Readonly<Record<string, OpenCodeServerMessage>>;
+  childSessionsById: Readonly<Record<string, OpenCodeThreadState>>;
   pendingUserMessages: Readonly<Record<string, PendingUserMessage>>;
   interactions: {
     permissions: {
@@ -1939,7 +1948,7 @@ declare namespace entry_root_exports {
   export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
 }
 
-declare const projectOpenCodeThreadMessages: (state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>) => OpenCodeProjectedThreadMessage[];
+declare function projectOpenCodeThreadMessages(state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>): OpenCodeProjectedThreadMessage[];
 
 declare const reduceOpenCodeThreadState: (state: OpenCodeThreadState, event: OpenCodeStateEvent) => OpenCodeThreadState;
 

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1070,6 +1070,7 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private reconnectSyncToken;
   private readonly childControllersById;
   private ancestorSessionIds;
+  private isChildSession;
   private readonly stagedMessages;
   private readonly client;
   private readonly sessionId;

--- a/apps/docs/content/docs/runtimes/opencode/hooks.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/hooks.mdx
@@ -112,6 +112,7 @@ The returned `OpenCodeThreadState` includes:
 
 - `sessionId`, `session`, `sessionStatus`, `loadState`, `runState`
 - `messageOrder`, `messagesById`, `pendingUserMessages`
+- `childSessionsById` (OpenCode `task` child-session projections keyed by session ID)
 - `interactions.permissions` (pending + resolved), `interactions.questions` (pending + answered + rejected)
 - `unhandledEvents`, `sync` timestamps
 

--- a/apps/docs/content/docs/runtimes/opencode/overview.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/overview.mdx
@@ -32,6 +32,8 @@ If your backend is not OpenCode-based, see [picking a runtime](/docs/runtimes/pi
 
 OpenCode `task` tool calls expose their child session through tool metadata. The runtime loads those child sessions, keeps them synchronized from the same OpenCode event stream, and projects their transcripts into `ToolCallMessagePart.messages`. Parallel and recursively nested tasks are supported.
 
+Loading is eager, not keyed to what a renderer displays. Once a thread is subscribed, every `task` part in its transcript fetches its child session, and each child does the same for its own nested tasks, so a long session with many task calls fetches every sub-agent transcript whether or not any of them is expanded.
+
 Use assistant-ui's [`MessagePartPrimitive.Messages`](/docs/tools/multi-agent) inside a `task` tool renderer to display the child conversation. Nested conversations are read-only and inherit the parent thread's tool renderers.
 
 ## Install

--- a/apps/docs/content/docs/runtimes/opencode/overview.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/overview.mdx
@@ -28,6 +28,12 @@ If your backend is not OpenCode-based, see [picking a runtime](/docs/runtimes/pi
 - A running [OpenCode](https://opencode.ai/) server (defaults to `http://localhost:4096`).
 - React 18 or 19.
 
+## Sub-agent conversations
+
+OpenCode `task` tool calls expose their child session through tool metadata. The runtime loads those child sessions, keeps them synchronized from the same OpenCode event stream, and projects their transcripts into `ToolCallMessagePart.messages`. Parallel and recursively nested tasks are supported.
+
+Use assistant-ui's [`MessagePartPrimitive.Messages`](/docs/tools/multi-agent) inside a `task` tool renderer to display the child conversation. Nested conversations are read-only and inherit the parent thread's tool renderers.
+
 ## Install
 
 <InstallCommand npm={["@assistant-ui/react", "@assistant-ui/react-opencode", "@opencode-ai/sdk"]} />

--- a/apps/docs/content/docs/runtimes/opencode/overview.mdx
+++ b/apps/docs/content/docs/runtimes/opencode/overview.mdx
@@ -32,7 +32,9 @@ If your backend is not OpenCode-based, see [picking a runtime](/docs/runtimes/pi
 
 OpenCode `task` tool calls expose their child session through tool metadata. The runtime loads those child sessions, keeps them synchronized from the same OpenCode event stream, and projects their transcripts into `ToolCallMessagePart.messages`. Parallel and recursively nested tasks are supported.
 
-Loading is eager, not keyed to what a renderer displays. Once a thread is subscribed, every `task` part in its transcript fetches its child session, and each child does the same for its own nested tasks, so a long session with many task calls fetches every sub-agent transcript whether or not any of them is expanded.
+Loading is eager, not keyed to what a renderer displays. Once a thread is subscribed, every `task` part in its transcript fetches its child session, and each child does the same for its own nested tasks, so a long session with many task calls fetches every sub-agent transcript whether or not any of them is expanded. Each child session is fetched once and then kept current from the event stream, so re-subscribing a thread does not refetch it.
+
+A `task` part carries `messages` only once its child session has loaded. While the child is still loading, the part projects as an ordinary tool call, so an empty `messages` array always means the sub-agent produced nothing rather than that its transcript is still in flight.
 
 Use assistant-ui's [`MessagePartPrimitive.Messages`](/docs/tools/multi-agent) inside a `task` tool renderer to display the child conversation. Nested conversations are read-only and inherit the parent thread's tool renderers.
 

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -17,20 +17,65 @@ const createDeferred = <T>() => {
 };
 
 const createEventSource = () => {
-  let listener: ((event: OpenCodeServerEvent) => void) | undefined;
+  const listeners = new Set<(event: OpenCodeServerEvent) => void>();
   const unsubscribe = vi.fn();
 
   return {
     emit(event: OpenCodeServerEvent) {
-      listener?.(event);
+      for (const listener of listeners) listener(event);
     },
     subscribe: vi.fn((nextListener: (event: OpenCodeServerEvent) => void) => {
-      listener = nextListener;
-      return unsubscribe;
+      listeners.add(nextListener);
+      return () => {
+        listeners.delete(nextListener);
+        unsubscribe();
+      };
     }),
     unsubscribe,
   };
 };
+
+const createTaskMessage = (
+  sessionID: string,
+  messageID: string,
+  children: readonly string[],
+) => ({
+  info: {
+    id: messageID,
+    role: "assistant",
+    sessionID,
+    parentID: `${messageID}-parent`,
+    modelID: "model",
+    providerID: "provider",
+    mode: "primary",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    time: { created: 1 },
+    finish: "stop",
+  },
+  parts: children.map((childSessionID, index) => ({
+    id: `${messageID}-task-${index}`,
+    callID: `${messageID}-call-${index}`,
+    sessionID,
+    messageID,
+    type: "tool",
+    tool: "task",
+    state: {
+      status: "completed",
+      input: { description: `Task ${index}` },
+      output: "Done",
+      title: `Task ${index}`,
+      metadata: { sessionId: childSessionID },
+      time: { start: 1, end: 2 },
+    },
+  })),
+});
 
 const streamReconnected: OpenCodeServerEvent = {
   type: STREAM_RECONNECTED_EVENT_TYPE,
@@ -317,6 +362,404 @@ describe("OpenCodeThreadController", () => {
     unsubscribe();
 
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers child-session work until the parent has a listener", async () => {
+    const eventSource = createEventSource();
+    const messages = vi.fn(({ sessionID }: { sessionID: string }) =>
+      Promise.resolve({
+        data:
+          sessionID === "ses_parent"
+            ? [
+                createTaskMessage("ses_parent", "parent-assistant", [
+                  "ses_child",
+                ]),
+              ]
+            : [],
+      }),
+    );
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages,
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+
+    await controller.load();
+
+    expect(messages).toHaveBeenCalledTimes(1);
+    expect(eventSource.subscribe).not.toHaveBeenCalled();
+    expect(
+      controller.getState().childSessionsById.ses_child?.loadState.type,
+    ).toBe("idle");
+
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await vi.waitFor(() => {
+      expect(messages).toHaveBeenCalledTimes(2);
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it("loads parallel and recursive Task child sessions without following ancestor cycles", async () => {
+    const eventSource = createEventSource();
+    const messagesBySessionId: Record<string, unknown[]> = {
+      ses_parent: [
+        createTaskMessage("ses_parent", "parent-assistant", [
+          "ses_child_a",
+          "ses_child_b",
+        ]),
+      ],
+      ses_child_a: [
+        createTaskMessage("ses_child_a", "child-a-assistant", [
+          "ses_grandchild",
+        ]),
+      ],
+      ses_child_b: [],
+      ses_grandchild: [
+        createTaskMessage("ses_grandchild", "grandchild-assistant", [
+          "ses_parent",
+        ]),
+      ],
+    };
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({ data: messagesBySessionId[sessionID] ?? [] }),
+        ),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+
+    await vi.waitFor(() => {
+      expect(client.session.messages).toHaveBeenCalledTimes(4);
+      expect(
+        controller.getState().childSessionsById.ses_child_a?.childSessionsById
+          .ses_grandchild?.loadState.type,
+      ).toBe("ready");
+    });
+    expect(Object.keys(controller.getState().childSessionsById).sort()).toEqual(
+      ["ses_child_a", "ses_child_b"],
+    );
+    expect(
+      client.session.messages.mock.calls.map(([request]) => request.sessionID),
+    ).toEqual(
+      expect.arrayContaining([
+        "ses_parent",
+        "ses_child_a",
+        "ses_child_b",
+        "ses_grandchild",
+      ]),
+    );
+    expect(
+      controller.getState().childSessionsById.ses_child_a?.childSessionsById
+        .ses_grandchild?.childSessionsById,
+    ).toEqual({});
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(4);
+
+    unsubscribe();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(4);
+  });
+
+  it("routes live child-session events into the nested state", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data:
+              sessionID === "ses_parent"
+                ? [
+                    {
+                      info: {
+                        id: "parent-assistant",
+                        role: "assistant",
+                        sessionID: "ses_parent",
+                        parentID: "parent-user",
+                        modelID: "model",
+                        providerID: "provider",
+                        mode: "primary",
+                        path: { cwd: "/", root: "/" },
+                        cost: 0,
+                        tokens: {
+                          input: 0,
+                          output: 0,
+                          reasoning: 0,
+                          cache: { read: 0, write: 0 },
+                        },
+                        time: { created: 1 },
+                      },
+                      parts: [
+                        {
+                          id: "parent-task",
+                          callID: "parent-call",
+                          sessionID: "ses_parent",
+                          messageID: "parent-assistant",
+                          type: "tool",
+                          tool: "task",
+                          state: {
+                            status: "running",
+                            input: { description: "Inspect" },
+                            metadata: { sessionId: "ses_child" },
+                            time: { start: 1 },
+                          },
+                        },
+                      ],
+                    },
+                  ]
+                : [],
+          }),
+        ),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const listener = vi.fn();
+    const unsubscribe = controller.subscribe(listener);
+
+    await controller.load();
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+
+    eventSource.emit({
+      type: "message.updated",
+      sessionId: "ses_child",
+      properties: {
+        info: {
+          id: "child-assistant",
+          role: "assistant",
+          sessionID: "ses_child",
+          parentID: "child-user",
+          modelID: "model",
+          providerID: "provider",
+          mode: "subagent",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 2 },
+        },
+      },
+      raw: {},
+    });
+    eventSource.emit({
+      type: "message.part.updated",
+      sessionId: "ses_child",
+      properties: {
+        part: {
+          id: "child-text",
+          sessionID: "ses_child",
+          messageID: "child-assistant",
+          type: "text",
+          text: "Live child output",
+        },
+      },
+      raw: {},
+    });
+
+    expect(
+      controller.getState().childSessionsById.ses_child?.messagesById[
+        "child-assistant"
+      ]?.parts,
+    ).toMatchObject([{ type: "text", text: "Live child output" }]);
+    expect(listener).toHaveBeenCalled();
+
+    unsubscribe();
+  });
+
+  it("removes a child controller when its Task part is removed", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data:
+              sessionID === "ses_parent"
+                ? [
+                    {
+                      info: {
+                        id: "parent-assistant",
+                        role: "assistant",
+                        sessionID: "ses_parent",
+                        parentID: "parent-user",
+                        modelID: "model",
+                        providerID: "provider",
+                        mode: "primary",
+                        path: { cwd: "/", root: "/" },
+                        cost: 0,
+                        tokens: {
+                          input: 0,
+                          output: 0,
+                          reasoning: 0,
+                          cache: { read: 0, write: 0 },
+                        },
+                        time: { created: 1 },
+                      },
+                      parts: [
+                        {
+                          id: "parent-task",
+                          callID: "parent-call",
+                          sessionID: "ses_parent",
+                          messageID: "parent-assistant",
+                          type: "tool",
+                          tool: "task",
+                          state: {
+                            status: "running",
+                            input: { description: "Inspect" },
+                            metadata: { sessionId: "ses_child" },
+                            time: { start: 1 },
+                          },
+                        },
+                      ],
+                    },
+                  ]
+                : [],
+          }),
+        ),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+
+    eventSource.emit({
+      type: "message.part.removed",
+      sessionId: "ses_parent",
+      properties: {
+        messageID: "parent-assistant",
+        partID: "parent-task",
+      },
+      raw: {},
+    });
+
+    expect(controller.getState().childSessionsById).toEqual({});
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not attach descendants from a removed Task's in-flight history", async () => {
+    const eventSource = createEventSource();
+    const childMessages = createDeferred<{ data: unknown[] }>();
+    const messages = vi.fn(({ sessionID }: { sessionID: string }) => {
+      if (sessionID === "ses_parent") {
+        return Promise.resolve({
+          data: [
+            createTaskMessage("ses_parent", "parent-assistant", ["ses_child"]),
+          ],
+        });
+      }
+      if (sessionID === "ses_child") return childMessages.promise;
+      return Promise.resolve({ data: [] });
+    });
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages,
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+    await vi.waitFor(() => {
+      expect(messages).toHaveBeenCalledTimes(2);
+      expect(eventSource.subscribe).toHaveBeenCalledTimes(2);
+    });
+
+    eventSource.emit({
+      type: "message.part.removed",
+      sessionId: "ses_parent",
+      properties: {
+        messageID: "parent-assistant",
+        partID: "parent-assistant-task-0",
+      },
+      raw: {},
+    });
+
+    childMessages.resolve({
+      data: [
+        createTaskMessage("ses_child", "child-assistant", ["ses_grandchild"]),
+      ],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(messages).toHaveBeenCalledTimes(2);
+    expect(eventSource.subscribe).toHaveBeenCalledTimes(2);
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
   });
 
   it("re-syncs history and status when the stream reconnects", async () => {

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -417,6 +417,96 @@ describe("OpenCodeThreadController", () => {
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
   });
 
+  it("reports a child discovered on a live thread as loading before its history resolves", async () => {
+    const eventSource = createEventSource();
+    let resolveChildMessages: ((value: unknown) => void) | undefined;
+    const messages = vi.fn(({ sessionID }: { sessionID: string }) => {
+      if (sessionID === "ses_parent") return Promise.resolve({ data: [] });
+      return new Promise((resolve) => {
+        resolveChildMessages = resolve;
+      });
+    });
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages,
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+
+    eventSource.emit({
+      type: "message.updated",
+      sessionId: "ses_parent",
+      properties: {
+        info: {
+          id: "parent-assistant",
+          role: "assistant",
+          sessionID: "ses_parent",
+          parentID: "parent-user",
+          modelID: "model",
+          providerID: "provider",
+          mode: "primary",
+          path: { cwd: "/", root: "/" },
+          cost: 0,
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cache: { read: 0, write: 0 },
+          },
+          time: { created: 1 },
+        },
+      },
+      raw: {},
+    });
+    eventSource.emit({
+      type: "message.part.updated",
+      sessionId: "ses_parent",
+      properties: {
+        part: {
+          id: "parent-task",
+          callID: "parent-call",
+          sessionID: "ses_parent",
+          messageID: "parent-assistant",
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "running",
+            input: { description: "Inspect" },
+            metadata: { sessionId: "ses_child" },
+            time: { start: 1 },
+          },
+        },
+      },
+      raw: {},
+    });
+
+    expect(
+      controller.getState().childSessionsById.ses_child?.loadState.type,
+    ).toBe("loading");
+
+    resolveChildMessages?.({ data: [] });
+
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+
+    unsubscribe();
+  });
+
   it("loads parallel and recursive Task child sessions without following ancestor cycles", async () => {
     const eventSource = createEventSource();
     const messagesBySessionId: Record<string, unknown[]> = {

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -417,6 +417,64 @@ describe("OpenCodeThreadController", () => {
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps the global reconnect probes on the root session", async () => {
+    const eventSource = createEventSource();
+    const status = vi.fn().mockResolvedValue({ data: {} });
+    const permissions = vi.fn().mockResolvedValue({ data: [] });
+    const questions = vi.fn().mockResolvedValue({ data: [] });
+    const sessionMessages = vi.fn(({ sessionID }: { sessionID: string }) =>
+      Promise.resolve({
+        data:
+          sessionID === "ses_parent"
+            ? [
+                createTaskMessage("ses_parent", "parent-assistant", [
+                  "ses_child",
+                ]),
+              ]
+            : [],
+      }),
+    );
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages: sessionMessages,
+        status,
+      },
+      permission: { list: permissions },
+      question: { list: questions },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    controller.subscribe(vi.fn());
+
+    await controller.load();
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+    const callsBeforeReconnect = sessionMessages.mock.calls.length;
+
+    eventSource.emit(streamReconnected);
+
+    await vi.waitFor(() => {
+      expect(sessionMessages.mock.calls.length).toBeGreaterThan(
+        callsBeforeReconnect + 1,
+      );
+    });
+
+    expect(status).toHaveBeenCalledTimes(1);
+    expect(permissions).toHaveBeenCalledTimes(1);
+    expect(questions).toHaveBeenCalledTimes(1);
+  });
+
   it("does not refetch a loaded child when the parent re-attaches", async () => {
     const eventSource = createEventSource();
     const messages = vi.fn(({ sessionID }: { sessionID: string }) =>

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -417,6 +417,57 @@ describe("OpenCodeThreadController", () => {
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
   });
 
+  it("does not refetch a loaded child when the parent re-attaches", async () => {
+    const eventSource = createEventSource();
+    const messages = vi.fn(({ sessionID }: { sessionID: string }) =>
+      Promise.resolve({
+        data:
+          sessionID === "ses_parent"
+            ? [
+                createTaskMessage("ses_parent", "parent-assistant", [
+                  "ses_child",
+                ]),
+              ]
+            : [],
+      }),
+    );
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages,
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+
+    await controller.load();
+    const unsubscribe = controller.subscribe(vi.fn());
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+
+    const callsAfterFirstAttach = messages.mock.calls.length;
+
+    unsubscribe();
+    const resubscribe = controller.subscribe(vi.fn());
+
+    expect(messages.mock.calls.length).toBe(callsAfterFirstAttach);
+    expect(
+      controller.getState().childSessionsById.ses_child?.loadState.type,
+    ).toBe("ready");
+
+    resubscribe();
+  });
+
   it("reports a child discovered on a live thread as loading before its history resolves", async () => {
     const eventSource = createEventSource();
     let resolveChildMessages: ((value: unknown) => void) | undefined;

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -198,6 +198,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     ChildControllerEntry
   >();
   private ancestorSessionIds: ReadonlySet<string>;
+  private isChildSession = false;
   private readonly stagedMessages = new Map<
     string,
     {
@@ -314,6 +315,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
         ...this.ancestorSessionIds,
         sessionId,
       ]);
+      controller.isChildSession = true;
       const entry: ChildControllerEntry = {
         controller,
         unsubscribe: null,
@@ -330,10 +332,9 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       this.state = { ...this.state, childSessionsById };
     }
 
-    if (this.listeners.size > 0) {
-      for (const [sessionId, entry] of added) {
-        this.attachChildController(sessionId, entry);
-      }
+    for (const [sessionId, entry] of added) {
+      if (this.listeners.size === 0) break;
+      this.attachChildController(sessionId, entry);
     }
   }
 
@@ -353,6 +354,8 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private handleStreamReconnect() {
     this.refreshInBackground();
     const token = ++this.reconnectSyncToken;
+
+    if (this.isChildSession) return;
 
     void this.client.session
       .status(undefined, OPEN_CODE_REQUEST_OPTIONS)

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -299,6 +299,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       childSessionsById = remaining;
     }
 
+    const added: [string, ChildControllerEntry][] = [];
     for (const sessionId of sessionIds) {
       if (this.childControllersById.has(sessionId)) continue;
 
@@ -320,13 +321,17 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
         ...childSessionsById,
         [sessionId]: controller.getState(),
       };
-      if (this.listeners.size > 0) {
-        this.attachChildController(sessionId, entry);
-      }
+      added.push([sessionId, entry]);
     }
 
     if (childSessionsById !== this.state.childSessionsById) {
       this.state = { ...this.state, childSessionsById };
+    }
+
+    if (this.listeners.size > 0) {
+      for (const [sessionId, entry] of added) {
+        this.attachChildController(sessionId, entry);
+      }
     }
   }
 

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -254,7 +254,9 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       this.updateChildSnapshot(sessionId, entry.controller.getState());
     });
     this.updateChildSnapshot(sessionId, entry.controller.getState());
-    void entry.controller.load().catch(() => undefined);
+    if (entry.controller.getState().loadState.type !== "ready") {
+      void entry.controller.load().catch(() => undefined);
+    }
   }
 
   private detachChildControllers() {

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -16,6 +16,7 @@ import type {
   OpenCodeQuestionRequest,
   QuestionAnswer,
   OpenCodeServerEvent,
+  OpenCodeStateEvent,
   OpenCodeThreadControllerLike,
   OpenCodeThreadState,
   OpenCodeUnhandledEvent,
@@ -28,8 +29,20 @@ import {
 } from "./OpenCodeEventSource";
 import { OPEN_CODE_REQUEST_OPTIONS } from "./openCodeRequestOptions";
 import { serializeUserParts } from "./serializeUserParts";
+import { getOpenCodeTaskSessionId } from "./openCodeTaskSession";
 
 type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
+
+type ChildControllerEntry = {
+  controller: OpenCodeThreadController;
+  unsubscribe: (() => void) | null;
+};
+
+const shouldSyncChildControllers = (event: OpenCodeStateEvent) =>
+  event.type === "history.loaded" ||
+  event.type === "message.removed" ||
+  event.type === "part.updated" ||
+  event.type === "part.removed";
 
 const createLocalId = (prefix: string) =>
   `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
@@ -180,6 +193,11 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private unsubscribeFromEvents: (() => void) | null = null;
   private loadPromise: Promise<void> | null = null;
   private reconnectSyncToken = 0;
+  private readonly childControllersById = new Map<
+    string,
+    ChildControllerEntry
+  >();
+  private ancestorSessionIds: ReadonlySet<string>;
   private readonly stagedMessages = new Map<
     string,
     {
@@ -201,6 +219,115 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     this.sessionId = sessionId;
     this.state = createOpenCodeThreadState(sessionId);
     this.getEventSource = getEventSource;
+    this.ancestorSessionIds = new Set([sessionId]);
+  }
+
+  private notifyListeners() {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private updateChildSnapshot(
+    sessionId: string,
+    childState: OpenCodeThreadState,
+  ) {
+    if (this.state.childSessionsById[sessionId] === childState) return;
+
+    this.state = {
+      ...this.state,
+      childSessionsById: {
+        ...this.state.childSessionsById,
+        [sessionId]: childState,
+      },
+    };
+    this.notifyListeners();
+  }
+
+  private attachChildController(
+    sessionId: string,
+    entry: ChildControllerEntry,
+  ) {
+    if (entry.unsubscribe) return;
+
+    entry.unsubscribe = entry.controller.subscribe(() => {
+      this.updateChildSnapshot(sessionId, entry.controller.getState());
+    });
+    this.updateChildSnapshot(sessionId, entry.controller.getState());
+    void entry.controller.load().catch(() => undefined);
+  }
+
+  private detachChildControllers() {
+    for (const entry of this.childControllersById.values()) {
+      entry.unsubscribe?.();
+      entry.unsubscribe = null;
+    }
+  }
+
+  private discard() {
+    this.loadPromise = null;
+    this.reconnectSyncToken += 1;
+    this.unsubscribeFromEvents?.();
+    this.unsubscribeFromEvents = null;
+    for (const entry of this.childControllersById.values()) {
+      entry.unsubscribe?.();
+      entry.controller.discard();
+    }
+    this.childControllersById.clear();
+    this.listeners.clear();
+  }
+
+  private syncChildControllers() {
+    const sessionIds = new Set<string>();
+    for (const message of Object.values(this.state.messagesById)) {
+      for (const part of message.parts) {
+        const sessionId = getOpenCodeTaskSessionId(part);
+        if (sessionId && !this.ancestorSessionIds.has(sessionId)) {
+          sessionIds.add(sessionId);
+        }
+      }
+    }
+
+    let childSessionsById = this.state.childSessionsById;
+    for (const [sessionId, entry] of this.childControllersById) {
+      if (sessionIds.has(sessionId)) continue;
+
+      entry.unsubscribe?.();
+      entry.controller.discard();
+      this.childControllersById.delete(sessionId);
+      const { [sessionId]: _removed, ...remaining } = childSessionsById;
+      childSessionsById = remaining;
+    }
+
+    for (const sessionId of sessionIds) {
+      if (this.childControllersById.has(sessionId)) continue;
+
+      const controller = new OpenCodeThreadController(
+        this.client,
+        this.getEventSource,
+        sessionId,
+      );
+      controller.ancestorSessionIds = new Set([
+        ...this.ancestorSessionIds,
+        sessionId,
+      ]);
+      const entry: ChildControllerEntry = {
+        controller,
+        unsubscribe: null,
+      };
+      this.childControllersById.set(sessionId, entry);
+      childSessionsById = {
+        ...childSessionsById,
+        [sessionId]: controller.getState(),
+      };
+      if (this.listeners.size > 0) {
+        this.attachChildController(sessionId, entry);
+      }
+    }
+
+    if (childSessionsById !== this.state.childSessionsById) {
+      this.state = { ...this.state, childSessionsById };
+    }
   }
 
   private ensureEventSubscription() {
@@ -267,6 +394,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   public dispose() {
     this.unsubscribeFromEvents?.();
     this.unsubscribeFromEvents = null;
+    this.detachChildControllers();
     this.listeners.clear();
   }
 
@@ -275,14 +403,21 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   };
 
   public subscribe = (listener: () => void) => {
+    const wasDetached = this.listeners.size === 0;
     this.listeners.add(listener);
     this.ensureEventSubscription();
+    if (wasDetached) {
+      for (const [sessionId, entry] of this.childControllersById) {
+        this.attachChildController(sessionId, entry);
+      }
+    }
 
     return () => {
       this.listeners.delete(listener);
       if (this.listeners.size === 0) {
         this.unsubscribeFromEvents?.();
         this.unsubscribeFromEvents = null;
+        this.detachChildControllers();
       }
     };
   };
@@ -745,8 +880,9 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     const nextState = reduceOpenCodeThreadState(this.state, event);
     if (nextState === this.state) return;
     this.state = nextState;
-    for (const listener of this.listeners) {
-      listener();
+    if (shouldSyncChildControllers(event)) {
+      this.syncChildControllers();
     }
+    this.notifyListeners();
   }
 }

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -146,6 +146,7 @@ describe("projectOpenCodeThreadMessages", () => {
   it("projects Task child sessions into nested tool-call messages", () => {
     const grandchildState: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_grandchild"),
+      loadState: { type: "ready" },
       messageOrder: ["grandchild-assistant"],
       messagesById: {
         "grandchild-assistant": {
@@ -184,6 +185,7 @@ describe("projectOpenCodeThreadMessages", () => {
     };
     const childState: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_child"),
+      loadState: { type: "ready" },
       childSessionsById: { ses_grandchild: grandchildState },
       messageOrder: ["child-user", "child-assistant"],
       messagesById: {
@@ -811,6 +813,7 @@ describe("projectOpenCodeThreadMessages", () => {
   it("reuses the projected child transcript while the child state is unchanged", () => {
     const childState: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_child"),
+      loadState: { type: "ready" },
       messageOrder: ["child-assistant"],
       messagesById: {
         "child-assistant": {
@@ -908,5 +911,71 @@ describe("projectOpenCodeThreadMessages", () => {
 
     expect(first).toHaveLength(1);
     expect(second).toBe(first);
+  });
+
+  it("omits nested messages until the child session has loaded", () => {
+    const state = (loadState: OpenCodeThreadState["loadState"]) =>
+      ({
+        ...createOpenCodeThreadState("ses_parent"),
+        childSessionsById: {
+          ses_child: {
+            ...createOpenCodeThreadState("ses_child"),
+            loadState,
+          },
+        },
+        messageOrder: ["assistant-1"],
+        messagesById: {
+          "assistant-1": {
+            id: "assistant-1",
+            info: {
+              id: "assistant-1",
+              role: "assistant",
+              sessionID: "ses_parent",
+              parentID: "user-1",
+              modelID: "model",
+              providerID: "provider",
+              mode: "primary",
+              path: { cwd: "/", root: "/" },
+              cost: 0,
+              tokens: {
+                input: 0,
+                output: 0,
+                reasoning: 0,
+                cache: { read: 0, write: 0 },
+              },
+              time: { created: 1 },
+            } as never,
+            parts: [
+              {
+                id: "task-part",
+                callID: "task-call",
+                sessionID: "ses_parent",
+                messageID: "assistant-1",
+                type: "tool",
+                tool: "task",
+                state: {
+                  status: "running",
+                  input: { description: "Inspect" },
+                  metadata: { sessionId: "ses_child" },
+                },
+              } as never,
+            ],
+            shadowParts: undefined,
+          },
+        },
+      }) satisfies OpenCodeThreadState;
+
+    const toolPart = (loadState: OpenCodeThreadState["loadState"]) =>
+      projectOpenCodeThreadMessages(state(loadState))[0]?.content.find(
+        (p) => p.type === "tool-call",
+      );
+
+    expect(toolPart({ type: "loading" })).toBeDefined();
+    expect(toolPart({ type: "loading" })).not.toHaveProperty("messages");
+    expect(toolPart({ type: "idle" })).not.toHaveProperty("messages");
+    expect(toolPart({ type: "error", error: "boom" })).not.toHaveProperty(
+      "messages",
+    );
+    expect(toolPart({ type: "ready" })).toHaveProperty("messages", []);
   });
 });

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -143,6 +143,273 @@ describe("projectOpenCodeThreadMessages", () => {
     ]);
   });
 
+  it("projects Task child sessions into nested tool-call messages", () => {
+    const grandchildState: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_grandchild"),
+      messageOrder: ["grandchild-assistant"],
+      messagesById: {
+        "grandchild-assistant": {
+          id: "grandchild-assistant",
+          info: {
+            id: "grandchild-assistant",
+            role: "assistant",
+            sessionID: "ses_grandchild",
+            parentID: "grandchild-user",
+            modelID: "model",
+            providerID: "provider",
+            mode: "subagent",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 4 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "grandchild-text",
+              sessionID: "ses_grandchild",
+              messageID: "grandchild-assistant",
+              type: "text",
+              text: "The nested dependency is healthy.",
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+    const childState: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_child"),
+      childSessionsById: { ses_grandchild: grandchildState },
+      messageOrder: ["child-user", "child-assistant"],
+      messagesById: {
+        "child-user": {
+          id: "child-user",
+          info: {
+            id: "child-user",
+            role: "user",
+            sessionID: "ses_child",
+            time: { created: 2 },
+          } as never,
+          parts: [
+            {
+              id: "child-user-text",
+              sessionID: "ses_child",
+              messageID: "child-user",
+              type: "text",
+              text: "Inspect the package",
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+        "child-assistant": {
+          id: "child-assistant",
+          info: {
+            id: "child-assistant",
+            role: "assistant",
+            sessionID: "ses_child",
+            parentID: "child-user",
+            modelID: "model",
+            providerID: "provider",
+            mode: "subagent",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 3 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "child-assistant-text",
+              sessionID: "ses_child",
+              messageID: "child-assistant",
+              type: "text",
+              text: "The package is healthy.",
+            } as never,
+            {
+              id: "child-task",
+              callID: "child-task-call",
+              sessionID: "ses_child",
+              messageID: "child-assistant",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: { description: "Inspect nested dependency" },
+                output: "Done",
+                metadata: { sessionId: "ses_grandchild" },
+              },
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_parent"),
+      childSessionsById: { ses_child: childState },
+      messageOrder: ["assistant-1"],
+      messagesById: {
+        "assistant-1": {
+          id: "assistant-1",
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+            sessionID: "ses_parent",
+            parentID: "user-1",
+            modelID: "model",
+            providerID: "provider",
+            mode: "primary",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 1 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "tool-1",
+              callID: "call-1",
+              sessionID: "ses_parent",
+              messageID: "assistant-1",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: { description: "Review package" },
+                output: "Done",
+                metadata: { sessionId: "ses_child" },
+              },
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+
+    const messages = projectOpenCodeThreadMessages(state);
+    const tool = messages[0]?.content[0];
+
+    expect(tool).toMatchObject({
+      type: "tool-call",
+      toolName: "task",
+      messages: [
+        { id: "child-user", role: "user" },
+        { id: "child-assistant", role: "assistant" },
+      ],
+    });
+    if (typeof tool === "string" || tool?.type !== "tool-call") {
+      throw new Error("Expected a task tool call");
+    }
+    expect(tool.messages?.[0]?.content).toEqual([
+      { type: "text", text: "Inspect the package" },
+    ]);
+    expect(tool.messages?.[1]?.content).toEqual([
+      { type: "text", text: "The package is healthy." },
+      expect.objectContaining({
+        type: "tool-call",
+        toolName: "task",
+        messages: [
+          expect.objectContaining({
+            id: "grandchild-assistant",
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: "The nested dependency is healthy.",
+              },
+            ],
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("does not associate non-Task tools or invalid child metadata", () => {
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_parent"),
+      childSessionsById: {
+        ses_child: createOpenCodeThreadState("ses_child"),
+      },
+      messageOrder: ["assistant-1"],
+      messagesById: {
+        "assistant-1": {
+          id: "assistant-1",
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+            sessionID: "ses_parent",
+            parentID: "user-1",
+            modelID: "model",
+            providerID: "provider",
+            mode: "primary",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 1 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "tool-1",
+              callID: "call-1",
+              sessionID: "ses_parent",
+              messageID: "assistant-1",
+              type: "tool",
+              tool: "read",
+              state: {
+                status: "completed",
+                input: {},
+                output: "Done",
+                metadata: { sessionId: "ses_child" },
+              },
+            } as never,
+            {
+              id: "tool-2",
+              callID: "call-2",
+              sessionID: "ses_parent",
+              messageID: "assistant-1",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: {},
+                output: "Done",
+                metadata: { sessionId: 42 },
+              },
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+
+    const messages = projectOpenCodeThreadMessages(state);
+    expect(messages[0]?.content).toEqual([
+      expect.not.objectContaining({ messages: expect.anything() }),
+      expect.not.objectContaining({ messages: expect.anything() }),
+    ]);
+  });
+
   it("marks assistant messages with pending permission requests as requires-action", () => {
     const state: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_1"),

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -807,4 +807,106 @@ describe("projectOpenCodeThreadMessages", () => {
       error: "Request failed",
     });
   });
+
+  it("reuses the projected child transcript while the child state is unchanged", () => {
+    const childState: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_child"),
+      messageOrder: ["child-assistant"],
+      messagesById: {
+        "child-assistant": {
+          id: "child-assistant",
+          info: {
+            id: "child-assistant",
+            role: "assistant",
+            sessionID: "ses_child",
+            parentID: "child-user",
+            modelID: "model",
+            providerID: "provider",
+            mode: "subagent",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 2 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "child-text",
+              sessionID: "ses_child",
+              messageID: "child-assistant",
+              type: "text",
+              text: "Subagent finished.",
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_parent"),
+      childSessionsById: { ses_child: childState },
+      messageOrder: ["assistant-1"],
+      messagesById: {
+        "assistant-1": {
+          id: "assistant-1",
+          info: {
+            id: "assistant-1",
+            role: "assistant",
+            sessionID: "ses_parent",
+            parentID: "user-1",
+            modelID: "model",
+            providerID: "provider",
+            mode: "primary",
+            path: { cwd: "/", root: "/" },
+            cost: 0,
+            tokens: {
+              input: 0,
+              output: 0,
+              reasoning: 0,
+              cache: { read: 0, write: 0 },
+            },
+            time: { created: 1 },
+            finish: "stop",
+          } as never,
+          parts: [
+            {
+              id: "task-part",
+              callID: "task-call",
+              sessionID: "ses_parent",
+              messageID: "assistant-1",
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "completed",
+                input: { description: "Inspect dependency" },
+                output: "Done",
+                metadata: { sessionId: "ses_child" },
+              },
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+
+    const readNested = (
+      projected: ReturnType<typeof projectOpenCodeThreadMessages>,
+    ) => {
+      const part = projected[0]?.content.find((p) => p.type === "tool-call");
+      return part?.type === "tool-call" ? part.messages : undefined;
+    };
+
+    const first = readNested(projectOpenCodeThreadMessages(state));
+    const second = readNested(
+      projectOpenCodeThreadMessages({ ...state, runState: { type: "idle" } }),
+    );
+
+    expect(first).toHaveLength(1);
+    expect(second).toBe(first);
+  });
 });

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -305,9 +305,10 @@ const projectAssistantContent = (
         const childState = childSessionId
           ? state.childSessionsById[childSessionId]
           : undefined;
-        const childMessages = childState
-          ? getChildMessages(childState)
-          : undefined;
+        const childMessages =
+          childState?.loadState.type === "ready"
+            ? getChildMessages(childState)
+            : undefined;
         const permission = getPendingPermissionForToolCall(state, toolCallId);
         const resolvedPermission = permission
           ? undefined

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -287,9 +287,9 @@ const projectAssistantContent = (
           ? state.childSessionsById[childSessionId]
           : undefined;
         const childMessages = childState
-          ? ExportedMessageRepository.fromArray(
-              projectOpenCodeThreadMessages(childState),
-            ).messages.map(({ message }) => message)
+          ? projectOpenCodeThreadRepository(childState).messages.map(
+              ({ message }) => message,
+            )
           : undefined;
         const permission = getPendingPermissionForToolCall(state, toolCallId);
         const resolvedPermission = permission
@@ -633,11 +633,11 @@ export function projectOpenCodeThreadMessages(
   return mergeProjectedMessages(serverMessages, pendingMessages);
 }
 
-export const projectOpenCodeThreadRepository = (
+export function projectOpenCodeThreadRepository(
   state: OpenCodeThreadState,
   messageTiming: Record<string, MessageTiming> = {},
-) => {
+) {
   return ExportedMessageRepository.fromArray(
     projectOpenCodeThreadMessages(state, messageTiming),
   );
-};
+}

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -10,6 +10,7 @@ import type {
 import {
   ExportedMessageRepository,
   type MessageTiming,
+  type ThreadMessage,
 } from "@assistant-ui/react";
 import {
   projectOpenCodePermissionApproval,
@@ -156,6 +157,24 @@ const getPermissionIndex = (state: OpenCodeThreadState): PermissionIndex => {
   return index;
 };
 
+const childMessagesCache = new WeakMap<
+  OpenCodeThreadState,
+  readonly ThreadMessage[]
+>();
+
+const getChildMessages = (
+  childState: OpenCodeThreadState,
+): readonly ThreadMessage[] => {
+  const cached = childMessagesCache.get(childState);
+  if (cached) return cached;
+
+  const messages = projectOpenCodeThreadRepository(childState).messages.map(
+    ({ message }) => message,
+  );
+  childMessagesCache.set(childState, messages);
+  return messages;
+};
+
 const getPendingPermissionForToolCall = (
   state: OpenCodeThreadState,
   toolCallId: string,
@@ -287,9 +306,7 @@ const projectAssistantContent = (
           ? state.childSessionsById[childSessionId]
           : undefined;
         const childMessages = childState
-          ? projectOpenCodeThreadRepository(childState).messages.map(
-              ({ message }) => message,
-            )
+          ? getChildMessages(childState)
           : undefined;
         const permission = getPendingPermissionForToolCall(state, toolCallId);
         const resolvedPermission = permission

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -15,6 +15,7 @@ import {
   projectOpenCodePermissionApproval,
   projectResolvedOpenCodePermissionApproval,
 } from "./openCodePermissionApproval";
+import { getOpenCodeTaskSessionId } from "./openCodeTaskSession";
 
 type ProjectedContentPart = Exclude<
   OpenCodeProjectedThreadMessage["content"],
@@ -281,6 +282,15 @@ const projectAssistantContent = (
       case "tool": {
         const toolState = mapToolState(part.state);
         const toolCallId = part.callID ?? part.id ?? `tool-${index}`;
+        const childSessionId = getOpenCodeTaskSessionId(part);
+        const childState = childSessionId
+          ? state.childSessionsById[childSessionId]
+          : undefined;
+        const childMessages = childState
+          ? ExportedMessageRepository.fromArray(
+              projectOpenCodeThreadMessages(childState),
+            ).messages.map(({ message }) => message)
+          : undefined;
         const permission = getPendingPermissionForToolCall(state, toolCallId);
         const resolvedPermission = permission
           ? undefined
@@ -295,6 +305,7 @@ const projectAssistantContent = (
             ? { result: toolState.result }
             : {}),
           ...(toolState.isError ? { isError: true } : {}),
+          ...(childMessages !== undefined ? { messages: childMessages } : {}),
           ...(permission
             ? { approval: projectOpenCodePermissionApproval(permission) }
             : resolvedPermission
@@ -594,10 +605,10 @@ const projectPendingMessage = (
   },
 });
 
-export const projectOpenCodeThreadMessages = (
+export function projectOpenCodeThreadMessages(
   state: OpenCodeThreadState,
   messageTiming: Record<string, MessageTiming> = {},
-): OpenCodeProjectedThreadMessage[] => {
+): OpenCodeProjectedThreadMessage[] {
   const mergedServerMessages = mergeServerMessages(
     state.messageOrder.flatMap((messageId: string) => {
       const message = state.messagesById[messageId];
@@ -620,7 +631,7 @@ export const projectOpenCodeThreadMessages = (
     .map((pending) => projectPendingMessage(pending));
 
   return mergeProjectedMessages(serverMessages, pendingMessages);
-};
+}
 
 export const projectOpenCodeThreadRepository = (
   state: OpenCodeThreadState,

--- a/packages/react-opencode/src/openCodeTaskSession.test.ts
+++ b/packages/react-opencode/src/openCodeTaskSession.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { getOpenCodeTaskSessionId } from "./openCodeTaskSession";
+
+const taskPart = (overrides: Record<string, unknown>) =>
+  ({
+    type: "tool",
+    tool: "task",
+    state: { status: "running" },
+    ...overrides,
+  }) as never;
+
+describe("getOpenCodeTaskSessionId", () => {
+  it.each([
+    [
+      "state metadata sessionId",
+      taskPart({ state: { status: "running", metadata: { sessionId: "a" } } }),
+      "a",
+    ],
+    [
+      "state metadata sessionID",
+      taskPart({ state: { status: "running", metadata: { sessionID: "b" } } }),
+      "b",
+    ],
+    [
+      "part metadata sessionId",
+      taskPart({ metadata: { sessionId: "c" } }),
+      "c",
+    ],
+    [
+      "part metadata sessionID",
+      taskPart({ metadata: { sessionID: "d" } }),
+      "d",
+    ],
+  ])("reads %s", (_name, part, expected) => {
+    expect(getOpenCodeTaskSessionId(part)).toBe(expected);
+  });
+
+  it("ignores non-Task tools and invalid metadata", () => {
+    expect(
+      getOpenCodeTaskSessionId(
+        taskPart({ tool: "read", metadata: { sessionId: "child" } }),
+      ),
+    ).toBeUndefined();
+    expect(
+      getOpenCodeTaskSessionId(taskPart({ metadata: { sessionId: 42 } })),
+    ).toBeUndefined();
+  });
+});

--- a/packages/react-opencode/src/openCodeTaskSession.test.ts
+++ b/packages/react-opencode/src/openCodeTaskSession.test.ts
@@ -45,4 +45,15 @@ describe("getOpenCodeTaskSessionId", () => {
       getOpenCodeTaskSessionId(taskPart({ metadata: { sessionId: 42 } })),
     ).toBeUndefined();
   });
+
+  it("reads a Task part whose state is absent", () => {
+    expect(
+      getOpenCodeTaskSessionId(taskPart({ state: undefined })),
+    ).toBeUndefined();
+    expect(
+      getOpenCodeTaskSessionId(
+        taskPart({ state: undefined, metadata: { sessionId: "child" } }),
+      ),
+    ).toBe("child");
+  });
 });

--- a/packages/react-opencode/src/openCodeTaskSession.ts
+++ b/packages/react-opencode/src/openCodeTaskSession.ts
@@ -13,7 +13,9 @@ const getSessionId = (metadata: unknown) => {
 export const getOpenCodeTaskSessionId = (part: Part) => {
   if (part.type !== "tool" || part.tool !== "task") return undefined;
 
-  const stateSessionId =
-    "metadata" in part.state ? getSessionId(part.state.metadata) : undefined;
+  const state: unknown = part.state;
+  const stateSessionId = isRecord(state)
+    ? getSessionId(state.metadata)
+    : undefined;
   return stateSessionId ?? getSessionId(part.metadata);
 };

--- a/packages/react-opencode/src/openCodeTaskSession.ts
+++ b/packages/react-opencode/src/openCodeTaskSession.ts
@@ -1,0 +1,19 @@
+import type { Part } from "./types";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getSessionId = (metadata: unknown) => {
+  if (!isRecord(metadata)) return undefined;
+
+  const value = metadata.sessionId ?? metadata.sessionID;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+export const getOpenCodeTaskSessionId = (part: Part) => {
+  if (part.type !== "tool" || part.tool !== "task") return undefined;
+
+  const stateSessionId =
+    "metadata" in part.state ? getSessionId(part.state.metadata) : undefined;
+  return stateSessionId ?? getSessionId(part.metadata);
+};

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -253,6 +253,7 @@ export const createOpenCodeThreadState = (
   runState: { type: "idle" },
   messageOrder: [],
   messagesById: {} as Readonly<Record<string, OpenCodeServerMessage>>,
+  childSessionsById: {} as Readonly<Record<string, OpenCodeThreadState>>,
   pendingUserMessages: {} as Readonly<Record<string, PendingUserMessage>>,
   interactions: {
     permissions: {

--- a/packages/react-opencode/src/types.ts
+++ b/packages/react-opencode/src/types.ts
@@ -125,6 +125,7 @@ export type OpenCodeThreadState = {
   runState: OpenCodeRunState;
   messageOrder: readonly string[];
   messagesById: Readonly<Record<string, OpenCodeServerMessage>>;
+  childSessionsById: Readonly<Record<string, OpenCodeThreadState>>;
   pendingUserMessages: Readonly<Record<string, PendingUserMessage>>;
   interactions: {
     permissions: {

--- a/packages/react-opencode/src/useOpenCodeStreamingTiming.test.ts
+++ b/packages/react-opencode/src/useOpenCodeStreamingTiming.test.ts
@@ -20,6 +20,7 @@ function makeState(
     runState: { type: "idle" },
     messageOrder: overrides.messageOrder ?? [],
     messagesById: overrides.messagesById ?? {},
+    childSessionsById: {},
     pendingUserMessages: {},
     interactions: {
       permissions: { pending: {}, resolved: {} },


### PR DESCRIPTION
## Summary

- load OpenCode `task` child sessions from their explicit tool metadata
- keep child transcripts synchronized through the existing session-scoped event stream
- project child transcripts into the standard `ToolCallMessagePart.messages` contract
- support parallel and recursively nested Task calls
- document rendering with `MessagePartPrimitive.Messages`

Closes #5396

## Why

assistant-ui already has a backend-neutral nested-message contract, but the OpenCode adapter projected Task calls only as ordinary tool calls. OpenCode provides the child session ID directly on Task metadata and exposes both the child transcript and session-scoped events, so the adapter can populate the existing contract without a new UI abstraction or a heuristic correlation layer.

## Implementation

Each controller owns read-only child controllers keyed by the explicit Task session ID. Child controllers reuse the existing OpenCode reducer and message projection, subscribe only while the parent has listeners, and are discarded deterministically when their Task part disappears. Ancestor session IDs prevent recursive cycles. Removed controllers reject late async loads so deleted child state cannot reappear.

The message projection passes each child transcript through `ExportedMessageRepository` before assigning `messages`, preserving the same message normalization used by the parent runtime. Non-Task tools and Task parts without valid metadata remain unchanged.

## Validation

- `@assistant-ui/react-opencode`: 11 files, 77 tests passed
- package and dependency builds passed
- package TypeScript check passed
- targeted oxlint and oxfmt checks passed
- `git diff --check` passed
- real OpenCode 1.18.7 Task-session smoke test passed

Tests cover metadata variants, absent/invalid metadata, initial child history, live child updates, parallel and recursive Tasks, ancestor cycles, delayed loads, listener lifecycle, parent removal, and late async invalidation.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Q7yCDAhFiNQCe9ZF95_bUsyVd5Nki1meLJ3x3TSfjXBKZ8uSjJp1ASKUFbY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->