### PR TITLE
fix(assistant-stream): close out tool calls that have no result

### DIFF
--- a/.changeset/unresolved-tool-call-results.md
+++ b/.changeset/unresolved-tool-call-results.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: synthesize a result for tool calls that have none, so a thread holding a cancelled or abandoned tool call no longer breaks every later run

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -905,6 +905,11 @@ type MessagePartLike = {
   state?: string;
   result?: unknown;
   isError?: boolean;
+  approval?: {
+    resolution?: string;
+    [key: string]: unknown;
+  };
+  interrupt?: unknown;
 };
 
 declare type NatMap = {

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -906,6 +906,7 @@ type MessagePartLike = {
   result?: unknown;
   isError?: boolean;
   approval?: {
+    approved?: boolean;
     resolution?: string;
     [key: string]: unknown;
   };

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -902,6 +902,7 @@ type MessagePartLike = {
   toolCallId?: string;
   toolName?: string;
   args?: Record<string, unknown>;
+  state?: string;
   result?: unknown;
   isError?: boolean;
 };

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -308,7 +308,7 @@ describe("toGenericMessages", () => {
       ]);
     });
 
-    it("converts tool calls without results", () => {
+    it("closes out tool calls without results", () => {
       const result = toGenericMessages([
         {
           role: "assistant",
@@ -334,6 +334,68 @@ describe("toGenericMessages", () => {
               args: { city: "London" },
             },
           ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              result: { error: "Tool call was not completed" },
+              isError: true,
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("closes out a tool call left unresolved before a later message", () => {
+      const result = toGenericMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "never mind" }],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              result: { error: "Tool call was not completed" },
+              isError: true,
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "never mind" }],
         },
       ]);
     });
@@ -537,6 +599,18 @@ describe("toGenericMessages", () => {
             },
           ],
         },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "no_args_tool",
+              result: { error: "Tool call was not completed" },
+              isError: true,
+            },
+          ],
+        },
       ]);
     });
 
@@ -602,6 +676,13 @@ describe("toGenericMessages", () => {
               toolCallId: "call_1",
               toolName: "tool_a",
               result: "result_a",
+            },
+            {
+              type: "tool-result",
+              toolCallId: "call_2",
+              toolName: "tool_b",
+              result: { error: "Tool call was not completed" },
+              isError: true,
             },
             {
               type: "tool-result",

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -390,7 +390,10 @@ describe("toGenericMessages", () => {
       ]);
     });
 
