### PR TITLE
fix(react-ai-sdk): wire replacement chat transports

### DIFF
--- a/.changeset/fix-dynamic-chat-transport-wiring.md
+++ b/.changeset/fix-dynamic-chat-transport-wiring.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: keep replacement chat transports connected to the current runtime

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
+import type { UIMessage } from "ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
@@ -68,17 +69,18 @@ describe("useChatRuntime", () => {
 
     const { rerender } = renderHook(() => useChatRuntime());
     const dynamicTransport = mocks.useChat.mock.calls[0]![0]
-      .transport as AssistantChatTransport;
+      .transport as AssistantChatTransport<UIMessage>;
 
     setRuntime.mockClear();
     dynamicTransport.setRuntime(mocks.runtime as never);
-    const initialTransport = setRuntime.mock.instances[0];
+    const initialTransport = setRuntime.mock.contexts[0];
+    expect(initialTransport).toBeInstanceOf(AssistantChatTransport);
 
     rerender();
 
     setRuntime.mockClear();
     dynamicTransport.setRuntime(mocks.runtime as never);
-    expect(setRuntime.mock.instances[0]).toBe(initialTransport);
+    expect(setRuntime.mock.contexts[0]).toBe(initialTransport);
   });
 
   it("wires a replacement AssistantChatTransport", () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.test.ts
@@ -52,6 +52,7 @@ vi.mock("./useAISDKRuntime", () => ({
   useAISDKRuntime: mocks.useAISDKRuntime,
 }));
 
+import { AssistantChatTransport } from "./AssistantChatTransport";
 import { useChatRuntime } from "./useChatRuntime";
 
 describe("useChatRuntime", () => {
@@ -59,6 +60,82 @@ describe("useChatRuntime", () => {
     vi.clearAllMocks();
     mocks.state.isLoadingHistory = false;
     mocks.subscribers.clear();
+    mocks.useChat.mockReturnValue({});
+  });
+
+  it("keeps the default transport instance across rerenders", () => {
+    const setRuntime = vi.spyOn(AssistantChatTransport.prototype, "setRuntime");
+
+    const { rerender } = renderHook(() => useChatRuntime());
+    const dynamicTransport = mocks.useChat.mock.calls[0]![0]
+      .transport as AssistantChatTransport;
+
+    setRuntime.mockClear();
+    dynamicTransport.setRuntime(mocks.runtime as never);
+    const initialTransport = setRuntime.mock.instances[0];
+
+    rerender();
+
+    setRuntime.mockClear();
+    dynamicTransport.setRuntime(mocks.runtime as never);
+    expect(setRuntime.mock.instances[0]).toBe(initialTransport);
+  });
+
+  it("wires a replacement AssistantChatTransport", () => {
+    const firstTransport = new AssistantChatTransport();
+    const secondTransport = new AssistantChatTransport();
+    const firstSetRuntime = vi.spyOn(firstTransport, "setRuntime");
+    const secondSetRuntime = vi.spyOn(secondTransport, "setRuntime");
+
+    const { rerender } = renderHook(
+      ({ transport }) => useChatRuntime({ transport }),
+      {
+        initialProps: { transport: firstTransport },
+      },
+    );
+    rerender({ transport: secondTransport });
+
+    expect(firstSetRuntime).toHaveBeenCalledWith(mocks.runtime);
+    expect(secondSetRuntime).toHaveBeenCalledWith(mocks.runtime);
+  });
+
+  it("supports switching from AssistantChatTransport to a custom transport", () => {
+    const assistantTransport = new AssistantChatTransport();
+    const customTransport = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn(),
+    };
+
+    const { rerender } = renderHook(
+      ({ transport }) => useChatRuntime({ transport: transport as never }),
+      {
+        initialProps: { transport: assistantTransport as never },
+      },
+    );
+
+    rerender({ transport: customTransport as never });
+    expect(() =>
+      rerender({ transport: customTransport as never }),
+    ).not.toThrow();
+  });
+
+  it("wires AssistantChatTransport after switching from a custom transport", () => {
+    const customTransport = {
+      sendMessages: vi.fn(),
+      reconnectToStream: vi.fn(),
+    };
+    const assistantTransport = new AssistantChatTransport();
+    const setRuntime = vi.spyOn(assistantTransport, "setRuntime");
+
+    const { rerender } = renderHook(
+      ({ transport }) => useChatRuntime({ transport: transport as never }),
+      {
+        initialProps: { transport: customTransport as never },
+      },
+    );
+    rerender({ transport: assistantTransport as never });
+
+    expect(setRuntime).toHaveBeenCalledWith(mocks.runtime);
   });
 
   it("waits for external history to load before resuming a stream", async () => {

--- a/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useChatRuntime.ts
@@ -105,9 +105,12 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ? true
     : never;
 
-  const transport = useDynamicChatTransport(
-    transportOptions ?? new AssistantChatTransport(),
+  const defaultTransport = useMemo(
+    () => new AssistantChatTransport<UI_MESSAGE>(),
+    [],
   );
+  const currentTransport = transportOptions ?? defaultTransport;
+  const transport = useDynamicChatTransport(currentTransport);
 
   const id = useAuiState((s) => s.threadListItem.id);
   const aui = useAui();
@@ -126,9 +129,9 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
     ...(joinStrategy && { joinStrategy }),
   });
 
-  if (transport instanceof AssistantChatTransport) {
-    transport.setRuntime(runtime);
-    transport.__internal_setGetThreadListItem(() =>
+  if (currentTransport instanceof AssistantChatTransport) {
+    currentTransport.setRuntime(runtime);
+    currentTransport.__internal_setGetThreadListItem(() =>
       aui.threadListItem.source ? aui.threadListItem : undefined,
     );
   }
@@ -154,7 +157,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
   });
   useEffect(() => {
     if (resumeFiredRef.current || isLoadingHistory) return;
-    const adapter = getResumableAdapter(transport);
+    const adapter = getResumableAdapter(currentTransport);
     if (!adapter) return;
     const pending = adapter.storage.getStreamId();
     if (!pending) return;
@@ -175,7 +178,7 @@ const useChatThreadRuntime = <UI_MESSAGE extends UIMessage = UIMessage>(
         adapter.storage.clear();
       }
     });
-  }, [transport, chat, isLoadingHistory]);
+  }, [currentTransport, chat, isLoadingHistory]);
 
   return runtime;
 };


### PR DESCRIPTION
## Summary

- keep the default `AssistantChatTransport` stable across rerenders
- configure the concrete transport from the current render instead of routing setup through the stable proxy
- resolve resumable adapters from the current transport when options change

## Why

`useDynamicChatTransport` intentionally keeps one proxy so AI SDK chat state survives transport option updates. Runtime setup was using that proxy for `instanceof` checks and method calls, even though the proxy can later delegate to a different concrete transport.

This left replacement/default transports without runtime context and thread initialization. Switching from `AssistantChatTransport` to a custom transport could also make a later render call `setRuntime` on a transport that does not implement it, while switching in the opposite direction skipped setup entirely.

The fix keeps the proxy contract but performs setup and resumable-adapter discovery against the current concrete transport.

## Verification

- confirmed the regression tests fail on the previous implementation: unstable default instance, built-in to custom crash, and custom to built-in missing setup
- `pnpm --filter @assistant-ui/react-ai-sdk test` (173 tests)
- `pnpm --filter @assistant-ui/react-ai-sdk... build`
- focused oxlint and oxfmt checks
- patch changeset included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bc4DMdZPIJ9Ao8LHqC-gLu0lBbCE0vUtRP37voillOsLvDAlbS8Za-HTljY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->