### PR TITLE
fix(assistant-stream): guard pending tool settlement after cancellation

### DIFF
--- a/.changeset/calm-tools-settle.md
+++ b/.changeset/calm-tools-settle.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: prevent pending frontend tool output from enqueuing after stream cancellation

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -48,6 +48,7 @@ const enqueueIfOpen = (
   try {
     controller.enqueue(chunk);
   } catch (error) {
+    // enqueue() throwing TypeError is the portable termination signal for TransformStream controllers.
     if (!(error instanceof TypeError)) throw error;
   }
 };

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -41,6 +41,17 @@ type ToolExecutionOptions = {
   onExecutionEnd?: ((toolCallId: string, toolName: string) => void) | undefined;
 };
 
+const enqueueIfOpen = (
+  controller: TransformStreamDefaultController<AssistantStreamChunk>,
+  chunk: AssistantStreamChunk,
+) => {
+  try {
+    controller.enqueue(chunk);
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+  }
+};
+
 export class ToolExecutionStream extends PipeableTransformStream<
   AssistantStreamChunk,
   AssistantStreamChunk
@@ -174,7 +185,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
                     modelContent: c.modelContent,
                   });
                   streamController.setResponse(result);
-                  controller.enqueue({
+                  enqueueIfOpen(controller, {
                     type: "result",
                     path: chunk.path,
                     ...result,
@@ -191,7 +202,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   });
 
                   streamController.setResponse(result);
-                  controller.enqueue({
+                  enqueueIfOpen(controller, {
                     type: "result",
                     path: chunk.path,
                     ...result,
@@ -215,7 +226,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   toolCallControllers.delete(toolCallId);
                   toolCallIdsWithBackendResult.delete(toolCallId);
 
-                  controller.enqueue(chunk);
+                  enqueueIfOpen(controller, chunk);
                 });
               } else {
                 toolCallControllers.delete(toolCallId);

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -7,6 +7,7 @@ import { ToolResponse } from "./ToolResponse";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import type { AssistantMessage, ToolCallPart } from "../utils/types";
 import type { Tool } from "./tool-types";
+import { promiseWithResolvers } from "../../utils/promiseWithResolvers";
 
 const createDelayedTool = (delay: number, result?: string): Tool => ({
   parameters: { type: "object", properties: {} },
@@ -15,6 +16,21 @@ const createDelayedTool = (delay: number, result?: string): Tool => ({
     return result ?? `Tool with ${delay}ms delay executed`;
   },
 });
+
+const captureUnhandledRejections = async (
+  callback: () => Promise<void>,
+): Promise<unknown[]> => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    await callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
 
 describe("unstable_runPendingTools", () => {
   it("removes the abort listener after tool execution settles", async () => {
@@ -67,61 +83,77 @@ describe("unstable_runPendingTools", () => {
     );
   });
 
-  it("does not enqueue pending tool output after cancellation", async () => {
-    let resolveTool!: (value: string) => void;
-    const toolResult = new Promise<string>((resolve) => {
-      resolveTool = resolve;
-    });
-    let markToolStarted!: () => void;
-    const toolStarted = new Promise<void>((resolve) => {
-      markToolStarted = resolve;
-    });
-    const inputChunks: AssistantStreamChunk[] = [
-      {
-        type: "part-start",
-        path: [],
-        part: {
-          type: "tool-call",
-          toolCallId: "tc-cancelled",
-          toolName: "slowTool",
-        },
-      },
-      { type: "text-delta", path: [0], textDelta: "{}" },
-      { type: "tool-call-args-text-finish", path: [0] },
-      { type: "part-finish", path: [0] },
-    ];
-    const inputStream = new ReadableStream<AssistantStreamChunk>({
-      start(controller) {
-        for (const chunk of inputChunks) controller.enqueue(chunk);
-        controller.close();
-      },
-    });
-    const output = inputStream.pipeThrough(
-      unstable_toolResultStream(
+  it.each(["resolves", "rejects"] as const)(
+    "does not enqueue pending tool output after cancellation when execution %s",
+    async (settlement) => {
+      const toolResult = promiseWithResolvers<string>();
+      const toolStarted = promiseWithResolvers<void>();
+      const inputChunks: AssistantStreamChunk[] = [
         {
-          slowTool: {
-            parameters: { type: "object", properties: {} },
-            execute: () => {
-              markToolStarted();
-              return toolResult;
-            },
+          type: "part-start",
+          path: [],
+          part: {
+            type: "tool-call",
+            toolCallId: "tc-cancelled",
+            toolName: "slowTool",
           },
         },
-        new AbortController().signal,
-        async () => {},
-      ),
-    );
-    const reader = output.getReader();
+        { type: "text-delta", path: [0], textDelta: "{}" },
+        { type: "tool-call-args-text-finish", path: [0] },
+        { type: "part-finish", path: [0] },
+      ];
+      const inputStream = new ReadableStream<AssistantStreamChunk>({
+        start(controller) {
+          for (const chunk of inputChunks) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+      const output = inputStream.pipeThrough(
+        unstable_toolResultStream(
+          {
+            slowTool: {
+              parameters: { type: "object", properties: {} },
+              execute: () => {
+                toolStarted.resolve();
+                return toolResult.promise;
+              },
+            },
+          },
+          new AbortController().signal,
+          async () => {},
+        ),
+      );
+      const reader = output.getReader();
+      const expectedForwardedTypes = [
+        "part-start",
+        "text-delta",
+        "tool-call-args-text-finish",
+      ];
 
-    for (let index = 0; index < 3; index++) {
-      expect((await reader.read()).done).toBe(false);
-    }
-    await toolStarted;
-    const cancellation = reader.cancel();
-    resolveTool("done");
-    await cancellation;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  });
+      for (const expectedType of expectedForwardedTypes) {
+        const chunk = await reader.read();
+        expect(chunk.done).toBe(false);
+        expect(chunk.value?.type).toBe(expectedType);
+      }
+      await toolStarted.promise;
+
+      const unhandledRejections = await captureUnhandledRejections(async () => {
+        const cancellation = reader.cancel();
+        if (settlement === "resolves") {
+          toolResult.resolve("done");
+        } else {
+          toolResult.reject(new Error("tool failed"));
+        }
+        await cancellation;
+      });
+
+      expect(unhandledRejections).toEqual([]);
+      await expect(reader.read()).resolves.toEqual({
+        value: undefined,
+        done: true,
+      });
+    },
+  );
 
   describe("parallel execution", () => {
     it("should run tool calls in parallel", async () => {

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -67,6 +67,62 @@ describe("unstable_runPendingTools", () => {
     );
   });
 
+  it("does not enqueue pending tool output after cancellation", async () => {
+    let resolveTool!: (value: string) => void;
+    const toolResult = new Promise<string>((resolve) => {
+      resolveTool = resolve;
+    });
+    let markToolStarted!: () => void;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const inputChunks: AssistantStreamChunk[] = [
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "tool-call",
+          toolCallId: "tc-cancelled",
+          toolName: "slowTool",
+        },
+      },
+      { type: "text-delta", path: [0], textDelta: "{}" },
+      { type: "tool-call-args-text-finish", path: [0] },
+      { type: "part-finish", path: [0] },
+    ];
+    const inputStream = new ReadableStream<AssistantStreamChunk>({
+      start(controller) {
+        for (const chunk of inputChunks) controller.enqueue(chunk);
+        controller.close();
+      },
+    });
+    const output = inputStream.pipeThrough(
+      unstable_toolResultStream(
+        {
+          slowTool: {
+            parameters: { type: "object", properties: {} },
+            execute: () => {
+              markToolStarted();
+              return toolResult;
+            },
+          },
+        },
+        new AbortController().signal,
+        async () => {},
+      ),
+    );
+    const reader = output.getReader();
+
+    for (let index = 0; index < 3; index++) {
+      expect((await reader.read()).done).toBe(false);
+    }
+    await toolStarted;
+    const cancellation = reader.cancel();
+    resolveTool("done");
+    await cancellation;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
   describe("parallel execution", () => {
     it("should run tool calls in parallel", async () => {
       const tool1 = createDelayedTool(100, "Tool 1");


### PR DESCRIPTION
## Summary

- ignore delayed frontend-tool result chunks once the transform has been terminated
- guard the deferred tool-call completion chunk at the same cancellation boundary
- add regression coverage for resolved and rejected tools settling after cancellation

## Why

If a consumer cancels an assistant stream while an asynchronous frontend tool is still running, the tool can settle after the transform has closed. The result and deferred `part-finish` callbacks then try to enqueue into the terminated stream, causing a global `unhandledRejection` with `Invalid state: Unable to enqueue`. This can surface when a user stops generation or navigates away while a frontend tool is in flight.

The fix keeps active-stream behavior unchanged and drops only delayed output rejected by a terminated transform controller. Unlike the explicit cancellation flag used by plain `ReadableStream` utilities such as `merge.ts`, a portable transform cancellation callback is unavailable across this package's supported runtimes, so the guard handles the spec-defined `TypeError` from enqueueing into a terminated controller.

Cancelling this output stream does not independently abort the frontend tool. Tool cancellation remains controlled through the `AbortSignal` already supplied to `toolResultStream`; this change only makes late settlement safe when a tool has not stopped yet.

## Testing

- reproduced the failure before the fix with the focused cancellation regression
- explicitly asserted no `unhandledRejection` for both resolved and rejected tool executions
- asserted the pre-cancellation chunks and closed reader state
- `assistant-stream`: 364 tests passed, 20 skipped on Node 24
- `assistant-stream` package build
- oxlint on the changed source and test files

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EGTEJStjEAAsN1DNbHAfo4DzIaFDUgXODPDSBoY0tMqsMwi7cEcKtVUhHCA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->