### PR TITLE
feat(core,react-a2a,react-ag-ui,react-google-adk): honor sourceType "url" in remaining file converters

### DIFF
--- a/.changeset/file-source-type-adapter-parity.md
+++ b/.changeset/file-source-type-adapter-parity.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/react-a2a": patch
+"@assistant-ui/react-ag-ui": patch
+"@assistant-ui/react-google-adk": patch
+"@assistant-ui/core": patch
+---
+
+feat: honor sourceType "url" in a2a, ag-ui, and adk file converters

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1863,6 +1863,7 @@ declare function contentPartsToA2AParts(content: ReadonlyArray<{
   data?: unknown;
   mimeType?: string | undefined;
   filename?: string | undefined;
+  sourceType?: "url" | "id" | undefined;
   audio?: {
     data: string;
     format: string;

--- a/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/attachments/custom-adapter.mdx
@@ -491,7 +491,7 @@ In the adapter's `add`, call Uploadthing's client upload and read `url` from the
 
 ### Opaque file references (LangGraph / LangChain)
 
-When the backend resolves stored files itself and the browser never holds a usable URL, send the storage id instead: set `sourceType: "id"` on the file part in `send()`, and the LangChain-family runtimes emit a `source_type: "id"` block with the value in the `id` key. `sourceType: "url"` similarly forces a url block for non-http references. Other runtimes ignore the field.
+When the backend resolves stored files itself and the browser never holds a usable URL, send the storage id instead: set `sourceType: "id"` on the file part in `send()`, and the LangChain-family runtimes emit a `source_type: "id"` block with the value in the `id` key. `sourceType: "url"` similarly forces a url reference for non-http data and is honored by the LangChain-family, A2A, AG-UI, and Google ADK runtimes. `sourceType: "id"` is LangChain-family only; runtimes without the concept ignore the field.
 
 ```ts
 const content = [

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -62,7 +62,7 @@ export type FileMessagePart = {
   readonly filename?: string;
   readonly data: string;
   readonly mimeType: string;
-  /** How `data` goes on the wire: a url or id reference; omitted = inferred (http(s) → url, else base64). Honored by the LangChain-family runtimes; others ignore it. */
+  /** How `data` goes on the wire: a url or id reference; omitted = inferred (http(s) → url, else base64). "url" is honored by the LangChain-family, A2A, AG-UI, and Google ADK runtimes; "id" by the LangChain family only. */
   readonly sourceType?: "url" | "id";
   readonly parentId?: string;
 };

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -326,6 +326,52 @@ describe("contentPartsToA2AParts", () => {
     ]);
   });
 
+  it("honors sourceType url for non-http references", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "s3://bucket/report.pdf",
+        mimeType: "application/pdf",
+        filename: "report.pdf",
+        sourceType: "url",
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        url: "s3://bucket/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      },
+    ]);
+  });
+
+  it("treats non-http references as raw bytes without sourceType", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "s3://bucket/report.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+    expect(result).toEqual([
+      { raw: "s3://bucket/report.pdf", mediaType: "application/pdf" },
+    ]);
+  });
+
+  it("ignores sourceType id", () => {
+    const result = contentPartsToA2AParts([
+      {
+        type: "file",
+        data: "file-abc123",
+        mimeType: "application/pdf",
+        sourceType: "id",
+      },
+    ]);
+    expect(result).toEqual([
+      { raw: "file-abc123", mediaType: "application/pdf" },
+    ]);
+  });
+
   it("converts file parts with data URLs to raw bytes", () => {
     const result = contentPartsToA2AParts([
       {

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -95,6 +95,7 @@ export function contentPartsToA2AParts(
     data?: unknown;
     mimeType?: string | undefined;
     filename?: string | undefined;
+    sourceType?: "url" | "id" | undefined;
     audio?: { data: string; format: string } | undefined;
   }>,
   fallbackMimeType?: string,
@@ -123,7 +124,7 @@ export function contentPartsToA2AParts(
         case "file": {
           if (typeof part.data !== "string" || !part.data) return null;
           const declaredMimeType = part.mimeType || fallbackMimeType;
-          if (httpUrlPattern.test(part.data)) {
+          if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
             return {
               url: part.data,
               ...(declaredMimeType && { mediaType: declaredMimeType }),

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -161,12 +161,14 @@ function mediaTypeForMime(mimeType: string | undefined): MediaInputType {
 
 // Build an AG-UI multimodal source from a data URL, raw base64 payload, or an
 // http(s) URL. A `url` source may omit the mime type; a `data` source always
-// resolves one (falling back to application/octet-stream).
+// resolves one (falling back to application/octet-stream). An explicit
+// `sourceType: "url"` on the part forces the url leg for non-http references.
 function buildInputSource(
   value: string,
   declaredMimeType: string | undefined,
+  sourceType?: string,
 ): InputContentSource {
-  if (httpUrlPattern.test(value)) {
+  if (sourceType === "url" || httpUrlPattern.test(value)) {
     return declaredMimeType !== undefined
       ? { type: "url", value, mimeType: declaredMimeType }
       : { type: "url", value };
@@ -204,7 +206,11 @@ function toInputContent(
     if (data === undefined) return null;
     const declaredMimeType = getString(part, "mimeType") || fallbackMimeType;
     const filename = getString(part, "filename");
-    const source = buildInputSource(data, declaredMimeType);
+    const source = buildInputSource(
+      data,
+      declaredMimeType,
+      getString(part, "sourceType"),
+    );
     const metadata = filename !== undefined ? { filename } : undefined;
     switch (mediaTypeForMime(source.mimeType)) {
       case "image":
@@ -245,14 +251,18 @@ const mediaInputTypes = new Set(["image", "audio", "video", "document"]);
 // Inverse of buildInputSource.
 function inputSourceToString(
   value: unknown,
-): { value: string; mimeType?: string } | null {
+): { value: string; mimeType?: string; isUrl?: boolean } | null {
   if (!isObject(value)) return null;
   const sourceValue = getString(value, "value");
   if (sourceValue === undefined) return null;
   const mimeType = getString(value, "mimeType");
   const type = getString(value, "type");
   if (type === "url") {
-    return { value: sourceValue, ...(mimeType !== undefined && { mimeType }) };
+    return {
+      value: sourceValue,
+      isUrl: true,
+      ...(mimeType !== undefined && { mimeType }),
+    };
   }
   if (type === "data") {
     const resolvedMimeType = mimeType ?? "application/octet-stream";
@@ -337,6 +347,7 @@ function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
           type: "file",
           data: source.value,
           mimeType,
+          ...(source.isUrl && { sourceType: "url" as const }),
           ...(filename !== undefined && { filename }),
         },
       ],

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -1063,6 +1063,121 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
+  it("honors sourceType url for non-http file references", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "file",
+            name: "report.pdf",
+            content: [
+              {
+                type: "file",
+                data: "s3://bucket/report.pdf",
+                mimeType: "application/pdf",
+                filename: "report.pdf",
+                sourceType: "url",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "document",
+          source: {
+            type: "url",
+            value: "s3://bucket/report.pdf",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "report.pdf" },
+        },
+      ],
+    });
+    expect((result[0] as any).content[0].source).not.toHaveProperty("data");
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
+  });
+
+  it("routes non-http file references to a data source without sourceType", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [],
+        attachments: [
+          {
+            id: "a-1",
+            type: "file",
+            name: "report.pdf",
+            content: [
+              {
+                type: "file",
+                data: "s3://bucket/report.pdf",
+                mimeType: "application/pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    expect((result[0] as any).content[0].source).toMatchObject({
+      type: "data",
+      value: "s3://bucket/report.pdf",
+    });
+  });
+
+  it("stamps sourceType url on restored url file parts so they round-trip", () => {
+    const restored = fromAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: {
+              type: "url",
+              value: "s3://bucket/spec.pdf",
+              mimeType: "application/pdf",
+            },
+            metadata: { filename: "spec.pdf" },
+          },
+        ],
+      },
+    ]);
+
+    expect(restored[0]).toMatchObject({
+      role: "user",
+      attachments: [
+        {
+          type: "document",
+          content: [
+            {
+              type: "file",
+              data: "s3://bucket/spec.pdf",
+              mimeType: "application/pdf",
+              sourceType: "url",
+            },
+          ],
+        },
+      ],
+    });
+
+    const resent = toAgUiMessages([restored[0]] as any);
+    expect((resent[0] as any).content[0].source).toMatchObject({
+      type: "url",
+      value: "s3://bucket/spec.pdf",
+    });
+  });
+
   it("restores a document input part as a user attachment", () => {
     const result = fromAgUiMessages([
       {

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -26,6 +26,52 @@ describe("convertAdkMessage - human messages", () => {
     });
   });
 
+  it("restores a file_url part as a file part stamped with sourceType url", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [
+        {
+          type: "file_url",
+          url: "gs://bucket/report.pdf",
+          mimeType: "application/pdf",
+        },
+      ],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          data: "gs://bucket/report.pdf",
+          mimeType: "application/pdf",
+          sourceType: "url",
+        },
+      ],
+    });
+  });
+
+  it("falls back to application/octet-stream for file_url parts without mimeType", () => {
+    const msg: AdkMessage = {
+      id: "m1",
+      type: "human",
+      content: [{ type: "file_url", url: "gs://bucket/blob" }],
+    };
+    const result = convertAdkMessage(msg, {});
+    expect(result).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "file",
+          data: "gs://bucket/blob",
+          mimeType: "application/octet-stream",
+          sourceType: "url",
+        },
+      ],
+    });
+  });
+
   it("restores an audio/mp3 file part as an audio message part", () => {
     const msg: AdkMessage = {
       id: "m1",

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -8,7 +8,13 @@ type ContentPart =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }
   | { type: "image"; image: string }
-  | { type: "file"; data: string; mimeType: string; filename?: string }
+  | {
+      type: "file";
+      data: string;
+      mimeType: string;
+      filename?: string;
+      sourceType?: "url";
+    }
   | { type: "audio"; audio: { data: string; format: "mp3" | "wav" } }
   | { type: "data"; name: string; data: unknown };
 
@@ -53,6 +59,14 @@ const contentToParts = (
           };
         }
         case "file_url":
+          if (role === "user") {
+            return {
+              type: "file",
+              data: part.url,
+              mimeType: part.mimeType ?? "application/octet-stream",
+              sourceType: "url",
+            };
+          }
           return {
             type: "data",
             name: "file_url",

--- a/packages/react-google-adk/src/useAdkRuntime.test.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.test.ts
@@ -4,6 +4,7 @@ import {
   getPendingCancellations,
   getPendingToolCalls,
 } from "./useAdkRuntime";
+import { convertAdkMessage } from "./convertAdkMessages";
 import type { AppendMessage } from "@assistant-ui/core";
 import type { AdkMessage } from "./types";
 
@@ -206,6 +207,89 @@ describe("getMessageContent", () => {
     );
     expect(result).toEqual([
       { type: "file", mimeType: "application/pdf", data: "AAAA" },
+    ]);
+  });
+
+  it("emits a file_url part for file parts with sourceType url", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          mimeType: "application/pdf",
+          data: "gs://bucket/report.pdf",
+          filename: "report.pdf",
+          sourceType: "url",
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      {
+        type: "file_url",
+        url: "gs://bucket/report.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("keeps file parts inline without sourceType", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          mimeType: "application/pdf",
+          data: "gs://bucket/report.pdf",
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      {
+        type: "file",
+        mimeType: "application/pdf",
+        data: "gs://bucket/report.pdf",
+      },
+    ]);
+  });
+
+  it("round-trips a file_url part through convert and edit-resend", () => {
+    const converted = convertAdkMessage(
+      {
+        id: "m1",
+        type: "human",
+        content: [
+          {
+            type: "file_url",
+            url: "gs://bucket/report.pdf",
+            mimeType: "application/pdf",
+          },
+        ],
+      },
+      {},
+    );
+    const content = (converted as { content: AppendMessage["content"] })
+      .content;
+    const result = getMessageContent(makeAppendMessage(content));
+    expect(result).toEqual([
+      {
+        type: "file_url",
+        url: "gs://bucket/report.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("ignores sourceType id on file parts", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          mimeType: "application/pdf",
+          data: "file-abc123",
+          sourceType: "id",
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      { type: "file", mimeType: "application/pdf", data: "file-abc123" },
     ]);
   });
 

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -50,6 +50,13 @@ export const getMessageContent = (msg: AppendMessage) => {
       case "image":
         return { type: "image_url" as const, url: part.image };
       case "file":
+        if (part.sourceType === "url") {
+          return {
+            type: "file_url" as const,
+            url: part.data,
+            mimeType: part.mimeType,
+          };
+        }
         return {
           type: "file" as const,
           mimeType: part.mimeType,


### PR DESCRIPTION
## What

- react-a2a and react-ag-ui: `sourceType: "url"` forces the protocol's url source for non-http(s) references (s3://, gs://, signed schemes) instead of falling through to the bytes leg.
- react-google-adk: file parts with `sourceType: "url"` now go out as `fileData.fileUri` (the `file_url` leg existed but was unreachable outbound), and user-role `file_url` parts convert back to file parts stamped `sourceType: "url"` so the reference stays visible and survives edit-resend.
- react-ag-ui inbound: url sources restored from snapshots stamp `sourceType: "url"` on the file part so a resend round-trips instead of getting base64-mislabeled.
- core: the `FileMessagePart.sourceType` JSDoc and the attachments docs page now state the actual runtime coverage.

## Why

#5439 (from #4792) added the opt-in to core but only taught the LangChain-family converters to honor it. These three protocols each have a native url leg, so per the cross-runtime parity rule the flag should work there too. While checking ADK I found it never takes its `fileData.fileUri` leg at all, even though gs:// references are the native use case for it in the Gemini API.

## Impact

- Zero behavior change without `sourceType` set: every existing sniff path is untouched, the flag only adds a branch ahead of it.
- Users of these three adapters can now send storage references the backend resolves, same as LangChain/LangGraph since #5439.

## Scope 

- `sourceType: "id"` stays LangChain-family only: none of these three protocols has a file-id concept, so the flag passes through ignored (existing behavior). Tests pin this per adapter.
- ADK deliberately gets no new http(s) sniff: it has never sniffed, and silently rerouting existing http-in-data payloads from `inlineData` to `fileData` would change current users' wire. Divergence from the sniffing adapters is intentional.
- ADK drops `filename` on the `file_url` leg: the published part type has no filename field and I did not want to widen it here.
- ADK assistant-role `file_url` parts keep the existing data-part mapping; only user-role parts changed, so model-output `fileData` rendering is untouched.
- Rare behavior change: a user-role `file_url` loaded from an ADK session used to surface as a `data` part named `file_url`; it now surfaces as a renderable file part. Without this, an opted-in url file was invisible in the user's bubble and silently dropped on edit-resend.
- react-a2a needs no inbound stamp: it never produces file parts inbound.
- The stamp covers file parts only: an `s3://` file with an image mime routes through the image branch, and `ImageMessagePart` has no `sourceType` in core, so it still base64-mislabels on resend; same limitation as the LangChain adapters from #5439.
- react-ai-sdk and eve are unaffected: their file converters forward `data` verbatim with no sniff.
- Additive only: the one api-surface change is an optional field on a2a's exported converter param type.
- Tests: outbound forced-url, no-flag fall-through, and ignored-id per adapter; ag-ui also covers the inbound stamp, a full snapshot round-trip, and wire validity via `UserMessageSchema.parse`.
- Changeset: patch (react-a2a, react-ag-ui, react-google-adk, core).



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.LV06T1fZkkXDE_St3tp6nf7bOaKZcgNYx-7geQoj216k9m2M-tmwpH0kMTs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->