### PR TITLE
fix(docs): cover the missing pages in the sitemap

### DIFF
--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { source, tapDocs, blog, examples, careers } from "@/lib/source";
 import { DEMOS } from "@/lib/demos";
+import { GALLERY_TEMPLATES } from "@/lib/gallery-templates";
 import { BASE_URL, PRODUCTS } from "@/lib/constants";
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -11,6 +12,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/showcase`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${BASE_URL}/gallery`, changeFrequency: "weekly", priority: 0.7 },
+    {
+      url: `${BASE_URL}/gallery/components`,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
     { url: `${BASE_URL}/oss`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${BASE_URL}/packages`, changeFrequency: "weekly", priority: 0.6 },
     { url: `${BASE_URL}/changelog`, changeFrequency: "weekly", priority: 0.6 },
@@ -71,6 +77,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }));
 
+  const galleryPages: MetadataRoute.Sitemap = GALLERY_TEMPLATES.map(
+    (template) => ({
+      url: `${BASE_URL}/gallery/${template.slug}`,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }),
+  );
+
   const careerPages: MetadataRoute.Sitemap = careers.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
     lastModified: page.data.lastModified,
@@ -86,6 +100,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...blogPages,
     ...examplePages,
     ...demoPages,
+    ...galleryPages,
     ...careerPages,
   ];
 }

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 import { source, tapDocs, blog, examples, careers } from "@/lib/source";
 import { DEMOS } from "@/lib/demos";
-import { BASE_URL } from "@/lib/constants";
+import { BASE_URL, PRODUCTS } from "@/lib/constants";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
@@ -10,23 +10,28 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/careers`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/showcase`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${BASE_URL}/gallery`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${BASE_URL}/oss`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${BASE_URL}/packages`, changeFrequency: "weekly", priority: 0.6 },
+    { url: `${BASE_URL}/changelog`, changeFrequency: "weekly", priority: 0.6 },
+    { url: `${BASE_URL}/traction`, changeFrequency: "weekly", priority: 0.5 },
+    { url: `${BASE_URL}/brand`, changeFrequency: "yearly", priority: 0.3 },
     {
       url: `${BASE_URL}/playground`,
       changeFrequency: "monthly",
       priority: 0.6,
     },
     { url: `${BASE_URL}/tap`, changeFrequency: "monthly", priority: 0.6 },
-    {
-      url: `${BASE_URL}/safe-content-frame`,
-      changeFrequency: "monthly",
-      priority: 0.4,
-    },
-    {
-      url: `${BASE_URL}/tw-shimmer`,
-      changeFrequency: "monthly",
-      priority: 0.4,
-    },
+    { url: `${BASE_URL}/tw-glass`, changeFrequency: "monthly", priority: 0.4 },
   ];
+
+  const productPages: MetadataRoute.Sitemap = PRODUCTS.filter(
+    (product) => !product.external,
+  ).map((product) => ({
+    url: `${BASE_URL}${product.href}`,
+    changeFrequency: "monthly" as const,
+    priority: 0.4,
+  }));
 
   const docsPages: MetadataRoute.Sitemap = source.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
@@ -75,6 +80,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [
     ...staticPages,
+    ...productPages,
     ...docsPages,
     ...tapDocsPages,
     ...blogPages,


### PR DESCRIPTION
## summary

- the sitemap's static list was hand maintained and had fallen behind: `/oss`, `/packages`, `/traction`, `/gallery`, `/changelog` and `/brand` were never listed, so nothing pointed a crawler at them
- of the product pages only `/tap`, `/tw-shimmer` and `/safe-content-frame` were there while `/native`, `/ink`, `/cloud-ai-sdk`, `/heat-graph` and `/react-o11y` were missing. those entries now derive from `PRODUCTS`, so the next product page is covered without a second edit here
- `/tw-glass` is listed explicitly because it has a route but is not in `PRODUCTS`

no test plan, sitemap data only.

### already verified

- [x] `/sitemap.xml` served by next dev -> 338 urls, every page named above present, no duplicate `<loc>` (the two entries that moved into the `PRODUCTS` list appear exactly once)
- [x] `tsc --noEmit` in apps/docs -> 0 errors; oxlint and oxfmt clean

## notes

- the legal pages (`/terms-of-service`, `/privacy-policy`) are still absent. left out deliberately rather than overlooked, since they carry no discovery value; say the word and they go in.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

