### PR TITLE
feat(core,react,ui): per-thread run state and thread list rename

### DIFF
--- a/.changeset/olive-pugs-shave.md
+++ b/.changeset/olive-pugs-shave.md
@@ -1,0 +1,12 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: expose `threadListItem.isRunning` so a thread list row can show its own run
+
+a thread list row had no supported way to tell whether its thread was running: `thread.isRunning` describes the open thread, and the item state carried no run state at all, so a run continuing on a thread the user had switched away from was invisible.
+
+`threadListItem.isRunning` now reports it, and stays true for a background run. runtimes that keep background threads alive answer it through the new optional `ThreadListRuntimeCore.unstable_isThreadRunning`; the rest report the open thread's run state, which they already track.
+
+`InMemoryThreadList` also renames threads for real instead of dropping the new title.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -4262,7 +4262,7 @@ declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
 declare const ThreadListItemClient: Resource<ClientOutput<"threadListItem">, [
   {
     runtime: ThreadListItemRuntime;
-    mainThreadIsRunning: boolean;
+    mainThreadIsRunning?: boolean | undefined;
   }
 ]>;
 

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3549,6 +3549,7 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
   __internal_subscribeRunningChanged(callback: () => void): Unsubscribe$1;
   private _publishThreadRuntime;
   private _trackRunning;
+  private _setRunning;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
   private _RuntimeBinder;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -3544,6 +3544,11 @@ declare class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     unstable_refetchThread?: (() => Promise<void>) | undefined;
     unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
   }> | undefined;
+  __internal_isThreadRunning(threadId: string): boolean;
+  private runningSubscribers;
+  __internal_subscribeRunningChanged(callback: () => void): Unsubscribe$1;
+  private _publishThreadRuntime;
+  private _trackRunning;
   stopThreadRuntime(threadId: string): void;
   setRuntimeHook(newRuntimeHook: RemoteThreadListHook): void;
   private _RuntimeBinder;
@@ -3706,6 +3711,7 @@ declare class RemoteThreadListThreadListRuntimeCore extends BaseSubscribable imp
     unstable_refetchThread?: (() => Promise<void>) | undefined;
     unstable_on<E extends ThreadRuntimeEventType>(event: E, callback: ThreadRuntimeEventCallback<E>): Unsubscribe$1;
   }>;
