### PR TITLE
fix(assistant-stream): keep partial args parseable at a lone minus sign

### DIFF
--- a/.changeset/fix-json-lone-minus.md
+++ b/.changeset/fix-json-lone-minus.md
@@ -1,0 +1,9 @@
+---
+"assistant-stream": patch
+---
+
+fix: keep partial tool-call args parseable when a negative number is cut before its digits
+
+`fixJson` treated the `-` that opens an array element as a complete value, so a stream cut at `{"a":[-` repaired to `{"a":[-]}`. That is not valid JSON, `parsePartialJsonObject` fell into its catch and returned `undefined`, and callers that fall back to `{}` dropped every field streamed so far until the next delta landed.
+
+The `INSIDE_ARRAY_START` default branch advanced `lastValidIndex` before delegating to `processValueStart`, which deliberately leaves it alone for `-` because a lone minus carries no value yet. Every other value-start site already lets `processValueStart` own that index, which is why `{"a":-` and `{"a":[1,-` truncated correctly and only the first element of an array did not.

--- a/packages/assistant-stream/src/utils/json/fix-json.ts
+++ b/packages/assistant-stream/src/utils/json/fix-json.ts
@@ -294,7 +294,6 @@ export function fixJson(input: string): [string, string[]] {
           }
 
           default: {
-            lastValidIndex = i;
             currentKey = "0";
             processValueStart(char, i, "INSIDE_ARRAY_AFTER_VALUE");
             break;

--- a/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
+++ b/packages/assistant-stream/src/utils/json/parse-partial-json-object.test.ts
@@ -205,6 +205,22 @@ const tests: PartialJsonTest[] = [
     query: ["\u25CF"],
     result: "partial",
   },
+  // negative number whose digits have not arrived yet
+  {
+    input: `{"foo": [-`,
+    query: ["foo"],
+    result: "partial",
+  },
+  {
+    input: `{"foo": [-`,
+    query: ["foo", 0],
+    result: "partial",
+  },
+  {
+    input: `{"foo": [[-`,
+    query: ["foo", 0, 0],
+    result: "partial",
+  },
 ];
 
 describe("parsePartialJsonObject and getPartialJsonObjectFieldState", () => {


### PR DESCRIPTION
### What breaks

When a tool call streams a negative number as the first element of an array, there is a moment where the model has emitted the `-` but not yet the digits. `parsePartialJsonObject` returns `undefined` for that chunk, so every consumer that falls back to `{}` throws away all the fields streamed so far and re-renders the tool UI empty until the next delta lands.

```js
parsePartialJsonObject('{"a":[-')   // undefined
parsePartialJsonObject('{"a":[[-')  // undefined
```

Callers this reaches: `thread-message-like.ts` and `appendLangChainChunk.ts` both do `?? {}`, so args collapse. `assistant-message-accumulator`, `convertMessage` and `ToolCallReader` fall back to the previous value, so args freeze for a frame instead.

It only hits the first element of an array. `{"a":-` and `{"a":[1,-` already truncate correctly.

### Root cause

`fixJson` returns `input.slice(0, lastValidIndex + 1)` plus closing brackets, so `lastValidIndex` has to point at the last character that actually completes a value. `processValueStart` knows this and deliberately does not advance it for `-`, since a lone minus carries no value yet.

The `INSIDE_ARRAY_START` default branch set `lastValidIndex = i` itself before delegating to `processValueStart`. So the `-` got kept, and the unwind appended `]` after it:

```
'{"a":[-'  ->  '{"a":[-]}'
```

which is not valid JSON, so `sjson.parse` throws and `parsePartialJsonObject` hits its catch. `ROOT`, `INSIDE_OBJECT_BEFORE_VALUE` and `INSIDE_ARRAY_AFTER_COMMA` all let `processValueStart` own the index, which is exactly why the other three positions were fine.

### Fix

Drop that one assignment so the array-start branch behaves like the other three value-start sites. Truncating at the `[` gives `'{"a":[]}'`, the same repair `{"a":[` already produced, and the partial path still reports `["a", "0"]` so the element reads as partial.

### Test

Three rows added to the existing table in `parse-partial-json-object.test.ts`, covering an array element, its field state, and a nested array. All three fail on main with "unable to parse args" and pass with the change.

I also fuzzed every prefix of a set of payloads containing negative numbers, nested arrays and empty arrays, asserting the repair always parses and that complete input round-trips unchanged with an empty partial path. That check is red on main and green here. I left it out of the diff since it reads as a repro test rather than a contract test, happy to add it if you want it in the suite.

Verified: `assistant-stream` 365 tests, `core` 694, `react-ai-sdk` 79, `react-langgraph` 52, plus `tsc --noEmit`, oxlint and oxfmt.

### Note on scope

The same fuzz turned up a second, separate defect in the same function: a string cut inside a `\uXXXX` escape repairs to a dangling `\u25C"`, which is also unparseable. Different mechanism (`INSIDE_STRING_ESCAPE` pops after one character regardless of `u`), so I kept it out of this PR. Happy to open a follow-up.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qDPafz6N4KVKmKMj9lqBJLumjmJKElqcPwrBx7AU8imNBFhNWzIuR8aFLO0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

