### PR TITLE
fix(react-langgraph): let cancelRun end a run whose stream hangs

### DIFF
--- a/.changeset/eleven-hands-move.md
+++ b/.changeset/eleven-hands-move.md
@@ -1,0 +1,9 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: `cancelRun` now settles a run whose stream hangs instead of yielding
+
+`sendMessage` consumed the caller's stream with `for await`, so a stream that ignores its `abortSignal` and then parks awaiting its own work left the loop waiting on `next()` with nothing to wake it. The run never settled, `isRunning` stayed on, and anything serialized behind it never started. #5525 stopped such a stream from being applied after cancellation, but only once it yielded again.
+
+The stream is now consumed through a wrapper that reports it as exhausted at cancellation, and finalizes it without waiting for a source that would not settle either.

--- a/.changeset/eleven-hands-move.md
+++ b/.changeset/eleven-hands-move.md
@@ -6,4 +6,4 @@ fix: `cancelRun` now settles a run whose stream hangs instead of yielding
 
 `sendMessage` consumed the caller's stream with `for await`, so a stream that ignores its `abortSignal` and then parks awaiting its own work left the loop waiting on `next()` with nothing to wake it. The run never settled, `isRunning` stayed on, and anything serialized behind it never started. #5525 stopped such a stream from being applied after cancellation, but only once it yielded again.
 
-The stream is now consumed through a wrapper that reports it as exhausted at cancellation, and finalizes it without waiting for a source that would not settle either.
+The stream is now consumed through a wrapper that reports it as exhausted at cancellation, and finalizes it without waiting for a source that would not settle either. The await that opens the stream is raced against cancellation too, since a stream that parks before handing the iterable over stranded the run the same way.

