### PR TITLE
docs(core,react): deprecate Unstable_AudioMessagePart in favour of file parts

### DIFF
--- a/.changeset/deprecate-audio-message-part.md
+++ b/.changeset/deprecate-audio-message-part.md
@@ -5,4 +5,4 @@
 
 docs: deprecate Unstable_AudioMessagePart in favour of file parts
 
-Audio belongs on a `file` part with an `audio/*` mime type, which reaches the same provider audio inputs, exists on both the user and assistant unions, carries a filename, and supports url and id references. The audio part and the `Unstable_Audio` slot stay honored everywhere they are accepted and will not gain fields.
+Audio belongs on a `file` part with an `audio/*` mime type. `file` is a member of both the user and assistant unions, carries a filename, and supports url and id references through `sourceType`, none of which the audio part can express. The audio part and the `Unstable_Audio` slot stay honored everywhere they are accepted and will not gain fields.

--- a/.changeset/deprecate-audio-message-part.md
+++ b/.changeset/deprecate-audio-message-part.md
@@ -5,4 +5,4 @@
 
 docs: deprecate Unstable_AudioMessagePart in favour of file parts
 
-Audio belongs on a `file` part with an `audio/*` mime type. `file` is a member of both the user and assistant unions, carries a filename, and supports url and id references through `sourceType`, none of which the audio part can express. The audio part and the `Unstable_Audio` slot stay honored everywhere they are accepted and will not gain fields.
+Audio belongs on a `file` part with an `audio/*` mime type. `file` is a member of both the user and assistant unions and carries a filename, neither of which the audio part can express. The payload form a `file` part needs is still adapter specific; the message primitive docs enumerate it. The audio part and the `Unstable_Audio` slot stay honored everywhere they are accepted and will not gain fields.

--- a/.changeset/deprecate-audio-message-part.md
+++ b/.changeset/deprecate-audio-message-part.md
@@ -1,0 +1,8 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+docs: deprecate Unstable_AudioMessagePart in favour of file parts
+
+Audio belongs on a `file` part with an `audio/*` mime type, which reaches the same provider audio inputs, exists on both the user and assistant unions, carries a filename, and supports url and id references. The audio part and the `Unstable_Audio` slot stay honored everywhere they are accepted and will not gain fields.

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -138,7 +138,9 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 ```
 
 <Callout type="warn">
-`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. Send audio as a `file` part with an `audio/*` mime type and render it from the `File` slot. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Existing audio parts keep working; they will not gain fields.
+`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, giving it a filename and a data URL or http source rather than bare base64.
+
+Adapter coverage for the file path is still uneven: `react-ag-ui` carries binary through `attachments` rather than content parts, and `react-google-adk` still restores a filename-less `audio/mp3` file part back into an audio part. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -138,9 +138,9 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 ```
 
 <Callout type="warn">
-`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, giving it a filename and a data URL or http source rather than bare base64.
+`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven: `react-ag-ui` carries binary through `attachments` rather than content parts, and `react-google-adk` still restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven, and the payload form a `file` part needs is currently adapter-specific rather than uniform: `react-ai-sdk` needs a data URL or an http source, `react-google-adk` needs bare base64 and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part, and `react-ag-ui` carries binary through `attachments` rather than content parts. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -112,6 +112,35 @@ Runtime setup: primitives require runtime context. Wrap your UI in `AssistantRun
 For most new code, prefer `MessagePrimitive.Parts` with a `children` render function. When you need adjacent grouping, use `MessagePrimitive.GroupedParts`.
 </Callout>
 
+### Part Types
+
+A message part is one of three kinds, and which kind a new capability belongs to is decided by the list below rather than case by case.
+
+| Kind | Parts | Grows by |
+|------|-------|----------|
+| Modality | `text`, `image`, `file` | Never. `file` carries every non-image binary modality through its `mimeType`. |
+| Provider channel | `reasoning`, `source`, `tool-call`, `generative-ui` | Never. These mirror channels a model already emits. |
+| Extensibility | `data` | Freely, through `name`. This is the growth path for anything app-level. |
+
+`file` is the media carrier. Audio, video, PDFs and everything else are `{ type: "file", mimeType: "audio/mpeg" }` rather than part types of their own, so one renderer and one converter branch handle them all, and a part can be inline base64, a URL, or an opaque storage id through `sourceType`.
+
+Anything that is not a modality the model consumes or a channel it emits is a `data` part, routed by `name`:
+
+```tsx
+<MessagePrimitive.Parts
+  components={{
+    data: {
+      by_name: { citation: MyCitation },
+      Fallback: MyDataFallback,
+    },
+  }}
+/>
+```
+
+<Callout type="warn">
+`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. Send audio as a `file` part with an `audio/*` mime type and render it from the `File` slot. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Existing audio parts keep working; they will not gain fields.
+</Callout>
+
 ### Tool Resolution
 
 Tool call parts resolve in this order:
