### PR TITLE
fix(react-data-stream): report cancellation during request setup

### DIFF
--- a/.changeset/data-stream-early-cancel.md
+++ b/.changeset/data-stream-early-cancel.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: report cancellations that occur while resolving request options

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -110,6 +110,37 @@ describe("useDataStreamRuntime request errors", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("reports cancellation while resolving request options", async () => {
+    const controller = new AbortController();
+    const abortError = new DOMException("Cancelled", "AbortError");
+    const onCancel = vi.fn();
+    const onError = vi.fn();
+    let resolveHeaders: ((headers: Headers) => void) | undefined;
+    const headers = new Promise<Headers>((resolve) => {
+      resolveHeaders = resolve;
+    });
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      Promise.reject(init?.signal?.reason),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const adapter = createAdapter({
+      api: "/api/chat",
+      headers: () => headers,
+      onCancel,
+      onError,
+    });
+    const result = runOnce(adapter, createRunOptions(controller.signal));
+
+    controller.abort(abortError);
+    resolveHeaders?.(new Headers());
+
+    await expect(result).rejects.toBe(abortError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("normalizes non-Error resolver failures for onError", async () => {
     const onError = vi.fn();
     const rejection = "headers failed";

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -84,6 +84,19 @@ describe("useDataStreamRuntime request errors", () => {
     expect(onError).toHaveBeenCalledExactlyOnceWith(error);
   });
 
+  it("keeps response callback failures separate from request errors", async () => {
+    const error = new Error("response callback failed");
+    const onResponse = vi.fn().mockRejectedValue(error);
+    const onError = vi.fn();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response()));
+
+    const adapter = createAdapter({ api: "/api/chat", onResponse, onError });
+
+    await expect(runOnce(adapter, createRunOptions())).rejects.toBe(error);
+    expect(onResponse).toHaveBeenCalledOnce();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("reports resolver failures that race with cancellation", async () => {
     const controller = new AbortController();
     const error = new Error("headers failed");

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -144,7 +144,12 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
 
     try {
       await this.options.onResponse?.(result);
+    } catch (error: unknown) {
+      abortSignal.removeEventListener("abort", handleAbort);
+      throw error;
+    }
 
+    try {
       if (!result.ok) {
         throw new Error(`Status ${result.status}: ${await result.text()}`);
       }

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -79,6 +79,16 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     unstable_parentId,
     unstable_getMessage,
   }: ChatModelRunOptions) {
+    const handleAbort = () => {
+      if (!abortSignal.reason?.detach) this.options.onCancel?.();
+    };
+
+    if (abortSignal.aborted) {
+      handleAbort();
+    } else {
+      abortSignal.addEventListener("abort", handleAbort, { once: true });
+    }
+
     let result: Response;
     try {
       const headersValue =
@@ -90,14 +100,6 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
         typeof this.options.body === "function"
           ? await this.options.body()
           : this.options.body;
-
-      abortSignal.addEventListener(
-        "abort",
-        () => {
-          if (!abortSignal.reason?.detach) this.options.onCancel?.();
-        },
-        { once: true },
-      );
 
       const headers = new Headers(headersValue);
       headers.set("Content-Type", "application/json");
@@ -131,6 +133,7 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
         signal: abortSignal,
       });
     } catch (error: unknown) {
+      abortSignal.removeEventListener("abort", handleAbort);
       if (!(error instanceof Error && error.name === "AbortError")) {
         this.options.onError?.(
           error instanceof Error ? error : new Error(String(error)),
@@ -139,9 +142,9 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
       throw error;
     }
 
-    await this.options.onResponse?.(result);
-
     try {
+      await this.options.onResponse?.(result);
+
       if (!result.ok) {
         throw new Error(`Status ${result.status}: ${await result.text()}`);
       }
@@ -187,6 +190,8 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     } catch (error: unknown) {
       this.options.onError?.(error as Error);
       throw error;
+    } finally {
+      abortSignal.removeEventListener("abort", handleAbort);
     }
   }
 }


### PR DESCRIPTION
## Summary

- register the cancellation listener before resolving async request headers or body
- report already-aborted runs through `onCancel`
- remove the listener after request/stream settlement
- add a regression test for cancellation during async request setup

## Why

When a user clicked Stop while an async `headers()` or `body()` resolver was still pending, the request eventually observed the aborted signal, but the listener was attached too late. The request stopped while `onCancel` was never called, so cancellation UI, telemetry, or cleanup wired to that callback could be skipped.

The regression test reproduced the current behavior with `onCancel` called zero times before the fix and exactly once afterward.

## Validation

- `pnpm --filter @assistant-ui/react-data-stream test` (21 tests)
- `pnpm --filter @assistant-ui/react-data-stream exec tsc --noEmit`
- `pnpm --filter @assistant-ui/react-data-stream build`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rlO2TeyWKChYiulvlmI01IOU8LAAgHSjGka5pzoF6bawfSFoODpBspgq4Cg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->