### PR TITLE
fix(store): preserve notification subscriptions across render replays

### DIFF
--- a/.changeset/fuzzy-composers-listen.md
+++ b/.changeset/fuzzy-composers-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: keep assistant state subscriptions connected across pre-commit render replays

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format:fix": "pnpm exec oxfmt",
     "sync-templates": "bash scripts/sync-templates.sh",
     "test": "turbo test && pnpm test:react-compiler && pnpm test:types",
-    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core",
+    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core --filter=@assistant-ui/store",
     "test:types": "pnpm -r --workspace-concurrency=4 --no-bail exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
     "prepare": "husky && pnpm --filter @assistant-ui/react-devtools run build:css",
     "deps:check": "npx taze major -f -r",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "build": "aui-build",
     "test": "vitest run",
+    "test:react-compiler": "vitest run --config vitest.react-compiler.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {

--- a/packages/store/src/utils/NotificationManager.react-compiler.test.tsx
+++ b/packages/store/src/utils/NotificationManager.react-compiler.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { StrictMode } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resource, useResource } from "@assistant-ui/tap";
+import { useNotificationManager } from "./NotificationManager";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("compiled useNotificationManager", () => {
+  it("keeps subscriptions connected across pre-commit render replays", () => {
+    const managers: ReturnType<typeof useNotificationManager>[] = [];
+
+    const useManager = () => {
+      const manager = useNotificationManager();
+      managers.push(manager);
+      return manager;
+    };
+    const Manager = resource(useManager);
+
+    const App = () => {
+      useResource(Manager());
+      return null;
+    };
+
+    render(
+      <StrictMode>
+        <App />
+      </StrictMode>,
+    );
+
+    expect(managers.length).toBeGreaterThan(1);
+
+    const subscriber = vi.fn();
+    managers[0]!.subscribe(subscriber);
+    managers.at(-1)!.notifySubscribers();
+
+    expect(subscriber).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useState } from "react";
 import type { ClientStack } from "./tap-client-stack-context";
 import type {
   AssistantEventName,
@@ -26,7 +26,7 @@ export type NotificationManager = {
 };
 
 export const useNotificationManager = (): NotificationManager => {
-  return useMemo(() => {
+  const [manager] = useState<NotificationManager>(() => {
     const listeners = new Map<string, Set<InternalCallback>>();
     const wildcardListeners = new Set<InternalCallback>();
     const subscribers = new Set<() => void>();
@@ -109,5 +109,7 @@ export const useNotificationManager = (): NotificationManager => {
         }
       },
     };
-  }, []);
+  });
+
+  return manager;
 };

--- a/packages/store/vitest.react-compiler.config.ts
+++ b/packages/store/vitest.react-compiler.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const compiledNotificationManager = fileURLToPath(
+  new URL("./dist/utils/NotificationManager.js", import.meta.url),
+);
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^\.\/NotificationManager$/,
+        replacement: compiledNotificationManager,
+      },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/utils/NotificationManager.react-compiler.test.tsx"],
+  },
+});


### PR DESCRIPTION
## Summary

- keep `NotificationManager` as mount-lifetime state with lazy `useState`
- add a StrictMode regression test against the React Compiler output
- run the store compiler regression suite from the root test command

## Problem

On `main` at `932bd90f9c46fd343176791eae3299fc514d2fa4`, the default template's composer accepted DOM input events but immediately rendered an empty controlled value again, leaving the send button disabled.

The store state changed correctly. During a pre-commit render replay, however, the compiled `useMemo` implementation returned a different `NotificationManager`. The committed client could retain the first manager while the active store effect notified the later manager, disconnecting `useSyncExternalStore` subscribers from updates.

## Fix

The manager owns mutable listener and subscriber sets, so its identity is runtime state rather than a droppable computation cache. Initializing it with lazy `useState` preserves one manager for the full mount across render replays.

The new test runs against `packages/store/dist`, subscribes through the manager returned by the first StrictMode render, and notifies through the manager returned by the last render. It fails on the original implementation with zero subscriber calls and passes with one call after this change.

## Reproduction

1. Check out `932bd90f9c46fd343176791eae3299fc514d2fa4`.
2. Run `pnpm install` and `pnpm -C templates/default dev`.
3. Open the template and type in the composer.
4. Observe that the controlled input remains empty and the send button stays disabled.

## Testing

- `pnpm --filter @assistant-ui/store test`
- `pnpm test:react-compiler`
- `pnpm --filter @assistant-ui/store exec tsc --noEmit`
- `pnpm check:resource-memo`
- targeted oxlint and oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

