### PR TITLE
fix(react-ai-sdk): wrap bare base64 file and image payloads in a data url

### DIFF
--- a/.changeset/ai-sdk-file-part-base64-envelope.md
+++ b/.changeset/ai-sdk-file-part-base64-envelope.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: wrap bare base64 file and image payloads in a data URL envelope
+
+`convertToModelMessages` passes a file part's `url` to an unguarded `new URL()`, so a `FileMessagePart` or `ImageMessagePart` whose payload is raw base64 rather than a data URL or an http source rejected with `Invalid URL`. Both branches now wrap a non-URL payload using the part's own media type; data URLs and http sources are still forwarded untouched.

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven: `react-google-adk` needs the payload as bare base64 rather than a data URL, and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part; `react-ag-ui` carries binary through `attachments` rather than content parts. Elsewhere a `file` part takes base64, a data URL or an http source interchangeably. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven, so check your adapter's converter before relying on a particular payload form. Known so far: `react-google-adk` needs the payload as bare base64 rather than a data URL, and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part; `react-ag-ui` carries binary through `attachments` rather than content parts; `react-opencode` forwards the payload into a `url` field without inspecting it, so bare base64 is corrupted there. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven, and the payload form a `file` part needs is currently adapter-specific rather than uniform: `react-ai-sdk` and `@assistant-ui/eve` need a data URL or an http source, `react-google-adk` needs bare base64 and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part, and `react-ag-ui` carries binary through `attachments` rather than content parts. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven: `react-google-adk` needs the payload as bare base64 rather than a data URL, and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part; `react-ag-ui` carries binary through `attachments` rather than content parts. Elsewhere a `file` part takes base64, a data URL or an http source interchangeably. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -247,6 +247,62 @@ describe("toCreateMessage", () => {
     ]);
   });
 
+  it("wraps bare base64 file data so the url survives convertToModelMessages", async () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        { type: "file", data: "JVBERi0xLjQ=", mimeType: "application/pdf" },
+      ],
+    } as unknown as AppendMessage;
+
+    const result = toCreateMessage(message);
+
+    expect(result.parts).toEqual([
+      {
+        type: "file",
+        url: "data:application/pdf;base64,JVBERi0xLjQ=",
+        mediaType: "application/pdf",
+      },
+    ]);
+
+    // convertToModelMessages is async and passes `url` to an unguarded
+    // `new URL()`, so the bare payload rejects while the wrapped one resolves.
+    const { convertToModelMessages } = await import("ai");
+    await expect(
+      convertToModelMessages([{ ...result, id: "m1" } as never]),
+    ).resolves.toBeDefined();
+    await expect(
+      convertToModelMessages([
+        {
+          id: "m1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "JVBERi0xLjQ=",
+              mediaType: "application/pdf",
+            },
+          ],
+        } as never,
+      ]),
+    ).rejects.toThrow(/Invalid URL/);
+  });
+
+  it("wraps bare base64 image data", () => {
+    const message = {
+      ...baseMessage,
+      content: [{ type: "image", image: "/9j/4AAQSkZJRg==" }],
+    } as unknown as AppendMessage;
+
+    expect(toCreateMessage(message).parts).toEqual([
+      {
+        type: "file",
+        url: "data:image/png;base64,/9j/4AAQSkZJRg==",
+        mediaType: "image/png",
+      },
+    ]);
+  });
+
   it("converts an audio part into a file part with the format-derived media type", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -288,18 +288,41 @@ describe("toCreateMessage", () => {
     ).rejects.toThrow(/Invalid URL/);
   });
 
-  it("wraps bare base64 image data", () => {
+  it("wraps bare base64 image data using the resolved media type", () => {
     const message = {
       ...baseMessage,
-      content: [{ type: "image", image: "/9j/4AAQSkZJRg==" }],
+      content: [{ type: "image", image: "QUJD", contentType: "image/webp" }],
     } as unknown as AppendMessage;
 
     expect(toCreateMessage(message).parts).toEqual([
       {
         type: "file",
-        url: "data:image/png;base64,/9j/4AAQSkZJRg==",
-        mediaType: "image/png",
+        url: "data:image/webp;base64,QUJD",
+        mediaType: "image/webp",
       },
+    ]);
+  });
+
+  it("forwards blob and other parsable url schemes untouched", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        { type: "image", image: "blob:https://app.example/1-2-3" },
+        {
+          type: "file",
+          data: "blob:https://app.example/4-5-6",
+          mimeType: "application/pdf",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    const urls = toCreateMessage(message).parts.map((p) =>
+      "url" in p ? p.url : undefined,
+    );
+
+    expect(urls).toEqual([
+      "blob:https://app.example/1-2-3",
+      "blob:https://app.example/4-5-6",
     ]);
   });
 

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -303,6 +303,24 @@ describe("toCreateMessage", () => {
     ]);
   });
 
