### PR TITLE
fix(react-langchain,react-langgraph): carry audio through file parts

### DIFF
--- a/.changeset/langchain-audio-file-blocks.md
+++ b/.changeset/langchain-audio-file-blocks.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: emit an audio block for base64 file parts with an audio media type

--- a/.changeset/langchain-audio-file-blocks.md
+++ b/.changeset/langchain-audio-file-blocks.md
@@ -3,4 +3,6 @@
 "@assistant-ui/react-langgraph": patch
 ---
 
-fix: emit an audio block for base64 file parts with an audio media type
+fix: carry audio through file message parts in both converter directions
+
+A `file` part with an audio media type now goes out as a LangChain `audio` block, so it reaches a provider's audio input instead of the document path. Inbound, an `audio` block now converts to a `file` part rather than `Unstable_AudioMessagePart`, which keeps the round trip stable, stops dropping audio on assistant messages, and stops dropping audio whose media type is neither mp3 nor wav. Code reading `Unstable_AudioMessagePart` from these converters should read `file` parts with an `audio/*` mime type instead.

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -565,11 +565,11 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "audio", audio: { data: "c291bmQ=", format: "mp3" } }],
+      content: [{ type: "file", data: "c291bmQ=", mimeType: "audio/mp3" }],
     });
   });
 
-  it("drops an inbound audio block with an unrepresentable mime type", () => {
+  it("keeps an inbound audio block whose mime type has no wire format", () => {
     const result = convertLangChainBaseMessage(
       {
         _getType: () => "human",
@@ -586,10 +586,13 @@ describe("contentToParts audio blocks", () => {
       {},
     );
 
-    expect(result).toMatchObject({ role: "user", content: [] });
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "file", data: "b2dn", mimeType: "audio/ogg" }],
+    });
   });
 
-  it("drops an audio block on an assistant message", () => {
+  it("keeps an audio block on an assistant message", () => {
     const result = convertLangChainBaseMessage(
       {
         _getType: () => "ai",
@@ -609,8 +612,43 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "assistant",
-      content: [{ type: "text", text: "done" }],
+      content: [
+        { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+        { type: "text", text: "done" },
+      ],
     });
+  });
+  it("round-trips an audio file part through both converters", () => {
+    const outbound = getMessageContent({
+      content: [
+        {
+          type: "file",
+          data: "data:audio/mpeg;base64,c291bmQ=",
+          mimeType: "audio/mpeg",
+          filename: "memo.mp3",
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    const inbound = convertLangChainBaseMessage(
+      {
+        _getType: () => "human",
+        id: "h1",
+        content: outbound as never,
+      },
+      {},
+    );
+
+    expect(contentOf(inbound)).toEqual([
+      { type: "text", text: " " },
+      { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+    ]);
+
+    expect(
+      getMessageContent({
+        content: contentOf(inbound),
+      } as unknown as AppendMessage),
+    ).toEqual(outbound);
   });
 });
 

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -393,6 +393,38 @@ describe("getMessageContent file blocks", () => {
     ).toMatchObject({ type: "file", source_type: "id" });
   });
 
+  it("does not treat inherited object keys as audio media types", () => {
+    for (const mimeType of ["__proto__", "constructor"]) {
+      expect(
+        getMessageContent(
+          appendMessage({
+            type: "file",
+            data: "ZmFrZQ==",
+            mimeType,
+            filename: "a.bin",
+          }),
+        )[1],
+      ).toMatchObject({ type: "file", mime_type: mimeType });
+    }
+  });
+
+  it("detects audio from the data URL envelope when the declared type is generic", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "data:audio/mpeg;base64,c291bmQ=",
+          mimeType: "application/octet-stream",
+        }),
+      )[1],
+    ).toEqual({
+      type: "audio",
+      data: "c291bmQ=",
+      mime_type: "audio/mp3",
+      source_type: "base64",
+    });
+  });
+
   it("leaves non-audio file parts as file blocks", () => {
     expect(
       getMessageContent(

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -546,6 +546,18 @@ describe("getMessageContent audio and data parts", () => {
 });
 
 describe("contentToParts audio blocks", () => {
+  const inboundAudioPart = (block: Record<string, unknown>) => {
+    const result = convertLangChainBaseMessage(
+      {
+        _getType: () => "human",
+        id: "h1",
+        content: [{ type: "audio", data: "c291bmQ=", ...block }],
+      },
+      {},
+    );
+    return contentOf(result)[0];
+  };
+
   it("converts an inbound base64 audio block back to an audio part", () => {
     const result = convertLangChainBaseMessage(
       {
@@ -565,7 +577,14 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "file", data: "c291bmQ=", mimeType: "audio/mp3" }],
+      content: [
+        {
+          type: "file",
+          filename: "audio.mp3",
+          data: "c291bmQ=",
+          mimeType: "audio/mp3",
+        },
+      ],
     });
   });
 
@@ -588,7 +607,14 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "file", data: "b2dn", mimeType: "audio/ogg" }],
+      content: [
+        {
+          type: "file",
+          filename: "audio.ogg",
+          data: "b2dn",
+          mimeType: "audio/ogg",
+        },
+      ],
     });
   });
 
