### PR TITLE
fix(react-opencode): isolate thread controller subscribers

### DIFF
--- a/.changeset/quiet-owls-listen.md
+++ b/.changeset/quiet-owls-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-opencode": patch
+---
+
+fix: isolate thread controller subscriber errors

--- a/packages/react-opencode/src/OpenCodeThreadController.test.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, onTestFinished, vi } from "vitest";
 import { OpenCodeThreadController } from "./OpenCodeThreadController";
 import { STREAM_RECONNECTED_EVENT_TYPE } from "./OpenCodeEventSource";
 import { rejectWhenThrowing } from "./testUtils";
@@ -804,6 +804,46 @@ describe("OpenCodeThreadController", () => {
         parts: [{ type: "text", text: "hello" }],
       },
       { throwOnError: true },
+    );
+  });
+
+  it("isolates subscriber errors while sending messages", async () => {
+    const promptAsync = vi.fn().mockResolvedValue({});
+    const controller = new OpenCodeThreadController(
+      { session: { promptAsync } } as never,
+      () => ({ subscribe: () => () => {} }),
+      "ses_1",
+    );
+    const listenerError = new Error("listener failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const laterListener = vi.fn();
+
+    controller.subscribe(() => {
+      throw listenerError;
+    });
+    controller.subscribe(laterListener);
+
+    await expect(
+      controller.sendMessage({
+        role: "user",
+        parentId: null,
+        sourceId: null,
+        content: [{ type: "text", text: "hello" }],
+        attachments: [],
+        metadata: { custom: {} },
+        runConfig: {},
+        createdAt: new Date(),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(promptAsync).toHaveBeenCalledOnce();
+    expect(laterListener).toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[react-opencode] Listener threw an error",
+      listenerError,
     );
   });
 

--- a/packages/react-opencode/src/OpenCodeThreadController.ts
+++ b/packages/react-opencode/src/OpenCodeThreadController.ts
@@ -256,7 +256,11 @@ export class OpenCodeThreadController implements OpenCodeThreadControllerLike {
 
   private notifyListeners() {
     for (const listener of this.listeners) {
-      listener();
+      try {
+        listener();
+      } catch (error) {
+        console.error("[react-opencode] Listener threw an error", error);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- isolate each `OpenCodeThreadController` subscriber so one failure does not interrupt state delivery
- log subscriber failures consistently with `OpenCodeEventSource`
- add a regression test covering message delivery and later subscribers

## Why

While testing a subscriber that reports UI state to telemetry, I found that a thrown callback escaped `notifyListeners()` during `local.message.queued`. That rejected `sendMessage()` before `promptMessage()` ran, so the message remained locally queued and never reached `client.session.promptAsync()`.

Subscriber callbacks are observers and should not be able to stop controller operations or prevent other subscribers from receiving the same update. This change catches each callback independently, reports the error, and continues the notification loop and send flow.

## Verification

- reproduced the failure before the implementation: `sendMessage()` rejected with the listener error and `promptAsync()` was not called
- `OpenCodeThreadController.test.ts`: 46 tests passed
- `@assistant-ui/react-opencode` build passed
- targeted Oxlint and Oxfmt checks passed

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IZvyIxhxtZzXC8BLXOxAf7RlTAs18m031o8ryiIU8okTNfuq4p8KRhwWNNw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->