### PR TITLE
feat(core,react-langgraph,react-langchain): sourceType opt-in on file message parts

### DIFF
--- a/.changeset/file-part-source-type.md
+++ b/.changeset/file-part-source-type.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-langgraph": patch
+"@assistant-ui/react-langchain": patch
+---
+
+feat: sourceType opt-in on file message parts so attachment adapters can send url/id file references

--- a/.changeset/file-part-source-type.md
+++ b/.changeset/file-part-source-type.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 "@assistant-ui/react-langgraph": patch
 "@assistant-ui/react-langchain": patch
 ---

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1836,6 +1836,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -441,6 +441,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -753,6 +753,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -470,6 +470,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -814,6 +814,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -665,6 +665,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-generative-ui.ts
+++ b/api-surface/assistant-ui__react-generative-ui.ts
@@ -319,6 +319,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1135,6 +1135,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-hook-form.ts
+++ b/api-surface/assistant-ui__react-hook-form.ts
@@ -52,6 +52,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -1554,6 +1554,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -757,6 +757,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -776,6 +776,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -1386,6 +1386,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -533,6 +533,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -535,6 +535,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2193,6 +2193,7 @@ type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  readonly sourceType?: "id" | "url";
   readonly parentId?: string;
 };
 

--- a/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
@@ -489,6 +489,22 @@ In the adapter's `add`, call Uploadthing's client upload and read `url` from the
 </Tab>
 </Tabs>
 
+### Opaque file references (LangGraph / LangChain)
+
+When the backend resolves stored files itself and the browser never holds a usable URL, send the storage id instead: set `sourceType: "id"` on the file part in `send()`, and the LangChain-family runtimes emit a `source_type: "id"` block with the value in the `id` key. `sourceType: "url"` similarly forces a url block for non-http references. Other runtimes ignore the field.
+
+```ts
+content: [
+  {
+    type: "file" as const,
+    filename: name,
+    mimeType: contentType ?? "application/octet-stream",
+    data: fileId,
+    sourceType: "id" as const,
+  },
+];
+```
+
 ## Notes
 
 - **Persistence.** A URL the model sees on Monday must still resolve next week if the thread is reloaded. Either use storage with no expiry on the public URL, or have your [history adapter](/docs/integrations/persistence/custom-adapter) regenerate signed URLs on `load`. Don't store presigned URLs in the message row.

