### PR TITLE
fix(react-a2a): restore inbound file and audio parts as file message parts

### DIFF
--- a/.changeset/a2a-inbound-file-parts.md
+++ b/.changeset/a2a-inbound-file-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: restore inbound file and audio parts as file message parts instead of text placeholders

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -30,26 +30,41 @@ describe("a2aPartToContent", () => {
     });
   });
 
-  it("converts non-image URL as text link", () => {
+  it("converts non-image URL to a url-sourced file part", () => {
     const part: A2APart = {
       url: "https://example.com/doc.pdf",
       mediaType: "application/pdf",
       filename: "doc.pdf",
     };
     expect(a2aPartToContent(part)).toEqual({
-      type: "text",
-      text: "[doc.pdf](https://example.com/doc.pdf)",
+      type: "file",
+      data: "https://example.com/doc.pdf",
+      mimeType: "application/pdf",
+      sourceType: "url",
+      filename: "doc.pdf",
     });
   });
 
-  it("converts URL without filename as plain text", () => {
+  it("converts URL without filename to a file part without filename", () => {
     const part: A2APart = {
       url: "https://example.com/doc.pdf",
       mediaType: "application/pdf",
     };
     expect(a2aPartToContent(part)).toEqual({
-      type: "text",
-      text: "https://example.com/doc.pdf",
+      type: "file",
+      data: "https://example.com/doc.pdf",
+      mimeType: "application/pdf",
+      sourceType: "url",
+    });
+  });
+
+  it("falls back to application/octet-stream for a URL without mediaType", () => {
+    const part: A2APart = { url: "https://example.com/download" };
+    expect(a2aPartToContent(part)).toEqual({
+      type: "file",
+      data: "https://example.com/download",
+      mimeType: "application/octet-stream",
+      sourceType: "url",
     });
   });
 
@@ -64,26 +79,38 @@ describe("a2aPartToContent", () => {
     });
   });
 
-  it("converts raw non-image bytes as file reference", () => {
+  it("converts raw non-image bytes to a base64 file part", () => {
     const part: A2APart = {
       raw: "AAAA",
       mediaType: "application/pdf",
       filename: "report.pdf",
     };
     expect(a2aPartToContent(part)).toEqual({
-      type: "text",
-      text: "[File: report.pdf]",
+      type: "file",
+      data: "AAAA",
+      mimeType: "application/pdf",
+      filename: "report.pdf",
     });
   });
 
-  it("converts raw bytes without filename", () => {
+  it("converts raw audio bytes to a file part with the audio mime type", () => {
     const part: A2APart = {
-      raw: "AAAA",
-      mediaType: "application/octet-stream",
+      raw: "SGVsbG8=",
+      mediaType: "audio/mp3",
     };
     expect(a2aPartToContent(part)).toEqual({
-      type: "text",
-      text: "[File: download]",
+      type: "file",
+      data: "SGVsbG8=",
+      mimeType: "audio/mp3",
+    });
+  });
+
+  it("falls back to application/octet-stream for raw bytes without mediaType", () => {
+    const part: A2APart = { raw: "AAAA" };
+    expect(a2aPartToContent(part)).toEqual({
+      type: "file",
+      data: "AAAA",
+      mimeType: "application/octet-stream",
     });
   });
 
@@ -100,6 +127,49 @@ describe("a2aPartToContent", () => {
   it("returns empty text for empty part", () => {
     const part: A2APart = {};
     expect(a2aPartToContent(part)).toEqual({ type: "text", text: "" });
+  });
+});
+
+describe("inbound file part round trip", () => {
+  const restoreFilePart = (part: A2APart) => {
+    const restored = a2aPartToContent(part);
+    if (restored.type !== "file") throw new Error("expected a file part");
+    return restored;
+  };
+
+  it("reproduces a url wire part through the outbound converter", () => {
+    const part: A2APart = {
+      url: "https://example.com/doc.pdf",
+      mediaType: "application/pdf",
+      filename: "doc.pdf",
+    };
+    expect(contentPartsToA2AParts([restoreFilePart(part)])).toEqual([part]);
+  });
+
+  it("reproduces a raw wire part through the outbound converter", () => {
+    const part: A2APart = {
+      raw: "AAAA",
+      mediaType: "application/pdf",
+      filename: "report.pdf",
+    };
+    expect(contentPartsToA2AParts([restoreFilePart(part)])).toEqual([part]);
+  });
+
+  it("resends a url part without mediaType with the octet-stream fallback", () => {
+    const part: A2APart = { url: "https://example.com/download" };
+    expect(contentPartsToA2AParts([restoreFilePart(part)])).toEqual([
+      {
+        url: "https://example.com/download",
+        mediaType: "application/octet-stream",
+      },
+    ]);
+  });
+
+  it("resends a raw part without mediaType with the octet-stream fallback", () => {
+    const part: A2APart = { raw: "AAAA" };
+    expect(contentPartsToA2AParts([restoreFilePart(part)])).toEqual([
+      { raw: "AAAA", mediaType: "application/octet-stream" },
+    ]);
   });
 });
 

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -19,8 +19,11 @@ export function a2aPartToContent(
       return { type: "image", image: part.url };
     }
     return {
-      type: "text",
-      text: part.filename ? `[${part.filename}](${part.url})` : part.url,
+      type: "file",
+      data: part.url,
+      mimeType: part.mediaType ?? "application/octet-stream",
+      sourceType: "url",
+      ...(part.filename && { filename: part.filename }),
     };
   }
   if (part.raw !== undefined) {
@@ -31,8 +34,10 @@ export function a2aPartToContent(
       };
     }
     return {
-      type: "text",
-      text: `[File: ${part.filename ?? "download"}]`,
+      type: "file",
+      data: part.raw,
+      mimeType: part.mediaType ?? "application/octet-stream",
+      ...(part.filename && { filename: part.filename }),
     };
   }
   if (part.data !== undefined) {


### PR DESCRIPTION
## What

The react-a2a inbound converter now restores non-image url and raw wire parts as real `file` message parts instead of degrading them to text. Url parts come back with `sourceType: "url"`, raw parts keep their bare base64 payload, and a missing wire `mediaType` falls back to `application/octet-stream`.

## Why

While tracing an agent reply carrying raw bytes, I found the converter drops the payload entirely and renders the literal text `[File: download]`, so the bytes are unrecoverable from the thread and the File renderer never fires. This is the last adapter placeholder arm left after the file-part normalization wave (#5444, #5456, #5461). Closes #5546.

## Impact

- Agent-returned files and audio now render through the File part renderer with a working download instead of a text stub.
- Restored parts round-trip through the existing outbound converter unchanged (pinned by test).
- Copy and speech text extraction no longer includes the placeholder string, since the part is no longer text; same delta the adk and langchain restores accepted.

## Scope 

- The `data` arm stays JSON text: `DataMessagePart` requires a `name` the A2A wire does not carry (already litigated on #5220).
- No filename synthesis for filename-less audio: the A2A wire has a real filename slot, so absence is signal; matches adk (#5456), while langchain synthesizes only because its wire block lacks the slot.
- Known round-trip asymmetry, pinned by test: a url part with no wire `mediaType` resends with `application/octet-stream`, same as the sibling adapters.
- Image arms untouched; the pre-existing drop of `filename` on image parts is tracked as a follow-up, not folded in here.
- Additive only: no exports added or reshaped, output stays inside the documented assistant content union.
- Tests: both restored arms, both fallbacks, audio mime passthrough, and three round-trip contract tests; the three tests that pinned the old placeholder text were rewritten to pin the new shapes.
- Changeset: patch (`@assistant-ui/react-a2a`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.1UgD9AMZJ6VYM04cAmI6FKkqCsPbvOGZNOrgefDSlgnuPoWxu611Bbj28dw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->