### PR TITLE
fix(ui): replace invalid hsl() fade mask colors with color-mix in reasoning

### DIFF
--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -143,7 +143,7 @@ function ReasoningFade({
         className={cn(
           "aui-reasoning-fade pointer-events-none absolute inset-x-0 top-0 z-10 h-8",
           "bg-[linear-gradient(to_bottom,var(--color-background),transparent)]",
-          "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,color-mix(in_oklab,var(--color-muted)_50%,transparent),transparent)]",
+          "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,color-mix(in_oklab,var(--color-muted)_50%,var(--color-background)),transparent)]",
           "fade-in-0 animate-in",
           "duration-(--animation-duration)",
           className,
@@ -159,7 +159,7 @@ function ReasoningFade({
       className={cn(
         "aui-reasoning-fade pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8",
         "bg-[linear-gradient(to_top,var(--color-background),transparent)]",
-        "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_top,color-mix(in_oklab,var(--color-muted)_50%,transparent),transparent)]",
+        "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_top,color-mix(in_oklab,var(--color-muted)_50%,var(--color-background)),transparent)]",
         "fade-in-0 animate-in",
         "duration-(--animation-duration)",
         className,

--- a/packages/ui/src/components/assistant-ui/reasoning.tsx
+++ b/packages/ui/src/components/assistant-ui/reasoning.tsx
@@ -143,7 +143,7 @@ function ReasoningFade({
         className={cn(
           "aui-reasoning-fade pointer-events-none absolute inset-x-0 top-0 z-10 h-8",
           "bg-[linear-gradient(to_bottom,var(--color-background),transparent)]",
-          "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,hsl(var(--muted)/0.5),transparent)]",
+          "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_bottom,color-mix(in_oklab,var(--color-muted)_50%,transparent),transparent)]",
           "fade-in-0 animate-in",
           "duration-(--animation-duration)",
           className,
@@ -159,7 +159,7 @@ function ReasoningFade({
       className={cn(
         "aui-reasoning-fade pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8",
         "bg-[linear-gradient(to_top,var(--color-background),transparent)]",
-        "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_top,hsl(var(--muted)/0.5),transparent)]",
+        "group-data-[variant=muted]/reasoning-root:bg-[linear-gradient(to_top,color-mix(in_oklab,var(--color-muted)_50%,transparent),transparent)]",
         "fade-in-0 animate-in",
         "duration-(--animation-duration)",
         className,


### PR DESCRIPTION
## what

both `ReasoningFade` masks in `packages/ui/src/components/assistant-ui/reasoning.tsx` used `hsl(var(--muted)/0.5)` for the muted variant. the theme tokens are oklch, so that expands to `hsl(oklch(0.967 0.001 286.375)/0.5)`, which is unparseable. because the declaration contains `var()` it fails at computed-value time rather than parse time, so `background-image` resolves to its initial value instead of falling back to the earlier declaration. the muted-variant fades rendered nothing at all.

## fix

both masks now start from `color-mix(in oklab, var(--color-muted) 50%, var(--color-background))`, matching the two existing uses of this shape in `thread.tsx:118` and `thread.tsx:234`.

the third argument is the background rather than `transparent` on purpose. these are occluding masks: the gradient has to be fully opaque where it meets the panel edge, or the text underneath stays half visible at exactly the point the fade is supposed to hide it. mixing toward the background gives an opaque approximation of what `bg-muted/50` actually renders as once composited, which is the colour the mask needs to match.

## verification

measured in chrome against the tokens as defined in `globals.css`:

| declaration | `CSS.supports` | computed `background-image` |
| --- | --- | --- |
| `hsl(var(--muted)/0.5)` | false | `none` |
| `color-mix(in oklab, var(--color-muted) 50%, var(--color-background))` | true | `linear-gradient(oklab(0.9835 0.000140962 -0.000479718), rgba(0, 0, 0, 0))` |

for comparison, mixing toward `transparent` instead computes to `oklab(0.967 … / 0.5)`, which is byte-identical to the panel's own `bg-muted/50` but only half opaque, and therefore does not occlude.

tailwind v4 compiles the arbitrary value with a progressive-enhancement fallback (plain `var(--color-muted)` plus an `@supports (color: color-mix(…))` upgrade) for free.

no changeset: `@assistant-ui/ui` is private. no template or example carries a copy of `reasoning.tsx`, and the docs sample at `apps/docs/components/docs/samples/reasoning.tsx` does not contain the fade.

the same class of dead declaration exists in `packages/ui/src/components/ui/radix/sidebar.tsx:482`, where `hsl()` wraps the oklch `--sidebar-border` and `--sidebar-accent` tokens. that one is vendoring drift (upstream already dropped the wrapper) and is tracked separately in #5581.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.DFcnM4ieR_n7Rx147sAFuLUSNAubklOK-npNBdW2xZM9aMluqxFk0nEXeIA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
