### PR TITLE
test(tap): add react-compiler compiled-dist test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format:fix": "pnpm exec oxfmt",
     "sync-templates": "bash scripts/sync-templates.sh",
     "test": "turbo test && pnpm test:react-compiler && pnpm test:types",
-    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core --filter=@assistant-ui/store",
+    "test:react-compiler": "turbo test:react-compiler --filter=@assistant-ui/core --filter=@assistant-ui/store --filter=@assistant-ui/tap",
     "test:types": "pnpm -r --workspace-concurrency=4 --no-bail exec sh -c '! test -f tsconfig.json || tsc --noEmit'",
     "prepare": "husky && pnpm --filter @assistant-ui/react-devtools run build:css",
     "deps:check": "npx taze major -f -r",

--- a/packages/tap/package.json
+++ b/packages/tap/package.json
@@ -41,6 +41,7 @@
     "build": "aui-build",
     "prepublishOnly": "pnpm turbo build",
     "test": "vitest run",
+    "test:react-compiler": "vitest run --config vitest.react-compiler.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {

--- a/packages/tap/src/react-shim/compiler-runtime.react-compiler.test.tsx
+++ b/packages/tap/src/react-shim/compiler-runtime.react-compiler.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { StrictMode, useRef, useState } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTapHost } from "../index";
+import { c } from "./compiler-runtime";
+
+const MEMO_CACHE_SENTINEL = Symbol.for("react.memo_cache_sentinel");
+
+type RenderRecord = {
+  cache: unknown[];
+  memoized: object;
+  ref: { current: object };
+  state: object;
+};
+
+// Emulates React Compiler output running inside a tap resource: compiled
+// consumer dist allocates its memo cache through `c()` from this module.
+function useCompiledEmulation(records: RenderRecord[]) {
+  const $ = c(1);
+  let memoized: object;
+  if ($[0] === MEMO_CACHE_SENTINEL) {
+    memoized = {};
+    $[0] = memoized;
+  } else {
+    memoized = $[0] as object;
+  }
+  const ref = useRef<object>({});
+  const [state] = useState<object>(() => ({}));
+  records.push({ cache: $, memoized, ref, state });
+}
+
+const makeHarness = (records: RenderRecord[]) => {
+  return function Harness(_props: { tick: number }) {
+    useTapHost(function CompiledHost() {
+      useCompiledEmulation(records);
+      return null;
+    });
+    return null;
+  };
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("compiled memo cache inside a tap resource", () => {
+  it("re-seeds the c() cache on an uncommitted StrictMode replay while hook cells survive", () => {
+    const records: RenderRecord[] = [];
+    const Harness = makeHarness(records);
+
+    render(
+      <StrictMode>
+        <Harness tick={0} />
+      </StrictMode>,
+    );
+
+    expect(records.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(records.map((r) => r.cache))).toHaveLength(records.length);
+    expect(new Set(records.map((r) => r.memoized))).toHaveLength(
+      records.length,
+    );
+    expect(new Set(records.map((r) => r.ref))).toHaveLength(1);
+    expect(new Set(records.map((r) => r.state))).toHaveLength(1);
+  });
+
+  it("persists the committed c() cache across post-mount re-renders", () => {
+    const records: RenderRecord[] = [];
+    const Harness = makeHarness(records);
+
+    const view = render(
+      <StrictMode>
+        <Harness tick={0} />
+      </StrictMode>,
+    );
+    const committed = records.at(-1)!;
+
+    const mountRecords = records.length;
+    view.rerender(
+      <StrictMode>
+        <Harness tick={1} />
+      </StrictMode>,
+    );
+
+    const postCommit = records.slice(mountRecords);
+    expect(postCommit.length).toBeGreaterThanOrEqual(1);
+    for (const record of postCommit) {
+      expect(record.memoized).toBe(committed.memoized);
+      expect(record.ref).toBe(committed.ref);
+      expect(record.state).toBe(committed.state);
+    }
+  });
+});

--- a/packages/tap/vitest.react-compiler.config.ts
+++ b/packages/tap/vitest.react-compiler.config.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const compiledCompilerRuntime = fileURLToPath(
+  new URL("./dist/react-shim/compiler-runtime.js", import.meta.url),
+);
+const compiledIndex = fileURLToPath(
+  new URL("./dist/index.js", import.meta.url),
+);
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^\.\/compiler-runtime$/,
+        replacement: compiledCompilerRuntime,
+      },
+      {
+        find: /^\.\.\/index$/,
+        replacement: compiledIndex,
+      },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["src/react-shim/compiler-runtime.react-compiler.test.tsx"],
+  },
+});


### PR DESCRIPTION
## What

Adds a `test:react-compiler` run to `packages/tap`, mirroring the harness core and store already have (#5411): a vitest config that aliases the test's relative imports to the built dist, plus a StrictMode replay contract test, wired into the root `test:react-compiler` script.

## Why

tap hosts the entire replay machinery that #5422 hit (memoCache reset and promote in `ResourceFiber`, the `c()` routing in `react-shim/compiler-runtime`), yet it was the only one of the three packages with no test against built dist. While building this I confirmed both failure directions with dist mutations: breaking the per-render cache reset fails the first test, breaking promote-at-commit fails the second, so a regression here now fails in tap instead of surfacing as a downstream store mystery.

## Impact

- CI already runs the root `test:react-compiler` script, so tap coverage kicks in with no workflow change.
- Test-only: no runtime code changes, no new public surface.

## Scope

- tap itself is deliberately never compiled by React Compiler (`x-buildutils` excludes it by design), so unlike store the test does not import a compiled tap module: it emulates what compiled consumer output does, calling `c()` from the dist shim inside a resource render with the sentinel pattern the compiler emits.
- The contract pinned is the #5422 semantics at its home: an uncommitted StrictMode replay re-seeds the `c()` cache from empty while state and ref cells survive on the fiber, and the committed cache persists across post-mount re-renders.
- The new file also matches tap's default vitest include and runs against source there too; that double-run is intentional and matches store, whose react-compiler test does the same under its default config.
- Tests: both assertions are mutation-verified against dist; not covered: the shim's non-tap fallback path (`reactC` outside a resource render), same scope line the store template drew.
- No changeset: test-only change, matching repo precedent for test-only PRs (#5366, #5189); the config and test are not published surface.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lzvdx3jDo4bQ91Tb83acK2dq4DglFUdA221Shr5jgv_Bf1w7lml7a_DejV8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->