@@ -149,7 +178,7 @@ Returning `null` still allows registered tool UIs and data renderer UIs to rende
 - `components.ChainOfThought` takes over all reasoning and tool-call rendering (mutually exclusive with `ToolGroup`, `ReasoningGroup`, `tools`, and `Reasoning`). This legacy path is deprecated; use `MessagePrimitive.GroupedParts` for grouped Chain of Thought in new code.
 - `data.by_name` and `data.Fallback` let you route custom data part types
 - `Quote` renders quoted message references from metadata
-- `Empty` and `Unstable_Audio` are available for edge and experimental rendering paths
+- `Empty` renders for messages with no parts; `Unstable_Audio` is deprecated, render `audio/*` from `File` instead
 
 ```tsx
 <MessagePrimitive.Parts

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -138,7 +138,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 ```
 
 <Callout type="warn">
-`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
+`Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
 Adapter coverage for the file path is still uneven, and the payload form a `file` part needs is currently adapter-specific rather than uniform: `react-ai-sdk` and `@assistant-ui/eve` need a data URL or an http source, `react-google-adk` needs bare base64 and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part, and `react-ag-ui` carries binary through `attachments` rather than content parts. Existing audio parts keep working; they will not gain fields.
 </Callout>

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, giving it a filename and a data URL or http source rather than bare base64.
 
-Adapter coverage for the file path is still uneven: `react-ag-ui` carries binary through `attachments` rather than content parts, and `react-google-adk` still restores a filename-less `audio/mp3` file part back into an audio part. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven: `react-ag-ui` carries binary through `attachments` rather than content parts, and `react-google-adk` still restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution
@@ -180,7 +180,8 @@ Returning `null` still allows registered tool UIs and data renderer UIs to rende
 - `components.ChainOfThought` takes over all reasoning and tool-call rendering (mutually exclusive with `ToolGroup`, `ReasoningGroup`, `tools`, and `Reasoning`). This legacy path is deprecated; use `MessagePrimitive.GroupedParts` for grouped Chain of Thought in new code.
 - `data.by_name` and `data.Fallback` let you route custom data part types
 - `Quote` renders quoted message references from metadata
