### PR TITLE
fix(react-opencode): align pending message fingerprints

### DIFF
--- a/.changeset/quiet-files-reconcile.md
+++ b/.changeset/quiet-files-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: reconcile pending file messages after OpenCode normalizes their wire URLs

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -28,9 +28,12 @@ import {
   STREAM_RECONNECTED_EVENT_TYPE,
   type OpenCodeEventSource,
 } from "./OpenCodeEventSource";
-import { isParsableUrl, parseDataUrl } from "@assistant-ui/core/internal";
+import { parseDataUrl } from "@assistant-ui/core/internal";
 import { OPEN_CODE_REQUEST_OPTIONS } from "./openCodeRequestOptions";
-import { serializeUserParts } from "./serializeUserParts";
+import {
+  serializeOpenCodeParts,
+  toOpenCodeWireUrl,
+} from "./serializeUserParts";
 import { getOpenCodeTaskSessionId } from "./openCodeTaskSession";
 
 type OpenCodeEventSourceProvider = () => Pick<OpenCodeEventSource, "subscribe">;
@@ -44,21 +47,7 @@ const createLocalId = (prefix: string) =>
   `${prefix}_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 
 const getTextContent = (parts: readonly ThreadUserMessagePart[]) =>
-  serializeUserParts(parts).trim();
-
-// OpenCode forwards this into an AI SDK file part, where `url` reaches an
-// unguarded `new URL()` and a data URL's own media type wins over the declared
-// one. So an inline payload is always re-enveloped with the resolved type, and
-// only a payload that is already a url of some other scheme is forwarded.
-const toWireUrl = (
-  payload: string,
-  mime: string,
-  parsed: { data: string } | null,
-) => {
-  if (parsed) return `data:${mime};base64,${parsed.data}`;
-  if (isParsableUrl(payload)) return payload;
-  return `data:${mime};base64,${payload}`;
-};
+  serializeOpenCodeParts(parts).trim();
 
 // The attachment carries a name and content type its parts do not, so they
 // ride along rather than being dropped at the flatten. Both the outbound
@@ -104,7 +93,7 @@ const getPromptParts = (message: AppendMessage) => {
         type: "file",
         ...(part.filename != null && { filename: part.filename }),
         mime,
-        url: toWireUrl(part.image, mime, parsed),
+        url: toOpenCodeWireUrl(part.image, mime, parsed),
       });
       continue;
     }
@@ -125,7 +114,7 @@ const getPromptParts = (message: AppendMessage) => {
         url:
           part.sourceType === "id"
             ? part.data
-            : toWireUrl(part.data, fileMime, parsedFile),
+            : toOpenCodeWireUrl(part.data, fileMime, parsedFile),
       });
     }
   }

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -98,6 +98,28 @@ describe("reduceOpenCodeThreadState", () => {
     expect(history.messageOrder).toEqual(["msg_1"]);
   });
 
+  it("loads history containing a file part that carries no url", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+
+    const history = reduceOpenCodeThreadState(initial, {
+      type: "history.loaded",
+      session: null,
+      messages: [
+        {
+          info: {
+            id: "msg_1",
+            role: "user",
+            sessionID: "ses_1",
+            time: { created: 1000 },
+          },
+          parts: [{ type: "file" }],
+        } as unknown as MessageWithParts,
+      ],
+    });
+
+    expect(history.messageOrder).toEqual(["msg_1"]);
+  });
+
   it("adds assistant parts without losing message order", () => {
     const initial = createOpenCodeThreadState("ses_1");
 

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -46,6 +46,55 @@ describe("reduceOpenCodeThreadState", () => {
     expect(history.messagesById.msg_1?.shadowParts).toEqual(pending.parts);
   });
 
+  it("reconciles a filename-less inline file after its media type is rewritten", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+    const pending: PendingUserMessage = {
+      clientId: "local_1",
+      sessionId: "ses_1",
+      createdAt: 1000,
+      parentId: null,
+      sourceId: null,
+      runConfig: undefined,
+      contentText: "data:image/jpeg;base64,QUJD",
+      parts: [
+        {
+          type: "file",
+          data: "data:image/jpeg;base64,QUJD",
+          mimeType: "image/png",
+        },
+      ],
+      status: "pending",
+    };
+
+    const queued = reduceOpenCodeThreadState(initial, {
+      type: "local.message.queued",
+      pending,
+    });
+    const history = reduceOpenCodeThreadState(queued, {
+      type: "history.loaded",
+      session: null,
+      messages: [
+        {
+          info: {
+            id: "msg_1",
+            role: "user",
+            sessionID: "ses_1",
+            time: { created: 1000 },
+          },
+          parts: [
+            {
+              type: "file",
+              url: "data:image/png;base64,QUJD",
+            },
+          ],
+        } as unknown as MessageWithParts,
+      ],
+    });
+
+    expect(Object.keys(history.pendingUserMessages)).toHaveLength(0);
+    expect(history.messageOrder).toEqual(["msg_1"]);
+  });
+
   it("adds assistant parts without losing message order", () => {
     const initial = createOpenCodeThreadState("ses_1");
 

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -55,6 +55,9 @@ describe("reduceOpenCodeThreadState", () => {
       parentId: null,
       sourceId: null,
       runConfig: undefined,
+      // deliberately the un-rewritten payload, as a copy created before this
+      // fix would hold. it cannot match the server url, which forces the match
+      // through `partTextFingerprint`, the arm under test.
       contentText: "data:image/jpeg;base64,QUJD",
       parts: [
         {

--- a/packages/react-opencode/src/openCodeThreadState.ts
+++ b/packages/react-opencode/src/openCodeThreadState.ts
@@ -8,7 +8,7 @@ import type {
   PendingUserMessage,
   ThreadUserMessagePart,
 } from "./types";
-import { serializeUserParts } from "./serializeUserParts";
+import { serializeOpenCodeParts } from "./serializeUserParts";
 
 const PENDING_MATCH_WINDOW_MS = 2 * 60 * 1000;
 const MAX_UNHANDLED_EVENTS = 25;
@@ -25,20 +25,10 @@ const pendingFingerprint = (pending: PendingUserMessage) =>
   normalizeText(pending.contentText);
 
 const partTextFingerprint = (parts: readonly ThreadUserMessagePart[]) =>
-  normalizeText(serializeUserParts(parts));
+  normalizeText(serializeOpenCodeParts(parts));
 
 const serverFingerprint = (message: MessageWithParts) =>
-  normalizeText(
-    message.parts
-      .map((part) => {
-        if (part.type === "text") return part.text ?? "";
-        if (part.type === "file") return part.filename ?? part.url ?? "";
-        if (part.type === "tool")
-          return JSON.stringify(part.state?.input ?? {});
-        return "";
-      })
-      .join("\n"),
-  );
+  normalizeText(serializeOpenCodeParts(message.parts));
 
 const sortMessageIds = (
   messagesById: Readonly<Record<string, OpenCodeServerMessage>>,

--- a/packages/react-opencode/src/serializeUserParts.ts
+++ b/packages/react-opencode/src/serializeUserParts.ts
@@ -29,7 +29,10 @@ export const serializeOpenCodeParts = (
       }
       if (part.type === "file") {
         if (part.filename) return part.filename;
-        if ("url" in part) return part.url;
+        // The server shape is the one without `data`, so a malformed part that
+        // reaches history without a url renders empty rather than throwing
+        // inside the reducer and taking the whole load down.
+        if (!("data" in part)) return part.url ?? "";
         if (part.sourceType === "id") return part.data;
         return toMediaWireUrl(
           part.data,

--- a/packages/react-opencode/src/serializeUserParts.ts
+++ b/packages/react-opencode/src/serializeUserParts.ts
@@ -1,12 +1,46 @@
-import type { ThreadUserMessagePart } from "./types";
+import { isParsableUrl, parseDataUrl } from "@assistant-ui/core/internal";
+import type { Part, ThreadUserMessagePart } from "./types";
 
-export const serializeUserParts = (parts: readonly ThreadUserMessagePart[]) => {
+// OpenCode forwards file URLs to an unguarded `new URL()`, and a data URL's
+// media type wins over the separately declared one.
+export const toOpenCodeWireUrl = (
+  payload: string,
+  mime: string,
+  parsed: { data: string } | null,
+) => {
+  if (parsed) return `data:${mime};base64,${parsed.data}`;
+  if (isParsableUrl(payload)) return payload;
+  return `data:${mime};base64,${payload}`;
+};
+
+export const serializeOpenCodeParts = (
+  parts: readonly (Part | ThreadUserMessagePart)[],
+) => {
   return parts
     .map((part) => {
       if (part.type === "text") return part.text;
-      if (part.type === "image") return part.filename ?? part.image;
-      if (part.type === "file") return part.filename ?? part.data;
-      if (part.type === "data") return JSON.stringify(part.data);
+      if (part.type === "image") {
+        if (part.filename) return part.filename;
+        const parsed = parseDataUrl(part.image);
+        const contentType = (part as { contentType?: string }).contentType;
+        const mime = contentType?.startsWith("image/")
+          ? contentType
+          : parsed?.mimeType?.startsWith("image/")
+            ? parsed.mimeType
+            : "image/png";
+        return toOpenCodeWireUrl(part.image, mime, parsed);
+      }
+      if (part.type === "file") {
+        if (part.filename) return part.filename;
+        if ("url" in part) return part.url;
+        if (part.sourceType === "id") return part.data;
+        const parsed = parseDataUrl(part.data);
+        const mime =
+          part.mimeType || parsed?.mimeType || "application/octet-stream";
+        return toOpenCodeWireUrl(part.data, mime, parsed);
+      }
+      if (part.type === "tool") return JSON.stringify(part.state?.input ?? {});
+      if (part.type === "data") return JSON.stringify(part.data) ?? "";
       if (part.type === "audio") return part.audio.data;
       return "";
     })


### PR DESCRIPTION
## Summary

- serialize pending file and image fingerprints with the same wire URL rules used for OpenCode requests
- share that serialization with server-history fingerprints so the two representations cannot drift
- cover a filename-less inline file whose declared media type differs from its data URL

## Why

OpenCode can re-envelope an inline payload with its resolved media type before sending it. The pending message previously fingerprinted the original data while loaded history fingerprinted the rewritten URL. A refresh during that window could fail to reconcile the optimistic message and show the same user message twice.

Closes #5477

## Validation

- `vitest run src/openCodeThreadState.test.ts` (8 tests)
- `aui-build`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

