### PR TITLE
fix(react-google-adk): stop mangling file parts with an audio mime type

### DIFF
--- a/.changeset/adk-audio-file-parts.md
+++ b/.changeset/adk-audio-file-parts.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: stop mangling file parts that carry an audio mime type
+
+Outbound, the `file` branch forwarded `data` verbatim into Gemini `inlineData.data`, which takes bare base64, while the `audio` branch stripped the data URL envelope first. A `file` part carrying a data URL therefore shipped `data:audio/wav;base64,...` as the payload. Both branches now strip it.
+
+Inbound, a user-role `file` part with no filename and a mime type of exactly `audio/mp3` or `audio/wav` was reclassified into the deprecated `Unstable_AudioMessagePart`, so a caller following the `file` plus `audio/*` convention got a different part type back than it sent. File parts now stay file parts, which also means an audio file part on an assistant message survives instead of being dropped.

--- a/.changeset/adk-audio-file-parts.md
+++ b/.changeset/adk-audio-file-parts.md
@@ -6,4 +6,6 @@ fix: stop mangling file parts that carry an audio mime type
 
 Outbound, the `file` branch forwarded `data` verbatim into Gemini `inlineData.data`, which takes bare base64, while the `audio` branch stripped the data URL envelope first. A `file` part carrying a data URL therefore shipped `data:audio/wav;base64,...` as the payload. Both branches now strip it.
 
+The `file` branch also now infers a url source from an unmarked `http(s)` payload, matching the four sibling converters; previously only an explicit `sourceType: "url"` took that leg, so a plain URL was sent as if it were base64.
+
 Inbound, a user-role `file` part with no filename and a mime type of exactly `audio/mp3` or `audio/wav` was reclassified into the deprecated `Unstable_AudioMessagePart`, so a caller following the `file` plus `audio/*` convention got a different part type back than it sent. File parts now stay file parts, which also means an audio file part on an assistant message survives instead of being dropped.

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven, so check your adapter's converter before relying on a particular payload form. Known so far: `react-google-adk` needs the payload as bare base64 rather than a data URL, and additionally restores a filename-less `audio/mp3` or `audio/wav` file part back into an audio part; `react-ag-ui` carries binary through `attachments` rather than content parts; `react-opencode` forwards the payload into a `url` field without inspecting it, so bare base64 is corrupted there. Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven, so check your adapter's converter before relying on a particular payload form. Known so far: `react-ag-ui` carries binary through `attachments` rather than content parts; `react-opencode` forwards the payload into a `url` field without inspecting it, so bare base64 is corrupted there. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -86,18 +86,6 @@ describe("convertAdkMessage - human messages", () => {
     }
   });
 
