### PR TITLE
fix(react-langgraph): make cancelRun a hard stop

### DIFF
--- a/.changeset/langgraph-cancel-hard-stop.md
+++ b/.changeset/langgraph-cancel-hard-stop.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: make `cancelRun` a hard stop. the abort signal is handed to the caller's `stream`, so a callback that does not check it kept feeding chunks into the thread after cancellation; the consume loop now stops on its own.

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -244,6 +244,8 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         let lastValuesMessages: TMessage[] | null = null;
         let lastValuesUIMessages: UIMessage[] | null = null;
         for await (const chunk of response) {
+          // Holds even when the caller's `stream` ignores its abortSignal.
+          if (abortController.signal.aborted) break;
           const { type: eventType, namespace: eventNamespace } = parseEventType(
             chunk.event,
           );

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -1129,6 +1129,55 @@ describe("useLangGraphRuntime", () => {
       expect(streamMock).toHaveBeenCalledTimes(1);
     });
 
+    it("stops applying chunks after cancelRun even when the stream ignores its abortSignal", async () => {
+      const gate = deferred<void>();
+      const streamMock = vi.fn(async function* () {
+        yield {
+          event: "messages/partial",
+          data: [
+            { type: "ai" as const, id: "run-1", content: "before-cancel" },
+          ],
+        };
+        await gate.promise;
+        yield {
+          event: "messages/partial",
+          data: [{ type: "ai" as const, id: "run-2", content: "after-cancel" }],
+        };
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock as never,
+          unstable_allowCancellation: true,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer.setText("hello");
+        auiResult.current.composer.send();
+      });
+      await waitFor(() =>
+        expect(
+          JSON.stringify(runtimeResult.current.thread.getState().messages),
+        ).toContain("before-cancel"),
+      );
+
+      await act(async () => {
+        runtimeResult.current.thread.cancelRun();
+      });
+
+      await act(async () => {
+        gate.resolve();
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+      expect(
+        JSON.stringify(runtimeResult.current.thread.getState().messages),
+      ).not.toContain("after-cancel");
+    });
+
     it("drops the queued resume when the draining run errors", async () => {
       const gate = deferred<void>();
       const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {


### PR DESCRIPTION
`cancelRun()` is not a hard stop today.

`useLangGraphMessages.sendMessage` hands `abortSignal` to the caller's `stream` callback and then consumes whatever that callback yields, with no check of its own:

```ts
const response = await stream(newMessagesWithId, { ...config, abortSignal: abortController.signal, ... });
for await (const chunk of response) {   // no signal check
```

so honouring cancellation is entirely the callback's job. a `stream` that ignores its signal keeps writing messages into the thread after `cancelRun()`, after `onCancel` has run, and after the composer has returned to idle. the documented LangGraph SDK usage does honour it, so the common path is fine; anything hand-rolled is not.

one line in the consume loop closes it.

## why it is its own PR

found while reviewing #5522, where a refetched thread was overwritten by the run it had just cancelled. but it is not a refetch problem: `cancelActiveRun` is shared with `onCancel`, so this changes cancellation semantics for every consumer of the adapter, which does not belong under a changelog entry about reloading a thread. #5522 splits into this plus the reload work.

## test plan

- [x] react-langgraph 235/235, with a new case whose mock stream deliberately never checks `abortSignal`
- [x] verified the test is diagnostic: removing the guard fails it with `expected ... not to contain 'after-cancel'`
- [x] `pnpm lint` and oxfmt clean


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pal8Qi9t-qaJXtQaoQG8QEG2GycomQnB5La_HMnOssmPqFocwmQ-BMWoFdo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->