### PR TITLE
fix(docs): index the tap docs everywhere the main docs are indexed

### DIFF
--- a/apps/docs/app/(home)/llms-full.txt/route.ts
+++ b/apps/docs/app/(home)/llms-full.txt/route.ts
@@ -1,12 +1,14 @@
-import { examples, source } from "@/lib/source";
+import { examples, source, getTapDocsPages } from "@/lib/source";
 import { getLLMText } from "@/lib/get-llm-text";
 
 export const revalidate = false;
 
 export async function GET() {
-  const scan = [...source.getPages(), ...examples.getPages()].map((page) =>
-    getLLMText(page),
-  );
+  const scan = [
+    ...source.getPages(),
+    ...getTapDocsPages(),
+    ...examples.getPages(),
+  ].map((page) => getLLMText(page));
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join("\n\n"), {

--- a/apps/docs/app/(home)/llms.txt/route.ts
+++ b/apps/docs/app/(home)/llms.txt/route.ts
@@ -1,13 +1,16 @@
-import { examples, source } from "@/lib/source";
+import { examples, source, getTapDocsPages } from "@/lib/source";
 import { buildLLMSIndex } from "@/lib/llms-index";
 
 export const revalidate = false;
 
 export async function GET() {
-  return new Response(buildLLMSIndex(source.getPages(), examples.getPages()), {
-    headers: {
-      "Cache-Control": "no-cache, must-revalidate",
-      "Content-Type": "text/plain; charset=utf-8",
+  return new Response(
+    buildLLMSIndex(source.getPages(), getTapDocsPages(), examples.getPages()),
+    {
+      headers: {
+        "Cache-Control": "no-cache, must-revalidate",
+        "Content-Type": "text/plain; charset=utf-8",
+      },
     },
-  });
+  );
 }

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -6,7 +6,11 @@ import path from "node:path";
 import { injectQuoteContext } from "@assistant-ui/react-ai-sdk";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateDocChatInput } from "@/lib/validate-input";
-import { source, examples as examplesSource } from "@/lib/source";
+import {
+  source,
+  examples as examplesSource,
+  tapDocs as tapSource,
+} from "@/lib/source";
 import { getModel, withTracing } from "@/lib/ai/provider";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
 import { createBashTool } from "bash-tool";
@@ -140,6 +144,19 @@ function normalizeDocPath(slugOrUrl: string, routeUrl: string): string {
   return cleaned;
 }
 
+function resolveDocSource(slugs: string[]) {
+  if (slugs[0] === "examples") {
+    return { docSource: examplesSource, docSlugs: slugs.slice(1) };
+  }
+  if (slugs[0] === "tap") {
+    return {
+      docSource: tapSource,
+      docSlugs: slugs.slice(slugs[1] === "docs" ? 2 : 1),
+    };
+  }
+  return { docSource: source, docSlugs: slugs };
+}
+
 export const maxDuration = 300;
 
 export const DOC_CHAT_PRUNE_OPTIONS = {
@@ -248,7 +265,7 @@ You have two documentation tools:
 
 1. **listDocs** - Browse documentation structure
    - Use with no path for root categories
-   - Use with path (e.g., "ui", "runtimes") to see pages in that section
+   - Use with path (e.g., "ui", "runtimes", "tap") to see pages in that section
    - Returns: list of folders and pages with URLs
 
 2. **readDoc** - Read a specific documentation page
@@ -367,6 +384,12 @@ export async function POST(req: Request): Promise<Response> {
                   description:
                     "Examples of app types users can build with assistant-ui, showing instructions, recommended patterns, and UI structure.",
                 },
+                {
+                  type: "folder",
+                  name: "tap",
+                  description:
+                    "Documentation for @assistant-ui/tap and @assistant-ui/store, the reactive primitives the runtime is built on.",
+                },
               ];
             }
 
@@ -376,6 +399,16 @@ export async function POST(req: Request): Promise<Response> {
               const target = rest
                 ? findFolderByPath(examplesSource.pageTree, rest)
                 : examplesSource.pageTree;
+              if (!target) return { error: "Path not found" };
+              return listChildren(target.children);
+            }
+            if (segments[0] === "tap") {
+              const rest = segments
+                .slice(segments[1] === "docs" ? 2 : 1)
+                .join("/");
+              const target = rest
+                ? findFolderByPath(tapSource.pageTree, rest)
+                : tapSource.pageTree;
               if (!target) return { error: "Path not found" };
               return listChildren(target.children);
             }
@@ -406,9 +439,7 @@ export async function POST(req: Request): Promise<Response> {
             }
 
             const slugs = normalized.split("/").filter(Boolean);
-            const isExample = slugs[0] === "examples";
-            const docSource = isExample ? examplesSource : source;
-            const docSlugs = isExample ? slugs.slice(1) : slugs;
+            const { docSource, docSlugs } = resolveDocSource(slugs);
 
             const page = docSource.getPage(docSlugs);
             if (!page) return { error: `Page not found: ${slugOrUrl}` };

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -150,7 +150,12 @@ function resolveDocPage(slugs: string[]) {
     return examplesSource.getPage(slugs.slice(1));
   }
   if (slugs[0] === "tap") {
-    return getTapDocsPage(slugs.slice(slugs[1] === "docs" ? 2 : 1));
+    // "tap" is both the url prefix and a section inside the tree, so a
+    // shorthand slug like "tap/api-reference" needs the unstripped form too.
+    return (
+      getTapDocsPage(slugs.slice(slugs[1] === "docs" ? 2 : 1)) ??
+      tapSource.getPage(slugs)
+    );
   }
   return source.getPage(slugs);
 }

