### PR TITLE
fix: keep a settled tool call distinguishable from an unfinished one

### DIFF
--- a/.changeset/settled-tool-call-result.md
+++ b/.changeset/settled-tool-call-result.md
@@ -1,0 +1,7 @@
+---
+"assistant-stream": patch
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: keep a settled tool call distinguishable from an unfinished one, so a tool returning false, 0, "" or null no longer loses its result on the cloud round trip and no longer reads as never completed

--- a/packages/assistant-stream/src/core/converters/toGenericMessages.ts
+++ b/packages/assistant-stream/src/core/converters/toGenericMessages.ts
@@ -4,6 +4,8 @@
  * various LLM provider formats (AI SDK, LangChain, etc.).
  */
 
+import { NO_RESULT } from "../tool/ToolResponse";
+
 export type GenericTextPart = {
   type: "text";
   text: string;
@@ -163,7 +165,7 @@ function processToolCall(
     result: !settled
       ? { error: "Tool call was not completed" }
       : part.result === undefined
-        ? "<no result>"
+        ? NO_RESULT
         : part.result,
   };
   if (!settled || part.isError) {

--- a/packages/assistant-stream/src/core/modules/tool-call.ts
+++ b/packages/assistant-stream/src/core/modules/tool-call.ts
@@ -1,6 +1,6 @@
 import type { AssistantStream } from "../AssistantStream";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
-import type { ToolResponseLike } from "../tool/ToolResponse";
+import { NO_RESULT, type ToolResponseLike } from "../tool/ToolResponse";
 import type { ReadonlyJSONValue } from "../../utils/json/json-value";
 import type { UnderlyingReadable } from "../utils/stream/UnderlyingReadable";
 import { createTextStream, type TextStreamController } from "./text";
@@ -74,13 +74,18 @@ class ToolCallStreamControllerImpl implements ToolCallStreamController {
   async setResponse(response: ToolResponseLike<ReadonlyJSONValue>) {
     if (this._isClosed) return;
 
+    // Wire decoders hand this a raw payload, so an omitted result is
+    // materialized here rather than reaching the message part as a settled call
+    // indistinguishable from one that never finished.
+    const result = response.result;
+
     this._controller.enqueue({
       type: "result",
       path: [],
       ...(response.artifact !== undefined
         ? { artifact: response.artifact }
         : {}),
-      result: response.result,
+      result: result === undefined ? NO_RESULT : result,
       isError: response.isError ?? false,
       ...(response.modelContent !== undefined
         ? { modelContent: response.modelContent }

--- a/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/ui-message-stream/UIMessageStream.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { UIMessageStreamDecoder } from "./UIMessageStream";
 import type { AssistantStreamChunk } from "../../AssistantStreamChunk";
+import { NO_RESULT } from "../../tool/ToolResponse";
 
 // Helper function to collect all chunks from a stream
 async function collectChunks<T>(stream: ReadableStream<T>): Promise<T[]> {
@@ -750,5 +751,36 @@ describe("UIMessageStreamDecoder", () => {
     const byPath = new Map(argDeltas.map((c) => [c.path[0], c.textDelta]));
     expect(byPath.get(0)).toBe("{}");
     expect(byPath.get(1)).toBe('{"x":1}');
+  });
+
+  it("materializes a tool result frame that carries no result", async () => {
+    const events = [
+      JSON.stringify({ type: "start", messageId: "msg_123" }),
+      JSON.stringify({
+        type: "tool-call-start",
+        id: "tc_1",
+        toolCallId: "call_abc",
+        toolName: "notify",
+      }),
+      JSON.stringify({ type: "tool-call-delta", argsText: "{}" }),
+      JSON.stringify({ type: "tool-call-end" }),
+      JSON.stringify({ type: "tool-result", toolCallId: "call_abc" }),
+      JSON.stringify({
+        type: "finish",
+        finishReason: "stop",
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }),
+      "[DONE]",
+    ];
+
+    const stream = createUIMessageStream(events);
+    const decodedStream = stream.pipeThrough(new UIMessageStreamDecoder());
+    const chunks = await collectChunks(decodedStream);
+
+    const result = chunks.find(
+      (c): c is AssistantStreamChunk & { type: "result" } =>
+        c.type === "result",
+    );
+    expect(result?.result).toBe(NO_RESULT);
   });
 });

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -177,7 +177,6 @@ export class ToolExecutionStream extends PipeableTransformStream<
 
                   if (c === undefined) return;
 
-                  // TODO how to handle new ToolResult({ result: undefined })?
                   const result = new ToolResponse({
                     artifact: c.artifact,
                     result: c.result,

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -9,7 +9,7 @@ import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "../../utils/json/json-value";
-import { NO_RESULT, ToolResponse } from "./ToolResponse";
+import { ToolResponse } from "./ToolResponse";
 import { withPromiseOrValue } from "../utils/withPromiseOrValue";
 import { ToolCallReaderImpl } from "./ToolCallReader";
 import type { ToolCallReader } from "./tool-types";
@@ -179,7 +179,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
 
                   const result = new ToolResponse({
                     artifact: c.artifact,
-                    result: c.result === undefined ? NO_RESULT : c.result,
+                    result: c.result,
                     isError: c.isError,
                     messages: c.messages,
                     modelContent: c.modelContent,

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -9,7 +9,7 @@ import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from "../../utils/json/json-value";
-import { ToolResponse } from "./ToolResponse";
+import { NO_RESULT, ToolResponse } from "./ToolResponse";
 import { withPromiseOrValue } from "../utils/withPromiseOrValue";
 import { ToolCallReaderImpl } from "./ToolCallReader";
 import type { ToolCallReader } from "./tool-types";
@@ -179,7 +179,7 @@ export class ToolExecutionStream extends PipeableTransformStream<
 
                   const result = new ToolResponse({
                     artifact: c.artifact,
-                    result: c.result,
+                    result: c.result === undefined ? NO_RESULT : c.result,
                     isError: c.isError,
                     messages: c.messages,
                     modelContent: c.modelContent,

--- a/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { NO_RESULT, ToolResponse } from "./ToolResponse";
+
+describe("ToolResponse", () => {
+  describe("constructor", () => {
+    it("materializes an absent result", () => {
+      expect(new ToolResponse({ result: undefined }).result).toBe(NO_RESULT);
+    });
+
+    it.each([
+      ["false", false],
+      ["zero", 0],
+      ["an empty string", ""],
+      ["null", null],
+    ])("keeps %s as the result", (_label, result) => {
+      expect(new ToolResponse({ result }).result).toBe(result);
+    });
+
+    it("defaults isError to false", () => {
+      expect(new ToolResponse({ result: "ok" }).isError).toBe(false);
+    });
+  });
+
+  describe("toResponse", () => {
+    it("returns an existing response unchanged", () => {
+      const response = new ToolResponse({ result: "ok" });
+      expect(ToolResponse.toResponse(response)).toBe(response);
+    });
+
+    it("materializes an absent result", () => {
+      expect(ToolResponse.toResponse(undefined).result).toBe(NO_RESULT);
+    });
+
+    it("wraps a plain value", () => {
+      expect(ToolResponse.toResponse({ temp: 20 }).result).toEqual({
+        temp: 20,
+      });
+    });
+  });
+});

--- a/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
@@ -3,8 +3,8 @@ import { NO_RESULT, ToolResponse } from "./ToolResponse";
 
 describe("ToolResponse", () => {
   describe("constructor", () => {
-    it("materializes an absent result", () => {
-      expect(new ToolResponse({ result: undefined }).result).toBe(NO_RESULT);
+    it("keeps an absent result absent, leaving materialization to the emitter", () => {
+      expect(new ToolResponse({ result: undefined }).result).toBeUndefined();
     });
 
     it.each([

--- a/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.test.ts
@@ -3,8 +3,8 @@ import { NO_RESULT, ToolResponse } from "./ToolResponse";
 
 describe("ToolResponse", () => {
   describe("constructor", () => {
-    it("keeps an absent result absent, leaving materialization to the emitter", () => {
-      expect(new ToolResponse({ result: undefined }).result).toBeUndefined();
+    it("materializes an absent result", () => {
+      expect(new ToolResponse({ result: undefined }).result).toBe(NO_RESULT);
     });
 
     it.each([

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -7,6 +7,9 @@ import type {
 
 const TOOL_RESPONSE_SYMBOL = Symbol.for("aui.tool-response");
 
+/** Stand-in result for a tool that completed without returning a value. */
+export const NO_RESULT = "<no result>";
+
 /**
  * Shape accepted anywhere a {@link ToolResponse} can be returned.
  */
@@ -64,7 +67,13 @@ export class ToolResponse<TResult> {
     if (options.artifact !== undefined) {
       this.artifact = options.artifact;
     }
-    this.result = options.result;
+    // A settled tool call is recognized downstream by carrying a result, so an
+    // absent one is materialized rather than left indistinguishable from a call
+    // that never completed.
+    this.result =
+      options.result === undefined
+        ? (NO_RESULT as unknown as TResult)
+        : options.result;
     this.isError = options.isError ?? false;
     if (options.modelContent !== undefined) {
       this.modelContent = options.modelContent;
@@ -93,8 +102,6 @@ export class ToolResponse<TResult> {
     if (result instanceof ToolResponse) {
       return result;
     }
-    return new ToolResponse({
-      result: result === undefined ? "<no result>" : result,
-    });
+    return new ToolResponse({ result });
   }
 }

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -70,10 +70,9 @@ export class ToolResponse<TResult> {
     // A part written with `state: "result"` is recognized as settled by
     // carrying a result, and several writers put a response onto the part
     // without ever emitting a chunk, so an absent result is materialized here.
+    const result = options.result;
     this.result =
-      options.result === undefined
-        ? (NO_RESULT as unknown as TResult)
-        : options.result;
+      result === undefined ? (NO_RESULT as unknown as TResult) : result;
     this.isError = options.isError ?? false;
     if (options.modelContent !== undefined) {
       this.modelContent = options.modelContent;

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -67,13 +67,7 @@ export class ToolResponse<TResult> {
     if (options.artifact !== undefined) {
       this.artifact = options.artifact;
     }
-    // A settled tool call is recognized downstream by carrying a result, so an
-    // absent one is materialized rather than left indistinguishable from a call
-    // that never completed.
-    this.result =
-      options.result === undefined
-        ? (NO_RESULT as unknown as TResult)
-        : options.result;
+    this.result = options.result;
     this.isError = options.isError ?? false;
     if (options.modelContent !== undefined) {
       this.modelContent = options.modelContent;
@@ -102,6 +96,8 @@ export class ToolResponse<TResult> {
     if (result instanceof ToolResponse) {
       return result;
     }
-    return new ToolResponse({ result });
+    return new ToolResponse({
+      result: result === undefined ? NO_RESULT : result,
+    });
   }
 }

--- a/packages/assistant-stream/src/core/tool/ToolResponse.ts
+++ b/packages/assistant-stream/src/core/tool/ToolResponse.ts
@@ -67,7 +67,13 @@ export class ToolResponse<TResult> {
     if (options.artifact !== undefined) {
       this.artifact = options.artifact;
     }
-    this.result = options.result;
+    // A part written with `state: "result"` is recognized as settled by
+    // carrying a result, and several writers put a response onto the part
+    // without ever emitting a chunk, so an absent result is materialized here.
+    this.result =
+      options.result === undefined
+        ? (NO_RESULT as unknown as TResult)
+        : options.result;
     this.isError = options.isError ?? false;
     if (options.modelContent !== undefined) {
       this.modelContent = options.modelContent;

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -3,7 +3,7 @@ import {
   toolResultStream as unstable_toolResultStream,
   unstable_runPendingTools,
 } from "./toolResultStream";
-import { ToolResponse } from "./ToolResponse";
+import { NO_RESULT, ToolResponse } from "./ToolResponse";
 import type { AssistantStreamChunk } from "../AssistantStreamChunk";
 import type { AssistantMessage, ToolCallPart } from "../utils/types";
 import type { Tool } from "./tool-types";
@@ -33,6 +33,45 @@ const captureUnhandledRejections = async (
 };
 
 describe("unstable_runPendingTools", () => {
+  it("settles a tool that returns no value with a concrete result", async () => {
+    const message: AssistantMessage = {
+      role: "assistant",
+      status: { type: "requires-action", reason: "tool-calls" },
+      parts: [
+        {
+          type: "tool-call",
+          toolCallId: "1",
+          toolName: "notify",
+          args: {},
+        } as ToolCallPart,
+      ],
+      content: [],
+      metadata: {
+        unstable_state: {},
+        unstable_data: [],
+        unstable_annotations: [],
+        steps: [],
+        custom: {},
+      },
+    };
+
+    const settled = await unstable_runPendingTools(
+      message,
+      {
+        notify: {
+          parameters: { type: "object", properties: {} },
+          execute: async () => new ToolResponse({ result: undefined }),
+        },
+      },
+      new AbortController().signal,
+      async () => {},
+    );
+
+    const part = settled.parts[0] as ToolCallPart;
+    expect(part.state).toBe("result");
+    expect(part.result).toBe(NO_RESULT);
+  });
+
   it("removes the abort listener after tool execution settles", async () => {
     const abortController = new AbortController();
     const addEventListener = vi.spyOn(

--- a/packages/core/src/react/runtimes/cloud/auiV0.ts
+++ b/packages/core/src/react/runtimes/cloud/auiV0.ts
@@ -257,7 +257,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
           };
 
         case "tool-call": {
-          if (!isJSONValue(part.result)) {
+          if (part.result !== undefined && !isJSONValue(part.result)) {
             console.warn(
               `tool-call result is not JSON! ${JSON.stringify(part)}`,
             );
@@ -269,7 +269,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             ...(JSON.stringify(part.args) === part.argsText
               ? { args: part.args }
               : { argsText: part.argsText }),
-            ...(part.result
+            ...(part.result !== undefined
               ? { result: part.result as ReadonlyJSONValue }
               : undefined),
             ...(part.isError ? { isError: true } : undefined),

--- a/packages/core/src/tests/auiV0Encode.test.ts
+++ b/packages/core/src/tests/auiV0Encode.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { auiV0Decode, auiV0Encode } from "../react/runtimes/cloud/auiV0";
 
 describe("auiV0Encode", () => {
@@ -406,5 +406,74 @@ describe("auiV0Decode", () => {
         ],
       },
     ]);
+  });
+
+  const toolCallMessage = (
+    part: Record<string, unknown>,
+  ): Parameters<typeof auiV0Encode>[0] => ({
+    id: "m1",
+    createdAt: new Date("2026-03-15T00:00:00.000Z"),
+    role: "assistant",
+    status: { type: "complete", reason: "stop" },
+    metadata: {
+      unstable_state: null,
+      unstable_annotations: [],
+      unstable_data: [],
+      steps: [],
+      custom: {},
+    },
+    content: [
+      {
+        type: "tool-call",
+        toolCallId: "call-1",
+        toolName: "check_flag",
+        args: {},
+        argsText: "{}",
+        ...part,
+      },
+    ],
+  });
+
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+    ["null", null],
+  ])("preserves %s as a tool-call result", (_label, result) => {
+    const encoded = auiV0Encode(toolCallMessage({ result }));
+
+    const toolCall = encoded.content.find((p) => p.type === "tool-call");
+    expect(toolCall).toHaveProperty("result", result);
+  });
+
+  it("omits the result of a tool call that has not settled", () => {
+    const encoded = auiV0Encode(toolCallMessage({}));
+
+    const toolCall = encoded.content.find((p) => p.type === "tool-call");
+    expect(toolCall).not.toHaveProperty("result");
+  });
+
+  it("does not warn about a tool call that has not settled", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      auiV0Encode(toolCallMessage({}));
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("carries a falsy tool-call result through a decode round trip", () => {
+    const encoded = auiV0Encode(toolCallMessage({ result: false }));
+    const { message } = auiV0Decode({
+      id: "m1",
+      parent_id: null,
+      format: "aui/v0",
+      content: encoded,
+      created_at: new Date("2026-03-15T00:00:00.000Z"),
+    } as unknown as Parameters<typeof auiV0Decode>[0]);
+
+    const toolCall = message.content.find((p) => p.type === "tool-call");
+    expect(toolCall).toHaveProperty("result", false);
   });
 });

--- a/packages/react/src/legacy-runtime/cloud/auiV0.ts
+++ b/packages/react/src/legacy-runtime/cloud/auiV0.ts
@@ -257,7 +257,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
           };
 
         case "tool-call": {
-          if (!isJSONValue(part.result)) {
+          if (part.result !== undefined && !isJSONValue(part.result)) {
             console.warn(
               `tool-call result is not JSON! ${JSON.stringify(part)}`,
             );
@@ -269,7 +269,7 @@ export function auiV0Encode(message: ThreadMessage): AuiV0Message {
             ...(JSON.stringify(part.args) === part.argsText
               ? { args: part.args }
               : { argsText: part.argsText }),
-            ...(part.result
+            ...(part.result !== undefined
               ? { result: part.result as ReadonlyJSONValue }
               : undefined),
             ...(part.isError ? { isError: true } : undefined),


### PR DESCRIPTION
closes #5536

## summary

- a tool that completes without a meaningful return value was indistinguishable from one that never completed, so it read as unresolved everywhere downstream. #5535 made that visible by converting an unresolved call into a synthetic `{ error: "Tool call was not completed" }` for the model
- the repo already states the invariant that closes this. `ToolResponse.toResponse` documents that `undefined` becomes `"<no result>"` **so downstream protocol chunks always carry a concrete result**. this makes that invariant true instead of adding a parallel marker on the message part
- **an absent result is materialized at both entry classes.** the real invariant is a property of the part, not of the chunk: a part written with `state: "result"` must carry a concrete result. the `ToolResponse` constructor covers every path that carries a response object, including the two that settle a part without emitting a chunk at all (`addToolResult` through `local-thread-runtime-core`, and `unstable_runPendingTools` in `toolResultStream`). `ToolCallStreamController.setResponse` covers the raw payload the wire decoders build from unvalidated JSON, which never passes through a `ToolResponse`
- **the `aui/v0` encoder no longer drops falsy results.** it guarded with `part.result ? ... : undefined`, so a tool returning `false`, `0`, `""` or `null` had its result stripped on the way into storage and came back looking unfinished. this is wider than the `undefined` case in the issue and is real data loss. both the core encoder and the `@assistant-ui/react` legacy copy are fixed
- **an absent result no longer trips the non-JSON warning.** `isJSONValue(undefined)` is `false`, so every pending approval and every in-flight frontend tool logged `tool-call result is not JSON!` with the whole part dumped to the console

## why not a settled marker on the part

#5536 proposed adding an explicit marker to `ToolCallMessagePart` and carrying it through the persistence encoder. that was rejected after reading the paths: it is a public type change across two packages, it cannot repair already-persisted rows, and it would sit next to the defect rather than fix it. with the invariant true end to end, `result !== undefined` is correct by construction. `@assistant-ui/core`, the `aui/v0` stored shape, and `ToolCallMessagePart` are all untouched.

## why two materialization points

review drove this to the right shape twice, so it is worth writing down. normalizing only in the constructor misses the wire decoders: `setResponse` accepts a `ToolResponseLike`, and `DataStream.ts` and `UIMessageStream.ts` both hand it a raw object literal, so a backend result frame omitting `result` never touches a `ToolResponse`. normalizing only at the chunk emitters misses `addToolResult` and `unstable_runPendingTools`, which write a settled part directly from a response object with no chunk in between. the two together cover every writer, and each has a regression test that fails without it.

## test plan

### already verified

each new case was checked against the pre-fix code by reverting the corresponding line and re-running:

- [x] `UIMessageStream`: a `tool-result` frame with no `result` (the wire decoder path) -> fails without the `setResponse` line
- [x] `toolResultStream`: `unstable_runPendingTools` with a tool returning `new ToolResponse({ result: undefined })` (the no-chunk path) -> fails without the constructor line
- [x] `auiV0Encode`: 5 falsy-result cases -> fail on the pre-fix encoder
- [x] `assistant-stream` 382 passed / 20 skipped, `@assistant-ui/core` 875 passed, `@assistant-ui/react` 381 passed, `@assistant-ui/react-data-stream` 20 passed
- [x] `tsc --noEmit` and `oxlint` / `oxfmt --check` report nothing on any touched file (`@assistant-ui/core` and `@assistant-ui/react` carry pre-existing errors in unrelated test files, unchanged in count from the base commit)

### reviewer should verify

- [ ] a frontend tool returning `false` (a boolean check, a "did it apply" flag) keeps its result across a cloud reload instead of coming back as an unfinished call
- [ ] a backend tool result frame that omits `result` settles the call rather than leaving it open