### PR TITLE
fix(react): allow callers to override default type on action buttons

### DIFF
--- a/.changeset/action-button-type-override.md
+++ b/.changeset/action-button-type-override.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: allow callers to override the default type="button" on action button primitives

--- a/packages/react/src/utils/createActionButton.test.tsx
+++ b/packages/react/src/utils/createActionButton.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createActionButton } from "./createActionButton";
+
+const TestButton = createActionButton("TestButton", () => () => {});
+
+describe("createActionButton", () => {
+  it("defaults to type=button", () => {
+    const html = renderToStaticMarkup(<TestButton />);
+    expect(html).toContain('type="button"');
+  });
+
+  it("allows the caller to override type", () => {
+    const html = renderToStaticMarkup(<TestButton type="submit" />);
+    expect(html).toContain('type="submit"');
+    expect(html).not.toContain('type="button"');
+  });
+});

--- a/packages/react/src/utils/createActionButton.tsx
+++ b/packages/react/src/utils/createActionButton.tsx
@@ -41,8 +41,8 @@ export const createActionButton = <TProps,>(
     const callback = useActionButton(forwardedProps as TProps) ?? undefined;
     return (
       <Primitive.button
-        {...primitiveProps}
         type="button"
+        {...primitiveProps}
         ref={forwardedRef}
         disabled={primitiveProps.disabled || !callback}
         onClick={composeEventHandlers(primitiveProps.onClick, callback)}


### PR DESCRIPTION
`createActionButton` stamped `type="button"` after spreading the caller's props, so passing a `type` to any action-button primitive was silently discarded. it now sits before the spread, which turns it from an unconditional override back into a default: every primitive still renders `type="button"` unless the caller says otherwise.

that ordering was the odd one out. the three attributes that stay after the spread each have a reason to be there: `ref` has to win, and `disabled` and `onClick` compose with whatever the caller passed. `type` did neither, so it was a default sitting in the override position.

no in-repo consumer passes a `type`, so nothing in this repo changes. the new test's override case fails against the previous ordering (`expected '<button type="button">' to contain 'type="submit"'`) and passes with this change.

## caveat for callers

giving an action button `type="submit"` inside `ComposerPrimitive.Root` fires the action twice, once from the button's own `onClick` and once from the form's `onSubmit`, because the root already sends on submit and the click handler does not prevent the default. that is measured rather than assumed. `type="submit"` is for a form the caller owns, not for the composer's own root.

<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.FZCL3eDs3rxpwnk7AP6pBl4Jyfk1ug95rr2md-FWT7EP-CzGGFK1rPJe4GY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->