### PR TITLE
fix(ui): drop invalid hsl() wrapper from radix sidebar outline shadow

### DIFF
--- a/packages/ui/src/components/ui/radix/sidebar.tsx
+++ b/packages/ui/src/components/ui/radix/sidebar.tsx
@@ -479,7 +479,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_var(--sidebar-border)] hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",


### PR DESCRIPTION
The Radix sidebar's `outline` menu-button variant rendered without its 1px border shadow, and hovering produced no accent shadow either. The variant wrapped its shadow colors as `hsl(var(--sidebar-border))`, but the sidebar tokens are full oklch colors throughout the repo, so the declaration compiled to `box-shadow: 0 0 0 1px hsl(oklch(…))` — invalid CSS that browsers drop entirely. The Base UI flavor already references the tokens bare; this copies that form, bringing the two flavors back in line on this variant. A repo-wide search found no other occurrence of the broken pattern, and `@assistant-ui/ui` is private, so no changeset is included.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SFHXDd5GYIbqDzx2daXnrHaz5eLZ8T607XEoiIENA-O-HNQaTIJL9MXUCRs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->