### PR TITLE
feat(ui): render numeric markdown links as inline citation badges

### DIFF
--- a/apps/docs/components/assistant-ui/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/markdown-text.tsx
@@ -148,6 +148,7 @@ const defaultComponents = memoizeMarkdownComponents({
       return (
         <a
           href={href}
+          title={href}
           target="_blank"
           rel="noopener noreferrer"
           className={cn(

--- a/apps/docs/components/assistant-ui/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/markdown-text.tsx
@@ -142,15 +142,35 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, href, children, ...props }) => {
+    const label = typeof children === "string" ? children.trim() : undefined;
+    if (label && /^\d{1,3}$/.test(label)) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "aui-md-citation bg-muted text-muted-foreground hover:bg-primary hover:text-primary-foreground mx-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 align-super text-[10px] font-medium tabular-nums no-underline transition-colors",
+            className,
+          )}
+          {...props}
+        >
+          {label}
+        </a>
+      );
+    }
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
+          className,
+        )}
+        href={href}
+        {...props}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/apps/docs/components/assistant-ui/markdown-text.tsx
+++ b/apps/docs/components/assistant-ui/markdown-text.tsx
@@ -144,7 +144,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   a: ({ className, href, children, ...props }) => {
     const label = typeof children === "string" ? children.trim() : undefined;
-    if (label && /^\d{1,3}$/.test(label)) {
+    if (label && /^\d{1,3}$/.test(label) && href && /^https?:\/\//.test(href)) {
       return (
         <a
           href={href}
@@ -168,7 +168,9 @@ const defaultComponents = memoizeMarkdownComponents({
         )}
         href={href}
         {...props}
-      />
+      >
+        {children}
+      </a>
     );
   },
   blockquote: ({ className, ...props }) => (

--- a/apps/docs/content/docs/ui/markdown.mdx
+++ b/apps/docs/content/docs/ui/markdown.mdx
@@ -54,6 +54,14 @@ const AssistantMessage: FC = () => {
 
 </Steps>
 
+## Inline citations
+
+Links whose text is only a number, e.g. `[1](https://example.com)`, render as compact citation badges inside the streamed text and open the source in a new tab. All other links render as regular underlined links.
+
+To produce inline citations, instruct your model accordingly:
+
+> When citing sources, insert inline citations as markdown links whose text is the source number, e.g. `[1](https://example.com/article)`.
+
 ## Syntax highlighting
 
 Syntax Highlighting is not included by default, see [Syntax Highlighting](/docs/ui/syntax-highlighting) to learn how to add it.

--- a/apps/docs/content/docs/ui/markdown.mdx
+++ b/apps/docs/content/docs/ui/markdown.mdx
@@ -56,7 +56,7 @@ const AssistantMessage: FC = () => {
 
 ## Inline citations
 
-Links whose text is only a number, e.g. `[1](https://example.com)`, render as compact citation badges inside the streamed text and open the source in a new tab. All other links render as regular underlined links.
+Links whose text is only a number and that point to an absolute `http(s)` URL, e.g. `[1](https://example.com)`, render as compact citation badges inside the streamed text and open the source in a new tab. All other links — including GFM footnote references — render as regular underlined links.
 
 To produce inline citations, instruct your model accordingly:
 

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -140,15 +140,35 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, href, children, ...props }) => {
+    const label = typeof children === "string" ? children.trim() : undefined;
+    if (label && /^\d{1,3}$/.test(label)) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "aui-md-citation bg-muted text-muted-foreground hover:bg-primary hover:text-primary-foreground mx-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 align-super text-[10px] font-medium tabular-nums no-underline transition-colors",
+            className,
+          )}
+          {...props}
+        >
+          {label}
+        </a>
+      );
+    }
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
+          className,
+        )}
+        href={href}
+        {...props}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -142,7 +142,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   a: ({ className, href, children, ...props }) => {
     const label = typeof children === "string" ? children.trim() : undefined;
-    if (label && /^\d{1,3}$/.test(label)) {
+    if (label && /^\d{1,3}$/.test(label) && href && /^https?:\/\//.test(href)) {
       return (
         <a
           href={href}
@@ -166,7 +166,9 @@ const defaultComponents = memoizeMarkdownComponents({
         )}
         href={href}
         {...props}
-      />
+      >
+        {children}
+      </a>
     );
   },
   blockquote: ({ className, ...props }) => (

--- a/packages/ui/src/components/assistant-ui/markdown-text.tsx
+++ b/packages/ui/src/components/assistant-ui/markdown-text.tsx
@@ -146,6 +146,7 @@ const defaultComponents = memoizeMarkdownComponents({
       return (
         <a
           href={href}
+          title={href}
           target="_blank"
           rel="noopener noreferrer"
           className={cn(

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -140,15 +140,35 @@ const defaultComponents = memoizeMarkdownComponents({
       {...props}
     />
   ),
-  a: ({ className, ...props }) => (
-    <a
-      className={cn(
-        "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
-        className,
-      )}
-      {...props}
-    />
-  ),
+  a: ({ className, href, children, ...props }) => {
+    const label = typeof children === "string" ? children.trim() : undefined;
+    if (label && /^\d{1,3}$/.test(label)) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            "aui-md-citation bg-muted text-muted-foreground hover:bg-primary hover:text-primary-foreground mx-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 align-super text-[10px] font-medium tabular-nums no-underline transition-colors",
+            className,
+          )}
+          {...props}
+        >
+          {label}
+        </a>
+      );
+    }
+    return (
+      <a
+        className={cn(
+          "aui-md-a text-primary hover:text-primary/80 underline underline-offset-2",
+          className,
+        )}
+        href={href}
+        {...props}
+      />
+    );
+  },
   blockquote: ({ className, ...props }) => (
     <blockquote
       className={cn(

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -142,7 +142,7 @@ const defaultComponents = memoizeMarkdownComponents({
   ),
   a: ({ className, href, children, ...props }) => {
     const label = typeof children === "string" ? children.trim() : undefined;
-    if (label && /^\d{1,3}$/.test(label)) {
+    if (label && /^\d{1,3}$/.test(label) && href && /^https?:\/\//.test(href)) {
       return (
         <a
           href={href}
@@ -166,7 +166,9 @@ const defaultComponents = memoizeMarkdownComponents({
         )}
         href={href}
         {...props}
-      />
+      >
+        {children}
+      </a>
     );
   },
   blockquote: ({ className, ...props }) => (

--- a/templates/minimal/components/assistant-ui/markdown-text.tsx
+++ b/templates/minimal/components/assistant-ui/markdown-text.tsx
@@ -146,6 +146,7 @@ const defaultComponents = memoizeMarkdownComponents({
       return (
         <a
           href={href}
+          title={href}
           target="_blank"
           rel="noopener noreferrer"
           className={cn(


### PR DESCRIPTION
## What

Markdown links whose text is only a number — `[1](https://example.com)` — now render as compact superscript citation badges inside streamed assistant text, opening the source in a new tab (`target="_blank"`, `rel="noopener noreferrer"`). All other links keep the existing underlined style.

## Why

assistant-ui has `source` message parts and the `Sources` badge list, but no way to anchor a citation at its position *inside* the streamed text (the pattern popularized by Perplexity / AI SDK Elements' `InlineCitation`). Since citations arrive as plain markdown links in the text stream, this is purely a rendering concern in `markdown-text.tsx` — no runtime or protocol change, and streaming works without extra wiring.

To produce them, prompt the model: *"When citing sources, insert inline citations as markdown links whose text is the source number, e.g. `[1](https://example.com/article)`."*

## How

- `packages/ui/src/components/assistant-ui/markdown-text.tsx`: the `a` component checks whether the link's only child is a 1–3 digit numeric string; if so it renders the `aui-md-citation` pill, otherwise the existing `aui-md-a` anchor. Non-string children (bold/nested content) always take the regular path.
- Mirrored byte-equal into `templates/minimal` and into the `apps/docs` copy (which diverges from canonical only by its `SyntaxHighlighter` wiring).
- Docs: added an "Inline citations" section to `docs/ui/markdown.mdx`.

No changeset: `@assistant-ui/ui` is private; templates and docs are unpublished.

## Verification

- Ran `examples/with-chain-of-thought` (aliases the canonical `markdown-text.tsx`) with the no-key fallback temporarily emitting `[1](…)`/`[2](…)` in the text stream: both rendered as inline pills with correct `href`, `target`, and `rel`; zero regressions on regular links. Scaffolding reverted before commit.
- `tsc --noEmit` clean in `packages/ui`; oxlint/oxfmt clean; `sync-templates` check passes (minimal copy byte-equal).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ZTID8p2fBd0sua3SEaxgdxYz1NZLif1dUzG_kOlNhIWGrk6U6ier2SclTok?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->