### PR TITLE
fix(react-langgraph): drop in-session attachment duplicates from converted content

### DIFF
--- a/.changeset/langgraph-attachment-dedupe.md
+++ b/.changeset/langgraph-attachment-dedupe.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: drop in-session attachment duplicates from converted message content

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1611,92 +1611,65 @@ describe("convertLangChainMessages attachment dedupe", () => {
     expect(result.content).toEqual([{ type: "text", text: "here is my file" }]);
   });
 
+  const deriveWire = (attachments: readonly unknown[]) =>
+    getMessageContent({
+      role: "user",
+      content: [],
+      attachments,
+    } as unknown as AppendMessage) as LangChainMessage["content"];
+
   it("drops the flattened copy of an attachment image from content", () => {
+    const attachment = {
+      id: "att-img",
+      type: "image",
+      name: "img.png",
+      status: { type: "complete" },
+      content: [{ type: "image", image: "data:image/png;base64,aW1n" }],
+    };
     const result = convertLangChainMessages(
-      {
-        type: "human",
-        id: "m1",
-        content: [
-          {
-            type: "image_url",
-            image_url: { url: "data:image/png;base64,aW1n" },
-          },
-        ],
-      },
-      withAttachments("m1", [
-        {
-          id: "att-img",
-          type: "image",
-          name: "img.png",
-          status: { type: "complete" },
-          content: [{ type: "image", image: "data:image/png;base64,aW1n" }],
-        },
-      ]),
+      { type: "human", id: "m1", content: deriveWire([attachment]) },
+      withAttachments("m1", [attachment]),
     );
 
-    expect(result.content).toEqual([]);
+    expect(result.content).toEqual([{ type: "text", text: " " }]);
   });
 
   it("matches across the wire's data URL stripping", () => {
-    const result = convertLangChainMessages(
-      {
-        type: "human",
-        id: "m1",
-        content: [
-          {
-            type: "audio",
-            data: "QUJD",
-            mime_type: "audio/mp3",
-            source_type: "base64",
-          },
-        ],
-      },
-      withAttachments("m1", [
+    const attachment = {
+      id: "att-audio",
+      type: "file",
+      name: "voice.mp3",
+      status: { type: "complete" },
+      content: [
         {
-          id: "att-audio",
           type: "file",
-          name: "voice.mp3",
-          status: { type: "complete" },
-          content: [
-            {
-              type: "file",
-              data: "data:audio/mp3;base64,QUJD",
-              mimeType: "audio/mp3",
-            },
-          ],
+          data: "data:audio/mp3;base64,QUJD",
+          mimeType: "audio/mp3",
         },
-      ]),
+      ],
+    };
+    const result = convertLangChainMessages(
+      { type: "human", id: "m1", content: deriveWire([attachment]) },
+      withAttachments("m1", [attachment]),
     );
 
-    expect(result.content).toEqual([]);
+    expect(result.content).toEqual([{ type: "text", text: " " }]);
   });
 
   it("dedupes an attachment carrying a legacy audio part", () => {
+    const attachment = {
+      id: "att-legacy-audio",
+      type: "file",
+      name: "voice.mp3",
+      status: { type: "complete" },
+      content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+    };
     const result = convertLangChainMessages(
-      {
-        type: "human",
-        id: "m1",
-        content: [
-          {
-            type: "audio",
-            data: "QUJD",
-            mime_type: "audio/mp3",
-            source_type: "base64",
-          },
-        ],
-      },
-      withAttachments("m1", [
-        {
-          id: "att-legacy-audio",
-          type: "file",
-          name: "voice.mp3",
-          status: { type: "complete" },
-          content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
-        },
-      ]),
+      { type: "human", id: "m1", content: deriveWire([attachment]) },
+      withAttachments("m1", [attachment]),
     );
 
-    expect(result.content).toEqual([]);
+    expect(result.content).toEqual([{ type: "text", text: " " }]);
   });
 
   it("keeps direct-content media sent alongside an attachment", () => {
@@ -1711,6 +1684,36 @@ describe("convertLangChainMessages attachment dedupe", () => {
 
     expect(result.content).toEqual([
       expect.objectContaining({ type: "file", data: "REVG" }),
+    ]);
+  });
+
+  it("keeps the direct part when it shares a payload with an attachment", () => {
+    const directBlock = {
+      type: "file" as const,
+      data: "QUJD",
+      mime_type: "application/pdf",
+      source_type: "base64" as const,
+      metadata: { filename: "mine.pdf" },
+    };
+    const flattenedBlock = {
+      ...fileBlock("QUJD"),
+      metadata: { filename: "attached.pdf" },
+    };
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [directBlock, flattenedBlock],
+      },
+      withAttachments("m1", [fileAttachment("QUJD", "attached.pdf")]),
+    );
+
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: "file",
+        data: "QUJD",
+        filename: "mine.pdf",
+      }),
     ]);
   });
 

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1573,3 +1573,196 @@ describe("convertLangChainMessages audio transcripts", () => {
     }
   });
 });