-- `Empty` renders for messages with no parts; `Unstable_Audio` is deprecated, render `audio/*` from `File` instead
+- `Empty` is available for edge rendering paths
+- `Unstable_Audio` is deprecated; render `audio/*` from the `File` slot instead
 
 ```tsx
 <MessagePrimitive.Parts

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, cannot reference a URL or storage id, and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven, and the payload form a `file` part needs is currently adapter-specific rather than uniform: `react-ai-sdk` needs a data URL or an http source, `react-google-adk` needs bare base64 and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part, and `react-ag-ui` carries binary through `attachments` rather than content parts. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven, and the payload form a `file` part needs is currently adapter-specific rather than uniform: `react-ai-sdk` and `@assistant-ui/eve` need a data URL or an http source, `react-google-adk` needs bare base64 and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part, and `react-ag-ui` carries binary through `attachments` rather than content parts. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -122,7 +122,7 @@ A message part is one of three kinds, and which kind a new capability belongs to
 | Provider channel | `reasoning`, `source`, `tool-call`, `generative-ui` | Never. These mirror channels a model already emits. |
 | Extensibility | `data` | Freely, through `name`. This is the growth path for anything app-level. |
 
-`file` is the media carrier. Audio, video, PDFs and everything else are `{ type: "file", mimeType: "audio/mpeg" }` rather than part types of their own, so one renderer and one converter branch handle them all, and a part can be inline base64, a URL, or an opaque storage id through `sourceType`.
+`file` is the media carrier. Audio, video, PDFs and everything else are `{ type: "file", mimeType: "audio/mpeg" }` rather than part types of their own, so one renderer and one converter branch handle them all. The payload can be inline base64 or a URL; `sourceType` additionally allows an opaque storage id, which the LangChain-family runtimes honor and other adapters ignore.
 
 Anything that is not a modality the model consumes or a channel it emits is a `data` part, routed by `name`:
 

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -437,7 +437,7 @@ Renders message content parts via a `components` prop. Tool call and data parts 
 | `Reasoning` | `ReasoningMessagePartComponent` | Reasoning part renderer |
 | `Source` | `SourceMessagePartComponent` | Source part renderer |
 | `File` | `FileMessagePartComponent` | File part renderer |
-| `Unstable_Audio` | `AudioMessagePartComponent` | Audio part renderer (experimental) |
+| `Unstable_Audio` | `AudioMessagePartComponent` | Audio part renderer (deprecated, render `audio/*` from `File`) |
 | `tools` | `{ by_name?, Fallback? }` or `{ Override }` | Tool call rendering config — use `by_name` to map tool names to components, `Fallback` for unregistered tools, or `Override` to handle all tool calls |
 | `data` | `{ by_name?, Fallback? }` | Data part rendering config — use `by_name` to map data event names, `Fallback` for unmatched events |
 | `Empty` | `EmptyMessagePartComponent` | Component shown for empty messages |

--- a/apps/docs/content/docs/react-native/primitives.mdx
+++ b/apps/docs/content/docs/react-native/primitives.mdx
@@ -437,7 +437,7 @@ Renders message content parts via a `components` prop. Tool call and data parts 
 | `Reasoning` | `ReasoningMessagePartComponent` | Reasoning part renderer |
 | `Source` | `SourceMessagePartComponent` | Source part renderer |
 | `File` | `FileMessagePartComponent` | File part renderer |
-| `Unstable_Audio` | `AudioMessagePartComponent` | Audio part renderer (deprecated, render `audio/*` from `File`) |
+| `Unstable_Audio` | `Unstable_AudioMessagePartComponent` | Audio part renderer (deprecated, render `audio/*` from `File`) |
 | `tools` | `{ by_name?, Fallback? }` or `{ Override }` | Tool call rendering config — use `by_name` to map tool names to components, `Fallback` for unregistered tools, or `Override` to handle all tool calls |
 | `data` | `{ by_name?, Fallback? }` | Data part rendering config — use `by_name` to map data event names, `Fallback` for unmatched events |
 | `Empty` | `EmptyMessagePartComponent` | Component shown for empty messages |

--- a/apps/docs/content/docs/ui/part-grouping.mdx
+++ b/apps/docs/content/docs/ui/part-grouping.mdx
@@ -575,7 +575,7 @@ Use `MessagePrimitive.Unstable_PartsGrouped` only when you need to collect non-a
               name: "Unstable_Audio",
               type: "Unstable_AudioMessagePartComponent",
               description:
-                "Component for rendering audio content (experimental)",
+                "Component for rendering audio content (deprecated, render audio/* from File)",
             },
             {
               name: "tools",

--- a/packages/core/src/react/primitives/message/MessageParts.tsx
+++ b/packages/core/src/react/primitives/message/MessageParts.tsx
@@ -214,7 +214,12 @@ export namespace MessagePrimitiveParts {
     Image?: ImageMessagePartComponent | undefined;
     /** Component for rendering file content */
     File?: FileMessagePartComponent | undefined;
