### PR TITLE
fix(ui): open standalone base tooltips instantly instead of after 600ms

### DIFF
--- a/packages/ui/src/components/ui/base/tooltip.tsx
+++ b/packages/ui/src/components/ui/base/tooltip.tsx
@@ -18,7 +18,11 @@ function TooltipProvider({
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {

--- a/templates/minimal/components/ui/tooltip.tsx
+++ b/templates/minimal/components/ui/tooltip.tsx
@@ -18,7 +18,11 @@ function TooltipProvider({
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {


### PR DESCRIPTION
A bare `<Tooltip>` from the Base UI kit opened only after Base UI's built-in 600ms delay, while the identical Radix markup opened instantly: the base variant never wrapped itself in `TooltipProvider`, so the provider's `delay = 0` default never applied (Base UI resolves `delay ?? providerDelay ?? 600`, and without a provider the 600ms floor wins). `Tooltip` now self-wraps in `TooltipProvider`, matching the Radix variant, and the byte-equal copy in `templates/minimal` is synced via `pnpm sync-templates --write`.

Only registry/template consumers using a standalone `<Tooltip>` were affected — every in-repo caller already wraps in a provider explicitly. Trade-off, the same one the Radix variant already accepts: each tooltip now carries its own provider, so an outer `<TooltipProvider delay={…}>` grouping is overridden by the inner delay-0 provider; accepted for cross-variant parity.

No changeset: `@assistant-ui/ui` is private and the template is unpublished.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.yH2ZvDj9uDEKtELMjGARlponEywDO9f-2HIbg7yLNmTVahAaMGDzGSmi4q8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->