### PR TITLE
refactor(core): share the media type ladder and wire url between adapters

### DIFF
--- a/.changeset/shared-wire-media.md
+++ b/.changeset/shared-wire-media.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react-ai-sdk": patch
+"@assistant-ui/react-opencode": patch
+---
+
+refactor: share the media type ladder and wire url between adapters
+
+`resolveImageMediaType`, `resolveFileMediaType` and `toMediaWireUrl` join the data URL helpers in `@assistant-ui/core/internal`. react-ai-sdk and react-opencode had arrived at identical ladders and an identical wire url builder by construction rather than by sharing code, and they had already drifted apart twice while getting there. Both now call the shared functions and keep only their own part-shape plumbing.
+
+No behavior change: both adapters' existing suites pass untouched.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5700,7 +5700,7 @@ declare namespace entry_store_exports {
 }
 
 declare namespace entry_internal_exports {
-  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createThreadMappingId, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, parseDataUrl, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
+  export { AssistantRuntimeImpl, AttachmentRuntimeImpl, BaseAssistantRuntimeCore, BaseComposerRuntimeCore, BaseSubject, BaseSubscribable, BaseThreadRuntimeCore, ComposerRuntimeCoreBinding, ComposerRuntimeImpl, CompositeContextProvider, ConverterCallback, DefaultEditComposerRuntimeCore, DefaultThreadComposerRuntimeCore, EMPTY_THREAD_CORE, EditComposerAttachmentRuntimeImpl, EditComposerRuntimeCoreBinding, EditComposerRuntimeImpl, EventSubscribable, EventSubscriptionSubject, ExportedMessageRepository, ExportedMessageRepositoryItem, ExternalStoreRuntimeCore, ExternalStoreThreadFactory, ExternalStoreThreadListRuntimeCore, ExternalStoreThreadRuntimeCore, LazyMemoizeSubject, LocalRuntimeCore, LocalRuntimeOptionsBase, LocalThreadFactory, LocalThreadListRuntimeCore, LocalThreadRuntimeCore, MessageAttachmentRuntimeImpl, MessagePartRuntimeImpl, MessageRepository, MessageRuntimeImpl, MessageStateBinding, NestedSubscribable, NestedSubscriptionSubject, OptimisticState, ReadonlyThreadRuntimeCore, RemoteThreadData, RemoteThreadInitializeResponse, RemoteThreadListOptions, RemoteThreadState, SKIP_UPDATE, SKIP_UPDATE as SKIP_UPDATE_TYPE, ShallowMemoizeSubject, Subscribable, SubscribableWithState, THREAD_MAPPING_ID, ThreadComposerAttachmentRuntimeImpl, ThreadComposerRuntimeCoreBinding, ThreadComposerRuntimeImpl, ThreadListItemRuntimeBinding, ThreadListItemRuntimeImpl, ThreadListItemStateBinding, ThreadListRuntimeCoreBinding, ThreadListRuntimeImpl, ThreadMessageConverter, ThreadRuntimeCoreBinding, ThreadRuntimeImpl, ToolInvocationTracker, consumeSuggestionResult, createThreadMappingId, dataUrlMediaType, detectImageMediaType, fileMatchesAccept, fromThreadMessageLike, generateErrorMessageId, generateId, getAutoStatus, getFileDataURL, getThreadData, getThreadMessageText, getThreadState, hasUpcomingMessage, httpUrlPattern, isAutoStatus, isCreateAttachment, isErrorMessageId, isJSONValue, isParsableUrl, isRecord, parseDataUrl, resolveFileMediaType, resolveImageMediaType, resolveToolApprovalResponse, shouldContinue, stableStringifyToolArgs, symbolInnerMessage, toMediaWireUrl, toMessagePartStatus, trackToolArgsKeyOrder, updateStatusReducer };
 }
 
 declare namespace entry_store_internal_exports {
@@ -5739,6 +5739,10 @@ declare function parseDataUrl(value: string): {
 declare const pickExternalStoreSharedOptions: (options: ExternalStoreSharedOptions) => ExternalStoreSharedOptions;
 
 declare function providerTool(_config: ProviderToolConfig): never;
+
+declare function resolveFileMediaType(data: string, mimeType?: string | undefined): string;
+
+declare function resolveImageMediaType(image: string, contentType?: string | undefined): string;
 
 declare const resolveToolApprovalResponse: (approval: {
   readonly id: string;
@@ -5780,6 +5784,8 @@ declare function stubTool(): never;
 declare const symbolInnerMessage: unique symbol;
 
 declare const toAssistantError: (error: unknown) => AssistantError;
+
+declare function toMediaWireUrl(payload: string, mediaType: string): string;
 
 declare const toMessagePartStatus: (message: ThreadMessage, partIndex: number, part: ThreadUserMessagePart | ThreadAssistantMessagePart) => ToolCallMessagePartStatus;
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -64,6 +64,11 @@ export {
   parseDataUrl,
 } from "./utils/data-url";
 export { detectImageMediaType } from "./utils/image-media-type";
+export {
+  resolveFileMediaType,
+  resolveImageMediaType,
+  toMediaWireUrl,
+} from "./utils/wire-media";
 
 export * from "./runtime/internal";
 export * from "./runtimes/internal";

--- a/packages/core/src/utils/wire-media.test.ts
+++ b/packages/core/src/utils/wire-media.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveFileMediaType,
+  resolveImageMediaType,
+  toMediaWireUrl,
+} from "./wire-media";
+
+const JPEG = "/9j/4AAQSkZJRg==";
+
+describe("resolveImageMediaType", () => {
+  it("prefers an image content type over everything else", () => {
+    expect(
+      resolveImageMediaType(`data:image/png;base64,${JPEG}`, "image/webp"),
+    ).toBe("image/webp");
+  });
+
+  it("ignores a content type that is not an image", () => {
+    expect(resolveImageMediaType(JPEG, "application/octet-stream")).toBe(
+      "image/jpeg",
+    );
+  });
+
+  it("takes the data url declaration when it is an image type", () => {
+    expect(
+      resolveImageMediaType("data:image/svg+xml,%3Csvg%3E%3C/svg%3E"),
+    ).toBe("image/svg+xml");
+  });
+
+  it("sniffs through a declaration that is not an image type", () => {
+    expect(
+      resolveImageMediaType(`data:application/octet-stream;base64,${JPEG}`),
+    ).toBe("image/jpeg");
+  });
+
+  it("sniffs a bare base64 payload", () => {
+    expect(resolveImageMediaType(JPEG)).toBe("image/jpeg");
+  });
+
+  it("floors to image/png when there are no bytes to read", () => {
+    expect(resolveImageMediaType("https://cdn.example.com/photo")).toBe(
+      "image/png",
+    );
+  });
+
+  it("floors to image/png when the bytes match no signature", () => {
+    expect(resolveImageMediaType("QUJD")).toBe("image/png");
+  });
+});
+
+describe("resolveFileMediaType", () => {
+  it("prefers the declared type", () => {
+    expect(
+      resolveFileMediaType(
+        "data:application/octet-stream;base64,QUJD",
+        "application/pdf",
+      ),
+    ).toBe("application/pdf");
+  });
+
+  it("falls back to the data url declaration when none is declared", () => {
+    expect(resolveFileMediaType("data:text/plain,hello", "")).toBe(
+      "text/plain",
+    );
+  });
+
+  it("floors to application/octet-stream", () => {
+    expect(resolveFileMediaType("QUJD", "")).toBe("application/octet-stream");
+  });
+});
+
+describe("toMediaWireUrl", () => {
+  it("forwards an envelope that agrees byte for byte", () => {
+    const payload = "data:image/jpeg;base64,QUJD";
+    expect(toMediaWireUrl(payload, "image/jpeg")).toBe(payload);
+  });
+
+  it("rebuilds an envelope that disagrees", () => {
+    expect(
+      toMediaWireUrl("data:application/octet-stream;base64,QUJD", "image/jpeg"),
+    ).toBe("data:image/jpeg;base64,QUJD");
+  });
+
+  it("wraps a bare base64 payload", () => {
+    expect(toMediaWireUrl("QUJD", "application/pdf")).toBe(
+      "data:application/pdf;base64,QUJD",
+    );
+  });
+
+  it.each([
+    "https://cdn.example.com/a.pdf",
+    "blob:https://app.example/1-2-3",
+    "data:text/plain,hello",
+  ])("forwards %s untouched", (payload) => {
+    expect(toMediaWireUrl(payload, "application/pdf")).toBe(payload);
+  });
+});

--- a/packages/core/src/utils/wire-media.ts
+++ b/packages/core/src/utils/wire-media.ts
@@ -51,9 +51,12 @@ export function resolveFileMediaType(
  *
  * Two hazards drive this. A consumer may hand the value to an unguarded
  * `new URL()`, so a payload that is not a url has to be wrapped; and a data
- * URL's own media type wins over a separately declared one downstream, so an
- * envelope that disagrees with `mediaType` has to be rebuilt. An envelope that
- * agrees, and a url of any other scheme, pass through byte for byte.
+ * URL's own media type wins over a separately declared one downstream, so a
+ * base64 envelope that disagrees with `mediaType` is rebuilt around the same
+ * bytes. Everything else passes through byte for byte: an envelope that agrees,
+ * a url of any other scheme, and a percent-encoded data URL, whose declaration
+ * cannot be corrected without transcoding the payload and is authoritative for
+ * the bytes it carries anyway.
  */
 export function toMediaWireUrl(payload: string, mediaType: string): string {
   const parsed = parseDataUrl(payload);

--- a/packages/core/src/utils/wire-media.ts
+++ b/packages/core/src/utils/wire-media.ts
@@ -1,0 +1,67 @@
+import { dataUrlMediaType, isParsableUrl, parseDataUrl } from "./data-url";
+import { detectImageMediaType } from "./image-media-type";
+
+/**
+ * The media type to declare for an `ImageMessagePart`, which carries none of
+ * its own: an attachment's content type, then the payload's data URL
+ * declaration, then its leading bytes, then `image/png`.
+ *
+ * The floor cannot be a wildcard. `image/*` is rejected outright by the AI SDK
+ * for a url source and whenever inline bytes fail to sniff, so it fails exactly
+ * where a fallback is needed.
+ */
+export function resolveImageMediaType(
+  image: string,
+  contentType?: string | undefined,
+): string {
+  if (contentType?.startsWith("image/")) return contentType;
+
+  const declared = dataUrlMediaType(image);
+  if (declared?.startsWith("image/")) return declared;
+
+  // Read through a data URL envelope too, so a generic one such as
+  // `application/octet-stream` does not mask the format. A url of any other
+  // scheme has no local bytes to read.
+  const parsed = parseDataUrl(image);
+  const payload = parsed?.data ?? (isParsableUrl(image) ? undefined : image);
+  if (payload !== undefined) {
+    const sniffed = detectImageMediaType(payload);
+    if (sniffed) return sniffed;
+  }
+
+  return "image/png";
+}
+
+/**
+ * The media type to declare for a `FileMessagePart`: its own `mimeType`, then
+ * the payload's data URL declaration, then `application/octet-stream`.
+ *
+ * `mimeType` is a plain string, and an adapter reading `file.type` on a file
+ * the OS cannot type yields `""`, so the declared value is not always present.
+ */
+export function resolveFileMediaType(
+  data: string,
+  mimeType?: string | undefined,
+): string {
+  return mimeType || dataUrlMediaType(data) || "application/octet-stream";
+}
+
+/**
+ * A payload placed into a wire field that is contractually a url.
+ *
+ * Two hazards drive this. A consumer may hand the value to an unguarded
+ * `new URL()`, so a payload that is not a url has to be wrapped; and a data
+ * URL's own media type wins over a separately declared one downstream, so an
+ * envelope that disagrees with `mediaType` has to be rebuilt. An envelope that
+ * agrees, and a url of any other scheme, pass through byte for byte.
+ */
+export function toMediaWireUrl(payload: string, mediaType: string): string {
+  const parsed = parseDataUrl(payload);
+  if (parsed) {
+    return parsed.mimeType === mediaType
+      ? payload
+      : `data:${mediaType};base64,${parsed.data}`;
+  }
+  if (isParsableUrl(payload)) return payload;
+  return `data:${mediaType};base64,${payload}`;
+}

--- a/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
+++ b/packages/react-ai-sdk/src/ui/utils/toCreateMessage.ts
@@ -1,10 +1,10 @@
 import type { AppendMessage } from "@assistant-ui/core";
 import {
-  dataUrlMediaType,
-  detectImageMediaType,
   httpUrlPattern,
-  isParsableUrl,
   parseDataUrl,
+  resolveFileMediaType,
+  resolveImageMediaType,
+  toMediaWireUrl,
 } from "@assistant-ui/core/internal";
 import type {
   CreateUIMessage,
@@ -17,43 +17,6 @@ import type {
 type InputPart = AppendMessage["content"][number] & {
   readonly contentType?: string | undefined;
   readonly filename?: string | undefined;
-};
-
-// A data URL's own media type wins over `mediaType` downstream, so an envelope
-// that disagrees with the resolved type is rebuilt. One that agrees, and a url
-// of any other scheme, passes through byte for byte.
-const toWireUrl = (payload: string, mediaType: string) => {
-  const parsed = parseDataUrl(payload);
-  if (parsed) {
-    return parsed.mimeType === mediaType
-      ? payload
-      : `data:${mediaType};base64,${parsed.data}`;
-  }
-  if (isParsableUrl(payload)) return payload;
-  return `data:${mediaType};base64,${payload}`;
-};
-
-const getImageMediaType = (part: {
-  readonly contentType?: string | undefined;
-  readonly image: string;
-}) => {
-  if (part.contentType?.startsWith("image/")) return part.contentType;
-
-  const envelopeType = dataUrlMediaType(part.image);
-  if (envelopeType?.startsWith("image/")) return envelopeType;
-
-  // The payload's own leading bytes, read through a data URL envelope too so a
-  // generic one such as `application/octet-stream` does not mask the format.
-  // Only a url of some other scheme has no bytes to read here.
-  const parsed = parseDataUrl(part.image);
-  const payload =
-    parsed?.data ?? (isParsableUrl(part.image) ? undefined : part.image);
-  if (payload !== undefined) {
-    const sniffed = detectImageMediaType(payload);
-    if (sniffed) return sniffed;
-  }
-
-  return "image/png";
 };
 
 export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
@@ -78,10 +41,10 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
           text: part.text,
         };
       case "image": {
-        const mediaType = getImageMediaType(part);
+        const mediaType = resolveImageMediaType(part.image, part.contentType);
         return {
           type: "file",
-          url: toWireUrl(part.image, mediaType),
+          url: toMediaWireUrl(part.image, mediaType),
           ...(part.filename && { filename: part.filename }),
           mediaType,
         };
@@ -90,10 +53,7 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
         // `mimeType` is a plain string, and an adapter reading `file.type` on a
         // file the OS cannot type yields "". Same ladder as images: declared,
         // then the envelope, then the floor.
-        const mediaType =
-          part.mimeType ||
-          dataUrlMediaType(part.data) ||
-          "application/octet-stream";
+        const mediaType = resolveFileMediaType(part.data, part.mimeType);
         return {
           type: "file",
           // An `id` reference is an opaque provider handle, not base64, and
@@ -102,7 +62,7 @@ export const toCreateMessage = <UI_MESSAGE extends UIMessage = UIMessage>(
           url:
             part.sourceType === "id"
               ? part.data
-              : toWireUrl(part.data, mediaType),
+              : toMediaWireUrl(part.data, mediaType),
           mediaType,
           ...(part.filename && { filename: part.filename }),
         };

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -29,10 +29,9 @@ import {
   type OpenCodeEventSource,
 } from "./OpenCodeEventSource";
 import {
-  dataUrlMediaType,
-  detectImageMediaType,
-  isParsableUrl,
-  parseDataUrl,
+  resolveFileMediaType,
+  resolveImageMediaType,
+  toMediaWireUrl,
 } from "@assistant-ui/core/internal";
 import { OPEN_CODE_REQUEST_OPTIONS } from "./openCodeRequestOptions";
 import { serializeUserParts } from "./serializeUserParts";
@@ -50,24 +49,6 @@ const createLocalId = (prefix: string) =>
 
 const getTextContent = (parts: readonly ThreadUserMessagePart[]) =>
   serializeUserParts(parts).trim();
-
-// OpenCode forwards this into an AI SDK file part, where `url` reaches an
-// unguarded `new URL()` and a data URL's own media type wins over the declared
-// one. So an envelope that disagrees with the resolved type is rebuilt, while
-// one that agrees, and a url of any other scheme, passes through byte for byte.
-const toWireUrl = (
-  payload: string,
-  mime: string,
-  parsed: { mimeType: string; data: string } | null,
-) => {
-  if (parsed) {
-    return parsed.mimeType === mime
-      ? payload
-      : `data:${mime};base64,${parsed.data}`;
-  }
-  if (isParsableUrl(payload)) return payload;
-  return `data:${mime};base64,${payload}`;
-};
 
 // The attachment carries a name and content type its parts do not, so they
 // ride along rather than being dropped at the flatten. Both the outbound
@@ -99,34 +80,22 @@ const getPromptParts = (message: AppendMessage) => {
 
     if (part.type === "image") {
       // OpenCode has no image part: its input union is text, file, agent and
-      // subtask, so an `image` part never reached the model. A wildcard is not
-      // usable as the floor: `resolveFullMediaType` rejects one outright for a
-      // url source and whenever the inline bytes cannot be sniffed.
-      const contentType = (part as { contentType?: string }).contentType;
-      const parsed = parseDataUrl(part.image);
-      const mime = contentType?.startsWith("image/")
-        ? contentType
-        : dataUrlMediaType(part.image)?.startsWith("image/")
-          ? dataUrlMediaType(part.image)!
-          : (detectImageMediaType(parsed?.data ?? part.image) ?? "image/png");
+      // subtask, so an `image` part never reached the model.
+      const mime = resolveImageMediaType(
+        part.image,
+        (part as { contentType?: string }).contentType,
+      );
       promptParts.push({
         type: "file",
         ...(part.filename != null && { filename: part.filename }),
         mime,
-        url: toWireUrl(part.image, mime, parsed),
+        url: toMediaWireUrl(part.image, mime),
       });
       continue;
     }
 
     if (part.type === "file") {
-      // `FileMessagePart.mimeType` is a plain string, and an adapter reading
-      // `file.type` on a typeless file yields "". Same ladder as the image
-      // branch: declared, then the envelope, then the floor.
-      const parsedFile = parseDataUrl(part.data);
-      const fileMime =
-        part.mimeType ||
-        dataUrlMediaType(part.data) ||
-        "application/octet-stream";
+      const fileMime = resolveFileMediaType(part.data, part.mimeType);
       promptParts.push({
         type: "file",
         filename: part.filename,
@@ -136,7 +105,7 @@ const getPromptParts = (message: AppendMessage) => {
         url:
           part.sourceType === "id"
             ? part.data
-            : toWireUrl(part.data, fileMime, parsedFile),
+            : toMediaWireUrl(part.data, fileMime),
       });
     }
   }


### PR DESCRIPTION
closes #5482

## summary

- `resolveImageMediaType`, `resolveFileMediaType` and `toMediaWireUrl` join the data URL helpers in `@assistant-ui/core/internal`.
- react-ai-sdk and react-opencode drop their local copies and keep only their own part-shape plumbing: how each flattens `contentType` and `filename` onto parts, and the `sourceType: "id"` passthrough on their file branches.
- net 66 lines out of the two adapters.

## why now

The two had arrived at identical ladders and an identical wire url builder by construction rather than by sharing code, and they drifted twice on the way there: react-opencode had no byte rung at all until #5479, and react-ai-sdk's rung 2 read any data URL while react-opencode's read only base64 ones. Nothing prevented a third drift.

## no behavior change

Both adapters' existing suites pass untouched, 189 and 104, which is what a faithful extraction should look like. The new behavior tests live in core against the three functions directly.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 829/829 green, 16 new covering each rung of both ladders and every branch of the wire url
- [x] `pnpm --filter @assistant-ui/react-ai-sdk test` -> 189/189 green, **no test file changed**
- [x] `pnpm --filter @assistant-ui/react-opencode test` -> 104/104 green, **no test file changed**
- [x] `pnpm exec tsc --noEmit` -> unchanged from baseline in all three (core 6, react-ai-sdk 1, react-opencode 4, all pre-existing in test files)
- [x] `pnpm api-surface` regenerated for the three new internal exports
- [x] `pnpm exec oxlint` and `pnpm exec oxfmt --check` -> clean

## notes

- the floor for images stays `image/png` rather than a wildcard, and the reason is now written where the function lives: `image/*` is rejected outright by the AI SDK for a url source and whenever inline bytes fail to sniff, so it fails exactly where a fallback is needed.
- #5477 is being handled separately in #5480.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

