### PR TITLE
feat(react-opencode): add OpenCodeAttachmentAdapter for native file inputs

### DIFF
--- a/.changeset/opencode-attachment-adapter.md
+++ b/.changeset/opencode-attachment-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+feat: add OpenCodeAttachmentAdapter, converting browser files into attachments that preserve OpenCode's native file semantics

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -855,6 +855,20 @@ type ObjectKey<T> = keyof T & (string | number);
 
 type OnSchemaValidationErrorFunction<TResult> = ToolExecuteFunction<unknown, TResult>;
 
+declare class OpenCodeAttachmentAdapter implements AttachmentAdapter {
+  accept: string;
+  constructor(options?: OpenCodeAttachmentAdapterOptions);
+  add(state: {
+    file: File;
+  }): Promise<PendingAttachment>;
+  send(attachment: PendingAttachment): Promise<CompleteAttachment>;
+  remove(): Promise<void>;
+}
+
+type OpenCodeAttachmentAdapterOptions = {
+  accept?: string | undefined;
+};
+
 declare class OpenCodeEventSource {
   private readonly listeners;
   private readonly reconnectDelayMs;
@@ -1952,7 +1966,7 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
+  export { AssistantMessage, Event, FilePart, GlobalSession, Message$2 as Message, MessageWithParts, Model, OpenCodeAttachmentAdapter, OpenCodeAttachmentAdapterOptions, OpenCodeEventSource, OpenCodeLoadState, OpenCodePartPayload, OpenCodePermissionRequest, OpenCodePermissionResponse, OpenCodeProjectedThreadMessage, OpenCodeQuestionRequest, OpenCodeRunState, OpenCodeRuntime, OpenCodeRuntimeExtras, OpenCodeRuntimeOptions, OpenCodeServerEvent, OpenCodeServerMessage, OpenCodeStateEvent, OpenCodeThreadController, OpenCodeThreadControllerLike, OpenCodeThreadControllerSnapshot, OpenCodeThreadState, OpenCodeThreadStateSelector, OpenCodeUnhandledEvent, OpenCodeUserMessageOptions, OpencodeClient$1 as OpencodeClient, OpencodeClientConfig, Part$1 as Part, PendingUserMessage, PermissionRequest$1 as PermissionRequest, Provider, QuestionAnswer$1 as QuestionAnswer, QuestionRequest$1 as QuestionRequest, ReasoningPart, STREAM_RECONNECTED_EVENT_TYPE, Session$1 as Session, SessionStatus$1 as SessionStatus, SnapshotPart, StepFinishPart, StepStartPart, TextPart, ToolPart, ToolState, UserMessage, createOpenCodeThreadState, createOpencodeClient$1 as createOpencodeClient, projectOpenCodeThreadMessages, reduceOpenCodeThreadState, useOpenCodePermissions, useOpenCodeQuestions, useOpenCodeRuntime, useOpenCodeRuntimeExtras, useOpenCodeSession, useOpenCodeStreamingTiming, useOpenCodeThreadState };
 }
 
 declare function projectOpenCodeThreadMessages(state: OpenCodeThreadState, messageTiming?: Record<string, MessageTiming>): OpenCodeProjectedThreadMessage[];

--- a/packages/react-opencode/src/index.ts
+++ b/packages/react-opencode/src/index.ts
@@ -1,4 +1,8 @@
 export { useOpenCodeRuntime } from "./useOpenCodeRuntime";
