### PR TITLE
ci: scope autofix and claude review to prs targeting main

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -1,6 +1,8 @@
 name: autofix.ci
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,8 +5,10 @@ name: Claude Code Review
 # come only from the trusted base branch.
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
   pull_request_target:
+    branches: [main]
     types: [opened, synchronize, ready_for_review, reopened]
 
 env:


### PR DESCRIPTION
## what

`autofix.ci` and `claude code review` were the only two `pull_request` workflows in the repo without a base branch filter. this adds `branches: [main]` to both, including the `pull_request_target` leg of claude review that handles fork PRs.

## why

the other five `pull_request` workflows already carry it (`code-quality`, `changeset-semver-check`, `pkg-pr-new`, `python-tests`, `template-metrics`), so this makes the trigger surface uniform.

it also gets us ready for GitHub's stacked pull requests, which went into public preview on 2026-07-30. in a stack, the intermediate layers target another feature branch rather than `main`. without the filter, autofix.ci pushes a fix commit onto every layer of a stack concurrently, and each of those pushes invalidates the layers above it, so an n-layer stack lands as n mutually diverged branches that all have to be reconciled in one restack. with the filter, the fix commit only ever lands on the layer that is currently at the bottom, and the restack is serial and clean. claude code review is the same story for cost, and it cannot review a layer whose base is not `main` with full context anyway.

## behavior change for existing PRs

none. `branches:` filters on the PR's base, and every one of the last 200 PRs in this repo targets `main`, forks included (a fork PR's base is still upstream `main`). the condition is trivially true for every PR that exists today, so stacked and non-stacked flows run under the same single rule rather than two modes.

## known gap

`pull_request` default types are `opened, synchronize, reopened`, and a base change on its own emits `edited`, which is not in that set. so if GitHub's auto-retarget ever moves a stacked PR to `main` without also rebasing its head, that layer could reach `base == main` without either workflow firing. that can only happen when the layers are independent, which is not a case worth stacking. leaving `types` alone rather than adding `edited`, which would re-run claude review on every title and description edit; will revisit once a real stack shows what events retargeting actually emits.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fQVik5dQlOllLibJcMkNkladbR3MmqFntZEuCea0hrA8JCdozgkvV_fEe3E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->