--- a/apps/docs/app/api/doc/chat/route.ts
+++ b/apps/docs/app/api/doc/chat/route.ts
@@ -10,6 +10,7 @@ import {
   source,
   examples as examplesSource,
   tapDocs as tapSource,
+  getTapDocsPage,
 } from "@/lib/source";
 import { getModel, withTracing } from "@/lib/ai/provider";
 import { frontendTools } from "@assistant-ui/react-ai-sdk";
@@ -144,17 +145,14 @@ function normalizeDocPath(slugOrUrl: string, routeUrl: string): string {
   return cleaned;
 }
 
-function resolveDocSource(slugs: string[]) {
+function resolveDocPage(slugs: string[]) {
   if (slugs[0] === "examples") {
-    return { docSource: examplesSource, docSlugs: slugs.slice(1) };
+    return examplesSource.getPage(slugs.slice(1));
   }
   if (slugs[0] === "tap") {
-    return {
-      docSource: tapSource,
-      docSlugs: slugs.slice(slugs[1] === "docs" ? 2 : 1),
-    };
+    return getTapDocsPage(slugs.slice(slugs[1] === "docs" ? 2 : 1));
   }
-  return { docSource: source, docSlugs: slugs };
+  return source.getPage(slugs);
 }
 
 export const maxDuration = 300;
@@ -439,9 +437,7 @@ export async function POST(req: Request): Promise<Response> {
             }
 
             const slugs = normalized.split("/").filter(Boolean);
-            const { docSource, docSlugs } = resolveDocSource(slugs);
-
-            const page = docSource.getPage(docSlugs);
+            const page = resolveDocPage(slugs);
             if (!page) return { error: `Page not found: ${slugOrUrl}` };
 
             const content = await getLLMText(page);

--- a/apps/docs/app/api/mcp/route.ts
+++ b/apps/docs/app/api/mcp/route.ts
@@ -7,7 +7,13 @@ import {
 } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import { getLLMText } from "@/lib/get-llm-text";
-import { examples, getTapDocsPage, source, tapDocs } from "@/lib/source";
+import {
+  examples,
+  getTapDocsPage,
+  getTapDocsPages,
+  source,
+  tapDocs,
+} from "@/lib/source";
 import { normalizeMcpRequestHeaders } from "./normalize-mcp-headers";
 
 export const revalidate = false;
@@ -55,7 +61,7 @@ function allPages() {
       kind: "examples" as const,
       page,
     })),
