### PR TITLE
feat(docs): open source project index at /oss

### DIFF
--- a/apps/docs/app/(home)/oss.json/route.ts
+++ b/apps/docs/app/(home)/oss.json/route.ts
@@ -1,0 +1,30 @@
+import { BASE_URL } from "@/lib/constants";
+import {
+  OSS_CATEGORIES,
+  OSS_PROJECTS,
+  ossPrimaryUrl,
+  ossRepoUrl,
+} from "@/lib/oss";
+
+export const revalidate = false;
+
+const absolute = (url: string) =>
+  url.startsWith("http") ? url : BASE_URL + url;
+
+export function GET() {
+  const body = {
+    organization: "assistant-ui",
+    categories: OSS_CATEGORIES,
+    projects: OSS_PROJECTS.map((project) => ({
+      ...project,
+      url: absolute(ossPrimaryUrl(project)),
+      repoUrl: ossRepoUrl(project),
+      ...(project.docs ? { docs: absolute(project.docs) } : {}),
+      ...(project.site ? { site: absolute(project.site) } : {}),
+    })),
+  };
+
+  return Response.json(body, {
+    headers: { "Cache-Control": "public, max-age=0, s-maxage=3600" },
+  });
+}

--- a/apps/docs/app/(home)/oss.json/route.ts
+++ b/apps/docs/app/(home)/oss.json/route.ts
@@ -2,6 +2,7 @@ import { BASE_URL } from "@/lib/constants";
 import {
   OSS_CATEGORIES,
   OSS_PROJECTS,
+  ossNpmUrl,
   ossPrimaryUrl,
   ossRepoUrl,
 } from "@/lib/oss";
@@ -21,6 +22,10 @@ export function GET() {
       repoUrl: ossRepoUrl(project),
       ...(project.docs ? { docs: absolute(project.docs) } : {}),
       ...(project.site ? { site: absolute(project.site) } : {}),
+      ...(project.npm ? { npmUrl: ossNpmUrl(project.npm) } : {}),
+      ...(project.pypi
+        ? { pypiUrl: `https://pypi.org/project/${project.pypi}/` }
+        : {}),
     })),
   };
 

