### PR TITLE
test(tap): deterministic flush wait in scheduler update-depth test

### DIFF
--- a/packages/tap/src/__tests__/scheduler.update-depth.test.ts
+++ b/packages/tap/src/__tests__/scheduler.update-depth.test.ts
@@ -1,26 +1,32 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { UpdateScheduler, flushTapSync } from "../core/scheduler";
 
 describe("scheduler update depth", () => {
   it("runs many independent schedulers in one flush without tripping the limit", async () => {
     let runCount = 0;
+    let flushes = 0;
+    let batching = false;
     const schedulers = Array.from(
       { length: 60 },
-      () => new UpdateScheduler(() => runCount++),
+      () =>
+        new UpdateScheduler(() => {
+          if (!batching) {
+            batching = true;
+            flushes++;
+            // The drain is synchronous, so the microtask resetting the flag
+            // runs after it; flushes counts drain batches, not tasks.
+            queueMicrotask(() => {
+              batching = false;
+            });
+          }
+          runCount++;
+        }),
     );
 
     for (const scheduler of schedulers) scheduler.markDirty();
-    // The flush arrives as a MessagePort macrotask where MessageChannel
-    // exists; a single setTimeout tick can be ordered before it.
-    for (
-      let attempt = 0;
-      runCount < schedulers.length && attempt < 200;
-      attempt++
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    }
+    await vi.waitFor(() => expect(runCount).toBe(60));
 
-    expect(runCount).toBe(60);
+    expect(flushes).toBe(1);
     expect(schedulers.every((scheduler) => !scheduler.isDirty)).toBe(true);
   });
 

--- a/packages/tap/src/__tests__/scheduler.update-depth.test.ts
+++ b/packages/tap/src/__tests__/scheduler.update-depth.test.ts
@@ -10,7 +10,15 @@ describe("scheduler update depth", () => {
     );
 
     for (const scheduler of schedulers) scheduler.markDirty();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // The flush arrives as a MessagePort macrotask where MessageChannel
+    // exists; a single setTimeout tick can be ordered before it.
+    for (
+      let attempt = 0;
+      runCount < schedulers.length && attempt < 200;
+      attempt++
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
 
     expect(runCount).toBe(60);
     expect(schedulers.every((scheduler) => !scheduler.isDirty)).toBe(true);


### PR DESCRIPTION
<!-- standup: fixed the tap scheduler test flake that kept rerunning CI on #5510, the test now waits deterministically for the async flush instead of racing it -->

## What
Makes the "runs many independent schedulers in one flush" test in `scheduler.update-depth.test.ts` wait deterministically: `await vi.waitFor(() => expect(runCount).toBe(60))` instead of a single bare `setTimeout(0)` tick. Also adds a flush counter so the single-flush batching the test is named for is asserted directly.

## Why
This test failed three times on #5510's CI in one day (runs 30693974107 and 30696002736, always `expected +0 to be 60` on the dev project). Since #5181 the scheduler flushes via a MessageChannel port message, and macrotask ordering between a `setTimeout(0)` and a port message is unguaranteed, so when the timeout wins the assertion runs before anything has flushed.

## Impact
- Test-only, no runtime code touched.
- The flaky rerun tax on unrelated PRs goes away; a real regression still fails with the same diagnostic message, since `vi.waitFor` rethrows the last assertion error on timeout.
- The single-flush property is now stronger than before: a change that chunked the drain across macrotasks would fail on `expect(flushes).toBe(1)`.

## Scope & caveats
- `flushTapSync` is intentionally not used: the async macrotask flush path is the thing under test.
- No new async flush primitive on the scheduler: that would be a runtime change for a test-only fix.
- The flush counter piggybacks on the drain being synchronous: a `queueMicrotask` resets the batching flag after the drain, so `flushes` counts drain batches, not tasks.
- The same latent race exists at the `waitForNextTick` call sites in other tap tests; tracked as a follow-up sweep, not folded in here (not a drop-in swap, one site asserts a re-render did NOT happen).
- Tests: 30/30 repeat runs of the file plus the full tap suite (463 passing) locally.
- Changeset: none, test-only precedent (#5506, #5366, #5189).