--- a/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
@@ -494,7 +494,7 @@ In the adapter's `add`, call Uploadthing's client upload and read `url` from the
 When the backend resolves stored files itself and the browser never holds a usable URL, send the storage id instead: set `sourceType: "id"` on the file part in `send()`, and the LangChain-family runtimes emit a `source_type: "id"` block with the value in the `id` key. `sourceType: "url"` similarly forces a url block for non-http references. Other runtimes ignore the field.
 
 ```ts
-content: [
+const content = [
   {
     type: "file" as const,
     filename: name,

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -77,6 +77,7 @@ type AuiV0MessagePart =
       readonly data: string;
       readonly mimeType: string;
       readonly filename?: string;
+      readonly sourceType?: "url" | "id";
     };
 
 type AuiV0AttachmentPart =
@@ -94,6 +95,7 @@ type AuiV0AttachmentPart =
       readonly data: string;
       readonly mimeType: string;
       readonly filename?: string;
+      readonly sourceType?: "url" | "id";
     }
   | {
       readonly type: "audio";
@@ -157,6 +159,9 @@ const encodeAttachmentPart = (
         data: part.data,
         mimeType: part.mimeType,
         ...(part.filename != null ? { filename: part.filename } : undefined),
+        ...(part.sourceType != null
+          ? { sourceType: part.sourceType }
+          : undefined),
       };
 
     case "audio":
@@ -281,6 +286,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             data: part.data,
             mimeType: part.mimeType,
             ...(part.filename ? { filename: part.filename } : undefined),
+            ...(part.sourceType ? { sourceType: part.sourceType } : undefined),
           };
 
         default: {

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -127,6 +127,61 @@ describe("auiV0Encode", () => {
     ]);
   });
 
+  it("preserves file sourceType in the core cloud encoder", () => {
+    const encoded = auiV0Encode({
+      id: "m1",
+      createdAt: new Date("2026-03-15T00:00:00.000Z"),
+      role: "user",
+      metadata: { custom: {} },
+      content: [
+        {
+          type: "file",
+          data: "file-abc123",
+          mimeType: "application/pdf",
+          filename: "a.pdf",
+          sourceType: "id",
+        },
+      ],
+      attachments: [
+        {
+          id: "att-1",
+          type: "document",
+          name: "a.pdf",
+          contentType: "application/pdf",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "file-abc123",
+              mimeType: "application/pdf",
+              filename: "a.pdf",
+              sourceType: "id",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(encoded.content).toEqual([
+      {
+        type: "file",
+        data: "file-abc123",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+        sourceType: "id",
+      },
+    ]);
+    expect(encoded.attachments?.[0]?.content).toEqual([
+      {
+        type: "file",
+        data: "file-abc123",
+        mimeType: "application/pdf",
+        filename: "a.pdf",
+        sourceType: "id",
+      },
+    ]);
+  });
+
   it("omits missing attachment contentType in the core cloud encoder", () => {
     const encoded = auiV0Encode({
       id: "m1",

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -62,6 +62,8 @@ export type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
+  /** How `data` goes on the wire: a url or id reference; omitted = inferred (http(s) → url, else base64). Honored by the LangChain-family runtimes; others ignore it. */
+  readonly sourceType?: "url" | "id";
   readonly parentId?: string;
 };
 

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -87,6 +87,7 @@ describe("convertLangChainBaseMessage file content parts", () => {
         filename: "file.pdf",
         data: "https://r2.example/u/abc/file.pdf",
         mimeType: "application/pdf",
+        sourceType: "url",
       },
     ]);
   });
@@ -103,6 +104,7 @@ describe("convertLangChainBaseMessage file content parts", () => {
         filename: "file",
         data: "file-abc123",
         mimeType: "application/octet-stream",
+        sourceType: "id",
       },
     ]);
   });
@@ -197,6 +199,111 @@ describe("getMessageContent file blocks", () => {
         mime_type: "application/pdf",
         metadata: { filename: "a.pdf" },
         source_type: "base64",
+      },
+    ]);
+  });
+
+  it("emits an id source block with the value in the id key for sourceType id", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "flx::storage:file_object:abc",
+        mimeType: "application/pdf",
+        filename: "invoice.pdf",
+        sourceType: "id",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        id: "flx::storage:file_object:abc",
+        mime_type: "application/pdf",
+        metadata: { filename: "invoice.pdf" },
+        source_type: "id",
+      },
+    ]);
+    expect(content[1]).not.toHaveProperty("data");
+  });
+
+  it("lets sourceType url override sniffing for non-http data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "s3://bucket/key.pdf",
+        mimeType: "application/pdf",
+        filename: "key.pdf",
+        sourceType: "url",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        url: "s3://bucket/key.pdf",
+        mime_type: "application/pdf",
+        metadata: { filename: "key.pdf" },
+        source_type: "url",
+      },
+    ]);
+  });
+
+  it("emits an id source block for attachment content parts", () => {
+    const content = getMessageContent({
+      content: [{ type: "text", text: "see attached" }],
+      attachments: [
+        {
+          content: [
+            {
+              type: "file",
+              data: "file-abc123",
+              mimeType: "application/pdf",
+              filename: "a.pdf",
+              sourceType: "id",
+            },
+          ],
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    expect(content).toEqual([
+      { type: "text", text: "see attached" },
+      {
+        type: "file",
+        id: "file-abc123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "id",
+      },
+    ]);
+  });
+
+  it("round-trips an id source block through both converters", () => {
+    const converted = convertLangChainBaseMessage(
+      humanMessage([
+        {
+          type: "file",
+          id: "file-abc123",
+          mime_type: "application/pdf",
+          source_type: "id",
+          metadata: { filename: "a.pdf" },
+        },
+      ]),
+      {},
+    );
+
+    const content = getMessageContent(converted as unknown as AppendMessage);
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        id: "file-abc123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "id",
       },
     ]);
   });

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -64,6 +64,9 @@ const contentToParts = (content: unknown, role: "user" | "assistant") => {
                   ? part.id
                   : part.data,
             mimeType: part.mime_type ?? "application/octet-stream",
+            ...((part.source_type === "url" || part.source_type === "id") && {
+              sourceType: part.source_type,
+            }),
           };
         case "audio": {
           if (role !== "user") return null;
@@ -229,7 +232,16 @@ export const getMessageContent = (msg: AppendMessage) => {
         return { type: "image_url" as const, image_url: { url: part.image } };
       case "file": {
         const metadata = { filename: part.filename ?? "file" };
-        if (httpUrlPattern.test(part.data)) {
+        if (part.sourceType === "id") {
+          return {
+            type: "file" as const,
+            id: part.data,
+            mime_type: part.mimeType,
+            metadata,
+            source_type: "id" as const,
+          };
+        }
+        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
           return {
             type: "file" as const,
             url: part.data,

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -473,6 +473,7 @@ describe("convertLangChainMessages file content", () => {
           filename: "file.pdf",
           data: "https://r2.example/u/abc/file.pdf",
           mimeType: "application/pdf",
+          sourceType: "url",
         },
       ],
     });
@@ -499,6 +500,7 @@ describe("convertLangChainMessages file content", () => {
           filename: "file",
           data: "file-abc123",
           mimeType: "application/octet-stream",
+          sourceType: "id",
         },
       ],
     });
@@ -594,6 +596,112 @@ describe("getMessageContent file blocks", () => {
         mime_type: "application/pdf",
         metadata: { filename: "a.pdf" },
         source_type: "base64",
+      },
+    ]);
+  });
+
+  it("emits an id source block with the value in the id key for sourceType id", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "flx::storage:file_object:abc",
+        mimeType: "application/pdf",
+        filename: "invoice.pdf",
+        sourceType: "id",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        id: "flx::storage:file_object:abc",
+        mime_type: "application/pdf",
+        metadata: { filename: "invoice.pdf" },
+        source_type: "id",
+      },
+    ]);
+    expect(content[1]).not.toHaveProperty("data");
+  });
+
+  it("lets sourceType url override sniffing for non-http data", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "s3://bucket/key.pdf",
+        mimeType: "application/pdf",
+        filename: "key.pdf",
+        sourceType: "url",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        url: "s3://bucket/key.pdf",
+        mime_type: "application/pdf",
+        metadata: { filename: "key.pdf" },
+        source_type: "url",
+      },
+    ]);
+  });
+
+  it("emits an id source block for attachment content parts", () => {
+    const content = getMessageContent({
+      content: [{ type: "text", text: "see attached" }],
+      attachments: [
+        {
+          content: [
+            {
+              type: "file",
+              data: "file-abc123",
+              mimeType: "application/pdf",
+              filename: "a.pdf",
+              sourceType: "id",
+            },
+          ],
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    expect(content).toEqual([
+      { type: "text", text: "see attached" },
+      {
+        type: "file",
+        id: "file-abc123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "id",
+      },
+    ]);
+  });
+
+  it("round-trips an id source block through both converters", () => {
+    const converted = convertLangChainMessages({
+      type: "human",
+      id: "human-roundtrip-id-file",
+      content: [
+        {
+          type: "file",
+          id: "file-abc123",
+          mime_type: "application/pdf",
+          source_type: "id",
+          metadata: { filename: "a.pdf" },
+        },
+      ],
+    });
+
+    const content = getMessageContent(converted as unknown as AppendMessage);
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "file",
+        id: "file-abc123",
+        mime_type: "application/pdf",
+        metadata: { filename: "a.pdf" },
+        source_type: "id",
       },
     ]);
   });

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -161,6 +161,9 @@ const contentToParts = (
                     ? part.id
                     : part.data,
               mimeType: part.mime_type ?? "application/octet-stream",
+              ...((part.source_type === "url" || part.source_type === "id") && {
+                sourceType: part.source_type,
+              }),
             };
 
           case "audio": {
@@ -353,7 +356,16 @@ export const getMessageContent = (msg: AppendMessage) => {
         return { type: "image_url" as const, image_url: { url: part.image } };
       case "file": {
         const metadata = { filename: part.filename ?? "file" };
-        if (httpUrlPattern.test(part.data)) {
+        if (part.sourceType === "id") {
+          return {
+            type: "file" as const,
+            id: part.data,
+            mime_type: part.mimeType,
+            metadata,
+            source_type: "id" as const,
+          };
+        }
+        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
           return {
             type: "file" as const,
             url: part.data,

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -77,6 +77,7 @@ type AuiV0MessagePart =
       readonly data: string;
       readonly mimeType: string;
       readonly filename?: string;
+      readonly sourceType?: "url" | "id";
     };
 
 type AuiV0AttachmentPart =
@@ -94,6 +95,7 @@ type AuiV0AttachmentPart =
       readonly data: string;
       readonly mimeType: string;
       readonly filename?: string;
+      readonly sourceType?: "url" | "id";
     }
   | {
       readonly type: "audio";
@@ -157,6 +159,9 @@ const encodeAttachmentPart = (
         data: part.data,
         mimeType: part.mimeType,
         ...(part.filename != null ? { filename: part.filename } : undefined),
+        ...(part.sourceType != null
+          ? { sourceType: part.sourceType }
+          : undefined),
       };
 
     case "audio":
@@ -281,6 +286,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             data: part.data,
             mimeType: part.mimeType,
             ...(part.filename ? { filename: part.filename } : undefined),
+            ...(part.sourceType ? { sourceType: part.sourceType } : undefined),
           };
 
         default: {


### PR DESCRIPTION
Closes assistant-ui/assistant-ui#5425

## What

Adds an optional `sourceType?: "url" | "id"` field to `FileMessagePart` and teaches the react-langgraph and react-langchain outbound converters to emit the matching LangChain source block, with the value in the `url` or `id` key. The inbound converters now stamp `sourceType: "id"` when decoding an id block so a re-sent history message keeps its reference kind.

## Why

An attachment adapter that uploads to internal storage holds only an opaque file id: the browser never has the bytes and the storage URL is signed and short lived, so neither existing wire shape fits, and the reporter was smuggling the id through `data` with a magic prefix.

## Impact

* Adapters can return `{ type: "file", data: "<file-id>", mimeType, sourceType: "id" }` and the backend receives a spec conformant `source_type: "id"` block.
* With `sourceType` omitted, output is byte identical to today (http(s) sniffing then base64), pinned by the pre-existing tests.

## Scope

* Neither of the issue's two proposals is implemented as written: spreading unknown fields would emit non spec blocks (the reason assistant-ui/assistant-ui#4795 was closed) and a `convertAppendMessage` option is a much larger surface; the narrow opt-in covers the reported use case with spec conformant output.
* `"base64"` is deliberately not in the union: base64 data cannot false positive the url sniff (no `://` in the alphabet), so an explicit base64 override has no use case; the union can widen later, narrowing could not.
* Inbound `url` and `id` blocks both stamp `sourceType`, so non-http url references (e.g. s3) also survive a resend; base64 stays the unset default.
* The wire unions in both packages already had the `id` leg (inbound only until now); no wire type changes.
* Additive only: one optional field on `FileMessagePart`, no exports removed or reshaped; api-surface snapshots regenerated (one identical line in 16 files).
* The aui/v0 codec carries the field in both copies (core and legacy react), so cloud persistence cannot strip it and re-create the assistant-ui/assistant-ui#5425 corruption one reload later.
* Tests: id emission, url override of sniffing, the attachments path, an inbound to outbound round trip, and an aui/v0 encode round trip; unchanged default behavior is covered by the existing file block tests.
* Changeset: patch (`@assistant-ui/core`, `@assistant-ui/react`, `@assistant-ui/react-langgraph`, `@assistant-ui/react-langchain`).

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)

![Track in Rupic](https://camo.githubusercontent.com/35ad877989bf2ab419d9ac7f06c11a3b70a2b0e1d585ec6aba1649066e396507/68747470733a2f2f72757069632e6465762f6261646765732f747261636b2d6c696768742d76312e737667)