### PR TITLE
fix(react-a2a): keep the wire filename on inbound image parts

### DIFF
--- a/.changeset/a2a-inbound-image-filename.md
+++ b/.changeset/a2a-inbound-image-filename.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: keep the wire filename on inbound image parts

--- a/packages/react-a2a/src/conversions.test.ts
+++ b/packages/react-a2a/src/conversions.test.ts
@@ -68,6 +68,19 @@ describe("a2aPartToContent", () => {
     });
   });
 
+  it("keeps the wire filename on an image URL part", () => {
+    const part: A2APart = {
+      url: "https://example.com/img.png",
+      mediaType: "image/png",
+      filename: "img.png",
+    };
+    expect(a2aPartToContent(part)).toEqual({
+      type: "image",
+      image: "https://example.com/img.png",
+      filename: "img.png",
+    });
+  });
+
   it("converts raw image bytes to data URI", () => {
     const part: A2APart = {
       raw: "iVBORw0KGgo=",
@@ -76,6 +89,19 @@ describe("a2aPartToContent", () => {
     expect(a2aPartToContent(part)).toEqual({
       type: "image",
       image: "data:image/png;base64,iVBORw0KGgo=",
+    });
+  });
+
+  it("keeps the wire filename on raw image bytes", () => {
+    const part: A2APart = {
+      raw: "iVBORw0KGgo=",
+      mediaType: "image/png",
+      filename: "img.png",
+    };
+    expect(a2aPartToContent(part)).toEqual({
+      type: "image",
+      image: "data:image/png;base64,iVBORw0KGgo=",
+      filename: "img.png",
     });
   });
 
@@ -153,6 +179,17 @@ describe("inbound file part round trip", () => {
       filename: "report.pdf",
     };
     expect(contentPartsToA2AParts([restoreFilePart(part)])).toEqual([part]);
+  });
+
+  it("reproduces a raw image wire part through the outbound converter", () => {
+    const part: A2APart = {
+      raw: "iVBORw0KGgo=",
+      mediaType: "image/png",
+      filename: "img.png",
+    };
+    const restored = a2aPartToContent(part);
+    if (restored.type !== "image") throw new Error("expected an image part");
+    expect(contentPartsToA2AParts([restored])).toEqual([part]);
   });
 
   it("resends a url part without mediaType with the octet-stream fallback", () => {

--- a/packages/react-a2a/src/conversions.ts
+++ b/packages/react-a2a/src/conversions.ts
@@ -16,7 +16,11 @@ export function a2aPartToContent(
   }
   if (part.url !== undefined) {
     if (isImageMediaType(part.mediaType)) {
-      return { type: "image", image: part.url };
+      return {
+        type: "image",
+        image: part.url,
+        ...(part.filename && { filename: part.filename }),
+      };
     }
     return {
       type: "file",
@@ -31,6 +35,7 @@ export function a2aPartToContent(
       return {
         type: "image",
         image: `data:${part.mediaType};base64,${part.raw}`,
+        ...(part.filename && { filename: part.filename }),
       };
     }
     return {


### PR DESCRIPTION
## What

The react-a2a inbound converter now keeps the wire `filename` on both image restores (url and raw data-URI) instead of discarding it.

## Why

Surfaced while verifying the inbound file-part restore: `ImageMessagePart` has a `filename` slot and the outbound image leg already forwards it, so the restore was the only place a named agent image lost its name. Stacked on #5547 and will rebase once it lands.

## Impact

- Named agent images round-trip with their filename; unnamed ones are unchanged.
- No output change for any part without a wire filename.

## Scope 

- Two-line change, same `...(part.filename && { filename })` idiom as the parent PR and the outbound legs.
- Round-trip test covers the raw image leg only: the outbound url-image leg drops `mediaType` by design (pre-existing, no `fallbackMimeType`), so a url-image round-trip would pin unrelated behavior.
- Additive only: `filename` is an existing optional field on `ImageMessagePart`.
- Tests: filename kept on both restores, plus the raw image round-trip.
- Changeset: patch (`@assistant-ui/react-a2a`).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._W_ajzPFRwouEzV-eSeVarLpGrQ2HmDi8nCEZ1uMzzkk8a9KK1mlf6i_6Vw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->