### PR TITLE
fix(react-langgraph): preserve custom fields on file content parts

### DIFF
--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -325,9 +325,19 @@ export const getMessageContent = (msg: AppendMessage) => {
       case "image":
         return { type: "image_url" as const, image_url: { url: part.image } };
       case "file": {
+        // Preserve adapter-defined custom fields (e.g. storage ids) by
+        // spreading the remainder after extracting known keys (#5425).
+        const {
+          type: _type,
+          data: _data,
+          mimeType: _mimeType,
+          filename: _filename,
+          ...customFields
+        } = part;
         const metadata = { filename: part.filename ?? "file" };
         if (httpUrlPattern.test(part.data)) {
           return {
+            ...customFields,
             type: "file" as const,
             url: part.data,
             mime_type: part.mimeType,
@@ -337,6 +347,7 @@ export const getMessageContent = (msg: AppendMessage) => {
         }
         const parsed = parseDataUrl(part.data);
         return {
+          ...customFields,
           type: "file" as const,
           data: parsed?.data ?? part.data,
           mime_type: parsed?.mimeType ?? part.mimeType,


### PR DESCRIPTION
## Summary

`getMessageContent()` rebuilt file content parts with only known keys (`data`, `mime_type`, `metadata`, `source_type`), silently dropping any adapter-defined custom fields (e.g. internal storage ids like `fileObjectFid`).

This change destructures the known keys and spreads the remainder so custom fields survive the AppendMessage → LangChain conversion.

## Before

```ts
// adapter returns
{ type: 'file', source_type: 'flexport_file_object', fileObjectFid: 'flx::...', filename: 'invoice.pdf' }
// after getMessageContent — fileObjectFid is gone
{ type: 'file', data: '...', mime_type: '...', metadata: { filename: 'invoice.pdf' }, source_type: 'base64' }
```

## After

```ts
// custom fields preserved
{ type: 'file', fileObjectFid: 'flx::...', data: '...', mime_type: '...', metadata: { filename: 'invoice.pdf' }, source_type: 'base64' }
```

Closes #5425

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mIGaYYm1Kn7axLhNwgK6zog-Am-SLXeVRY_YzuNDvfyD3b4Z63c1o4_KkRA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->