### PR TITLE
fix(react-google-adk): keep message ids stable across event replays

### DIFF
--- a/.changeset/olive-crabs-repeat.md
+++ b/.changeset/olive-crabs-repeat.md
@@ -1,0 +1,11 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: a tool message keeps its id when its event is replayed
+
+`AdkEventAccumulator` minted a tool message's id with `uuidv4()` on every pass, so replaying a stored event through a fresh accumulator produced a different id each time. A session load does exactly that, which churned the id of every tool message on every load: React remounted those message subtrees and any per-message metadata keyed on the old id was orphaned. Assistant and human messages were already derived from the event id and unaffected.
+
+The id now derives from the event that carries the response, disambiguated by the response id and falling back to the part index when the payload omits it. An event with no id of its own still gets a generated one, since it has never been through the session and has nothing stable to derive from.
+
+This is about replaying one stored event; a message the client sent optimistically still carries a different id from the one the session assigns it, for tool messages as for every other type.

--- a/.changeset/olive-crabs-repeat.md
+++ b/.changeset/olive-crabs-repeat.md
@@ -2,10 +2,10 @@
 "@assistant-ui/react-google-adk": patch
 ---
 
-fix: a tool message keeps its id when its event is replayed
+fix: a message keeps its id when its event is replayed
 
-`AdkEventAccumulator` minted a tool message's id with `uuidv4()` on every pass, so replaying a stored event through a fresh accumulator produced a different id each time. A session load does exactly that, which churned the id of every tool message on every load: React remounted those message subtrees and any per-message metadata keyed on the old id was orphaned. Assistant and human messages were already derived from the event id and unaffected.
+`AdkEventAccumulator` minted assistant and tool message ids with `uuidv4()` on every pass, so replaying a stored event through a fresh accumulator produced different ids each time. A session load does exactly that, which churned those ids on every load: React remounted the message subtrees, and `messageMetadataMap` entries (grounding, citation, usage) keyed on the old id were orphaned. Human messages already derived theirs from the event id.
 
-The id now derives from the event that carries the response, disambiguated by the response id and falling back to the part index when the payload omits it. An event with no id of its own still gets a generated one, since it has never been through the session and has nothing stable to derive from.
+Both now derive from the event that carries them, and keep the bare event id free for the human message that has always used it: a tool message by the index of its part, an assistant message by how many that event has already opened. An event with no id of its own still gets a generated one, since it has never been through the session and has nothing stable to derive from.
 
-This is about replaying one stored event; a message the client sent optimistically still carries a different id from the one the session assigns it, for tool messages as for every other type.
+This is about replaying one stored event; a message the client sent optimistically still carries a different id from the one the session assigns it.

