### PR TITLE
fix(react-opencode): stop fingerprinting parts the outbound path never sends

### DIFF
--- a/.changeset/opencode-unsendable-fingerprint.md
+++ b/.changeset/opencode-unsendable-fingerprint.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: stop fingerprinting audio and data parts the outbound path never sends, so their pending copies reconcile with the server echo

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -3,7 +3,12 @@ import {
   createOpenCodeThreadState,
   reduceOpenCodeThreadState,
 } from "./openCodeThreadState";
-import type { MessageWithParts, PendingUserMessage } from "./types";
+import { serializeOpenCodeParts } from "./serializeUserParts";
+import type {
+  MessageWithParts,
+  PendingUserMessage,
+  ThreadUserMessagePart,
+} from "./types";
 
 describe("reduceOpenCodeThreadState", () => {
   it("reconciles a pending user message with loaded history", () => {
@@ -44,6 +49,49 @@ describe("reduceOpenCodeThreadState", () => {
     expect(Object.keys(history.pendingUserMessages)).toHaveLength(0);
     expect(history.messageOrder).toEqual(["msg_1"]);
     expect(history.messagesById.msg_1?.shadowParts).toEqual(pending.parts);
+  });
+
+  it("reconciles a pending copy whose unsendable parts never reached the wire", () => {
+    const initial = createOpenCodeThreadState("ses_1");
+    const parts = [
+      { type: "text", text: "hello" },
+      { type: "audio", audio: { data: "QUJD", format: "mp3" } },
+      { type: "data", data: { foo: "bar" } },
+    ] as unknown as readonly ThreadUserMessagePart[];
+    const pending: PendingUserMessage = {
+      clientId: "local_1",
+      sessionId: "ses_1",
+      createdAt: 1000,
+      parentId: null,
+      sourceId: null,
+      runConfig: undefined,
+      contentText: serializeOpenCodeParts(parts).trim(),
+      parts,
+      status: "pending",
+    };
+
+    const queued = reduceOpenCodeThreadState(initial, {
+      type: "local.message.queued",
+      pending,
+    });
+    const history = reduceOpenCodeThreadState(queued, {
+      type: "history.loaded",
+      session: null,
+      messages: [
+        {
+          info: {
+            id: "msg_1",
+            role: "user",
+            sessionID: "ses_1",
+            time: { created: 1000 },
+          },
+          parts: [{ type: "text", text: "hello" }],
+        } as unknown as MessageWithParts,
+      ],
+    });
+
+    expect(Object.keys(history.pendingUserMessages)).toHaveLength(0);
+    expect(history.messageOrder).toEqual(["msg_1"]);
   });
 
   it("reconciles a filename-less inline file after its media type is rewritten", () => {

--- a/packages/react-opencode/src/openCodeThreadState.test.ts
+++ b/packages/react-opencode/src/openCodeThreadState.test.ts
@@ -53,11 +53,11 @@ describe("reduceOpenCodeThreadState", () => {
 
   it("reconciles a pending copy whose unsendable parts never reached the wire", () => {
     const initial = createOpenCodeThreadState("ses_1");
-    const parts = [
+    const parts: readonly ThreadUserMessagePart[] = [
       { type: "text", text: "hello" },
       { type: "audio", audio: { data: "QUJD", format: "mp3" } },
-      { type: "data", data: { foo: "bar" } },
-    ] as unknown as readonly ThreadUserMessagePart[];
+      { type: "data", name: "custom", data: { foo: "bar" } },
+    ];
     const pending: PendingUserMessage = {
       clientId: "local_1",
       sessionId: "ses_1",

--- a/packages/react-opencode/src/serializeUserParts.ts
+++ b/packages/react-opencode/src/serializeUserParts.ts
@@ -11,7 +11,9 @@ import type { Part, ThreadUserMessagePart } from "./types";
  * The pending copy and the loaded history are fingerprinted against each other
  * to reconcile an optimistic message, so an inline payload has to be rendered
  * as the url that actually went out. Rendering the original payload on one side
- * and the rewritten url on the other leaves the two unable to match.
+ * and the rewritten url on the other leaves the two unable to match. Parts the
+ * outbound path never sends render empty for the same reason: the echo cannot
+ * carry them back.
  */
 export const serializeOpenCodeParts = (
   parts: readonly (Part | ThreadUserMessagePart)[],
@@ -40,8 +42,6 @@ export const serializeOpenCodeParts = (
         );
       }
       if (part.type === "tool") return JSON.stringify(part.state?.input ?? {});
-      if (part.type === "data") return JSON.stringify(part.data) ?? "";
-      if (part.type === "audio") return part.audio.data;
       return "";
     })
     .join("\n");


### PR DESCRIPTION
## problem

`serializeOpenCodeParts` rendered `audio` and `data` parts, but `getPromptParts` has branches for text, image, and file only, so neither part type is ever put on the wire. the pending copy's fingerprint then contains content the server echo cannot carry back, `findPendingMatchByHistory` misses, and the optimistic message stays beside the server one, the same duplicate as #5477. fixes #5486.

## approach

the serializer stops rendering what the outbound path cannot send: the `audio` and `data` branches are gone, so those parts render empty on both sides and the fingerprints agree. this keeps the two representations honest rather than growing `getPromptParts` branches for content OpenCode does not carry (audio is not part of the OpenCode input union, and a `data` part has no wire representation at all).

## verification

new reducer-level contract test: a pending copy holding text plus audio plus data parts, with `contentText` computed through the production serializer, reconciles against a server echo holding only the text. it fails on main's serializer with exactly the reported symptom (the pending copy survives) and passes with the fix. full package suite 107 green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