-    /** Component for rendering audio content (experimental) */
+    /**
+     * Component for rendering audio content.
+     *
+     * @deprecated Render audio through the `File` slot instead, branching on an
+     * `audio/*` mime type.
+     */
     Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
     /** Configuration for data part rendering */
     data?: DataConfig | undefined;

--- a/packages/core/src/react/types/MessagePartComponentTypes.ts
+++ b/packages/core/src/react/types/MessagePartComponentTypes.ts
@@ -44,8 +44,16 @@ export type ImageMessagePartComponent = ComponentType<ImageMessagePartProps>;
 export type FileMessagePartProps = MessagePartState & FileMessagePart;
 export type FileMessagePartComponent = ComponentType<FileMessagePartProps>;
 
+/**
+ * @deprecated Use {@link FileMessagePartProps} and render `audio/*` mime types
+ * from the `File` slot.
+ */
 export type Unstable_AudioMessagePartProps = MessagePartState &
   Unstable_AudioMessagePart;
+/**
+ * @deprecated Use {@link FileMessagePartComponent} and render `audio/*` mime
+ * types from the `File` slot.
+ */
 export type Unstable_AudioMessagePartComponent =
   ComponentType<Unstable_AudioMessagePartProps>;
 

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -67,6 +67,14 @@ export type FileMessagePart = {
   readonly parentId?: string;
 };
 
