### PR TITLE
fix(react-ai-sdk): detect the media type of a bare base64 image

### DIFF
--- a/.changeset/image-media-type-sniff.md
+++ b/.changeset/image-media-type-sniff.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: detect the media type of a bare base64 image instead of assuming png
+
+`getImageMediaType` resolved an explicit `contentType`, then a data URL envelope, then fell back to `image/png`. An `ImageMessagePart` carrying raw base64 has neither, so JPEG, GIF and WebP payloads were all announced to the provider as png. The leading bytes are now read with `detectMediaType` from `@ai-sdk/provider-utils`, the same helper the AI SDK uses internally, and `image/png` remains the fallback when no signature matches.
+
+The sniff only runs on a payload that is not a parsable url, and never propagates a throw: `detectMediaType` raises on input that is not valid base64.

--- a/packages/react-ai-sdk/package.json
+++ b/packages/react-ai-sdk/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@ai-sdk/mcp": "^2.0.16",
+    "@ai-sdk/provider-utils": "^5.0.12",
     "@ai-sdk/react": "^4.0.40",
     "@assistant-ui/core": "^0.3.3",
     "@assistant-ui/store": "^0.3.2",

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.test.ts
@@ -288,6 +288,59 @@ describe("toCreateMessage", () => {
     ).rejects.toThrow(/Invalid URL/);
   });
 
+  it("sniffs the media type of a bare base64 image", () => {
+    const cases = [
+      { image: "/9j/4AAQSkZJRg==", mediaType: "image/jpeg" },
+      { image: "iVBORw0KGgoAAAANSUhEUg==", mediaType: "image/png" },
+      { image: "R0lGODlhAQABAA==", mediaType: "image/gif" },
+      { image: "UklGRiIAAABXRUJQVlA4", mediaType: "image/webp" },
+    ];
+
+    for (const { image, mediaType } of cases) {
+      const message = {
+        ...baseMessage,
+        content: [{ type: "image", image }],
+      } as unknown as AppendMessage;
+
+      expect(toCreateMessage(message).parts).toEqual([
+        { type: "file", url: `data:${mediaType};base64,${image}`, mediaType },
+      ]);
+    }
+  });
+
+  it("does not sniff a payload that is not base64", () => {
+    for (const image of [
+      "https://cdn.example.com/photo",
+      "blob:https://app.example/1-2-3",
+      "not base64 at all!!",
+    ]) {
+      const message = {
+        ...baseMessage,
+        content: [{ type: "image", image }],
+      } as unknown as AppendMessage;
+
+      expect(() => toCreateMessage(message)).not.toThrow();
+      expect(toCreateMessage(message).parts[0]).toMatchObject({
+        mediaType: "image/png",
+      });
+    }
+  });
+
+  it("falls back to image/png when the bytes match no known signature", () => {
+    const message = {
+      ...baseMessage,
+      content: [{ type: "image", image: "QUJD" }],
+    } as unknown as AppendMessage;
+
+    expect(toCreateMessage(message).parts).toEqual([
+      {
+        type: "file",
+        url: "data:image/png;base64,QUJD",
+        mediaType: "image/png",
+      },
+    ]);
+  });
+
   it("wraps bare base64 image data using the resolved media type", () => {
     const message = {
       ...baseMessage,

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -1,3 +1,4 @@
+import { detectMediaType } from "@ai-sdk/provider-utils";
 import type { AppendMessage } from "@assistant-ui/core";
 import {
   httpUrlPattern,
@@ -22,6 +23,16 @@ const getDataUrlMediaType = (url: string) => {
   return match?.[1]?.toLowerCase();
 };
 
+// `detectMediaType` throws on a payload that is not valid base64, and this
+// runs on unvalidated input.
+const sniffImageMediaType = (data: string) => {
+  try {
+    return detectMediaType({ data, topLevelType: "image" });
+  } catch {
+    return undefined;
+  }
+};
+
 const getImageMediaType = (part: {
   readonly contentType?: string | undefined;
   readonly image: string;
@@ -30,6 +41,13 @@ const getImageMediaType = (part: {
 
   const dataUrlMediaType = getDataUrlMediaType(part.image);
   if (dataUrlMediaType?.startsWith("image/")) return dataUrlMediaType;
+
+  // A bare base64 payload carries its format in its leading bytes; without
+  // this the declared type is `image/png` whatever the image actually is.
+  if (!isParsableUrl(part.image)) {
+    const sniffed = sniffImageMediaType(part.image);
+    if (sniffed) return sniffed;
+  }
 
   return "image/png";
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3901,6 +3901,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: ^2.0.16
         version: 2.0.16(zod@4.4.3)
+      '@ai-sdk/provider-utils':
+        specifier: ^5.0.12
+        version: 5.0.12(zod@4.4.3)
       '@ai-sdk/react':
         specifier: ^4.0.40
         version: 4.0.40(react@19.2.8)(zod@4.4.3)


### PR DESCRIPTION
closes #5453

## summary

- `getImageMediaType` resolved an explicit `contentType`, then a data URL envelope, then fell back to `image/png`. an `ImageMessagePart` carrying raw base64 has neither, so JPEG, GIF and WebP payloads were all announced to the provider as png.
- the leading bytes are now read with `detectMediaType` from `@ai-sdk/provider-utils`, the same helper the AI SDK uses internally for inline data, rather than a hand-rolled signature table. `image/png` stays the fallback when nothing matches.

## why it became consequential

before #5452 a bare base64 image produced `url: "<base64>"`, which `convertToModelMessages` rejected with `Invalid URL`, so the part never left the client and the mislabel was inert. #5452 wraps the payload so it now ships, and the wrong media type shipped with it.

## two guards, both load-bearing

`detectMediaType` throws `InvalidCharacterError` on input that is not valid base64, which the pre-existing tests caught immediately: a `https://` or `blob:` image payload would have crashed the whole conversion.

- the sniff only runs when the payload is not a parsable url, which is the same split the wrapping already uses
- a throw from it is still swallowed, because this runs on unvalidated input and a converter must not throw on a non-spec payload

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 183/183 green (3 new)
- [x] the sniff is covered against real JPEG, PNG, GIF and WebP signatures, plus the no-match fallback
- [x] a dedicated case asserts `https://`, `blob:` and plain non-base64 text neither throw nor get sniffed
- [x] behavior was probed directly against the installed `@ai-sdk/provider-utils` before adopting it, which is how the throw surfaced
- [x] `pnpm exec tsc --noEmit` -> no errors in the touched file
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

## notes

- `@ai-sdk/provider-utils` becomes a direct dependency. it was already in the tree transitively through `ai` and `@ai-sdk/react`, so this adds no install weight, and it is the same vendor family this package already depends on. pinned `^5.0.12` in line with the AI SDK v7 family posture.
- #5458 (react-opencode image parts) was waiting on this fallback decision and can now follow.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

