### PR TITLE
fix(core): clean up disconnected voice session

### DIFF
--- a/.changeset/voice-session-cleanup.md
+++ b/.changeset/voice-session-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: clean up disconnected voice sessions

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -87,6 +87,31 @@ describe("createVoiceSession", () => {
     await Promise.resolve();
 
     session.disconnect();
+    session.disconnect();
+    abortController.abort();
+
+    expect(controls.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("keeps abort teardown available after the session ends", async () => {
+    const abortController = new AbortController();
+    const controls = {
+      disconnect: vi.fn(),
+      mute: vi.fn(),
+      unmute: vi.fn(),
+    };
+    let helpers: VoiceSessionHelpers | undefined;
+    createVoiceSession(
+      { abortSignal: abortController.signal },
+      async (sessionHelpers) => {
+        helpers = sessionHelpers;
+        return controls;
+      },
+    );
+    await Promise.resolve();
+    if (!helpers) throw new Error("Voice session setup did not start");
+
+    helpers.end("error");
     abortController.abort();
 
     expect(controls.disconnect).toHaveBeenCalledOnce();

--- a/packages/core/src/adapters/voice.test.ts
+++ b/packages/core/src/adapters/voice.test.ts
@@ -73,6 +73,50 @@ describe("createVoiceSession", () => {
     expect(controls.mute).not.toHaveBeenCalled();
   });
 
+  it("removes the abort listener after disconnecting", async () => {
+    const abortController = new AbortController();
+    const controls = {
+      disconnect: vi.fn(),
+      mute: vi.fn(),
+      unmute: vi.fn(),
+    };
+    const session = createVoiceSession(
+      { abortSignal: abortController.signal },
+      async () => controls,
+    );
+    await Promise.resolve();
+
+    session.disconnect();
+    abortController.abort();
+
+    expect(controls.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("cleans up when the adapter disconnect throws", async () => {
+    const disconnectError = new Error("disconnect failed");
+    let helpers: VoiceSessionHelpers | undefined;
+    const session = createVoiceSession({}, async (sessionHelpers) => {
+      helpers = sessionHelpers;
+      return {
+        disconnect: () => {
+          throw disconnectError;
+        },
+        mute: vi.fn(),
+        unmute: vi.fn(),
+      };
+    });
+    await Promise.resolve();
+    if (!helpers) throw new Error("Voice session setup did not start");
+    const transcriptListener = vi.fn();
+    session.onTranscript(transcriptListener);
+
+    expect(() => session.disconnect()).toThrow(disconnectError);
+    expect(helpers.isDisposed()).toBe(true);
+
+    helpers.emitTranscript({ role: "assistant", text: "stale" });
+    expect(transcriptListener).not.toHaveBeenCalled();
+  });
+
   it("continues notifying listeners when one throws", () => {
     const listenerError = new Error("listener failed");
     const consoleError = vi

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -87,16 +87,20 @@ export function createVoiceSession(
   let currentStatus: RealtimeVoiceAdapter.Status = { type: "starting" };
   let isMuted = false;
   let disposed = false;
+  let disconnected = false;
   let controls: VoiceSessionControls | null = null;
   const abortSignal = options.abortSignal;
   let abortHandler: (() => void) | undefined;
 
-  const cleanup = () => {
-    disposed = true;
+  const detachAbortHandler = () => {
     if (abortHandler) {
       abortSignal?.removeEventListener("abort", abortHandler);
       abortHandler = undefined;
     }
+  };
+
+  const cleanup = () => {
+    disposed = true;
     statusCbs.clear();
     transcriptCbs.clear();
     modeCbs.clear();
@@ -138,6 +142,9 @@ export function createVoiceSession(
       return isMuted;
     },
     disconnect: () => {
+      if (disconnected) return;
+      disconnected = true;
+      detachAbortHandler();
       try {
         controls?.disconnect();
       } finally {

--- a/packages/core/src/adapters/voice.ts
+++ b/packages/core/src/adapters/voice.ts
@@ -88,9 +88,15 @@ export function createVoiceSession(
   let isMuted = false;
   let disposed = false;
   let controls: VoiceSessionControls | null = null;
+  const abortSignal = options.abortSignal;
+  let abortHandler: (() => void) | undefined;
 
   const cleanup = () => {
     disposed = true;
+    if (abortHandler) {
+      abortSignal?.removeEventListener("abort", abortHandler);
+      abortHandler = undefined;
+    }
     statusCbs.clear();
     transcriptCbs.clear();
     modeCbs.clear();
@@ -132,8 +138,11 @@ export function createVoiceSession(
       return isMuted;
     },
     disconnect: () => {
-      controls?.disconnect();
-      cleanup();
+      try {
+        controls?.disconnect();
+      } finally {
+        cleanup();
+      }
     },
     mute: () => {
       controls?.mute();
@@ -161,10 +170,9 @@ export function createVoiceSession(
     },
   };
 
-  if (options.abortSignal) {
-    options.abortSignal.addEventListener("abort", () => session.disconnect(), {
-      once: true,
-    });
+  if (abortSignal) {
+    abortHandler = () => session.disconnect();
+    abortSignal.addEventListener("abort", abortHandler, { once: true });
   }
 
   const doSetup = async () => {


### PR DESCRIPTION
## Summary

- detach a voice session's abort listener when disconnect is requested
- make session disconnect idempotent across direct and abort callers
- guarantee session cleanup when an adapter's `disconnect()` throws
- add regressions for duplicate disconnects and failed-disconnect cleanup

## Why

While testing voice-session teardown, I found that manually disconnecting a session left its abort listener attached. Aborting the original signal later called the adapter's `disconnect()` a second time and retained the disconnected session until the signal fired. Repeated direct calls had the same duplicate-disconnect behavior.

I also found that an adapter `disconnect()` error skipped cleanup entirely, leaving the session undisposed and its subscribers active. Cleanup now runs in a `finally`, while the original adapter error still propagates to the caller. The abort handler remains active after `helpers.end()` so adapters can still tear down a live transport after reporting an ended state.

## Follow-up

Resetting `BaseThreadRuntimeCore` voice state when a session disconnect throws is a separate ownership-layer issue and is intentionally left for a follow-up PR.

## Validation

- `voice.test.ts`: 6 tests passed
- targeted `oxlint` passed
- targeted `oxfmt --check` passed
