### PR TITLE
fix(react-pi): isolate thread controller subscribers

### DIFF
--- a/.changeset/react-pi-controller-listeners.md
+++ b/.changeset/react-pi-controller-listeners.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: isolate thread controller subscriber failures

--- a/packages/react-pi/src/runtime/ThreadController.test.ts
+++ b/packages/react-pi/src/runtime/ThreadController.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import type { AppendMessage } from "@assistant-ui/react";
 import { PiThreadController } from "./ThreadController";
 import type {
@@ -240,6 +240,33 @@ describe("PiThreadController", () => {
       content: "second",
       streamingBehavior: "followUp",
     });
+  });
+
+  it("isolates subscriber errors while sending messages", async () => {
+    const client = createFakeClient();
+    const controller = new PiThreadController(client, THREAD);
+    const listenerError = new Error("listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const laterListener = vi.fn();
+
+    controller.subscribe(() => {
+      throw listenerError;
+    });
+    controller.subscribe(laterListener);
+
+    await expect(
+      controller.sendMessage(userMessage("hello")),
+    ).resolves.toBeUndefined();
+
+    expect(client.sent).toHaveLength(1);
+    expect(laterListener).toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[react-pi] Listener threw an error",
+      listenerError,
+    );
   });
 
   it("maps image attachments to Pi image content", async () => {

--- a/packages/react-pi/src/runtime/ThreadController.ts
+++ b/packages/react-pi/src/runtime/ThreadController.ts
@@ -82,6 +82,16 @@ const defaultScheduleNotify: PiNotificationScheduler = (flush) => {
   setTimeout(flush, 16);
 };
 
+const notifyListeners = (listeners: Iterable<() => void>) => {
+  for (const listener of listeners) {
+    try {
+      listener();
+    } catch (error) {
+      console.error("[react-pi] Listener threw an error", error);
+    }
+  }
+};
+
 /** Event types the reducer acts on. Anything else triggers a snapshot refresh
  * (forward-compat for Pi's open, module-augmented event union). */
 const MESSAGE_DIRTY_EVENT_TYPES: ReadonlySet<string> = new Set([
@@ -679,13 +689,13 @@ export class PiThreadController implements PiThreadControllerLike {
 
   private notifyMetadataListeners() {
     this.bumpVersion();
-    for (const listener of this.metadataListeners) listener();
-    for (const listener of this.allListeners) listener();
+    notifyListeners(this.metadataListeners);
+    notifyListeners(this.allListeners);
   }
 
   private notifyMessageListeners() {
     this.bumpVersion();
-    for (const listener of this.messageListeners) listener();
-    for (const listener of this.allListeners) listener();
+    notifyListeners(this.messageListeners);
+    notifyListeners(this.allListeners);
   }
 }


### PR DESCRIPTION
## Summary

- isolate each React Pi thread-controller subscriber invocation
- report subscriber failures without interrupting later listeners or controller operations
- add a regression test covering a failed subscriber during message sending

## Why

While testing the thread controller with multiple subscribers, I found that one subscriber throwing during the optimistic running-state notification caused `sendMessage()` itself to reject before `client.sendMessage()` was called. This meant a UI or telemetry subscriber could prevent a valid user message from reaching Pi and also prevent later subscribers from receiving the update.

Subscriber failures are now handled independently, matching the existing React Pi HTTP event-listener behavior.

## Validation

- `ThreadController.test.ts`: 30 tests passed
- targeted `oxlint` passed
- targeted `oxfmt --check` passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eipGW4Qmpp6DhtGWbK0M5CHNTn0w_tDFHcghL1rLKKW5ahHrLgkpNTxqCYU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->