### PR TITLE
fix(react-langgraph): report loading on initial thread frame

### DIFF
--- a/.changeset/early-threads-load.md
+++ b/.changeset/early-threads-load.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: report thread loading on the first render frame

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import type {
   AssistantRuntime,
   AttachmentAdapter,
@@ -535,6 +535,53 @@ describe("useLangGraphRuntime", () => {
     });
 
     await waitFor(() => expect(isLoadingResult.current).toBe(false));
+  });
+
+  it("reports loading on the first frame of a controlled thread", async () => {
+    const pending = deferred<LoadResult>();
+    const load = vi.fn(() => pending.promise);
+    const streamMock = vi
+      .fn()
+      .mockImplementation(() => mockStreamCallbackFactory([])());
+    const adapter = makeThreadListAdapter();
+    const frames: Array<{ threadId: string; isLoading: boolean }> = [];
+
+    const LoadingProbe = () => {
+      const threadId = useAuiState((s) => s.threads.mainThreadId);
+      const isLoading = useAuiState((s) => s.thread.isLoading);
+      frames.push({ threadId, isLoading });
+      return null;
+    };
+
+    const TestRuntime = () => {
+      const runtime = useLangGraphRuntime({
+        stream: streamMock,
+        load,
+        unstable_threadListAdapter: adapter,
+        threadId: "lg-thread-1",
+      });
+
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <LoadingProbe />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const { unmount } = render(<TestRuntime />);
+
+    await waitFor(() =>
+      expect(load).toHaveBeenCalledWith("lg-thread-1", {
+        signal: expect.any(AbortSignal),
+      }),
+    );
+
+    const firstThreadFrame = frames.find(
+      ({ threadId }) => threadId === "lg-thread-1",
+    );
+    expect(firstThreadFrame?.isLoading).toBe(true);
+
+    unmount();
   });
 
   it("should reset thread.isLoading to false and surface the error when load rejects", async () => {

--- a/packages/react-langgraph/src/useLangGraphRuntime.ts
+++ b/packages/react-langgraph/src/useLangGraphRuntime.ts
@@ -196,7 +196,12 @@ const useLangGraphRuntimeImpl = (options: UseLangGraphRuntimeOptions) => {
   });
 
   const [isRunning, setIsRunning] = useState(false);
-  const [isLoadingThread, setIsLoadingThread] = useState(false);
+  const [isLoadingThread, setIsLoadingThread] = useState(
+    () =>
+      load !== undefined &&
+      aui.threadListItem.source !== null &&
+      aui.threadListItem.getState().externalId != null,
+  );
   const [toolStatuses, setToolStatuses] = useState<
     Record<string, ToolExecutionStatus>
   >({});


### PR DESCRIPTION
Closes #5423

## Summary

- initialize LangGraph thread loading from the current thread-list item during render
- report `thread.isLoading: true` on the first frame when a load handler and external thread ID are already available
- add a controlled deep-link regression test and a patch changeset

## Why

`isLoadingThread` previously started as `false` and only changed to `true` inside the history-loading effect. Effects run after the first committed frame, so mounting a controlled existing thread briefly rendered an empty conversation and composer before switching to the loading skeleton.

The runtime already knows during render whether loading is inevitable: a `load` handler exists, the thread-list item is live, and it has an external ID. The state now lazily initializes from those same guards. The existing effect still owns loading completion, rejection, cancellation, and later thread switches.

## Verification

- reproduced on current `main`: the first frame for the controlled thread reported `isLoading: false`
- new regression passes with the first controlled-thread frame reporting `isLoading: true`
- `@assistant-ui/react-langgraph` tests: 10 files, 215 tests passed
- `@assistant-ui/react-langgraph` build
- focused oxlint and oxfmt checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.hgpebybct5f8EPr--I09qTMBGbNn28Q1wRIOcqdqTZnEfuN3XNPlhgyumO4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->