### PR TITLE
fix(ui): honor file part sourceType in File download and size

### DIFF
--- a/apps/docs/content/docs/ui/file.mdx
+++ b/apps/docs/content/docs/ui/file.mdx
@@ -115,7 +115,7 @@ import {
 | `File.Icon` | MIME type-aware icon, or pass custom `children` |
 | `File.Name` | Truncated filename |
 | `File.Size` | Human-readable file size |
-| `File.Download` | Download link button |
+| `File.Download` | Download link button; renders nothing without a browser-resolvable target (`sourceType: "id"`, urls that are not http(s)/blob/data) |
 
 ### Custom Icon
 
@@ -142,8 +142,9 @@ import {
 // Get icon component for a MIME type
 const Icon = getMimeTypeIcon("application/pdf"); // FileTextIcon
 
-// Classify the data field of a file part
+// Classify the data field of a file part; a declared sourceType wins over sniffing, except a data: payload declared as "url"
 const kind = getFileDataKind("https://example.com/report.pdf"); // "url"
+const ref = getFileDataKind("file-abc123", "id"); // "id"
 
 // Calculate size from base64 string
 const bytes = getBase64Size("SGVsbG8gV29ybGQh"); // 12

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -59,9 +59,14 @@ function getMimeTypeIcon(mimeType: string): FC<{ className?: string }> {
   return FileIcon;
 }
 
-export type FileDataKind = "data-uri" | "url" | "base64";
+export type FileDataKind = "data-uri" | "url" | "base64" | "id";
 
-function getFileDataKind(data: string): FileDataKind {
+function getFileDataKind(
+  data: string,
+  sourceType?: "url" | "id",
+): FileDataKind {
+  if (sourceType === "url" && /^data:/i.test(data)) return "data-uri";
+  if (sourceType) return sourceType;
   if (/^data:/i.test(data)) return "data-uri";
   if (/^https?:\/\//i.test(data)) return "url";
   return "base64";
@@ -166,17 +171,21 @@ type FileDownloadProps = Omit<React.ComponentProps<"a">, "href"> & {
   data: string;
   mimeType: string;
   filename?: string;
+  sourceType?: "url" | "id";
 };
 
 function FileDownload({
   data,
   mimeType,
   filename,
+  sourceType,
   className,
   children,
   ...props
 }: FileDownloadProps) {
-  const kind = getFileDataKind(data);
+  const kind = getFileDataKind(data, sourceType);
+  if (kind === "id") return null;
+  if (kind === "url" && !/^(https?:\/\/|blob:)/i.test(data)) return null;
   const href = kind === "base64" ? `data:${mimeType};base64,${data}` : data;
 
   return (
@@ -196,8 +205,14 @@ function FileDownload({
   );
 }
 
-const FileImpl: FileMessagePartComponent = ({ filename, data, mimeType }) => {
-  const showSize = getFileDataKind(data) !== "url";
+const FileImpl: FileMessagePartComponent = ({
+  filename,
+  data,
+  mimeType,
+  sourceType,
+}) => {
+  const kind = getFileDataKind(data, sourceType);
+  const showSize = kind === "base64" || kind === "data-uri";
 
   return (
     <FileRoot>
@@ -212,6 +227,7 @@ const FileImpl: FileMessagePartComponent = ({ filename, data, mimeType }) => {
         data={data}
         mimeType={mimeType}
         {...(filename !== undefined && { filename })}
+        {...(sourceType !== undefined && { sourceType })}
       />
     </FileRoot>
   );


### PR DESCRIPTION
Closes #5472
## What

The `File` component now honors a declared `FileMessagePart.sourceType`: `getFileDataKind` takes it as an optional second argument and returns it before sniffing, `File.Download` renders nothing for `"id"` parts, and the size row only shows for payload kinds (`base64`, `data-uri`).

## Why

While wiring up the opaque file reference flow the attachment docs describe, an `sourceType: "id"` part rendered a download link whose href was `data:application/pdf;base64,file-abc123` and a size row from base64-decoding the id. The renderer receives `sourceType` as a prop but never consulted it. 

## Impact

- `sourceType: "id"` parts: icon and name only, no download link (nothing browser-resolvable), no size row.
- `sourceType: "url"` parts: direct href for http(s) and blob: urls; other schemes render the card without a link, same as `"id"`.
- Parts without `sourceType`: byte-identical to current behavior.

## Scope 

- The null-return lives in `File.Download` itself, not the parent, so composable users passing part fields straight through cannot render a broken link.
- Declared `sourceType` deliberately wins over sniffing, even if the data string would sniff differently: the declaration is the part author's contract.
- `attachment.tsx` has no equivalent sniffing, so no sibling fix is needed.
- Converter and core work is done (#5439, #5444, #5445); this is the renderer remainder flagged non-blocking on the #5439 review.
- Additive only: `FileDataKind` union widened, optional parameter and optional prop added, no exports removed or reshaped.
- Tests: none; `packages/ui` has no vitest setup and #5443 shipped the same way. Verified via typecheck and build.
- Changeset: none, private package (`@assistant-ui/ui`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VXD_sg3Bgp6pqQTH9RbZ4dBsDcX02itZAFzdIeXfpKxYpyfGhHT8p6n9CiI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->