@@ -613,7 +639,12 @@ describe("contentToParts audio blocks", () => {
     expect(result).toMatchObject({
       role: "assistant",
       content: [
-        { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+        {
+          type: "file",
+          filename: "audio.mp3",
+          data: "c291bmQ=",
+          mimeType: "audio/mp3",
+        },
         { type: "text", text: "done" },
       ],
     });
@@ -641,7 +672,12 @@ describe("contentToParts audio blocks", () => {
 
     expect(contentOf(inbound)).toEqual([
       { type: "text", text: " " },
-      { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+      {
+        type: "file",
+        filename: "audio.mp3",
+        data: "c291bmQ=",
+        mimeType: "audio/mp3",
+      },
     ]);
 
     expect(
@@ -649,6 +685,15 @@ describe("contentToParts audio blocks", () => {
         content: contentOf(inbound),
       } as unknown as AppendMessage),
     ).toEqual(outbound);
+  });
+  it("names an inbound audio attachment from its media subtype", () => {
+    expect(inboundAudioPart({ mime_type: "audio/wav" })).toMatchObject({
+      filename: "audio.wav",
+    });
+    expect(inboundAudioPart({})).toMatchObject({
+      filename: "audio",
+      mimeType: "application/octet-stream",
+    });
   });
 });
 

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -307,6 +307,104 @@ describe("getMessageContent file blocks", () => {
       },
     ]);
   });
+
+  it("emits an audio block for a base64 file part with an audio mime type", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "c291bmQ=",
+        mimeType: "audio/mp3",
+        filename: "memo.mp3",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "audio",
+        data: "c291bmQ=",
+        mime_type: "audio/mp3",
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("normalizes audio/mpeg and audio/x-wav to the accepted spellings", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "c291bmQ=",
+          mimeType: "audio/mpeg",
+        }),
+      )[1],
+    ).toMatchObject({ type: "audio", mime_type: "audio/mp3" });
+
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "c291bmQ=",
+          mimeType: "audio/x-wav",
+        }),
+      )[1],
+    ).toMatchObject({ type: "audio", mime_type: "audio/wav" });
+  });
+
+  it("strips the data URL envelope from an audio file part", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "data:audio/mpeg;base64,c291bmQ=",
+        mimeType: "audio/mp3",
+      }),
+    );
+
+    expect(content[1]).toEqual({
+      type: "audio",
+      data: "c291bmQ=",
+      mime_type: "audio/mp3",
+      source_type: "base64",
+    });
+  });
+
+  it("keeps url and id audio references as file blocks", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "https://cdn.example.com/memo.mp3",
+          mimeType: "audio/mp3",
+          filename: "memo.mp3",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", source_type: "url" });
+
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "file-abc123",
+          mimeType: "audio/mp3",
+          filename: "memo.mp3",
+          sourceType: "id",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", source_type: "id" });
+  });
+
+  it("leaves non-audio file parts as file blocks", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "ZmFrZQ==",
+          mimeType: "application/pdf",
+          filename: "a.pdf",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", mime_type: "application/pdf" });
+  });
 });
 
 describe("getMessageContent audio and data parts", () => {

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -213,13 +213,13 @@ export const convertLangChainBaseMessage = (
  * `audio` block. `langchain-openai`'s completions converter accepts exactly
  * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
  */
-const audioBlockMimeTypes: Record<string, "audio/mp3" | "audio/wav"> = {
-  "audio/mp3": "audio/mp3",
-  "audio/mpeg": "audio/mp3",
-  "audio/wav": "audio/wav",
-  "audio/wave": "audio/wav",
-  "audio/x-wav": "audio/wav",
-};
+const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
+  ["audio/mp3", "audio/mp3"],
+  ["audio/mpeg", "audio/mp3"],
+  ["audio/wav", "audio/wav"],
+  ["audio/wave", "audio/wav"],
+  ["audio/x-wav", "audio/wav"],
+]);
 
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
@@ -264,7 +264,9 @@ export const getMessageContent = (msg: AppendMessage) => {
           };
         }
         const parsed = parseDataUrl(part.data);