+  it("leaves an id reference unwrapped rather than shipping it as base64", () => {
+    const message = {
+      ...baseMessage,
+      content: [
+        {
+          type: "file",
+          data: "file-abc123",
+          mimeType: "application/pdf",
+          sourceType: "id",
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    expect(toCreateMessage(message).parts).toEqual([
+      { type: "file", url: "file-abc123", mediaType: "application/pdf" },
+    ]);
+  });
+
   it("forwards blob and other parsable url schemes untouched", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -13,6 +13,9 @@ type InputPart = AppendMessage["content"][number] & {
   readonly filename?: string | undefined;
 };
 
+const isUrl = (value: string) =>
+  /^data:/i.test(value) || httpUrlPattern.test(value);
+
 const getDataUrlMediaType = (url: string) => {
   const match = /^data:([^;,]+)(?:[;,])/i.exec(url);
   return match?.[1]?.toLowerCase();
@@ -51,17 +54,26 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
           type: "text",
           text: part.text,
         };
-      case "image":
+      case "image": {
+        const mediaType = getImageMediaType(part);
         return {
           type: "file",
-          url: part.image,
+          url: isUrl(part.image)
+            ? part.image
+            : `data:${mediaType};base64,${part.image}`,
           ...(part.filename && { filename: part.filename }),
-          mediaType: getImageMediaType(part),
+          mediaType,
         };
+      }
       case "file":
         return {
           type: "file",
-          url: part.data,
+          // `convertToModelMessages` passes this through an unguarded
+          // `new URL()`, so a payload that is not already a URL is wrapped
+          // rather than forwarded.
+          url: isUrl(part.data)
+            ? part.data
+            : `data:${part.mimeType};base64,${part.data}`,
           mediaType: part.mimeType,
           ...(part.filename && { filename: part.filename }),
         };

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -13,8 +13,17 @@ type InputPart = AppendMessage["content"][number] & {
   readonly filename?: string | undefined;
 };
 
-const isUrl = (value: string) =>
-  /^data:/i.test(value) || httpUrlPattern.test(value);
+// Mirrors the upstream failure condition exactly: `convertToModelMessages`
+// hands `url` to an unguarded `new URL()`. Base64 cannot contain a colon, so
+// no payload is misread as a URL.
+const isUrl = (value: string) => {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 const getDataUrlMediaType = (url: string) => {
   const match = /^data:([^;,]+)(?:[;,])/i.exec(url);
@@ -68,9 +77,6 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
       case "file":
         return {
           type: "file",
-          // `convertToModelMessages` passes this through an unguarded
-          // `new URL()`, so a payload that is not already a URL is wrapped
-          // rather than forwarded.
           url: isUrl(part.data)
             ? part.data
             : `data:${part.mimeType};base64,${part.data}`,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -77,9 +77,13 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
       case "file":
         return {
           type: "file",
-          url: isUrl(part.data)
-            ? part.data
-            : `data:${part.mimeType};base64,${part.data}`,
+          // An `id` reference is an opaque provider handle, not base64, and
+          // this adapter has no way to send one. Left unwrapped so it fails
+          // loudly upstream rather than shipping a corrupt payload.
+          url:
+            isUrl(part.data) || part.sourceType === "id"
+              ? part.data
+              : `data:${part.mimeType};base64,${part.data}`,
           mediaType: part.mimeType,
           ...(part.filename && { filename: part.filename }),
         };


### PR DESCRIPTION
closes #5448

## summary

- a `file` or `image` message part whose payload is raw base64 rather than a data URL or an http source now gets wrapped in a `data:<mediaType>;base64,` envelope before it becomes a `FileUIPart.url`. previously it was forwarded verbatim.
- this was a throw, not a silently malformed request: `convertToModelMessages` passes `part.url` to an unguarded `new URL(part.url)` (`ai@7.0.37`, `dist/index.js:10510`), so the raw payload rejected with `TypeError: Invalid URL`. verified directly against the installed SDK rather than inferred.
- data URLs and http sources are still forwarded untouched, so the existing tests covering those shapes are unchanged.
- the `image` branch had the identical defect one case up and is fixed in the same pass.

## why this surfaced now

#5447 deprecates `Unstable_AudioMessagePart` in favour of `{ type: "file", mimeType: "audio/*" }`, and the mechanical migration `{ audio: { data: "QUJD", format: "mp3" } }` to `{ data: "QUJD", mimeType: "audio/mp3" }` produced exactly this shape. the `audio` branch already rebuilt the envelope (#5441); the `file` branch it points people at did not.

`@assistant-ui/eve` looks like it has the same split but is **not** affected, and the difference is worth writing down: its field is an AI SDK core `FilePart.data` (`DataContent | URL`), which reaches `convertToLanguageModelV4FilePart` where the same `new URL()` sits inside a try/catch and falls back to inline data. only the UI-message `url` field is strict.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 178/178 green (2 new)
- [x] the new file-part test drives the real `convertToModelMessages`: it asserts the wrapped output resolves **and** that the unwrapped shape rejects with `Invalid URL`, so it cannot pass vacuously
- [x] `pnpm exec tsc --noEmit` -> no errors in the touched file
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

### reviewer should verify

- [ ] send an attachment through an adapter that yields raw base64 (no data URL envelope) on a `useChatRuntime` app and confirm the request reaches the provider instead of throwing `Invalid URL`.

## notes

- `convertToModelMessages` is async, so a synchronous `expect(...).not.toThrow()` around it passes vacuously. the test awaits the promise on both arms; worth knowing for anything else asserting on that function.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