--- a/packages/react-langgraph/src/abortableIterable.test.ts
+++ b/packages/react-langgraph/src/abortableIterable.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import { abortableIterable } from "./abortableIterable";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+const collect = async <T>(iterable: AsyncIterable<T>) => {
+  const seen: T[] = [];
+  for await (const value of iterable) seen.push(value);
+  return seen;
+};
+
+describe("abortableIterable", () => {
+  it("passes a stream that completes on its own through untouched", async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+    }
+    const controller = new AbortController();
+
+    expect(
+      await collect(abortableIterable(source(), controller.signal)),
+    ).toEqual([1, 2]);
+  });
+
+  // the reason this wrapper exists: the source ignores the signal and parks on
+  // its own work, so nothing but the abort can end the loop
+  it("ends the loop while the source is parked mid-chunk", async () => {
+    const hang = deferred<void>();
+    const finallyRan = vi.fn();
+    async function* source() {
+      try {
+        yield 1;
+        await hang.promise;
+        yield 2;
+      } finally {
+        finallyRan();
+      }
+    }
+    const controller = new AbortController();
+
+    const seen: number[] = [];
+    const consuming = (async () => {
+      for await (const value of abortableIterable(
+        source(),
+        controller.signal,
+      )) {
+        seen.push(value);
+      }
+    })();
+    // let the loop take the first chunk and park awaiting the second
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    controller.abort();
+
+    // settles even though the source never does
+    await consuming;
+    expect(seen).toEqual([1]);
+    expect(finallyRan).not.toHaveBeenCalled();
+  });
+
+  it("finalizes a source still suspended at a yield when the signal aborts", async () => {
+    const finallyRan = vi.fn();
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        finallyRan();
+      }
+    }
+    const controller = new AbortController();
+
+    const seen: number[] = [];
+    for await (const value of abortableIterable(source(), controller.signal)) {
+      seen.push(value);
+      controller.abort();
+    }
+
+    expect(seen).toEqual([1]);
+    expect(finallyRan).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a stream aborted before the first read as exhausted", async () => {
+    const next = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+
+    const seen = await collect(
+      abortableIterable(
+        {
+          [Symbol.asyncIterator]: () => ({ next }),
+        } as AsyncIterable<number>,
+        controller.signal,
+      ),
+    );
+
+    expect(seen).toEqual([]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("propagates a source failure", async () => {
+    async function* source() {
+      yield 1;
+      throw new Error("stream failed");
+    }
+    const controller = new AbortController();
+
+    await expect(
+      collect(abortableIterable(source(), controller.signal)),
+    ).rejects.toThrow("stream failed");
+  });
+
+  it("finalizes the source when the consumer breaks out", async () => {
+    const finallyRan = vi.fn();
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        finallyRan();
+      }
+    }
+    const controller = new AbortController();
+
+    for await (const _ of abortableIterable(source(), controller.signal)) {
+      break;
+    }
+
+    expect(finallyRan).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases its abort listener after each chunk", async () => {
+    const controller = new AbortController();
+    const added = vi.spyOn(controller.signal, "addEventListener");
+    const removed = vi.spyOn(controller.signal, "removeEventListener");
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    await collect(abortableIterable(source(), controller.signal));
+
+    expect(added).toHaveBeenCalledTimes(removed.mock.calls.length);
+    expect(added.mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/react-langgraph/src/abortableIterable.test.ts
+++ b/packages/react-langgraph/src/abortableIterable.test.ts
@@ -132,7 +132,27 @@ describe("abortableIterable", () => {
       break;
     }
 
+    // finalized without the break waiting on it
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(finallyRan).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a source that parks in its own cleanup stall the break", async () => {
+    const hang = deferred<void>();
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        await hang.promise;
+      }
+    }
+    const controller = new AbortController();
+
+    // resolves even though the source's finally never does
+    for await (const _ of abortableIterable(source(), controller.signal)) {
+      break;
+    }
   });
 
   it("releases its abort listener after each chunk", async () => {

--- a/packages/react-langgraph/src/abortableIterable.ts
+++ b/packages/react-langgraph/src/abortableIterable.ts
@@ -1,0 +1,68 @@
+const done = <T>(): IteratorResult<T> => ({ done: true, value: undefined });
+
+/**
+ * Presents a stream as exhausted once the signal aborts, so a consumer stops
+ * waiting on it.
+ *
+ * A caller's stream is free to ignore the abort signal it is handed. One that
+ * also stops yielding, because it is awaiting its own work, leaves `for await`
+ * parked on `next()` with nothing left to wake it: the run never settles and
+ * whatever is serialized behind it never starts. Reporting the stream as
+ * exhausted ends the loop at cancellation instead.
+ *
+ * The source is finalized on the way out, but never awaited, since a stream
+ * that is already parked would not settle that either.
+ */
+export const abortableIterable = <T>(
+  source: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]: () => {
+    const iterator = source[Symbol.asyncIterator]();
+    const finalize = () => {
+      try {
+        iterator.return?.(undefined)?.catch(() => {});
+      } catch {
+        // a source that throws on finalize has nothing left to clean up
+      }
+    };
+
+    return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: () => {
+        if (signal.aborted) {
+          finalize();
+          return Promise.resolve(done<T>());
+        }
+
+        return new Promise<IteratorResult<T>>((resolve, reject) => {
+          // Registered per chunk and released as soon as the chunk settles, so
+          // a long stream does not accumulate one reaction per chunk.
+          const onAbort = () => {
+            finalize();
+            resolve(done<T>());
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          const release = () => signal.removeEventListener("abort", onAbort);
+
+          iterator.next().then(
+            (result) => {
+              release();
+              resolve(result);
+            },
+            (error: unknown) => {
+              release();
+              reject(error);
+            },
+          );
+        });
+      },
+      return: async (value?: unknown) => {
+        const result = await iterator.return?.(value);
+        return result ?? done<T>();
+      },
+    };
+  },
+});

--- a/packages/react-langgraph/src/abortableIterable.ts
+++ b/packages/react-langgraph/src/abortableIterable.ts
@@ -1,5 +1,12 @@
 const done = <T>(): IteratorResult<T> => ({ done: true, value: undefined });
 
