### PR TITLE
fix(core): isolate message queue subscriber errors

### DIFF
--- a/.changeset/silent-queues-listen.md
+++ b/.changeset/silent-queues-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: isolate message queue subscriber errors

--- a/packages/core/src/runtime/queue/message-queue.ts
+++ b/packages/core/src/runtime/queue/message-queue.ts
@@ -4,6 +4,7 @@ import {
   type QueueItemState,
 } from "../../store/scopes/queue-item";
 import { generateId } from "../../utils/id";
+import { notifyEventListeners } from "../../utils/notify-event-listeners";
 import { getThreadMessageText } from "../../utils/text";
 import type { ExternalThreadQueueAdapter } from "./external-thread-queue-adapter";
 
@@ -34,7 +35,7 @@ export const createMessageQueue = (
   let suppressIdle = 0;
 
   const notify = () => {
-    for (const callback of subscribers) callback();
+    notifyEventListeners(subscribers, undefined, "Message queue");
   };
 
   const setItems = (next: readonly QueueItemState[]) => {

--- a/packages/core/src/tests/message-queue.test.ts
+++ b/packages/core/src/tests/message-queue.test.ts
@@ -152,6 +152,34 @@ describe("createMessageQueue", () => {
     expect(cb).toHaveBeenCalled();
   });
 
+  it("isolates subscriber errors while enqueueing", () => {
+    const run = vi.fn();
+    const { adapter, subscribe } = createMessageQueue({ run });
+    const error = new Error("subscriber failed");
+    const laterSubscriber = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    subscribe(() => {
+      throw error;
+    });
+    subscribe(laterSubscriber);
+
+    try {
+      expect(() => adapter.enqueue(msg("a"), { steer: false })).not.toThrow();
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(adapter.items).toHaveLength(0);
+      expect(laterSubscriber).toHaveBeenCalledTimes(2);
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Message queue listener threw an error",
+        error,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("buffers when a run started outside the queue is marked busy", () => {
     const run = vi.fn();
     const { adapter, notifyBusy, notifyIdle } = createMessageQueue({ run });


### PR DESCRIPTION
## Summary

- isolate message queue subscriber failures with the shared event-listener helper
- continue notifying later subscribers and advancing an idle queue after a listener throws
- add regression coverage for the interrupted enqueue path

## Why

A message queue subscriber could throw after `enqueue()` stored the item but before `advance()` ran. That left the item queued, prevented `driver.run()` from starting, and skipped every later subscriber. This can turn an unrelated telemetry or UI listener failure into a stalled message send.

The shared listener helper reports the subscriber error while allowing queue processing to continue.

## Testing

- reproduced before the fix: one queued item, zero driver runs, and the later subscriber was not called
- `vitest run packages/core/src/tests/message-queue.test.ts`
- `oxlint packages/core/src/runtime/queue/message-queue.ts packages/core/src/tests/message-queue.test.ts`
- `aui-build` in `packages/core`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.ilXHcEcP7MYaqN51wvl-kkyHExuB2y-MJ90JBs3g0OFIxaNZKX_6KS1tKV4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->