### PR TITLE
fix(react-opencode): project user file parts as attachments

### DIFF
--- a/.changeset/opencode-user-file-attachments.md
+++ b/.changeset/opencode-user-file-attachments.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: project OpenCode user file parts as standard message attachments

--- a/packages/react-opencode/src/openCodeMessageProjection.test.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.test.ts
@@ -4,6 +4,160 @@ import { createOpenCodeThreadState } from "./openCodeThreadState";
 import type { OpenCodeThreadState } from "./types";
 
 describe("projectOpenCodeThreadMessages", () => {
+  it("projects user file parts as standard message attachments", () => {
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_1"),
+      messageOrder: ["user-1"],
+      messagesById: {
+        "user-1": {
+          id: "user-1",
+          info: {
+            id: "user-1",
+            role: "user",
+            sessionID: "ses_1",
+            time: { created: 1 },
+          } as never,
+          parts: [
+            {
+              id: "text-1",
+              sessionID: "ses_1",
+              messageID: "user-1",
+              type: "text",
+              text: "Inspect these files",
+            } as never,
+            {
+              id: "image-1",
+              sessionID: "ses_1",
+              messageID: "user-1",
+              type: "file",
+              mime: "image/png",
+              filename: "photo.png",
+              url: "data:image/png;base64,AA==",
+            } as never,
+            {
+              id: "file-1",
+              sessionID: "ses_1",
+              messageID: "user-1",
+              type: "file",
+              mime: "application/pdf",
+              filename: "report.pdf",
+              url: "data:application/pdf;base64,AA==",
+            } as never,
+          ],
+          shadowParts: undefined,
+        },
+      },
+    };
+
+    const message = projectOpenCodeThreadMessages(state)[0];
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "Inspect these files" },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "image-1",
+        type: "image",
+        name: "photo.png",
+        contentType: "image/png",
+        content: [
+          {
+            type: "image",
+            image: "data:image/png;base64,AA==",
+            filename: "photo.png",
+          },
+        ],
+        status: { type: "complete" },
+      },
+      {
+        id: "file-1",
+        type: "file",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        content: [
+          {
+            type: "file",
+            filename: "report.pdf",
+            data: "data:application/pdf;base64,AA==",
+            mimeType: "application/pdf",
+          },
+        ],
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
+  it("projects pending files with the same attachment presentation", () => {
+    const state: OpenCodeThreadState = {
+      ...createOpenCodeThreadState("ses_1"),
+      pendingUserMessages: {
+        "pending-1": {
+          clientId: "pending-1",
+          sessionId: "ses_1",
+          createdAt: 1,
+          parentId: null,
+          sourceId: null,
+          runConfig: undefined,
+          contentText: "Inspect these files",
+          parts: [
+            { type: "text", text: "Inspect these files" },
+            {
+              type: "image",
+              image: "data:image/webp;base64,AA==",
+              filename: "photo.webp",
+              contentType: "image/webp",
+            } as never,
+            {
+              type: "file",
+              data: "data:application/pdf;base64,AA==",
+              filename: "report.pdf",
+              mimeType: "application/pdf",
+            },
+          ],
+          status: "pending",
+        },
+      },
+    };
+
+    const message = projectOpenCodeThreadMessages(state)[0];
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "Inspect these files" },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "local:pending-1:attachment:1",
+        type: "image",
+        name: "photo.webp",
+        contentType: "image/webp",
+        content: [
+          {
+            type: "image",
+            image: "data:image/webp;base64,AA==",
+            filename: "photo.webp",
+            contentType: "image/webp",
+          },
+        ],
+        status: { type: "complete" },
+      },
+      {
+        id: "local:pending-1:attachment:2",
+        type: "file",
+        name: "report.pdf",
+        contentType: "application/pdf",
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,AA==",
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+          },
+        ],
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
   it("merges consecutive assistant messages into one projected message", () => {
     const state: OpenCodeThreadState = {
       ...createOpenCodeThreadState("ses_1"),

--- a/packages/react-opencode/src/openCodeMessageProjection.ts
+++ b/packages/react-opencode/src/openCodeMessageProjection.ts
@@ -9,8 +9,10 @@ import type {
 } from "./types";
 import {
   ExportedMessageRepository,
+  type CompleteAttachment,
   type MessageTiming,
   type ThreadMessage,
+  type ThreadUserMessagePart,
 } from "@assistant-ui/react";
 import {
   projectOpenCodePermissionApproval,
@@ -264,6 +266,42 @@ const convertFilePart = (part: Extract<Part, { type: "file" }>) => {
   };
 };
 
+const projectUserAttachment = (
+  part: Extract<ThreadUserMessagePart, { type: "image" | "file" }>,
+  id: string,
+  contentType?: string,
+): CompleteAttachment => ({
+  id,
+  type: part.type === "image" ? "image" : "file",
+  name: part.filename ?? "file",
+  ...(contentType ? { contentType } : {}),
+  content: [part],
+  status: { type: "complete" },
+});
+
+const projectPendingUserParts = (
+  parts: readonly ThreadUserMessagePart[],
+  messageId: string,
+) => ({
+  content: parts.filter(
+    (part) => part.type !== "image" && part.type !== "file",
+  ) as ProjectedContentPart[],
+  attachments: parts.flatMap((part, index) => {
+    if (part.type !== "image" && part.type !== "file") return [];
+    const contentType =
+      part.type === "file"
+        ? part.mimeType
+        : (part as { contentType?: string }).contentType;
+    return [
+      projectUserAttachment(
+        part,
+        `${messageId}:attachment:${index}`,
+        contentType,
+      ),
+    ];
+  }),
+});
+
 const projectAssistantContent = (
   state: OpenCodeThreadState,
   message: OpenCodeServerMessage,
@@ -447,25 +485,32 @@ const projectAssistantContent = (
   return content;
 };
 
-const projectUserContent = (
-  message: OpenCodeServerMessage,
-): ProjectedContentPart[] => {
+const projectServerUserParts = (message: OpenCodeServerMessage) => {
   if (message.parts.length === 0) {
-    return (message.shadowParts ?? []) as ProjectedContentPart[];
+    return projectPendingUserParts(message.shadowParts ?? [], message.id);
   }
 
-  return message.parts.flatMap((part) => {
-    switch (part.type) {
-      case "text":
-        return [
-          { type: "text" as const, text: part.text ?? "" },
-        ] satisfies ProjectedContentPart[];
-      case "file":
-        return [convertFilePart(part)] satisfies ProjectedContentPart[];
-      default:
-        return [] as ProjectedContentPart[];
+  const content: ProjectedContentPart[] = [];
+  const attachments: CompleteAttachment[] = [];
+
+  for (const [index, part] of message.parts.entries()) {
+    if (part.type === "text") {
+      content.push({ type: "text", text: part.text ?? "" });
+      continue;
     }
-  });
+    if (part.type !== "file") continue;
+
+    const projected = convertFilePart(part);
+    attachments.push(
+      projectUserAttachment(
+        projected,
+        part.id ?? `${message.id}:attachment:${index}`,
+        part.mime ?? "application/octet-stream",
+      ),
+    );
+  }
+
+  return { content, attachments };
 };
 
 const getMessageStatus = (
@@ -586,12 +631,13 @@ const projectServerMessage = (
   }
 
   if (message.info.role === "user") {
+    const projected = projectServerUserParts(message);
     return {
       id: message.info.id,
       role: "user",
       createdAt: new Date(message.info.time?.created ?? Date.now()),
-      content: projectUserContent(message),
-      attachments: [],
+      content: projected.content,
+      attachments: projected.attachments,
       metadata,
     };
   }
@@ -605,8 +651,7 @@ const projectPendingMessage = (
   id: `local:${pending.clientId}`,
   role: "user",
   createdAt: new Date(pending.createdAt),
-  content: pending.parts as OpenCodeProjectedThreadMessage["content"],
-  attachments: [],
+  ...projectPendingUserParts(pending.parts, `local:${pending.clientId}`),
   metadata: {
     custom: {
       opencode: {


### PR DESCRIPTION
## What

- project OpenCode user file parts into the standard assistant-ui attachments field
- keep user text and non-file parts in message content
- apply the same projection to pending and server-backed messages
- cover image and document attachments, mixed content, pending messages, and stable identities

## Why

react-opencode currently puts every user file part in content while hard-coding attachments to an empty array. That prevents MessagePrimitive.Attachments and the canonical user attachment components from rendering OpenCode files.

This fixes the projection at the provider adapter boundary without changing core APIs or adding OpenCode-specific UI.

## Validation

- pnpm exec oxfmt --check on changed source and tests
- pnpm exec oxlint on changed source and tests
- pnpm --filter @assistant-ui/react-opencode test: 108 passed
- pnpm --filter @assistant-ui/react-opencode build

Fixes #5487

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

