### PR TITLE
fix(core): handle failed initial thread runtime starts

### DIFF
--- a/.changeset/calm-runtime-starts.md
+++ b/.changeset/calm-runtime-starts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: handle stopped initial thread runtime starts

--- a/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
+++ b/packages/core/src/react/runtimes/RemoteThreadListThreadListRuntimeCore.tsx
@@ -473,7 +473,10 @@ export class RemoteThreadListThreadListRuntimeCore
     if (this.mainThreadId !== undefined) {
       await task;
     } else {
-      task.then(() => this._notifySubscribers());
+      void task.then(
+        () => this._notifySubscribers(),
+        () => undefined,
+      );
     }
 
     if (generation !== this._switchGeneration) return;

--- a/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-order.test.ts
+++ b/packages/core/src/tests/RemoteThreadListThreadListRuntimeCore-switchToThread-order.test.ts
@@ -64,6 +64,37 @@ describe("RemoteThreadListThreadListRuntimeCore.switchToThread order", () => {
     expect(core.mainThreadId).toBe(core.getItemById("thread-c")?.id);
   });
 
+  it("handles a stopped initial runtime start", async () => {
+    const rejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    const priorListeners = process.listeners("unhandledRejection");
+    process.removeAllListeners("unhandledRejection");
+    process.on("unhandledRejection", onUnhandledRejection);
+    try {
+      const core = createCore(makeAdapter());
+      const newThreadId = core.newThreadId;
+      if (!newThreadId) throw new Error("Expected an initial new thread");
+      const runtimeId = core.getItemById(newThreadId)?.id;
+      if (!runtimeId) throw new Error("Expected an initial runtime id");
+
+      (
+        core as unknown as {
+          _hookManager: { stopThreadRuntime: (id: string) => void };
+        }
+      )._hookManager.stopThreadRuntime(runtimeId);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandledRejection);
+      for (const listener of priorListeners) {
+        process.on("unhandledRejection", listener);
+      }
+    }
+
+    expect(rejections).toEqual([]);
+  });
+
   it("invalidates an earlier switch while a new thread request is pending", async () => {
     const initializeThread = deferred<{
       remoteId: string;


### PR DESCRIPTION
## Summary

- handle the detached initial runtime start rejection
- preserve successful initial runtime notifications
- add regression coverage for stop-before-mount

## Why

This is a follow-up to #5066. The initial thread switch cannot await runtime attachment because React must mount its binder first. If that runtime is stopped before mount, #5066 correctly rejects the pending start, but the success-only `.then()` propagated the rejection as a global `unhandledRejection`.

This can happen when the initial thread is removed or replaced before its runtime binder mounts. The detached initial branch now consumes that expected rejection. Later thread switches still await and propagate start failures normally.

## Verification

- confirmed the regression test fails on the old code with `Thread was deleted before runtime was started`
- focused switch-order suite: 8 tests passed
- core suite: 87 files and 883 tests passed
- `@assistant-ui/core` build
- oxlint, oxfmt, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4gYVS8sdRLN7sljZjA54L97gj3GztlN1zm-q6cc4jw86Zv0fyJIu5BSO254?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->