### PR TITLE
fix(ui): render file parts in user messages and note the shipped default in docs

### DIFF
--- a/apps/docs/content/docs/ui/file.mdx
+++ b/apps/docs/content/docs/ui/file.mdx
@@ -22,7 +22,7 @@ import { FileSample } from "@/components/docs/samples/file";
 
 ### Use in your application
 
-Pass `File` to `MessagePrimitive.Parts`:
+The shipped `Thread` component renders `file` parts through `File` by default, in both assistant and user messages. In a custom thread, pass `File` to `MessagePrimitive.Parts`:
 
 ```tsx title="/components/assistant-ui/thread.tsx" {1,8}
 import { File } from "@/components/assistant-ui/file";

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -181,6 +181,7 @@ export const registry: RegistryItem[] = [
     registryDependencies: [
       "button",
       "https://r.assistant-ui.com/attachment.json",
+      "https://r.assistant-ui.com/file.json",
       "https://r.assistant-ui.com/follow-up-suggestions.json",
       "https://r.assistant-ui.com/markdown-text.json",
       "https://r.assistant-ui.com/reasoning.json",

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -212,7 +212,8 @@ const FileImpl: FileMessagePartComponent = ({
   sourceType,
 }) => {
   const kind = getFileDataKind(data, sourceType);
-  const showSize = kind === "base64" || kind === "data-uri";
+  const showSize =
+    typeof data === "string" && (kind === "base64" || kind === "data-uri");
 
   return (
     <FileRoot>

--- a/packages/ui/src/components/assistant-ui/file.tsx
+++ b/packages/ui/src/components/assistant-ui/file.tsx
@@ -183,6 +183,7 @@ function FileDownload({
   children,
   ...props
 }: FileDownloadProps) {
+  if (typeof data !== "string") return null;
   const kind = getFileDataKind(data, sourceType);
   if (kind === "id") return null;
   if (kind === "url" && !/^(https?:\/\/|blob:)/i.test(data)) return null;

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -36,6 +36,7 @@ import {
   MessagePrimitive,
   SuggestionPrimitive,
   ThreadPrimitive,
+  type FileMessagePartComponent,
   type ToolCallMessagePartComponent,
   useAuiState,
 } from "@assistant-ui/react";
@@ -483,6 +484,12 @@ const AssistantActionBar: FC = () => {
   );
 };
 
+const UserFilePart: FileMessagePartComponent = (part) => (
+  <div data-slot="aui_user-message-file" className="py-1">
+    <File {...part} />
+  </div>
+);
+
 const UserMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -494,7 +501,7 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts />
+          <MessagePrimitive.Parts components={{ File: UserFilePart }} />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -5,6 +5,7 @@ import {
   ComposerAttachments,
   UserMessageAttachments,
 } from "@/components/assistant-ui/attachment";
+import { File } from "@/components/assistant-ui/file";
 import { ThreadFollowupSuggestions } from "@/components/assistant-ui/follow-up-suggestions";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import {
@@ -398,6 +399,8 @@ const AssistantMessage: FC = () => {
                 return part.toolUI ?? <ToolFallbackComponent {...part} />;
               case "data":
                 return part.dataRendererUI;
+              case "file":
+                return <File {...part} />;
               case "indicator":
                 return (
                   <span

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -490,7 +490,7 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts components={{ File }} />
+          <MessagePrimitive.Parts />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -400,7 +400,11 @@ const AssistantMessage: FC = () => {
               case "data":
                 return part.dataRendererUI;
               case "file":
-                return <File {...part} />;
+                return (
+                  <div data-slot="aui_assistant-message-file" className="py-1">
+                    <File {...part} />
+                  </div>
+                );
               case "indicator":
                 return (
                   <span

--- a/packages/ui/src/components/assistant-ui/thread.tsx
+++ b/packages/ui/src/components/assistant-ui/thread.tsx
@@ -490,7 +490,7 @@ const UserMessage: FC = () => {
 
       <div className="aui-user-message-content-wrapper relative col-start-2 min-w-0">
         <div className="aui-user-message-content peer bg-muted text-foreground rounded-xl px-4 py-2 wrap-break-word empty:hidden">
-          <MessagePrimitive.Parts />
+          <MessagePrimitive.Parts components={{ File }} />
         </div>
         <div className="aui-user-action-bar-wrapper absolute start-0 top-1/2 -translate-x-full -translate-y-1/2 pe-2 peer-empty:hidden rtl:translate-x-full">
           <UserActionBar />


### PR DESCRIPTION
## What

User messages in the shipped Thread now render `file` parts through the `File` component (`components={{ File }}` on `MessagePrimitive.Parts`), and the File docs note that the shipped Thread renders file parts by default on both sides.

## Why

This re-lands the arm built and reverted on #5548 (commit 2303b46): back then, react-langgraph would have double-rendered every in-session attachment as chip plus card. #5550 fixed that at the source by deduping the flattened attachment copies, so restored-history user file parts (adk `file_url`, langgraph content parts) can finally render instead of dropping the whole bubble through `empty:hidden`. Closes #5549.

## Impact

- Restored user file parts render as File cards; previously the bubble showed nothing.
- Live composer attachments still render once, as chips: langgraph dedupes in-session (#5550), react-ai-sdk and react-ag-ui already keep user media out of content.

## Scope 

- Stacked on #5548 and merges after #5550 lands; will rebase once the parent merges.
- react-ai-sdk needs no change: `convertParts` already strips user file parts from content (convertMessage.ts:189-193, since #3695); the earlier claim otherwise on #5549 was corrected there.
- The `" "` text filler for attachment-only langgraph sends still renders an empty-looking bubble; pre-existing wire behavior, tracked separately, needs a shape call.
- Docs: one sentence in `file.mdx`; the manual wiring example stays as the custom-thread path.
- Tests: none in packages/ui (no harness); the langgraph side is pinned by #5550's runtime round-trip test.
- No changeset: `@assistant-ui/ui` and docs are private.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.6Zl7-SmTMGwcxwqXHXAy1HoW1qOeIp_LB5CNd-ylTe6ti2-b1A2CgYg4dKU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->