-        const audioMimeType = audioBlockMimeTypes[part.mimeType.toLowerCase()];
+        const audioMimeType = audioBlockMimeTypes.get(
+          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
+        );
         if (audioMimeType) {
           return {
             type: "audio" as const,

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -68,12 +68,18 @@ const contentToParts = (content: unknown) => {
               sourceType: part.source_type,
             }),
           };
-        case "audio":
+        case "audio": {
+          const mimeType = part.mime_type ?? "application/octet-stream";
+          const subtype = mimeType.startsWith("audio/")
+            ? mimeType.slice("audio/".length)
+            : undefined;
           return {
             type: "file" as const,
+            filename: subtype ? `audio.${subtype}` : "audio",
             data: part.data,
-            mimeType: part.mime_type ?? "application/octet-stream",
+            mimeType,
           };
+        }
         case "thinking":
           return { type: "reasoning" as const, text: part.thinking };
         case "reasoning":

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -208,6 +208,19 @@ export const convertLangChainBaseMessage = (
   }
 };
 
+/**
+ * Audio media types that reach a provider's audio input through the LangChain
+ * `audio` block. `langchain-openai`'s completions converter accepts exactly
+ * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
+ */
+const audioBlockMimeTypes: Record<string, "audio/mp3" | "audio/wav"> = {
+  "audio/mp3": "audio/mp3",
+  "audio/mpeg": "audio/mp3",
+  "audio/wav": "audio/wav",
+  "audio/wave": "audio/wav",
+  "audio/x-wav": "audio/wav",
+};
+
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
     ...msg.content,
@@ -251,6 +264,15 @@ export const getMessageContent = (msg: AppendMessage) => {
           };
         }
         const parsed = parseDataUrl(part.data);
+        const audioMimeType = audioBlockMimeTypes[part.mimeType.toLowerCase()];
+        if (audioMimeType) {
+          return {
+            type: "audio" as const,
+            data: parsed?.data ?? part.data,
+            mime_type: audioMimeType,
+            source_type: "base64" as const,
+          };
+        }
         return {
           type: "file" as const,
           data: parsed?.data ?? part.data,

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -208,8 +208,9 @@ export const convertLangChainBaseMessage = (
 
 /**
  * Audio media types that reach a provider's audio input through the LangChain
- * `audio` block. `langchain-openai`'s completions converter accepts exactly
- * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
+ * `audio` block. langchain-core derives OpenAI's `input_audio.format` by
+ * splitting `mime_type` on `/`, and that format is a wav-or-mp3 enum, so
+ * `audio/mpeg` passes the converter and is rejected at the provider.
  */
 const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
   ["audio/mp3", "audio/mp3"],

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -33,7 +33,7 @@ export const getMessageType = (message: LangChainBaseMessage): string => {
   throw new Error("Cannot determine message type");
 };
 
-const contentToParts = (content: unknown, role: "user" | "assistant") => {
+const contentToParts = (content: unknown) => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
 
@@ -68,20 +68,12 @@ const contentToParts = (content: unknown, role: "user" | "assistant") => {
               sourceType: part.source_type,
             }),
           };
-        case "audio": {
-          if (role !== "user") return null;
-          const format =
-            part.mime_type === "audio/wav"
-              ? ("wav" as const)
-              : part.mime_type === "audio/mp3"
-                ? ("mp3" as const)
-                : null;
-          if (!format) return null;
+        case "audio":
           return {
-            type: "audio" as const,
-            audio: { data: part.data, format },
+            type: "file" as const,
+            data: part.data,
+            mimeType: part.mime_type ?? "application/octet-stream",
           };
-        }
         case "thinking":
           return { type: "reasoning" as const, text: part.thinking };
         case "reasoning":
@@ -137,7 +129,7 @@ export const convertLangChainBaseMessage = (
       return {
         role: "user",
         id: message.id,
-        content: contentToParts(message.content, "user"),
+        content: contentToParts(message.content),
         metadata: {
           custom: getCustomMetadata(message.additional_kwargs),
         },
@@ -169,7 +161,7 @@ export const convertLangChainBaseMessage = (
         role: "assistant",
         id: message.id,
         content: [
-          ...contentToParts(message.content, "assistant"),
+          ...contentToParts(message.content),
           ...toolCallParts,
           ...uiDataParts,
         ],

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1266,6 +1266,18 @@ describe("getMessageContent audio and data parts", () => {
 });
 
 describe("contentToParts audio blocks", () => {
+  const inboundAudioPart = (block: Record<string, unknown>) => {
+    const result = convertLangChainMessagesImpl(
+      {
+        type: "human",
+        id: "h1",
+        content: [{ type: "audio", data: "c291bmQ=", ...block }],
+      } as never,
+      {},
+    );
+    return (result as unknown as { content: unknown[] }).content[0];
+  };
+
   it("converts an inbound base64 audio block back to an audio part", () => {
     const result = convertLangChainMessagesImpl(
       {
@@ -1285,7 +1297,14 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "file", data: "c291bmQ=", mimeType: "audio/mp3" }],
+      content: [
+        {
+          type: "file",
+          filename: "audio.mp3",
+          data: "c291bmQ=",
+          mimeType: "audio/mp3",
+        },
+      ],
     });
   });
 
@@ -1308,7 +1327,14 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "file", data: "b2dn", mimeType: "audio/ogg" }],
+      content: [
+        {
+          type: "file",
+          filename: "audio.ogg",
+          data: "b2dn",
+          mimeType: "audio/ogg",
+        },
+      ],
     });
   });
 
