### PR TITLE
fix(cloud): validate anonymous auth token responses

### DIFF
--- a/.changeset/cloud-auth-response-validation.md
+++ b/.changeset/cloud-auth-response-validation.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: validate anonymous authentication token responses

--- a/.changeset/cloud-auth-response-validation.md
+++ b/.changeset/cloud-auth-response-validation.md
@@ -2,4 +2,6 @@
 "assistant-cloud": patch
 ---
 
-fix: validate anonymous authentication token responses
+fix: validate successful anonymous authentication responses before use
+
+Malformed successful responses now throw a `CloudResponseError` instead of persisting invalid refresh-token data or failing during JWT parsing.

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -2,7 +2,6 @@ import {
   CloudResponseError,
   readCloudRecord,
   readCloudString,
-  readCloudTimestamp,
 } from "./cloudResponse";
 
 export type AssistantCloudAuthStrategy = {
@@ -61,12 +60,19 @@ const readRefreshTokenResponse = (
   field: string,
 ): RefreshToken => {
   const refreshToken = readCloudRecord(value, field);
+  const expiresAt = readNonEmptyCloudString(
+    refreshToken.expires_at,
+    `${field}.expires_at`,
+  );
+  if (Number.isNaN(new Date(expiresAt).getTime())) {
+    throw new CloudResponseError(
+      `Invalid Assistant Cloud response for "${field}.expires_at": expected a valid timestamp`,
+    );
+  }
+
   return {
     token: readNonEmptyCloudString(refreshToken.token, `${field}.token`),
-    expires_at: readCloudTimestamp(
-      refreshToken.expires_at,
-      `${field}.expires_at`,
-    ).toISOString(),
+    expires_at: expiresAt,
   };
 };
 
@@ -248,7 +254,7 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
               response,
               "refresh auth token response",
             );
