### PR TITLE
fix(assistant-stream,react-data-stream): carry a file part filename to the model message

### DIFF
--- a/.changeset/generic-file-part-filename.md
+++ b/.changeset/generic-file-part-filename.md
@@ -1,0 +1,8 @@
+---
+"assistant-stream": patch
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: carry a file part's filename through to the model message
+
+`GenericFilePart` had no `filename` field, so a `FileMessagePart` or `ImageMessagePart` carrying one arrived at the provider anonymous even though `LanguageModelV2FilePart` accepts a filename. The field is now declared and forwarded by both `toGenericMessages` and the react-data-stream converter, and omitted entirely when the source part has none.

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -703,6 +703,7 @@ type GenericFilePart = {
   type: "file";
   data: string | URL;
   mediaType: string;
+  filename?: string;
 };
 
 type GenericMessage = GenericSystemMessage | GenericUserMessage | GenericAssistantMessage | GenericToolMessage;
@@ -897,6 +898,7 @@ type MessagePartLike = {
   image?: string;
   data?: string;
   mimeType?: string;
+  filename?: string;
   toolCallId?: string;
   toolName?: string;
   args?: Record<string, unknown>;

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -151,6 +151,54 @@ describe("toGenericMessages", () => {
       ]);
     });
 
+    it("carries a file part filename through", () => {
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: "https://cdn.example.com/a.pdf",
+              mimeType: "application/pdf",
+              filename: "invoice.pdf",
+            },
+          ],
+        },
+      ] as never);
+
+      expect(result).toEqual([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: new URL("https://cdn.example.com/a.pdf"),
+              mediaType: "application/pdf",
+              filename: "invoice.pdf",
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("omits filename when the part has none", () => {
+      const result = toGenericMessages([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              data: "https://cdn.example.com/a.pdf",
+              mimeType: "application/pdf",
+            },
+          ],
+        },
+      ] as never);
+
+      const part = (result[0] as { content: unknown[] }).content[0];
+      expect(part).not.toHaveProperty("filename");
+    });
+
     it("filters invalid parts", () => {
       const result = toGenericMessages([
         {

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -13,6 +13,7 @@ export type GenericFilePart = {
   type: "file";
   data: string | URL;
   mediaType: string;
+  filename?: string;
 };
 
 export type GenericToolCallPart = {
@@ -62,6 +63,7 @@ type MessagePartLike = {
   image?: string;
   data?: string;
   mimeType?: string;
+  filename?: string;
   toolCallId?: string;
   toolName?: string;
   args?: Record<string, unknown>;
@@ -194,12 +196,14 @@ function convertUserMessage(
         type: "file",
         data: toUrlOrString(part.image),
         mediaType: inferImageMediaType(part.image),
+        ...(part.filename && { filename: part.filename }),
       });
     } else if (part.type === "file" && part.data && part.mimeType) {
       content.push({
         type: "file",
         data: toUrlOrString(part.data),
         mediaType: part.mimeType,
+        ...(part.filename && { filename: part.filename }),
       });
     }
   }

--- a/packages/react-data-stream/src/converters/toLanguageModelMessages.test.ts
+++ b/packages/react-data-stream/src/converters/toLanguageModelMessages.test.ts
@@ -22,6 +22,39 @@ const convertFileData = (data: string) => {
 };
 
 describe("toLanguageModelMessages", () => {
+  it("carries a file part filename through to the model message", () => {
+    const [message] = toLanguageModelMessages([
+      {
+        id: "user-1",
+        role: "user",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        content: [
+          {
+            type: "file",
+            data: "SGVsbG8=",
+            mimeType: "text/plain",
+            filename: "notes.txt",
+          },
+        ],
+        attachments: [],
+        metadata: { custom: {} },
+      },
+    ]);
+    if (message?.role !== "user") throw new Error("Expected a user message");
+
+    expect(message.content[0]).toMatchObject({
+      type: "file",
+      filename: "notes.txt",
+    });
+  });
+
+  it("omits filename when the part has none", () => {
+    const [message] = toLanguageModelMessages([createFileMessage("SGVsbG8=")]);
+    if (message?.role !== "user") throw new Error("Expected a user message");
+
+    expect(message.content[0]).not.toHaveProperty("filename");
+  });
+
   it("preserves base64 file data as a string", () => {
     expect(convertFileData("SGVsbG8=")).toBe("SGVsbG8=");
   });

--- a/packages/react-data-stream/src/converters/toLanguageModelMessages.ts
+++ b/packages/react-data-stream/src/converters/toLanguageModelMessages.ts
@@ -26,6 +26,7 @@ function convertUserContent(
       type: "file",
       data: part.data,
       mediaType: part.mediaType,
+      ...(part.filename && { filename: part.filename }),
     };
   });
 }


### PR DESCRIPTION
closes #5462

## summary

- `GenericFilePart` gains an optional `filename`, and both `toGenericMessages` and the react-data-stream converter forward it. a `FileMessagePart` or `ImageMessagePart` carrying a filename previously arrived at the provider anonymous.
- the field is omitted rather than set to `undefined` when the source part has none, so nothing changes for parts without one.
- `MessagePartLike`, assistant-stream's local structural stand-in for a message part, gains `filename` too; without it the forward does not typecheck.

## why this is worth fixing

the destination already supports it: `LanguageModelV2FilePart` declares `filename?: string` (`@ai-sdk/provider@3.0.14`). the field was being dropped purely because our intermediate type had nowhere to put it.

it also undercut an argument we are making elsewhere. #5447 tells users to migrate off `Unstable_AudioMessagePart` onto a `file` part, and one of the stated reasons is that the audio part cannot carry a filename. on the react-data-stream path the filename was lost anyway, so that specific benefit did not materialise.

## what I did not change

#5462 also proposed defaulting a falsy `mimeType` instead of dropping the part. I left that alone: `mimeType` is a required field on `FileMessagePart`, so a falsy one means the caller broke the type, and `toGenericMessages.test.ts` deliberately pins the drop under "filters invalid parts". the inbound converters I compared it to in the issue default it because their wire genuinely may omit it, which is not the same situation. the issue is updated to say so.

## test plan

### already verified

- [x] `pnpm --filter assistant-stream test` -> 362 passed, 20 skipped (2 new)
- [x] `pnpm --filter @assistant-ui/react-data-stream test` -> 20/20 green (2 new)
- [x] the react-data-stream test failed before `assistant-stream` was rebuilt, which confirms it exercises the change rather than passing on a stale dist
- [x] both new suites cover the negative case: no `filename` property when the source part has none
- [x] `pnpm exec tsc --noEmit` -> 0 errors in both packages
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

