### PR TITLE
feat(core): support main thread reload in tap runtimes

### DIFF
--- a/.changeset/tap-thread-refetch.md
+++ b/.changeset/tap-thread-refetch.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+feat: support in-place main thread reloads in tap runtimes

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -4649,6 +4649,7 @@ type ThreadMethods = {
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  unstable_refetchThread?: (() => Promise<void>) | undefined;
   importExternalState(state: unknown): void;
   message(selector: {
     id: string;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -4649,7 +4649,7 @@ type ThreadMethods = {
   export(): ExportedMessageRepository;
   import(repository: ExportedMessageRepository): void;
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  unstable_refetchThread?: (() => Promise<void>) | undefined;
+  unstable_refetchThread?(): Promise<void>;
   importExternalState(state: unknown): void;
   message(selector: {
     id: string;
@@ -5955,7 +5955,7 @@ declare const useActionBarFeedbackPositive: () => {
 
 declare const useActionBarReload: () => {
   reload: () => void;
-  disabled: any;
+  disabled: boolean;
 };
 
 declare const useActionBarSpeak: () => {
@@ -6013,7 +6013,7 @@ declare const useComposerDictate: () => {
 
 declare const useComposerSend: () => {
   send: (opts?: ComposerSendOptions) => void;
-  disabled: any;
+  disabled: boolean;
 };
 
 declare const useEditComposerCancel: () => {
@@ -6096,7 +6096,7 @@ declare const useStreamingTiming: <TMessage>(messages: readonly TMessage[], isRu
 
 declare const useSuggestionTrigger: (_param20: UseSuggestionTriggerOptions) => {
   trigger: () => void;
-  disabled: any;
+  disabled: boolean;
 };
 
 declare const useThreadIsEmpty: () => boolean;

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -5955,7 +5955,7 @@ declare const useActionBarFeedbackPositive: () => {
 
 declare const useActionBarReload: () => {
   reload: () => void;
-  disabled: boolean;
+  disabled: any;
 };
 
 declare const useActionBarSpeak: () => {
@@ -6013,7 +6013,7 @@ declare const useComposerDictate: () => {
 
 declare const useComposerSend: () => {
   send: (opts?: ComposerSendOptions) => void;
-  disabled: boolean;
+  disabled: any;
 };
 
 declare const useEditComposerCancel: () => {
@@ -6096,7 +6096,7 @@ declare const useStreamingTiming: <TMessage>(messages: readonly TMessage[], isRu
 
 declare const useSuggestionTrigger: (_param20: UseSuggestionTriggerOptions) => {
   trigger: () => void;
-  disabled: boolean;
+  disabled: any;
 };
 
 declare const useThreadIsEmpty: () => boolean;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2159,6 +2159,7 @@ type ExternalThreadProps = {
   onNew?: (message: AppendMessage) => void;
   onEdit?: (message: AppendMessage) => void;
   onReload?: (parentId: string | null) => void;
+  onRefetchThread?: (() => Promise<void>) | undefined;
   onStartRun?: () => void;
   onCancel?: () => void;
   onResume?: (() => void) | undefined;

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -108,6 +108,12 @@ export type ThreadMethods = {
    * @param initialMessages - Optional array of initial messages to populate the thread
    */
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  /**
+   * Re-fetches this thread's state from its backing store in place, preserving
+   * runtime identity and composer drafts. Presence enables
+   * `threads.reloadMainThread()`, which calls this method and propagates its
+   * rejection. Implementations own coordination with any run in progress.
+   */
   unstable_refetchThread?(): Promise<void>;
   importExternalState(state: unknown): void;
   message(selector: { id: string } | { index: number }): MessageMethods;

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -108,6 +108,7 @@ export type ThreadMethods = {
    * @param initialMessages - Optional array of initial messages to populate the thread
    */
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
+  unstable_refetchThread?: (() => Promise<void>) | undefined;
   importExternalState(state: unknown): void;
   message(selector: { id: string } | { index: number }): MessageMethods;
   /** @deprecated This API is still under active development and might change without notice. */

--- a/packages/core/src/store/scopes/thread.ts
+++ b/packages/core/src/store/scopes/thread.ts
@@ -108,7 +108,7 @@ export type ThreadMethods = {
    * @param initialMessages - Optional array of initial messages to populate the thread
    */
   reset(initialMessages?: readonly ThreadMessageLike[]): void;
-  unstable_refetchThread?: (() => Promise<void>) | undefined;
+  unstable_refetchThread?(): Promise<void>;
   importExternalState(state: unknown): void;
   message(selector: { id: string } | { index: number }): MessageMethods;
   /** @deprecated This API is still under active development and might change without notice. */

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -88,6 +88,8 @@ export type ExternalThreadProps = {
   onNew?: (message: AppendMessage) => void;
   onEdit?: (message: AppendMessage) => void;
   onReload?: (parentId: string | null) => void;
+  /** Refetches this thread's remote state when `threads.reloadMainThread()` is called. */
+  onRefetchThread?: (() => Promise<void>) | undefined;
   onStartRun?: () => void;
   onCancel?: () => void;
   onResume?: (() => void) | undefined;
@@ -733,6 +735,7 @@ const useExternalThread = ({
   onNew,
   onEdit,
   onReload,
+  onRefetchThread,
   onStartRun,
   onCancel,
   onResume,
@@ -819,6 +822,7 @@ const useExternalThread = ({
   const hasBranches = !!branches;
   const hasEdit = !!onEdit;
   const hasReload = !!onReload;
+  const hasRefetchThread = !!onRefetchThread;
   const hasAttachments = !!attachmentAdapter;
   const state = useMemo(() => {
     const messageStates = messageClients.state.map((s, idx, arr) => ({
@@ -835,7 +839,7 @@ const useExternalThread = ({
         edit: hasEdit,
         delete: false,
         reload: hasReload,
-        refetchThread: false,
+        refetchThread: hasRefetchThread,
         cancel: isRunning,
         speech: false,
         attachments: hasAttachments,
@@ -865,6 +869,7 @@ const useExternalThread = ({
     hasBranches,
     hasEdit,
     hasReload,
+    hasRefetchThread,
     hasAttachments,
     messageClients.state,
     composerClient.state,
@@ -926,6 +931,7 @@ const useExternalThread = ({
     export: () => ({ messages: [] }),
     import: () => {},
     reset: () => {},
+    unstable_refetchThread: onRefetchThread,
     message: (selector) => {
       if ("id" in selector) {
         return messageClients.get({ key: selector.id });

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -88,7 +88,12 @@ export type ExternalThreadProps = {
   onNew?: (message: AppendMessage) => void;
   onEdit?: (message: AppendMessage) => void;
   onReload?: (parentId: string | null) => void;
-  /** Refetches this thread's remote state when `threads.reloadMainThread()` is called. */
+  /**
+   * Re-fetches the thread's state from its backing store in place when
+   * `threads.reloadMainThread()` is called. Rejections reach the caller, and
+   * the implementation owns coordination with any run in progress. Unrelated
+   * to `onReload`, which re-generates an assistant message.
+   */
   onRefetchThread?: (() => Promise<void>) | undefined;
   onStartRun?: () => void;
   onCancel?: () => void;

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -931,7 +931,7 @@ const useExternalThread = ({
     export: () => ({ messages: [] }),
     import: () => {},
     reset: () => {},
-    unstable_refetchThread: onRefetchThread,
+    ...(onRefetchThread ? { unstable_refetchThread: onRefetchThread } : {}),
     message: (selector) => {
       if ("id" in selector) {
         return messageClients.get({ key: selector.id });

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -189,7 +189,8 @@ const useInMemoryThreadList = (
     switchToNewThread: handleSwitchToNewThread,
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
-    reloadMainThread: () => RESOLVED_PROMISE,
+    reloadMainThread: () =>
+      mainThreadClient.methods.unstable_refetchThread?.() ?? RESOLVED_PROMISE,
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (selector === "main") {

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -189,8 +189,9 @@ const useInMemoryThreadList = (
     switchToNewThread: handleSwitchToNewThread,
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
-    reloadMainThread: () =>
-      mainThreadClient.methods.unstable_refetchThread?.() ?? RESOLVED_PROMISE,
+    reloadMainThread: async () => {
+      await mainThreadClient.methods.unstable_refetchThread?.();
+    },
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (selector === "main") {

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -82,7 +82,8 @@ const useSingleThreadList = ({
     },
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
-    reloadMainThread: () => RESOLVED_PROMISE,
+    reloadMainThread: () =>
+      threadClient.methods.unstable_refetchThread?.() ?? RESOLVED_PROMISE,
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (

--- a/packages/react/src/client/SingleThreadList.ts
+++ b/packages/react/src/client/SingleThreadList.ts
@@ -82,8 +82,9 @@ const useSingleThreadList = ({
     },
     getLoadThreadsPromise: () => RESOLVED_PROMISE,
     reload: () => RESOLVED_PROMISE,
-    reloadMainThread: () =>
-      threadClient.methods.unstable_refetchThread?.() ?? RESOLVED_PROMISE,
+    reloadMainThread: async () => {
+      await threadClient.methods.unstable_refetchThread?.();
+    },
     loadMore: () => RESOLVED_PROMISE,
     item: (selector) => {
       if (

--- a/packages/react/src/tests/tap-thread-reload.test.tsx
+++ b/packages/react/src/tests/tap-thread-reload.test.tsx
@@ -25,9 +25,31 @@ describe("tap thread reload", () => {
     expect(onRefetchThread).toHaveBeenCalledOnce();
   });
 
+  it("rejects when the automatic thread list refetch throws synchronously", async () => {
+    const error = new Error("refetch failed");
+    const onRefetchThread = vi.fn(() => {
+      throw error;
+    });
+    let aui!: ReturnType<typeof useAui>;
+
+    const App = () => {
+      aui = useAui({
+        thread: ExternalThread({ messages: [], onRefetchThread }),
+      });
+      return null;
+    };
+
+    render(<App />);
+
+    const reloadPromise = aui.threads.reloadMainThread();
+    await expect(reloadPromise).rejects.toBe(error);
+  });
+
   it("propagates InMemoryThreadList refetch failures", async () => {
     const error = new Error("refetch failed");
-    const onRefetchThread = vi.fn().mockRejectedValue(error);
+    const onRefetchThread = vi.fn(() => {
+      throw error;
+    });
     let aui!: ReturnType<typeof useAui>;
 
     const App = () => {
@@ -41,7 +63,8 @@ describe("tap thread reload", () => {
 
     render(<App />);
 
-    await expect(aui.threads.reloadMainThread()).rejects.toBe(error);
+    const reloadPromise = aui.threads.reloadMainThread();
+    await expect(reloadPromise).rejects.toBe(error);
     expect(onRefetchThread).toHaveBeenCalledOnce();
   });
 

--- a/packages/react/src/tests/tap-thread-reload.test.tsx
+++ b/packages/react/src/tests/tap-thread-reload.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { render } from "@testing-library/react";
+import { useAui } from "@assistant-ui/store";
+import { describe, expect, it, vi } from "vitest";
+import { ExternalThread } from "../client/ExternalThread";
+import { InMemoryThreadList } from "../client/InMemoryThreadList";
+
+describe("tap thread reload", () => {
+  it("refetches an ExternalThread through its automatic thread list", async () => {
+    const onRefetchThread = vi.fn().mockResolvedValue(undefined);
+    let aui!: ReturnType<typeof useAui>;
+
+    const App = () => {
+      aui = useAui({
+        thread: ExternalThread({ messages: [], onRefetchThread }),
+      });
+      return null;
+    };
+
+    render(<App />);
+
+    expect(aui.thread.getState().capabilities.refetchThread).toBe(true);
+    await aui.threads.reloadMainThread();
+    expect(onRefetchThread).toHaveBeenCalledOnce();
+  });
+
+  it("propagates InMemoryThreadList refetch failures", async () => {
+    const error = new Error("refetch failed");
+    const onRefetchThread = vi.fn().mockRejectedValue(error);
+    let aui!: ReturnType<typeof useAui>;
+
+    const App = () => {
+      aui = useAui({
+        threads: InMemoryThreadList({
+          thread: () => ExternalThread({ messages: [], onRefetchThread }),
+        }),
+      });
+      return null;
+    };
+
+    render(<App />);
+
+    await expect(aui.threads.reloadMainThread()).rejects.toBe(error);
+    expect(onRefetchThread).toHaveBeenCalledOnce();
+  });
+
+  it("keeps reload a no-op when the thread has no remote state", async () => {
+    let aui!: ReturnType<typeof useAui>;
+
+    const App = () => {
+      aui = useAui({ thread: ExternalThread({ messages: [] }) });
+      return null;
+    };
+
+    render(<App />);
+
+    expect(aui.thread.getState().capabilities.refetchThread).toBe(false);
+    await expect(aui.threads.reloadMainThread()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- add `onRefetchThread` to tap `ExternalThread` resources and expose the matching capability
- route `threads.reloadMainThread()` through both the automatic single-thread list and `InMemoryThreadList`
- preserve the existing resolved no-op when no refetch callback is configured, while propagating callback failures

## Why

Tap clients already expose `threads.reloadMainThread()`, but external tap threads always resolved without refreshing anything. Apps that need to reconcile remote state after polling, reconnects, or out-of-band updates therefore had to remount the thread and could lose in-progress UI state. This completes the tap path for the in-place refetch contract introduced in #5522.

Closes #5532

## Test plan

- `pnpm --filter @assistant-ui/core test`
- `pnpm --filter @assistant-ui/react test`
- `pnpm --filter @assistant-ui/react... build`
- `pnpm lint`
- `pnpm --filter @assistant-ui/docs generate:api-reference --strict`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.M4uulNR5EexPI2zwRn3y4IiFfP5zKmxtdvBXaaqZv0UiNPcPbi-JPzFA074?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->