+export {
+  OpenCodeAttachmentAdapter,
+  type OpenCodeAttachmentAdapterOptions,
+} from "./openCodeAttachmentAdapter";
 
 export {
   useOpenCodePermissions,

--- a/packages/react-opencode/src/openCodeAttachmentAdapter.test.ts
+++ b/packages/react-opencode/src/openCodeAttachmentAdapter.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { OpenCodeAttachmentAdapter } from "./openCodeAttachmentAdapter";
+
+const pngFile = () =>
+  new File([new Uint8Array([0x41, 0x42, 0x43])], "photo.png", {
+    type: "image/png",
+  });
+
+const pdfFile = () =>
+  new File([new Uint8Array([0x41, 0x42, 0x43])], "report.pdf", {
+    type: "application/pdf",
+  });
+
+const unknownFile = () =>
+  new File([new Uint8Array([0x41, 0x42, 0x43])], "script.xyz", { type: "" });
+
+describe("OpenCodeAttachmentAdapter", () => {
+  it("exposes the OpenCode-native accept list and allows overriding it", () => {
+    expect(new OpenCodeAttachmentAdapter().accept).toBe(
+      "image/*,application/pdf,text/*",
+    );
+    expect(
+      new OpenCodeAttachmentAdapter({ accept: "image/*,.ts" }).accept,
+    ).toBe("image/*,.ts");
+  });
+
+  it("adds an image file as a pending image attachment", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const attachment = await adapter.add({ file: pngFile() });
+
+    expect(attachment).toMatchObject({
+      type: "image",
+      name: "photo.png",
+      contentType: "image/png",
+      status: { type: "requires-action", reason: "composer-send" },
+    });
+  });
+
+  it("adds a non-image file as a pending file attachment", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const attachment = await adapter.add({ file: pdfFile() });
+
+    expect(attachment).toMatchObject({
+      type: "file",
+      name: "report.pdf",
+      contentType: "application/pdf",
+    });
+  });
+
+  it("defaults an unknown browser MIME type to application/octet-stream", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const attachment = await adapter.add({ file: unknownFile() });
+
+    expect(attachment).toMatchObject({
+      type: "file",
+      name: "script.xyz",
+      contentType: "application/octet-stream",
+    });
+  });
+
+  it("sends an image as an inline image part with its filename", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const pending = await adapter.add({ file: pngFile() });
+    const complete = await adapter.send(pending);
+
+    expect(complete.status).toEqual({ type: "complete" });
+    expect(complete.content).toEqual([
+      {
+        type: "image",
+        image: "data:image/png;base64,QUJD",
+        filename: "photo.png",
+      },
+    ]);
+  });
+
+  it("sends a non-image file as an inline file part with mime and filename", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const pending = await adapter.add({ file: pdfFile() });
+    const complete = await adapter.send(pending);
+
+    expect(complete.content).toEqual([
+      {
+        type: "file",
+        data: "data:application/pdf;base64,QUJD",
+        mimeType: "application/pdf",
+        filename: "report.pdf",
+      },
+    ]);
+  });
+});

--- a/packages/react-opencode/src/openCodeAttachmentAdapter.test.ts
+++ b/packages/react-opencode/src/openCodeAttachmentAdapter.test.ts
@@ -3,32 +3,30 @@
 import { describe, expect, it } from "vitest";
 import { OpenCodeAttachmentAdapter } from "./openCodeAttachmentAdapter";
 
-const pngFile = () =>
-  new File([new Uint8Array([0x41, 0x42, 0x43])], "photo.png", {
-    type: "image/png",
-  });
+const textPayload = new Uint8Array([0x41, 0x42, 0x43]);
+const binaryPayload = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
 
