### PR TITLE
fix(safe-content-frame): surface iframe content load errors

### DIFF
--- a/.changeset/tidy-dodos-report.md
+++ b/.changeset/tidy-dodos-report.md
@@ -1,0 +1,5 @@
+---
+"safe-content-frame": patch
+---
+
+fix: surface iframe content load errors instead of reporting a timeout

--- a/packages/safe-content-frame/src/index.test.ts
+++ b/packages/safe-content-frame/src/index.test.ts
@@ -6,6 +6,10 @@ import { SafeContentFrame } from "./index";
 class MockMessagePort {
   onmessage: ((event: MessageEvent) => void) | null = null;
   readonly close = vi.fn();
+
+  emit(data: unknown) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
 }
 
 class MockMessageChannel {
@@ -95,5 +99,39 @@ describe("SafeContentFrame", () => {
     expect(container.childElementCount).toBe(0);
     expect(MockMessageChannel.instances[0]!.port1.close).toHaveBeenCalledOnce();
     expect(MockMessageChannel.instances[0]!.port2.close).toHaveBeenCalledOnce();
+  });
+
+  it("surfaces shim errors reported after the iframe loads", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const renderer = new SafeContentFrame("test", {
+      salt: "fixed",
+      useShadowDom: true,
+    });
+
+    const framePromise = renderer.renderHtml("<p>Hello</p>", container);
+    await vi.waitFor(() => {
+      expect(shadowRoot?.querySelector("iframe")).toBeTruthy();
+    });
+
+    const iframe = shadowRoot!.querySelector("iframe")!;
+    Object.defineProperty(iframe, "contentWindow", {
+      configurable: true,
+      value: { postMessage: vi.fn() },
+    });
+    iframe.dispatchEvent(new Event("load"));
+    const frame = await framePromise;
+
+    MockMessageChannel.instances[0]!.port1.emit({
+      type: "error",
+      message: "shim decode failed",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    await expect(frame.fullyLoadedPromiseWithTimeout(10)).rejects.toThrow(
+      "shim decode failed",
+    );
+    expect(container.childElementCount).toBe(0);
+    expect(MockMessageChannel.instances[0]!.port1.close).toHaveBeenCalledOnce();
   });
 });

--- a/packages/safe-content-frame/src/index.ts
+++ b/packages/safe-content-frame/src/index.ts
@@ -165,13 +165,20 @@ export class SafeContentFrame {
       };
 
       let onLoaded: () => void;
-      const loaded = new Promise<void>((r) => {
-        onLoaded = r;
+      let onLoadError: (error: Error) => void;
+      const loaded = new Promise<void>((resolveLoaded, rejectLoaded) => {
+        onLoaded = resolveLoaded;
+        onLoadError = rejectLoaded;
       });
+      void loaded.catch(() => {});
 
       channel.port1.onmessage = (e) => {
         if (e.data?.type === "msg") onLoaded();
-        else if (e.data?.type === "error") reject(new Error(e.data.message));
+        else if (e.data?.type === "error") {
+          const error = new Error(e.data.message);
+          onLoadError(error);
+          cleanup();
+        }
       };
 
       let loadHandled = false;


### PR DESCRIPTION
## Summary

- reject the frame's full-load waiter when the iframe shim reports an error
- clean up the failed frame and message channel
- keep delayed consumers from producing an unhandled rejection
- add regression coverage for an error reported after the iframe load event

## Why

The iframe render promise resolves as soon as the iframe loads. A later error message from the shim previously rejected that already-settled promise, so the real error was discarded. Consumers calling fullyLoadedPromiseWithTimeout() then received a generic Timeout instead.

This can happen when the shim cannot decode or render supplied content. Preserving the shim error gives callers the actual failure and removes the unusable frame.

## Validation

- vitest run src/index.test.ts
- aui-build
- oxlint packages/safe-content-frame/src/index.ts packages/safe-content-frame/src/index.test.ts

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Kf1Qr4vUjtsk9FY8KIv9DfK-ByqlFWivjmH47UgUf8kmoX9iLeedqQ9e1BY?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->