### PR TITLE
fix(react-langchain,react-langgraph): surface audio transcripts

### DIFF
--- a/.changeset/heavy-donkeys-shave.md
+++ b/.changeset/heavy-donkeys-shave.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/react-langchain": patch
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: surface an audio response transcript instead of rendering a blank message

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -949,6 +949,12 @@ type LangChainMessage = {
     reasoning?: MessageContentReasoning;
     tool_outputs?: MessageContentComputerCall[];
     metadata?: Record<string, unknown>;
+    audio?: {
+      id?: string;
+      data?: string;
+      expires_at?: number;
+      transcript?: string;
+    };
   };
 };
 

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -880,13 +880,17 @@ describe("convertLangChainBaseMessage audio transcripts", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "spoken words" }]);
   });
 
-  it("does not throw on a non-spec text block that omits text", () => {
-    const result = convertLangChainBaseMessage(
-      audioMessage([{ type: "text" }], { transcript: "spoken words" }),
-      {},
-    );
+  it("does not throw on a non-spec text block whose text is missing or not a string", () => {
+    for (const block of [{ type: "text" }, { type: "text", text: 42 }]) {
+      const result = convertLangChainBaseMessage(
+        audioMessage([block], { transcript: "spoken words" }),
+        {},
+      );
 
-    expect(contentOf(result)).toEqual([{ type: "text", text: "spoken words" }]);
+      expect(contentOf(result)).toEqual([
+        { type: "text", text: "spoken words" },
+      ]);
+    }
   });
 
   it("keeps non-text parts when it substitutes the transcript", () => {

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -841,3 +841,77 @@ describe("convertLangChainBaseMessage image content parts", () => {
     expect(contentOf(result)).toEqual([]);
   });
 });
+
+describe("convertLangChainBaseMessage audio transcripts", () => {
+  const audioMessage = (
+    content: unknown,
+    audio: unknown,
+  ): LangChainBaseMessage => ({
+    _getType: () => "ai",
+    id: "msg-3",
+    content,
+    additional_kwargs: { audio },
+  });
+
+  it("surfaces the transcript when the provider leaves content empty", () => {
+    const result = convertLangChainBaseMessage(
+      audioMessage("", {
+        id: "audio_1",
+        data: "UklGRg==",
+        expires_at: 1,
+        transcript: "the secret number is four seven two",
+      }),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      { type: "text", text: "the secret number is four seven two" },
+    ]);
+  });
+
+  it("keeps non-text parts when it substitutes the transcript", () => {
+    const result = convertLangChainBaseMessage(
+      audioMessage(
+        [
+          { type: "text", text: "" },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/a.png" },
+          },
+        ],
+        { transcript: "spoken words" },
+      ),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      { type: "image", image: "https://example.com/a.png" },
+      { type: "text", text: "spoken words" },
+    ]);
+  });
+
+  it("leaves existing text alone so the transcript is not duplicated", () => {
+    const result = convertLangChainBaseMessage(
+      audioMessage([{ type: "text", text: "written answer" }], {
+        transcript: "written answer",
+      }),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([
+      { type: "text", text: "written answer" },
+    ]);
+  });
+
+  it("ignores an absent, empty, or non-string transcript", () => {
+    for (const audio of [
+      undefined,
+      {},
+      { transcript: "" },
+      { transcript: 42 },
+    ]) {
+      const result = convertLangChainBaseMessage(audioMessage("", audio), {});
+      expect(contentOf(result)).toEqual([{ type: "text", text: "" }]);
+    }
+  });
+});

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -927,11 +927,12 @@ describe("convertLangChainBaseMessage audio transcripts", () => {
     ]);
   });
 