+/** Resolves at cancellation, so an await on a stream can stop being the only way out. */
+export const whenAborted = (signal: AbortSignal): Promise<undefined> =>
+  new Promise((resolve) => {
+    if (signal.aborted) return resolve(undefined);
+    signal.addEventListener("abort", () => resolve(undefined), { once: true });
+  });
+
 /**
  * Presents a stream as exhausted once the signal aborts, so a consumer stops
  * waiting on it.
@@ -59,9 +66,12 @@ export const abortableIterable = <T>(
           );
         });
       },
-      return: async (value?: unknown) => {
-        const result = await iterator.return?.(value);
-        return result ?? done<T>();
+      // The consumer breaks out of the loop to stop a cancelled run, so this is
+      // reached on the same path as an abort and finalizes the same way: a
+      // source whose own cleanup parks must not stall the break either.
+      return: async () => {
+        finalize();
+        return done<T>();
       },
     };
   },

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { LangGraphMessageAccumulator } from "./LangGraphMessageAccumulator";
-import { abortableIterable } from "./abortableIterable";
+import { abortableIterable, whenAborted } from "./abortableIterable";
 import {
   type EventType,
   type LangChainMessageTupleEvent,
@@ -241,13 +241,29 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         activeAccumulatorRef.current = accumulator;
         setMessagesImmediate(accumulator.addMessages(newMessagesWithId));
 
-        const response = await stream(newMessagesWithId, {
-          ...config,
-          abortSignal: abortController.signal,
-          initialize: async () => {
-            return await aui.threadListItem.initialize();
-          },
-        });
+        // A stream that ignores its abortSignal can park before handing the
+        // iterable over, which strands this the same way parking mid-chunk
+        // strands the loop below.
+        const opened = Promise.resolve(
+          stream(newMessagesWithId, {
+            ...config,
+            abortSignal: abortController.signal,
+            initialize: async () => {
+              return await aui.threadListItem.initialize();
+            },
+          }),
+        );
+        const response = await Promise.race([
+          opened,
+          whenAborted(abortController.signal),
+        ]);
+        if (!response) {
+          // finalize whatever it eventually hands over, without waiting for it
+          void opened
+            .then((late) => late?.[Symbol.asyncIterator]().return?.(undefined))
+            .catch(() => {});
+          return;
+        }
 
         let hasTupleMessageEvents = false;
         let lastValuesMessages: TMessage[] | null = null;

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { LangGraphMessageAccumulator } from "./LangGraphMessageAccumulator";
+import { abortableIterable } from "./abortableIterable";
 import {
   type EventType,
   type LangChainMessageTupleEvent,
@@ -251,7 +252,10 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
         let hasTupleMessageEvents = false;
         let lastValuesMessages: TMessage[] | null = null;
         let lastValuesUIMessages: UIMessage[] | null = null;
-        for await (const chunk of response) {
+        for await (const chunk of abortableIterable(
+          response,
+          abortController.signal,
+        )) {
           // Holds even when the caller's `stream` ignores its abortSignal.
           if (abortController.signal.aborted) break;
           const { type: eventType, namespace: eventNamespace } = parseEventType(

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -2084,6 +2084,60 @@ describe("useLangGraphRuntime", () => {
           JSON.stringify(runtimeResult.current.thread.getState().messages),
         ).toContain("second-run"),
       );
+      // the second run has to settle on its own, not inherit the parked state
+      await waitFor(() =>
+        expect(runtimeResult.current.thread.getState().isRunning).toBe(false),
+      );
+    });
+
+    it("cancelRun settles a run whose stream hangs before yielding the iterable", async () => {
+      // parks before handing the iterable over, one await earlier than the
+      // loop, and ignores the signal just the same
+      const hang = deferred<void>();
+      const streamMock = vi.fn(async () => {
+        if (streamMock.mock.calls.length === 1) {
+          await hang.promise;
+        }
+        return (async function* () {
+          yield {
+            event: "messages/partial",
+            data: [{ type: "ai" as const, id: "run-2", content: "second-run" }],
+          };
+        })();
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock as never,
+          unstable_allowCancellation: true,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer.setText("hello");
+        auiResult.current.composer.send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        runtimeResult.current.thread.cancelRun();
+      });
+
+      await waitFor(() =>
+        expect(runtimeResult.current.thread.getState().isRunning).toBe(false),
+      );
+
+      await act(async () => {
+        auiResult.current.composer.setText("second");
+        auiResult.current.composer.send();
+      });
+      await waitFor(() =>
+        expect(
+          JSON.stringify(runtimeResult.current.thread.getState().messages),
+        ).toContain("second-run"),
+      );
     });
 
     it("drops the queued resume when the draining run errors", async () => {

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -2024,6 +2024,68 @@ describe("useLangGraphRuntime", () => {
       ).not.toContain("after-cancel");
     });
 
+    it("cancelRun settles a run whose stream hangs instead of yielding", async () => {
+      // never resolved: the stream ignores its abortSignal and parks on its own
+      // work, so the consuming loop is left waiting on next()
+      const hang = deferred<void>();
+      const streamMock = vi.fn(async function* () {
+        if (streamMock.mock.calls.length === 1) {
+          yield {
+            event: "messages/partial",
+            data: [
+              { type: "ai" as const, id: "run-1", content: "before-cancel" },
+            ],
+          };
+          await hang.promise;
+          return;
+        }
+        yield {
+          event: "messages/partial",
+          data: [{ type: "ai" as const, id: "run-2", content: "second-run" }],
+        };
+      });
+
+      const { result: runtimeResult } = renderHook(() =>
+        useLangGraphRuntime({
+          stream: streamMock as never,
+          unstable_allowCancellation: true,
+        }),
+      );
+      const wrapper = wrapperFactory(runtimeResult.current);
+      const { result: auiResult } = renderHook(() => useAui(), { wrapper });
+
+      await act(async () => {
+        auiResult.current.composer.setText("hello");
+        auiResult.current.composer.send();
+      });
+      await waitFor(() =>
+        expect(
+          JSON.stringify(runtimeResult.current.thread.getState().messages),
+        ).toContain("before-cancel"),
+      );
+
+      await act(async () => {
+        runtimeResult.current.thread.cancelRun();
+      });
+
+      // the parked run must stop being the active run
+      await waitFor(() =>
+        expect(runtimeResult.current.thread.getState().isRunning).toBe(false),
+      );
+
+      // and the queue must accept work behind it
+      await act(async () => {
+        auiResult.current.composer.setText("second");
+        auiResult.current.composer.send();
+      });
+      await waitFor(() => expect(streamMock).toHaveBeenCalledTimes(2));
+      await waitFor(() =>
+        expect(
+          JSON.stringify(runtimeResult.current.thread.getState().messages),
+        ).toContain("second-run"),
+      );
+    });
+
     it("drops the queued resume when the draining run errors", async () => {
       const gate = deferred<void>();
       const streamMock = vi.fn(async function* (_messages: LangChainMessage[]) {


### PR DESCRIPTION
closes #5526

## summary

- `cancelRun()` now settles a run whose stream ignores its `abortSignal` and then parks awaiting its own work. before this, `sendMessage` stayed on `next()` with nothing to wake it, so the run never settled, `isRunning` stayed on, and the serial queue never reached anything behind it.
- the stream is consumed through a new `abortableIterable` wrapper that reports it as exhausted once the signal aborts. the hot loop is still a plain `for await`; the loop body and its ~180 lines of chunk handling are untouched.
- the wrapper registers its abort listener per chunk and releases it as soon as that chunk settles. racing every chunk against one long-lived abort promise (the obvious shape) attaches a reaction per chunk to a promise that only settles at cancellation, so a long token stream would retain one per chunk for the whole run.
- the source is finalized on the way out but never awaited, since a source that is already parked would not settle `return()` either. that holds on the wrapper's `return()` path too, which the in-loop guard's `break` reaches on the same terms as an abort.
- the await that opens the stream is raced against cancellation as well: a `stream` callback that ignores its signal can park before handing the iterable over and strand the run one await earlier, with the identical symptom.
- the in-loop `aborted` guard from #5525 stays: a stream that does yield again between the abort and the next read still must not be applied.

## breaking changes

none. `abortableIterable` and `whenAborted` are internal and are not exported from the package index; regenerating api-surface produces no diff.

## test plan

### already verified

- [x] the repro added to `useLangGraphRuntime.test.tsx` fails on `main` (`isRunning` stays `true` after `cancelRun()`, `expected false, received true`) and passes with the fix. it also asserts the queue accepts work behind the parked run, so `stream` is called a second time and the second run's message lands.
- [x] the second repro, for a stream that parks before yielding the iterable, likewise fails without the race on the opening await and passes with it.
- [x] `abortableIterable.test.ts` covers the wrapper directly: a normal stream passes through untouched, a source parked mid-chunk ends the loop while never settling itself, a source suspended at a `yield` is finalized, a source that parks in its own cleanup does not stall the `break`, an abort before the first read never calls `next()`, a source failure propagates, a consumer `break` finalizes, and the abort listener add/remove counts balance.
- [x] `pnpm --filter @assistant-ui/react-langgraph test` -> 260/260 green, including the two #5525 tests this interacts with (`stops applying chunks after cancelRun even when the stream ignores its abortSignal` and the `AbortError` case).
- [x] `pnpm exec turbo build --filter=@assistant-ui/react-langgraph` -> green, api-surface unchanged.
- [x] `pnpm lint` and `pnpm exec oxfmt --check` -> clean.

### reviewer should verify

- [ ] against a real LangGraph deployment, start a run, cancel it while the server is mid-step, and confirm the composer leaves the running state and the next send goes through rather than queueing behind the cancelled run.

## notes

- two behaviours are deliberately different for a source parked inside its own `await` versus one suspended at a `yield`: the first cannot be finalized (nothing would settle `return()`), the second is. both are covered by their own test.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NXfuLENp02_Bt8YNGwex7L8zwUAgV8-2f4iQdmIUQij7JfeD0R2VkdaCLE0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