-            if (data.refresh_token !== undefined) {
+            if (data.refresh_token != null) {
               writeRefreshToken(
                 readRefreshTokenResponse(
                   data.refresh_token,

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -1,3 +1,10 @@
+import {
+  CloudResponseError,
+  readCloudRecord,
+  readCloudString,
+  readCloudTimestamp,
+} from "./cloudResponse";
+
 export type AssistantCloudAuthStrategy = {
   readonly strategy: "anon" | "jwt" | "api-key";
   getAuthHeaders(): Promise<Record<string, string> | false>;
@@ -32,6 +39,56 @@ const getJwtExpiry = (jwt: string): number => {
   } catch (error) {
     throw new Error(`Unable to determine the token expiry: ${error}`);
   }
+};
+
+type RefreshToken = {
+  token: string;
+  expires_at: string;
+};
+
+const readNonEmptyCloudString = (value: unknown, field: string): string => {
+  const result = readCloudString(value, field);
+  if (result.length === 0) {
+    throw new CloudResponseError(
+      `Invalid Assistant Cloud response for "${field}": expected a non-empty string`,
+    );
+  }
+  return result;
+};
+
+const readRefreshTokenResponse = (
+  value: unknown,
+  field: string,
+): RefreshToken => {
+  const refreshToken = readCloudRecord(value, field);
+  return {
+    token: readNonEmptyCloudString(refreshToken.token, `${field}.token`),
+    expires_at: readCloudTimestamp(
+      refreshToken.expires_at,
+      `${field}.expires_at`,
+    ).toISOString(),
+  };
+};
+
+const readAuthTokenResponse = async (
+  response: Response,
+  field: string,
+): Promise<{ data: Record<string, unknown>; accessToken: string }> => {
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new CloudResponseError(
+      `Invalid Assistant Cloud response for "${field}": expected valid JSON`,
+    );
+  }
+
+  const data = readCloudRecord(value, field);
+  const accessToken = readNonEmptyCloudString(
+    data.access_token,
+    `${field}.access_token`,
+  );
+  return { data, accessToken };
 };
 
 export class AssistantCloudJWTAuthStrategy implements AssistantCloudAuthStrategy {
@@ -133,9 +190,7 @@ const getLocalStorage = (): Storage | null => {
   }
 };
 
-const readRefreshToken = ():
-  | { token: string; expires_at: string }
-  | undefined => {
+const readRefreshToken = (): RefreshToken | undefined => {
   const storage = getLocalStorage();
   if (!storage) return undefined;
   try {
@@ -148,10 +203,7 @@ const readRefreshToken = ():
   }
 };
 
-const writeRefreshToken = (refreshToken: {
-  token: string;
-  expires_at: string;
-}): void => {
+const writeRefreshToken = (refreshToken: RefreshToken): void => {
   const storage = getLocalStorage();
   if (!storage) return;
   try {
@@ -192,12 +244,19 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
           );
 
           if (response.ok) {
-            const data = await response.json();
-            const { access_token, refresh_token } = data;
-            if (refresh_token) {
-              writeRefreshToken(refresh_token);
+            const { data, accessToken } = await readAuthTokenResponse(
+              response,
+              "refresh auth token response",
+            );
+            if (data.refresh_token !== undefined) {
+              writeRefreshToken(
+                readRefreshTokenResponse(
+                  data.refresh_token,
+                  "refresh auth token response.refresh_token",
+                ),
+              );
             }
-            return access_token;
+            return accessToken;
           }
         } else {
           removeRefreshToken();
@@ -211,13 +270,18 @@ export class AssistantCloudAnonymousAuthStrategy implements AssistantCloudAuthSt
 
       if (!response.ok) return null;
 
-      const data = await response.json();
-      const { access_token, refresh_token } = data;
+      const { data, accessToken } = await readAuthTokenResponse(
+        response,
+        "anonymous auth token response",
+      );
 
-      if (!access_token || !refresh_token) return null;
-
-      writeRefreshToken(refresh_token);
-      return access_token;
+      writeRefreshToken(
+        readRefreshTokenResponse(
+          data.refresh_token,
+          "anonymous auth token response.refresh_token",
+        ),
+      );
+      return accessToken;
     });
   }
 

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -55,53 +55,17 @@ const readNonEmptyCloudString = (value: unknown, field: string): string => {
   return result;
 };
 
-const ISO_TIMESTAMP_PATTERN =
-  /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2}))?$/;
-
-const isValidTimestamp = (value: string): boolean => {
-  const match = ISO_TIMESTAMP_PATTERN.exec(value);
-  if (!match || Number.isNaN(Date.parse(value))) return false;
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const daysInMonth = [
-    31,
-    leapYear ? 29 : 28,
-    31,
-    30,
-    31,
-    30,
-    31,
-    31,
-    30,
-    31,
-    30,
-    31,
-  ][month - 1];
-
-  return day >= 1 && day <= (daysInMonth ?? 0);
-};
-
 const readRefreshTokenResponse = (
   value: unknown,
   field: string,
 ): RefreshToken => {
   const refreshToken = readCloudRecord(value, field);
-  const expiresAt = readNonEmptyCloudString(
-    refreshToken.expires_at,
-    `${field}.expires_at`,
-  );
-  if (!isValidTimestamp(expiresAt)) {
-    throw new CloudResponseError(
-      `Invalid Assistant Cloud response for "${field}.expires_at": expected a valid timestamp`,
-    );
-  }
-
   return {
     token: readNonEmptyCloudString(refreshToken.token, `${field}.token`),
-    expires_at: expiresAt,
+    expires_at: readNonEmptyCloudString(
+      refreshToken.expires_at,
+      `${field}.expires_at`,
+    ),
   };
 };
 

--- a/packages/cloud/src/AssistantCloudAuthStrategy.ts
+++ b/packages/cloud/src/AssistantCloudAuthStrategy.ts
@@ -55,6 +55,35 @@ const readNonEmptyCloudString = (value: unknown, field: string): string => {
   return result;
 };
 
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})(?:T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2}))?$/;
+
+const isValidTimestamp = (value: string): boolean => {
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (!match || Number.isNaN(Date.parse(value))) return false;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ][month - 1];
+
+  return day >= 1 && day <= (daysInMonth ?? 0);
+};
+
 const readRefreshTokenResponse = (
   value: unknown,
   field: string,
@@ -64,7 +93,7 @@ const readRefreshTokenResponse = (
     refreshToken.expires_at,
     `${field}.expires_at`,
   );
-  if (Number.isNaN(new Date(expiresAt).getTime())) {
+  if (!isValidTimestamp(expiresAt)) {
     throw new CloudResponseError(
       `Invalid Assistant Cloud response for "${field}.expires_at": expected a valid timestamp`,
     );

--- a/packages/cloud/src/tests/AssistantCloudAPI.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAPI.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssistantCloudAPI, CloudAPIError } from "../AssistantCloudAPI";
+import { CloudResponseError } from "../cloudResponse";
 
 describe("AssistantCloudAPI", () => {
   beforeEach(() => {
@@ -116,6 +117,30 @@ describe("AssistantCloudAPI", () => {
     });
 
     await expect(api.initializeAuth()).resolves.toBe(false);
+  });
+
+  it("rejects initializeAuth with context for malformed anonymous responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: 123,
+          refresh_token: null,
+        }),
+      }),
+    );
+
+    const api = new AssistantCloudAPI({
+      baseUrl: "https://test.example.com",
+      anonymous: true,
+    });
+
+    await expect(api.initializeAuth()).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "anonymous auth token response.access_token": expected a string',
+      ),
+    );
   });
 
   it("throws APIError with parsed message for JSON error responses", async () => {

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -54,36 +54,39 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     }
   });
 
