### PR TITLE
fix(cloud): enumerate the attachment content fields aui/v0 persists

### DIFF
--- a/.changeset/auiv0-attachment-part-enumeration.md
+++ b/.changeset/auiv0-attachment-part-enumeration.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: enumerate the attachment content fields the aui/v0 encoder persists so per-part status stays out of the stored shape

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -1,13 +1,8 @@
 import type {
-  DataMessagePart,
-  FileMessagePart,
-  ImageMessagePart,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
-  TextMessagePart,
   ToolApprovalOption,
-  Unstable_AudioMessagePart,
 } from "../../../types/message";
 import type { CompleteAttachment } from "../../../types/attachment";
 import { fromThreadMessageLike } from "../../../runtime/utils/thread-message-like";
@@ -85,11 +80,33 @@ type AuiV0MessagePart =
     };
 
 type AuiV0AttachmentPart =
-  | TextMessagePart
-  | ImageMessagePart
-  | FileMessagePart
-  | Unstable_AudioMessagePart
-  | DataMessagePart<ReadonlyJSONValue>;
+  | {
+      readonly type: "text";
+      readonly text: string;
+    }
+  | {
+      readonly type: "image";
+      readonly image: string;
+      readonly filename?: string;
+    }
+  | {
+      readonly type: "file";
+      readonly data: string;
+      readonly mimeType: string;
+      readonly filename?: string;
+    }
+  | {
+      readonly type: "audio";
+      readonly audio: {
+        readonly data: string;
+        readonly format: "mp3" | "wav";
+      };
+    }
+  | {
+      readonly type: "data";
+      readonly name: string;
+      readonly data: ReadonlyJSONValue;
+    };
 
 type AuiV0Attachment = {
   readonly id: string;
@@ -125,16 +142,38 @@ const encodeAttachmentPart = (
   const type = part.type;
   switch (type) {
     case "text":
+      return { type: "text", text: part.text };
+
     case "image":
+      return {
+        type: "image",
+        image: part.image,
+        ...(part.filename != null ? { filename: part.filename } : undefined),
+      };
+
     case "file":
+      return {
+        type: "file",
+        data: part.data,
+        mimeType: part.mimeType,
+        ...(part.filename != null ? { filename: part.filename } : undefined),
+      };
+
     case "audio":
-      return part;
+      return {
+        type: "audio",
+        audio: { data: part.audio.data, format: part.audio.format },
+      };
 
     case "data": {
       if (!isJSONValue(part.data)) {
         console.warn(`attachment data is not JSON! ${JSON.stringify(part)}`);
       }
-      return { ...part, data: part.data as ReadonlyJSONValue };
+      return {
+        type: "data",
+        name: part.name,
+        data: part.data as ReadonlyJSONValue,
+      };
     }
 
     default: {

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -155,6 +155,99 @@ describe("auiV0Encode", () => {
       },
     ]);
   });
+
+  it("drops per-part status from message parts in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "assistant",
+      status: { type: "complete", reason: "stop" },
+      metadata: {
+        unstable_state: null,
+        unstable_annotations: [],
+        unstable_data: [],
+        steps: [],
+        custom: {},
+      },
+      content: [
+        { type: "reasoning", text: "thinking", status: { type: "complete" } },
+        { type: "text", text: "answer", status: { type: "running" } },
+      ],
+    });
+
+    expect(encoded.content).toEqual([
+      { type: "reasoning", text: "thinking" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
+  it("drops per-part status from attachment content in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review this" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "notes.txt",
+          status: { type: "complete" },
+          content: [
+            { type: "text", text: "notes", status: { type: "running" } },
+          ],
+        },
+      ],
+    });
+
+    expect(encoded.attachments?.[0]?.content).toEqual([
+      { type: "text", text: "notes" },
+    ]);
+  });
+
+  it("preserves every attachment content field the wire shape carries in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [{ type: "text", text: "please review these" }],
+      attachments: [
+        {
+          id: "att-1",
+          type: "file",
+          name: "bundle",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "image",
+              image: "data:image/png;base64,iVBORw0KGgo=",
+              filename: "shot.png",
+            },
+            {
+              type: "audio",
+              audio: { data: "data:audio/mp3;base64,SUQzAw==", format: "mp3" },
+            },
+            { type: "data", name: "telemetry", data: { runs: 3 } },
+          ],
+        },
+      ],
+    });
+
+    expect(encoded.attachments?.[0]?.content).toEqual([
+      {
+        type: "image",
+        image: "data:image/png;base64,iVBORw0KGgo=",
+        filename: "shot.png",
+      },
+      {
+        type: "audio",
+        audio: { data: "data:audio/mp3;base64,SUQzAw==", format: "mp3" },
+      },
+      { type: "data", name: "telemetry", data: { runs: 3 } },
+    ]);
+  });
 });
 
 describe("auiV0Decode", () => {

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -1,14 +1,9 @@
 import type {
   CompleteAttachment,
-  DataMessagePart,
-  FileMessagePart,
-  ImageMessagePart,
   MessageStatus,
   SourceProviderMetadata,
   ThreadMessage,
-  TextMessagePart,
   ToolApprovalOption,
-  Unstable_AudioMessagePart,
 } from "@assistant-ui/core";
 import { fromThreadMessageLike } from "../runtime-cores/external-store/ThreadMessageLike";
 import type { CloudMessage } from "assistant-cloud";
@@ -85,11 +80,33 @@ type AuiV0MessagePart =
     };
 
 type AuiV0AttachmentPart =
-  | TextMessagePart
-  | ImageMessagePart
-  | FileMessagePart
-  | Unstable_AudioMessagePart
-  | DataMessagePart<ReadonlyJSONValue>;
+  | {
+      readonly type: "text";
+      readonly text: string;
+    }
+  | {
+      readonly type: "image";
+      readonly image: string;
+      readonly filename?: string;
+    }
+  | {
+      readonly type: "file";
+      readonly data: string;
+      readonly mimeType: string;
+      readonly filename?: string;
+    }
+  | {
+      readonly type: "audio";
+      readonly audio: {
+        readonly data: string;
+        readonly format: "mp3" | "wav";
+      };
+    }
+  | {
+      readonly type: "data";
+      readonly name: string;
+      readonly data: ReadonlyJSONValue;
+    };
 
 type AuiV0Attachment = {
   readonly id: string;
@@ -125,16 +142,38 @@ const encodeAttachmentPart = (
   const type = part.type;
   switch (type) {
     case "text":
+      return { type: "text", text: part.text };
+
     case "image":
+      return {
+        type: "image",
+        image: part.image,
+        ...(part.filename != null ? { filename: part.filename } : undefined),
+      };
+
     case "file":
+      return {
+        type: "file",
+        data: part.data,
+        mimeType: part.mimeType,
+        ...(part.filename != null ? { filename: part.filename } : undefined),
+      };
+
     case "audio":
-      return part;
+      return {
+        type: "audio",
+        audio: { data: part.audio.data, format: part.audio.format },
+      };
 
     case "data": {
       if (!isJSONValue(part.data)) {
         console.warn(`attachment data is not JSON! ${JSON.stringify(part)}`);
       }
-      return { ...part, data: part.data as ReadonlyJSONValue };
+      return {
+        type: "data",
+        name: part.name,
+        data: part.data as ReadonlyJSONValue,
+      };
     }
 
     default: {


### PR DESCRIPTION
closes #5408

## summary

- decides the question #5408 raised: a per-part status is live-stream only and does not belong in the persisted shape. `toMessagePartStatus` honours a supplied part status only while `message.status.type === "running"` (the gate #5403 established, pinned by `message-runtime.test.ts:112`), and `auiV0Decode` always rehydrates a settled message: a running message is encoded as `{ type: "incomplete", reason: "cancelled" }` and the decode fallback is `{ type: "complete", reason: "unknown" }`. so a persisted part status has no read path and could never affect rendering. making it live would mean dropping that gate on the restore path, which reintroduces exactly what it prevents, a stored thread rendering a part as running under a finished message.
- fixes the accidental half. `encodeAttachmentPart` returned text, image, file, and audio parts by reference (`return part`) while `auiV0Encode` builds every message part field by field, so any field added to a core part type reached the stored payload without a decision. #5403's optional `status` was the first one to arrive; it typechecked only because that field was narrowed to the JSON-safe `MessagePartStreamStatus`.
- `AuiV0AttachmentPart` now declares the wire variants explicitly instead of aliasing core's runtime part types, mirroring how `AuiV0MessagePart` in the same file has always declared them. the encoder builds each variant field by field, so a new optional field on a core part type can no longer reach the stored shape without someone choosing to put it there.
- both encoder copies move together: `packages/core/src/react/runtimes/cloud/auiV0.ts` and `packages/react/src/legacy-runtime/cloud/auiV0.ts` are byte-identical apart from four import lines, and remain so after this change.

## breaking changes

- attachment content parts no longer carry `status`, `providerMetadata`, or `parentId` into the stored payload (`TextMessagePart` declares all three as optional, `FileMessagePart` declares `parentId`). no in-repo attachment adapter sets any of them: the `status` values in `core/src/adapters/attachment.ts` and `vercelAttachmentAdapter.ts` are attachment-level, not part-level. so this is a no-op on real data. all three were reaching storage the same way, by structural pass-through through an alias of core's runtime part types rather than by a decision to persist them, which is the asymmetry this change removes.
- no migration needed for a payload that already leaked one. `fromThreadMessageLike` still passes a stored `status` through, and the running gate ignores it.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core exec vitest run src/tests/auiV0Encode.test.ts` -> 9/9 green (6 pre-existing plus 3 new)
- [x] `pnpm --filter @assistant-ui/core test` -> 798/798 green (83 files)
- [x] `pnpm --filter @assistant-ui/react test` -> 375/375 green (46 files)
- [x] `pnpm --filter @assistant-ui/react... build` -> exit 0, no TS errors; aui-build runs tsc under `@tsconfig/strictest` with `exactOptionalPropertyTypes`, and building react after core is what catches a cross-package type error in the legacy copy
- [x] `pnpm lint` -> oxlint clean, oxfmt reports all matched files correctly formatted
- [x] red/green counterfactual, run by temporarily restoring the `origin/main` encoder and re-running the file: 1 failed, 8 passed

### reviewer should verify

- [ ] the three new cases are not equally load-bearing, and the body of the diff rests on only one of them. `drops per-part status from attachment content` is the discriminating one, it is the case that fails against the unmodified encoder. `drops per-part status from message parts` passes either way; message parts were already enumerated, so it pins the decision rather than a change. `preserves every attachment content field the wire shape carries` also passes either way; it guards this diff against over-narrowing, since an enumeration that forgets a field is the failure mode this change introduces, and it covers the image, audio, and data variants that no existing case touched.

## notes

- `auiV0Encode.test.ts` only exercises the core copy (every case name says "in the core cloud encoder"), so the legacy copy in `@assistant-ui/react` has no direct coverage here. i did not duplicate the suite for it in this PR: the legacy runtime is being migrated out per AGENTS.md, and a second copy of the assertions would have to be deleted with it. the two files are kept in sync by hand today, and a divergence would be caught only by the react package's own tests.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Ew9IrFHuRk1EzOvitZ9Ry5rGEUvgl30DDVLGnwOH8eEPoTi5bfla4db5PM8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->