--- a/apps/docs/app/(home)/oss/page.tsx
+++ b/apps/docs/app/(home)/oss/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight } from "lucide-react";
+import {
+  OSS_CATEGORIES,
+  OSS_PROJECTS,
+  fetchOssStats,
+  ossPrimaryUrl,
+  type OssCategory,
+  type OssProject,
+  type OssStats,
+} from "@/lib/oss";
+import { formatCompact } from "@/lib/format";
+import { createOgMetadata } from "@/lib/og";
+
+const title = "Open source";
+const description =
+  "Every open source project from the assistant-ui organization, with links to its docs, source, and packages.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  ...createOgMetadata(title, description),
+};
+
+export default async function OssPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ refresh?: string }>;
+}) {
+  const forceFresh = (await searchParams).refresh === "true";
+  const stats = await fetchOssStats(forceFresh ? 0 : undefined);
+
+  const grouped = groupByCategory(OSS_PROJECTS);
+  const visibleCategories = (
+    Object.keys(OSS_CATEGORIES) as OssCategory[]
+  ).filter((category) => (grouped[category]?.length ?? 0) > 0);
+
+  const headline = [
+    stats.totalStars > 0
+      ? `${formatCompact(stats.totalStars)} stars on GitHub`
+      : null,
+    stats.totalWeekly > 0
+      ? `${formatCompact(stats.totalWeekly)} downloads a week`
+      : null,
+  ].filter((fact): fact is string => fact !== null);
+
+  return (
+    <main className="mx-auto w-full max-w-7xl px-4 pt-20 pb-32 md:pt-32">
+      <header className="max-w-3xl">
+        <h1 className="text-4xl font-medium tracking-tight text-balance md:text-6xl">
+          Everything we build, in the open.
+        </h1>
+        <p className="text-muted-foreground mt-6 max-w-2xl text-lg leading-relaxed md:text-xl">
+          {OSS_PROJECTS.length} projects across the assistant-ui organization,
+          from the chat runtime to the primitives we extracted along the way.
+        </p>
+        {headline.length > 0 ? (
+          <p className="text-muted-foreground/70 mt-8 text-sm tabular-nums">
+            {headline.join(" · ")}
+          </p>
+        ) : null}
+      </header>
+
+      <div className="mt-24 flex flex-col gap-16 md:mt-32">
+        {visibleCategories.map((category) => (
+          <section
+            key={category}
+            className="md:grid md:grid-cols-[180px_minmax(0,1fr)] md:gap-12"
+          >
+            <h2 className="text-muted-foreground mb-4 text-sm md:mb-0 md:pt-5">
+              {OSS_CATEGORIES[category].label}
+            </h2>
+            <div className="flex flex-col">
+              {grouped[category]!.map((project) => (
+                <ProjectRow key={project.id} project={project} stats={stats} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <footer className="mt-32">
+        <Link
+          href="/packages"
+          className="text-muted-foreground hover:text-foreground group inline-flex items-center gap-1.5 text-sm transition-colors"
+        >
+          Every package we publish on npm
+          <ArrowUpRight className="size-3.5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </Link>
+      </footer>
+    </main>
+  );
+}
+
+function ProjectRow({
+  project,
+  stats,
+}: {
+  project: OssProject;
+  stats: OssStats;
+}) {
+  const stars = project.path ? 0 : (stats.stars[project.repo] ?? 0);
+  const weekly = project.npm ? (stats.weekly[project.npm] ?? 0) : 0;
+  const stat =
+    stars > 0
+      ? `${formatCompact(stars)} stars`
+      : weekly > 0
+        ? `${formatCompact(weekly)} / week`
+        : null;
+
+  const href = ossPrimaryUrl(project);
+  const external = href.startsWith("http");
+  const className =
+    "group hover:bg-muted/40 -mx-3 flex flex-col gap-1 rounded-lg px-3 py-5 transition-colors md:flex-row md:items-baseline md:gap-8";
+  const content = (
+    <>
+      <span className="flex items-center gap-1.5 font-medium md:w-72 md:flex-shrink-0">
+        {project.name}
+        <ArrowUpRight className="size-3.5 opacity-0 transition-opacity group-hover:opacity-50" />
+      </span>
+      <span className="text-muted-foreground flex-1 text-sm md:text-base">
+        {project.description}
+      </span>
+      {stat ? (
+        <span className="text-muted-foreground/60 text-sm tabular-nums">
+          {stat}
+        </span>
+      ) : null}
+    </>
+  );
+
+  return external ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+    >
+      {content}
+    </a>
+  ) : (
+    <Link href={href} className={className}>
+      {content}
+    </Link>
+  );
+}
+
+function groupByCategory(
+  projects: OssProject[],
+): Record<OssCategory, OssProject[]> {
+  const result = {} as Record<OssCategory, OssProject[]>;
+  for (const project of projects) {
+    const list = result[project.category] ?? [];
+    list.push(project);
+    result[project.category] = list;
+  }
+  return result;
+}

--- a/apps/docs/app/(home)/oss/page.tsx
+++ b/apps/docs/app/(home)/oss/page.tsx
@@ -23,27 +23,13 @@ export const metadata: Metadata = {
   ...createOgMetadata(title, description),
 };
 
-export default async function OssPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ refresh?: string }>;
-}) {
-  const forceFresh = (await searchParams).refresh === "true";
-  const stats = await fetchOssStats(forceFresh ? 0 : undefined);
+export default async function OssPage() {
+  const stats = await fetchOssStats();
 
   const grouped = groupByCategory(OSS_PROJECTS);
   const visibleCategories = (
     Object.keys(OSS_CATEGORIES) as OssCategory[]
   ).filter((category) => (grouped[category]?.length ?? 0) > 0);
-
-  const headline = [
-    stats.totalStars > 0
-      ? `${formatCompact(stats.totalStars)} stars on GitHub`
-      : null,
-    stats.totalWeekly > 0
-      ? `${formatCompact(stats.totalWeekly)} downloads a week`
-      : null,
-  ].filter((fact): fact is string => fact !== null);
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 pt-20 pb-32 md:pt-32">
@@ -55,11 +41,6 @@ export default async function OssPage({
           {OSS_PROJECTS.length} projects across the assistant-ui organization,
           from the chat runtime to the primitives we extracted along the way.
         </p>
-        {headline.length > 0 ? (
-          <p className="text-muted-foreground/70 mt-8 text-sm tabular-nums">
-            {headline.join(" · ")}
-          </p>
-        ) : null}
       </header>
 
       <div className="mt-24 flex flex-col gap-16 md:mt-32">

--- a/apps/docs/components/shared/footer.tsx
+++ b/apps/docs/components/shared/footer.tsx
@@ -32,6 +32,7 @@ const FOOTER_LINKS: Record<string, FooterLinkItem[]> = {
     { label: "Examples", href: "/examples" },
     { label: "Showcase", href: "/showcase" },
     { label: "Traction", href: "/traction" },
+    { label: "Open source", href: "/oss" },
     { label: "Packages", href: "/packages" },
     { label: "Blog", href: "/blog" },
   ],

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -165,6 +165,12 @@ export const NAV_ITEMS: NavItem[] = [
         label: "Open source",
         items: [
           {
+            label: "All projects",
+            href: "/oss",
+            description: "Everything we build in the open",
+            external: false,
+          },
+          {
             label: "GitHub",
             href: "https://github.com/assistant-ui/assistant-ui",
             description: "Star us on GitHub",

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -37,10 +37,11 @@ async function ghFetch(
   path: string,
   revalidate: number,
   init?: RequestInit & { headers?: Record<string, string> },
+  base: string = API_BASE,
 ): Promise<Response> {
   const { next: initNext, ...rest } = init ?? {};
   const cache = cacheInit(revalidate);
-  return fetch(`${API_BASE}${path}`, {
+  return fetch(`${base}${path}`, {
     ...rest,
     headers: ghHeaders(init?.headers),
     ...("next" in cache
@@ -64,9 +65,15 @@ export type RepoStats = {
 
 export async function getRepo(
   revalidate: number = REVALIDATE.WARM,
+  fullName: string = REPO,
 ): Promise<RepoStats | null> {
   try {
-    const res = await ghFetch("", revalidate);
+    const res = await ghFetch(
+      "",
+      revalidate,
+      undefined,
+      `https://api.github.com/repos/${fullName}`,
+    );
     if (!res.ok) return null;
     const data = await res.json();
     if (typeof data?.stargazers_count !== "number") return null;
@@ -76,25 +83,6 @@ export async function getRepo(
       openIssues: data.open_issues_count,
       watchers: data.subscribers_count,
     };
-  } catch {
-    return null;
-  }
-}
-
-export async function getRepoStars(
-  fullName: string,
-  revalidate: number = REVALIDATE.WARM,
-): Promise<number | null> {
-  try {
-    const res = await fetch(`https://api.github.com/repos/${fullName}`, {
-      headers: ghHeaders(),
-      ...cacheInit(revalidate),
-    });
-    if (!res.ok) return null;
-    const data = await res.json();
-    return typeof data?.stargazers_count === "number"
-      ? data.stargazers_count
-      : null;
   } catch {
     return null;
   }

--- a/apps/docs/lib/github.ts
+++ b/apps/docs/lib/github.ts
@@ -81,6 +81,25 @@ export async function getRepo(
   }
 }
 
+export async function getRepoStars(
+  fullName: string,
+  revalidate: number = REVALIDATE.WARM,
+): Promise<number | null> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${fullName}`, {
+      headers: ghHeaders(),
+      ...cacheInit(revalidate),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return typeof data?.stargazers_count === "number"
+      ? data.stargazers_count
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export type GitHubRelease = {
   draft: boolean;
   prerelease: boolean;

--- a/apps/docs/lib/oss.ts
+++ b/apps/docs/lib/oss.ts
@@ -1,5 +1,6 @@
-import { getRepoStars } from "./github";
-import { getWeeklyDownloads } from "./npm";
+import { REVALIDATE, getRepo } from "./github";
+import { NPM_REVALIDATE, getWeeklyDownloads } from "./npm";
+import { PACKAGES } from "./traction";
 
 export const OSS_MONOREPO = "assistant-ui/assistant-ui";
 
@@ -55,11 +56,14 @@ export const OSS_CATEGORIES: Record<
   },
 };
 
-export const OSS_PROJECTS: OssProject[] = [
+type OssProjectInput = Omit<OssProject, "description"> & {
+  description?: string;
+};
+
+const OSS_PROJECT_INPUTS: OssProjectInput[] = [
   {
     id: "assistant-ui",
     name: "assistant-ui",
-    description: "TypeScript and React library for AI chat.",
     category: "sdk",
     repo: OSS_MONOREPO,
     docs: "/docs",
@@ -69,7 +73,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "tap",
     name: "@assistant-ui/tap",
-    description: "Zero-dependency reactive primitives.",
     category: "libraries",
     repo: OSS_MONOREPO,
     path: "packages/tap",
@@ -80,7 +83,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "store",
     name: "@assistant-ui/store",
-    description: "Tap-based state management.",
     category: "libraries",
     repo: OSS_MONOREPO,
     path: "packages/store",
@@ -91,7 +93,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "assistant-stream",
     name: "assistant-stream",
-    description: "Streaming utilities for AI assistants.",
     category: "libraries",
     repo: OSS_MONOREPO,
     path: "packages/assistant-stream",
@@ -138,7 +139,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "tw-shimmer",
     name: "tw-shimmer",
-    description: "Tailwind v4 plugin for shimmer effects.",
     category: "primitives",
     repo: OSS_MONOREPO,
     path: "packages/tw-shimmer",
@@ -149,7 +149,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "tw-glass",
     name: "tw-glass",
-    description: "Tailwind v4 plugin for glass refraction effects.",
     category: "primitives",
     repo: OSS_MONOREPO,
     path: "packages/tw-glass",
@@ -160,7 +159,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "heat-graph",
     name: "heat-graph",
-    description: "Headless React components for activity heatmaps.",
     category: "primitives",
     repo: OSS_MONOREPO,
     path: "packages/heat-graph",
@@ -171,7 +169,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "safe-content-frame",
     name: "safe-content-frame",
-    description: "Secure iframe rendering for untrusted content.",
     category: "primitives",
     repo: OSS_MONOREPO,
     path: "packages/safe-content-frame",
@@ -190,7 +187,6 @@ export const OSS_PROJECTS: OssProject[] = [
   {
     id: "mcp-docs-server",
     name: "@assistant-ui/mcp-docs-server",
-    description: "MCP server exposing assistant-ui docs.",
     category: "agents",
     repo: OSS_MONOREPO,
     path: "packages/mcp-docs-server",
@@ -206,6 +202,22 @@ export const OSS_PROJECTS: OssProject[] = [
     license: null,
   },
 ];
+
+function describe(project: OssProjectInput): string {
+  if (project.description) return project.description;
+  const pkg = PACKAGES.find((entry) => entry.name === project.npm);
+  if (!pkg) {
+    throw new Error(
+      `OSS project "${project.id}" has no description and no matching package in PACKAGES.`,
+    );
+  }
+  return pkg.description;
+}
+
+export const OSS_PROJECTS: OssProject[] = OSS_PROJECT_INPUTS.map((project) => ({
+  ...project,
+  description: describe(project),
+}));
 
 export function ossRepoUrl(project: OssProject): string {
   return project.path
@@ -224,11 +236,9 @@ export function ossNpmUrl(pkg: string): string {
 export type OssStats = {
   stars: Record<string, number>;
   weekly: Record<string, number>;
-  totalStars: number;
-  totalWeekly: number;
 };
 
-export async function fetchOssStats(revalidate?: number): Promise<OssStats> {
+export async function fetchOssStats(): Promise<OssStats> {
   const repos = [
     ...new Set(
       OSS_PROJECTS.filter((project) => !project.path).map(
@@ -247,32 +257,32 @@ export async function fetchOssStats(revalidate?: number): Promise<OssStats> {
   const [repoEntries, packageEntries] = await Promise.all([
     Promise.all(
       repos.map(
-        async (repo) => [repo, await getRepoStars(repo, revalidate)] as const,
+        async (repo) =>
+          [
+            repo,
+            (await getRepo(REVALIDATE.WARM, repo))?.stars ?? null,
+          ] as const,
       ),
     ),
     Promise.all(
       packages.map(
         async (name) =>
-          [name, await getWeeklyDownloads(name, revalidate)] as const,
+          [name, await getWeeklyDownloads(name, NPM_REVALIDATE.WARM)] as const,
       ),
     ),
   ]);
 
   const stars: Record<string, number> = {};
-  let totalStars = 0;
   for (const [repo, count] of repoEntries) {
     if (count === null) continue;
     stars[repo] = count;
-    totalStars += count;
   }
 
   const weekly: Record<string, number> = {};
-  let totalWeekly = 0;
   for (const [name, count] of packageEntries) {
     if (count === null) continue;
     weekly[name] = count;
-    totalWeekly += count;
   }
 
-  return { stars, weekly, totalStars, totalWeekly };
+  return { stars, weekly };
 }

--- a/apps/docs/lib/oss.ts
+++ b/apps/docs/lib/oss.ts
@@ -1,0 +1,278 @@
+import { getRepoStars } from "./github";
+import { getWeeklyDownloads } from "./npm";
+
+export const OSS_MONOREPO = "assistant-ui/assistant-ui";
+
+export type OssCategory =
+  | "sdk"
+  | "libraries"
+  | "apps"
+  | "primitives"
+  | "agents"
+  | "infrastructure";
+
+export type OssProject = {
+  id: string;
+  name: string;
+  description: string;
+  category: OssCategory;
+  repo: string;
+  path?: string;
+  docs?: string;
+  site?: string;
+  npm?: string;
+  pypi?: string;
+  license: string | null;
+};
+
+export const OSS_CATEGORIES: Record<
+  OssCategory,
+  { label: string; description: string }
+> = {
+  sdk: {
+    label: "Core SDK",
+    description: "The chat runtime and everything that ships with it.",
+  },
+  libraries: {
+    label: "Libraries",
+    description: "Standalone libraries with their own release cycle.",
+  },
+  apps: {
+    label: "Applications",
+    description: "Complete products, open sourced end to end.",
+  },
+  primitives: {
+    label: "Primitives",
+    description: "Small packages we extracted along the way.",
+  },
+  agents: {
+    label: "Agent tooling",
+    description: "What coding agents use to build with assistant-ui.",
+  },
+  infrastructure: {
+    label: "Infrastructure",
+    description: "Services that run behind an assistant.",
+  },
+};
+
+export const OSS_PROJECTS: OssProject[] = [
+  {
+    id: "assistant-ui",
+    name: "assistant-ui",
+    description: "TypeScript and React library for AI chat.",
+    category: "sdk",
+    repo: OSS_MONOREPO,
+    docs: "/docs",
+    npm: "@assistant-ui/react",
+    license: "MIT",
+  },
+  {
+    id: "tap",
+    name: "@assistant-ui/tap",
+    description: "Zero-dependency reactive primitives.",
+    category: "libraries",
+    repo: OSS_MONOREPO,
+    path: "packages/tap",
+    docs: "/tap/docs",
+    npm: "@assistant-ui/tap",
+    license: "MIT",
+  },
+  {
+    id: "store",
+    name: "@assistant-ui/store",
+    description: "Tap-based state management.",
+    category: "libraries",
+    repo: OSS_MONOREPO,
+    path: "packages/store",
+    docs: "/tap/docs/store/why-store",
+    npm: "@assistant-ui/store",
+    license: "MIT",
+  },
+  {
+    id: "assistant-stream",
+    name: "assistant-stream",
+    description: "Streaming utilities for AI assistants.",
+    category: "libraries",
+    repo: OSS_MONOREPO,
+    path: "packages/assistant-stream",
+    npm: "assistant-stream",
+    pypi: "assistant-stream",
+    license: "MIT",
+  },
+  {
+    id: "tool-ui",
+    name: "tool-ui",
+    description: "UI components for AI interfaces.",
+    category: "libraries",
+    repo: "assistant-ui/tool-ui",
+    site: "https://tool-ui.com",
+    license: "MIT",
+  },
+  {
+    id: "xpm",
+    name: "@assistant-ui/xpm",
+    description: "One command for npm, yarn, pnpm, bun, deno, and uv.",
+    category: "libraries",
+    repo: "assistant-ui/xpm",
+    npm: "@assistant-ui/xpm",
+    license: "MIT",
+  },
+  {
+    id: "modelpedia",
+    name: "modelpedia",
+    description: "Open catalog of AI models across providers.",
+    category: "apps",
+    repo: "assistant-ui/modelpedia",
+    site: "https://modelpedia.dev",
+    license: "MIT",
+  },
+  {
+    id: "open-prism",
+    name: "open-prism",
+    description: "AI LaTeX writing workspace with live preview.",
+    category: "apps",
+    repo: "assistant-ui/open-prism",
+    site: "https://openprism.vercel.app",
+    license: "MIT",
+  },
+  {
+    id: "tw-shimmer",
+    name: "tw-shimmer",
+    description: "Tailwind v4 plugin for shimmer effects.",
+    category: "primitives",
+    repo: OSS_MONOREPO,
+    path: "packages/tw-shimmer",
+    site: "/tw-shimmer",
+    npm: "tw-shimmer",
+    license: "MIT",
+  },
+  {
+    id: "tw-glass",
+    name: "tw-glass",
+    description: "Tailwind v4 plugin for glass refraction effects.",
+    category: "primitives",
+    repo: OSS_MONOREPO,
+    path: "packages/tw-glass",
+    site: "/tw-glass",
+    npm: "tw-glass",
+    license: "MIT",
+  },
+  {
+    id: "heat-graph",
+    name: "heat-graph",
+    description: "Headless React components for activity heatmaps.",
+    category: "primitives",
+    repo: OSS_MONOREPO,
+    path: "packages/heat-graph",
+    site: "/heat-graph",
+    npm: "heat-graph",
+    license: "MIT",
+  },
+  {
+    id: "safe-content-frame",
+    name: "safe-content-frame",
+    description: "Secure iframe rendering for untrusted content.",
+    category: "primitives",
+    repo: OSS_MONOREPO,
+    path: "packages/safe-content-frame",
+    site: "/safe-content-frame",
+    npm: "safe-content-frame",
+    license: "MIT",
+  },
+  {
+    id: "skills",
+    name: "skills",
+    description: "Agent skills for building AI chat interfaces.",
+    category: "agents",
+    repo: "assistant-ui/skills",
+    license: null,
+  },
+  {
+    id: "mcp-docs-server",
+    name: "@assistant-ui/mcp-docs-server",
+    description: "MCP server exposing assistant-ui docs.",
+    category: "agents",
+    repo: OSS_MONOREPO,
+    path: "packages/mcp-docs-server",
+    npm: "@assistant-ui/mcp-docs-server",
+    license: "MIT",
+  },
+  {
+    id: "sync-server",
+    name: "assistant-ui-sync-server",
+    description: "Resumable streaming proxy for long-running AI tasks.",
+    category: "infrastructure",
+    repo: "assistant-ui/assistant-ui-sync-server",
+    license: null,
+  },
+];
+
+export function ossRepoUrl(project: OssProject): string {
+  return project.path
+    ? `https://github.com/${project.repo}/tree/main/${project.path}`
+    : `https://github.com/${project.repo}`;
+}
+
+export function ossPrimaryUrl(project: OssProject): string {
+  return project.docs ?? project.site ?? ossRepoUrl(project);
+}
+
+export function ossNpmUrl(pkg: string): string {
+  return `https://www.npmjs.com/package/${pkg}`;
+}
+
+export type OssStats = {
+  stars: Record<string, number>;
+  weekly: Record<string, number>;
+  totalStars: number;
+  totalWeekly: number;
+};
+
+export async function fetchOssStats(revalidate?: number): Promise<OssStats> {
+  const repos = [
+    ...new Set(
+      OSS_PROJECTS.filter((project) => !project.path).map(
+        (project) => project.repo,
+      ),
+    ),
+  ];
+  const packages = [
+    ...new Set(
+      OSS_PROJECTS.map((project) => project.npm).filter(
+        (name): name is string => name !== undefined,
+      ),
+    ),
+  ];
+
+  const [repoEntries, packageEntries] = await Promise.all([
+    Promise.all(
+      repos.map(
+        async (repo) => [repo, await getRepoStars(repo, revalidate)] as const,
+      ),
+    ),
+    Promise.all(
+      packages.map(
+        async (name) =>
+          [name, await getWeeklyDownloads(name, revalidate)] as const,
+      ),
+    ),
+  ]);
+
+  const stars: Record<string, number> = {};
+  let totalStars = 0;
+  for (const [repo, count] of repoEntries) {
+    if (count === null) continue;
+    stars[repo] = count;
+    totalStars += count;
+  }
+
+  const weekly: Record<string, number> = {};
+  let totalWeekly = 0;
+  for (const [name, count] of packageEntries) {
+    if (count === null) continue;
+    weekly[name] = count;
+    totalWeekly += count;
+  }
+
+  return { stars, weekly, totalStars, totalWeekly };
+}


### PR DESCRIPTION
## summary

- adds `/oss`, an index of every project the organization maintains in the open, grouped by category, each row linking to that project's docs, its site, or its source
- shows stars for projects that have their own repository and weekly npm downloads for the packages we publish out of this monorepo, fetched at request time and cached for an hour
- publishes the same curated list at `/oss.json` so other sites, READMEs, and future tooling read one source of truth instead of each keeping a copy
- links it from the footer and the resources menu

## test plan

### already verified

- [x] `tsc --noEmit` in apps/docs -> 0 errors
- [x] `oxlint` and `oxfmt --check` on the touched files -> clean
- [x] every URL the manifest produces (25 internal and external links) requested -> all 200 or an expected redirect
- [x] rendered at 1440 and 390 wide, light and dark

### reviewer should verify

- [ ] the curation reads right: 15 entries, standalone projects only, with npm distributions that are not projects of their own left to /packages

## notes

- `skills` and `assistant-ui-sync-server` carry no LICENSE file in their repositories, so the manifest records a null license and the page prints nothing for them. worth fixing before this page gets traffic.
- `tool-ui` has no npm link because the `tool-ui` name on npm belongs to an unrelated project.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-jXeCFeBtZdJ_F9Qjz0L3TW99q9kbImOdbF0iL-VzoZULalveGyeGPnIJ6Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->