### PR TITLE
test(tap): drop stray argument from zero-arg Stream resource call

### DIFF
--- a/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/concurrent-version-replay.test.tsx
@@ -60,7 +60,7 @@ describe("React-hosted reducer replay below the committed version", () => {
     let api!: { chunks: readonly string[]; push: (c: string) => void };
 
     function App() {
-      const value = useResource(Stream({}));
+      const value = useResource(Stream());
       api = value;
       return <div>{value.chunks.join(",")}</div>;
     }


### PR DESCRIPTION
## What

Fixes a call-arity type error in `concurrent-version-replay.test.tsx`: `Stream({})` passes an argument to a resource whose hook takes none, now `Stream()`.

## Why

I hit this while typechecking tap for #5506: `tsc --noEmit` fails with TS2554 on this line, which breaks the root `pnpm test` locally (it runs `test:types`). CI never runs the typecheck, so it slipped through when the test landed in #5331.

## Impact

No behavior change: the argument was ignored at runtime and the test passes identically. Local root `pnpm test` goes back to green for tap.

## Scope &

- One line, test-only; runtime and published surface untouched.
- Getting CI to run `test:types` is a separate question, deliberately not touched here.
- No changeset: test-only change to a test file.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NiogBT1vQVsZDT30sB0rSZL1J_bMe0IqwtTfWY40EbxJoOom9Yd8kI8lNZw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->