### PR TITLE
fix(react-ai-sdk,eve): forward audio parts instead of throwing

### DIFF
--- a/.changeset/ai-sdk-audio-part-forwarding.md
+++ b/.changeset/ai-sdk-audio-part-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix(react-ai-sdk): forward audio message parts as file parts instead of throwing

--- a/.changeset/eve-audio-part-forwarding.md
+++ b/.changeset/eve-audio-part-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix(eve): forward audio message parts as file parts and skip data parts instead of throwing

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -349,6 +349,26 @@ describe("getEveMessageContent", () => {
     ]);
   });
 
+  it("forwards an http audio source instead of wrapping it in a data URL", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [
+        {
+          type: "audio",
+          audio: { data: "https://cdn.example.com/memo.mp3", format: "mp3" },
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toEqual([
+      {
+        type: "file",
+        data: "https://cdn.example.com/memo.mp3",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
   it("skips data parts while keeping surrounding text", () => {
     const message = {
       ...baseAppendMessage,

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -280,19 +280,85 @@ describe("convertEveMessages", () => {
 });
 
 describe("getEveMessageContent", () => {
+  const baseAppendMessage = {
+    role: "user",
+    createdAt: new Date(),
+    parentId: null,
+    sourceId: null,
+    runConfig: undefined,
+    metadata: { custom: {} },
+    attachments: [],
+  } as const;
+
   it("returns plain text for text-only messages", () => {
     const message = {
-      role: "user",
-      createdAt: new Date(),
-      parentId: null,
-      sourceId: null,
-      runConfig: undefined,
+      ...baseAppendMessage,
       content: [{ type: "text", text: "Hello" }],
-      metadata: { custom: {} },
-      attachments: [],
     } satisfies AppendMessage;
 
     expect(getEveMessageContent(message)).toBe("Hello");
+  });
+
+  it("converts an audio part into a file part with the format-derived media type", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toEqual([
+      {
+        type: "file",
+        data: "data:audio/mp3;base64,QUJD",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
+  it("converts a wav audio part", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [{ type: "audio", audio: { data: "QUJD", format: "wav" } }],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toEqual([
+      {
+        type: "file",
+        data: "data:audio/wav;base64,QUJD",
+        mediaType: "audio/wav",
+      },
+    ]);
+  });
+
+  it("rebuilds the audio data URL envelope from the typed format", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [
+        {
+          type: "audio",
+          audio: { data: "data:audio/mpeg;base64,QUJD", format: "mp3" },
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toEqual([
+      {
+        type: "file",
+        data: "data:audio/mp3;base64,QUJD",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
+  it("skips data parts while keeping surrounding text", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [
+        { type: "text", text: "hi" },
+        { type: "data", name: "chart", data: { x: 1 } },
+      ],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toBe("hi");
   });
 });
 

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -10,6 +10,7 @@ import {
   type ToolApprovalOption,
   type ToolCallMessagePart,
 } from "@assistant-ui/core";
+import { parseDataUrl } from "@assistant-ui/core/internal";
 import type {
   EveDynamicToolPart,
   EveMessage,
@@ -280,7 +281,7 @@ export const getEveMessageContent = (
     ...(message.attachments?.flatMap((attachment) => attachment.content) ?? []),
   ];
 
-  const parts = content.map((part) => {
+  const parts = content.flatMap((part) => {
     const type = part.type;
     switch (type) {
       case "text":
@@ -302,10 +303,23 @@ export const getEveMessageContent = (
           ...(part.filename && { filename: part.filename }),
         };
 
+      case "audio": {
+        // A data URL's own media type wins over `mediaType` downstream, so the
+        // envelope is rebuilt from the typed format rather than forwarded.
+        const mediaType = `audio/${part.audio.format}`;
+        const base64 = parseDataUrl(part.audio.data)?.data ?? part.audio.data;
+        return {
+          type: "file" as const,
+          data: `data:${mediaType};base64,${base64}`,
+          mediaType,
+        };
+      }
+
+      case "data":
+        return [];
+
       default: {
         const _exhaustiveCheck:
-          | "audio"
-          | "data"
           | "generative-ui"
           | "reasoning"
           | "source"

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -10,7 +10,7 @@ import {
   type ToolApprovalOption,
   type ToolCallMessagePart,
 } from "@assistant-ui/core";
-import { parseDataUrl } from "@assistant-ui/core/internal";
+import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
 import type {
   EveDynamicToolPart,
   EveMessage,
@@ -307,10 +307,12 @@ export const getEveMessageContent = (
         // A data URL's own media type wins over `mediaType` downstream, so the
         // envelope is rebuilt from the typed format rather than forwarded.
         const mediaType = `audio/${part.audio.format}`;
-        const base64 = parseDataUrl(part.audio.data)?.data ?? part.audio.data;
+        const data = part.audio.data;
         return {
           type: "file" as const,
-          data: `data:${mediaType};base64,${base64}`,
+          data: httpUrlPattern.test(data)
+            ? data
+            : `data:${mediaType};base64,${parseDataUrl(data)?.data ?? data}`,
           mediaType,
         };
       }

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -303,6 +303,28 @@ describe("toCreateMessage", () => {
     ]);
   });
 
+  it("forwards an http audio source instead of wrapping it in a data URL", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "audio",
+          audio: { data: "https://cdn.example.com/memo.mp3", format: "mp3" },
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "https://cdn.example.com/memo.mp3",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
   it("keeps the attachment name on audio attachment content", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -246,4 +246,88 @@ describe("toCreateMessage", () => {
       },
     ]);
   });
+
+  it("converts an audio part into a file part with the format-derived media type", () => {
+    const message = {
+      ...baseMessage,
+      content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:audio/mp3;base64,QUJD",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
+  it("converts a wav audio part", () => {
+    const message = {
+      ...baseMessage,
+      content: [{ type: "audio", audio: { data: "QUJD", format: "wav" } }],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:audio/wav;base64,QUJD",
+        mediaType: "audio/wav",
+      },
+    ]);
+  });
+
+  it("rebuilds the audio data URL envelope from the typed format", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "audio",
+          audio: { data: "data:audio/mpeg;base64,QUJD", format: "mp3" },
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:audio/mp3;base64,QUJD",
+        mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
+  it("keeps the attachment name on audio attachment content", () => {
+    const message = {
+      ...baseMessage,
+      content: [],
+      attachments: [
+        {
+          id: "some-id",
+          type: "audio",
+          name: "audio.mp3",
+          contentType: "audio/mp3",
+          status: { type: "complete" },
+          content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:audio/mp3;base64,QUJD",
+        mediaType: "audio/mp3",
+        filename: "audio.mp3",
+      },
+    ]);
+  });
 });

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -1,5 +1,5 @@
 import type { AppendMessage } from "@assistant-ui/core";
-import { parseDataUrl } from "@assistant-ui/core/internal";
+import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
 import type {
   CreateUIMessage,
   UIDataTypes,
@@ -69,10 +69,12 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
         // A data URL's own media type wins over `mediaType` downstream, so the
         // envelope is rebuilt from the typed format rather than forwarded.
         const mediaType = `audio/${part.audio.format}`;
-        const base64 = parseDataUrl(part.audio.data)?.data ?? part.audio.data;
+        const data = part.audio.data;
         return {
           type: "file",
-          url: `data:${mediaType};base64,${base64}`,
+          url: httpUrlPattern.test(data)
+            ? data
+            : `data:${mediaType};base64,${parseDataUrl(data)?.data ?? data}`,
           mediaType,
           ...(part.filename && { filename: part.filename }),
         };

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -1,4 +1,5 @@
 import type { AppendMessage } from "@assistant-ui/core";
+import { parseDataUrl } from "@assistant-ui/core/internal";
 import type {
   CreateUIMessage,
   UIDataTypes,
@@ -64,6 +65,18 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
           mediaType: part.mimeType,
           ...(part.filename && { filename: part.filename }),
         };
+      case "audio": {
+        // A data URL's own media type wins over `mediaType` downstream, so the
+        // envelope is rebuilt from the typed format rather than forwarded.
+        const mediaType = `audio/${part.audio.format}`;
+        const base64 = parseDataUrl(part.audio.data)?.data ?? part.audio.data;
+        return {
+          type: "file",
+          url: `data:${mediaType};base64,${base64}`,
+          mediaType,
+          ...(part.filename && { filename: part.filename }),
+        };
+      }
       case "data":
         return {
           type: `data-${part.name}`,


### PR DESCRIPTION
## summary

- `react-ai-sdk` and `eve` threw `Unsupported part type: audio` on `Unstable_AudioMessagePart`, so a part that react-langgraph, react-langchain, react-ag-ui, react-google-adk and react-a2a all forward crashed these two lanes instead. both now map it onto the adapter's own file part with an `audio/<format>` media type, the same shape #5223, #5220 and #5315 landed for the other adapters.
- `eve` also stops throwing on `DataMessagePart`: the converter moved from `map` to `flatMap` so data parts are skipped, matching react-langchain, react-google-adk and react-ag-ui (eve's wire has no data channel).
- the data URL envelope is rebuilt from the typed `format` rather than forwarded. the AI SDK's `convertPartToLanguageModelPart` lets a data URL's own media type win over `mediaType`, and a browser writes `audio/mpeg` for mp3, which upstream audio inputs reject. both packages sit on that path, since eve's `message` payload is an AI SDK `UserContent`.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 175/175 green (4 new: mp3, wav, envelope rebuild, attachment filename)
- [x] `pnpm --filter @assistant-ui/eve test` -> 16/16 green (4 new: mp3, wav, envelope rebuild, data part skipped)
- [x] `pnpm exec tsc --noEmit` in both packages -> eve clean, react-ai-sdk down to the pre-existing `src/generativeTools.test.ts(548,38)` error only
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both packages -> clean

### reviewer should verify

- [ ] send an audio attachment through a `useChatRuntime` app whose attachment adapter emits `{ type: "audio", audio: { data, format } }`, and confirm the request carries a `file` part with `mediaType: "audio/mp3"` instead of throwing.

## notes

- context is #5309 (content part follow-ups). this closes the two remaining adapter lanes of that parity work; the union simplification decision on the same issue is untouched.
- no exported types changed, so no api-surface regeneration.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.AW8N0VwxQ_MM3d2pa8DDmCl6Z-r56QPnxIfIhVDgMJtOQRfTxv9BcxF2hpo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->