-  it("ignores an absent, empty, or non-string transcript", () => {
+  it("ignores an absent, blank, or non-string transcript", () => {
     for (const audio of [
       undefined,
       {},
       { transcript: "" },
+      { transcript: "   " },
       { transcript: 42 },
     ]) {
       const result = convertLangChainBaseMessage(audioMessage("", audio), {});

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -880,6 +880,15 @@ describe("convertLangChainBaseMessage audio transcripts", () => {
     expect(contentOf(result)).toEqual([{ type: "text", text: "spoken words" }]);
   });
 
+  it("does not throw on a non-spec text block that omits text", () => {
+    const result = convertLangChainBaseMessage(
+      audioMessage([{ type: "text" }], { transcript: "spoken words" }),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "spoken words" }]);
+  });
+
   it("keeps non-text parts when it substitutes the transcript", () => {
     const result = convertLangChainBaseMessage(
       audioMessage(

--- a/packages/react-langchain/src/convertMessages.test.ts
+++ b/packages/react-langchain/src/convertMessages.test.ts
@@ -869,6 +869,17 @@ describe("convertLangChainBaseMessage audio transcripts", () => {
     ]);
   });
 
+  it("treats a whitespace-only placeholder as no text", () => {
+    const result = convertLangChainBaseMessage(
+      audioMessage([{ type: "text", text: "   " }], {
+        transcript: "spoken words",
+      }),
+      {},
+    );
+
+    expect(contentOf(result)).toEqual([{ type: "text", text: "spoken words" }]);
+  });
+
   it("keeps non-text parts when it substitutes the transcript", () => {
     const result = convertLangChainBaseMessage(
       audioMessage(

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -115,7 +115,8 @@ const withAudioTranscript = (
 ): ReturnType<typeof contentToParts> => {
   const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
   const transcript = audio?.transcript;
-  if (typeof transcript !== "string" || !transcript) return parts;
+  if (typeof transcript !== "string" || !hasVisibleText(transcript))
+    return parts;
   if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
     return parts;
   return [

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -113,7 +113,8 @@ const withAudioTranscript = (
   const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
   const transcript = audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text)) return parts;
+  if (parts.some((part) => part.type === "text" && part.text.trim()))
+    return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),
     { type: "text" as const, text: transcript },

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -113,7 +113,7 @@ const withAudioTranscript = (
   const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
   const transcript = audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text.trim()))
+  if (parts.some((part) => part.type === "text" && part.text?.trim()))
     return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -100,6 +100,9 @@ const contentToParts = (content: unknown) => {
     .filter((p) => p !== null);
 };
 
+const hasVisibleText = (text: unknown): boolean =>
+  typeof text === "string" && text.trim() !== "";
+
 /**
  * Audio output arrives outside the content array: providers leave `content`
  * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
@@ -113,7 +116,7 @@ const withAudioTranscript = (
   const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
   const transcript = audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text?.trim()))
+  if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
     return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),

--- a/packages/react-langchain/src/convertMessages.ts
+++ b/packages/react-langchain/src/convertMessages.ts
@@ -100,6 +100,26 @@ const contentToParts = (content: unknown) => {
     .filter((p) => p !== null);
 };
 
+/**
+ * Audio output arrives outside the content array: providers leave `content`
+ * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
+ * audio bytes stay behind because no provider reports their media type, and a
+ * streamed response carries raw PCM rather than a playable file.
+ */
+const withAudioTranscript = (
+  parts: ReturnType<typeof contentToParts>,
+  additionalKwargs: Record<string, unknown> | undefined,
+): ReturnType<typeof contentToParts> => {
+  const audio = additionalKwargs?.audio as { transcript?: unknown } | undefined;
+  const transcript = audio?.transcript;
+  if (typeof transcript !== "string" || !transcript) return parts;
+  if (parts.some((part) => part.type === "text" && part.text)) return parts;
+  return [
+    ...parts.filter((part) => part.type !== "text"),
+    { type: "text" as const, text: transcript },
+  ];
+};
+
 const getCustomMetadata = (
   additionalKwargs: Record<string, unknown> | undefined,
 ): Record<string, unknown> =>
@@ -167,7 +187,10 @@ export const convertLangChainBaseMessage = (
         role: "assistant",
         id: message.id,
         content: [
-          ...contentToParts(message.content),
+          ...withAudioTranscript(
+            contentToParts(message.content),
+            message.additional_kwargs,
+          ),
           ...toolCallParts,
           ...uiDataParts,
         ],

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1468,3 +1468,76 @@ describe("convertLangChainMessages unknown message types", () => {
     expect(result[0]?.role).toBe("user");
   });
 });
+
+describe("convertLangChainMessages audio transcripts", () => {
+  const audioMessage = (
+    content: LangChainMessage["content"],
+    audio: unknown,
+  ): LangChainMessage =>
+    ({
+      id: "msg-audio",
+      type: "ai",
+      content,
+      additional_kwargs: { audio },
+    }) as LangChainMessage;
+
+  it("surfaces the transcript when the provider leaves content empty", () => {
+    const result = convertLangChainMessages(
+      audioMessage("", {
+        id: "audio_1",
+        data: "UklGRg==",
+        expires_at: 1,
+        transcript: "the secret number is four seven two",
+      }),
+    );
+
+    expect(result.content).toEqual([
+      { type: "text", text: "the secret number is four seven two" },
+    ]);
+  });
+
+  it("keeps non-text parts when it substitutes the transcript", () => {
+    const result = convertLangChainMessages(
+      audioMessage(
+        [
+          { type: "text", text: "" },
+          {
+            type: "image_url",
+            image_url: { url: "https://example.com/a.png" },
+          },
+        ] as LangChainMessage["content"],
+        { transcript: "spoken words" },
+      ),
+    );
+
+    expect(result.content).toEqual([
+      { type: "image", image: "https://example.com/a.png" },
+      { type: "text", text: "spoken words" },
+    ]);
+  });
+
+  it("leaves existing text alone so the transcript is not duplicated", () => {
+    const result = convertLangChainMessages(
+      audioMessage(
+        [
+          { type: "text", text: "written answer" },
+        ] as LangChainMessage["content"],
+        { transcript: "written answer" },
+      ),
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "written answer" }]);
+  });
+
+  it("ignores an absent, empty, or non-string transcript", () => {
+    for (const audio of [
+      undefined,
+      {},
+      { transcript: "" },
+      { transcript: 42 },
+    ]) {
+      const result = convertLangChainMessages(audioMessage("", audio));
+      expect(result.content).toEqual([{ type: "text", text: "" }]);
+    }
+  });
+});

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1507,14 +1507,16 @@ describe("convertLangChainMessages audio transcripts", () => {
     expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
   });
 
-  it("does not throw on a non-spec text block that omits text", () => {
-    const result = convertLangChainMessages(
-      audioMessage([{ type: "text" }] as LangChainMessage["content"], {
-        transcript: "spoken words",
-      }),
-    );
+  it("does not throw on a non-spec text block whose text is missing or not a string", () => {
+    for (const block of [{ type: "text" }, { type: "text", text: 42 }]) {
+      const result = convertLangChainMessages(
+        audioMessage([block] as LangChainMessage["content"], {
+          transcript: "spoken words",
+        }),
+      );
 
-    expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
+      expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
+    }
   });
 
   it("keeps non-text parts when it substitutes the transcript", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1552,11 +1552,12 @@ describe("convertLangChainMessages audio transcripts", () => {
     expect(result.content).toEqual([{ type: "text", text: "written answer" }]);
   });
 
-  it("ignores an absent, empty, or non-string transcript", () => {
+  it("ignores an absent, blank, or non-string transcript", () => {
     for (const audio of [
       undefined,
       {},
       { transcript: "" },
+      { transcript: "   " },
       { transcript: 42 },
     ]) {
       const result = convertLangChainMessages(audioMessage("", audio));

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1496,6 +1496,17 @@ describe("convertLangChainMessages audio transcripts", () => {
     ]);
   });
 
+  it("treats a whitespace-only placeholder as no text", () => {
+    const result = convertLangChainMessages(
+      audioMessage(
+        [{ type: "text", text: "   " }] as LangChainMessage["content"],
+        { transcript: "spoken words" },
+      ),
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
+  });
+
   it("keeps non-text parts when it substitutes the transcript", () => {
     const result = convertLangChainMessages(
       audioMessage(

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1507,6 +1507,16 @@ describe("convertLangChainMessages audio transcripts", () => {
     expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
   });
 
+  it("does not throw on a non-spec text block that omits text", () => {
+    const result = convertLangChainMessages(
+      audioMessage([{ type: "text" }] as LangChainMessage["content"], {
+        transcript: "spoken words",
+      }),
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "spoken words" }]);
+  });
+
   it("keeps non-text parts when it substitutes the transcript", () => {
     const result = convertLangChainMessages(
       audioMessage(

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -239,7 +239,7 @@ const withAudioTranscript = (
 ): ReturnType<typeof contentToParts> => {
   const transcript: unknown = additionalKwargs?.audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text.trim()))
+  if (parts.some((part) => part.type === "text" && part.text?.trim()))
     return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -224,6 +224,28 @@ const contentToParts = (
     .filter((a) => a !== null);
 };
 
+/**
+ * Audio output arrives outside the content array: providers leave `content`
+ * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
+ * audio bytes stay behind because no provider reports their media type, and a
+ * streamed response carries raw PCM rather than a playable file.
+ */
+const withAudioTranscript = (
+  parts: ReturnType<typeof contentToParts>,
+  additionalKwargs: Extract<
+    LangChainMessage,
+    { type: "ai" }
+  >["additional_kwargs"],
+): ReturnType<typeof contentToParts> => {
+  const transcript: unknown = additionalKwargs?.audio?.transcript;
+  if (typeof transcript !== "string" || !transcript) return parts;
+  if (parts.some((part) => part.type === "text" && part.text)) return parts;
+  return [
+    ...parts.filter((part) => part.type !== "text"),
+    { type: "text" as const, text: transcript },
+  ];
+};
+
 export const convertLangChainMessages: useExternalMessageConverter.Callback<
   LangChainMessage
 > = (message, metadata: LangGraphMessageConverterMetadata = {}) => {
@@ -301,7 +323,10 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         role: "assistant",
         id: message.id,
         content: [
-          ...contentToParts(allContent, metadata, message.id),
+          ...withAudioTranscript(
+            contentToParts(allContent, metadata, message.id),
+            message.additional_kwargs,
+          ),
           ...toolCallParts,
           ...uiDataParts,
         ],

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -241,7 +241,8 @@ const withAudioTranscript = (
   >["additional_kwargs"],
 ): ReturnType<typeof contentToParts> => {
   const transcript: unknown = additionalKwargs?.audio?.transcript;
-  if (typeof transcript !== "string" || !transcript) return parts;
+  if (typeof transcript !== "string" || !hasVisibleText(transcript))
+    return parts;
   if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
     return parts;
   return [

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -239,7 +239,8 @@ const withAudioTranscript = (
 ): ReturnType<typeof contentToParts> => {
   const transcript: unknown = additionalKwargs?.audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text)) return parts;
+  if (parts.some((part) => part.type === "text" && part.text.trim()))
+    return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),
     { type: "text" as const, text: transcript },

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -224,6 +224,9 @@ const contentToParts = (
     .filter((a) => a !== null);
 };
 
+const hasVisibleText = (text: unknown): boolean =>
+  typeof text === "string" && text.trim() !== "";
+
 /**
  * Audio output arrives outside the content array: providers leave `content`
  * empty and put the spoken text in `additional_kwargs.audio.transcript`. The
@@ -239,7 +242,7 @@ const withAudioTranscript = (
 ): ReturnType<typeof contentToParts> => {
   const transcript: unknown = additionalKwargs?.audio?.transcript;
   if (typeof transcript !== "string" || !transcript) return parts;
-  if (parts.some((part) => part.type === "text" && part.text?.trim()))
+  if (parts.some((part) => part.type === "text" && hasVisibleText(part.text)))
     return parts;
   return [
     ...parts.filter((part) => part.type !== "text"),

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -175,6 +175,12 @@ export type LangChainMessage =
         reasoning?: MessageContentReasoning;
         tool_outputs?: MessageContentComputerCall[];
         metadata?: Record<string, unknown>;
+        audio?: {
+          id?: string;
+          data?: string;
+          expires_at?: number;
+          transcript?: string;
+        };
       };
     };
 


### PR DESCRIPTION
closes #5500

## summary

- a provider that returns audio leaves `content` empty and puts the spoken text in `additional_kwargs.audio.transcript`, so both converters emitted a single empty text part and the assistant message rendered blank. the transcript now becomes a text part instead.
- the substitution only fires when the converted content carries no text of its own, so a written answer is never duplicated, and non-text parts (images, tool calls) are preserved.
- the audio bytes are deliberately left behind. no provider reports their media type (`additional_kwargs.audio` carries only `id`, `data`, `expires_at`, `transcript`), and a streamed response is raw `pcm16` rather than a playable file, so a file part could only guess at a mime type.
- `LangChainMessage`'s ai `additional_kwargs` gains an optional `audio` field describing the shape that already arrives on the wire.

## test plan

### already verified

- [x] `vitest run --root packages/react-langchain` -> 104/104 green (4 new cases)
- [x] `vitest run --root packages/react-langgraph` -> 232/232 green (4 new cases)
- [x] replayed the exact payload captured from a live OpenAI `gpt-audio` response through `convertLangChainBaseMessage`: previously `[{ type: "text", text: "" }]`, now `[{ type: "text", text: "The secret number is four seven two" }]`
- [x] `pnpm lint` clean on the changed files
- [x] `tsc --noEmit` clean for react-langchain; react-langgraph's two pre-existing `useLangGraphRuntime.test.tsx` errors about `process.on` are untouched by this change

### reviewer should verify

- [ ] point a LangGraph agent at an audio capable model (`ChatOpenAI(model="gpt-audio", modalities=["text", "audio"], audio={"voice": "alloy", "format": "wav"})`) and confirm the assistant message shows the spoken text instead of rendering blank

## notes

- found while closing #5489. that same live run also turned up #5501 (attachment filenames reaching OpenAI as `LC_AUTOGENERATED`), which is a separate fix.
- streaming stays out of reach from here. OpenAI does send `delta.audio` carrying the transcript on the wire, but langchain-openai drops it during chunk conversion, so nothing reaches the adapter at all. this fix covers the completed message that a LangGraph node's `llm.invoke()` puts into state, which is the common shape.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.xG-ccHgRMxL2UCyDaww4cOxzThQmgS-5GK8V5qzFQN-AKQR_c5-ZterfAeY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->