### PR TITLE
fix(react-opencode): project user file parts as message attachments

### DIFF
--- a/.changeset/opencode-file-parts-as-attachments.md
+++ b/.changeset/opencode-file-parts-as-attachments.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: project user file parts as message attachments instead of inline content, for server, pending, and shadow copies alike

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -1110,6 +1110,7 @@ describe("user message projection", () => {
         id: "0",
         type: "image",
         name: "photo.png",
+        contentType: "image/png",
         status: { type: "complete" },
         content: [
           {

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -979,3 +979,190 @@ describe("projectOpenCodeThreadMessages", () => {
     expect(toolPart({ type: "ready" })).toHaveProperty("messages", []);
   });
 });
+
+describe("user message projection", () => {
+  const userInfo = {
+    id: "user-1",
+    role: "user",
+    sessionID: "ses_1",
+    time: { created: 1 },
+  } as never;
+
+  const serverUserMessage = (parts: unknown[]) => ({
+    ...createOpenCodeThreadState("ses_1"),
+    messageOrder: ["user-1"],
+    messagesById: {
+      "user-1": {
+        id: "user-1",
+        info: userInfo,
+        parts: parts as never,
+        shadowParts: undefined,
+      },
+    },
+  });
+
+  it("projects a user image file part as a complete image attachment", () => {
+    const state: OpenCodeThreadState = serverUserMessage([
+      {
+        id: "part-text",
+        sessionID: "ses_1",
+        messageID: "user-1",
+        type: "text",
+        text: "look at this",
+      },
+      {
+        id: "part-file",
+        sessionID: "ses_1",
+        messageID: "user-1",
+        type: "file",
+        mime: "image/png",
+        filename: "photo.png",
+        url: "data:image/png;base64,AA==",
+      },
+    ]);
+
+    const [message] = projectOpenCodeThreadMessages(state);
+
+    expect(message?.content).toEqual([{ type: "text", text: "look at this" }]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "part-file",
+        type: "image",
+        name: "photo.png",
+        contentType: "image/png",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "image",
+            image: "data:image/png;base64,AA==",
+            filename: "photo.png",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("projects a non-image user file part as a complete file attachment", () => {
+    const state: OpenCodeThreadState = serverUserMessage([
+      {
+        id: "part-file",
+        sessionID: "ses_1",
+        messageID: "user-1",
+        type: "file",
+        mime: "application/pdf",
+        filename: "report.pdf",
+        url: "https://example.com/report.pdf",
+      },
+    ]);
+
+    const [message] = projectOpenCodeThreadMessages(state);
+
+    expect(message?.content).toEqual([]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "part-file",
+        type: "file",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            filename: "report.pdf",
+            data: "https://example.com/report.pdf",
+            mimeType: "application/pdf",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("splits pending user parts between content and attachments", () => {
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_1"),
+      pendingUserMessages: {
+        client_1: {
+          clientId: "client_1",
+          sessionId: "ses_1",
+          createdAt: 1,
+          parentId: null,
+          sourceId: null,
+          runConfig: undefined,
+          contentText: "look at this",
+          parts: [
+            { type: "text", text: "look at this" },
+            {
+              type: "image",
+              image: "data:image/png;base64,AA==",
+              filename: "photo.png",
+            },
+          ],
+          status: "pending",
+        },
+      },
+    };
+
+    const [message] = projectOpenCodeThreadMessages(state);
+
+    expect(message?.content).toEqual([{ type: "text", text: "look at this" }]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "image",
+        name: "photo.png",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "image",
+            image: "data:image/png;base64,AA==",
+            filename: "photo.png",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("splits shadow parts the same way while server parts are empty", () => {
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_1"),
+      messageOrder: ["user-1"],
+      messagesById: {
+        "user-1": {
+          id: "user-1",
+          info: userInfo,
+          parts: [],
+          shadowParts: [
+            { type: "text", text: "look at this" },
+            {
+              type: "file",
+              data: "data:application/pdf;base64,AA==",
+              mimeType: "application/pdf",
+              filename: "report.pdf",
+            },
+          ] as never,
+        },
+      },
+    };
+
+    const [message] = projectOpenCodeThreadMessages(state);
+
+    expect(message?.content).toEqual([{ type: "text", text: "look at this" }]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "file",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        status: { type: "complete" },
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,AA==",
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -6,6 +6,7 @@ import type {
   OpenCodeThreadState,
   Part,
   PendingUserMessage,
+  ThreadUserMessagePart,
 } from "./types";
 import {
   ExportedMessageRepository,
@@ -447,25 +448,69 @@ const projectAssistantContent = (
   return content;
 };
 
-const projectUserContent = (
+type ProjectedAttachment = NonNullable<
+  OpenCodeProjectedThreadMessage["attachments"]
+>[number];
+
+const getUserPartContentType = (part: ThreadUserMessagePart) => {
+  if (part.type === "file") return part.mimeType;
+  return (part as { contentType?: string }).contentType;
+};
+
+const splitUserParts = (
+  parts: readonly ThreadUserMessagePart[],
+): { content: ProjectedContentPart[]; attachments: ProjectedAttachment[] } => {
+  const content: ProjectedContentPart[] = [];
+  const attachments: ProjectedAttachment[] = [];
+  for (const part of parts) {
+    if (part.type !== "image" && part.type !== "file") {
+      content.push(part as ProjectedContentPart);
+      continue;
+    }
+    const contentType = getUserPartContentType(part);
+    attachments.push({
+      id: attachments.length.toString(),
+      type: part.type === "image" ? "image" : "file",
+      name: part.filename ?? "file",
+      ...(contentType != null && { contentType }),
+      status: { type: "complete" },
+      content: [part],
+    });
+  }
+  return { content, attachments };
+};
+
+const projectUserFileAttachment = (
+  part: Extract<Part, { type: "file" }>,
+): ProjectedAttachment => {
+  const content = convertFilePart(part);
+  return {
+    id: part.id,
+    type: content.type === "image" ? "image" : "file",
+    name: part.filename ?? "file",
+    contentType: part.mime ?? "application/octet-stream",
+    status: { type: "complete" },
+    content: [content],
+  };
+};
+
+const projectUserMessage = (
   message: OpenCodeServerMessage,
-): ProjectedContentPart[] => {
+): { content: ProjectedContentPart[]; attachments: ProjectedAttachment[] } => {
   if (message.parts.length === 0) {
-    return (message.shadowParts ?? []) as ProjectedContentPart[];
+    return splitUserParts(message.shadowParts ?? []);
   }
 
-  return message.parts.flatMap((part) => {
-    switch (part.type) {
-      case "text":
-        return [
-          { type: "text" as const, text: part.text ?? "" },
-        ] satisfies ProjectedContentPart[];
-      case "file":
-        return [convertFilePart(part)] satisfies ProjectedContentPart[];
-      default:
-        return [] as ProjectedContentPart[];
+  const content: ProjectedContentPart[] = [];
+  const attachments: ProjectedAttachment[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      content.push({ type: "text", text: part.text ?? "" });
+    } else if (part.type === "file") {
+      attachments.push(projectUserFileAttachment(part));
     }
-  });
+  }
+  return { content, attachments };
 };
 
 const getMessageStatus = (
@@ -586,12 +631,13 @@ const projectServerMessage = (
   }
 
   if (message.info.role === "user") {
+    const { content, attachments } = projectUserMessage(message);
     return {
       id: message.info.id,
       role: "user",
       createdAt: new Date(message.info.time?.created ?? Date.now()),
-      content: projectUserContent(message),
-      attachments: [],
+      content,
+      attachments,
       metadata,
     };
   }
@@ -605,8 +651,7 @@ const projectPendingMessage = (
   id: `local:${pending.clientId}`,
   role: "user",
   createdAt: new Date(pending.createdAt),
-  content: pending.parts as OpenCodeProjectedThreadMessage["content"],
-  attachments: [],
+  ...splitUserParts(pending.parts),
   metadata: {
     custom: {
       opencode: {

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -14,6 +14,10 @@ import {
   type ThreadMessage,
 } from "@assistant-ui/react";
 import {
+  resolveFileMediaType,
+  resolveImageMediaType,
+} from "@assistant-ui/core/internal";
+import {
   projectOpenCodePermissionApproval,
   projectResolvedOpenCodePermissionApproval,
 } from "./openCodePermissionApproval";
@@ -452,11 +456,6 @@ type ProjectedAttachment = NonNullable<
   OpenCodeProjectedThreadMessage["attachments"]
 >[number];
 
-const getUserPartContentType = (part: ThreadUserMessagePart) => {
-  if (part.type === "file") return part.mimeType;
-  return (part as { contentType?: string }).contentType;
-};
-
 const splitUserParts = (
   parts: readonly ThreadUserMessagePart[],
 ): { content: ProjectedContentPart[]; attachments: ProjectedAttachment[] } => {
@@ -467,12 +466,20 @@ const splitUserParts = (
       content.push(part as ProjectedContentPart);
       continue;
     }
-    const contentType = getUserPartContentType(part);
+    // The same ladders the outbound prompt uses, so the pending copy and the
+    // reconciled server copy agree on the attachment's type and content type.
+    const mediaType =
+      part.type === "image"
+        ? resolveImageMediaType(
+            part.image,
+            (part as { contentType?: string }).contentType,
+          )
+        : resolveFileMediaType(part.data, part.mimeType);
     attachments.push({
       id: attachments.length.toString(),
-      type: part.type === "image" ? "image" : "file",
+      type: mediaType.startsWith("image/") ? "image" : "file",
       name: part.filename ?? "file",
-      ...(contentType != null && { contentType }),
+      contentType: mediaType,
       status: { type: "complete" },
       content: [part],
     });


### PR DESCRIPTION
## problem

`projectServerMessage` put every user `file` part in `content` and hard-coded `attachments: []`, and `projectPendingMessage` did the same with the pending parts. that diverges from the standard assistant-ui shape (the AI SDK converter puts user file parts into message attachments and keeps text in content), so `MessagePrimitive.Attachments` and the canonical `UserMessageAttachments` component cannot render OpenCode user attachments, and consumers have to special-case OpenCode file parts in `MessagePrimitive.Parts`. fixes #5487.

## approach

the projection now splits user parts: text stays in `content`, files become complete attachments. one `splitUserParts` helper covers the two aui-part surfaces (the pending copy and the `shadowParts` shadow of a reconciled message), so both render identically to the server-backed copy; server `file` parts go through the existing `convertFilePart` and wrap into an attachment carrying the part id, filename, and mime. the attachment shape mirrors the AI SDK converter (`type` image for image mimes, `file` otherwise, `status: complete`).

## verification

package vitest suite green (110 tests, 4 new: server image file part, server non-image file part, pending split, shadow-parts split). package tsc sits at the same 4 pre-existing baseline errors as main.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