@@ -1333,7 +1359,12 @@ describe("contentToParts audio blocks", () => {
     expect(result).toMatchObject({
       role: "assistant",
       content: [
-        { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+        {
+          type: "file",
+          filename: "audio.mp3",
+          data: "c291bmQ=",
+          mimeType: "audio/mp3",
+        },
         { type: "text", text: "done" },
       ],
     });
@@ -1358,12 +1389,26 @@ describe("contentToParts audio blocks", () => {
     const content = (inbound as unknown as { content: unknown[] }).content;
     expect(content).toEqual([
       { type: "text", text: " " },
-      { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+      {
+        type: "file",
+        filename: "audio.mp3",
+        data: "c291bmQ=",
+        mimeType: "audio/mp3",
+      },
     ]);
 
     expect(getMessageContent({ content } as unknown as AppendMessage)).toEqual(
       outbound,
     );
+  });
+  it("names an inbound audio attachment from its media subtype", () => {
+    expect(inboundAudioPart({ mime_type: "audio/wav" })).toMatchObject({
+      filename: "audio.wav",
+    });
+    expect(inboundAudioPart({})).toMatchObject({
+      filename: "audio",
+      mimeType: "application/octet-stream",
+    });
   });
 });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -791,6 +791,38 @@ describe("getMessageContent file blocks", () => {
     ).toMatchObject({ type: "file", source_type: "id" });
   });
 
+  it("does not treat inherited object keys as audio media types", () => {
+    for (const mimeType of ["__proto__", "constructor"]) {
+      expect(
+        getMessageContent(
+          appendMessage({
+            type: "file",
+            data: "ZmFrZQ==",
+            mimeType,
+            filename: "a.bin",
+          }),
+        )[1],
+      ).toMatchObject({ type: "file", mime_type: mimeType });
+    }
+  });
+
+  it("detects audio from the data URL envelope when the declared type is generic", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "data:audio/mpeg;base64,c291bmQ=",
+          mimeType: "application/octet-stream",
+        }),
+      )[1],
+    ).toEqual({
+      type: "audio",
+      data: "c291bmQ=",
+      mime_type: "audio/mp3",
+      source_type: "base64",
+    });
+  });
+
   it("leaves non-audio file parts as file blocks", () => {
     expect(
       getMessageContent(

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -705,6 +705,104 @@ describe("getMessageContent file blocks", () => {
       },
     ]);
   });
+
+  it("emits an audio block for a base64 file part with an audio mime type", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "c291bmQ=",
+        mimeType: "audio/mp3",
+        filename: "memo.mp3",
+      }),
+    );
+
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      {
+        type: "audio",
+        data: "c291bmQ=",
+        mime_type: "audio/mp3",
+        source_type: "base64",
+      },
+    ]);
+  });
+
+  it("normalizes audio/mpeg and audio/x-wav to the accepted spellings", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "c291bmQ=",
+          mimeType: "audio/mpeg",
+        }),
+      )[1],
+    ).toMatchObject({ type: "audio", mime_type: "audio/mp3" });
+
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "c291bmQ=",
+          mimeType: "audio/x-wav",
+        }),
+      )[1],
+    ).toMatchObject({ type: "audio", mime_type: "audio/wav" });
+  });
+
+  it("strips the data URL envelope from an audio file part", () => {
+    const content = getMessageContent(
+      appendMessage({
+        type: "file",
+        data: "data:audio/mpeg;base64,c291bmQ=",
+        mimeType: "audio/mp3",
+      }),
+    );
+
+    expect(content[1]).toEqual({
+      type: "audio",
+      data: "c291bmQ=",
+      mime_type: "audio/mp3",
+      source_type: "base64",
+    });
+  });
+
+  it("keeps url and id audio references as file blocks", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "https://cdn.example.com/memo.mp3",
+          mimeType: "audio/mp3",
+          filename: "memo.mp3",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", source_type: "url" });
+
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "file-abc123",
+          mimeType: "audio/mp3",
+          filename: "memo.mp3",
+          sourceType: "id",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", source_type: "id" });
+  });
+
+  it("leaves non-audio file parts as file blocks", () => {
+    expect(
+      getMessageContent(
+        appendMessage({
+          type: "file",
+          data: "ZmFrZQ==",
+          mimeType: "application/pdf",
+          filename: "a.pdf",
+        }),
+      )[1],
+    ).toMatchObject({ type: "file", mime_type: "application/pdf" });
+  });
 });
 
 describe("convertLangChainMessages reasoning content", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1285,11 +1285,11 @@ describe("contentToParts audio blocks", () => {
 
     expect(result).toMatchObject({
       role: "user",
-      content: [{ type: "audio", audio: { data: "c291bmQ=", format: "mp3" } }],
+      content: [{ type: "file", data: "c291bmQ=", mimeType: "audio/mp3" }],
     });
   });
 
-  it("drops an inbound audio block with an unrepresentable mime type", () => {
+  it("keeps an inbound audio block whose mime type has no wire format", () => {
     const result = convertLangChainMessagesImpl(
       {
         type: "human",
@@ -1306,10 +1306,13 @@ describe("contentToParts audio blocks", () => {
       {},
     );
 
-    expect(result).toMatchObject({ role: "user", content: [] });
+    expect(result).toMatchObject({
+      role: "user",
+      content: [{ type: "file", data: "b2dn", mimeType: "audio/ogg" }],
+    });
   });
 
-  it("drops an audio block on an assistant message", () => {
+  it("keeps an audio block on an assistant message", () => {
     const result = convertLangChainMessagesImpl(
       {
         type: "ai",
@@ -1327,17 +1330,40 @@ describe("contentToParts audio blocks", () => {
       {},
     );
 
-    expect(result).toMatchObject({ role: "assistant" });
-    expect(
-      (result as { content: { type: string }[] }).content.some(
-        (part) => part.type === "audio",
-      ),
-    ).toBe(false);
-    expect(
-      (result as { content: { type: string }[] }).content.some(
-        (part) => part.type === "text",
-      ),
-    ).toBe(true);
+    expect(result).toMatchObject({
+      role: "assistant",
+      content: [
+        { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+        { type: "text", text: "done" },
+      ],
+    });
+  });
+  it("round-trips an audio file part through both converters", () => {
+    const outbound = getMessageContent({
+      content: [
+        {
+          type: "file",
+          data: "data:audio/mpeg;base64,c291bmQ=",
+          mimeType: "audio/mpeg",
+          filename: "memo.mp3",
+        },
+      ],
+    } as unknown as AppendMessage);
+
+    const inbound = convertLangChainMessagesImpl(
+      { type: "human", id: "h1", content: outbound } as never,
+      {},
+    );
+
+    const content = (inbound as unknown as { content: unknown[] }).content;
+    expect(content).toEqual([
+      { type: "text", text: " " },
+      { type: "file", data: "c291bmQ=", mimeType: "audio/mp3" },
+    ]);
+
+    expect(getMessageContent({ content } as unknown as AppendMessage)).toEqual(
+      outbound,
+    );
   });
 });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -332,6 +332,19 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
   }
 };
 
+/**
+ * Audio media types that reach a provider's audio input through the LangChain
+ * `audio` block. `langchain-openai`'s completions converter accepts exactly
+ * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
+ */
+const audioBlockMimeTypes: Record<string, "audio/mp3" | "audio/wav"> = {
+  "audio/mp3": "audio/mp3",
+  "audio/mpeg": "audio/mp3",
+  "audio/wav": "audio/wav",
+  "audio/wave": "audio/wav",
+  "audio/x-wav": "audio/wav",
+};
+
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
     ...msg.content,
@@ -375,6 +388,15 @@ export const getMessageContent = (msg: AppendMessage) => {
           };
         }
         const parsed = parseDataUrl(part.data);
+        const audioMimeType = audioBlockMimeTypes[part.mimeType.toLowerCase()];
+        if (audioMimeType) {
+          return {
+            type: "audio" as const,
+            data: parsed?.data ?? part.data,
+            mime_type: audioMimeType,
+            source_type: "base64" as const,
+          };
+        }
         return {
           type: "file" as const,
           data: parsed?.data ?? part.data,

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -331,8 +331,9 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
 
 /**
  * Audio media types that reach a provider's audio input through the LangChain
- * `audio` block. `langchain-openai`'s completions converter accepts exactly
- * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
+ * `audio` block. langchain-core derives OpenAI's `input_audio.format` by
+ * splitting `mime_type` on `/`, and that format is a wav-or-mp3 enum, so
+ * `audio/mpeg` passes the converter and is rejected at the provider.
  */
 const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
   ["audio/mp3", "audio/mp3"],

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -125,7 +125,6 @@ const contentToParts = (
   content: LangChainMessage["content"],
   metadata: LangGraphMessageConverterMetadata,
   messageId: string | undefined,
-  role: "user" | "assistant",
 ) => {
   if (typeof content === "string")
     return [{ type: "text" as const, text: content }];
@@ -166,20 +165,12 @@ const contentToParts = (
               }),
             };
 
-          case "audio": {
-            if (role !== "user") return null;
-            const format =
-              part.mime_type === "audio/wav"
-                ? ("wav" as const)
-                : part.mime_type === "audio/mp3"
-                  ? ("mp3" as const)
-                  : null;
-            if (!format) return null;
+          case "audio":
             return {
-              type: "audio" as const,
-              audio: { data: part.data, format },
+              type: "file" as const,
+              data: part.data,
+              mimeType: part.mime_type ?? "application/octet-stream",
             };
-          }
 
           case "thinking":
             return { type: "reasoning", text: part.thinking };
@@ -246,7 +237,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       return {
         role: "user",
         id: message.id,
-        content: contentToParts(message.content, metadata, message.id, "user"),
+        content: contentToParts(message.content, metadata, message.id),
         metadata: { custom: getCustomMetadata(message.additional_kwargs) },
         ...(attachments?.length ? { attachments } : {}),
       };
@@ -304,7 +295,7 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         role: "assistant",
         id: message.id,
         content: [
-          ...contentToParts(allContent, metadata, message.id, "assistant"),
+          ...contentToParts(allContent, metadata, message.id),
           ...toolCallParts,
           ...uiDataParts,
         ],

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -337,13 +337,13 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
  * `audio` block. `langchain-openai`'s completions converter accepts exactly
  * `audio/mp3` and `audio/wav`, so the spelling is normalized, not forwarded.
  */
-const audioBlockMimeTypes: Record<string, "audio/mp3" | "audio/wav"> = {
-  "audio/mp3": "audio/mp3",
-  "audio/mpeg": "audio/mp3",
-  "audio/wav": "audio/wav",
-  "audio/wave": "audio/wav",
-  "audio/x-wav": "audio/wav",
-};
+const audioBlockMimeTypes = new Map<string, "audio/mp3" | "audio/wav">([
+  ["audio/mp3", "audio/mp3"],
+  ["audio/mpeg", "audio/mp3"],
+  ["audio/wav", "audio/wav"],
+  ["audio/wave", "audio/wav"],
+  ["audio/x-wav", "audio/wav"],
+]);
 
 export const getMessageContent = (msg: AppendMessage) => {
   const allContent = [
@@ -388,7 +388,9 @@ export const getMessageContent = (msg: AppendMessage) => {
           };
         }
         const parsed = parseDataUrl(part.data);
-        const audioMimeType = audioBlockMimeTypes[part.mimeType.toLowerCase()];
+        const audioMimeType = audioBlockMimeTypes.get(
+          (parsed?.mimeType ?? part.mimeType).toLowerCase(),
+        );
         if (audioMimeType) {
           return {
             type: "audio" as const,

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -165,12 +165,18 @@ const contentToParts = (
               }),
             };
 
-          case "audio":
+          case "audio": {
+            const mimeType = part.mime_type ?? "application/octet-stream";
+            const subtype = mimeType.startsWith("audio/")
+              ? mimeType.slice("audio/".length)
+              : undefined;
             return {
               type: "file" as const,
+              filename: subtype ? `audio.${subtype}` : "audio",
               data: part.data,
-              mimeType: part.mime_type ?? "application/octet-stream",
+              mimeType,
             };
+          }
 
           case "thinking":
             return { type: "reasoning", text: part.thinking };


### PR DESCRIPTION
## summary

- a `file` message part carrying an audio media type now goes out as a LangChain `audio` block instead of a `file` block, so it reaches a provider's audio input (`langchain-openai` maps the audio block to OpenAI `input_audio`; a file block goes down the document path and never gets there).
- inbound, an `audio` block now converts to a `file` part instead of `Unstable_AudioMessagePart`. this is what keeps the round trip stable: `useLangGraphRuntime` stages the converted human message into its own list and renders it back through `contentToParts`, so an outbound-only change made the user's audio attachment vanish from their own message the moment they sent it (the default `Unstable_Audio` renderer is `() => null`) and dropped `filename`.
- two things stop being silently discarded as a result: an `audio` block on an assistant message (the old code returned null for `role !== "user"` because the assistant union has no audio member, while it does have `file`), and an `audio` block whose media type is neither mp3 nor wav.
- the wire spelling is normalized rather than forwarded. langchain-core derives OpenAI's `input_audio.format` by splitting `mime_type` on `/` (`block_translators/openai.py`), and that format is a wav-or-mp3 enum, so `audio/mpeg` (what a browser writes for mp3) would pass the converter and be rejected at the provider. `audio/mpeg`, `audio/x-wav` and `audio/wave` map onto the two accepted spellings; every other media type keeps the existing file block untouched.
- the remap applies only where a base64 file block would have been emitted. the wire union has no url or id variant of the audio block, so `sourceType: "url"` and `sourceType: "id"` references stay file blocks, as does an http(s) `data` value.

## breaking changes

- code reading `Unstable_AudioMessagePart` out of these two converters now receives `file` parts with an `audio/*` mime type. the outbound `Unstable_AudioMessagePart` branch is unchanged, so sending one still works; only the inbound shape moves.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-langchain test` -> 100/100 green
- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 228/228 green
- [x] both packages gain a round trip test asserting outbound -> inbound -> outbound is a fixed point and stays a `file` part, which is the exact regression an outbound-only change introduced
- [x] `pnpm exec tsc --noEmit` against a freshly built core: react-langchain clean; react-langgraph down from 4 pre-existing errors on `main` to the 2 in `useLangGraphRuntime.test.tsx` that are unrelated to this diff (the two `convertLangChainMessages.test.ts` cast errors are gone because the rewritten tests no longer need the cast)
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` on both packages -> clean

### reviewer should verify

- [ ] send a base64 audio attachment through a LangGraph server backed by an OpenAI audio model and confirm the request reaches `input_audio` rather than being treated as a document, and that the attachment stays visible in the sent message.

## notes

- context is #5309. this makes `{ type: "file", mimeType: "audio/*" }` the working audio carrier on the LangChain family, which is the precondition for deprecating `Unstable_AudioMessagePart` in favour of `file` plus a media type.
- a filename on an audio file part is not carried across the wire. the audio arm of `LangChainContentBlock` (`packages/react-langchain/src/types.ts`) is hand written here and declares no `metadata`, and widening it to emit a key upstream does not declare on its v0 audio block is the shape #4795 was closed for, so this stays as is. inbound synthesizes `audio.<subtype>` instead, matching what `partToCompleteAttachment` produced before, and the round trip is stable from the first hop onward.
- `contentToParts` loses its `role` parameter in both packages, which existed solely for the removed assistant-side audio guard.