### PR TITLE
fix(docs): center sidebar indent line under section icons

### DIFF
--- a/apps/docs/components/docs/layout/sidebar-content.tsx
+++ b/apps/docs/components/docs/layout/sidebar-content.tsx
@@ -170,7 +170,7 @@ function SidebarSection({
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
             className="overflow-hidden"
           >
-            <div className="border-border/50 mt-0.5 mb-1 ml-3 flex flex-col gap-0.5 border-l pl-2">
+            <div className="border-border/50 mt-0.5 mb-1 ml-4 flex flex-col gap-0.5 border-l pl-2">
               {folder.children.map((child) => (
                 <SectionItem
                   key={child.$id}


### PR DESCRIPTION
## What

Align the docs sidebar's vertical indent line (the `border-l` on each open section's child list) with the center of the section icons. It previously sat slightly left of center on every docs page.

## Why

The child-links container in `SidebarContent` used `ml-3` (12px), but the section icon center sits at 16px from the section's left edge (8px button `px-2` + half of the 16px `size-4` icon span). Measured in the browser: line center at x=24.5 vs icon center at x=28 — 3.5px left of center, visible on every page since the sidebar is one shared component.

## How

One-line change in `apps/docs/components/docs/layout/sidebar-content.tsx`: `ml-3` → `ml-4` on the section children container. The 1px line now spans x=28–29 against an icon center of x=28 — 0.5px, the pixel-snapped optimum (exact centering would need a fractional offset, which anti-aliases the 1px line into a blurry 2px on 1x displays).

Verified by DOM measurement and visually on `/docs` and `/tap/docs`.

No changeset: only touches the private `apps/docs` app.

## Screenshots

### Before — annotated

![Getting Started section with indent line offset left of the icon center annotated](https://artifacts.duncan.land/aui-sidebar-indent-line-before.png)

### After — annotated

![Getting Started section with indent line centered under the icon annotated](https://artifacts.duncan.land/aui-sidebar-indent-line-after.png)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.id1wbSreMazShR2jOrlihoh0otbClJyA64XAiC3nb0Uyau3zoyz4Tacbk34?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->