### PR TITLE
chore(docs): refresh the model list to the cheapest current models

### DIFF
--- a/apps/docs/app/api/playground-chat/route.ts
+++ b/apps/docs/app/api/playground-chat/route.ts
@@ -157,7 +157,7 @@ export async function POST(req: Request) {
       return new Response("Config too large", { status: 400 });
     }
 
-    const model = getModel("openai/gpt-5.4-nano");
+    const model = getModel();
 
     const prunedMessages = pruneMessages({
       messages: await convertToModelMessages(messages),

--- a/apps/docs/app/api/xulux/chat/route.ts
+++ b/apps/docs/app/api/xulux/chat/route.ts
@@ -66,7 +66,7 @@ function resolveXuluxModel(config: unknown) {
   }
 
   return {
-    model: modelName ? getModel(modelName) : getModel("gpt-5.4-mini"),
+    model: getModel(modelName),
     providerOptions: undefined,
   };
 }

--- a/apps/docs/components/docs/samples/model-selector.radix.tsx
+++ b/apps/docs/components/docs/samples/model-selector.radix.tsx
@@ -23,6 +23,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   openai: "OpenAI",
   "google-ai-studio": "Google",
   grok: "xAI",
+  deepseek: "DeepSeek",
   groq: "Groq",
 };
 
@@ -32,11 +33,7 @@ function providerOf(modelId: string): string {
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
-const EFFORT_SUPPORTED_MODELS = new Set([
-  "gpt-5.4-nano",
-  "gpt-5.4-mini",
-  "grok/grok-3-mini",
-]);
+const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna", "grok/grok-4-1-fast"]);
 
 const models: ModelOption[] = [];
 const modelsByProvider = new Map<string, ModelOption[]>();

--- a/apps/docs/components/docs/samples/model-selector.radix.tsx
+++ b/apps/docs/components/docs/samples/model-selector.radix.tsx
@@ -33,7 +33,7 @@ function providerOf(modelId: string): string {
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
-const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna", "grok/grok-4-1-fast"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna"]);
 
 const models: ModelOption[] = [];
 const modelsByProvider = new Map<string, ModelOption[]>();

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -24,6 +24,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   openai: "OpenAI",
   "google-ai-studio": "Google",
   grok: "xAI",
+  deepseek: "DeepSeek",
   groq: "Groq",
 };
 