-    ...tapDocs.getPages().map((page) => ({
+    ...getTapDocsPages().map((page) => ({
       kind: "tap" as const,
       page,
     })),

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,8 +1,8 @@
-import { source } from "@/lib/source";
+import { source, getTapDocsPages } from "@/lib/source";
 import { createSearchAPI } from "fumadocs-core/search/server";
 
 export const { GET } = createSearchAPI("advanced", {
-  indexes: source.getPages().map((page) => ({
+  indexes: [...source.getPages(), ...getTapDocsPages()].map((page) => ({
     title: page.data.title,
     description: page.data.description ?? "",
     structuredData: page.data.structuredData,

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { source, tapDocs, blog, examples, careers } from "@/lib/source";
+import { source, getTapDocsPages, blog, examples, careers } from "@/lib/source";
 import { DEMOS } from "@/lib/demos";
 import { GALLERY_TEMPLATES } from "@/lib/gallery-templates";
 import { BASE_URL, PRODUCTS } from "@/lib/constants";
@@ -46,14 +46,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.9,
   }));
 
-  const tapDocsPages: MetadataRoute.Sitemap = tapDocs
-    .getPages()
-    .map((page) => ({
-      url: `${BASE_URL}${page.url}`,
-      lastModified: page.data.lastModified,
-      changeFrequency: "weekly",
-      priority: 0.7,
-    }));
+  const tapDocsPages: MetadataRoute.Sitemap = getTapDocsPages().map((page) => ({
+    url: `${BASE_URL}${page.url}`,
+    lastModified: page.data.lastModified,
+    changeFrequency: "weekly",
+    priority: 0.7,
+  }));
 
   const blogPages: MetadataRoute.Sitemap = blog.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,

--- a/apps/docs/app/static.json/route.ts
+++ b/apps/docs/app/static.json/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from "next/server";
 import type { DocumentRecord } from "fumadocs-core/search/algolia";
-import { source } from "@/lib/source";
+import { source, getTapDocsPages } from "@/lib/source";
 
 export const revalidate = false;
 
 export function GET() {
   const results: DocumentRecord[] = [];
 
-  for (const page of source.getPages()) {
+  for (const page of [...source.getPages(), ...getTapDocsPages()]) {
     results.push({
       _id: page.url,
       structured: page.data.structuredData,

--- a/apps/docs/lib/llms-index.ts
+++ b/apps/docs/lib/llms-index.ts
@@ -42,7 +42,7 @@ export function buildLLMSIndex(
     "- Per-page markdown: append `.md` to any docs page URL. `.mdx` is kept as a backwards-compatible alias for agents that request source-style URLs. For example, `/docs/installation.md` and `/docs/installation.mdx` both return markdown for `/docs/installation`.",
   );
   lines.push(
-    "- Markdown by Accept header: requesting a docs or examples page with `Accept: text/markdown` also returns that page's markdown.",
+    "- Markdown by Accept header: requesting a docs, examples or tap docs page with `Accept: text/markdown` also returns that page's markdown.",
   );
   lines.push(
     "- Use the index below to choose a specific page. Remove the `.md` or `.mdx` suffix to open the human-readable docs page.",

--- a/apps/docs/lib/llms-index.ts
+++ b/apps/docs/lib/llms-index.ts
@@ -25,6 +25,7 @@ function addPageToSection(
 
 export function buildLLMSIndex(
   docsPages: LLMIndexPage[],
+  tapPages: LLMIndexPage[],
   examplesPages: LLMIndexPage[],
 ) {
   const lines: string[] = [];
@@ -35,7 +36,7 @@ export function buildLLMSIndex(
   lines.push("## LLM Documentation Files");
   lines.push("");
   lines.push(
-    `- [Full documentation](${BASE_URL}/llms-full.txt): all docs and examples pages rendered into one large text file.`,
+    `- [Full documentation](${BASE_URL}/llms-full.txt): every documentation page rendered into one large text file.`,
   );
   lines.push(
     "- Per-page markdown: append `.md` to any docs page URL. `.mdx` is kept as a backwards-compatible alias for agents that request source-style URLs. For example, `/docs/installation.md` and `/docs/installation.mdx` both return markdown for `/docs/installation`.",
@@ -53,6 +54,10 @@ export function buildLLMSIndex(
 
   for (const page of docsPages) {
     addPageToSection(map, page.slugs[0] || "root", page);
+  }
+
+  for (const page of tapPages) {
+    addPageToSection(map, "tap", page);
   }
 
   for (const page of examplesPages) {

--- a/apps/docs/lib/source.tsx
+++ b/apps/docs/lib/source.tsx
@@ -59,6 +59,14 @@ export function getTapDocsPage(slugs: string[] | undefined) {
   );
 }
 
+/**
+ * The tap docs root is a redirect stub, so it carries no content to index and
+ * throws NEXT_REDIRECT when rendered.
+ */
+export function getTapDocsPages() {
+  return tapDocs.getPages().filter((page) => page.url !== "/tap/docs");
+}
+
 export const examples = loader({
   baseUrl: "/examples",
   source: toFumadocsSource(examplePages, []),

--- a/apps/docs/lib/source.tsx
+++ b/apps/docs/lib/source.tsx
@@ -64,7 +64,7 @@ export function getTapDocsPage(slugs: string[] | undefined) {
  * throws NEXT_REDIRECT when rendered.
  */
 export function getTapDocsPages() {
-  return tapDocs.getPages().filter((page) => page.url !== "/tap/docs");
+  return tapDocs.getPages().filter((page) => page.slugs.length > 0);
 }
 
 export const examples = loader({

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -173,6 +173,13 @@ const config: NextConfig = {
         destination: "/llms.mdx/examples/:path*",
       },
       {
+        source: "/tap/docs/:path*",
+        has: [
+          { type: "header", key: "accept", value: "(?:.*text/markdown.*)" },
+        ],
+        destination: "/tap-llms.mdx/:path*",
+      },
+      {
         source: "/umami/:path*",
         destination: "https://assistant-ui-umami.vercel.app/:path*",
       },


### PR DESCRIPTION
## summary

- the tap tree was reachable by URL and through `/api/mcp`, but nothing else knew it existed: site search indexed only the main docs, `llms.txt` and `llms-full.txt` skipped it, `static.json` skipped it, and the docs assistant could neither list nor read a tap page. searching "resource" from a tap docs page returned zero tap results
- all five consumers now read it alongside the main docs. the assistant gets a `tap` branch in `listDocs`/`readDoc` that mirrors how `examples` is already handled, and `tap` appears as a root folder so it is discoverable without prior knowledge
- `content/tap-docs/index.mdx` is a redirect stub. rendering it into `llms-full.txt` threw `NEXT_REDIRECT`, which answered the entire route with a 307 instead of the corpus, so that endpoint was broken the moment tap pages were added to it. `getTapDocsPages()` drops the stub and every consumer goes through it

## test plan

### already verified

- [x] `/api/search?query=resource` -> 168 results, 123 of them tap pages including anchors like `/tap/docs/tap/api-reference#resource` (zero before)
- [x] `/llms.txt` -> a `### tap` section, and the `.md` URL it advertises (`/tap/docs/overview/introduction.md`) returns 200
- [x] `/llms-full.txt` -> 200 with 46 tap references (307 before the stub filter)
- [x] `/static.json` -> 288 records, 22 of them tap, redirect stub absent
- [x] `tsc --noEmit` in apps/docs -> 0 errors; oxlint and oxfmt clean

### reviewer should verify

- [ ] open the search dialog from any `/tap/docs/*` page and search for a tap concept (`resource`, `scopes`): results should now include the page you are standing on

## notes

- `app/api/xulux/chat/tools/docs-tools.ts` has the same shape and was left alone deliberately: that agent scaffolds apps in the playground from UI docs, and tap internals are noise for that job rather than a missing surface.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

