### PR TITLE
fix(react-opencode): avoid repeated child session scans

### DIFF
--- a/.changeset/calm-tools-index.md
+++ b/.changeset/calm-tools-index.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: avoid repeated child session scans during streaming

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1069,6 +1069,7 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private loadPromise;
   private reconnectSyncToken;
   private readonly childControllersById;
+  private readonly childSessionIdByPartId;
   private ancestorSessionIds;
   private isChildSession;
   private readonly stagedMessages;
@@ -1080,7 +1081,11 @@ declare class OpenCodeThreadController implements OpenCodeThreadControllerLike {
   private attachChildController;
   private detachChildControllers;
   private discard;
+  private rebuildChildSessionIndex;
+  private updateChildSessionIndex;
+  private removeFromChildSessionIndex;
   private syncChildControllers;
+  private syncChildSessionIndex;
   private ensureEventSubscription;
   private handleStreamReconnect;
   dispose(): void;

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -4,6 +4,23 @@ import { STREAM_RECONNECTED_EVENT_TYPE } from "./OpenCodeEventSource";
 import { rejectWhenThrowing } from "./testUtils";
 import type { OpenCodeServerEvent } from "./types";
 
+const getOpenCodeTaskSessionIdSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("./openCodeTaskSession", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("./openCodeTaskSession")>();
+
+  return {
+    ...original,
+    getOpenCodeTaskSessionId: (
+      part: Parameters<typeof original.getOpenCodeTaskSessionId>[0],
+    ) => {
+      getOpenCodeTaskSessionIdSpy(part);
+      return original.getOpenCodeTaskSessionId(part);
+    },
+  };
+});
+
 const createDeferred = <T>() => {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -362,6 +379,56 @@ describe("OpenCodeThreadController", () => {
     unsubscribe();
 
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("inspects only the updated part during live child-session sync", async () => {
+    getOpenCodeTaskSessionIdSpy.mockClear();
+    const eventSource = createEventSource();
+    const message = {
+      ...createTaskMessage("ses_parent", "parent-assistant", []),
+      parts: Array.from({ length: 50 }, (_, index) => ({
+        id: `parent-text-${index}`,
+        sessionID: "ses_parent",
+        messageID: "parent-assistant",
+        type: "text",
+        text: `Part ${index}`,
+      })),
+    };
+    const client = {
+      session: {
+        get: vi.fn().mockResolvedValue({
+          data: { id: "ses_parent", title: "Parent", time: {} },
+        }),
+        messages: vi.fn().mockResolvedValue({ data: [message] }),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+    const inspectionsAfterLoad = getOpenCodeTaskSessionIdSpy.mock.calls.length;
+
+    eventSource.emit({
+      type: "message.part.updated",
+      sessionId: "ses_parent",
+      properties: {
+        part: {
+          ...message.parts[0],
+          text: "Updated",
+        },
+      },
+      raw: {},
+    });
+
+    expect(getOpenCodeTaskSessionIdSpy).toHaveBeenCalledTimes(
+      inspectionsAfterLoad + 1,
+    );
+
+    unsubscribe();
   });
 
   it("defers child-session work until the parent has a listener", async () => {
@@ -896,6 +963,73 @@ describe("OpenCodeThreadController", () => {
     unsubscribe();
 
     expect(eventSource.unsubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a child controller while another Task part references it", async () => {
+    const eventSource = createEventSource();
+    const client = {
+      session: {
+        get: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data: { id: sessionID, title: sessionID, time: {} },
+          }),
+        ),
+        messages: vi.fn(({ sessionID }: { sessionID: string }) =>
+          Promise.resolve({
+            data:
+              sessionID === "ses_parent"
+                ? [
+                    createTaskMessage("ses_parent", "parent-assistant", [
+                      "ses_child",
+                      "ses_child",
+                    ]),
+                  ]
+                : [],
+          }),
+        ),
+      },
+    };
+    const controller = new OpenCodeThreadController(
+      client as never,
+      () => eventSource,
+      "ses_parent",
+    );
+    const unsubscribe = controller.subscribe(vi.fn());
+
+    await controller.load();
+    await vi.waitFor(() => {
+      expect(
+        controller.getState().childSessionsById.ses_child?.loadState.type,
+      ).toBe("ready");
+    });
+
+    eventSource.emit({
+      type: "message.part.removed",
+      sessionId: "ses_parent",
+      properties: {
+        messageID: "parent-assistant",
+        partID: "parent-assistant-task-0",
+      },
+      raw: {},
+    });
+
+    expect(controller.getState().childSessionsById.ses_child).toBeDefined();
+    expect(eventSource.unsubscribe).not.toHaveBeenCalled();
+
+    eventSource.emit({
+      type: "message.part.removed",
+      sessionId: "ses_parent",
+      properties: {
+        messageID: "parent-assistant",
+        partID: "parent-assistant-task-1",
+      },
+      raw: {},
+    });
+
+    expect(controller.getState().childSessionsById).toEqual({});
+    expect(eventSource.unsubscribe).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
   });
 
   it("does not attach descendants from a removed Task's in-flight history", async () => {

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -14,6 +14,7 @@ import type {
   OpenCodePermissionRequest,
   OpenCodePermissionResponse,
   OpenCodeQuestionRequest,
+  Part,
   QuestionAnswer,
   OpenCodeServerEvent,
   OpenCodeStateEvent,
@@ -37,12 +38,6 @@ type ChildControllerEntry = {
   controller: OpenCodeThreadController;
   unsubscribe: (() => void) | null;
 };
-
-const shouldSyncChildControllers = (event: OpenCodeStateEvent) =>
-  event.type === "history.loaded" ||
-  event.type === "message.removed" ||
-  event.type === "part.updated" ||
-  event.type === "part.removed";
 
 const createLocalId = (prefix: string) =>
   `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
@@ -197,6 +192,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     string,
     ChildControllerEntry
   >();
+  private readonly childSessionIdByPartId = new Map<string, string>();
   private ancestorSessionIds: ReadonlySet<string>;
   private isChildSession = false;
   private readonly stagedMessages = new Map<
@@ -277,18 +273,45 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
       entry.controller.discard();
     }
     this.childControllersById.clear();
+    this.childSessionIdByPartId.clear();
     this.listeners.clear();
   }
 
-  private syncChildControllers() {
-    const sessionIds = new Set<string>();
+  private rebuildChildSessionIndex() {
+    this.childSessionIdByPartId.clear();
     for (const message of Object.values(this.state.messagesById)) {
       for (const part of message.parts) {
         const sessionId = getOpenCodeTaskSessionId(part);
-        if (sessionId && !this.ancestorSessionIds.has(sessionId)) {
-          sessionIds.add(sessionId);
+        if (sessionId) {
+          this.childSessionIdByPartId.set(part.id, sessionId);
         }
       }
+    }
+    this.syncChildControllers();
+  }
+
+  private updateChildSessionIndex(part: Part) {
+    const previousSessionId = this.childSessionIdByPartId.get(part.id);
+    const sessionId = getOpenCodeTaskSessionId(part);
+    if (sessionId === previousSessionId) return;
+
+    if (sessionId) {
+      this.childSessionIdByPartId.set(part.id, sessionId);
+    } else {
+      this.childSessionIdByPartId.delete(part.id);
+    }
+    this.syncChildControllers();
+  }
+
+  private removeFromChildSessionIndex(partId: string) {
+    if (!this.childSessionIdByPartId.delete(partId)) return;
+    this.syncChildControllers();
+  }
+
+  private syncChildControllers() {
+    const sessionIds = new Set(this.childSessionIdByPartId.values());
+    for (const sessionId of this.ancestorSessionIds) {
+      sessionIds.delete(sessionId);
     }
 
     let childSessionsById = this.state.childSessionsById;
@@ -335,6 +358,23 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     for (const [sessionId, entry] of added) {
       if (this.listeners.size === 0) break;
       this.attachChildController(sessionId, entry);
+    }
+  }
+
+  private syncChildSessionIndex(event: OpenCodeStateEvent) {
+    switch (event.type) {
+      case "history.loaded":
+      case "message.removed":
+        this.rebuildChildSessionIndex();
+        break;
+      case "part.updated":
+        this.updateChildSessionIndex(event.part);
+        break;
+      case "part.removed":
+        this.removeFromChildSessionIndex(event.partId);
+        break;
+      default:
+        break;
     }
   }
 
@@ -890,9 +930,7 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
     const nextState = reduceOpenCodeThreadState(this.state, event);
     if (nextState === this.state) return;
     this.state = nextState;
-    if (shouldSyncChildControllers(event)) {
-      this.syncChildControllers();
-    }
+    this.syncChildSessionIndex(event);
     this.notifyListeners();
   }
 }


### PR DESCRIPTION
## Summary

- index Task part IDs to their child session IDs inside `OpenCodeThreadController`
- update the index incrementally for live part updates and removals
- rebuild from the transcript only after history loads or whole-message removals

## Why

Task child-session synchronization previously walked every part in the transcript after every `part.updated` event. Since those events fire throughout streaming, long sessions accumulated quadratic work even when the updated part could not change the child-session set.

The index also keeps removal behavior correct after the reducer has already removed the part from state, and deduplicates multiple Task parts that reference the same child session.

Closes #5424

## Validation

- `@assistant-ui/react-opencode` tests: 85 passed across 11 files
- `@assistant-ui/react-opencode` build passed
- targeted oxlint and oxfmt checks passed
- regression test verifies a live update in a 50-part transcript performs one Task-session inspection instead of rescanning all 50 parts

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.2GjKKXJeRl28NMOGQRQjoPLZABb38OB27TneqO9iPZfUaM-8RrpwbNtzIQg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->