### PR TITLE
fix(core): accept all valid image data URLs in sanitizeImageContent

### DIFF
--- a/.changeset/sanitize-image-any-image-data-url.md
+++ b/.changeset/sanitize-image-any-image-data-url.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: accept all valid image data URLs in sanitizeImageContent instead of a hardcoded format list

--- a/packages/core/src/runtime/utils/thread-message-like.ts
+++ b/packages/core/src/runtime/utils/thread-message-like.ts
@@ -1,5 +1,6 @@
 import { parsePartialJsonObject } from "assistant-stream/utils";
 import { generateId } from "../../utils/id";
+import { parseDataUrl } from "../../utils/data-url";
 import type {
   ReasoningMessagePart,
   SourceMessagePart,
@@ -130,10 +131,7 @@ export const fromThreadMessageLike = (
     ...rest
   }: ImageMessagePart): ImageMessagePart | null => {
     if (typeof image !== "string") return null;
-    const dataUri = image.match(
-      /^data:image\/(png|jpeg|jpg|gif|webp|svg\+xml);base64,(.*)$/i,
-    );
-    if (dataUri) {
+    if (parseDataUrl(image)?.mimeType.startsWith("image/")) {
       return { ...rest, image };
     }
     if (/^(https:\/\/|blob:)/i.test(image)) {

--- a/packages/core/src/tests/thread-message-like.test.ts
+++ b/packages/core/src/tests/thread-message-like.test.ts
@@ -174,6 +174,72 @@ describe("fromThreadMessageLike", () => {
         { type: "image", image: "DATA:IMAGE/PNG;base64,AAAA" },
       ]);
     });
+
+    it.each([
+      "data:image/avif;base64,AAAA",
+      "data:image/bmp;base64,AAAA",
+      "data:image/heic;base64,AAAA",
+      "data:image/heif;base64,AAAA",
+      "data:image/tiff;base64,AAAA",
+    ])("keeps an image part with a %s data URL", (image) => {
+      const result = fromThreadMessageLike(
+        { role: "assistant", content: [{ type: "image", image }] },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([{ type: "image", image }]);
+    });
+
+    it("keeps an image part with a parameterized data URL", () => {
+      const image = "data:image/png;charset=utf-8;base64,AAAA";
+      const result = fromThreadMessageLike(
+        { role: "assistant", content: [{ type: "image", image }] },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([{ type: "image", image }]);
+    });
+
+    it("drops an image part with a non-image data URL", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "image", image: "data:text/plain;base64,AAAA" }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("drops an image part with a non-base64 data URL", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "image", image: "data:image/png,rawpayload" }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
+
+    it("drops an image part with a non-URL string", () => {
+      const result = fromThreadMessageLike(
+        {
+          role: "assistant",
+          content: [{ type: "image", image: "not-an-image" }],
+        },
+        fallbackId,
+        fallbackStatus,
+      );
+
+      expect(result.content).toEqual([]);
+    });
   });
 
   describe("providerMetadata passthrough", () => {


### PR DESCRIPTION
## What
`sanitizeImageContent` now validates assistant image data URLs with core's shared `parseDataUrl` plus an `image/*` mime check, replacing the hardcoded `(png|jpeg|jpg|gif|webp|svg+xml)` alternation.

## Why
A `data:image/avif;base64,...` part is silently dropped on ingest with `Invalid image data format detected` in the console, and the same happens for any data URL carrying a parameter like `;charset=utf-8`. The gate had drifted from `parseDataUrl` in the same package, which already accepts both. Follow-up from the #5318 review 

## Impact
- Assistant image parts with avif, bmp, heic, heif, tiff, or any other `image/*` base64 data URL now survive ingest instead of vanishing.
- Parameterized data URLs (`data:image/png;charset=utf-8;base64,...`) are kept too.
- Everything the old regex accepted is still accepted; rejection of non-image data URLs and garbage strings is unchanged.

## Scope 
- `startsWith("image/")` instead of a longer allowlist is deliberate: the gate answers "is this an image data URL", and any allowlist would just drift again the way this one did.
- Non-base64 RFC 2397 data URLs (`data:image/png,<url-encoded>`) stay rejected, matching `parseDataUrl`; widening that is a separate contract question and would reopen the SVG-without-base64 case. Pinned by a test.
- The `https://` / `blob:` URL branch and the `console.warn` message are untouched on purpose.
- Unrelated to #5479's `detectImageMediaType`, which sniffs payload bytes to declare a wire media type; this gate validates the declared mime.
- Tests: accept path per new format plus parameterized and uppercase-scheme URLs; reject path for non-image, non-base64, and non-URL inputs.
- Additive only, no exports touched.
- Changeset: patch (`@assistant-ui/core`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.HZu8tJuxPUtABGKGFW8GwEYN_nSiZdbmbQ8XMw0w52uCRHGltKHp8jx0-i8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->