-  it.each(["2099-01-01", "2099-01-01T00:00:00Z", "2099-01-01T00:00:00+00:00"])(
-    "persists refresh tokens with valid expiry %s",
-    async (expiresAt) => {
-      const nextRefreshToken = { ...refreshToken, expires_at: expiresAt };
-      const values = new Map<string, string>();
-      installLocalStorage({
-        getItem: (key) => values.get(key) ?? null,
-        setItem: (key, value) => {
-          values.set(key, value);
-        },
-        removeItem: (key) => {
-          values.delete(key);
-        },
-      } as Storage);
-      const fetchMock = mockAnonymousTokenFetch(nextRefreshToken);
+  it.each([
+    "2099-01-01",
+    "2099-01-01T00:00:00Z",
+    "2099-01-01T00:00:00+0000",
+    "2099-01-01T00:00:00",
+    "2099-01-01 00:00:00+00",
+  ])("persists refresh tokens with expiry %s", async (expiresAt) => {
+    const nextRefreshToken = { ...refreshToken, expires_at: expiresAt };
+    const values = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        values.set(key, value);
+      },
+      removeItem: (key) => {
+        values.delete(key);
+      },
+    } as Storage);
+    const fetchMock = mockAnonymousTokenFetch(nextRefreshToken);
 
-      const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
 
-      await expect(strategy.getAuthHeaders()).resolves.toEqual({
-        Authorization: `Bearer ${accessToken}`,
-      });
-      expect(values.get("aui:refresh_token")).toBe(
-        JSON.stringify(nextRefreshToken),
-      );
-      expect(fetchMock).toHaveBeenCalledWith(
-        `${baseUrl}/v1/auth/tokens/anonymous`,
-        { method: "POST" },
-      );
-    },
-  );
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(values.get("aui:refresh_token")).toBe(
+      JSON.stringify(nextRefreshToken),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseUrl}/v1/auth/tokens/anonymous`,
+      { method: "POST" },
+    );
+  });
 
   it("deduplicates concurrent anonymous token requests", async () => {
     delete (globalThis as { localStorage?: Storage }).localStorage;
@@ -209,7 +212,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     expect(setItem).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid calendar expiry timestamps without persisting them", async () => {
+  it("rejects empty refresh token expiry without persisting it", async () => {
     const setItem = vi.fn();
     installLocalStorage({
       getItem: () => null,
@@ -224,7 +227,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
           access_token: accessToken,
           refresh_token: {
             token: "r2",
-            expires_at: "2026-02-30T12:15:00Z",
+            expires_at: "",
           },
         }),
       }),
@@ -234,7 +237,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
 
     await expect(strategy.getAuthHeaders()).rejects.toThrow(
       new CloudResponseError(
-        'Invalid Assistant Cloud response for "anonymous auth token response.refresh_token.expires_at": expected a valid timestamp',
+        'Invalid Assistant Cloud response for "anonymous auth token response.refresh_token.expires_at": expected a non-empty string',
       ),
     );
     expect(setItem).not.toHaveBeenCalled();

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -9,7 +9,7 @@ const baseUrl = "https://test.example.com";
 const accessToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(JSON.stringify({ exp: 4102444800 })).toString("base64url")}.sig`;
 const refreshToken = {
   token: "r1",
-  expires_at: "2099-01-01T00:00:00Z",
+  expires_at: "2099-01-01",
 };
 
 let originalLocalStorageDescriptor: PropertyDescriptor | undefined;