-  it("keeps an audio file part on an assistant message", () => {
-    const msg: AdkMessage = {
-      id: "m1",
-      type: "ai",
-      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
-    };
-    expect(convertAdkMessage(msg, {})).toMatchObject({
-      role: "assistant",
-      content: [{ type: "file", data: "QUJD", mimeType: "audio/mp3" }],
-    });
-  });
-
   it("keeps attachment-derived audio file parts (with filename) as file parts", () => {
     const msg: AdkMessage = {
       id: "m1",

--- a/packages/react-google-adk/src/convertAdkMessages.test.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.test.ts
@@ -72,29 +72,29 @@ describe("convertAdkMessage - human messages", () => {
     });
   });
 
-  it("restores an audio/mp3 file part as an audio message part", () => {
-    const msg: AdkMessage = {
-      id: "m1",
-      type: "human",
-      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
-    };
-    const result = convertAdkMessage(msg, {});
-    expect(result).toMatchObject({
-      role: "user",
-      content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
-    });
+  it("keeps an audio file part as a file part", () => {
+    for (const mimeType of ["audio/mp3", "audio/wav"]) {
+      const msg: AdkMessage = {
+        id: "m1",
+        type: "human",
+        content: [{ type: "file", mimeType, data: "QUJD" }],
+      };
+      expect(convertAdkMessage(msg, {})).toMatchObject({
+        role: "user",
+        content: [{ type: "file", data: "QUJD", mimeType }],
+      });
+    }
   });
 
-  it("restores an audio/wav file part as an audio message part", () => {
+  it("keeps an audio file part on an assistant message", () => {
     const msg: AdkMessage = {
       id: "m1",
-      type: "human",
-      content: [{ type: "file", mimeType: "audio/wav", data: "QUJD" }],
+      type: "ai",
+      content: [{ type: "file", mimeType: "audio/mp3", data: "QUJD" }],
     };
-    const result = convertAdkMessage(msg, {});
-    expect(result).toMatchObject({
-      role: "user",
-      content: [{ type: "audio", audio: { data: "QUJD", format: "wav" } }],
+    expect(convertAdkMessage(msg, {})).toMatchObject({
+      role: "assistant",
+      content: [{ type: "file", data: "QUJD", mimeType: "audio/mp3" }],
     });
   });
 

--- a/packages/react-google-adk/src/convertAdkMessages.ts
+++ b/packages/react-google-adk/src/convertAdkMessages.ts
@@ -15,7 +15,6 @@ type ContentPart =
       filename?: string;
       sourceType?: "url";
     }
-  | { type: "audio"; audio: { data: string; format: "mp3" | "wav" } }
   | { type: "data"; name: string; data: unknown };
 
 const contentToParts = (
@@ -39,25 +38,13 @@ const contentToParts = (
           };
         case "image_url":
           return { type: "image", image: part.url };
-        case "file": {
-          const format =
-            role === "user" && part.filename == null
-              ? part.mimeType === "audio/wav"
-                ? ("wav" as const)
-                : part.mimeType === "audio/mp3"
-                  ? ("mp3" as const)
-                  : null
-              : null;
-          if (format) {
-            return { type: "audio", audio: { data: part.data, format } };
-          }
+        case "file":
           return {
             type: "file",
             data: part.data,
             mimeType: part.mimeType,
             ...(part.filename != null && { filename: part.filename }),
           };
-        }
         case "file_url":
           if (role === "user") {
             return {

--- a/packages/react-google-adk/src/useAdkRuntime.test.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.test.ts
@@ -329,6 +329,64 @@ describe("getMessageContent", () => {
     ]);
   });
 
+  it("strips a data URL envelope from file data", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          data: "data:application/pdf;base64,QUJD",
+          mimeType: "application/pdf",
+          filename: "a.pdf",
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      {
+        type: "file",
+        mimeType: "application/pdf",
+        data: "QUJD",
+        filename: "a.pdf",
+      },
+    ]);
+  });
+
+  it("leaves bare base64 file data untouched", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        { type: "file", data: "QUJD", mimeType: "application/pdf" },
+      ]),
+    );
+    expect(result).toEqual([
+      { type: "file", mimeType: "application/pdf", data: "QUJD" },
+    ]);
+  });
+
+  it("round-trips an audio file part through both converters", () => {
+    const outbound = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          data: "data:audio/mp3;base64,QUJD",
+          mimeType: "audio/mp3",
+        },
+      ]),
+    );
+
+    expect(outbound).toEqual([
+      { type: "file", mimeType: "audio/mp3", data: "QUJD" },
+    ]);
+
+    const inbound = convertAdkMessage(
+      { id: "m1", type: "human", content: outbound } as never,
+      {},
+    );
+
+    expect(inbound).toMatchObject({
+      role: "user",
+      content: [{ type: "file", data: "QUJD", mimeType: "audio/mp3" }],
+    });
+  });
+
   it("skips data parts while keeping surrounding text", () => {
     const result = getMessageContent(
       makeAppendMessage([

--- a/packages/react-google-adk/src/useAdkRuntime.test.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.test.ts
@@ -350,6 +350,25 @@ describe("getMessageContent", () => {
     ]);
   });
 
+  it("emits a file_url part for an unmarked http source", () => {
+    const result = getMessageContent(
+      makeAppendMessage([
+        {
+          type: "file",
+          data: "https://cdn.example.com/a.pdf",
+          mimeType: "application/pdf",
+        },
+      ]),
+    );
+    expect(result).toEqual([
+      {
+        type: "file_url",
+        url: "https://cdn.example.com/a.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
   it("leaves bare base64 file data untouched", () => {
     const result = getMessageContent(
       makeAppendMessage([

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -60,7 +60,9 @@ export const getMessageContent = (msg: AppendMessage) => {
         return {
           type: "file" as const,
           mimeType: part.mimeType,
-          data: part.data,
+          // Lands in Gemini `inlineData.data`, which takes bare base64, so a
+          // data URL envelope is stripped rather than forwarded.
+          data: parseDataUrl(part.data)?.data ?? part.data,
           ...(part.filename != null && { filename: part.filename }),
         };
       case "audio": {

--- a/packages/react-google-adk/src/useAdkRuntime.ts
+++ b/packages/react-google-adk/src/useAdkRuntime.ts
@@ -13,7 +13,7 @@ import {
   type ToolExecutionStatus,
   generateId,
 } from "@assistant-ui/core";
-import { parseDataUrl } from "@assistant-ui/core/internal";
+import { httpUrlPattern, parseDataUrl } from "@assistant-ui/core/internal";
 import {
   useCloudThreadListAdapter,
   useRemoteThreadListRuntime,
@@ -50,7 +50,7 @@ export const getMessageContent = (msg: AppendMessage) => {
       case "image":
         return { type: "image_url" as const, url: part.image };
       case "file":
-        if (part.sourceType === "url") {
+        if (part.sourceType === "url" || httpUrlPattern.test(part.data)) {
           return {
             type: "file_url" as const,
             url: part.data,


### PR DESCRIPTION
closes #5449

## summary

- outbound, the `file` branch forwarded `data` verbatim into Gemini `inlineData.data`, which takes bare base64, while the `audio` branch stripped the data URL envelope first (`useAdkRuntime.ts`, `contentToParts.ts:18`). a `file` part carrying a data URL therefore shipped `data:audio/wav;base64,...` as the payload. both branches now strip it, so the two paths finally want the same input.
- inbound, a user-role `file` part with no filename and a mime type of exactly `audio/mp3` or `audio/wav` was reclassified into `Unstable_AudioMessagePart`. a caller following the `file` plus `audio/*` convention got a different part type back than it sent, so their `File` renderer never fired and only the deprecated `Unstable_Audio` slot did. file parts now stay file parts.
- dropping that heuristic also stops a silent loss: it was gated on `role === "user"` because the audio part only exists on the user union, so an audio file part on an assistant message had nowhere to go. `FileMessagePart` is on both unions, so it survives now.
- the local `ContentPart` union loses its `audio` member, which nothing produces any more.

## why this ordering

this sits on top of #5445, which added the `sourceType: "url"` leg to the same two switches. that PR handled explicitly-declared url references; this one handles the base64 leg and the reclassification, which it deliberately left alone.

## breaking changes

- code reading `Unstable_AudioMessagePart` out of this adapter now receives `file` parts with an `audio/*` mime type. this matches what #5444 did for the LangChain family and is the direction #5447 documents. sending an audio part still works; only the inbound shape moves.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-google-adk test` -> 212/212 green
- [x] the two tests that pinned the reclassification are rewritten to pin the new contract, plus a new assistant-role case that the old `role === "user"` guard made impossible
- [x] a round-trip test asserts outbound then inbound leaves an audio file part as a file part with the envelope stripped
- [x] `pnpm exec tsc --noEmit` -> clean
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

### reviewer should verify

- [ ] send a base64 audio attachment through an ADK app and confirm Gemini receives `inlineData.data` as bare base64, and that the part renders through the `File` slot rather than disappearing.

## notes

- the Part Types callout in the message primitive docs drops react-google-adk from its list of adapters with an uneven file path, since both of its entries are fixed here. `react-ag-ui` (#5450) and `react-opencode` (#5454) remain.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