+/**
+ * @deprecated Use {@link FileMessagePart} with an `audio/*` mime type. `file`
+ * is the carrier for every non-image binary modality: it reaches the same
+ * provider audio inputs, is a member of both the user and assistant unions,
+ * carries a filename, and supports url and id references through `sourceType`,
+ * none of which this shape can express. Still honored everywhere it is
+ * accepted; it will not gain fields.
+ */
 export type Unstable_AudioMessagePart = {
   readonly type: "audio";
   readonly audio: {

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -70,9 +70,10 @@ export type FileMessagePart = {
 /**
  * @deprecated Use {@link FileMessagePart} with an `audio/*` mime type. `file`
  * is the carrier for every non-image binary modality: it is a member of both
- * the user and assistant unions, carries a filename, and supports url and id
- * references through `sourceType`, none of which this shape can express. Still
- * honored everywhere it is accepted; it will not gain fields.
+ * the user and assistant unions and carries a filename, neither of which this
+ * shape can express. The payload form a `file` part needs is still adapter
+ * specific; see the Part Types section of the message primitive docs. Honored
+ * everywhere it is accepted; it will not gain fields.
  */
 export type Unstable_AudioMessagePart = {
   readonly type: "audio";

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -69,11 +69,10 @@ export type FileMessagePart = {
 
 /**
  * @deprecated Use {@link FileMessagePart} with an `audio/*` mime type. `file`
- * is the carrier for every non-image binary modality: it reaches the same
- * provider audio inputs, is a member of both the user and assistant unions,
- * carries a filename, and supports url and id references through `sourceType`,
- * none of which this shape can express. Still honored everywhere it is
- * accepted; it will not gain fields.
+ * is the carrier for every non-image binary modality: it is a member of both
+ * the user and assistant unions, carries a filename, and supports url and id
+ * references through `sourceType`, none of which this shape can express. Still
+ * honored everywhere it is accepted; it will not gain fields.
  */
 export type Unstable_AudioMessagePart = {
   readonly type: "audio";

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -71,9 +71,10 @@ export type FileMessagePart = {
  * @deprecated Use {@link FileMessagePart} with an `audio/*` mime type. `file`
  * is the carrier for every non-image binary modality: it is a member of both
  * the user and assistant unions, carries a filename, and can declare how its
- * payload goes on the wire, none of which this shape can express. The payload form a `file` part needs is still adapter
- * specific; see the Part Types section of the message primitive docs. Honored
- * everywhere it is accepted; it will not gain fields.
+ * payload goes on the wire, none of which this shape can express. The payload
+ * form a `file` part needs is still adapter specific; see the Part Types
+ * section of the message primitive docs. Honored everywhere it is accepted; it
+ * will not gain fields.
  */
 export type Unstable_AudioMessagePart = {
   readonly type: "audio";

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -70,8 +70,8 @@ export type FileMessagePart = {
 /**
  * @deprecated Use {@link FileMessagePart} with an `audio/*` mime type. `file`
  * is the carrier for every non-image binary modality: it is a member of both
- * the user and assistant unions and carries a filename, neither of which this
- * shape can express. The payload form a `file` part needs is still adapter
+ * the user and assistant unions, carries a filename, and can declare how its
+ * payload goes on the wire, none of which this shape can express. The payload form a `file` part needs is still adapter
  * specific; see the Part Types section of the message primitive docs. Honored
  * everywhere it is accepted; it will not gain fields.
  */

--- a/packages/react/src/primitives/message/MessagePartsGrouped.tsx
+++ b/packages/react/src/primitives/message/MessagePartsGrouped.tsx
@@ -151,7 +151,12 @@ export namespace MessagePrimitiveUnstable_PartsGrouped {
           Image?: ImageMessagePartComponent | undefined;
           /** Component for rendering file content */
           File?: FileMessagePartComponent | undefined;
-          /** Component for rendering audio content (experimental) */
+          /**
+           * Component for rendering audio content.
+           *
+           * @deprecated Render audio through the `File` slot instead, branching
+           * on an `audio/*` mime type.
+           */
           Unstable_Audio?: Unstable_AudioMessagePartComponent | undefined;
           /** Configuration for data part rendering */
           data?:


### PR DESCRIPTION
## summary

- marks `Unstable_AudioMessagePart`, `Unstable_AudioMessagePartProps`, `Unstable_AudioMessagePartComponent` and the `Unstable_Audio` slot on both `Parts` and `GroupedParts` as `@deprecated`, pointing at `FileMessagePart` with an `audio/*` mime type. nothing is removed and no behavior changes; the append-only surface is intact and every audio branch in every adapter still works.
- writes the content part rule down in a new "Part Types" section on the message primitive page: modalities (`text`, `image`, `file`) and provider channels (`reasoning`, `source`, `tool-call`, `generative-ui`) are closed sets, `file` carries every non-image binary modality through its `mimeType`, and `data` plus `name` is the single growth path for anything app-level. the point is that the next "should this be a new part type" question has a written answer.
- the three doc references that presented `Unstable_Audio` as an ordinary option (message primitive prose, the react-native component table, the part-grouping component list) now say it is deprecated and name the replacement.

## why the audio part loses

it is strictly less capable than a `file` part for the same modality: it cannot carry a filename, cannot reference a URL or a storage id (`sourceType`, added in #5439), is closed to `mp3 | wav` so a browser recording cannot be typed, and exists only on `ThreadUserMessagePart`, so a model that returns audio has no way to express it. #5441 and #5444 made `file` plus an `audio/*` mime type work end to end on the LangChain family, react-a2a and react-ai-sdk. three adapter gaps remain and are filed as #5448, #5449 and #5450; the docs callout names them so nobody migrates into one. they are pre-existing defects rather than something this PR introduces, and the `Unstable_` prefix already carried the "this may change" contract that `@deprecated` now sharpens.

no test plan, docs and JSDoc only.

## test plan

### already verified

- [x] `pnpm exec tsc --noEmit` in core and react -> no errors in any touched file (both packages carry pre-existing test-file errors on `main`, unchanged here)
- [x] `pnpm -C apps/docs generate:api-reference -- --strict` -> exit 0, no drift; none of these exports are generator-owned
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean on the touched trees

## notes

- context is #5309, whose remaining open question was exactly this decision. `DataMessagePart` is documented as the extensibility valve rather than a client-side-only routing key, which is what it already is in practice: the AI SDK carries `data-*` parts on the wire in both directions and react-a2a maps it to a protobuf `Value`.
- removal stays out of scope. it is a breaking range change under the append-only rule and belongs to a major line discussion; this PR only stops pointing new code at the shape.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.fKQ3rWm6QGbvCCw7UDanHkaRxSkJVPoI_KGAcsfCblMD9XUmVGueVgEi2q8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->