@@ -21,12 +21,12 @@ const installLocalStorage = (storage: Storage): void => {
   });
 };
 
-const mockAnonymousTokenFetch = () => {
+const mockAnonymousTokenFetch = (nextRefreshToken = refreshToken) => {
   const fetchMock = vi.fn().mockResolvedValue({
     ok: true,
     json: vi.fn().mockResolvedValue({
       access_token: accessToken,
-      refresh_token: refreshToken,
+      refresh_token: nextRefreshToken,
     }),
   });
   vi.stubGlobal("fetch", fetchMock);
@@ -54,30 +54,36 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     }
   });
 
-  it("persists refresh tokens with valid non-canonical expiry timestamps", async () => {
-    const values = new Map<string, string>();
-    installLocalStorage({
-      getItem: (key) => values.get(key) ?? null,
-      setItem: (key, value) => {
-        values.set(key, value);
-      },
-      removeItem: (key) => {
-        values.delete(key);
-      },
-    } as Storage);
-    const fetchMock = mockAnonymousTokenFetch();
+  it.each(["2099-01-01", "2099-01-01T00:00:00Z", "2099-01-01T00:00:00+00:00"])(
+    "persists refresh tokens with valid expiry %s",
+    async (expiresAt) => {
+      const nextRefreshToken = { ...refreshToken, expires_at: expiresAt };
+      const values = new Map<string, string>();
+      installLocalStorage({
+        getItem: (key) => values.get(key) ?? null,
+        setItem: (key, value) => {
+          values.set(key, value);
+        },
+        removeItem: (key) => {
+          values.delete(key);
+        },
+      } as Storage);
+      const fetchMock = mockAnonymousTokenFetch(nextRefreshToken);
 
-    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+      const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
 
-    await expect(strategy.getAuthHeaders()).resolves.toEqual({
-      Authorization: `Bearer ${accessToken}`,
-    });
-    expect(values.get("aui:refresh_token")).toBe(JSON.stringify(refreshToken));
-    expect(fetchMock).toHaveBeenCalledWith(
-      `${baseUrl}/v1/auth/tokens/anonymous`,
-      { method: "POST" },
-    );
-  });
+      await expect(strategy.getAuthHeaders()).resolves.toEqual({
+        Authorization: `Bearer ${accessToken}`,
+      });
+      expect(values.get("aui:refresh_token")).toBe(
+        JSON.stringify(nextRefreshToken),
+      );
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${baseUrl}/v1/auth/tokens/anonymous`,
+        { method: "POST" },
+      );
+    },
+  );
 
   it("deduplicates concurrent anonymous token requests", async () => {
     delete (globalThis as { localStorage?: Storage }).localStorage;
@@ -198,6 +204,37 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     await expect(strategy.getAuthHeaders()).rejects.toThrow(
       new CloudResponseError(
         'Invalid Assistant Cloud response for "anonymous auth token response.refresh_token": expected an object',
+      ),
+    );
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid calendar expiry timestamps without persisting them", async () => {
+    const setItem = vi.fn();
+    installLocalStorage({
+      getItem: () => null,
+      setItem,
+      removeItem: vi.fn(),
+    } as unknown as Storage);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: accessToken,
+          refresh_token: {
+            token: "r2",
+            expires_at: "2026-02-30T12:15:00Z",
+          },
+        }),
+      }),
+    );
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "anonymous auth token response.refresh_token.expires_at": expected a valid timestamp',
       ),
     );
     expect(setItem).not.toHaveBeenCalled();

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -9,7 +9,7 @@ const baseUrl = "https://test.example.com";
 const accessToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(JSON.stringify({ exp: 4102444800 })).toString("base64url")}.sig`;
 const refreshToken = {
   token: "r1",
-  expires_at: "2099-01-01T00:00:00.000Z",
+  expires_at: "2099-01-01T00:00:00Z",
 };
 
 let originalLocalStorageDescriptor: PropertyDescriptor | undefined;
@@ -54,7 +54,7 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     }
   });
 