--- a/api-surface/assistant-ui__react-google-adk.ts
+++ b/api-surface/assistant-ui__react-google-adk.ts
@@ -93,6 +93,7 @@ declare class AdkEventAccumulator {
   private authRequests;
   private escalated;
   private messageMetadataMap;
+  private aiMessageOrdinals;
   constructor(initialMessages?: AdkMessage[]);
   processEvent(rawEvent: AdkEvent): AdkMessage[];
   private processPart;

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -298,6 +298,51 @@ describe("AdkEventAccumulator - function responses", () => {
     expect(toolMessages[0]!.id).not.toBe(toolMessages[1]!.id);
   });
 
+  it("gives an assistant message the same id on every replay", () => {
+    const events = [
+      makeTextEvent("Hel", true),
+      makeTextEvent("lo", true),
+      makeTextEvent("Hello"),
+    ];
+    const replay = () => {
+      const acc = new AdkEventAccumulator();
+      let msgs: AdkMessage[] = [];
+      for (const event of events) msgs = acc.processEvent(event);
+      return msgs;
+    };
+
+    expect(replay().map((m) => m.id)).toEqual(replay().map((m) => m.id));
+  });
+
+  it("keeps two assistant messages opened by one event distinct and stable", () => {
+    const event = makeEvent({
+      id: "evt-mixed",
+      author: "agent",
+      content: {
+        role: "model",
+        parts: [
+          { text: "before" },
+          {
+            functionResponse: {
+              name: "search",
+              id: "tc-1",
+              response: { ok: true },
+            },
+          },
+          { text: "after" },
+        ],
+      },
+    });
+
+    const first = new AdkEventAccumulator().processEvent(event);
+    const second = new AdkEventAccumulator().processEvent(event);
+
+    const aiIds = first.filter((m) => m.type === "ai").map((m) => m.id);
+    expect(aiIds.length).toBeGreaterThan(1);
+    expect(new Set(aiIds).size).toBe(aiIds.length);
+    expect(first.map((m) => m.id)).toEqual(second.map((m) => m.id));
+  });
+
   it("keeps two tool messages distinct when the payload omits response ids", () => {
     const event = makeEvent({
       id: "evt-tool",

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -239,6 +239,89 @@ describe("AdkEventAccumulator - function responses", () => {
       content: JSON.stringify({ results: [] }),
     });
   });
+
+  // A session reload replays the stored events through a fresh accumulator, so
+  // an id minted per replay churns every tool message on every load.
+  it("gives a tool message the same id on every replay of an event", () => {
+    const event = makeEvent({
+      id: "evt-tool",
+      author: "agent",
+      content: {
+        role: "model",
+        parts: [
+          {
+            functionResponse: {
+              name: "search",
+              id: "tc-1",
+              response: { results: [] },
+            },
+          },
+        ],
+      },
+    });
+
+    const first = new AdkEventAccumulator().processEvent(event);
+    const second = new AdkEventAccumulator().processEvent(event);
+
+    expect(first[0]!.id).toBe(second[0]!.id);
+  });
+
+  it("keeps two tool messages from one event distinct", () => {
+    const msgs = new AdkEventAccumulator().processEvent(
+      makeEvent({
+        id: "evt-tool",
+        author: "agent",
+        content: {
+          role: "model",
+          parts: [
+            {
+              functionResponse: {
+                name: "search",
+                id: "tc-1",
+                response: { a: 1 },
+              },
+            },
+            {
+              functionResponse: {
+                name: "lookup",
+                id: "tc-2",
+                response: { b: 2 },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    const toolMessages = msgs.filter((m) => m.type === "tool");
+    expect(toolMessages).toHaveLength(2);
+    expect(toolMessages[0]!.id).not.toBe(toolMessages[1]!.id);
+  });
+
+  it("keeps two tool messages distinct when the payload omits response ids", () => {
+    const event = makeEvent({
+      id: "evt-tool",
+      author: "agent",
+      content: {
+        role: "model",
+        parts: [
+          { functionResponse: { name: "search", response: { a: 1 } } },
+          { functionResponse: { name: "lookup", response: { b: 2 } } },
+        ],
+      },
+    });
+
+    const first = new AdkEventAccumulator()
+      .processEvent(event)
+      .filter((m) => m.type === "tool");
+    const second = new AdkEventAccumulator()
+      .processEvent(event)
+      .filter((m) => m.type === "tool");
+
+    expect(first).toHaveLength(2);
+    expect(first[0]!.id).not.toBe(first[1]!.id);
+    expect(first.map((m) => m.id)).toEqual(second.map((m) => m.id));
+  });
 });
 
 describe("AdkEventAccumulator - code execution", () => {

--- a/packages/react-google-adk/src/AdkEventAccumulator.test.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.test.ts
@@ -240,8 +240,7 @@ describe("AdkEventAccumulator - function responses", () => {
     });
   });
 
-  // A session reload replays the stored events through a fresh accumulator, so
-  // an id minted per replay churns every tool message on every load.
+  // A session load replays the stored events through a fresh accumulator.
   it("gives a tool message the same id on every replay of an event", () => {
     const event = makeEvent({
       id: "evt-tool",

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -16,17 +16,20 @@ type InProgressMessage = AdkMessage & { type: "ai" };
 
 /**
  * A session load replays the stored events through a fresh accumulator, so a
- * tool message needs an id derived from the event that carries it rather than
- * one minted per replay. The response id separates several responses in one
- * event, and the part index covers a payload that omits it. An event with no
- * id of its own has never been through the session and has nothing stable to
- * derive from.
+ * message needs an id derived from the event that carries it rather than one
+ * minted per replay. An event with no id of its own has never been through the
+ * session and has nothing stable to derive from, so it keeps a generated one.
+ *
+ * A human message keeps the bare event id it has always had. The other kinds
+ * take a suffixed namespace, since one event can carry several of them: a tool
+ * message by the index of its part, an assistant message by how many this
+ * event has already opened.
  */
-const toolMessageId = (
-  event: AdkEvent,
-  responseId: string | undefined,
-  partIndex: number,
-): string => (event.id ? `${event.id}:${responseId ?? partIndex}` : uuidv4());
+const toolMessageId = (event: AdkEvent, partIndex: number): string =>
+  event.id ? `${event.id}:${partIndex}` : uuidv4();
+
+const aiMessageId = (event: AdkEvent, ordinal: number): string =>
+  event.id ? `${event.id}:ai${ordinal === 0 ? "" : ordinal}` : uuidv4();
 
 const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
 const ADK_REQUEST_CREDENTIAL = "adk_request_credential";
@@ -201,6 +204,9 @@ export class AdkEventAccumulator {
   private authRequests: AdkAuthRequest[] = [];
   private escalated = false;
   private messageMetadataMap = new Map<string, AdkMessageMetadata>();
+  // How many assistant messages each event has opened, so a replay of that
+  // event opens them with the same ids.
+  private aiMessageOrdinals = new Map<string, number>();
   constructor(initialMessages?: AdkMessage[]) {
     if (initialMessages) {
       for (const msg of initialMessages) {
@@ -493,7 +499,7 @@ export class AdkEventAccumulator {
     if (part.functionResponse) {
       this.finalizeCurrentMessage();
       const toolMsg: AdkMessage = {
-        id: toolMessageId(event, part.functionResponse.id, partIndex),
+        id: toolMessageId(event, partIndex),
         type: "tool",
         tool_call_id: part.functionResponse.id ?? "",
         name: part.functionResponse.name,
@@ -577,7 +583,9 @@ export class AdkEventAccumulator {
       }
     }
 
-    const id = uuidv4();
+    const ordinal = this.aiMessageOrdinals.get(event.id ?? "") ?? 0;
+    this.aiMessageOrdinals.set(event.id ?? "", ordinal + 1);
+    const id = aiMessageId(event, ordinal);
     const msg: InProgressMessage = {
       id,
       type: "ai",

--- a/packages/react-google-adk/src/AdkEventAccumulator.ts
+++ b/packages/react-google-adk/src/AdkEventAccumulator.ts
@@ -14,6 +14,20 @@ import type { ReadonlyJSONObject } from "assistant-stream/utils";
 
 type InProgressMessage = AdkMessage & { type: "ai" };
 
+/**
+ * A session load replays the stored events through a fresh accumulator, so a
+ * tool message needs an id derived from the event that carries it rather than
+ * one minted per replay. The response id separates several responses in one
+ * event, and the part index covers a payload that omits it. An event with no
+ * id of its own has never been through the session and has nothing stable to
+ * derive from.
+ */
+const toolMessageId = (
+  event: AdkEvent,
+  responseId: string | undefined,
+  partIndex: number,
+): string => (event.id ? `${event.id}:${responseId ?? partIndex}` : uuidv4());
+
 const ADK_REQUEST_CONFIRMATION = "adk_request_confirmation";
 const ADK_REQUEST_CREDENTIAL = "adk_request_credential";
 
@@ -344,8 +358,8 @@ export class AdkEventAccumulator {
       }
     }
 
-    for (const part of parts) {
-      this.processPart(part, event);
+    for (const [index, part] of parts.entries()) {
+      this.processPart(part, event, index);
     }
 
     // Track per-message metadata (grounding, citation, usage)
@@ -379,7 +393,11 @@ export class AdkEventAccumulator {
     return this.getMessages();
   }
 
-  private processPart(part: AdkEventPart, event: AdkEvent): void {
+  private processPart(
+    part: AdkEventPart,
+    event: AdkEvent,
+    partIndex: number,
+  ): void {
     // Detect special ADK function calls
     if (part.functionCall && !event.partial) {
       const name = part.functionCall.name;
@@ -475,7 +493,7 @@ export class AdkEventAccumulator {
     if (part.functionResponse) {
       this.finalizeCurrentMessage();
       const toolMsg: AdkMessage = {
-        id: uuidv4(),
+        id: toolMessageId(event, part.functionResponse.id, partIndex),
         type: "tool",
         tool_call_id: part.functionResponse.id ?? "",
         name: part.functionResponse.name,


### PR DESCRIPTION
## summary

- `AdkEventAccumulator` minted **assistant and tool** message ids with `uuidv4()` on every pass, so replaying a stored event through a fresh accumulator produced different ids every time.
- a session load does exactly that: `createAdkSessionAdapter`'s `load` replays the whole event log through a new accumulator. so those messages got fresh ids on every load, React remounted their subtrees, and `messageMetadataMap` entries (grounding, citation, usage) keyed on the old id were orphaned. assistant messages are the kind that carries that metadata. human messages already derived theirs from `event.id` and are untouched.
- both now derive from the event that carries them, and leave the bare event id to the human message that has always used it: a tool message by the index of its part, an assistant message by how many that event has already opened (one event can finalize a message and open another). an event with no id of its own keeps a generated one, since it has never been through the session and has nothing stable to derive from.

## breaking changes

none. the ids were already different on every load, so nothing could have been relying on a particular one; this only makes them deterministic. `tool_call_id`, which is what tool results are matched on, is unchanged.

## notes

- upstream confirms the derivation is sound: [`google/adk-python`](https://github.com/google/adk-python/blob/main/src/google/adk/events/event.py) declares `id: str = ''` with "Do not assign the ID. It will be assigned by the session", and `model_post_init` fills it when unset. every persisted event therefore carries a stable server-assigned id, and a session GET returns the same ids on every read.
- scope: this is about replaying one stored event. a message the client sent optimistically still carries a different id from the one the session assigns it, for tool messages as for every other type; the client posts `toolCallId` rather than an event id.
- groundwork for #5528. adopting `onRefetchThread` there wants a reconcile between the fetched snapshot and what a run produced since, and a merge is only well defined once the same stored event maps to the same message id.

## test plan

### already verified

- [x] each new `AdkEventAccumulator` case was confirmed to fail without its fix and pass with it: the same event replayed through two accumulators yields the same tool message id and the same assistant message id, an assistant message streamed across several partial events replays identically, two assistant messages opened by one event stay distinct and stable, and tool responses in one event stay distinct with or without response ids.
- [x] `pnpm --filter @assistant-ui/react-google-adk test` -> 217/217 green.
- [x] `pnpm exec turbo build --filter=@assistant-ui/react-google-adk` -> green.
- [x] `pnpm lint` and `pnpm exec oxfmt --check` -> clean.
- [x] checked the round trip: `AdkEventAccumulator`'s constructor seeds `messagesMap` directly rather than re-processing, so a seeded message keeps its id and the derivation cannot compound across passes.

### reviewer should verify

- [ ] against a real ADK session containing tool calls, switch away from the thread and back, and confirm the tool messages do not visibly remount.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QDFa0468HtRM7iXkh1YkAWv3eHo68JgdbZfBfPvb73e65yhroDuEAioZXFw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