+  unstable_isThreadRunning(threadIdOrRemoteId: string): boolean;
   getItemById(threadIdOrRemoteId: string): RemoteThreadData | undefined;
   switchToThread(threadIdOrRemoteId: string, options?: {
     unarchive?: boolean;
@@ -4256,6 +4262,7 @@ declare const ThreadListItemByIndexProvider: FC<PropsWithChildren<{
 declare const ThreadListItemClient: Resource<ClientOutput<"threadListItem">, [
   {
     runtime: ThreadListItemRuntime;
+    mainThreadIsRunning: boolean;
   }
 ]>;
 
@@ -4413,10 +4420,12 @@ type ThreadListItemState = {
   readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
+  readonly isRunning: boolean;
 };
 
 type ThreadListItemState$1 = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -4490,6 +4499,7 @@ type ThreadListRuntimeCore = {
   readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  unstable_isThreadRunning?(threadId: string): boolean;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -4548,7 +4558,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1058,6 +1058,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1096,7 +1097,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-a2a.ts
+++ b/api-surface/assistant-ui__react-a2a.ts
@@ -1420,6 +1420,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1458,7 +1459,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1152,6 +1152,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1190,7 +1191,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-ai-sdk.ts
+++ b/api-surface/assistant-ui__react-ai-sdk.ts
@@ -1586,6 +1586,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1624,7 +1625,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-data-stream.ts
+++ b/api-surface/assistant-ui__react-data-stream.ts
@@ -1423,6 +1423,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1461,7 +1462,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -1888,6 +1888,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1926,7 +1927,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-ink.ts
+++ b/api-surface/assistant-ui__react-ink.ts
@@ -3468,10 +3468,12 @@ type ThreadListItemState = {
   readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
+  readonly isRunning: boolean;
 };
 
 type ThreadListItemState$1 = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -3548,6 +3550,7 @@ type ThreadListRuntimeCore = {
   readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  unstable_isThreadRunning?(threadId: string): boolean;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -3606,7 +3609,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-langchain.ts
+++ b/api-surface/assistant-ui__react-langchain.ts
@@ -1590,6 +1590,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1628,7 +1629,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -1753,6 +1753,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1791,7 +1792,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-native.ts
+++ b/api-surface/assistant-ui__react-native.ts
@@ -2992,10 +2992,12 @@ type ThreadListItemState = {
   readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
+  readonly isRunning: boolean;
 };
 
 type ThreadListItemState$1 = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -3072,6 +3074,7 @@ type ThreadListRuntimeCore = {
   readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  unstable_isThreadRunning?(threadId: string): boolean;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -3130,7 +3133,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-opencode.ts
+++ b/api-surface/assistant-ui__react-opencode.ts
@@ -1531,6 +1531,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1569,7 +1570,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1959,6 +1959,7 @@ type ThreadListItemRuntimePath = {
 
 type ThreadListItemState = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -1997,7 +1998,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -4349,10 +4349,12 @@ type ThreadListItemState = {
   readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
+  readonly isRunning: boolean;
 };
 
 type ThreadListItemState$1 = {
   readonly isMain: boolean;
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;
@@ -4459,6 +4461,7 @@ type ThreadListRuntimeCore = {
   readonly threadItems: Readonly<Record<string, ThreadListItemCoreState>>;
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
+  unstable_isThreadRunning?(threadId: string): boolean;
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
   switchToThread(threadId: string, options?: {
     unarchive?: boolean;
@@ -4517,7 +4520,7 @@ type ThreadListState = {
   readonly isLoading: boolean;
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
-  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "threadId">>>;
+  readonly threadItems: Readonly<Record<string, Omit<ThreadListItemState$1, "isMain" | "isRunning" | "threadId">>>;
 };
 
 type ThreadMessage = BaseThreadMessage & (ThreadSystemMessage | ThreadUserMessage | ThreadAssistantMessage);

--- a/packages/core/src/react/providers/ReadonlyThreadProvider.tsx
+++ b/packages/core/src/react/providers/ReadonlyThreadProvider.tsx
@@ -26,6 +26,7 @@ const READONLY_THREAD_LIST_ITEM: ThreadListItemState = Object.freeze({
   remoteId: undefined,
   externalId: undefined,
   isMain: true,
+  isRunning: false,
   status: "regular" as const,
   title: undefined,
 });

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.running.test.tsx
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
+import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
+import type { ThreadMessage } from "../../types/message";
+import { RemoteThreadListHookInstanceManager } from "./RemoteThreadListHookInstanceManager";
+
+const makeRuntime = (
+  initial: Partial<Pick<ThreadRuntimeCore, "isRunning" | "messages">> = {},
+) => {
+  const subscribers = new Set<() => void>();
+  const runtime = {
+    isRunning: initial.isRunning,
+    messages: initial.messages ?? [],
+    subscribe: (callback: () => void) => {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+  } as unknown as ThreadRuntimeCore & {
+    isRunning: boolean | undefined;
+    messages: readonly ThreadMessage[];
+  };
+
+  return {
+    runtime,
+    subscriberCount: () => subscribers.size,
+    setRunning: (isRunning: boolean | undefined) => {
+      runtime.isRunning = isRunning;
+      for (const callback of subscribers) callback();
+    },
+  };
+};
+
+const makeManager = () =>
+  new RemoteThreadListHookInstanceManager(
+    () => ({}) as never,
+    {} as ThreadListRuntimeCore,
+  );
+
+// mirrors what the React binder does on every publication
+const publish = (
+  manager: RemoteThreadListHookInstanceManager,
+  threadId: string,
+  runtime: ThreadRuntimeCore,
+) => {
+  const internals = manager as unknown as {
+    instances: Map<string, { generation: number }>;
+    _publishThreadRuntime: (
+      threadId: string,
+      runtime: ThreadRuntimeCore,
+      generation: number,
+    ) => void;
+  };
+  const generation = internals.instances.get(threadId)!.generation;
+  internals._publishThreadRuntime(threadId, runtime, generation);
+};
+
+const start = (manager: RemoteThreadListHookInstanceManager, id: string) => {
+  manager.startThreadRuntime(id).catch(() => {});
+};
+
+describe("RemoteThreadListHookInstanceManager run tracking", () => {
+  it("reports a thread with no attached runtime as not running", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(false);
+    expect(manager.__internal_isThreadRunning("never-started")).toBe(false);
+  });
+
+  it("adopts the run state of the published runtime", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const { runtime } = makeRuntime({ isRunning: true });
+
+    publish(manager, "thread-1", runtime);
+
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(true);
+  });
+
+  it("falls back to the trailing assistant message when the runtime does not track runs", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const { runtime } = makeRuntime({
+      messages: [
+        { role: "assistant", status: { type: "running" } },
+      ] as unknown as readonly ThreadMessage[],
+    });
+
+    publish(manager, "thread-1", runtime);
+
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(true);
+  });
+
+  it("tracks a thread the user has switched away from", () => {
+    const manager = makeManager();
+    start(manager, "background");
+    start(manager, "main");
+    const background = makeRuntime({ isRunning: false });
+    publish(manager, "background", background.runtime);
+    publish(manager, "main", makeRuntime({ isRunning: false }).runtime);
+
+    background.setRunning(true);
+
+    expect(manager.__internal_isThreadRunning("background")).toBe(true);
+    expect(manager.__internal_isThreadRunning("main")).toBe(false);
+  });
+
+  it("notifies the thread list only when the thread crosses the running boundary", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const thread = makeRuntime({ isRunning: false });
+    publish(manager, "thread-1", thread.runtime);
+
+    const onChange = vi.fn();
+    manager.__internal_subscribeRunningChanged(onChange);
+
+    thread.setRunning(false);
+    expect(onChange).not.toHaveBeenCalled();
+
+    thread.setRunning(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    thread.setRunning(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    thread.setRunning(false);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("moves tracking to the runtime a restart publishes", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const before = makeRuntime({ isRunning: true });
+    publish(manager, "thread-1", before.runtime);
+
+    const after = makeRuntime({ isRunning: false });
+    publish(manager, "thread-1", after.runtime);
+
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(false);
+    expect(before.subscriberCount()).toBe(0);
+
+    after.setRunning(true);
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(true);
+  });
+
+  it("releases the run subscription when the thread runtime stops", () => {
+    const manager = makeManager();
+    start(manager, "thread-1");
+    const thread = makeRuntime({ isRunning: true });
+    publish(manager, "thread-1", thread.runtime);
+
+    manager.stopThreadRuntime("thread-1");
+
+    expect(thread.subscriberCount()).toBe(0);
+    expect(manager.__internal_isThreadRunning("thread-1")).toBe(false);
+  });
+});

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -166,17 +166,23 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     const runtime = instance.runtime;
     if (!runtime) {
       instance.unsubscribeRunning = undefined;
-      instance.isRunning = false;
+      this._setRunning(instance, false);
       return;
     }
 
-    instance.isRunning = getThreadRuntimeCoreIsRunning(runtime);
+    this._setRunning(instance, getThreadRuntimeCoreIsRunning(runtime));
     instance.unsubscribeRunning = runtime.subscribe(() => {
-      const isRunning = getThreadRuntimeCoreIsRunning(runtime);
-      if (instance.isRunning === isRunning) return;
-      instance.isRunning = isRunning;
-      for (const callback of this.runningSubscribers) callback();
+      this._setRunning(instance, getThreadRuntimeCoreIsRunning(runtime));
     });
+  }
+
+  private _setRunning(
+    instance: RemoteThreadListHookInstance,
+    isRunning: boolean,
+  ) {
+    if (instance.isRunning === isRunning) return;
+    instance.isRunning = isRunning;
+    for (const callback of this.runningSubscribers) callback();
   }
 
   public stopThreadRuntime(threadId: string) {

--- a/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListHookInstanceManager.tsx
@@ -18,8 +18,12 @@ import { ThreadListItemRuntimeProvider } from "../providers/ThreadListItemRuntim
 import type { ThreadRuntimeCore } from "../../runtime/interfaces/thread-runtime-core";
 import type { ThreadListRuntimeCore } from "../../runtime/interfaces/thread-list-runtime-core";
 import type { AssistantRuntime } from "../../runtime/api/assistant-runtime";
+import type { Unsubscribe } from "../../types/unsubscribe";
 import { BaseSubscribable } from "../../subscribable/subscribable";
-import type { ThreadRuntimeImpl } from "../../runtime/api/thread-runtime";
+import {
+  getThreadRuntimeCoreIsRunning,
+  type ThreadRuntimeImpl,
+} from "../../runtime/api/thread-runtime";
 import { ThreadListRuntimeImpl } from "../../runtime/api/thread-list-runtime";
 
 type RemoteThreadListHook = () => AssistantRuntime;
@@ -31,6 +35,8 @@ type RemoteThreadListHookInstance = {
   publishedGeneration?: number | undefined;
   // Part of the binder's React key, so only a bump remounts the hook.
   generation: number;
+  isRunning: boolean;
+  unsubscribeRunning?: Unsubscribe | undefined;
 };
 
 const ProviderRenderDetector: FC<{
@@ -85,7 +91,10 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
 
   public startThreadRuntime(threadId: string) {
     if (!this.instances.has(threadId)) {
-      this.instances.set(threadId, { generation: this.nextGeneration++ });
+      this.instances.set(threadId, {
+        generation: this.nextGeneration++,
+        isRunning: false,
+      });
       this.useAliveThreadsKeysChanged.setState({}, true);
     }
 
@@ -109,7 +118,69 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
     return instance.runtime;
   }
 
+  public __internal_isThreadRunning(threadId: string) {
+    return this.instances.get(threadId)?.isRunning ?? false;
+  }
+
+  private runningSubscribers = new Set<() => void>();
+
+  /**
+   * Fires when any thread crosses the running boundary. Separate from the
+   * general subscription so a run does not push the thread list through the
+   * channel that resolves pending runtime attachments.
+   */
+  public __internal_subscribeRunningChanged(callback: () => void): Unsubscribe {
+    this.runningSubscribers.add(callback);
+    return () => this.runningSubscribers.delete(callback);
+  }
+
+  private _publishThreadRuntime(
+    threadId: string,
+    runtime: ThreadRuntimeCore,
+    generation: number,
+  ) {
+    const instance = this.instances.get(threadId);
+    if (!instance)
+      throw new Error(
+        `Thread "${threadId}" runtime binding not found. This is a bug in assistant-ui.`,
+      );
+
+    // An outgoing binder outlives its generation until React commits the key
+    // change, and must not publish over the incoming one.
+    if (instance.generation !== generation) return;
+
+    const previousRuntime = instance.runtime;
+    instance.runtime = runtime;
+    instance.publishedGeneration = generation;
+    if (previousRuntime !== runtime) {
+      this._trackRunning(instance);
+    }
+    this._notifySubscribers();
+  }
+
+  // Run state changes far more often than the thread list does, so the list is
+  // only notified when a thread crosses the running boundary.
+  private _trackRunning(instance: RemoteThreadListHookInstance) {
+    instance.unsubscribeRunning?.();
+
+    const runtime = instance.runtime;
+    if (!runtime) {
+      instance.unsubscribeRunning = undefined;
+      instance.isRunning = false;
+      return;
+    }
+
+    instance.isRunning = getThreadRuntimeCoreIsRunning(runtime);
+    instance.unsubscribeRunning = runtime.subscribe(() => {
+      const isRunning = getThreadRuntimeCoreIsRunning(runtime);
+      if (instance.isRunning === isRunning) return;
+      instance.isRunning = isRunning;
+      for (const callback of this.runningSubscribers) callback();
+    });
+  }
+
   public stopThreadRuntime(threadId: string) {
+    this.instances.get(threadId)?.unsubscribeRunning?.();
     this.instances.delete(threadId);
     this.useAliveThreadsKeysChanged.setState({}, true);
     this._notifySubscribers();
@@ -134,19 +205,11 @@ export class RemoteThreadListHookInstanceManager extends BaseSubscribable {
       .__internal_threadBinding;
 
     const updateRuntime = useCallback(() => {
-      const aliveThread = this.instances.get(threadId);
-      if (!aliveThread)
-        throw new Error(
-          `Thread "${threadId}" runtime binding not found. This is a bug in assistant-ui.`,
-        );
-
-      // An outgoing binder outlives its generation until React commits the key
-      // change, and must not publish over the incoming one.
-      if (aliveThread.generation !== generation) return;
-
-      aliveThread.runtime = threadBinding.getState();
-      aliveThread.publishedGeneration = generation;
-      this._notifySubscribers();
+      this._publishThreadRuntime(
+        threadId,
+        threadBinding.getState(),
+        generation,
+      );
     }, [threadId, generation, threadBinding]);
 
     const isMounted = useRef(false);

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -185,6 +185,9 @@ export class RemoteThreadListThreadListRuntimeCore
       options.runtimeHook,
       this,
     );
+    this._hookManager.__internal_subscribeRunningChanged(() =>
+      this._notifySubscribers(),
+    );
     this.useProvider = create(() => ({
       Provider: options.adapter.unstable_Provider ?? Fragment,
     }));
@@ -347,6 +350,12 @@ export class RemoteThreadListThreadListRuntimeCore
         `Runtime for thread "${threadIdOrRemoteId}" not found while getting its runtime.`,
       );
     return result;
+  }
+
+  public unstable_isThreadRunning(threadIdOrRemoteId: string) {
+    const data = this.getItemById(threadIdOrRemoteId);
+    if (!data) return false;
+    return this._hookManager.__internal_isThreadRunning(data.id);
   }
 
   public getItemById(threadIdOrRemoteId: string) {

--- a/packages/core/src/runtime/api/bindings.ts
+++ b/packages/core/src/runtime/api/bindings.ts
@@ -37,6 +37,11 @@ export type MessageStateBinding = SubscribableWithState<
 
 export type ThreadListItemState = {
   readonly isMain: boolean;
+  /**
+   * Whether this thread has a run in progress, including a run that continues
+   * after the user switches to another thread.
+   */
+  readonly isRunning: boolean;
   readonly id: string;
   readonly remoteId: string | undefined;
   readonly externalId: string | undefined;

--- a/packages/core/src/runtime/api/thread-list-runtime.ts
+++ b/packages/core/src/runtime/api/thread-list-runtime.ts
@@ -31,7 +31,10 @@ export type ThreadListState = {
   readonly isLoadingMore: boolean;
   readonly hasMore: boolean;
   readonly threadItems: Readonly<
-    Record<string, Omit<ThreadListItemState, "isMain" | "threadId">>
+    Record<
+      string,
+      Omit<ThreadListItemState, "isMain" | "threadId" | "isRunning">
+    >
   >;
 };
 
@@ -103,6 +106,7 @@ const getThreadListItemState = (
     lastMessageAt: threadData.lastMessageAt,
     custom: threadData.custom,
     isMain: threadData.id === threadList.mainThreadId,
+    isRunning: threadList.unstable_isThreadRunning?.(threadData.id) ?? false,
   };
 };
 

--- a/packages/core/src/runtime/api/thread-runtime.ts
+++ b/packages/core/src/runtime/api/thread-runtime.ts
@@ -193,22 +193,31 @@ export type ThreadState = {
   readonly voice: VoiceSessionState | undefined;
 };
 
+/**
+ * The canonical `isRunning` derivation. A runtime that tracks run state itself
+ * reports it directly; the rest fall back to the trailing assistant message.
+ */
+export const getThreadRuntimeCoreIsRunning = (
+  runtime: ThreadRuntimeCore,
+): boolean => {
+  if (runtime.isRunning !== undefined) return runtime.isRunning;
+  const lastMessage = runtime.messages.at(-1);
+  return (
+    lastMessage?.role === "assistant" && lastMessage.status.type === "running"
+  );
+};
+
 export const getThreadState = (
   runtime: ThreadRuntimeCore,
   threadListItemState: ThreadListItemState,
 ): ThreadState => {
-  const lastMessage = runtime.messages.at(-1);
   return Object.freeze({
     threadId: threadListItemState.id,
     metadata: threadListItemState,
     capabilities: runtime.capabilities,
     isDisabled: runtime.isDisabled,
     isLoading: runtime.isLoading,
-    isRunning:
-      runtime.isRunning ??
-      (lastMessage?.role !== "assistant"
-        ? false
-        : lastMessage.status.type === "running"),
+    isRunning: getThreadRuntimeCoreIsRunning(runtime),
     messages: runtime.messages,
     state: runtime.state,
     suggestions: runtime.suggestions,

--- a/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
+++ b/packages/core/src/runtime/interfaces/thread-list-runtime-core.ts
@@ -31,6 +31,16 @@ export type ThreadListRuntimeCore = {
   getMainThreadRuntimeCore(): ThreadRuntimeCore;
   getThreadRuntimeCore(threadId: string): ThreadRuntimeCore;
 
+  /**
+   * Whether the thread currently has a run in progress, including a run on a
+   * thread that is not the main one. Implemented by thread lists that keep
+   * runtimes alive for non-main threads, and they notify their subscribers
+   * whenever the answer changes. A thread list that mounts only the main thread
+   * leaves this undefined: its other threads have no runtime and so cannot be
+   * running, and the main thread's run state is read from its runtime directly.
+   */
+  unstable_isThreadRunning?(threadId: string): boolean;
+
   getItemById(threadId: string): ThreadListItemCoreState | undefined;
 
   switchToThread(

--- a/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
@@ -10,12 +10,13 @@ import { useSubscribable } from "./useSubscribable";
 
 const useThreadListItemClient = ({
   runtime,
-  mainThreadIsRunning,
+  mainThreadIsRunning = false,
 }: {
   runtime: ThreadListItemRuntime;
   // A thread list that cannot report per-thread run state still leaves the open
-  // thread observable, and the thread client tracks that reactively.
-  mainThreadIsRunning: boolean;
+  // thread observable, and the thread client tracks that reactively. Omitted
+  // where the runtime state is already authoritative for every thread.
+  mainThreadIsRunning?: boolean | undefined;
 }): ClientOutput<"threadListItem"> => {
   const runtimeState = useSubscribable(runtime);
   const state = useMemo(() => {

--- a/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-item-runtime-client.ts
@@ -1,5 +1,5 @@
 import type { Unsubscribe } from "../../types/unsubscribe";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { resource } from "@assistant-ui/tap";
 import { type ClientOutput, useAssistantEmit } from "@assistant-ui/store";
 import type {
@@ -10,10 +10,20 @@ import { useSubscribable } from "./useSubscribable";
 
 const useThreadListItemClient = ({
   runtime,
+  mainThreadIsRunning,
 }: {
   runtime: ThreadListItemRuntime;
+  // A thread list that cannot report per-thread run state still leaves the open
+  // thread observable, and the thread client tracks that reactively.
+  mainThreadIsRunning: boolean;
 }): ClientOutput<"threadListItem"> => {
-  const state = useSubscribable(runtime);
+  const runtimeState = useSubscribable(runtime);
+  const state = useMemo(() => {
+    const isRunning =
+      runtimeState.isRunning || (runtimeState.isMain && mainThreadIsRunning);
+    if (isRunning === runtimeState.isRunning) return runtimeState;
+    return { ...runtimeState, isRunning };
+  }, [runtimeState, mainThreadIsRunning]);
   const emit = useAssistantEmit();
 
   // Bind thread list item events to event manager

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -15,9 +15,11 @@ import type { ThreadsState } from "../scopes/threads";
 const useThreadListItemClientById = ({
   runtime,
   id,
+  mainThreadIsRunning,
 }: {
   runtime: ThreadListRuntime;
   id: string;
+  mainThreadIsRunning: boolean;
 }) => {
   const threadListItemRuntime = useMemo(
     () => runtime.getItemById(id),
@@ -26,6 +28,7 @@ const useThreadListItemClientById = ({
   return useResource(
     ThreadListItemClient({
       runtime: threadListItemRuntime,
+      mainThreadIsRunning,
     }),
   );
 };
@@ -48,7 +51,15 @@ const useThreadListClient = ({
   );
   const threadItems = useClientLookup(
     Object.keys(runtimeState.threadItems).map((id) =>
-      withKey(id, ThreadListItemClientById({ runtime, id }), [runtime, id]),
+      withKey(
+        id,
+        ThreadListItemClientById({
+          runtime,
+          id,
+          mainThreadIsRunning: main.state.isRunning,
+        }),
+        [runtime, id],
+      ),
     ),
   );
 

--- a/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
+++ b/packages/core/src/store/runtime-clients/thread-list-runtime-client.ts
@@ -58,7 +58,7 @@ const useThreadListClient = ({
           id,
           mainThreadIsRunning: main.state.isRunning,
         }),
-        [runtime, id],
+        [runtime, id, main.state.isRunning],
       ),
     ),
   );

--- a/packages/core/src/store/scopes/thread-list-item.ts
+++ b/packages/core/src/store/scopes/thread-list-item.ts
@@ -9,6 +9,13 @@ export type ThreadListItemState = {
   readonly lastMessageAt?: Date | undefined;
   readonly status: ThreadListItemStatus;
   readonly custom?: Record<string, unknown> | undefined;
+  /**
+   * Whether this thread has a run in progress, including a run that continues
+   * after the user switches to another thread. A thread list that mounts only
+   * the open thread has no runtime to run the others, so they read as not
+   * running rather than as unknown.
+   */
+  readonly isRunning: boolean;
 };
 
 export type ThreadListItemMethods = {

--- a/packages/core/src/tests/event-subscription-listener-errors.test.ts
+++ b/packages/core/src/tests/event-subscription-listener-errors.test.ts
@@ -96,6 +96,7 @@ const makeThreadHarness = (): RuntimeHarness => {
       remoteId: undefined,
       externalId: undefined,
       isMain: true,
+      isRunning: false,
       status: "regular",
       title: undefined,
     }),

--- a/packages/react-ink/benchmarks/long-thread.bench.tsx
+++ b/packages/react-ink/benchmarks/long-thread.bench.tsx
@@ -37,6 +37,7 @@ const READONLY_THREAD_LIST_ITEM = Object.freeze({
   remoteId: undefined,
   externalId: undefined,
   isMain: true,
+  isRunning: false,
   status: "regular" as const,
   title: undefined,
 });

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -29,14 +29,24 @@ type ThreadData = {
 // ThreadListItem Client
 const useThreadListItemClient = (props: {
   data: ThreadData;
+  isRunning: boolean;
   onSwitchTo: () => void;
+  onRename: (title: string) => void;
   onUpdateCustom: (custom: Record<string, unknown> | undefined) => void;
   onArchive: () => void;
   onUnarchive: () => void;
   onDelete: () => void;
 }): ClientOutput<"threadListItem"> => {
-  const { data, onSwitchTo, onUpdateCustom, onArchive, onUnarchive, onDelete } =
-    props;
+  const {
+    data,
+    isRunning,
+    onSwitchTo,
+    onRename,
+    onUpdateCustom,
+    onArchive,
+    onUnarchive,
+    onDelete,
+  } = props;
   const state = useMemo(
     () => ({
       id: data.id,
@@ -45,14 +55,15 @@ const useThreadListItemClient = (props: {
       title: data.title,
       status: data.status,
       custom: data.custom,
+      isRunning,
     }),
-    [data.id, data.title, data.status, data.custom],
+    [data.id, data.title, data.status, data.custom, isRunning],
   );
 
   return {
     getState: () => state,
     switchTo: onSwitchTo,
-    rename: () => {},
+    rename: onRename,
     updateCustom: onUpdateCustom,
     archive: onArchive,
     unarchive: onUnarchive,
@@ -83,6 +94,12 @@ const useInMemoryThreadList = (
   const handleSwitchToThread = (threadId: string) => {
     setMainThreadId(threadId);
     onSwitchToThread?.(threadId);
+  };
+
+  const handleRename = (threadId: string, title: string) => {
+    setThreads((prev) =>
+      prev.map((t) => (t.id === threadId ? { ...t, title } : t)),
+    );
   };
 
   const handleArchive = (threadId: string) => {
@@ -128,13 +145,18 @@ const useInMemoryThreadList = (
     onSwitchToNewThread?.();
   };
 
+  // Only the main thread is mounted, so it is the only thread that can run.
+  const mainThreadClient = useClientResource(threadFactory(mainThreadId));
+
   const threadListItems = useClientLookup(
     threads.map((t) =>
       withKey(
         t.id,
         ThreadListItemClient({
           data: t,
+          isRunning: t.id === mainThreadId && mainThreadClient.state.isRunning,
           onSwitchTo: () => handleSwitchToThread(t.id),
+          onRename: (title) => handleRename(t.id, title),
           onUpdateCustom: (custom) => handleUpdateCustom(t.id, custom),
           onArchive: () => handleArchive(t.id),
           onUnarchive: () => handleUnarchive(t.id),
@@ -143,9 +165,6 @@ const useInMemoryThreadList = (
       ),
     ),
   );
-
-  // Create the main thread
-  const mainThreadClient = useClientResource(threadFactory(mainThreadId));
 
   const state = useMemo(() => {
     const regularThreads = threads.filter((t) => t.status === "regular");

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -9,7 +9,11 @@ import {
 const RESOLVED_PROMISE = Promise.resolve();
 const THREAD_ID = "default";
 
-const useSingleThreadListItem = (): ClientOutput<"threadListItem"> => {
+const useSingleThreadListItem = ({
+  isRunning,
+}: {
+  isRunning: boolean;
+}): ClientOutput<"threadListItem"> => {
   const [custom, setCustom] = useState<Record<string, unknown> | undefined>();
 
   return {
@@ -20,6 +24,7 @@ const useSingleThreadListItem = (): ClientOutput<"threadListItem"> => {
       title: undefined,
       status: "regular",
       custom,
+      isRunning,
     }),
     switchTo: () => {},
     rename: () => {},
@@ -47,8 +52,10 @@ type SingleThreadListProps = {
 const useSingleThreadList = ({
   thread,
 }: SingleThreadListProps): ClientOutput<"threads"> => {
-  const itemClient = useClientResource(SingleThreadListItem());
   const threadClient = useClientResource(thread);
+  const itemClient = useClientResource(
+    SingleThreadListItem({ isRunning: threadClient.state.isRunning }),
+  );
 
   const state = useMemo(
     () => ({

--- a/packages/react/src/tests/threadListItemIsRunning.test.tsx
+++ b/packages/react/src/tests/threadListItemIsRunning.test.tsx
@@ -3,14 +3,11 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { type FC, useEffect, useReducer } from "react";
 import { describe, expect, it } from "vitest";
-import {
-  useRemoteThreadListRuntime,
-  type AssistantRuntime,
-} from "@assistant-ui/core/react";
+import { useRemoteThreadListRuntime } from "@assistant-ui/core/react";
 import { makeAdapter } from "./remote-thread-list-test-helpers";
 import { AssistantRuntimeProvider } from "../context";
 import * as ThreadListPrimitive from "../primitives/threadList";
-import { useAui, useAuiState } from "../index";
+import { useAui, useAuiState, type AssistantRuntime } from "../index";
 import { useExternalStoreRuntime } from "../legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime";
 
 const Probe: FC = () => {

--- a/packages/react/src/tests/threadListItemIsRunning.test.tsx
+++ b/packages/react/src/tests/threadListItemIsRunning.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { type FC, useEffect, useReducer } from "react";
+import { describe, expect, it } from "vitest";
+import {
+  useRemoteThreadListRuntime,
+  type AssistantRuntime,
+} from "@assistant-ui/core/react";
+import { makeAdapter } from "./remote-thread-list-test-helpers";
+import { AssistantRuntimeProvider } from "../context";
+import * as ThreadListPrimitive from "../primitives/threadList";
+import { useAui, useAuiState } from "../index";
+import { useExternalStoreRuntime } from "../legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime";
+
+const Probe: FC = () => {
+  const id = useAuiState((s) => s.threadListItem.id);
+  const isRunning = useAuiState((s) => s.threadListItem.isRunning);
+  return (
+    <span data-testid={`item-${id}`}>{isRunning ? "running" : "idle"}</span>
+  );
+};
+
+const Items: FC = () => (
+  <ThreadListPrimitive.Items components={{ ThreadListItem: Probe }} />
+);
+
+describe("threadListItem.isRunning", () => {
+  it("reports the run of a single-thread runtime that cannot observe background threads", async () => {
+    const Inner: FC<{ isRunning: boolean }> = ({ isRunning }) => {
+      const runtime = useExternalStoreRuntime({
+        messages: [],
+        isRunning,
+        onNew: async () => {},
+      });
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <Items />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    const view = render(<Inner isRunning={false} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("item-DEFAULT_THREAD_ID").textContent).toBe(
+        "idle",
+      ),
+    );
+
+    await act(async () => {
+      view.rerender(<Inner isRunning />);
+    });
+
+    expect(screen.getByTestId("item-DEFAULT_THREAD_ID").textContent).toBe(
+      "running",
+    );
+  });
+
+  it("keeps reporting a thread the user switched away from as running", async () => {
+    const running = new Map<string, boolean>();
+    const listeners = new Set<() => void>();
+    const setRunning = (threadId: string, value: boolean) => {
+      running.set(threadId, value);
+      for (const listener of listeners) listener();
+    };
+
+    const useTestRuntimeHook = () => {
+      const aui = useAui();
+      const threadId = aui.threadListItem.getState().id;
+      const [, forceUpdate] = useReducer((n: number) => n + 1, 0);
+      useEffect(() => {
+        listeners.add(forceUpdate);
+        return () => {
+          listeners.delete(forceUpdate);
+        };
+      }, []);
+
+      return useExternalStoreRuntime({
+        messages: [],
+        isRunning: running.get(threadId) ?? false,
+        onNew: async () => {},
+      });
+    };
+
+    const adapter = makeAdapter({
+      list: async () => ({
+        threads: [
+          {
+            status: "regular" as const,
+            remoteId: "t-1",
+            externalId: "t-1",
+            title: "First",
+          },
+          {
+            status: "regular" as const,
+            remoteId: "t-2",
+            externalId: "t-2",
+            title: "Second",
+          },
+        ],
+      }),
+    });
+
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+    const Inner: FC = () => {
+      const runtime = useRemoteThreadListRuntime({
+        runtimeHook: useTestRuntimeHook,
+        adapter,
+      });
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <Items />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    await act(async () => {
+      render(<Inner />);
+    });
+    await waitFor(() => expect(screen.getByTestId("item-t-1")).toBeTruthy());
+
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("t-1");
+    });
+    await act(async () => {
+      setRunning("t-1", true);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("item-t-1").textContent).toBe("running"),
+    );
+
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("t-2");
+    });
+
+    expect(screen.getByTestId("item-t-1").textContent).toBe("running");
+    expect(screen.getByTestId("item-t-2").textContent).toBe("idle");
+
+    await act(async () => {
+      setRunning("t-1", false);
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("item-t-1").textContent).toBe("idle"),
+    );
+  });
+});

--- a/packages/react/src/tests/threadListItemIsRunning.test.tsx
+++ b/packages/react/src/tests/threadListItemIsRunning.test.tsx
@@ -7,8 +7,14 @@ import { useRemoteThreadListRuntime } from "@assistant-ui/core/react";
 import { makeAdapter } from "./remote-thread-list-test-helpers";
 import { AssistantRuntimeProvider } from "../context";
 import * as ThreadListPrimitive from "../primitives/threadList";
-import { useAui, useAuiState, type AssistantRuntime } from "../index";
+import {
+  useAui,
+  useAuiState,
+  type AssistantRuntime,
+  type ChatModelAdapter,
+} from "../index";
 import { useExternalStoreRuntime } from "../legacy-runtime/runtime-cores/external-store/useExternalStoreRuntime";
+import { useLocalRuntime } from "../legacy-runtime/runtime-cores/local/useLocalRuntime";
 
 const Probe: FC = () => {
   const id = useAuiState((s) => s.threadListItem.id);
@@ -23,6 +29,54 @@ const Items: FC = () => (
 );
 
 describe("threadListItem.isRunning", () => {
+  // LocalThreadListRuntimeCore reports no per-thread run state, so the item
+  // reaches its own run state only through the open thread.
+  it("tracks the open thread's run on a thread list with no per-thread capability", async () => {
+    let release!: () => void;
+    const adapter: ChatModelAdapter = {
+      async *run() {
+        await new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        yield { content: [{ type: "text", text: "done" }] };
+      },
+    };
+
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+    const Inner: FC = () => {
+      const runtime = useLocalRuntime(adapter);
+      capture.runtime = runtime;
+      return (
+        <AssistantRuntimeProvider runtime={runtime}>
+          <Probe />
+        </AssistantRuntimeProvider>
+      );
+    };
+
+    await act(async () => {
+      render(<Inner />);
+    });
+    const testId = `item-${capture.runtime!.threads.mainItem.getState().id}`;
+    expect(screen.getByTestId(testId).textContent).toBe("idle");
+
+    await act(async () => {
+      capture.runtime!.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "hi" }],
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId(testId).textContent).toBe("running"),
+    );
+
+    await act(async () => {
+      release();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId(testId).textContent).toBe("idle"),
+    );
+  });
+
   it("reports the run of a single-thread runtime that cannot observe background threads", async () => {
     const Inner: FC<{ isRunning: boolean }> = ({ isRunning }) => {
       const runtime = useExternalStoreRuntime({

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -9,11 +9,14 @@ import {
   ThreadListItemMorePrimitive,
   ThreadListItemPrimitive,
   ThreadListPrimitive,
+  useAui,
   useAuiState,
 } from "@assistant-ui/react";
 import {
   ArchiveIcon,
+  Loader2Icon,
   MoreHorizontalIcon,
+  PencilIcon,
   PlusIcon,
   SearchIcon,
   TrashIcon,
@@ -21,7 +24,9 @@ import {
 import {
   forwardRef,
   Fragment,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ComponentPropsWithoutRef,
   type FC,
@@ -262,28 +267,122 @@ const ThreadListSkeleton: FC = () => {
 };
 
 export const ThreadListItem: FC = () => {
+  const isRunning = useAuiState((s) => s.threadListItem.isRunning);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const restoreFocusRef = useRef(false);
+
+  useEffect(() => {
+    if (isRenaming || !restoreFocusRef.current) return;
+    restoreFocusRef.current = false;
+    triggerRef.current?.focus();
+  }, [isRenaming]);
+
   return (
     <ThreadListItemPrimitive.Root
       data-slot="aui_thread-list-item"
       className="group hover:bg-muted focus-visible:bg-muted data-active:bg-muted has-focus-visible:bg-muted has-data-[state=open]:bg-muted relative flex h-8 items-center rounded-md transition-colors focus-visible:outline-none"
     >
-      <ThreadListItemPrimitive.Trigger
-        data-slot="aui_thread-list-item-trigger"
-        className="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-[3px]"
-      >
-        <span
-          data-slot="aui_thread-list-item-title"
-          className="min-w-0 flex-1 truncate"
+      {isRenaming ? (
+        <ThreadListItemRename
+          onDone={(restoreFocus) => {
+            restoreFocusRef.current = restoreFocus;
+            setIsRenaming(false);
+          }}
+        />
+      ) : (
+        <ThreadListItemPrimitive.Trigger
+          ref={triggerRef}
+          data-slot="aui_thread-list-item-trigger"
+          className="focus-visible:ring-ring/50 flex h-full min-w-0 flex-1 items-center rounded-md px-2.5 text-start text-sm outline-none group-hover:pe-9 group-has-focus-visible:pe-9 group-has-data-[state=open]:pe-9 group-data-active:pe-9 focus-visible:ring-[3px]"
         >
-          <ThreadListItemPrimitive.Title fallback="New Chat" />
-        </span>
-      </ThreadListItemPrimitive.Trigger>
-      <ThreadListItemMore />
+          {isRunning && (
+            <Loader2Icon
+              aria-hidden
+              data-slot="aui_thread-list-item-running"
+              className="text-muted-foreground me-1.5 size-3.5 shrink-0 animate-spin"
+            />
+          )}
+          <span
+            data-slot="aui_thread-list-item-title"
+            className="min-w-0 flex-1 truncate"
+          >
+            <ThreadListItemPrimitive.Title fallback="New Chat" />
+          </span>
+          {isRunning && <span className="sr-only">Running</span>}
+        </ThreadListItemPrimitive.Trigger>
+      )}
+      <ThreadListItemMore onRename={() => setIsRenaming(true)} />
     </ThreadListItemPrimitive.Root>
   );
 };
 
-const ThreadListItemMore: FC = () => {
+const ThreadListItemRename: FC<{
+  onDone: (restoreFocus: boolean) => void;
+}> = ({ onDone }) => {
+  const aui = useAui();
+  const title = useAuiState((s) => s.threadListItem.title) ?? "";
+  const [value, setValue] = useState(title);
+  const [isPending, setIsPending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const settledRef = useRef(false);
+
+  useEffect(() => {
+    inputRef.current?.select();
+  }, []);
+
+  const commit = (restoreFocus: boolean) => {
+    if (settledRef.current) return;
+    settledRef.current = true;
+
+    const next = value.trim();
+    if (!next || next === title) {
+      onDone(restoreFocus);
+      return;
+    }
+
+    setIsPending(true);
+    Promise.resolve(aui.threadListItem.rename(next)).then(
+      () => onDone(restoreFocus),
+      () => {
+        settledRef.current = false;
+        setIsPending(false);
+        inputRef.current?.focus();
+      },
+    );
+  };
+
+  const cancel = () => {
+    if (settledRef.current) return;
+    settledRef.current = true;
+    onDone(true);
+  };
+
+  return (
+    <Input
+      ref={inputRef}
+      autoFocus
+      data-slot="aui_thread-list-item-rename"
+      aria-label="Rename thread"
+      value={value}
+      disabled={isPending}
+      className="h-7 min-w-0 flex-1 px-2.5 text-sm"
+      onChange={(event) => setValue(event.target.value)}
+      onBlur={() => commit(false)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit(true);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          cancel();
+        }
+      }}
+    />
+  );
+};
+
+const ThreadListItemMore: FC<{ onRename: () => void }> = ({ onRename }) => {
   return (
     <ThreadListItemMorePrimitive.Root sharedFocusGroup>
       <ThreadListItemMorePrimitive.Trigger asChild>
@@ -304,6 +403,14 @@ const ThreadListItemMore: FC = () => {
         data-slot="aui_thread-list-item-more-content"
         className="bg-popover/95 text-popover-foreground data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:animate-out data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden rounded-xl border p-1.5 shadow-lg backdrop-blur-sm"
       >
+        <ThreadListItemMorePrimitive.Item
+          data-slot="aui_thread-list-item-more-item"
+          className="hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground flex cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm outline-none select-none"
+          onSelect={onRename}
+        >
+          <PencilIcon className="size-4" />
+          Rename
+        </ThreadListItemMorePrimitive.Item>
         <ThreadListItemPrimitive.Archive asChild>
           <ThreadListItemMorePrimitive.Item
             data-slot="aui_thread-list-item-more-item"

--- a/packages/ui/src/components/assistant-ui/thread-list.tsx
+++ b/packages/ui/src/components/assistant-ui/thread-list.tsx
@@ -323,7 +323,6 @@ const ThreadListItemRename: FC<{
   const aui = useAui();
   const title = useAuiState((s) => s.threadListItem.title) ?? "";
   const [value, setValue] = useState(title);
-  const [isPending, setIsPending] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const settledRef = useRef(false);
 
@@ -341,15 +340,16 @@ const ThreadListItemRename: FC<{
       return;
     }
 
-    setIsPending(true);
-    Promise.resolve(aui.threadListItem.rename(next)).then(
-      () => onDone(restoreFocus),
-      () => {
-        settledRef.current = false;
-        setIsPending(false);
-        inputRef.current?.focus();
-      },
-    );
+    // Deferred so a synchronous throw lands on the rejection path too.
+    Promise.resolve()
+      .then(() => aui.threadListItem.rename(next))
+      .then(
+        () => onDone(restoreFocus),
+        () => {
+          settledRef.current = false;
+          if (restoreFocus) inputRef.current?.focus();
+        },
+      );
   };
 
   const cancel = () => {
@@ -365,8 +365,7 @@ const ThreadListItemRename: FC<{
       data-slot="aui_thread-list-item-rename"
       aria-label="Rename thread"
       value={value}
-      disabled={isPending}
-      className="h-7 min-w-0 flex-1 px-2.5 text-sm"
+      className="h-7 min-w-0 flex-1 ps-2.5 pe-9 text-sm"
       onChange={(event) => setValue(event.target.value)}
       onBlur={() => commit(false)}
       onKeyDown={(event) => {


### PR DESCRIPTION
closes #5513

## summary

- a thread list row can now read whether its own thread is running, via a new `threadListItem.isRunning` on the store scope, so a run that continues after the user switches to another thread stays visible in the list.
- the thread list component renders a running indicator from that state and adds a Rename action to the More menu, opening an inline editor over the row.
- thread lists that keep runtimes alive for non-main threads answer through a new optional `ThreadListRuntimeCore.unstable_isThreadRunning`, shaped like the `unstable_refetchThread` capability added in #5522. the remote thread list tracks each alive runtime and notifies the list only when a thread crosses the running boundary, so a streaming run does not push the whole list per token.
- a thread list that mounts only the open thread leaves the capability undefined. its other threads have no runtime and so cannot be running, and the item falls back to the open thread's run state, which the thread client already tracks reactively. that keeps single thread runtimes and the tap-native `InMemoryThreadList` working without touching the legacy cores.
- `InMemoryThreadList.rename` was a no-op stub, so the new Rename action would have been dead on the tap-native runtime. it now renames.

## breaking changes

none. `ThreadListItemState` gains a field on the read side, `ThreadListState.threadItems` resolves to exactly the shape it had before (`isRunning` is omitted from that record), and no export was removed or narrowed.

## test plan

### already verified

- [x] `pnpm --filter @assistant-ui/core --filter @assistant-ui/react test` -> core 882/882 and react 383/383 green, including two new files: run tracking on the hook instance manager (adopts the published runtime's state, tracks a thread the user switched away from, notifies only on a boundary crossing, re-tracks across a restart, releases the subscription on stop) and an integration test (a single thread external store reports its run, and a remote thread list keeps a background thread running after a switch and clears it when the run ends).
- [x] `pnpm exec turbo build --filter='./packages/*'` -> 39/39
- [x] `pnpm exec tsc -p packages/ui/tsconfig.json --noEmit` -> clean
- [x] `pnpm lint` and `pnpm exec oxfmt --check` -> clean
- [x] `bash scripts/sync-templates.sh` -> in sync
- [x] api-surface regenerated, and the API Reference Drift check reports no drift
- [x] browser, `examples/with-custom-thread-list` (remote thread list): indicator on the open thread, still on after switching away, both rows spinning during two parallel runs, cleared when a run ends. rename commits and the title updates.
- [x] browser, `examples/with-tap-runtime` (`InMemoryThreadList` + `ExternalThread`): indicator appears when the runtime starts running, and rename persists.
- [x] browser: Enter and Escape both hand focus back to the row trigger, so the thread list focus group keeps its place.

### reviewer should verify

- [ ] on a cloud or remote thread list, send in one thread, switch to another, and confirm the first row keeps its indicator until that run finishes.
- [ ] open More > Rename on a row, and confirm Enter commits, Escape cancels, blur commits, and focus lands back on the row after both keyboard exits.

## notes

- supersedes #5541, which targeted the same issue. that one read run state through `aui.threads.__internal_getAssistantRuntime()` and hand-bridged the legacy runtime with `useSyncExternalStore` inside `packages/ui`, which `shadcn add` copies into user projects. that path is undefined on the tap-native runtime, so the indicator never appeared there and the Rename action silently discarded the new title. it also left `s.threadListItem` without the state, so a user hitting the same gap still had no supported API. this PR fills the gap on the surviving surface instead, and the component reads it with a plain `useAuiState` selector.
- no new hook, and no new registry dependency (#5541 pulled in `sonner` for a rename failure toast; a rejected rename here reopens the editor with the attempted value instead).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.9bwG8cN5duPcTgFCd3H3K1VzyIRonzWNTyxBM827oROthHpnw7Dpad2cXLE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