-  it("persists the refresh token and returns the anonymous access token", async () => {
+  it("persists refresh tokens with valid non-canonical expiry timestamps", async () => {
     const values = new Map<string, string>();
     installLocalStorage({
       getItem: (key) => values.get(key) ?? null,
@@ -235,7 +235,10 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
     } as unknown as Storage);
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: vi.fn().mockResolvedValue({ access_token: accessToken }),
+      json: vi.fn().mockResolvedValue({
+        access_token: accessToken,
+        refresh_token: null,
+      }),
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
+++ b/packages/cloud/src/tests/AssistantCloudAuthStrategy.test.ts
@@ -3,10 +3,14 @@ import {
   AssistantCloudAnonymousAuthStrategy,
   AssistantCloudJWTAuthStrategy,
 } from "../AssistantCloudAuthStrategy";
+import { CloudResponseError } from "../cloudResponse";
 
 const baseUrl = "https://test.example.com";
 const accessToken = `${Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url")}.${Buffer.from(JSON.stringify({ exp: 4102444800 })).toString("base64url")}.sig`;
-const refreshToken = { token: "r1", expires_at: "2099-01-01" };
+const refreshToken = {
+  token: "r1",
+  expires_at: "2099-01-01T00:00:00.000Z",
+};
 
 let originalLocalStorageDescriptor: PropertyDescriptor | undefined;
 
@@ -169,6 +173,105 @@ describe("AssistantCloudAnonymousAuthStrategy", () => {
       Authorization: `Bearer ${accessToken}`,
     });
     expect(values.get("aui:refresh_token")).toBe(JSON.stringify(refreshToken));
+  });
+
+  it("rejects malformed anonymous token responses without persisting them", async () => {
+    const setItem = vi.fn();
+    installLocalStorage({
+      getItem: () => null,
+      setItem,
+      removeItem: vi.fn(),
+    } as unknown as Storage);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: accessToken,
+          refresh_token: "not-a-refresh-token",
+        }),
+      }),
+    );
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "anonymous auth token response.refresh_token": expected an object',
+      ),
+    );
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("contextualizes malformed refresh token responses", async () => {
+    installLocalStorage({
+      getItem: () => JSON.stringify(refreshToken),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    } as unknown as Storage);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ access_token: 123 }),
+      }),
+    );
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "refresh auth token response.access_token": expected a string',
+      ),
+    );
+  });
+
+  it("accepts valid refresh responses without a rotated refresh token", async () => {
+    const setItem = vi.fn();
+    installLocalStorage({
+      getItem: () => JSON.stringify(refreshToken),
+      setItem,
+      removeItem: vi.fn(),
+    } as unknown as Storage);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ access_token: accessToken }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).resolves.toEqual({
+      Authorization: `Bearer ${accessToken}`,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${baseUrl}/v1/auth/tokens/refresh`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refresh_token: refreshToken.token }),
+      },
+    );
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("contextualizes invalid JSON token responses", async () => {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockRejectedValue(new SyntaxError("Unexpected token")),
+      }),
+    );
+
+    const strategy = new AssistantCloudAnonymousAuthStrategy(baseUrl);
+
+    await expect(strategy.getAuthHeaders()).rejects.toThrow(
+      new CloudResponseError(
+        'Invalid Assistant Cloud response for "anonymous auth token response": expected valid JSON',
+      ),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- decode successful anonymous and refresh auth responses before use
- reject malformed access and refresh-token fields with `CloudResponseError` context
- prevent malformed response data from reaching refresh-token storage
- preserve non-empty expiry strings across wire formats and omitted or `null` refresh-token rotation

## Why

While testing anonymous Cloud authentication, I found that successful token responses were destructured without runtime validation. A malformed `refresh_token` could be persisted as-is, while a non-string `access_token` reached JWT parsing and failed with a low-context error such as `jwt.split is not a function`.

The Cloud API contract returns `{ access_token }` for refreshes and `{ access_token, refresh_token: { token, expires_at } }` for new anonymous sessions. This change validates those shapes before returning or persisting them without requiring one exact ISO timestamp serialization. Refresh responses continue to accept both omitted and `null` rotation values.

## Behavior

Unavailable authentication still follows the existing `false` path. A successful HTTP response with malformed JSON or token fields now rejects with the exported `CloudResponseError`; this is covered through `initializeAuth()` and called out in the changeset. Persisted-storage validation remains outside this response-validation PR.

## Verification

- reverse-tested malformed persistence and low-context JWT failures on unchanged `main`
- `assistant-cloud`: 8 test files and 58 tests passed
- `assistant-cloud` build
- oxlint, oxfmt, and `git diff --check`