### PR TITLE
fix(ui): handle url file parts in File download and size

### DIFF
--- a/apps/docs/content/docs/ui/file.mdx
+++ b/apps/docs/content/docs/ui/file.mdx
@@ -134,12 +134,16 @@ The component also exports utility functions:
 ```tsx
 import {
   getMimeTypeIcon,
+  getFileDataKind,
   getBase64Size,
   formatFileSize,
 } from "@/components/assistant-ui/file";
 
 // Get icon component for a MIME type
 const Icon = getMimeTypeIcon("application/pdf"); // FileTextIcon
+
+// Classify the data field of a file part
+const kind = getFileDataKind("https://example.com/report.pdf"); // "url"
 
 // Calculate size from base64 string
 const bytes = getBase64Size("SGVsbG8gV29ybGQh"); // 12

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -59,6 +59,14 @@ function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
   return FileIcon;
 }
 
+type FileDataKind = "data-uri" | "url" | "base64";
+
+function getFileDataKind(data: string): FileDataKind {
+  if (/^data:/i.test(data)) return "data-uri";
+  if (/^https?:\/\//i.test(data)) return "url";
+  return "base64";
+}
+
 function getBase64Size(base64: string): number {
   const commaIndex = base64.indexOf(",");
   const base64Data = commaIndex >= 0 ? base64.slice(commaIndex + 1) : base64;
@@ -168,13 +176,15 @@ function FileDownload({
   children,
   ...props
 }: FileDownloadProps) {
-  const href = /^data:/i.test(data) ? data : `data:${mimeType};base64,${data}`;
+  const kind = getFileDataKind(data);
+  const href = kind === "base64" ? `data:${mimeType};base64,${data}` : data;
 
   return (
     <a
       data-slot="file-download"
       href={href}
       download={filename || "download"}
+      {...(kind === "url" && { target: "_blank", rel: "noopener noreferrer" })}
       className={cn(
         "text-muted-foreground hover:bg-accent hover:text-accent-foreground shrink-0 rounded-md p-1 transition-colors",
         className,
@@ -187,14 +197,16 @@ function FileDownload({
 }
 
 const FileImpl: FileMessagePartComponent = ({ filename, data, mimeType }) => {
-  const bytes = getBase64Size(data);
+  const showSize = getFileDataKind(data) !== "url";
 
   return (
     <FileRoot>
       <FileIconDisplay mimeType={mimeType} />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <FileName>{filename}</FileName>
-        <FileSize bytes={bytes} className="text-xs" />
+        {showSize && (
+          <FileSize bytes={getBase64Size(data)} className="text-xs" />
+        )}
       </div>
       <FileDownload
         data={data}
@@ -229,6 +241,7 @@ export {
   FileDownload,
   fileVariants,
   getMimeTypeIcon,
+  getFileDataKind,
   getBase64Size,
   formatFileSize,
 };

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -59,7 +59,7 @@ function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
   return FileIcon;
 }
 
-type FileDataKind = "data-uri" | "url" | "base64";
+export type FileDataKind = "data-uri" | "url" | "base64";
 
 function getFileDataKind(data: string): FileDataKind {
   if (/^data:/i.test(data)) return "data-uri";


### PR DESCRIPTION
Closes #5442
## What

The `File` registry component now classifies `data` as data: URI, http(s) url, or raw base64. Urls become the download href directly and open in a new tab, and the size row is hidden for them since the byte count is unknowable. data: URI and base64 behavior is unchanged.

## Why

While rendering file parts coming out of react-ai-sdk (which maps `part.url` into `data`), the download link came out as `data:application/pdf;base64,https://...`, a malformed URI that downloads a corrupt file, and the size row showed the base64-decoded length of the url string ("31 B" for a 2 MB PDF). Cloud file attachments hit the same path via `CloudFileAttachmentAdapter`. 

## Impact

- Users of the `file` registry component get working download links and no bogus size for url-backed file parts.
- data: URI and raw base64 parts render byte-identical to before.
- New `getFileDataKind` utility exported alongside the existing helpers; docs utilities snippet updated in lockstep.

## Behavior

| `data` | href | size row |
|---|---|---|
| `data:application/pdf;base64,AAAA` | as-is (unchanged) | shown (unchanged) |
| `https://cdn/file.pdf` | `https://cdn/file.pdf`, new tab | hidden |
| `SGVsbG8=` | wrapped as data: URI (unchanged) | shown (unchanged) |

## Scope 

- `target="_blank" rel="noopener noreferrer"` applies only to the url branch: cross-origin the `download` attribute is ignored and a plain anchor would navigate the chat tab away. The `download` attribute is kept so same-origin urls still download. Attributes sit before the props spread so consumers can override.
- `image.tsx` already uses non-data: values directly as href, so this brings `file.tsx` in line with the sibling rather than inventing a new pattern.
- A `sourceType`-aware branch (e.g. `"id"` parts with no link) is deferred until #5439 lands; this PR only touches fields that already ship.
- `blob:` urls are not branched on: nothing writes them into `FileMessagePart.data` (they exist only as local preview object URLs).
- Tests: none added; `packages/ui` has zero test infrastructure package-wide, and adding vitest there is its own decision. Verified via typecheck, lint, full build, and the behavior table above.
- Additive only: no exports removed or reshaped.
- Changeset: none, `@assistant-ui/ui` is private; the registry picks the file up via `sourcePath` with unchanged dependencies.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IWrS4gH9bbdx2mekYbxAyfTRFXosWv-DQ1byMH1jRmwz2V66MOnLDGIrQgI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->