### PR TITLE
fix(assistant-stream): release assistant message stream iterators

### DIFF
--- a/.changeset/tidy-streams-release.md
+++ b/.changeset/tidy-streams-release.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: release assistant message stream readers after iteration

--- a/.changeset/tidy-streams-release.md
+++ b/.changeset/tidy-streams-release.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: release assistant message stream readers after iteration
+fix: cancel and release assistant message stream readers when iteration ends

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -97,9 +97,7 @@ declare class AssistantMessageStream {
   constructor(readable: ReadableStream<AssistantMessage>);
   static fromAssistantStream(stream: AssistantStream): AssistantMessageStream;
   unstable_result(): Promise<AssistantMessage>;
-  [Symbol.asyncIterator](): {
-    next(): Promise<IteratorResult<AssistantMessage, undefined>>;
-  };
+  [Symbol.asyncIterator](): AsyncIterator<AssistantMessage, any, any>;
   tee(): [
     AssistantMessageStream,
     AssistantMessageStream

--- a/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage } from "../utils/types";
+import { AssistantMessageStream } from "./AssistantMessageStream";
+
+const message: AssistantMessage = {
+  role: "assistant",
+  status: { type: "running" },
+  parts: [],
+  content: [],
+  metadata: {
+    unstable_state: null,
+    unstable_data: [],
+    unstable_annotations: [],
+    steps: [],
+    custom: {},
+  },
+};
+
+describe("AssistantMessageStream", () => {
+  it("cancels and unlocks the source when iteration stops early", async () => {
+    const cancel = vi.fn();
+    const readable = new ReadableStream<AssistantMessage>({
+      start(controller) {
+        controller.enqueue(message);
+        controller.enqueue(message);
+      },
+      cancel,
+    });
+    const stream = new AssistantMessageStream(readable);
+
+    const values: AssistantMessage[] = [];
+    for await (const value of stream) {
+      values.push(value);
+      break;
+    }
+
+    expect(values).toEqual([message]);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(readable.locked).toBe(false);
+  });
+
+  it("unlocks a fully consumed source without cancelling it", async () => {
+    const cancel = vi.fn();
+    const readable = new ReadableStream<AssistantMessage>({
+      start(controller) {
+        controller.enqueue(message);
+        controller.close();
+      },
+      cancel,
+    });
+    const stream = new AssistantMessageStream(readable);
+
+    const values: AssistantMessage[] = [];
+    for await (const value of stream) {
+      values.push(value);
+    }
+
+    expect(values).toEqual([message]);
+    expect(cancel).not.toHaveBeenCalled();
+    expect(readable.locked).toBe(false);
+  });
+});

--- a/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
+++ b/packages/assistant-stream/src/core/accumulators/AssistantMessageStream.ts
@@ -1,5 +1,6 @@
 import type { AssistantStream } from "../AssistantStream";
 import type { AssistantMessage } from "../utils/types";
+import { asAsyncIterableStream } from "../../utils/AsyncIterableStream";
 import { AssistantMessageAccumulator } from "./assistant-message-accumulator";
 
 export class AssistantMessageStream {
@@ -40,13 +41,7 @@ export class AssistantMessageStream {
   }
 
   [Symbol.asyncIterator]() {
-    const reader = this.readable.getReader();
-    return {
-      async next(): Promise<IteratorResult<AssistantMessage, undefined>> {
-        const { done, value } = await reader.read();
-        return done ? { done: true, value: undefined } : { done: false, value };
-      },
-    };
+    return asAsyncIterableStream(this.readable)[Symbol.asyncIterator]();
   }
 
   tee(): [AssistantMessageStream, AssistantMessageStream] {


### PR DESCRIPTION
## Summary

- delegate `AssistantMessageStream` iteration to the shared async iterable stream helper
- cancel the underlying reader when consumers stop iteration early
- release the reader lock after early exit and full consumption
- add regression coverage and a patch changeset

## Why

`AssistantMessageStream` created a reader and exposed only `next()`. Its iterator had no `return()` cleanup path, so breaking from `for await` did not cancel upstream work, and neither early exit nor complete iteration released the reader lock.

I reproduced this on current `main`: early exit reported `cancelled: 0` with `readable.locked === true`, while complete iteration also left `readable.locked === true`. That can leave model or network work running and makes the readable unusable by later consumers.

The fix reuses `asAsyncIterableStream`, which already implements cancellation and lock cleanup consistently for native and polyfilled stream iterators.

## Validation

- `AssistantMessageStream.test.ts`: 2 tests passed
- full `assistant-stream` suite: 29 files passed, 362 tests passed, existing skips unchanged
- `aui-build` for `assistant-stream`
- `oxlint` on changed TypeScript files
- `oxfmt --check` on changed TypeScript files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.xKl79xs8LuDTvsBYQ17qj9SMpgS6y4LjO6j-fESh6o0iNewrRb5HVduSYXA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->