### PR TITLE
feat(docs): add section icons to tap docs sidebar

### DIFF
--- a/apps/docs/content/tap-docs/overview/meta.json
+++ b/apps/docs/content/tap-docs/overview/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Overview",
+  "icon": "BookOpen",
   "root": true,
   "pages": ["introduction", "motivation"]
 }

--- a/apps/docs/content/tap-docs/store/meta.json
+++ b/apps/docs/content/tap-docs/store/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Store",
+  "icon": "Database",
   "root": true,
   "pages": [
     "why-store",

--- a/apps/docs/content/tap-docs/tap/meta.json
+++ b/apps/docs/content/tap-docs/tap/meta.json
@@ -1,5 +1,6 @@
 {
   "title": "Tap",
+  "icon": "Droplet",
   "root": true,
   "pages": [
     "quickstart",

--- a/apps/docs/lib/source.tsx
+++ b/apps/docs/lib/source.tsx
@@ -49,6 +49,7 @@ export const source = loader({
 export const tapDocs = loader({
   baseUrl: "/tap/docs",
   source: tapDocsCollection.toFumadocsSource(),
+  plugins: [lucideIconsPlugin()],
 });
 
 const TAP_DOCS_INDEX_SLUG = ["overview", "introduction"];


### PR DESCRIPTION
## What

Make the `/tap/docs` sidebar visually consistent with the main `/docs` sidebar by giving its sections the same lucide icons treatment.

## Why

Both routes already render through the same `DocsRootLayout` → `SidebarContent` component, but the tap docs sections (Overview, Tap, Store) rendered with empty icon slots: the `tapDocs` loader in `apps/docs/lib/source.tsx` didn't run `lucideIconsPlugin()`, and the tap `meta.json` files carried no `icon` field. The result was a visibly barer sidebar on tap docs pages.

## How

- `apps/docs/lib/source.tsx` — add `plugins: [lucideIconsPlugin()]` to the `tapDocs` loader (same plugin the main docs loader uses)
- `content/tap-docs/overview/meta.json` — `"icon": "BookOpen"` (mirrors the Getting Started section of the main docs)
- `content/tap-docs/tap/meta.json` — `"icon": "Droplet"`
- `content/tap-docs/store/meta.json` — `"icon": "Database"`

Intentionally unchanged: `platformAware` stays `false` for tap docs — the platform switcher card on `/docs` toggles React / React Native / Ink within the main docs tree, which has no equivalent for tap.

No changeset: only touches the private `apps/docs` app.

## Screenshots

### Before — annotated

![Tap docs sidebar before, section headers without icons annotated](https://artifacts.duncan.land/aui-tap-sidebar-before.png)

### After — annotated

![Tap docs sidebar after, section icons matching /docs annotated](https://artifacts.duncan.land/aui-tap-sidebar-after.png)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.8ICeQUC2Y20AouSm3rKAFLZICL_gMkRnlQXvV6ONqfUQTv7XYALrtl0eyLA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->