@@ -33,11 +34,7 @@ function providerOf(modelId: string): string {
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
-const EFFORT_SUPPORTED_MODELS = new Set([
-  "gpt-5.4-nano",
-  "gpt-5.4-mini",
-  "grok/grok-3-mini",
-]);
+const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna", "grok/grok-4-1-fast"]);
 
 const models: ModelOption[] = [];
 const modelsByProvider = new Map<string, ModelOption[]>();

--- a/apps/docs/components/docs/samples/model-selector.tsx
+++ b/apps/docs/components/docs/samples/model-selector.tsx
@@ -34,7 +34,7 @@ function providerOf(modelId: string): string {
 
 const compactNumber = new Intl.NumberFormat("en", { notation: "compact" });
 
-const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna", "grok/grok-4-1-fast"]);
+const EFFORT_SUPPORTED_MODELS = new Set(["gpt-5.6-luna"]);
 
 const models: ModelOption[] = [];
 const modelsByProvider = new Map<string, ModelOption[]>();

--- a/apps/docs/components/xulux/chat/XuluxThread.tsx
+++ b/apps/docs/components/xulux/chat/XuluxThread.tsx
@@ -31,14 +31,14 @@ import { useXuluxTemplateContext } from "./XuluxTemplateContext";
 import { XuluxToolCall } from "./XuluxToolCall";
 import { XuluxUsageLimitBanner } from "./XuluxUsageLimitBanner";
 
-const XULUX_CONTEXT_WINDOW = 400_000;
-const XULUX_DEFAULT_MODEL_ID = "gpt-5.4-mini";
+const XULUX_CONTEXT_WINDOW = 1_050_000;
+const XULUX_DEFAULT_MODEL_ID = "gpt-5.6-luna";
 
 const XULUX_MODELS = [
   {
-    id: "gpt-5.4-mini",
-    name: "GPT-5.4 Mini",
-    modelName: "gpt-5.4-mini",
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6 Luna",
+    modelName: "gpt-5.6-luna",
   },
 ] as const;
 

--- a/apps/docs/components/xulux/landing/xulux-suggestions.ts
+++ b/apps/docs/components/xulux/landing/xulux-suggestions.ts
@@ -246,7 +246,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
 

--- a/apps/docs/constants/model.ts
+++ b/apps/docs/constants/model.ts
@@ -40,9 +40,9 @@ export const MODELS = [
     contextWindow: 131_072,
   },
   {
-    name: "Llama 3.1 8B Instant",
-    value: "groq/llama-3.1-8b-instant",
-    icon: "/icons/meta.svg",
+    name: "GPT-OSS 120B",
+    value: "groq/openai/gpt-oss-120b",
+    icon: "/icons/openai.svg",
     disabled: false,
     contextWindow: 131_072,
   },

--- a/apps/docs/constants/model.ts
+++ b/apps/docs/constants/model.ts
@@ -1,23 +1,16 @@
 export const MODELS = [
   // OpenAI
   {
-    name: "GPT-5.4 Nano",
-    value: "gpt-5.4-nano",
+    name: "GPT-5.6 Luna",
+    value: "gpt-5.6-luna",
     icon: "/icons/openai.svg",
     disabled: false,
-    contextWindow: 400_000,
-  },
-  {
-    name: "GPT-5.4 Mini",
-    value: "gpt-5.4-mini",
-    icon: "/icons/openai.svg",
-    disabled: false,
-    contextWindow: 400_000,
+    contextWindow: 1_050_000,
   },
   // Google
   {
     name: "Gemini 3.1 Flash Lite",
-    value: "google-ai-studio/gemini-3.1-flash-lite-preview",
+    value: "google-ai-studio/gemini-3.1-flash-lite",
     icon: "/icons/google.svg",
     disabled: false,
     contextWindow: 1_048_576,
@@ -30,25 +23,26 @@ export const MODELS = [
     disabled: false,
     contextWindow: 2_000_000,
   },
+  // DeepSeek
   {
-    name: "Grok 3 Mini",
-    value: "grok/grok-3-mini",
-    icon: "/icons/xai.svg",
+    name: "DeepSeek V4 Flash",
+    value: "deepseek/deepseek-v4-flash",
+    icon: "/icons/deepseek.svg",
     disabled: false,
-    contextWindow: 131_072,
+    contextWindow: 1_000_000,
   },
   // Groq
   {
-    name: "Llama 4 Scout 17B",
-    value: "groq/meta-llama/llama-4-scout-17b-16e-instruct",
-    icon: "/icons/meta.svg",
+    name: "GPT-OSS 20B",
+    value: "groq/openai/gpt-oss-20b",
+    icon: "/icons/openai.svg",
     disabled: false,
     contextWindow: 131_072,
   },
   {
-    name: "Qwen3 32B",
-    value: "groq/qwen/qwen3-32b",
-    icon: "/icons/groq.svg",
+    name: "Llama 3.1 8B Instant",
+    value: "groq/llama-3.1-8b-instant",
+    icon: "/icons/meta.svg",
     disabled: false,
     contextWindow: 131_072,
   },

--- a/apps/docs/content/docs/(docs)/installation.mdx
+++ b/apps/docs/content/docs/(docs)/installation.mdx
@@ -140,7 +140,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     system,
     messages: await convertToModelMessages(messages),
     tools: frontendTools(tools),

--- a/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk-assistant-ui.mdx
@@ -393,7 +393,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages,
   });
 

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -391,7 +391,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages,
   });
 
