### PR TITLE
fix(assistant-stream): prevent stale resumable stream data

### DIFF
--- a/.changeset/warm-streams-wait.md
+++ b/.changeset/warm-streams-wait.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: prevent stale data from leaking into reacquired Redis streams

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -73,7 +73,10 @@ class FakeRedisClient implements RedisLikeClient {
     const entries = this.streams.get(key) ?? [];
     if (start === "-") return entries;
     const exclusiveId = start.startsWith("(") ? start.slice(1) : start;
-    return entries.filter((entry) => entry.id > exclusiveId);
+    const sequence = (id: string) => Number(id.split("-")[0]);
+    return entries.filter(
+      (entry) => sequence(entry.id) > sequence(exclusiveId),
+    );
   }
 
   async pipeline(commands: readonly PipelineCommand[]): Promise<void> {
@@ -169,6 +172,40 @@ describe("RedisResumableStreamStore", () => {
 
     expect(chunks).toEqual(["current"]);
     await expect(store.status("current")).resolves.toBe("done");
+  });
+
+  it("fences a superseded producer out of the reacquired stream", async () => {
+    const client = new FakeRedisClient();
+    const keyPrefix = "test";
+    const streamId = "fenced";
+    const metaKey = `${keyPrefix}:{${streamId}}:meta`;
+    const staleStore = new RedisResumableStreamStore(client, { keyPrefix });
+    await expect(staleStore.acquire(streamId)).resolves.toBe("producer");
+    await staleStore.append(streamId, encoder.encode("before"));
+
+    client.strings.delete(metaKey);
+    const freshStore = new RedisResumableStreamStore(client, { keyPrefix });
+    await expect(freshStore.acquire(streamId)).resolves.toBe("producer");
+    await freshStore.append(streamId, encoder.encode("fresh"));
+
+    await expect(
+      staleStore.append(streamId, encoder.encode("stale")),
+    ).rejects.toThrow(`Stream superseded by a new acquisition: ${streamId}`);
+    await expect(
+      staleStore.finalize(streamId, "done"),
+    ).resolves.toBeUndefined();
+    await expect(freshStore.status(streamId)).resolves.toBe("streaming");
+
+    await freshStore.finalize(streamId, "done");
+    const chunks: string[] = [];
+    for await (const entry of freshStore.read(
+      streamId,
+      "",
+      new AbortController().signal,
+    )) {
+      chunks.push(decoder.decode(entry.chunk));
+    }
+    expect(chunks).toEqual(["fresh"]);
   });
 
   it("stops an existing reader when the stream generation changes", async () => {

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  RedisResumableStreamStore,
+  type PipelineCommand,
+  type RedisLikeClient,
+} from "./redis-impl";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+class FakeRedisClient implements RedisLikeClient {
+  readonly strings = new Map<string, string>();
+  readonly streams = new Map<
+    string,
+    Array<{
+      id: string;
+      fields: Record<string, string | Uint8Array>;
+    }>
+  >();
+  onFirstAcquire: (() => Promise<void>) | undefined;
+  private nextStreamId = 0;
+
+  async setNX(key: string, value: string): Promise<boolean> {
+    if (this.strings.has(key)) return false;
+    this.strings.set(key, value);
+    const onFirstAcquire = this.onFirstAcquire;
+    this.onFirstAcquire = undefined;
+    await onFirstAcquire?.();
+    return true;
+  }
+
+  async set(key: string, value: string): Promise<void> {
+    this.strings.set(key, value);
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async expire(): Promise<void> {}
+
+  async exists(key: string): Promise<boolean> {
+    return this.strings.has(key) || this.streams.has(key);
+  }
+
+  async del(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.strings.delete(key);
+      this.streams.delete(key);
+    }
+  }
+
+  async xAdd(
+    key: string,
+    fields: Record<string, string | Uint8Array>,
+  ): Promise<string> {
+    const id = `${++this.nextStreamId}-0`;
+    const entries = this.streams.get(key) ?? [];
+    entries.push({ id, fields });
+    this.streams.set(key, entries);
+    return id;
+  }
+
+  async xRange(
+    key: string,
+    start: string,
+  ): Promise<
+    Array<{
+      id: string;
+      fields: Record<string, string | Uint8Array>;
+    }>
+  > {
+    const entries = this.streams.get(key) ?? [];
+    if (start === "-") return entries;
+    const exclusiveId = start.startsWith("(") ? start.slice(1) : start;
+    return entries.filter((entry) => entry.id > exclusiveId);
+  }
+
+  async pipeline(commands: readonly PipelineCommand[]): Promise<void> {
+    for (const command of commands) {
+      switch (command.type) {
+        case "xAdd":
+          await this.xAdd(command.key, command.fields);
+          break;
+        case "set":
+          await this.set(command.key, command.value);
+          break;
+        case "expire":
+          break;
+      }
+    }
+  }
+}
+
+describe("RedisResumableStreamStore", () => {
+  it("does not expose stale data while a stream id is reacquired", async () => {
+    const client = new FakeRedisClient();
+    const keyPrefix = "test";
+    const streamId = "stream";
+    const legacyDataKey = `${keyPrefix}:{${streamId}}:data`;
+    await client.xAdd(legacyDataKey, { c: encoder.encode("stale") });
+
+    const store = new RedisResumableStreamStore(client, {
+      keyPrefix,
+      pollIntervalMs: 1,
+    });
+    let firstChunk: string | undefined;
+
+    client.onFirstAcquire = async () => {
+      await expect(store.acquire(streamId)).resolves.toBe("consumer");
+      await store.append(streamId, encoder.encode("fresh"));
+
+      const abort = new AbortController();
+      const iterator = store
+        .read(streamId, "", abort.signal)
+        [Symbol.asyncIterator]();
+      const result = await iterator.next();
+      firstChunk = result.done ? undefined : decoder.decode(result.value.chunk);
+      abort.abort();
+      await iterator.return?.();
+    };
+
+    await expect(store.acquire(streamId)).resolves.toBe("producer");
+    expect(firstChunk).toBe("fresh");
+  });
+
+  it("continues reading legacy streams without a generation", async () => {
+    const client = new FakeRedisClient();
+    const keyPrefix = "test";
+    const streamId = "legacy";
+    client.strings.set(
+      `${keyPrefix}:{${streamId}}:meta`,
+      JSON.stringify({ status: "streaming", ttlSec: 60 }),
+    );
+
+    const store = new RedisResumableStreamStore(client, { keyPrefix });
+    await store.append(streamId, encoder.encode("legacy"));
+    await store.finalize(streamId, "done");
+
+    const chunks: string[] = [];
+    for await (const entry of store.read(
+      streamId,
+      "",
+      new AbortController().signal,
+    )) {
+      chunks.push(decoder.decode(entry.chunk));
+    }
+
+    expect(chunks).toEqual(["legacy"]);
+  });
+
+  it("finalizes and replays generation-scoped streams", async () => {
+    const client = new FakeRedisClient();
+    const store = new RedisResumableStreamStore(client, {
+      keyPrefix: "test",
+    });
+    await store.acquire("current");
+    await store.append("current", encoder.encode("current"));
+    await store.finalize("current", "done");
+
+    const chunks: string[] = [];
+    for await (const entry of store.read(
+      "current",
+      "",
+      new AbortController().signal,
+    )) {
+      chunks.push(decoder.decode(entry.chunk));
+    }
+
+    expect(chunks).toEqual(["current"]);
+    await expect(store.status("current")).resolves.toBe("done");
+  });
+
+  it("stops an existing reader when the stream generation changes", async () => {
+    const client = new FakeRedisClient();
+    const keyPrefix = "test";
+    const streamId = "reused";
+    const metaKey = `${keyPrefix}:{${streamId}}:meta`;
+    const store = new RedisResumableStreamStore(client, {
+      keyPrefix,
+      pollIntervalMs: 1,
+    });
+    await store.acquire(streamId);
+
+    const abort = new AbortController();
+    const iterator = store
+      .read(streamId, "", abort.signal)
+      [Symbol.asyncIterator]();
+    const next = iterator.next();
+    await new Promise((resolve) => setTimeout(resolve, 2));
+
+    client.strings.delete(metaKey);
+    await store.acquire(streamId);
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      next,
+      new Promise<"timeout">((resolve) => {
+        timeout = setTimeout(() => resolve("timeout"), 100);
+      }),
+    ]);
+    if (timeout !== undefined) clearTimeout(timeout);
+    abort.abort();
+    await iterator.return?.();
+
+    expect(result).not.toBe("timeout");
+    expect(result).toMatchObject({ done: true });
+  });
+});

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -88,23 +88,45 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     this.maxChunkBytes = options.maxChunkBytes;
   }
 
