### PR TITLE
fix(ui): render file message parts in the shipped Thread

### DIFF
--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -181,6 +181,7 @@ export const registry: RegistryItem[] = [
     registryDependencies: [
       "button",
       "https://r.assistant-ui.com/attachment.json",
+      "https://r.assistant-ui.com/file.json",
       "https://r.assistant-ui.com/follow-up-suggestions.json",
       "https://r.assistant-ui.com/markdown-text.json",
       "https://r.assistant-ui.com/reasoning.json",

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -212,7 +212,8 @@ const FileImpl: FileMessagePartComponent = ({
   sourceType,
 }) => {
   const kind = getFileDataKind(data, sourceType);
-  const showSize = kind === "base64" || kind === "data-uri";
+  const showSize =
+    typeof data === "string" && (kind === "base64" || kind === "data-uri");
 
   return (
     <FileRoot>

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -183,6 +183,7 @@ function FileDownload({
   children,
   ...props
 }: FileDownloadProps) {
+  if (typeof data !== "string") return null;
   const kind = getFileDataKind(data, sourceType);
   if (kind === "id") return null;
   if (kind === "url" && !/^(https?:\/\/|blob:)/i.test(data)) return null;

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -5,6 +5,7 @@ import {
   ComposerAttachments,
   UserMessageAttachments,
 } from "@/components/assistant-ui/attachment";
+import { File } from "@/components/assistant-ui/file";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
@@ -398,6 +399,8 @@ const AssistantMessage: FC = () => {
                 return part.toolUI ?? <ToolFallbackComponent {...part} />;
               case "data":
                 return part.dataRendererUI;
+              case "file":
+                return <File {...part} />;
               case "indicator":
                 return (
                   <span

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -490,7 +490,7 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts components={{ File }} />
+          <MessagePrimitive.Parts />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -400,7 +400,11 @@ const AssistantMessage: FC = () => {
               case "data":
                 return part.dataRendererUI;
               case "file":
-                return <File {...part} />;
+                return (
+                  <div data-slot="aui_assistant-message-file" className="py-1">
+                    <File {...part} />
+                  </div>
+                );
               case "indicator":
                 return (
                   <span

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -490,7 +490,7 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts />
+          <MessagePrimitive.Parts components={{ File }} />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />


### PR DESCRIPTION
## What

The shipped Thread now renders `file` message parts through the existing `File` component: a `case "file"` arm in the assistant GroupedParts switch, plus `file.json` in the thread registry item's `registryDependencies` so `shadcn add thread` stays self-contained.

## Why

The claude review on #5547 flagged (correctly) that restoring a2a inbound parts as `file` parts would render as nothing by default: the switch had no `file` arm and the platform default is `File: () => null`. This is also a hole today for the adapters that already emit file parts after the normalization wave (#5444, #5456, #5461). Lands first so #5547 merges regression-free.

## Impact

- File parts from any runtime now show icon, name, size, and a download affordance in the default Thread instead of nothing.
- Consumers who already registered their own `File` handling are unaffected; the arm only fills the previously-null default.

## Scope 

- `image` parts are also unrendered by the same switch: pre-existing and untouched here, since rendering images invites sizing/layout decisions this PR should not smuggle in; tracked as a follow-up.
- The minimal template's thread is an intentional slim fork (sync-templates OVERRIDES, renders text/tool-call only) and stays unchanged; sync check passes.
- User-side rendering was added in `0b8bc1b` and deliberately reverted in `2303b46`: react-langgraph flattens attachment content into the wire message and reattaches the attachment for chip rendering, so an in-session attachment would render twice (chip plus File card). The fix belongs in langgraph (dedupe the in-session copies, matching how react-ai-sdk and react-ag-ui strip user media from content); the user-side arm returns in a follow-up PR once that lands. Restored-history user file parts stay invisible until then, which is the pre-existing state, not a regression.
- Tests: none added; packages/ui carries no test harness, and the change is a render wiring covered by the registry build + template sync + full build gates.
- No changeset: `@assistant-ui/ui` and the registry app are both private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.c_R9qkNMrBuzr2ehiTh6wl5zPWzV8LKnIqQOZNyr1pGSLYsX1lfmUNgOgnw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->