@@ -459,7 +459,7 @@ export async function POST(req: Request) {
   const samplingCalls: Record<string, SamplingCallData[]> = {};
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages,
     tools: {
       delegate_to_gemini: tool({

--- a/apps/docs/content/docs/guides/chain-of-thought.mdx
+++ b/apps/docs/content/docs/guides/chain-of-thought.mdx
@@ -109,7 +109,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
 

--- a/apps/docs/content/docs/guides/electron.mdx
+++ b/apps/docs/content/docs/guides/electron.mdx
@@ -214,7 +214,7 @@ export function registerAssistantIpc(mainWindow: BrowserWindow) {
     void (async () => {
       try {
         const result = streamText({
-          model: openai("gpt-5.4-mini"),
+          model: openai("gpt-5.6-luna"),
           messages: request.messages,
           ...(request.system ? { system: request.system } : {}),
           abortSignal: abortController.signal,

--- a/apps/docs/content/docs/integrations/auth/better-auth.mdx
+++ b/apps/docs/content/docs/integrations/auth/better-auth.mdx
@@ -66,7 +66,7 @@ export async function POST(req: Request) {
 
   const { messages }: { messages: UIMessage[] } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
   return result.toUIMessageStreamResponse();

--- a/apps/docs/content/docs/integrations/auth/clerk.mdx
+++ b/apps/docs/content/docs/integrations/auth/clerk.mdx
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
 
   const { messages }: { messages: UIMessage[] } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
   return result.toUIMessageStreamResponse();

--- a/apps/docs/content/docs/integrations/auth/next-auth.mdx
+++ b/apps/docs/content/docs/integrations/auth/next-auth.mdx
@@ -72,7 +72,7 @@ export async function POST(req: Request) {
 
   const { messages }: { messages: UIMessage[] } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
   return result.toUIMessageStreamResponse();

--- a/apps/docs/content/docs/integrations/frameworks/cloudflare-agents/overview.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/cloudflare-agents/overview.mdx
@@ -68,7 +68,7 @@ export type Env = {
 export class Chat extends AIChatAgent<Env> {
   async onChatMessage(onFinish: Parameters<typeof streamText>[0]["onFinish"]) {
     return streamText({
-      model: openai("gpt-5.4-nano"),
+      model: openai("gpt-5.6-luna"),
       messages: await convertToModelMessages(this.messages),
       onFinish,
     });

--- a/apps/docs/content/docs/integrations/frameworks/mastra/full-stack.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/full-stack.mdx
@@ -81,11 +81,11 @@ export const chefAgent = new Agent({
   instructions:
     "You are Michel, a practical and experienced home chef. " +
     "You help people cook with whatever ingredients they have available.",
-  model: "openai/gpt-5.4-mini",
+  model: "openai/gpt-5.6-luna",
 });
 ```
 
-`model: "openai/gpt-5.4-mini"` uses Mastra's model router. Set the provider key in `.env.local` so Next.js auto-loads it:
+`model: "openai/gpt-5.6-luna"` uses Mastra's model router. Set the provider key in `.env.local` so Next.js auto-loads it:
 
 ```sh title=".env.local"
 OPENAI_API_KEY=sk-...

--- a/apps/docs/content/docs/integrations/frameworks/mastra/separate-server.mdx
+++ b/apps/docs/content/docs/integrations/frameworks/mastra/separate-server.mdx
@@ -50,7 +50,7 @@ export const chefAgent = new Agent({
   instructions:
     "You are Michel, a practical and experienced home chef. " +
     "You help people cook with whatever ingredients they have available.",
-  model: "openai/gpt-5.4-nano",
+  model: "openai/gpt-5.6-luna",
 });
 ```
 

--- a/apps/docs/content/docs/integrations/gateways/index.mdx
+++ b/apps/docs/content/docs/integrations/gateways/index.mdx
@@ -48,7 +48,7 @@ The rest of this page is what to put in `baseURL`, `headers`, and `model(...)` f
 
 ## OpenRouter
 
-[OpenRouter](https://openrouter.ai/) aggregates 100+ models behind one OpenAI-compatible endpoint. The model ID is `provider/model` (e.g., `anthropic/claude-sonnet-4.6`, `openai/gpt-5.4-mini`, `meta-llama/llama-3.3-70b-instruct`).
+[OpenRouter](https://openrouter.ai/) aggregates 100+ models behind one OpenAI-compatible endpoint. The model ID is `provider/model` (e.g., `anthropic/claude-sonnet-4.6`, `openai/gpt-5.6-luna`, `meta-llama/llama-3.3-70b-instruct`).
 
 ```sh title=".env.local"
 OPENROUTER_API_KEY=sk-or-...
@@ -129,7 +129,7 @@ const litellm = createOpenAI({
 });
 
 const result = streamText({
-  model: litellm("gpt-5.4-mini"),
+  model: litellm("gpt-5.6-luna"),
   messages: await convertToModelMessages(messages),
 });
 ```

--- a/apps/docs/content/docs/integrations/observability/helicone.mdx
+++ b/apps/docs/content/docs/integrations/observability/helicone.mdx
@@ -57,7 +57,7 @@ const openai = createOpenAI({
 export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
   return result.toUIMessageStreamResponse();
@@ -80,7 +80,7 @@ const openai = new OpenAI({
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const stream = await openai.chat.completions.create({
-    model: "gpt-5.4-mini",
+    model: "gpt-5.6-luna",
     messages,
     stream: true,
   });

--- a/apps/docs/content/docs/integrations/observability/langfuse.mdx
+++ b/apps/docs/content/docs/integrations/observability/langfuse.mdx
@@ -101,7 +101,7 @@ export async function POST(req: Request) {
     { traceName: "chat-completion", userId, sessionId },
     async () =>
       streamText({
-        model: openai("gpt-5.4-nano"),
+        model: openai("gpt-5.6-luna"),
         messages: await convertToModelMessages(messages),
         experimental_telemetry: { isEnabled: true },
       }),

--- a/apps/docs/content/docs/integrations/observability/langsmith.mdx
+++ b/apps/docs/content/docs/integrations/observability/langsmith.mdx
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await ai.convertToModelMessages(messages),
   });
 
@@ -84,7 +84,7 @@ Pass a `langsmith` provider option to tag traces with user, session, or run iden
 import { createLangSmithProviderOptions } from "langsmith/experimental/vercel";
 
 const result = streamText({
-  model: openai("gpt-5.4-nano"),
+  model: openai("gpt-5.6-luna"),
   messages: await ai.convertToModelMessages(messages),
   providerOptions: {
     langsmith: createLangSmithProviderOptions({

--- a/apps/docs/content/docs/react-native/index.mdx
+++ b/apps/docs/content/docs/react-native/index.mdx
@@ -69,7 +69,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
   });
   return result.toUIMessageStreamResponse();

--- a/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v4-legacy.mdx
@@ -35,7 +35,7 @@ import { openai } from "@ai-sdk/openai";
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
-  const result = streamText({ model: openai("gpt-5.4-nano"), messages });
+  const result = streamText({ model: openai("gpt-5.6-luna"), messages });
   return result.toDataStreamResponse();
 }
 ```

--- a/apps/docs/content/docs/runtimes/ai-sdk/v5-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v5-legacy.mdx
@@ -40,7 +40,7 @@ export const maxDuration = 30;
 export async function POST(req: Request) {
   const { messages }: { messages: Message[] } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages,
     tools: {
       get_current_weather: tool({

--- a/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v6-legacy.mdx
@@ -92,7 +92,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages), // async in v6
     tools: {
       get_current_weather: tool({
@@ -245,7 +245,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     system,
     messages: await convertToModelMessages(messages),
     tools: {
@@ -276,7 +276,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       /* ... */
@@ -305,7 +305,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       deploy: tool({
@@ -424,7 +424,7 @@ import { openai } from "@ai-sdk/openai";
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(injectQuoteContext(messages)),
   });
   return result.toUIMessageStreamResponse();

--- a/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
+++ b/apps/docs/content/docs/runtimes/ai-sdk/v7.mdx
@@ -90,7 +90,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages), // async in v7
     tools: {
       get_current_weather: tool({
@@ -245,7 +245,7 @@ export async function POST(req: Request) {
   } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     system,
     messages: await convertToModelMessages(messages),
     tools: {
@@ -280,7 +280,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       /* ... */
@@ -311,7 +311,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       deploy: tool({
@@ -439,7 +439,7 @@ import { openai } from "@ai-sdk/openai";
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(injectQuoteContext(messages)),
   });
   return createUIMessageStreamResponse({

--- a/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
+++ b/apps/docs/content/docs/runtimes/custom/local-runtime.mdx
@@ -353,7 +353,7 @@ const openai = new OpenAI();
 const MyModelAdapter: ChatModelAdapter = {
   async *run({ messages, abortSignal, context }) {
     const stream = await openai.chat.completions.create({
-      model: "gpt-5.4-mini",
+      model: "gpt-5.6-luna",
       messages: convertToOpenAIMessages(messages),
       stream: true,
       signal: abortSignal,
@@ -407,7 +407,7 @@ Accumulate tool calls in a `Map` outside the streaming loop so they persist acro
 ```tsx
 async *run({ messages, abortSignal, context }) {
   const stream = await openai.chat.completions.create({
-    model: "gpt-5.4-mini",
+    model: "gpt-5.6-luna",
     messages: convertToOpenAIMessages(messages),
     tools: context.tools,
     stream: true,
@@ -702,7 +702,7 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 const OpenAIAdapter: ChatModelAdapter = {
   async *run({ messages, abortSignal, context }) {
     const stream = await openai.chat.completions.create({
-      model: "gpt-5.4-mini",
+      model: "gpt-5.6-luna",
       messages: messages.map((m) => ({
         role: m.role,
         content: m.content

--- a/apps/docs/content/docs/tools/backend.mdx
+++ b/apps/docs/content/docs/tools/backend.mdx
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     system,
     messages: await convertToModelMessages(messages),
     tools: await aiToolkit.tools({ frontend: tools }),
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
   const { messages, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       ...frontendTools(tools ?? {}),

--- a/apps/docs/content/docs/tools/defining-tools.mdx
+++ b/apps/docs/content/docs/tools/defining-tools.mdx
@@ -157,7 +157,7 @@ export async function POST(req: Request) {
   const { messages, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: await aiToolkit.tools({ frontend: tools }),
   });

--- a/apps/docs/content/docs/tools/interactables.mdx
+++ b/apps/docs/content/docs/tools/interactables.mdx
@@ -199,7 +199,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(injectInteractableContext(messages)), // [!code ++]
   });
 

--- a/apps/docs/content/docs/tools/mcp-apps.mdx
+++ b/apps/docs/content/docs/tools/mcp-apps.mdx
@@ -176,7 +176,7 @@ const tools = await client.listTools();
 const { modelVisible } = splitMcpAppTools(tools);
 
 const result = streamText({
-  model: openai("gpt-5.4-nano"),
+  model: openai("gpt-5.6-luna"),
   tools: modelVisible.tools,
   // ...
 });

--- a/apps/docs/content/docs/tools/mcp.mdx
+++ b/apps/docs/content/docs/tools/mcp.mdx
@@ -177,7 +177,7 @@ export async function POST(req: Request) {
   const aiToolkit = new AISDKToolkit({ toolkit });
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: await aiToolkit.tools({ frontend: tools }),
     onFinish: async () => {
@@ -220,7 +220,7 @@ export async function POST(req: Request) {
   const tools = await mcpClient.tools();
 
   const result = streamText({
-    model: openai("gpt-5.4-mini"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools,
     onFinish: async () => {
@@ -400,7 +400,7 @@ MCP tools execute on the server, so approval is a server-side tool gate, not a `
 const tools = await mcpClient.tools();
 
 const result = streamText({
-  model: openai("gpt-5.4-mini"),
+  model: openai("gpt-5.6-luna"),
   messages: await convertToModelMessages(messages),
   tools,
   toolApproval: {

--- a/apps/docs/content/docs/tools/tool-ui.mdx
+++ b/apps/docs/content/docs/tools/tool-ui.mdx
@@ -215,7 +215,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     tools: {
       getWeather: tool({

--- a/apps/docs/content/docs/ui/model-selector.mdx
+++ b/apps/docs/content/docs/ui/model-selector.mdx
@@ -38,11 +38,11 @@ const ComposerAction: FC = () => {
     <div className="flex items-center gap-1">
       <ModelSelector
         models={[
-          { id: "gpt-5.4-nano", name: "GPT-5.4 Nano", description: "Fast and efficient" },
-          { id: "gpt-5.4-mini", name: "GPT-5.4 Mini", description: "Balanced performance" },
-          { id: "gpt-5.5", name: "GPT-5.5", description: "Most capable", efforts: true },
+          { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", description: "Fast and efficient" },
+          { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", description: "Balanced performance" },
+          { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", description: "Most capable", efforts: true },
         ]}
-        defaultValue="gpt-5.4-nano"
+        defaultValue="gpt-5.6-luna"
         defaultEffort="medium"
         size="sm"
       />
@@ -63,7 +63,7 @@ export async function POST(req: Request) {
   const { messages, config } = await req.json();
 
   const result = streamText({
-    model: openai(config?.modelName ?? "gpt-5.4-nano"),
+    model: openai(config?.modelName ?? "gpt-5.6-luna"),
     providerOptions: {
       openai:
         config?.reasoningEffort !== undefined
@@ -88,8 +88,8 @@ A model that declares `efforts` shows a "Thinking" row at the bottom of the popo
 
 ```tsx
 {
-  id: "gpt-5.5",
-  name: "GPT-5.5",
+  id: "gpt-5.6-sol",
+  name: "GPT-5.6 Sol",
   efforts: [
     { id: "minimal", name: "Minimal" },
     { id: "high", name: "High" },
@@ -156,7 +156,7 @@ import { ClaudeLogo, GeminiLogo, OpenAILogo } from "@/components/assistant-ui/lo
 
 <ModelSelector
   models={[
-    { id: "gpt-5.5", name: "GPT-5.5", icon: <OpenAILogo /> },
+    { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", icon: <OpenAILogo /> },
     { id: "claude-opus-4.5", name: "Claude Opus 4.5", icon: <ClaudeLogo /> },
     { id: "gemini-3-pro", name: "Gemini 3 Pro", icon: <GeminiLogo /> },
   ]}

--- a/apps/docs/content/examples/ai-sdk.mdx
+++ b/apps/docs/content/examples/ai-sdk.mdx
@@ -67,7 +67,7 @@ export async function POST(req: Request) {
   const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     // Optional: Add system prompt
     system: "You are a helpful assistant.",

--- a/apps/docs/content/examples/form-demo.mdx
+++ b/apps/docs/content/examples/form-demo.mdx
@@ -70,7 +70,7 @@ export async function POST(req: Request) {
   const { messages, system, tools } = await req.json();
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     messages: await convertToModelMessages(messages),
     system,
     tools: {

--- a/apps/docs/content/examples/mem0.mdx
+++ b/apps/docs/content/examples/mem0.mdx
@@ -86,7 +86,7 @@ ${memories}
 Use this context to personalize your responses.`;
 
   const result = streamText({
-    model: openai("gpt-5.4-nano"),
+    model: openai("gpt-5.6-luna"),
     system: systemPrompt,
     messages,
   });

--- a/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
+++ b/apps/docs/lib/xulux/demo-downloads/create-demo-zip.ts
@@ -56,7 +56,7 @@ export function createDemoFileMap(slug: string, snapshot: SourceSnapshot) {
     "components/assistant-ui/tool-fallback.tsx": toolFallbackShim(),
     "components/assistant-ui/tooltip-icon-button.tsx": tooltipIconButtonShim(),
     "components/docs/assistant/docs-model-options.ts": docsModelOptionsShim(),
-    "constants/model.ts": 'export const DEFAULT_MODEL_ID = "gpt-4.1-mini";\n',
+    "constants/model.ts": 'export const DEFAULT_MODEL_ID = "gpt-5.6-luna";\n',
     "public/favicon/icon.svg": faviconSvg(),
     [`components/examples/${manifest.slug}.tsx`]: demoSource,
   };
@@ -274,7 +274,7 @@ function runtimeProviderTsx() {
 }
 
 function chatRouteTs() {
-  return `import { openai } from "@ai-sdk/openai";\nimport {\n  convertToModelMessages,\n  createUIMessageStream,\n  createUIMessageStreamResponse,\n  streamText,\n} from "ai";\n\nexport const maxDuration = 30;\n\nexport async function POST(req: Request) {\n  const { messages } = await req.json();\n\n  if (!process.env.OPENAI_API_KEY) {\n    const stream = createUIMessageStream({\n      originalMessages: messages,\n      execute: async ({ writer }) => {\n        const messageId = \`msg-\${crypto.randomUUID()}\`;\n        const textId = "fallback-text";\n\n        writer.write({ type: "start", messageId });\n        writer.write({ type: "start-step" });\n        writer.write({ type: "text-start", id: textId });\n        writer.write({\n          type: "text-delta",\n          id: textId,\n          delta:\n            "This starter is running without OPENAI_API_KEY. Add one to .env.local to enable live AI responses.",\n        });\n        writer.write({ type: "text-end", id: textId });\n        writer.write({ type: "finish-step" });\n        writer.write({ type: "finish" });\n      },\n    });\n\n    return createUIMessageStreamResponse({ stream });\n  }\n\n  const result = streamText({\n    model: openai("gpt-4.1-mini"),\n    messages: await convertToModelMessages(messages),\n  });\n\n  return result.toUIMessageStreamResponse();\n}\n`;
+  return `import { openai } from "@ai-sdk/openai";\nimport {\n  convertToModelMessages,\n  createUIMessageStream,\n  createUIMessageStreamResponse,\n  streamText,\n} from "ai";\n\nexport const maxDuration = 30;\n\nexport async function POST(req: Request) {\n  const { messages } = await req.json();\n\n  if (!process.env.OPENAI_API_KEY) {\n    const stream = createUIMessageStream({\n      originalMessages: messages,\n      execute: async ({ writer }) => {\n        const messageId = \`msg-\${crypto.randomUUID()}\`;\n        const textId = "fallback-text";\n\n        writer.write({ type: "start", messageId });\n        writer.write({ type: "start-step" });\n        writer.write({ type: "text-start", id: textId });\n        writer.write({\n          type: "text-delta",\n          id: textId,\n          delta:\n            "This starter is running without OPENAI_API_KEY. Add one to .env.local to enable live AI responses.",\n        });\n        writer.write({ type: "text-end", id: textId });\n        writer.write({ type: "finish-step" });\n        writer.write({ type: "finish" });\n      },\n    });\n\n    return createUIMessageStreamResponse({ stream });\n  }\n\n  const result = streamText({\n    model: openai("gpt-5.6-luna"),\n    messages: await convertToModelMessages(messages),\n  });\n\n  return result.toUIMessageStreamResponse();\n}\n`;
 }
 
 function markdownTextShim() {
@@ -294,7 +294,7 @@ function tooltipIconButtonShim() {
 }
 
 function docsModelOptionsShim() {
-  return `export function docsModelOptions() {\n  return [\n    { id: "gpt-4.1-mini", name: "GPT-4.1 mini" },\n    { id: "gpt-4.1", name: "GPT-4.1" },\n  ];\n}\n`;
+  return `export function docsModelOptions() {\n  return [\n    { id: "gpt-5.6-luna", name: "GPT-5.6 Luna" },\n    { id: "gpt-5.6-terra", name: "GPT-5.6 Terra" },\n  ];\n}\n`;
 }
 
 function faviconSvg() {


### PR DESCRIPTION
## summary

- every entry in the docs model picker moves to its provider's cheapest current-generation model, priced off the modelpedia catalog that assistant-billing generates. gpt-5.6-luna becomes the default and strictly dominates the old gpt-5.4-nano ($0.20/$1.20 vs $0.20/$1.25 per million tokens, 1.05M context vs 400k).
- deepseek v4 flash joins as the cheapest reasoning entry ($0.14/$0.28), google drops the `-preview` suffix for the GA id at the same price, and groq swaps llama 4 scout and qwen3 32b for gpt-oss-20b and llama 3.1 8b instant.
- the runtime pins feeding the same picker follow: the xulux playground moves from gpt-5.4-mini to luna (3.75x cheaper in both directions, so the $1 per chat budget stretches further), and two model ids that were already invalid and silently falling back through `resolveModelId` now name the default directly.
- roughly 30 docs code examples pinned gpt-5.4-nano or gpt-5.4-mini, a generation behind what the site itself runs. they all move to gpt-5.6-luna, which is cheaper than either and is what a reader copying the snippet gets billed for.

## test plan

### already verified

- [x] `npx tsc --noEmit -p tsconfig.json` in apps/docs -> zero new errors in the touched files, the remainder is pre-existing baseline noise
- [x] `npx vitest run` in apps/docs -> 46/46 green across 10 files
- [x] `npx oxlint` and `npx oxfmt --check` on every touched ts/tsx file -> clean
- [x] rendered `/docs/ui/model-selector` in a real browser, Base UI and Radix variants both: 5 provider groups (OpenAI, Google, xAI, DeepSeek, Groq), all 6 entries present, every icon resolves (`naturalWidth: 16`, including the newly referenced `deepseek.svg`), context windows render 1.1M/1M/2M/1M/131K/131K, the effort toggle lands on luna, no new console errors
- [x] every swept docs page returns 200 in dev: model-selector, interactables, gateways, ai-sdk/v7, mastra/full-stack, custom/local-runtime

### reviewer should verify

- [ ] once the gateway credits below are topped up, pick each model in the picker and confirm it streams

## notes

- the five non-OpenAI entries do not stream today, and did not before this PR either. probing the gateway directly, `grok/`, `google-ai-studio/`, `groq/`, and `anthropic/` all return 402 `Insufficient wholesale credits` from Cloudflare AI Gateway, so topping up wholesale credits revives all of them with no code change. a bogus model id under the same prefix returns 400 `Model not found`, which is how we know the routing itself is intact.
- deepseek needs one extra step: `deepseek/`, `mistral/`, and `cerebras/` return 404 `Provider not available through Unified Billing`, so DeepSeek V4 Flash needs its own provider config with a `DEEPSEEK_API_KEY` in assistant-billing before it resolves.
- google stays on 3.1 rather than 3.5 on purpose. `gemini-3.5-flash-lite` and `gemini-3.6-flash` return 400 `Missing or invalid Authorization header` through the gateway, so unified billing only covers up to the 3.1 generation.
- two model references are deliberately untouched. `guides/chatgpt-subscription.mdx` names `gpt-5.4` and `gpt-5.3-codex` as examples of what a ChatGPT plan exposes, which is prose about someone else's lineup rather than an id we call. `app/api/xulux/chat/route.ts` keeps its `modelName === "gpt-5.4"` reasoning effort branch, because nothing in the UI sends `reasoningEffort` so it is dead today, and retargeting it would quietly change which API path the default model takes. worth its own PR.
- no changeset: apps/docs is `private: true`.

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Xyzm7SiK-z99afnlo2m9Oep0T_HVYEa-dJMCj-qvm8mOoNuv60onAEjZNMo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->