+
+describe("convertLangChainMessages attachment dedupe", () => {
+  const fileAttachment = (data: string, name = "doc.pdf") => ({
+    id: `att-${name}`,
+    type: "file" as const,
+    name,
+    contentType: "application/pdf",
+    status: { type: "complete" as const },
+    content: [{ type: "file" as const, data, mimeType: "application/pdf" }],
+  });
+
+  const withAttachments = (
+    messageId: string,
+    attachments: readonly unknown[],
+  ) => ({
+    attachmentsByMessageId: new Map([[messageId, attachments]]),
+  });
+
+  const fileBlock = (data: string) => ({
+    type: "file" as const,
+    data,
+    mime_type: "application/pdf",
+    source_type: "base64" as const,
+  });
+
+  it("drops the flattened copy of an attachment file from content", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [{ type: "text", text: "here is my file" }, fileBlock("QUJD")],
+      },
+      withAttachments("m1", [fileAttachment("QUJD")]),
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "here is my file" }]);
+  });
+
+  it("drops the flattened copy of an attachment image from content", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "data:image/png;base64,aW1n" },
+          },
+        ],
+      },
+      withAttachments("m1", [
+        {
+          id: "att-img",
+          type: "image",
+          name: "img.png",
+          status: { type: "complete" },
+          content: [{ type: "image", image: "data:image/png;base64,aW1n" }],
+        },
+      ]),
+    );
+
+    expect(result.content).toEqual([]);
+  });
+
+  it("matches across the wire's data URL stripping", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [
+          {
+            type: "audio",
+            data: "QUJD",
+            mime_type: "audio/mp3",
+            source_type: "base64",
+          },
+        ],
+      },
+      withAttachments("m1", [
+        {
+          id: "att-audio",
+          type: "file",
+          name: "voice.mp3",
+          status: { type: "complete" },
+          content: [
+            {
+              type: "file",
+              data: "data:audio/mp3;base64,QUJD",
+              mimeType: "audio/mp3",
+            },
+          ],
+        },
+      ]),
+    );
+
+    expect(result.content).toEqual([]);
+  });
+
+  it("dedupes an attachment carrying a legacy audio part", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [
+          {
+            type: "audio",
+            data: "QUJD",
+            mime_type: "audio/mp3",
+            source_type: "base64",
+          },
+        ],
+      },
+      withAttachments("m1", [
+        {
+          id: "att-legacy-audio",
+          type: "file",
+          name: "voice.mp3",
+          status: { type: "complete" },
+          content: [{ type: "audio", audio: { data: "QUJD", format: "mp3" } }],
+        },
+      ]),
+    );
+
+    expect(result.content).toEqual([]);
+  });
+
+  it("keeps direct-content media sent alongside an attachment", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [fileBlock("QUJD"), fileBlock("REVG")],
+      },
+      withAttachments("m1", [fileAttachment("QUJD")]),
+    );
+
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "file", data: "REVG" }),
+    ]);
+  });
+
+  it("drops one content part per duplicate attachment payload", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [fileBlock("QUJD"), fileBlock("QUJD"), fileBlock("QUJD")],
+      },
+      withAttachments("m1", [
+        fileAttachment("QUJD", "a.pdf"),
+        fileAttachment("QUJD", "b.pdf"),
+      ]),
+    );
+
+    expect(result.content).toEqual([
+      expect.objectContaining({ type: "file", data: "QUJD" }),
+    ]);
+  });
+
+  it("keeps content parts untouched when no attachments are staged", () => {
+    const result = convertLangChainMessages({
+      type: "human",
+      id: "m1",
+      content: [{ type: "text", text: "hello" }, fileBlock("QUJD")],
+    });
+
+    expect(result.content).toEqual([
+      { type: "text", text: "hello" },
+      expect.objectContaining({ type: "file", data: "QUJD" }),
+    ]);
+  });
+
+  it("never drops text parts even when an attachment carries text", () => {
+    const result = convertLangChainMessages(
+      {
+        type: "human",
+        id: "m1",
+        content: [{ type: "text", text: "pasted text" }],
+      },
+      withAttachments("m1", [
+        {
+          id: "att-txt",
+          type: "document",
+          name: "notes.txt",
+          status: { type: "complete" },
+          content: [{ type: "text", text: "pasted text" }],
+        },
+      ]),
+    );
+
+    expect(result.content).toEqual([{ type: "text", text: "pasted text" }]);
+  });
+});

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -245,8 +245,10 @@ const attachmentPartKey = (part: {
  * getMessageContent flattens attachment content into the wire message while
  * the runtime reattaches the original attachments for chip rendering, so in
  * the sender's session each attachment payload arrives back twice. Drops the
- * flattened copies, at most one content part per attachment part; on reload
- * the staging map is empty and content parts pass through untouched.
+ * flattened copies, at most one content part per attachment part, consuming
+ * from the trailing end because getMessageContent appends the flattened
+ * copies after the user's direct content; on reload the staging map is empty
+ * and content parts pass through untouched.
  */
 const dropAttachmentDuplicates = (
   parts: ReturnType<typeof contentToParts>,
@@ -258,14 +260,17 @@ const dropAttachmentDuplicates = (
     if (key) counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   if (counts.size === 0) return parts;
-  return parts.filter((part) => {
-    const key = attachmentPartKey(part);
-    if (!key) return true;
+  const dropped = new Set<number>();
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const key = attachmentPartKey(parts[i]!);
+    if (!key) continue;
     const remaining = counts.get(key);
-    if (!remaining) return true;
+    if (!remaining) continue;
     counts.set(key, remaining - 1);
-    return false;
-  });
+    dropped.add(i);
+  }
+  if (dropped.size === 0) return parts;
+  return parts.filter((_, i) => !dropped.has(i));
 };
 
 const hasVisibleText = (text: unknown): boolean =>

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -224,6 +224,50 @@ const contentToParts = (
     .filter((a) => a !== null);
 };
 
+const normalizePayload = (value: string) => parseDataUrl(value)?.data ?? value;
+
+const attachmentPartKey = (part: {
+  type: string;
+  image?: string;
+  data?: unknown;
+  audio?: { data: string };
+}): string | null => {
+  if (part.type === "image" && typeof part.image === "string")
+    return `image:${normalizePayload(part.image)}`;
+  if (part.type === "file" && typeof part.data === "string")
+    return `file:${normalizePayload(part.data)}`;
+  if (part.type === "audio" && part.audio)
+    return `file:${normalizePayload(part.audio.data)}`;
+  return null;
+};
+
+/**
+ * getMessageContent flattens attachment content into the wire message while
+ * the runtime reattaches the original attachments for chip rendering, so in
+ * the sender's session each attachment payload arrives back twice. Drops the
+ * flattened copies, at most one content part per attachment part; on reload
+ * the staging map is empty and content parts pass through untouched.
+ */
+const dropAttachmentDuplicates = (
+  parts: ReturnType<typeof contentToParts>,
+  attachments: readonly CompleteAttachment[],
+): ReturnType<typeof contentToParts> => {
+  const counts = new Map<string, number>();
+  for (const part of attachments.flatMap((a) => a.content)) {
+    const key = attachmentPartKey(part);
+    if (key) counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  if (counts.size === 0) return parts;
+  return parts.filter((part) => {
+    const key = attachmentPartKey(part);
+    if (!key) return true;
+    const remaining = counts.get(key);
+    if (!remaining) return true;
+    counts.set(key, remaining - 1);
+    return false;
+  });
+};
+
 const hasVisibleText = (text: unknown): boolean =>
   typeof text === "string" && text.trim() !== "";
 
@@ -267,10 +311,13 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
       const attachments = message.id
         ? metadata.attachmentsByMessageId?.get(message.id)
         : undefined;
+      const parts = contentToParts(message.content, metadata, message.id);
       return {
         role: "user",
         id: message.id,
-        content: contentToParts(message.content, metadata, message.id),
+        content: attachments?.length
+          ? dropAttachmentDuplicates(parts, attachments)
+          : parts,
         metadata: { custom: getCustomMetadata(message.additional_kwargs) },
         ...(attachments?.length ? { attachments } : {}),
       };

--- a/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
+++ b/packages/react-langgraph/src/useLangGraphRuntime.test.tsx
@@ -427,6 +427,12 @@ describe("useLangGraphRuntime", () => {
         mimeType: "application/pdf",
       },
     ]);
+
+    expect(userMessage?.content).toHaveLength(1);
+    expect(userMessage?.content?.[0]).toMatchObject({
+      type: "text",
+      text: " ",
+    });
   });
 
   it("should use unstable_threadListAdapter in place of the cloud adapter", async () => {


### PR DESCRIPTION
## What

In the sender's session, the langgraph converter now drops content parts that are flattened copies of the message's attachments, so each attachment payload appears exactly once on the converted message. Matching is payload-precise per attachment part, not a blanket media strip.

## Why

While re-landing the shipped Thread's user-side File renderer (#5548), the claude review caught that langgraph would render every attachment twice: the runtime flattens attachment content into the wire message and reattaches the original attachments for chip rendering, so both copies come back. Part of #5549.

## Impact

- langgraph users with an attachments adapter see chips only in their session; the duplicate content parts are gone once anything renders file parts.
- Fresh reload is untouched: the staging map is empty there, so restored history keeps its content parts.
- No wire change: the model still receives the flattened content.

## Scope & caveats

- Payload matching normalizes with `parseDataUrl(x)?.data ?? x` on both sides because the wire strips data URL envelopes for file and audio payloads but passes urls and ids verbatim.
- Not a blanket strip on purpose: direct-content media appended alongside attachments keeps rendering (covered by test). react-ai-sdk needs no equivalent: it already strips user file parts from content (convertMessage.ts:189-193, since #3695), so attachments are its single carrier.
- Session asymmetry is accepted and inherent to the chip design (#4790): the sender sees chips, other sessions see content parts; both see the payload once.
- Known theoretical edge: identical payload strings with different mime or filename dedupe by content order (direct part first); mime-matching would be unreliable since the wire remaps audio mimes and strips envelopes.
- Text parts are never dropped: flattened attachment text renders in the bubble today by design.
- react-langchain needs no change: it has no reattachment mechanism.
- Tests: all three key arms (file, image, legacy audio part), data URL normalization, multiset duplicates, direct-content survival, reload no-op, text immunity.
- Changeset: patch (`@assistant-ui/react-langgraph`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NUP7515IJHAXJ_NKw-1dAMUVavAZcDa8UFgOYFxbZbypbMAwjYX_6Uwg2W8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->