### PR TITLE
feat(core): add threads.reloadMainThread()

### DIFF
--- a/.changeset/soft-donuts-tap.md
+++ b/.changeset/soft-donuts-tap.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
 feat: add `threads.reloadMainThread()` to refetch the open thread's remote state in place

--- a/.changeset/soft-donuts-tap.md
+++ b/.changeset/soft-donuts-tap.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+feat: add `threads.reloadMainThread()` to refetch the open thread's remote state in place

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3381,7 +3381,59 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   private useAliveThreadsKeysChanged;
   private parent;
   constructor(runtimeHook: RemoteThreadListHook, parent: ThreadListRuntimeCore);
+  private _whenRuntimeAttached;
   startThreadRuntime(threadId: string): Promise<Readonly<{
+    getMessageById: (messageId: string) => {
+      parentId: string | null;
+      message: ThreadMessage;
+      index: number;
+    } | undefined;
+    getBranches: (messageId: string) => readonly string[];
+    switchToBranch: (branchId: string) => void;
+    append: (message: AppendMessage) => void;
+    deleteMessage: (messageId: string) => void | Promise<void>;
+    startRun: (config: StartRunConfig) => void;
+    resumeRun: (config: ResumeRunConfig) => void;
+    cancelRun: () => void;
+    addToolResult: (options: AddToolResultOptions) => void;
+    resumeToolCall: (options: ResumeToolCallOptions) => void;
+    respondToToolApproval: (options: RespondToToolApprovalOptions) => void;
+    speak: (messageId: string) => void;
+    stopSpeaking: () => void;
+    connectVoice: () => void;
+    disconnectVoice: () => void;
+    muteVoice: () => void;
+    unmuteVoice: () => void;
+    submitFeedback: (feedback: SubmitFeedbackOptions) => void;
+    getModelContext: () => ModelContext$1;
+    composer: ThreadComposerRuntimeCore;
+    getEditComposer: (messageId: string) => EditComposerRuntimeCore | undefined;
+    beginEdit: (messageId: string) => void;
+    getQueueItems?: () => readonly QueueItemState[];
+    steerQueueItem?: (queueItemId: string) => void;
+    removeQueueItem?: (queueItemId: string) => void;
+    speech: SpeechState | undefined;
+    voice: VoiceSessionState | undefined;
+    capabilities: Readonly<RuntimeCapabilities>;
+    isDisabled: boolean;
+    isSendDisabled: boolean;
+    isLoading: boolean;
+    isRunning?: boolean | undefined;
+    messages: readonly ThreadMessage[];
+    state: ReadonlyJSONValue;
+    suggestions: readonly ThreadSuggestion[];
+    extras: unknown;
+    subscribe: (callback: () => void) => Unsubscribe$1;
+    getVoiceVolume: () => number;
+    subscribeVoiceVolume: (callback: () => void) => Unsubscribe$1;
+    import(repository: ExportedMessageRepository): void;
+    export(): ExportedMessageRepository;
+    exportExternalState(): any;
+    importExternalState(state: any): void;
+    reset(initialMessages?: readonly ThreadMessageLike[]): void;
+    unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
+  }>>;
+  __internal_restartThreadRuntime(threadId: string): Promise<Readonly<{
     getMessageById: (messageId: string) => {
       parentId: string | null;
       message: ThreadMessage;
@@ -3529,6 +3581,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
   private useProvider;
   __internal_setOptions(options: RemoteThreadListOptions): void;
   __internal_load(): void;
+  reloadMainThread(): Promise<void>;
   reload(): Promise<void>;
   get isLoading(): boolean;
   get isLoadingMore(): boolean;
@@ -4410,6 +4463,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 
@@ -4431,6 +4485,7 @@ type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload?(): Promise<void>;
+  reloadMainThread?(): Promise<void>;
   loadMore?(): Promise<void>;
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
@@ -4460,6 +4515,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;
@@ -4965,6 +5021,7 @@ type ThreadsMethods = {
   thread(selector: "main"): ThreadMethods;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   __internal_getAssistantRuntime?(): AssistantRuntime;
 };

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1082,6 +1082,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1444,6 +1444,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1176,6 +1176,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1610,6 +1610,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1448,6 +1448,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1912,6 +1912,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3532,6 +3532,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 
@@ -3553,6 +3554,7 @@ type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload?(): Promise<void>;
+  reloadMainThread?(): Promise<void>;
   loadMore?(): Promise<void>;
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
@@ -3582,6 +3584,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1614,6 +1614,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1777,6 +1777,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -3056,6 +3056,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 
@@ -3077,6 +3078,7 @@ type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload?(): Promise<void>;
+  reloadMainThread?(): Promise<void>;
   loadMore?(): Promise<void>;
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
@@ -3106,6 +3108,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe$1;

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1555,6 +1555,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1983,6 +1983,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4442,6 +4442,7 @@ type ThreadListRuntime = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 
@@ -4463,6 +4464,7 @@ type ThreadListRuntimeCore = {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload?(): Promise<void>;
+  reloadMainThread?(): Promise<void>;
   loadMore?(): Promise<void>;
   detach(threadId: string): Promise<void>;
   rename(threadId: string, newTitle: string): Promise<void>;
@@ -4492,6 +4494,7 @@ declare class ThreadListRuntimeImpl implements ThreadListRuntime {
   switchToNewThread(): Promise<void>;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   getState(): ThreadListState;
   subscribe(callback: () => void): Unsubscribe;

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
@@ -16,3 +16,73 @@ describe("RemoteThreadListHookInstanceManager", () => {
     );
   });
 });
+
+describe("RemoteThreadListHookInstanceManager.__internal_restartThreadRuntime", () => {
+  const makeManager = () =>
+    new RemoteThreadListHookInstanceManager(
+      () => ({}) as never,
+      {} as ThreadListRuntimeCore,
+    );
+
+  // no React binder attaches a runtime in these tests, so the returned promises
+  // stay pending or reject on stop; neither is what is under test here
+  const start = (manager: RemoteThreadListHookInstanceManager, id: string) => {
+    manager.startThreadRuntime(id).catch(() => {});
+  };
+  const restart = (
+    manager: RemoteThreadListHookInstanceManager,
+    id: string,
+  ) => {
+    manager.__internal_restartThreadRuntime(id).catch(() => {});
+  };
+
+  const renderedKeys = (manager: RemoteThreadListHookInstanceManager) =>
+    Array.from(
+      (
+        manager as unknown as {
+          instances: Map<string, { generation: number }>;
+        }
+      ).instances.entries(),
+    ).map(([id, { generation }]) => `${id}:${generation}`);
+
+  it("changes the binder key so React remounts the runtime hook", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const before = renderedKeys(manager);
+
+    restart(manager, "thread-1");
+
+    expect(renderedKeys(manager)).not.toEqual(before);
+    expect(renderedKeys(manager)).toEqual(["thread-1:1"]);
+  });
+
+  it("keeps the thread alive across the restart", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+
+    restart(manager, "thread-1");
+
+    // never leaves a window where the thread is absent, unlike stop-then-start
+    expect(manager.getThreadRuntimeCore("thread-1")).toBeUndefined();
+    expect(renderedKeys(manager)).toHaveLength(1);
+  });
+
+  it("starts the runtime when the thread is not alive yet", () => {
+    const manager = makeManager();
+
+    restart(manager, "thread-1");
+
+    expect(renderedKeys(manager)).toEqual(["thread-1:0"]);
+  });
+
+  it("stop then start in one tick leaves the key unchanged, which is why the generation exists", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const before = renderedKeys(manager);
+
+    manager.stopThreadRuntime("thread-1");
+    start(manager, "thread-1");
+
+    expect(renderedKeys(manager)).toEqual(before);
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.test.tsx
@@ -56,15 +56,17 @@ describe("RemoteThreadListHookInstanceManager.__internal_restartThreadRuntime", 
     expect(renderedKeys(manager)).toEqual(["thread-1:1"]);
   });
 
-  it("keeps the thread alive across the restart", () => {
-    const manager = makeManager();
-    start(manager, "thread-1");
+  it("keeps the thread rendered across the restart, unlike stop", () => {
+    const restarted = makeManager();
+    start(restarted, "thread-1");
+    restart(restarted, "thread-1");
 
-    restart(manager, "thread-1");
+    const stopped = makeManager();
+    start(stopped, "thread-1");
+    stopped.stopThreadRuntime("thread-1");
 
-    // never leaves a window where the thread is absent, unlike stop-then-start
-    expect(manager.getThreadRuntimeCore("thread-1")).toBeUndefined();
-    expect(renderedKeys(manager)).toHaveLength(1);
+    expect(renderedKeys(restarted)).toHaveLength(1);
+    expect(renderedKeys(stopped)).toHaveLength(0);
   });
 
   it("starts the runtime when the thread is not alive yet", () => {

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -26,6 +26,9 @@ type RemoteThreadListHook = () => AssistantRuntime;
 
 type RemoteThreadListHookInstance = {
   runtime?: ThreadRuntimeCore;
+  // Part of the binder's React key. Deleting and re-adding an instance in one
+  // tick leaves the key set unchanged, so only a bump remounts the hook.
+  generation: number;
 };
 
 const ProviderRenderDetector: FC<{
@@ -53,12 +56,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     this.useRuntimeHook = create(() => ({ useRuntime: runtimeHook }));
   }
 
-  public startThreadRuntime(threadId: string) {
-    if (!this.instances.has(threadId)) {
-      this.instances.set(threadId, {});
-      this.useAliveThreadsKeysChanged.setState({}, true);
-    }
-
+  private _whenRuntimeAttached(threadId: string) {
     return new Promise<ThreadRuntimeCore>((resolve, reject) => {
       const callback = () => {
         const instance = this.instances.get(threadId);
@@ -75,6 +73,26 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       const dispose = this.subscribe(callback);
       callback();
     });
+  }
+
+  public startThreadRuntime(threadId: string) {
+    if (!this.instances.has(threadId)) {
+      this.instances.set(threadId, { generation: 0 });
+      this.useAliveThreadsKeysChanged.setState({}, true);
+    }
+
+    return this._whenRuntimeAttached(threadId);
+  }
+
+  public __internal_restartThreadRuntime(threadId: string) {
+    const instance = this.instances.get(threadId);
+    if (!instance) return this.startThreadRuntime(threadId);
+
+    this.instances.set(threadId, { generation: instance.generation + 1 });
+    this.useAliveThreadsKeysChanged.setState({}, true);
+    this._notifySubscribers();
+
+    return this._whenRuntimeAttached(threadId);
   }
 
   public getThreadRuntimeCore(threadId: string) {
@@ -208,12 +226,14 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   }> = ({ provider }) => {
     this.useAliveThreadsKeysChanged(); // trigger re-render on alive threads change
 
-    return Array.from(this.instances.keys()).map((threadId) => (
-      <this._OuterActiveThreadProvider
-        key={threadId}
-        threadId={threadId}
-        provider={provider}
-      />
-    ));
+    return Array.from(this.instances.entries()).map(
+      ([threadId, { generation }]) => (
+        <this._OuterActiveThreadProvider
+          key={`${threadId}:${generation}`}
+          threadId={threadId}
+          provider={provider}
+        />
+      ),
+    );
   };
 }

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -116,10 +116,9 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
   // Rendered as a child of the user's Provider so the runtime hook can
   // read context the Provider injects (e.g. RuntimeAdapterProvider).
-  private _RuntimeBinder: FC<PropsWithChildren<{ threadId: string }>> = ({
-    threadId,
-    children,
-  }) => {
+  private _RuntimeBinder: FC<
+    PropsWithChildren<{ threadId: string; generation: number }>
+  > = ({ threadId, generation, children }) => {
     const { useRuntime } = this.useRuntimeHook();
     const runtime = useRuntime();
 
@@ -133,9 +132,13 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
           `Thread "${threadId}" runtime binding not found. This is a bug in assistant-ui.`,
         );
 
+      // a restarted binder outlives its generation until React commits the key
+      // change, and must not publish its runtime over the incoming one
+      if (aliveThread.generation !== generation) return;
+
       aliveThread.runtime = threadBinding.getState();
       this._notifySubscribers();
-    }, [threadId, threadBinding]);
+    }, [threadId, generation, threadBinding]);
 
     const isMounted = useRef(false);
     if (!isMounted.current) {
@@ -186,8 +189,9 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
   private _OuterActiveThreadProvider: FC<{
     threadId: string;
+    generation: number;
     provider: ComponentType<PropsWithChildren>;
-  }> = memo(({ threadId, provider: Provider }) => {
+  }> = memo(({ threadId, generation, provider: Provider }) => {
     const runtime = useMemo(
       () => new ThreadListRuntimeImpl(this.parent).getItemById(threadId),
       [threadId],
@@ -213,7 +217,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     return (
       <ThreadListItemRuntimeProvider runtime={runtime}>
         <Provider>
-          <this._RuntimeBinder threadId={threadId}>
+          <this._RuntimeBinder threadId={threadId} generation={generation}>
             <ProviderRenderDetector detectorRef={detectorRef} />
           </this._RuntimeBinder>
         </Provider>
@@ -231,6 +235,7 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
         <this._OuterActiveThreadProvider
           key={`${threadId}:${generation}`}
           threadId={threadId}
+          generation={generation}
           provider={provider}
         />
       ),

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -88,7 +88,12 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     const instance = this.instances.get(threadId);
     if (!instance) return this.startThreadRuntime(threadId);
 
-    this.instances.set(threadId, { generation: instance.generation + 1 });
+    // the outgoing runtime stays readable until the new binder attaches, so
+    // getThreadRuntimeCore never falls back to the empty core mid-restart
+    this.instances.set(threadId, {
+      runtime: instance.runtime,
+      generation: instance.generation + 1,
+    });
     this.useAliveThreadsKeysChanged.setState({}, true);
     this._notifySubscribers();
 

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -245,6 +245,20 @@ export class RemoteThreadListThreadListRuntimeCore
     }
   }
 
+  public async reloadMainThread(): Promise<void> {
+    const threadId = this._mainThreadId;
+    if (threadId === undefined) return;
+
+    const generation = this._switchGeneration;
+    await this._hookManager.__internal_restartThreadRuntime(threadId);
+
+    // a switch started while the thread was remounting owns the main thread now
+    if (generation !== this._switchGeneration) return;
+    if (threadId !== this._mainThreadId) return;
+
+    this._notifySubscribers();
+  }
+
   public reload() {
     this._loadGeneration++;
     this._loadThreadsPromise = undefined;

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -249,6 +249,10 @@ export class RemoteThreadListThreadListRuntimeCore
     const threadId = this._mainThreadId;
     if (threadId === undefined) return;
 
+    // an optimistic thread holds no remote state, so restarting it would only
+    // discard what the user has typed so far
+    if (this.getItemById(threadId)?.status === "new") return;
+
     try {
       await this._hookManager.__internal_restartThreadRuntime(threadId);
     } catch (error) {

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -249,13 +249,16 @@ export class RemoteThreadListThreadListRuntimeCore
     const threadId = this._mainThreadId;
     if (threadId === undefined) return;
 
-    const generation = this._switchGeneration;
-    await this._hookManager.__internal_restartThreadRuntime(threadId);
+    try {
+      await this._hookManager.__internal_restartThreadRuntime(threadId);
+    } catch (error) {
+      // delete and detach switch the main thread away before stopping the
+      // runtime, so a rejection there means that operation owns the outcome
+      if (threadId !== this._mainThreadId) return;
+      throw error;
+    }
 
-    // a switch started while the thread was remounting owns the main thread now
-    if (generation !== this._switchGeneration) return;
     if (threadId !== this._mainThreadId) return;
-
     this._notifySubscribers();
   }
 

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -60,8 +60,11 @@ export type ThreadListRuntime = {
    * Refetches the open thread's remote state in place, for state that changed
    * out of band and so never reached the stream. The thread is restarted
    * rather than merged into: unsent composer input and optimistic messages are
-   * discarded, and a run that is still streaming is aborted. Resolves without
-   * doing anything on runtimes that hold no remote state.
+   * discarded, and a run that is still streaming is aborted. It resolves once
+   * the thread has been restarted, not once the refetch has landed, because
+   * the adapter owns that request. A thread that has not been sent yet holds
+   * no remote state, so it is left alone. Resolves without doing anything on
+   * runtimes that hold no remote state.
    */
   reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -56,6 +56,14 @@ export type ThreadListRuntime = {
 
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  /**
+   * Refetches the open thread's remote state in place, for state that changed
+   * out of band and so never reached the stream. The thread is restarted
+   * rather than merged into: unsent composer input and optimistic messages are
+   * discarded, and a run that is still streaming is aborted. Resolves without
+   * doing anything on runtimes that hold no remote state.
+   */
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
 };
 
@@ -155,6 +163,7 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
     this.switchToNewThread = this.switchToNewThread.bind(this);
     this.getLoadThreadsPromise = this.getLoadThreadsPromise.bind(this);
     this.reload = this.reload.bind(this);
+    this.reloadMainThread = this.reloadMainThread.bind(this);
     this.loadMore = this.loadMore.bind(this);
     this.getState = this.getState.bind(this);
     this.subscribe = this.subscribe.bind(this);
@@ -181,6 +190,10 @@ export class ThreadListRuntimeImpl implements ThreadListRuntime {
 
   public reload(): Promise<void> {
     return this._core.reload?.() ?? RESOLVED_PROMISE;
+  }
+
+  public reloadMainThread(): Promise<void> {
+    return this._core.reloadMainThread?.() ?? RESOLVED_PROMISE;
   }
 
   public loadMore(): Promise<void> {

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -41,6 +41,7 @@ export type ThreadListRuntimeCore = {
 
   getLoadThreadsPromise(): Promise<void>;
   reload?(): Promise<void>;
+  reloadMainThread?(): Promise<void>;
   loadMore?(): Promise<void>;
 
   detach(threadId: string): Promise<void>;

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -93,6 +93,7 @@ const useThreadListClient = ({
     },
     getLoadThreadsPromise: () => runtime.getLoadThreadsPromise(),
     reload: () => runtime.reload(),
+    reloadMainThread: () => runtime.reloadMainThread(),
     loadMore: () => runtime.loadMore(),
     __internal_getAssistantRuntime: () => __internal_assistantRuntime,
   };

--- a/packages/core/src/store/scopes/threads.ts
+++ b/packages/core/src/store/scopes/threads.ts
@@ -30,6 +30,7 @@ export type ThreadsMethods = {
   thread(selector: "main"): ThreadMethods;
   getLoadThreadsPromise(): Promise<void>;
   reload(): Promise<void>;
+  reloadMainThread(): Promise<void>;
   loadMore(): Promise<void>;
   __internal_getAssistantRuntime?(): AssistantRuntime;
 };

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { createCore, makeAdapter } from "./remote-thread-list-test-helpers";
+import type { RemoteThreadListThreadListRuntimeCore } from "../react/runtimes/RemoteThreadListThreadListRuntimeCore";
+
+type HookManagerStub = {
+  startThreadRuntime: (id: string) => Promise<unknown>;
+  __internal_restartThreadRuntime: (id: string) => Promise<unknown>;
+};
+
+const hookManagerOf = (core: RemoteThreadListThreadListRuntimeCore) =>
+  (core as unknown as { _hookManager: HookManagerStub })._hookManager;
+
+describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
+  it("restarts the runtime of the thread that is currently open", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+    const threadId = core.mainThreadId;
+
+    const restart = vi.fn(async () => ({}));
+    hookManagerOf(core).__internal_restartThreadRuntime = restart;
+
+    await core.reloadMainThread();
+
+    expect(restart).toHaveBeenCalledExactlyOnceWith(threadId);
+  });
+
+  it("notifies subscribers so the reloaded thread re-renders", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+    hookManagerOf(core).__internal_restartThreadRuntime = async () => ({});
+
+    const callback = vi.fn();
+    core.subscribe(callback);
+    await core.reloadMainThread();
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it("does nothing before the initial thread is open", async () => {
+    // the constructor switches to a new thread, so this is the window between
+    // construction and that switch settling
+    const core = createCore(makeAdapter());
+    (core as unknown as { _mainThreadId: string | undefined })._mainThreadId =
+      undefined;
+
+    const restart = vi.fn(async () => ({}));
+    hookManagerOf(core).__internal_restartThreadRuntime = restart;
+
+    await expect(core.reloadMainThread()).resolves.toBeUndefined();
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it("lets a thread switch started mid-reload win", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+
+    let releaseRestart!: () => void;
+    hookManagerOf(core).__internal_restartThreadRuntime = () =>
+      new Promise((resolve) => {
+        releaseRestart = () => resolve({});
+      });
+
+    const reloadTask = core.reloadMainThread();
+    await core.switchToNewThread();
+
+    const callback = vi.fn();
+    core.subscribe(callback);
+    releaseRestart();
+    await reloadTask;
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
@@ -50,7 +50,53 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
     expect(restart).not.toHaveBeenCalled();
   });
 
-  it("lets a thread switch started mid-reload win", async () => {
+  it("still notifies when a redundant switch to the same thread lands mid-reload", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+    const threadId = core.mainThreadId;
+
+    let releaseRestart!: () => void;
+    hookManagerOf(core).__internal_restartThreadRuntime = () =>
+      new Promise((resolve) => {
+        releaseRestart = () => resolve({});
+      });
+
+    const reloadTask = core.reloadMainThread();
+    // bumps the switch generation without changing the main thread
+    await core.switchToThread(threadId);
+
+    const callback = vi.fn();
+    core.subscribe(callback);
+    releaseRestart();
+    await reloadTask;
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it("resolves quietly when the thread is removed mid-reload", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+
+    hookManagerOf(core).__internal_restartThreadRuntime = async () => {
+      (core as unknown as { _mainThreadId: string })._mainThreadId = "other";
+      throw new Error("Thread was deleted before runtime was started");
+    };
+
+    await expect(core.reloadMainThread()).resolves.toBeUndefined();
+  });
+
+  it("surfaces a restart failure that is not a lifecycle handover", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+
+    hookManagerOf(core).__internal_restartThreadRuntime = async () => {
+      throw new Error("boom");
+    };
+
+    await expect(core.reloadMainThread()).rejects.toThrow("boom");
+  });
+
+  it("lets a switch to a different thread win the notification", async () => {
     const core = createCore(makeAdapter());
     await core.switchToNewThread();
 
@@ -61,7 +107,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
       });
 
     const reloadTask = core.reloadMainThread();
-    await core.switchToNewThread();
+    (core as unknown as { _mainThreadId: string })._mainThreadId = "elsewhere";
 
     const callback = vi.fn();
     core.subscribe(callback);

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-reloadMainThread.test.ts
@@ -10,10 +10,29 @@ type HookManagerStub = {
 const hookManagerOf = (core: RemoteThreadListThreadListRuntimeCore) =>
   (core as unknown as { _hookManager: HookManagerStub })._hookManager;
 
+const openRegularThread = async () => {
+  const core = createCore(
+    makeAdapter({
+      list: async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "t-1",
+            externalId: "t-1",
+            title: "Open",
+          },
+        ],
+      }),
+    }),
+  );
+  await core.getLoadThreadsPromise();
+  await core.switchToThread("t-1");
+  return core;
+};
+
 describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   it("restarts the runtime of the thread that is currently open", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
     const threadId = core.mainThreadId;
 
     const restart = vi.fn(async () => ({}));
@@ -25,8 +44,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   });
 
   it("notifies subscribers so the reloaded thread re-renders", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
     hookManagerOf(core).__internal_restartThreadRuntime = async () => ({});
 
     const callback = vi.fn();
@@ -34,6 +52,17 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
     await core.reloadMainThread();
 
     expect(callback).toHaveBeenCalled();
+  });
+
+  it("leaves an unsent thread alone, since it holds no remote state", async () => {
+    const core = createCore(makeAdapter());
+    await core.switchToNewThread();
+
+    const restart = vi.fn(async () => ({}));
+    hookManagerOf(core).__internal_restartThreadRuntime = restart;
+
+    await expect(core.reloadMainThread()).resolves.toBeUndefined();
+    expect(restart).not.toHaveBeenCalled();
   });
 
   it("does nothing before the initial thread is open", async () => {
@@ -51,8 +80,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   });
 
   it("still notifies when a redundant switch to the same thread lands mid-reload", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
     const threadId = core.mainThreadId;
 
     let releaseRestart!: () => void;
@@ -74,8 +102,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   });
 
   it("resolves quietly when the thread is removed mid-reload", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
 
     hookManagerOf(core).__internal_restartThreadRuntime = async () => {
       (core as unknown as { _mainThreadId: string })._mainThreadId = "other";
@@ -86,8 +113,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   });
 
   it("surfaces a restart failure that is not a lifecycle handover", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
 
     hookManagerOf(core).__internal_restartThreadRuntime = async () => {
       throw new Error("boom");
@@ -97,8 +123,7 @@ describe("RemoteThreadListThreadListRuntimeCore.reloadMainThread", () => {
   });
 
   it("lets a switch to a different thread win the notification", async () => {
-    const core = createCore(makeAdapter());
-    await core.switchToNewThread();
+    const core = await openRegularThread();
 
     let releaseRestart!: () => void;
     hookManagerOf(core).__internal_restartThreadRuntime = () =>

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -170,6 +170,7 @@ const useInMemoryThreadList = (
     switchToNewThread: handleSwitchToNewThread,
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
+    reloadMainThread: () => RESOLVED_PROMISE,
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (selector === "main") {

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -75,6 +75,7 @@ const useSingleThreadList = ({
     },
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
+    reloadMainThread: () => RESOLVED_PROMISE,
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (

--- a/packages/react/src/tests/RemoteThreadListRuntime.reloadMainThread.test.tsx
+++ b/packages/react/src/tests/RemoteThreadListRuntime.reloadMainThread.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import { type FC, useEffect } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  useRemoteThreadListRuntime,
+  type AssistantRuntime,
+} from "@assistant-ui/core/react";
+import { makeAdapter } from "./remote-thread-list-test-helpers";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
+import { AssistantRuntimeProvider } from "../context";
+import type { ChatModelAdapter } from "../index";
+
+const noOpAdapter: ChatModelAdapter = {
+  async *run() {},
+};
+
+const renderThreadList = async (mounts: { count: number }) => {
+  const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+
+  const adapter = makeAdapter({
+    list: async () => ({
+      threads: [
+        {
+          status: "regular" as const,
+          remoteId: "t-1",
+          externalId: "t-1",
+          title: "Open",
+        },
+      ],
+    }),
+  });
+
+  const Inner: FC = () => {
+    const runtime = useRemoteThreadListRuntime({
+      runtimeHook: function useTestRuntimeHook() {
+        useEffect(() => {
+          mounts.count++;
+        }, []);
+        return useLocalRuntime(noOpAdapter);
+      },
+      adapter,
+    });
+    capture.runtime = runtime;
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        {null}
+      </AssistantRuntimeProvider>
+    );
+  };
+
+  await act(async () => {
+    render(<Inner />);
+  });
+  await waitFor(() => expect(capture.runtime).not.toBeNull());
+  return capture;
+};
+
+// binders mount asynchronously, so a snapshot taken too early attributes a
+// still-pending mount to whatever ran next
+const settle = async (mounts: { count: number }) => {
+  let previous = -1;
+  await waitFor(() => {
+    const seen = mounts.count;
+    const stable = seen === previous;
+    previous = seen;
+    expect(stable).toBe(true);
+  });
+  return mounts.count;
+};
+
+describe("threads.reloadMainThread", () => {
+  it("remounts the runtime hook of the open thread", async () => {
+    const mounts = { count: 0 };
+    const capture = await renderThreadList(mounts);
+    const runtime = capture.runtime!;
+
+    await act(async () => {
+      await runtime.threads.switchToThread("t-1");
+    });
+    const beforeReload = await settle(mounts);
+    expect(beforeReload).toBeGreaterThan(0);
+
+    await act(async () => {
+      await runtime.threads.reloadMainThread();
+    });
+
+    // the hook ran again, which is what re-runs the adapter's load()
+    await waitFor(() => expect(mounts.count).toBe(beforeReload + 1));
+  });
+
+  it("keeps a thread runtime readable across the remount", async () => {
+    const mounts = { count: 0 };
+    const capture = await renderThreadList(mounts);
+    const runtime = capture.runtime!;
+
+    await act(async () => {
+      await runtime.threads.switchToThread("t-1");
+    });
+
+    const seen: boolean[] = [];
+    const unsubscribe = runtime.threads.subscribe(() => {
+      seen.push(runtime.threads.getState().mainThreadId === "t-1");
+    });
+
+    await act(async () => {
+      await runtime.threads.reloadMainThread();
+    });
+    unsubscribe();
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every(Boolean)).toBe(true);
+  });
+});


### PR DESCRIPTION
closes #5319

## summary

- a remote thread list only learns about server-side state through the live stream, so an out of band change (a LangGraph interrupt raised without a streamable event, or a stalled stream) leaves the open thread stale. `threads.reloadMainThread()` re-runs the runtime hook for the thread that is currently open, so its `load()` refetches messages and pending interrupts in place.
- the existing surface genuinely had no path for this, which the issue verified and i re-checked against the source: `reload()` refetches the thread list through `adapter.list()`, `thread.reset()` only touches local message state, and `switchToThread(currentThreadId)` silently early-returns at `RemoteThreadListThreadListRuntimeCore.tsx:433`. the remaining workaround, detach then switch, transits the empty new-thread slot and blanks the page for a frame.
- it lands as an optional method on `ThreadListRuntimeCore`, alongside the existing `reload?`, `loadMore?`, and `updateCustom?`, so the local and external-store thread lists are unaffected. those two hold no remote state, so there is nothing for them to reload; the concept does not exist there rather than being unimplemented.

## why it works this way

core cannot re-run the adapter's `load()` directly. the runtime hook is opaque to it (`RemoteThreadListHook = () => AssistantRuntime`), and `load()` belongs to the adapter's hook, so remounting that hook is the only lever core has.

the binder is rendered with `key={threadId}`, which means deleting and re-adding an instance in one tick leaves the rendered key set unchanged and React reconciles it as an update, so the hook keeps its state and `load()` never re-runs. the instance therefore carries a `generation` that is part of the key, and `__internal_restartThreadRuntime` bumps it.

this is a deliberate divergence worth calling out, since nothing else in the repo keys a component on a version counter: every existing `key=` is an identity key. the alternative of awaiting a macrotask between stop and start depends on React flushing the unmount within that tick, which is not guaranteed under concurrent rendering, and it also opens a window where the thread is not alive at all.

an event driven refresh (core emits, the runtime hook re-loads itself without unmounting) would be less destructive and would reuse the existing event surface. it is not what this PR does because a hook that does not subscribe would silently do nothing, which is the same failure the issue reports about `switchToThread`. worth revisiting if the lost local state below turns out to matter in practice.

## breaking changes

none. the core interface member is optional, and `__internal_restartThreadRuntime` uses the internal prefix so it is not a public API commitment.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core test` -> 844/844 green, including 4 new cases for `reloadMainThread` and 4 for the restart mechanism
- [x] a test pins the reason the generation exists: stop then start in one tick leaves the rendered key set unchanged
- [x] `pnpm api-surface:check` clean after regenerating; every added line traces to this change, no unrelated drift
- [x] `pnpm -C apps/docs generate:type-docs` and `generate:api-reference` re-run, no drift in tracked files
- [x] `pnpm lint` clean

### reviewer should verify

- [ ] against a LangGraph backend, raise an interrupt out of band and confirm `threads.reloadMainThread()` renders the approval card without navigating away

## notes

- reported with a reference implementation by @taoche, who is running it in production as a patch. the API shape is theirs; this changes the name from `reloadThread` to `reloadMainThread` to match the vocabulary the rest of the surface already uses for the active thread (`mainThreadId`, `mainItem`, `threads.main`), and replaces the `setTimeout(0)` with the generation key.
- the reload is destructive by nature: the thread is restarted rather than merged into, so unsent composer input and optimistic messages are discarded and a run that is still streaming is aborted by the hook's own cleanup. this is documented on the public JSDoc, which feeds the generated `ThreadListRuntime` reference page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.SCiSS4b2p5xxLIaz0pMa6Bfq_BfB5bcz7O7ldR1G-kT_FEGs-mJDRlfJRM0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->