-const pdfFile = () =>
-  new File([new Uint8Array([0x41, 0x42, 0x43])], "report.pdf", {
-    type: "application/pdf",
-  });
-
-const unknownFile = () =>
-  new File([new Uint8Array([0x41, 0x42, 0x43])], "script.xyz", { type: "" });
+const makeFile = (name: string, type: string, payload = textPayload) =>
+  new File([payload], name, { type });
 
 describe("OpenCodeAttachmentAdapter", () => {
-  it("exposes the OpenCode-native accept list and allows overriding it", () => {
-    expect(new OpenCodeAttachmentAdapter().accept).toBe(
-      "image/*,application/pdf,text/*",
+  it("defaults to the OpenCode client accept list and allows overriding it", () => {
+    const accept = new OpenCodeAttachmentAdapter().accept;
+    expect(accept).toContain("image/png");
+    expect(accept).toContain(".ts");
+    expect(accept).not.toContain("image/*");
+
+    expect(new OpenCodeAttachmentAdapter({ accept: "image/png" }).accept).toBe(
+      "image/png",
     );
-    expect(
-      new OpenCodeAttachmentAdapter({ accept: "image/*,.ts" }).accept,
-    ).toBe("image/*,.ts");
+    expect(new OpenCodeAttachmentAdapter({ accept: "" }).accept).toBe(accept);
   });
 
   it("adds an image file as a pending image attachment", async () => {
     const adapter = new OpenCodeAttachmentAdapter();
-    const attachment = await adapter.add({ file: pngFile() });
+    const attachment = await adapter.add({
+      file: makeFile("photo.png", "image/png"),
+    });
 
     expect(attachment).toMatchObject({
       type: "image",
@@ -38,9 +36,11 @@ describe("OpenCodeAttachmentAdapter", () => {
     });
   });
 
-  it("adds a non-image file as a pending file attachment", async () => {
+  it("adds a PDF as a pending file attachment", async () => {
     const adapter = new OpenCodeAttachmentAdapter();
-    const attachment = await adapter.add({ file: pdfFile() });
+    const attachment = await adapter.add({
+      file: makeFile("report.pdf", "application/pdf"),
+    });
 
     expect(attachment).toMatchObject({
       type: "file",
@@ -49,20 +49,59 @@ describe("OpenCodeAttachmentAdapter", () => {
     });
   });
 
-  it("defaults an unknown browser MIME type to application/octet-stream", async () => {
+  it("normalizes text-like MIME types to text/plain", async () => {
     const adapter = new OpenCodeAttachmentAdapter();
-    const attachment = await adapter.add({ file: unknownFile() });
+
+    for (const [name, type] of [
+      ["notes.md", "text/markdown"],
+      ["config.json", "application/json"],
+      ["feed.atom", "application/atom+xml"],
+    ] as const) {
+      const attachment = await adapter.add({ file: makeFile(name, type) });
+      expect(attachment).toMatchObject({
+        type: "file",
+        contentType: "text/plain",
+      });
+    }
+  });
+
+  it("sniffs files whose browser MIME type is unusable", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const attachment = await adapter.add({
+      file: makeFile("component.ts", "video/mp2t"),
+    });
 
     expect(attachment).toMatchObject({
       type: "file",
-      name: "script.xyz",
-      contentType: "application/octet-stream",
+      contentType: "text/plain",
     });
+  });
+
+  it("recovers an image MIME type from the extension when the browser reports none", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+    const attachment = await adapter.add({ file: makeFile("photo.png", "") });
+
+    expect(attachment).toMatchObject({
+      type: "image",
+      contentType: "image/png",
+    });
+  });
+
+  it("rejects a file that is neither an image, a PDF, nor readable text", async () => {
+    const adapter = new OpenCodeAttachmentAdapter();
+
+    await expect(
+      adapter.add({ file: makeFile("blob.bin", "", binaryPayload) }),
+    ).rejects.toThrow(
+      "OpenCodeAttachmentAdapter: blob.bin is not an image, a PDF, or readable text",
+    );
   });
 
   it("sends an image as an inline image part with its filename", async () => {
     const adapter = new OpenCodeAttachmentAdapter();
-    const pending = await adapter.add({ file: pngFile() });
+    const pending = await adapter.add({
+      file: makeFile("photo.png", "image/png"),
+    });
     const complete = await adapter.send(pending);
 
     expect(complete.status).toEqual({ type: "complete" });
@@ -75,17 +114,19 @@ describe("OpenCodeAttachmentAdapter", () => {
     ]);
   });
 
-  it("sends a non-image file as an inline file part with mime and filename", async () => {
+  it("sends a text-like file with the normalized MIME type", async () => {
     const adapter = new OpenCodeAttachmentAdapter();
-    const pending = await adapter.add({ file: pdfFile() });
+    const pending = await adapter.add({
+      file: makeFile("notes.md", "text/markdown"),
+    });
     const complete = await adapter.send(pending);
 
     expect(complete.content).toEqual([
       {
         type: "file",
-        data: "data:application/pdf;base64,QUJD",
-        mimeType: "application/pdf",
-        filename: "report.pdf",
+        data: "data:text/markdown;base64,QUJD",
+        mimeType: "text/plain",
+        filename: "notes.md",
       },
     ]);
   });

--- a/packages/react-opencode/src/openCodeAttachmentAdapter.ts
+++ b/packages/react-opencode/src/openCodeAttachmentAdapter.ts
@@ -1,0 +1,73 @@
+import {
+  generateId,
+  type AttachmentAdapter,
+  type CompleteAttachment,
+  type PendingAttachment,
+} from "@assistant-ui/react";
+import { getFileDataURL } from "@assistant-ui/core/internal";
+
+const DEFAULT_ACCEPT = "image/*,application/pdf,text/*";
+
+export type OpenCodeAttachmentAdapterOptions = {
+  /**
+   * File picker accept list. Defaults to the inputs OpenCode clients handle
+   * natively (images, PDF, and text). Code files often carry an empty or
+   * nonstandard browser MIME type, so widen this with extension entries
+   * (for example `".ts,.py"`) when they should be pickable.
+   */
+  accept?: string | undefined;
+};
+
+/**
+ * Converts browser files into standard assistant-ui attachments that preserve
+ * OpenCode's native file semantics: the filename, MIME type, and payload ride
+ * as an inline data url, and the thread controller turns the resulting message
+ * part into an OpenCode `FilePartInput`. Capability decisions and request
+ * failures stay owned by the OpenCode server.
+ */
+export class OpenCodeAttachmentAdapter implements AttachmentAdapter {
+  public accept: string;
+
+  constructor(options?: OpenCodeAttachmentAdapterOptions) {
+    this.accept = options?.accept ?? DEFAULT_ACCEPT;
+  }
+
+  public async add(state: { file: File }): Promise<PendingAttachment> {
+    return {
+      id: generateId(),
+      type: state.file.type.startsWith("image/") ? "image" : "file",
+      name: state.file.name,
+      contentType: state.file.type || "application/octet-stream",
+      file: state.file,
+      status: { type: "requires-action", reason: "composer-send" },
+    };
+  }
+
+  public async send(
+    attachment: PendingAttachment,
+  ): Promise<CompleteAttachment> {
+    const url = await getFileDataURL(attachment.file);
+    return {
+      ...attachment,
+      status: { type: "complete" },
+      content: [
+        attachment.type === "image"
+          ? {
+              type: "image",
+              image: url,
+              filename: attachment.name,
+            }
+          : {
+              type: "file",
+              data: url,
+              mimeType: attachment.contentType ?? "application/octet-stream",
+              filename: attachment.name,
+            },
+      ],
+    };
+  }
+
+  public async remove() {
+    // noop
+  }
+}

--- a/packages/react-opencode/src/openCodeAttachmentAdapter.ts
+++ b/packages/react-opencode/src/openCodeAttachmentAdapter.ts
@@ -6,38 +6,180 @@ import {
 } from "@assistant-ui/react";
 import { getFileDataURL } from "@assistant-ui/core/internal";
 
-const DEFAULT_ACCEPT = "image/*,application/pdf,text/*";
+// Mirrors ACCEPTED_FILE_TYPES in OpenCode's app (packages/app/src/constants/file-picker.ts),
+// including the extension entries that make source files pickable despite their
+// empty or nonstandard browser MIME types.
+const DEFAULT_ACCEPT = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "application/pdf",
+  "text/*",
+  "application/json",
+  "application/ld+json",
+  "application/toml",
+  "application/x-toml",
+  "application/x-yaml",
+  "application/xml",
+  "application/yaml",
+  ".c",
+  ".cc",
+  ".cjs",
+  ".conf",
+  ".cpp",
+  ".css",
+  ".csv",
+  ".cts",
+  ".env",
+  ".go",
+  ".gql",
+  ".graphql",
+  ".h",
+  ".hh",
+  ".hpp",
+  ".htm",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".jsx",
+  ".log",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".mts",
+  ".py",
+  ".rb",
+  ".rs",
+  ".sass",
+  ".scss",
+  ".sh",
+  ".sql",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".zsh",
+].join(",");
+
+const IMAGE_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+const IMAGE_EXTS = new Map([
+  ["gif", "image/gif"],
+  ["jpeg", "image/jpeg"],
+  ["jpg", "image/jpeg"],
+  ["png", "image/png"],
+  ["webp", "image/webp"],
+]);
+
+const TEXT_MIMES = new Set([
+  "application/json",
+  "application/ld+json",
+  "application/toml",
+  "application/x-toml",
+  "application/x-yaml",
+  "application/xml",
+  "application/yaml",
+]);
+
+const SAMPLE = 4096;
+
+const kind = (type: string) =>
+  type.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+
+const ext = (name: string) => {
+  const idx = name.lastIndexOf(".");
+  if (idx === -1) return "";
+  return name.slice(idx + 1).toLowerCase();
+};
+
+const textMime = (type: string) => {
+  if (!type) return false;
+  if (type.startsWith("text/")) return true;
+  if (TEXT_MIMES.has(type)) return true;
+  if (type.endsWith("+json")) return true;
+  return type.endsWith("+xml");
+};
+
+const textBytes = (bytes: Uint8Array) => {
+  if (bytes.length === 0) return true;
+  let count = 0;
+  for (const byte of bytes) {
+    if (byte === 0) return false;
+    if (byte < 9 || (byte > 13 && byte < 32)) count += 1;
+  }
+  return count / bytes.length <= 0.3;
+};
+
+// Port of `attachmentMime` in OpenCode's app (packages/app/src/components/prompt-input/files.ts).
+// The server only inlines a data url file part as readable text when its mime
+// is exactly `text/plain`, and forwards every other non-image, non-pdf mime to
+// the provider as an unrenderable binary part, so text-like inputs have to be
+// normalized before they go on the wire.
+const resolveOpenCodeMime = async (file: File): Promise<string | undefined> => {
+  const type = kind(file.type);
+  if (IMAGE_MIMES.has(type)) return type;
+  if (type === "application/pdf") return type;
+
+  const suffix = ext(file.name);
+  const fallback =
+    IMAGE_EXTS.get(suffix) ??
+    (suffix === "pdf" ? "application/pdf" : undefined);
+  if ((!type || type === "application/octet-stream") && fallback)
+    return fallback;
+
+  if (textMime(type)) return "text/plain";
+  const bytes = new Uint8Array(await file.slice(0, SAMPLE).arrayBuffer());
+  if (!textBytes(bytes)) return undefined;
+  return "text/plain";
+};
 
 export type OpenCodeAttachmentAdapterOptions = {
   /**
-   * File picker accept list. Defaults to the inputs OpenCode clients handle
-   * natively (images, PDF, and text). Code files often carry an empty or
-   * nonstandard browser MIME type, so widen this with extension entries
-   * (for example `".ts,.py"`) when they should be pickable.
+   * File picker accept list. Defaults to the list OpenCode's own clients use,
+   * including their extension entries for source files. An override replaces
+   * the whole list; an empty override falls back to the default.
    */
   accept?: string | undefined;
 };
 
 /**
  * Converts browser files into standard assistant-ui attachments that preserve
- * OpenCode's native file semantics: the filename, MIME type, and payload ride
- * as an inline data url, and the thread controller turns the resulting message
- * part into an OpenCode `FilePartInput`. Capability decisions and request
- * failures stay owned by the OpenCode server.
+ * OpenCode's native file semantics. The MIME type is normalized the same way
+ * OpenCode's own clients do (exact image types and PDF pass through, text-like
+ * inputs become `text/plain`, unreadable binaries are rejected), the filename
+ * and payload ride as an inline data url, and the thread controller turns the
+ * resulting message part into an OpenCode `FilePartInput`.
  */
 export class OpenCodeAttachmentAdapter implements AttachmentAdapter {
   public accept: string;
 
   constructor(options?: OpenCodeAttachmentAdapterOptions) {
-    this.accept = options?.accept ?? DEFAULT_ACCEPT;
+    this.accept = options?.accept || DEFAULT_ACCEPT;
   }
 
   public async add(state: { file: File }): Promise<PendingAttachment> {
+    const mimeType = await resolveOpenCodeMime(state.file);
+    if (!mimeType) {
+      throw new Error(
+        `OpenCodeAttachmentAdapter: ${state.file.name} is not an image, a PDF, or readable text`,
+      );
+    }
     return {
       id: generateId(),
-      type: state.file.type.startsWith("image/") ? "image" : "file",
+      type: IMAGE_MIMES.has(mimeType) ? "image" : "file",
       name: state.file.name,
-      contentType: state.file.type || "application/octet-stream",
+      contentType: mimeType,
       file: state.file,
       status: { type: "requires-action", reason: "composer-send" },
     };


### PR DESCRIPTION
## what

`useOpenCodeRuntime` accepts an `AttachmentAdapter`, but nothing shipped preserved OpenCode's native file semantics: `SimpleImageAttachmentAdapter` covers images only and `SimpleTextAttachmentAdapter` rewrites files into inline prompt text. this adds `OpenCodeAttachmentAdapter`: a browser `File` becomes a standard complete attachment carrying filename, MIME type, and an inline data url, images as an image attachment and everything else as a file attachment, and the existing thread controller performs the message-part to `FilePartInput` conversion unchanged. no storage, upload routes, provider detection, or core API. fixes #5488.

## the accept-list decision (resolved by upstream fidelity)

review surfaced that OpenCode's server only inlines a data url file part as readable text when its mime is exactly `text/plain`, and that OpenCode's own client normalizes every attachment mime through `attachmentMime` before building the data url (verified against sst/opencode: `packages/opencode/src/session/prompt.ts` and `packages/app/src/components/prompt-input/files.ts`). the adapter now ports that normalization verbatim (exact image mimes and pdf pass through, extension fallback for empty or octet-stream types, text-like mimes to `text/plain`, byte-sniffed rejection of unreadable binaries) and adopts `ACCEPTED_FILE_TYPES` from their file picker as the default accept, extension entries included. an `accept` override still replaces the list, and an empty override falls back to the default.

what still needs judging: this is a new public export, and the ported constants track upstream by copy, so they drift when OpenCode changes its list; the source pointers are in comments next to each block.

## verification

9 colocated tests: accept default, override, and empty-override fallback, pending shapes for image, pdf, normalized text-like mimes, byte-sniffed source files, and extension-recovered images, binary rejection, and send() payloads for image and normalized text. api-surface regenerated with the repo script. full package suite 115 green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


