### PR TITLE
fix(docs): keep blank code-block lines one line tall

### DIFF
--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -434,6 +434,12 @@ figure.shiki {
     padding-left: calc(0.875rem + 2.25rem) !important;
   }
 
+  /* Blank lines in plaintext fences render as an empty child span, dodging
+     fumadocs' .line:empty height rule; keep every line one line tall. */
+  & .line {
+    min-height: 1lh;
+  }
+
   /* Highlighted lines */
   & .highlighted {
     background: oklch(0.7 0.12 250 / 0.1) !important;


### PR DESCRIPTION
## What

Blank lines inside docs code blocks collapsed to zero height, making adjacent line numbers render on top of each other (e.g. the `text` tree diagram on `/tap/docs/tap/composition`, where gutter numbers 3 and 4 overlapped).

## Why

Shiki emits blank lines in plaintext fences as `<span class="line"><span></span></span>`. The empty *child* span means fumadocs' `.line:empty { height: 1lh }` rule never matches, and since fumadocs' `Pre` lays the `code` element out as a flex column (`*:flex *:flex-col`), the newline text nodes contribute no height either. The blank line collapses to 0px and its absolutely-positioned line number stacks on the next line's.

## How

Add `min-height: 1lh` to `.line` inside the existing `figure.shiki` overrides in `apps/docs/styles/fumadocs.css`. Line spans are flex items (blockified), so `min-height` applies; non-blank lines are unaffected since they already measure ≥1lh.

Verified in-browser on the composition page: all 7 lines of the tree diagram now measure 21.4px with distinct offsets, and the blank line keeps its own gutter number.

Docs-only change to a private app; no changeset needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1HZ4VSy_JzhlW3tXShPYOLvmNN9q_u9p64g2JKlb5KH44vpldhDkKv9XhQk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->