### PR TITLE
fix(react-ag-ui): convert file parts placed directly in message content

### DIFF
--- a/.changeset/agui-content-file-parts.md
+++ b/.changeset/agui-content-file-parts.md
@@ -1,0 +1,7 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: convert file parts placed directly in message content
+
+`buildUserContent` filtered every `file` part out of `message.content`, on the stated grounds that binary always flows through `message.attachments`. That rule was not actually implemented: `image` and `audio` content parts, equally binary, were converted from content all along, so only `file` was excluded. It also guarded nothing, because both composer paths put binary in attachments and leave content as text (the edit composer lifts non-text parts with `liftNonTextParts` and passes none through), and because content-sourced and attachment-sourced parts land in the same flat `InputContent[]` with no downstream distinction. The only way a file part reached that filter was a deliberate `append()`, where it was silently dropped.

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Existing audio parts keep working; they will not gain fields.
+Adapter coverage for the file path is still uneven, so check your adapter's converter before relying on file parts. Known so far: `react-pi` and the assistant-transport runtime have no file part on their user-content surface at all, so one is dropped; `react-data-stream` carries the payload but not the filename. Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/apps/docs/content/docs/primitives/message.mdx
+++ b/apps/docs/content/docs/primitives/message.mdx
@@ -140,7 +140,7 @@ Anything that is not a modality the model consumes or a channel it emits is a `d
 <Callout type="warn">
 `Unstable_AudioMessagePart` and the `Unstable_Audio` slot are deprecated. The audio part cannot carry a filename, has no way to declare how its payload goes on the wire (no `sourceType`, so no storage id), and exists only on user messages, so a model that returns audio has no way to express it. Send audio as a `file` part with an `audio/*` mime type instead, and give it a filename.
 
-Adapter coverage for the file path is still uneven, so check your adapter's converter before relying on a particular payload form. Known so far: `react-ag-ui` carries binary through `attachments` rather than content parts; `react-opencode` forwards the payload into a `url` field without inspecting it, so bare base64 is corrupted there. Existing audio parts keep working; they will not gain fields.
+Existing audio parts keep working; they will not gain fields.
 </Callout>
 
 ### Tool Resolution

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -357,13 +357,7 @@ function toSnapshotAttachments(content: unknown): SnapshotAttachment[] {
 }
 
 function buildUserContent(message: ThreadMessageLike): string | InputContent[] {
-  // File parts in message.content are intentionally skipped: the canonical
-  // binary payload for files always flows through message.attachments.
-  const contentParts = Array.isArray(message.content)
-    ? message.content.filter(
-        (part) => !(isObject(part) && part.type === "file"),
-      )
-    : [];
+  const contentParts = Array.isArray(message.content) ? message.content : [];
 
   const attachments = message.attachments ?? [];
 

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -695,6 +695,7 @@ describe("adapter conversions", () => {
         },
       ],
     });
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
   it("emits content and attachment file parts once each", () => {
@@ -736,6 +737,7 @@ describe("adapter conversions", () => {
       "QUFB",
       "QkJC",
     ]);
+    expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
   it("converts image attachment with data URL to AG-UI image source", () => {

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -663,6 +663,81 @@ describe("adapter conversions", () => {
     expect(() => UserMessageSchema.parse(result[0])).not.toThrow();
   });
 
+  it("converts a file part placed directly in message content", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          { type: "text", text: "review this" },
+          {
+            type: "file",
+            data: "data:application/pdf;base64,JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+            filename: "a.pdf",
+          },
+        ],
+      },
+    ] as any);
+
+    expect(result[0]).toMatchObject({
+      role: "user",
+      content: [
+        { type: "text", text: "review this" },
+        {
+          type: "document",
+          source: {
+            type: "data",
+            value: "JVBERi0xLjQ=",
+            mimeType: "application/pdf",
+          },
+          metadata: { filename: "a.pdf" },
+        },
+      ],
+    });
+  });
+
+  it("emits content and attachment file parts once each", () => {
+    const result = toAgUiMessages([
+      {
+        id: "u-1",
+        role: "user",
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,QUFB",
+            mimeType: "application/pdf",
+            filename: "from-content.pdf",
+          },
+        ],
+        attachments: [
+          {
+            id: "a-1",
+            type: "document",
+            name: "from-attachment.pdf",
+            content: [
+              {
+                type: "file",
+                data: "data:application/pdf;base64,QkJC",
+                mimeType: "application/pdf",
+                filename: "from-attachment.pdf",
+              },
+            ],
+          },
+        ],
+      },
+    ] as any);
+
+    const documents = (result[0] as any).content.filter(
+      (part: any) => part.type === "document",
+    );
+    expect(documents).toHaveLength(2);
+    expect(documents.map((part: any) => part.source.value)).toEqual([
+      "QUFB",
+      "QkJC",
+    ]);
+  });
+
   it("converts image attachment with data URL to AG-UI image source", () => {
     const result = toAgUiMessages([
       {


### PR DESCRIPTION
closes #5450

## summary

- `buildUserContent` filtered every `file` part out of `message.content`, so a file part placed there was silently dropped. it is now converted like every other part type.
- the docs callout listing adapters with an uneven file path goes away entirely: this was the last of the three it named, after #5456 (react-google-adk) and #5459 (react-opencode).

## why this is a removal, not a policy change

the comment justified the filter as "the canonical binary payload for files always flows through `message.attachments`". three things say that rule was not real:

1. **it was not implemented.** only `type === "file"` was filtered. `image` and `audio` content parts, equally binary, were converted from content all along. the rule described a general principle the code applied to exactly one part type.
2. **it guarded nothing.** the duplication it would prevent cannot occur through either composer path: send emits `content: [text]` plus attachments, and the edit composer lifts non-text parts into attachments via `liftNonTextParts` while setting `_nonTextPassthrough = []` for user messages (`default-edit-composer-runtime-core.ts:67-71`), so content is text-only on both. the only route to a file part in `content` is a deliberate `append()`.
3. **it made no downstream difference.** content-sourced and attachment-sourced parts are pushed into the same flat `InputContent[]`; nothing records which loop produced them, so "flowing through attachments" is not observable to the agent.

inbound is unaffected: `fromAgUiMessages` emits string content plus attachments, so `contentParts` is empty on a resend and the attachment-morph round trip is untouched.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ag-ui test` -> 303/303 green (2 new)
- [x] the suite passed at 301/301 with the filter removed and before any test was added, confirming nothing pinned the drop
- [x] one new test covers a file part in content converting to a `document` input with its filename; the other sends a file part in content **and** one in attachments and asserts exactly two documents with distinct payloads, which is the duplication the filter was ostensibly guarding
- [x] `pnpm exec tsc --noEmit` -> 0 errors
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

### reviewer should verify

- [ ] send a file part through `append({ role: "user", content: [{ type: "file", ... }] })` against an AG-UI agent and confirm it arrives.

## notes

- context is #5309. with this, every adapter gap found while documenting the `file` plus `audio/*` carrier is closed: #5448, #5449, #5450, #5454. the two that remain are about images rather than file parts (#5453, #5458).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

