### PR TITLE
fix(docs): drop the public cache bypass on the stats pages

### DIFF
--- a/apps/docs/app/(home)/packages/page.tsx
+++ b/apps/docs/app/(home)/packages/page.tsx
@@ -35,13 +35,8 @@ const HERO_STAT_ICONS = {
   Download,
 };
 
-export default async function PackagesPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ refresh?: string }>;
-}) {
-  const forceFresh = (await searchParams).refresh === "true";
-  const npm = await fetchNpmDownloads(forceFresh ? 0 : undefined);
+export default async function PackagesPage() {
+  const npm = await fetchNpmDownloads();
 
   const topPackages = PACKAGES.filter((pkg) => !pkg.deprecated)
     .map((pkg) => ({

--- a/apps/docs/app/(home)/traction/page.tsx
+++ b/apps/docs/app/(home)/traction/page.tsx
@@ -54,15 +54,8 @@ type HeroStat = {
   icon: typeof Star;
 };
 
-export default async function TractionPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ refresh?: string }>;
-}) {
-  const forceFresh = (await searchParams).refresh === "true";
-  const revalidate = forceFresh ? 0 : undefined;
-
-  const repo = await getRepo(revalidate);
+export default async function TractionPage() {
+  const repo = await getRepo();
 
   const [
     npm,
@@ -75,15 +68,15 @@ export default async function TractionPage({
     releaseActivity,
     commitStats,
   ] = await Promise.all([
-    fetchNpmDownloads(revalidate),
-    fetchStarHistory(repo?.stars ?? 0, revalidate),
-    fetchTimelineSeries(TIMELINE_PACKAGES, revalidate),
-    fetchContributors(revalidate),
-    fetchBotCoAuthors(revalidate),
-    getDependents(revalidate),
-    fetchCommitActivity(revalidate),
-    fetchReleaseActivity(revalidate),
-    getCommitStats(revalidate),
+    fetchNpmDownloads(),
+    fetchStarHistory(repo?.stars ?? 0),
+    fetchTimelineSeries(TIMELINE_PACKAGES),
+    fetchContributors(),
+    fetchBotCoAuthors(),
+    getDependents(),
+    fetchCommitActivity(),
+    fetchReleaseActivity(),
+    getCommitStats(),
   ]);
 
   const flagshipWeekly = npm.perPackage[FLAGSHIP_PACKAGE]?.weekly ?? 0;


### PR DESCRIPTION
## summary

- `/packages?refresh=true` and `/traction?refresh=true` made both pages skip the data cache, so any unauthenticated caller could force a fresh fan-out to GitHub and npm on every single request
- traction is the expensive one: contributors, stargazers, commit activity, releases and the dependents scrape all go out at once, and GitHub's unauthenticated limit is 60 requests an hour per IP. a handful of hits leaves the page with no figures at all, for everyone, until the window resets. this is not hypothetical: this machine tripped that limit while testing yesterday's PRs and `/traction` rendered every stat as a dash
- both pages already revalidate hourly on their own, so the parameter bought a maintainer a fresh render and cost everyone else the cache
- removing it also lets traction stop threading a `revalidate` argument through nine calls that all take the same default

## test plan

### already verified

- [x] `/packages`, `/traction`, and both with `?refresh=true` -> 200; the parameter is now inert rather than a cache bypass
- [x] `/traction` against a GitHub token -> 11.3k stars, 1.1M weekly, contributors and forks all still resolve
- [x] `tsc --noEmit` in apps/docs -> 0 errors; oxlint and oxfmt clean

### reviewer should verify

- [ ] nothing in the repo linked to `?refresh=true` as a maintainer affordance (`grep -r "refresh=true"` comes back empty outside these two pages before this change)

## notes

- the timeout half of this work shipped separately in #5460, which bounds every GitHub and npm fetch including the response body reads. this PR is only the parameter removal.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