+  // Fencing state for producers acquired through this instance: an append or
+  // finalize whose current metadata carries a different generation lost the
+  // stream to a newer acquisition and must not write into it.
+  private readonly acquiredGenerations = new Map<string, string>();
+
   async acquire(
     streamId: string,
     options?: ResumableStreamAcquireOptions,
   ): Promise<ResumableStreamRole> {
     validateStreamId(streamId);
     const ttlSec = msToSec(options?.ttlMs ?? this.defaultTtlMs);
+    const generation = generateId();
     const meta = JSON.stringify({
       status: "streaming",
       ttlSec,
-      generation: generateId(),
+      generation,
     });
     const acquired = await this.client.setNX(
       this.metaKey(streamId),
       meta,
       ttlSec,
     );
-    return acquired ? "producer" : "consumer";
+    if (!acquired) return "consumer";
+    this.acquiredGenerations.set(streamId, generation);
+    return "producer";
+  }
+
+  private isSupersededGeneration(streamId: string, meta: ParsedMeta): boolean {
+    const acquired = this.acquiredGenerations.get(streamId);
+    return acquired !== undefined && meta.generation !== acquired;
+  }
+
+  private assertOwnedGeneration(streamId: string, meta: ParsedMeta): void {
+    if (this.isSupersededGeneration(streamId, meta)) {
+      throw new ResumableStreamError(
+        "missing",
+        `Stream superseded by a new acquisition: ${streamId}`,
+      );
+    }
   }
 
   async append(streamId: string, chunk: Uint8Array): Promise<void> {
@@ -122,6 +144,7 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     if (!meta) {
       throw new Error(`Stream not found: ${streamId}`);
     }
+    this.assertOwnedGeneration(streamId, meta);
     if (meta.status !== "streaming") {
       throw new ResumableStreamError(
         "finalized",
@@ -148,8 +171,10 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     if (!existing) {
       throw new Error(`Stream not found: ${streamId}`);
     }
-    // a second finalize must not append a duplicate FIN entry.
+    // a second finalize must not append a duplicate FIN entry, and a producer
+    // superseded by a newer acquisition must not finalize the new stream.
     if (existing.status !== "streaming") return;
+    if (this.isSupersededGeneration(streamId, existing)) return;
     const ttlSec = existing.ttlSec ?? msToSec(this.defaultTtlMs);
     const meta = JSON.stringify({
       status,
@@ -171,6 +196,7 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       { type: "xAdd", key: dataKey, fields },
       { type: "expire", key: dataKey, ttlSec },
     ]);
+    this.acquiredGenerations.delete(streamId);
   }
 
   async *read(
@@ -235,6 +261,7 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
 
   async delete(streamId: string): Promise<void> {
     validateStreamId(streamId);
+    this.acquiredGenerations.delete(streamId);
     const meta = await this.readMeta(streamId);
     await this.client.del([
       this.metaKey(streamId),

--- a/packages/assistant-stream/src/resumable/stores/redis-impl.ts
+++ b/packages/assistant-stream/src/resumable/stores/redis-impl.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_TTL_MS } from "../constants";
 import { ResumableStreamError, validateStreamId } from "../errors";
+import { generateId } from "../../core/utils/generateId";
 import type {
   ResumableStreamAcquireOptions,
   ResumableStreamEntry,
@@ -93,18 +94,17 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
   ): Promise<ResumableStreamRole> {
     validateStreamId(streamId);
     const ttlSec = msToSec(options?.ttlMs ?? this.defaultTtlMs);
-    const meta = JSON.stringify({ status: "streaming", ttlSec });
+    const meta = JSON.stringify({
+      status: "streaming",
+      ttlSec,
+      generation: generateId(),
+    });
     const acquired = await this.client.setNX(
       this.metaKey(streamId),
       meta,
       ttlSec,
     );
-    if (acquired) {
-      // a prior producer's data key may outlive its expired meta key.
-      await this.client.del([this.dataKey(streamId)]);
-      return "producer";
-    }
-    return "consumer";
+    return acquired ? "producer" : "consumer";
   }
 
   async append(streamId: string, chunk: Uint8Array): Promise<void> {
@@ -117,7 +117,6 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
         `Chunk exceeds maxChunkBytes (${chunk.byteLength} > ${this.maxChunkBytes})`,
       );
     }
-    const dataKey = this.dataKey(streamId);
     const metaKey = this.metaKey(streamId);
     const meta = await this.readMeta(streamId);
     if (!meta) {
@@ -130,6 +129,7 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
       );
     }
     const ttlSec = meta.ttlSec ?? msToSec(this.defaultTtlMs);
+    const dataKey = this.dataKey(streamId, meta.generation);
     await this.client.pipeline([
       { type: "xAdd", key: dataKey, fields: { [FIELD_CHUNK]: chunk } },
       { type: "expire", key: dataKey, ttlSec },
@@ -143,7 +143,6 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     error?: string,
   ): Promise<void> {
     validateStreamId(streamId);
-    const dataKey = this.dataKey(streamId);
     const metaKey = this.metaKey(streamId);
     const existing = await this.readMeta(streamId);
     if (!existing) {
@@ -152,17 +151,21 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     // a second finalize must not append a duplicate FIN entry.
     if (existing.status !== "streaming") return;
     const ttlSec = existing.ttlSec ?? msToSec(this.defaultTtlMs);
-    const meta = JSON.stringify(
-      status === "error"
-        ? { status: "error", error: error ?? "Stream errored", ttlSec }
-        : { status: "done", ttlSec },
-    );
+    const meta = JSON.stringify({
+      status,
+      ...(status === "error" && { error: error ?? "Stream errored" }),
+      ttlSec,
+      ...(existing.generation !== undefined && {
+        generation: existing.generation,
+      }),
+    });
     const fields: Record<string, string> = {
       [FIELD_FIN]: status === "error" ? FIN_ERROR : FIN_DONE,
     };
     if (status === "error") {
       fields[FIELD_ERROR] = error ?? "Stream errored";
     }
+    const dataKey = this.dataKey(streamId, existing.generation);
     await this.client.pipeline([
       { type: "set", key: metaKey, value: meta, ttlSec },
       { type: "xAdd", key: dataKey, fields },
@@ -176,12 +179,13 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     signal: AbortSignal,
   ): AsyncIterable<ResumableStreamEntry> {
     validateStreamId(streamId);
-    const dataKey = this.dataKey(streamId);
     const metaKey = this.metaKey(streamId);
     const initialMeta = await this.client.get(metaKey);
     if (initialMeta === null) {
       throw new Error(`Stream not found: ${streamId}`);
     }
+    const generation = parseMeta(initialMeta)?.generation;
+    const dataKey = this.dataKey(streamId, generation);
 
     let lastId = cursor === "" ? STREAM_START_ID : cursor;
 
@@ -210,8 +214,9 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
 
       if (entries.length > 0) continue;
 
-      const stillExists = await this.client.exists(metaKey);
-      if (!stillExists) return;
+      const currentMeta = await this.client.get(metaKey);
+      if (currentMeta === null) return;
+      if (parseMeta(currentMeta)?.generation !== generation) return;
 
       await sleep(this.pollIntervalMs, signal);
     }
@@ -230,7 +235,14 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
 
   async delete(streamId: string): Promise<void> {
     validateStreamId(streamId);
-    await this.client.del([this.metaKey(streamId), this.dataKey(streamId)]);
+    const meta = await this.readMeta(streamId);
+    await this.client.del([
+      this.metaKey(streamId),
+      ...new Set([
+        this.dataKey(streamId, meta?.generation),
+        this.dataKey(streamId),
+      ]),
+    ]);
   }
 
   private async readMeta(streamId: string): Promise<ParsedMeta | undefined> {
@@ -245,8 +257,9 @@ export class RedisResumableStreamStore implements ResumableStreamStore {
     return `${this.keyPrefix}:{${streamId}}:meta`;
   }
 
-  private dataKey(streamId: string): string {
-    return `${this.keyPrefix}:{${streamId}}:data`;
+  private dataKey(streamId: string, generation?: string): string {
+    const base = `${this.keyPrefix}:{${streamId}}:data`;
+    return generation ? `${base}:${generation}` : base;
   }
 }
 
@@ -254,6 +267,7 @@ type ParsedMeta = {
   status?: string;
   error?: string;
   ttlSec?: number;
+  generation?: string;
 };
 
 function parseMeta(value: string): ParsedMeta | undefined {


### PR DESCRIPTION
## Summary

- scope Redis stream data to each acquisition generation
- stop existing readers when a stream ID is reacquired
- preserve compatibility with legacy metadata and data keys
- add deterministic regression coverage and a patch changeset

## Why

Redis stream metadata and data expire independently. Previously, reacquiring an ID created the new metadata and deleted the shared data key in separate operations. A consumer connecting between those operations could see the new metadata but replay chunks left by the previous stream.

The regression test reproduces that ordering and, before this fix, received "stale" instead of "fresh". Generation-specific data keys make newly acquired metadata point to isolated storage immediately, removing the cleanup window. Metadata created by older versions remains readable through the legacy key.

## Verification

- reproduced the stale-data race against the previous implementation
- pnpm --filter assistant-stream test (366 passed, 20 skipped; live Redis integration skipped without a Redis service)
- pnpm --filter assistant-stream build
- pnpm exec oxlint packages/assistant-stream/src/resumable/stores/redis-impl.ts packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
- pnpm exec oxfmt --check packages/assistant-stream/src/resumable/stores/redis-impl.ts packages/assistant-stream/src/resumable/stores/redis-impl.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.UBa9QiIbWE4c_BIaBg_zVC36b_OwSUeqcJ5BYh0igU7Ojbk-rJgXUPa-5Gg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->