-    it("closes out an approval resolved without a decision", () => {
+    it.each([
+      ["a cancelled approval", { id: "ap_1", resolution: "cancelled" }],
+      ["a denied approval carrying no result", { id: "ap_1", approved: false }],
+    ])("closes out %s", (_label, approval) => {
       const result = toGenericMessages([
         {
           role: "assistant",
@@ -400,7 +403,7 @@ describe("toGenericMessages", () => {
               toolCallId: "call_123",
               toolName: "get_weather",
               args: { city: "London" },
-              approval: { id: "ap_1", resolution: "cancelled" },
+              approval,
             },
           ],
         },

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -350,6 +350,89 @@ describe("toGenericMessages", () => {
       ]);
     });
 
+    it.each([
+      ["a pending approval", { approval: { id: "ap_1" } }],
+      [
+        "an approved call the host has not run yet",
+        {
+          approval: { id: "ap_1", approved: true },
+        },
+      ],
+      ["an interrupted call", { interrupt: { type: "human", payload: {} } }],
+    ])("leaves %s untouched instead of failing it", (_label, extra) => {
+      const result = toGenericMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+              ...extra,
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("closes out an approval resolved without a decision", () => {
+      const result = toGenericMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+              approval: { id: "ap_1", resolution: "cancelled" },
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              args: { city: "London" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "get_weather",
+              result: { error: "Tool call was not completed" },
+              isError: true,
+            },
+          ],
+        },
+      ]);
+    });
+
     it("treats a settled tool call carrying no result as completed", () => {
       const result = toGenericMessages([
         {

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.test.ts
@@ -350,6 +350,48 @@ describe("toGenericMessages", () => {
       ]);
     });
 
+    it("treats a settled tool call carrying no result as completed", () => {
+      const result = toGenericMessages([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "void_tool",
+              args: {},
+              state: "result",
+            },
+          ],
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call_123",
+              toolName: "void_tool",
+              args: {},
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_123",
+              toolName: "void_tool",
+              result: "<no result>",
+            },
+          ],
+        },
+      ]);
+    });
+
     it("closes out a tool call left unresolved before a later message", () => {
       const result = toGenericMessages([
         {

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -67,6 +67,7 @@ type MessagePartLike = {
   toolCallId?: string;
   toolName?: string;
   args?: Record<string, unknown>;
+  state?: string;
   result?: unknown;
   isError?: boolean;
 };
@@ -137,14 +138,18 @@ function processToolCall(
   });
 
   // Providers reject an assistant tool call that no tool result answers.
-  const unresolved = part.result === undefined;
+  const settled = part.state === "result" || part.result !== undefined;
   const toolResult: GenericToolResultPart = {
     type: "tool-result",
     toolCallId: part.toolCallId,
     toolName: part.toolName,
-    result: unresolved ? { error: "Tool call was not completed" } : part.result,
+    result: !settled
+      ? { error: "Tool call was not completed" }
+      : part.result === undefined
+        ? "<no result>"
+        : part.result,
   };
-  if (unresolved || part.isError) {
+  if (!settled || part.isError) {
     toolResult.isError = true;
   }
   accumulator.toolResults.push(toolResult);

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -70,6 +70,8 @@ type MessagePartLike = {
   state?: string;
   result?: unknown;
   isError?: boolean;
+  approval?: { resolution?: string; [key: string]: unknown };
+  interrupt?: unknown;
 };
 
 type AttachmentLike = {
@@ -124,6 +126,11 @@ type ToolCallAccumulator = {
   toolResults: GenericToolResultPart[];
 };
 
+function isAwaitingHost(part: MessagePartLike): boolean {
+  if (part.interrupt != null) return true;
+  return part.approval != null && part.approval.resolution === undefined;
+}
+
 function processToolCall(
   part: MessagePartLike,
   accumulator: ToolCallAccumulator,
@@ -137,8 +144,11 @@ function processToolCall(
     args: part.args ?? {},
   });
 
-  // Providers reject an assistant tool call that no tool result answers.
   const settled = part.state === "result" || part.result !== undefined;
+  // The in-flight message is converted on every roundtrip, so a call still awaiting a decision or an execution is live rather than failed.
+  if (!settled && isAwaitingHost(part)) return false;
+
+  // Providers reject an assistant tool call that no tool result answers.
   const toolResult: GenericToolResultPart = {
     type: "tool-result",
     toolCallId: part.toolCallId,

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -136,20 +136,19 @@ function processToolCall(
     args: part.args ?? {},
   });
 
-  if (part.result !== undefined) {
-    const toolResult: GenericToolResultPart = {
-      type: "tool-result",
-      toolCallId: part.toolCallId,
-      toolName: part.toolName,
-      result: part.result,
-    };
-    if (part.isError) {
-      toolResult.isError = true;
-    }
-    accumulator.toolResults.push(toolResult);
-    return true;
+  // Providers reject an assistant tool call that no tool result answers.
+  const unresolved = part.result === undefined;
+  const toolResult: GenericToolResultPart = {
+    type: "tool-result",
+    toolCallId: part.toolCallId,
+    toolName: part.toolName,
+    result: unresolved ? { error: "Tool call was not completed" } : part.result,
+  };
+  if (unresolved || part.isError) {
+    toolResult.isError = true;
   }
-  return false;
+  accumulator.toolResults.push(toolResult);
+  return true;
 }
 
 function flushAccumulator(

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -70,7 +70,11 @@ type MessagePartLike = {
   state?: string;
   result?: unknown;
   isError?: boolean;
-  approval?: { resolution?: string; [key: string]: unknown };
+  approval?: {
+    approved?: boolean;
+    resolution?: string;
+    [key: string]: unknown;
+  };
   interrupt?: unknown;
 };
 
@@ -128,7 +132,10 @@ type ToolCallAccumulator = {
 
 function isAwaitingHost(part: MessagePartLike): boolean {
   if (part.interrupt != null) return true;
-  return part.approval != null && part.approval.resolution === undefined;
+  if (part.approval == null) return false;
+  return (
+    part.approval.approved !== false && part.approval.resolution === undefined
+  );
 }
 
 function processToolCall(


### PR DESCRIPTION
## summary

- a thread holding a tool call that never got a result (a cancelled run, an abandoned frontend tool, a page closed mid flight) converted into a history whose assistant tool call nothing answers, so every later run on that thread failed before the request was even sent
- `toGenericMessages` pushed the `tool-call` part unconditionally but only emitted a matching `tool-result` when the part carried one. the AI SDK rejects that shape in `convertToLanguageModelPrompt` with `AI_MissingToolResultsError`, and providers reject it directly too (OpenAI 400s on an assistant `tool_calls` message that no tool message answers)
- a call nothing can still answer now gets a synthesized `{ error: "Tool call was not completed" }` result with `isError: true`. that is the shape the runtime already writes when a tool approval is denied (`packages/core/src/runtimes/local/local-thread-runtime-core.ts`), and downstream converters already map `isError` onto the AI SDK `error-json` output, so the model sees a tool that did not finish rather than a missing turn
- dropping the unresolved `tool-call` instead was the alternative and was rejected: an assistant turn holding only that call would vanish from the history, and the model would just call the same tool again

## what counts as "nothing can still answer"

this converter runs on the in-flight message, not only on settled history: `useDataStreamRuntime` sends `[...messages, unstable_getMessage()]` through `toLanguageModelMessages` on every roundtrip (`packages/react-data-stream/src/useDataStreamRuntime.ts:111`). so the predicate has to separate a dead call from a live one.

- settled, and left alone: `state === "result"`, or any `result` present
- live, and left alone: an `interrupt`, or an `approval` still undecided or approved but not yet executed. `respondToToolApproval` leaves `result` undefined on the approved branch and `shouldContinue` re-enters the run loop on `approval !== undefined`, so without this the call the host is about to execute would be reported to the model as a failure
- terminal, and closed out: no result and no live marker, an approval with `resolution` cancelled or expired, or an approval denied without a persisted result

`packages/core/src/react/runtimes/external-message-converter.ts:34-42` already encodes the live-versus-dead distinction as `isInterruptedToolCall`; this mirrors it.

## test plan

### already verified

- [x] `pnpm --filter assistant-stream test` -> 371 passed, 20 skipped
- [x] `pnpm --filter @assistant-ui/react-data-stream test` -> 20 passed (the only other in-repo consumer, through `toLanguageModelMessages`)
- [x] `tsc --noEmit` clean in both packages, `oxlint` and `oxfmt --check` clean

### reviewer should verify

- [ ] on a thread whose last assistant turn holds a tool call with no result (cancel a run mid tool call, or start a frontend tool and never answer it), send another message and confirm the run goes through instead of failing with `AI_MissingToolResultsError`
- [ ] approve a tool call that needs approval and confirm the model is not told the call failed while the host is still executing it
- [ ] 4 existing tests changed expectation deliberately, since they locked in "no result means no tool message"

## notes

- known gap, tracked in #5536: `ToolCallMessagePart` has no settled marker, so a tool completing with `new ToolResponse({ result: undefined })` still reads as unresolved on the ThreadMessage path. `isError` cannot stand in for it because `auiV0.ts:275` only persists the flag when truthy. closing it means a public type change across `@assistant-ui/core` and the persistence encoder
- a live call still emits no tool message, so text following it stays in the same assistant message. only a call that produces a tool result splits the assistant turn, which is the behavior that already existed for resolved calls

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.xjJf3if64goKCRzRbMKAkfN-d_u_47ICOyoaefBLNT-52i9LNXjAf0eN8D8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->