### PR TITLE
fix(react-mcp): handle auth storage failures

### DIFF
--- a/.changeset/quiet-auth-states.md
+++ b/.changeset/quiet-auth-states.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: report automatic authentication storage failures through server state

--- a/packages/react-mcp/SPEC.md
+++ b/packages/react-mcp/SPEC.md
@@ -362,6 +362,8 @@ mount McpManagerResource
   → toolkit memo recomputes; modelContext.register(toolkit) (re-registers on change)
 ```
 
+During auto-connect, a rejected `storage.loadAuthState()` sets `lastError` and transitions the server to `"error"` without creating a transport; failures from cancelled or superseded attempts are ignored.
+
 `McpServerResource.connect()`:
 
 1. `state = "connecting"`.

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -287,6 +287,39 @@ describe("McpServerResource automatic authentication", () => {
       root.unmount();
     }
   });
+
+  it("ignores successful auth storage loads superseded by disconnect", async () => {
+    let resolveLoad!: (value: { token: string }) => void;
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    const root = mount({
+      auth: { type: "bearer" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitFor(
+        () => vi.mocked(storage.loadAuthState).mock.calls.length > 0,
+      );
+      await root.getValue().disconnect();
+      resolveLoad({ token: "secret" });
+      await flushMacrotask();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "disconnected",
+        lastError: null,
+      });
+      expect(mocks.StreamableHTTPClientTransport).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+    }
+  });
 });
 
 describe("McpServerResource connectionTimeout", () => {

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -217,6 +217,76 @@ describe("McpServerResource automatic authentication", () => {
       root.unmount();
     }
   });
+
+  it("ignores auth storage failures from the cancelled StrictMode setup", async () => {
+    let rejectCancelledLoad!: (error: Error) => void;
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectCancelledLoad = reject;
+          }),
+      )
+      .mockResolvedValueOnce(null);
+    const root = mount({
+      auth: { type: "oauth" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitFor(
+        () => vi.mocked(storage.loadAuthState).mock.calls.length > 1,
+      );
+      rejectCancelledLoad(new Error("cancelled auth storage failure"));
+      await flushMacrotask();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "disconnected",
+        lastError: null,
+      });
+      expect(mocks.StreamableHTTPClientTransport).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+    }
+  });
+
+  it("ignores auth storage failures superseded by a manual connection", async () => {
+    let rejectLoad!: (error: Error) => void;
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState).mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectLoad = reject;
+        }),
+    );
+    const root = mount({
+      auth: { type: "oauth" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitFor(
+        () => vi.mocked(storage.loadAuthState).mock.calls.length > 0,
+      );
+      await root.getValue().connect();
+      await waitForResourceUpdate(
+        () => root.getValue().getState().connectionState === "connected",
+      );
+
+      rejectLoad(new Error("superseded auth storage failure"));
+      await flushMacrotask();
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "connected",
+        lastError: null,
+      });
+    } finally {
+      root.unmount();
+    }
+  });
 });
 
 describe("McpServerResource connectionTimeout", () => {

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -147,6 +147,8 @@ const resetMocks = () => {
 const mount = (
   props?: {
     auth?: MCPAuthConfig | undefined;
+    storage?: MCPStorage | undefined;
+    autoConnect?: boolean | undefined;
     connectionTimeout?: number | undefined;
     cache?: { readonly defaultTtlMs?: number } | undefined;
     elicitation?: boolean | undefined;
@@ -164,9 +166,9 @@ const mount = (
         name: "Docs",
         url: "https://example.com/mcp",
         auth: props?.auth ?? { type: "none" },
-        storage: createStorage(),
+        storage: props?.storage ?? createStorage(),
         redirectUri: "https://example.com/callback",
-        autoConnect: false,
+        autoConnect: props?.autoConnect ?? false,
         connectionTimeout,
         cache: props?.cache,
         ...(props?.elicitation !== undefined
@@ -181,6 +183,41 @@ const mount = (
     return server;
   });
 };
+
+describe("McpServerResource automatic authentication", () => {
+  beforeEach(resetMocks);
+
+  it("reports auth storage load failures", async () => {
+    const storage = createStorage();
+    vi.mocked(storage.loadAuthState).mockRejectedValue(
+      new Error("auth storage unavailable"),
+    );
+    const root = mount({
+      auth: { type: "oauth" },
+      storage,
+      autoConnect: true,
+    });
+
+    try {
+      await waitForResourceUpdate(
+        () => root.getValue().getState().connectionState === "error",
+      );
+
+      expect(storage.loadAuthState).toHaveBeenCalledWith("docs");
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "error",
+        tools: [],
+        lastError: {
+          message:
+            'MCP server "docs" failed to load saved authentication: auth storage unavailable',
+        },
+      });
+      expect(mocks.StreamableHTTPClientTransport).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+    }
+  });
+});
 
 describe("McpServerResource connectionTimeout", () => {
   beforeEach(() => {

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -474,7 +474,18 @@ const useMcpServerResource = (
         void doConnect();
         return;
       }
-      const persisted = await props.storage.loadAuthState(props.id);
+      let persisted: Awaited<ReturnType<MCPStorage["loadAuthState"]>>;
+      try {
+        persisted = await props.storage.loadAuthState(props.id);
+      } catch (error) {
+        if (signal.cancelled) return;
+        const message = error instanceof Error ? error.message : String(error);
+        setLastError({
+          message: `MCP server "${props.id}" failed to load saved authentication: ${message}`,
+        });
+        setConnectionState("error");
+        return;
+      }
       if (signal.cancelled) return;
       if (props.auth.type === "oauth") {
         if (!persisted?.tokens) return;

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -474,11 +474,12 @@ const useMcpServerResource = (
         void doConnect();
         return;
       }
+      const generation = connectionGenerationRef.current;
       let persisted: Awaited<ReturnType<MCPStorage["loadAuthState"]>>;
       try {
         persisted = await props.storage.loadAuthState(props.id);
       } catch (error) {
-        if (signal.cancelled) return;
+        if (signal.cancelled || !isCurrentConnection(generation)) return;
         const message = error instanceof Error ? error.message : String(error);
         setLastError({
           message: `MCP server "${props.id}" failed to load saved authentication: ${message}`,
@@ -486,7 +487,7 @@ const useMcpServerResource = (
         setConnectionState("error");
         return;
       }
-      if (signal.cancelled) return;
+      if (signal.cancelled || !isCurrentConnection(generation)) return;
       if (props.auth.type === "oauth") {
         if (!persisted?.tokens) return;
       } else if (!persisted?.token) {


### PR DESCRIPTION
## Summary

- catch rejected auth-state reads during automatic MCP authentication
- ignore failures from cancelled StrictMode, unmounted attempts, or superseded connection operations
- expose active failures through the server error state without creating a transport
- add focused regression coverage and a patch changeset

## Why

This is the auth-storage follow-up identified during #5347. Custom MCP storage backed by IndexedDB or a remote service can reject loadAuthState(). McpServerResource awaited that read inside tryAutoConnect(), but mounted it as a fire-and-forget promise, so the rejection escaped globally and the server remained disconnected without a useful error.

Before the fix, the regression produced two unhandled auth storage unavailable rejections during the StrictMode effect replay. The active attempt now moves the server to error with the server ID and original storage message, while cancelled or superseded reads exit without overwriting newer connection state.

## Verification

- reproduced the failing state and unhandled rejections against the previous implementation
- packages/react-mcp/node_modules/.bin/vitest run packages/react-mcp/src (102 tests passed)
- packages/react-mcp/node_modules/.bin/aui-build
- node_modules/.bin/oxlint packages/react-mcp/src/resources/McpServerResource.ts packages/react-mcp/src/resources/McpServerResource.test.ts
- node_modules/.bin/oxfmt --check packages/react-mcp/src/resources/McpServerResource.ts packages/react-mcp/src/resources/McpServerResource.test.ts .changeset/quiet-auth-states.md
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.uC6Rkyby7aMU0DutpFU9mTuuSCHgO_ASEla9srfDzyuxn7omYzVNus-ar-E?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->