### PR TITLE
fix: keep navbar submenu above banner

### DIFF
--- a/apps/docs/components/shared/nav-items.tsx
+++ b/apps/docs/components/shared/nav-items.tsx
@@ -76,7 +76,7 @@ export function NavItemsRoot({ children }: { children: ReactNode }) {
           align="start"
           sideOffset={0}
           collisionAvoidance={{ side: "none", align: "none" }}
-          className="z-40 hidden w-[var(--anchor-width)] md:block"
+          className="z-[60] hidden w-[var(--anchor-width)] md:block"
         >
           <NavigationMenuPopup className="bg-background border-border/60 h-[var(--popup-height)] w-full overflow-hidden border-b transition-[height,opacity] duration-200 data-[ending-style]:opacity-0 data-[starting-style]:opacity-0 motion-reduce:transition-none">
             <NavigationMenuViewport />


### PR DESCRIPTION
## Summary

Raise the portaled navbar submenu above the sticky header so the homepage hiring banner cannot cover menu content.

## Root cause

The hiring banner inherits the header's `z-50` stacking context, while the portaled navigation positioner used `z-40`. Because the portal renders outside the header, the whole submenu remained below the banner even though the menu was visually attached to the navbar.

## Validation

- `pnpm dlx oxfmt@0.60.0 --check apps/docs/components/shared/nav-items.tsx`
- `pnpm dlx oxlint@1.75.0 apps/docs/components/shared/nav-items.tsx`
- `git diff --check`

No changeset is required because the docs app is private.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kyQJZWlE9KKE2D7YwP5AEWEChdYbvw7o3k1lWiAyeitrutGXmO2eHTBdoh0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->