### PR TITLE
fix(react): restore assistant transport resume state

### DIFF
--- a/.changeset/assistant-transport-resume-state.md
+++ b/.changeset/assistant-transport-resume-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: hydrate assistant transport resumes from their retained initial state

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -3783,7 +3783,7 @@ declare const SelectionToolbarPrimitiveRoot: import("react").ForwardRefExoticCom
 
 type SendCommandsRequestBody = {
   commands: QueuedCommand[];
-  state: unknown;
+  state?: unknown;
   runId?: string;
   system: string | undefined;
   tools: Record<string, unknown> | undefined;

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -723,6 +723,7 @@ type AssistantTransportOptions<T> = {
   initialState: T;
   api: string;
   resumeApi?: string;
+  resumeStateApi?: string;
   protocol?: AssistantTransportProtocol;
   converter: AssistantTransportStateConverter<T>;
   headers: HeadersValue | (() => Promise<HeadersValue>);
@@ -3783,6 +3784,7 @@ declare const SelectionToolbarPrimitiveRoot: import("react").ForwardRefExoticCom
 type SendCommandsRequestBody = {
   commands: QueuedCommand[];
   state: unknown;
+  runId?: string;
   system: string | undefined;
   tools: Record<string, unknown> | undefined;
   callSettings: LanguageModelV1CallSettings | undefined;

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -527,7 +527,7 @@ Before resuming, the runtime posts `{ threadId }` to `resumeStateApi`. The endpo
 { "runId": "8b3a...", "state": { "messages": [] } }
 ```
 
-The runtime replaces its local base with this snapshot and includes `runId` in the resume request; the request carries no `state`, since the server replays from the snapshot it retained. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state. When no run is active, the endpoint responds `204 No Content` and the runtime skips the resume without raising an error. On a resume, `runId` takes precedence over fields supplied through `body` and survives `prepareSendCommandsRequest`.
+The runtime replaces its local base with this snapshot and includes `runId` in the resume request; the request carries no `state`, since the server replays from the snapshot it retained. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state. When no run is active, the endpoint responds `204 No Content` and the runtime skips the resume without raising an error. On a resume, `runId` takes precedence over fields supplied through `body` and survives `prepareSendCommandsRequest`; any `state` either of them supplies is stripped.
 
 ```tsx
 import { useAui } from "@assistant-ui/react";

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -300,6 +300,7 @@ aui-state:[{"type":"set","path":["status"],"value":"completed"}]
   initialState: T,
   api: string,
   resumeApi?: string,
+  resumeStateApi?: string,
   protocol?: "data-stream" | "assistant-transport",
   converter: (state: T, connectionMetadata: ConnectionMetadata) => AssistantTransportState,
   headers?: Record<string, string> | Headers | (() => Promise<Record<string, string> | Headers>),
@@ -516,8 +517,17 @@ const runtime = useAssistantTransportRuntime({
   // ...
   api: "http://localhost:8010/assistant",
   resumeApi: "http://localhost:8010/resume",
+  resumeStateApi: "http://localhost:8010/initial-state",
 });
 ```
+
+Before resuming, the runtime posts `{ threadId }` to `resumeStateApi`. The endpoint must return the state that started the active run together with its identity:
+
+```json
+{ "runId": "8b3a...", "state": { "messages": [] } }
+```
+
+The runtime replaces its local base with this snapshot and includes `runId` in the resume request. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state.
 
 ```tsx
 import { useAui } from "@assistant-ui/react";

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -527,7 +527,7 @@ Before resuming, the runtime posts `{ threadId }` to `resumeStateApi`. The endpo
 { "runId": "8b3a...", "state": { "messages": [] } }
 ```
 
-The runtime replaces its local base with this snapshot and includes `runId` in the resume request. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state. When no run is active, the endpoint responds `204 No Content` and the runtime skips the resume without raising an error. On a resume, the snapshot and `runId` take precedence over fields supplied through `body`.
+The runtime replaces its local base with this snapshot and includes `runId` in the resume request; the request carries no `state`, since the server replays from the snapshot it retained. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state. When no run is active, the endpoint responds `204 No Content` and the runtime skips the resume without raising an error. On a resume, `runId` takes precedence over fields supplied through `body` and survives `prepareSendCommandsRequest`.
 
 ```tsx
 import { useAui } from "@assistant-ui/react";

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -527,7 +527,7 @@ Before resuming, the runtime posts `{ threadId }` to `resumeStateApi`. The endpo
 { "runId": "8b3a...", "state": { "messages": [] } }
 ```
 
-The runtime replaces its local base with this snapshot and includes `runId` in the resume request. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state.
+The runtime replaces its local base with this snapshot and includes `runId` in the resume request. A sync server should reject the resume when that ID no longer identifies the same run, preventing replay operations from being applied to a drifted or replaced base state. When no run is active, the endpoint responds `204 No Content` and the runtime skips the resume without raising an error. On a resume, the snapshot and `runId` take precedence over fields supplied through `body`.
 
 ```tsx
 import { useAui } from "@assistant-ui/react";

--- a/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
+++ b/apps/docs/content/docs/runtimes/custom/assistant-transport.mdx
@@ -517,6 +517,14 @@ const runtime = useAssistantTransportRuntime({
   // ...
   api: "http://localhost:8010/assistant",
   resumeApi: "http://localhost:8010/resume",
+});
+```
+
+Setting `resumeStateApi` additionally hydrates resumed runs from the server-retained starting state. It requires a sync server that serves the initial-state route; do not configure it against a server without one, since a failing preflight fails the resume closed:
+
+```tsx
+const runtime = useAssistantTransportRuntime({
+  // ...
   resumeStateApi: "http://localhost:8010/initial-state",
 });
 ```

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
@@ -92,7 +92,8 @@ export type AssistantTransportProtocol = "data-stream" | "assistant-transport";
 
 export type SendCommandsRequestBody = {
   commands: QueuedCommand[];
-  state: unknown;
+  /** Absent on a resume with `resumeStateApi`; the server replays from its retained snapshot. */
+  state?: unknown;
   runId?: string;
   system: string | undefined;
   tools: Record<string, unknown> | undefined;

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
@@ -93,6 +93,7 @@ export type AssistantTransportProtocol = "data-stream" | "assistant-transport";
 export type SendCommandsRequestBody = {
   commands: QueuedCommand[];
   state: unknown;
+  runId?: string;
   system: string | undefined;
   tools: Record<string, unknown> | undefined;
   callSettings: LanguageModelV1CallSettings | undefined;
@@ -109,6 +110,8 @@ export type AssistantTransportOptions<T> = {
   initialState: T;
   api: string;
   resumeApi?: string;
+  /** Endpoint that returns the initial state and run ID for a resume stream. */
+  resumeStateApi?: string;
   protocol?: AssistantTransportProtocol;
   converter: AssistantTransportStateConverter<T>;
   headers: HeadersValue | (() => Promise<HeadersValue>);

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/types.ts
@@ -110,7 +110,7 @@ export type AssistantTransportOptions<T> = {
   initialState: T;
   api: string;
   resumeApi?: string;
-  /** Endpoint that returns the initial state and run ID for a resume stream. */
+  /** Endpoint that returns the retained initial state and run ID for a resume stream. A 204 response means no run is active and the resume is skipped. */
   resumeStateApi?: string;
   protocol?: AssistantTransportProtocol;
   converter: AssistantTransportStateConverter<T>;

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -16,6 +16,13 @@ Command Scheduling
   - If no run is in progress: start a run immediately and flush commands to the server.
 - A follow-up run that finds an empty queue is a no-op: no request is sent and no error is surfaced.
 - A resume run sends no commands; commands enqueued while it is pending or active are flushed in a follow-up run after it settles.
+
+Resume State
+
+- With `resumeStateApi` configured, a resume first posts `{ threadId }` there; the endpoint returns `{ runId, state }`, the state that started the active run.
+- The resume request carries that snapshot and `runId` in place of the local state, taking precedence over fields from `body`; `runId` is re-attached after `prepareSendCommandsRequest` so a rebuilt body cannot drop it. The local base is replaced by the snapshot only after the resume stream responds OK, so a rejected resume keeps the local state.
+- A 204 response means no active run: the resume is skipped without error, and queued commands are flushed in a follow-up run.
+- A malformed snapshot response fails the resume before the replay request is sent.
 - Runs execute on a `queueMicrotask`, so multiple synchronous enqueues coalesce into a single request: the first run's flush takes all of them, and the coalesced follow-up run no-ops.
 
 Command Queue

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -20,7 +20,7 @@ Command Scheduling
 Resume State
 
 - With `resumeStateApi` configured, a resume first posts `{ threadId }` there; the endpoint returns `{ runId, state }`, the state that started the active run.
-- The resume request carries that snapshot and `runId` in place of the local state, taking precedence over fields from `body`; `runId` is re-attached after `prepareSendCommandsRequest` so a rebuilt body cannot drop it. The local base is replaced by the snapshot only after the resume stream responds OK, so a rejected resume keeps the local state.
+- The resume request carries `runId` and no `state`: the server replays from the snapshot it retained for that run, so neither `body` overrides nor a `prepareSendCommandsRequest` rebuild can substitute a different base. `runId` takes precedence over `body` fields and is re-attached after `prepareSendCommandsRequest` so a rebuilt body cannot drop it. The local base is replaced by the snapshot only after the resume stream responds OK, so a rejected resume keeps the local state.
 - A 204 response means no active run: the resume is skipped without error, and queued commands are flushed in a follow-up run.
 - A malformed snapshot response fails the resume before the replay request is sent.
 - Runs execute on a `queueMicrotask`, so multiple synchronous enqueues coalesce into a single request: the first run's flush takes all of them, and the coalesced follow-up run no-ops.

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -383,9 +383,10 @@ describe("useAssistantTransportRuntime", () => {
     });
 
     expect(requests[1]!.body["runId"]).toBe("run-1");
+    expect(requests[1]!.body).not.toHaveProperty("state");
   });
 
-  it("re-attaches runId when prepareSendCommandsRequest rebuilds the body", async () => {
+  it("re-attaches runId and strips substituted state when prepareSendCommandsRequest rebuilds the body", async () => {
     const requests: RecordedRequest[] = [];
     vi.stubGlobal(
       "fetch",
@@ -411,7 +412,7 @@ describe("useAssistantTransportRuntime", () => {
       resumeStateApi: "https://example.com/resume-state",
       prepareSendCommandsRequest: (body) => ({
         commands: body.commands,
-        state: body.state,
+        state: { message: "Substituted" },
         rebuilt: true,
       }),
     });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -136,6 +136,7 @@ describe("useAssistantTransportRuntime", () => {
     expect(
       fetchMock.requests[0]!.body["commands"].map((c: any) => c.type),
     ).toEqual(["add-message", "add-message"]);
+    expect(fetchMock.requests[0]!.body["state"]).toEqual({});
 
     act(() => fetchMock.servers[0]!.close());
 
@@ -170,6 +171,7 @@ describe("useAssistantTransportRuntime", () => {
     await waitFor(() => expect(fetchMock.requests).toHaveLength(2));
     expect(fetchMock.requests[1]!.url).toBe("https://example.com/resume");
     expect(fetchMock.requests[1]!.body["commands"]).toEqual([]);
+    expect(fetchMock.requests[1]!.body).toHaveProperty("state");
 
     // "b" coalesced into the resume run and must not starve in the queue.
     act(() => fetchMock.servers[1]!.close());

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -234,10 +234,8 @@ describe("useAssistantTransportRuntime", () => {
       "https://example.com/resume-state",
       "https://example.com/resume",
     ]);
-    expect(requests[1]!.body).toMatchObject({
-      runId: "run-1",
-      state: { message: "Hello" },
-    });
+    expect(requests[1]!.body).toMatchObject({ runId: "run-1" });
+    expect(requests[1]!.body).not.toHaveProperty("state");
   });
 
   it("rejects malformed resume state responses before replay", async () => {
@@ -271,7 +269,7 @@ describe("useAssistantTransportRuntime", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("sends and commits a retained null state instead of falling back to local state", async () => {
+  it("commits a retained null state locally and omits state from the resume request", async () => {
     const requests: RecordedRequest[] = [];
     vi.stubGlobal(
       "fetch",
@@ -307,7 +305,8 @@ describe("useAssistantTransportRuntime", () => {
       await aui().thread.resumeRun({ parentId: null });
     });
 
-    expect(requests[1]!.body).toMatchObject({ runId: "run-1", state: null });
+    expect(requests[1]!.body).toMatchObject({ runId: "run-1" });
+    expect(requests[1]!.body).not.toHaveProperty("state");
     await waitFor(() =>
       expect(
         (aui().thread.getState().extras as { state: unknown }).state,
@@ -346,7 +345,7 @@ describe("useAssistantTransportRuntime", () => {
     ).toEqual({ message: "Kept" });
   });
 
-  it("keeps the retained snapshot over body overrides in the resume request", async () => {
+  it("keeps the retained runId over body overrides in the resume request", async () => {
     const requests: RecordedRequest[] = [];
     vi.stubGlobal(
       "fetch",
@@ -383,10 +382,7 @@ describe("useAssistantTransportRuntime", () => {
       await aui().thread.resumeRun({ parentId: null });
     });
 
-    expect(requests[1]!.body).toMatchObject({
-      runId: "run-1",
-      state: { message: "Hello" },
-    });
+    expect(requests[1]!.body["runId"]).toBe("run-1");
   });
 
   it("re-attaches runId when prepareSendCommandsRequest rebuilds the body", async () => {
@@ -430,11 +426,8 @@ describe("useAssistantTransportRuntime", () => {
       await aui().thread.resumeRun({ parentId: null });
     });
 
-    expect(requests[1]!.body).toMatchObject({
-      runId: "run-1",
-      state: { message: "Hello" },
-      rebuilt: true,
-    });
+    expect(requests[1]!.body).toMatchObject({ runId: "run-1", rebuilt: true });
+    expect(requests[1]!.body).not.toHaveProperty("state");
   });
 
   it("keeps local state when the matching resume stream is rejected", async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -271,6 +271,172 @@ describe("useAssistantTransportRuntime", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("sends and commits a retained null state instead of falling back to local state", async () => {
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (url: RequestInfo | URL, init: RequestInit = {}) => {
+        requests.push({
+          url: String(url),
+          init,
+          body: JSON.parse(init.body as string),
+        });
+
+        if (String(url) === "https://example.com/resume-state") {
+          return Response.json({ runId: "run-1", state: null });
+        }
+
+        return new Response("", { status: 200 });
+      },
+    );
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      aui().thread.importExternalState({ message: "Wrong" });
+    });
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    expect(requests[1]!.body).toMatchObject({ runId: "run-1", state: null });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { state: unknown }).state,
+      ).toBeNull(),
+    );
+  });
+
+  it("skips the resume without error when the state endpoint reports no active run", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+      onError,
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      aui().thread.importExternalState({ message: "Kept" });
+    });
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    await waitFor(() => expect(aui().thread.getState().isRunning).toBe(false));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(
+      (aui().thread.getState().extras as { state: unknown }).state,
+    ).toEqual({ message: "Kept" });
+  });
+
+  it("keeps the retained snapshot over body overrides in the resume request", async () => {
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (url: RequestInfo | URL, init: RequestInit = {}) => {
+        requests.push({
+          url: String(url),
+          init,
+          body: JSON.parse(init.body as string),
+        });
+
+        if (String(url) === "https://example.com/resume-state") {
+          return Response.json({
+            runId: "run-1",
+            state: { message: "Hello" },
+          });
+        }
+
+        return new Response("", { status: 200 });
+      },
+    );
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+      body: { state: { message: "Injected" }, runId: "bogus" },
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    expect(requests[1]!.body).toMatchObject({
+      runId: "run-1",
+      state: { message: "Hello" },
+    });
+  });
+
+  it("re-attaches runId when prepareSendCommandsRequest rebuilds the body", async () => {
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (url: RequestInfo | URL, init: RequestInit = {}) => {
+        requests.push({
+          url: String(url),
+          init,
+          body: JSON.parse(init.body as string),
+        });
+
+        if (String(url) === "https://example.com/resume-state") {
+          return Response.json({
+            runId: "run-1",
+            state: { message: "Hello" },
+          });
+        }
+
+        return new Response("", { status: 200 });
+      },
+    );
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+      prepareSendCommandsRequest: (body) => ({
+        commands: body.commands,
+        state: body.state,
+        rebuilt: true,
+      }),
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    expect(requests[1]!.body).toMatchObject({
+      runId: "run-1",
+      state: { message: "Hello" },
+      rebuilt: true,
+    });
+  });
+
   it("keeps local state when the matching resume stream is rejected", async () => {
     const fetchMock = vi
       .fn()

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -182,4 +182,132 @@ describe("useAssistantTransportRuntime", () => {
     act(() => fetchMock.servers[2]!.close());
     await waitFor(() => expect(aui().thread.getState().isRunning).toBe(false));
   });
+
+  it("applies resumed operations to the retained initial state", async () => {
+    const requests: RecordedRequest[] = [];
+    vi.stubGlobal(
+      "fetch",
+      async (url: RequestInfo | URL, init: RequestInit = {}) => {
+        requests.push({
+          url: String(url),
+          init,
+          body: JSON.parse(init.body as string),
+        });
+
+        if (String(url) === "https://example.com/resume-state") {
+          return Response.json({
+            runId: "run-1",
+            state: { message: "Hello" },
+          });
+        }
+
+        return new Response(
+          'aui-state:[{"type":"append-text","path":["message"],"value":" world"}]\n',
+          { status: 200 },
+        );
+      },
+    );
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      aui().thread.importExternalState({ message: "Wrong" });
+    });
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { state: unknown }).state,
+      ).toEqual({ message: "Hello world" }),
+    );
+    expect(requests.map((request) => request.url)).toEqual([
+      "https://example.com/resume-state",
+      "https://example.com/resume",
+    ]);
+    expect(requests[1]!.body).toMatchObject({
+      runId: "run-1",
+      state: { message: "Hello" },
+    });
+  });
+
+  it("rejects malformed resume state responses before replay", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ state: {} }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+      onError,
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Resume state response must contain state and runId",
+        }),
+        expect.anything(),
+      ),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps local state when the matching resume stream is rejected", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ runId: "run-1", state: { message: "Hello" } }),
+      )
+      .mockResolvedValueOnce(new Response("run mismatch", { status: 409 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const onError = vi.fn();
+    const { aui } = mountRuntime({
+      resumeApi: "https://example.com/resume",
+      resumeStateApi: "https://example.com/resume-state",
+      onError,
+    });
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() => {
+      aui().thread.importExternalState({ message: "Wrong" });
+    });
+    await act(async () => {
+      await aui().thread.resumeRun({ parentId: null });
+    });
+
+    await waitFor(() =>
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Status 409: run mismatch" }),
+        expect.anything(),
+      ),
+    );
+    expect(
+      (aui().thread.getState().extras as { state: unknown }).state,
+    ).toEqual({ message: "Wrong" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -214,20 +214,20 @@ const useAssistantTransportThreadRuntime = <T>(
         ...context.callSettings,
         ...context.config,
         ...(bodyValue ?? {}),
-        // The server replays a resume from the snapshot it retained for this
-        // runId; the request deliberately carries no state.
-        ...(resumeState !== undefined && { runId: resumeState.runId }),
       };
 
       if (options.prepareSendCommandsRequest) {
-        requestBody = {
-          ...(await options.prepareSendCommandsRequest(
-            requestBody as SendCommandsRequestBody,
-          )),
-          // The server validates the resume against this ID; a prepare hook
-          // that rebuilds the body must not be able to silently drop it.
-          ...(resumeState !== undefined && { runId: resumeState.runId }),
-        };
+        requestBody = await options.prepareSendCommandsRequest(
+          requestBody as SendCommandsRequestBody,
+        );
+      }
+
+      if (resumeState !== undefined) {
+        // The server replays a resume from the snapshot it retained for this
+        // runId. Body overrides and prepare hooks can neither substitute a
+        // state nor drop the ID the server validates against.
+        delete requestBody["state"];
+        requestBody["runId"] = resumeState.runId;
       }
 
       const response = await fetch(

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -72,7 +72,8 @@ const convertAppendMessageToCommand = (
 
 const readResumeState = async <T>(
   response: Response,
-): Promise<{ runId: string; state: T }> => {
+): Promise<{ runId: string; state: T } | null> => {
+  if (response.status === 204) return null;
   if (!response.ok) {
     throw new Error(
       `Resume state request failed with status ${response.status}: ${await response.text()}`,
@@ -181,7 +182,14 @@ const useAssistantTransportThreadRuntime = <T>(
           body: JSON.stringify({ threadId }),
           signal,
         });
-        resumeState = await readResumeState<T>(resumeStateResponse);
+        const retained = await readResumeState<T>(resumeStateResponse);
+        if (retained === null) {
+          if (commandQueue.state.queued.length > 0) {
+            runManager.schedule();
+          }
+          return;
+        }
+        resumeState = retained;
       }
 
       const bodyValue =
@@ -192,8 +200,7 @@ const useAssistantTransportThreadRuntime = <T>(
 
       let requestBody: Record<string, unknown> = {
         commands,
-        state: resumeState?.state ?? agentStateRef.current,
-        ...(resumeState !== undefined && { runId: resumeState.runId }),
+        state: agentStateRef.current,
         system: context.system,
         tools: context.tools ? toToolsJSONSchema(context.tools) : undefined,
         threadId,
@@ -207,12 +214,21 @@ const useAssistantTransportThreadRuntime = <T>(
         ...context.callSettings,
         ...context.config,
         ...(bodyValue ?? {}),
+        ...(resumeState !== undefined && {
+          state: resumeState.state,
+          runId: resumeState.runId,
+        }),
       };
 
       if (options.prepareSendCommandsRequest) {
-        requestBody = await options.prepareSendCommandsRequest(
-          requestBody as SendCommandsRequestBody,
-        );
+        requestBody = {
+          ...(await options.prepareSendCommandsRequest(
+            requestBody as SendCommandsRequestBody,
+          )),
+          // The server validates the resume against this ID; a prepare hook
+          // that rebuilds the body must not be able to silently drop it.
+          ...(resumeState !== undefined && { runId: resumeState.runId }),
+        };
       }
 
       const response = await fetch(

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -70,6 +70,35 @@ const convertAppendMessageToCommand = (
   };
 };
 
+const readResumeState = async <T>(
+  response: Response,
+): Promise<{ runId: string; state: T }> => {
+  if (!response.ok) {
+    throw new Error(
+      `Resume state request failed with status ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new Error("Resume state response was not valid JSON");
+  }
+
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("state" in value) ||
+    !("runId" in value) ||
+    typeof value.runId !== "string"
+  ) {
+    throw new Error("Resume state response must contain state and runId");
+  }
+
+  return { runId: value.runId, state: value.state as T };
+};
+
 const symbolAssistantTransportExtras = Symbol("assistant-transport-extras");
 type AssistantTransportExtras = {
   [symbolAssistantTransportExtras]: true;
@@ -144,6 +173,17 @@ const useAssistantTransportThreadRuntime = <T>(
       if (!isResume) parentIdRef.current = undefined;
 
       const headers = await createRequestHeaders(options.headers);
+      let resumeState: { runId: string; state: T } | undefined;
+      if (isResume && options.resumeStateApi) {
+        const resumeStateResponse = await fetch(options.resumeStateApi, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ threadId }),
+          signal,
+        });
+        resumeState = await readResumeState<T>(resumeStateResponse);
+      }
+
       const bodyValue =
         typeof options.body === "function"
           ? await options.body()
@@ -152,7 +192,8 @@ const useAssistantTransportThreadRuntime = <T>(
 
       let requestBody: Record<string, unknown> = {
         commands,
-        state: agentStateRef.current,
+        state: resumeState?.state ?? agentStateRef.current,
+        ...(resumeState !== undefined && { runId: resumeState.runId }),
         system: context.system,
         tools: context.tools ? toToolsJSONSchema(context.tools) : undefined,
         threadId,
@@ -192,6 +233,11 @@ const useAssistantTransportThreadRuntime = <T>(
 
       if (!response.body) {
         throw new Error("Response body is null");
+      }
+
+      if (resumeState !== undefined) {
+        agentStateRef.current = resumeState.state;
+        rerender((prev) => prev + 1);
       }
 
       const body = await createReplayBoundaryStream(response, {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -226,8 +226,8 @@ const useAssistantTransportThreadRuntime = <T>(
         // The server replays a resume from the snapshot it retained for this
         // runId. Body overrides and prepare hooks can neither substitute a
         // state nor drop the ID the server validates against.
+        requestBody = { ...requestBody, runId: resumeState.runId };
         delete requestBody["state"];
-        requestBody["runId"] = resumeState.runId;
       }
 
       const response = await fetch(

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -200,7 +200,7 @@ const useAssistantTransportThreadRuntime = <T>(
 
       let requestBody: Record<string, unknown> = {
         commands,
-        state: agentStateRef.current,
+        ...(resumeState === undefined && { state: agentStateRef.current }),
         system: context.system,
         tools: context.tools ? toToolsJSONSchema(context.tools) : undefined,
         threadId,
@@ -214,10 +214,9 @@ const useAssistantTransportThreadRuntime = <T>(
         ...context.callSettings,
         ...context.config,
         ...(bodyValue ?? {}),
-        ...(resumeState !== undefined && {
-          state: resumeState.state,
-          runId: resumeState.runId,
-        }),
+        // The server replays a resume from the snapshot it retained for this
+        // runId; the request deliberately carries no state.
+        ...(resumeState !== undefined && { runId: resumeState.runId }),
       };
 
       if (options.prepareSendCommandsRequest) {


### PR DESCRIPTION
## Summary

- add an optional `resumeStateApi` preflight to `useAssistantTransportRuntime`
- hydrate resumed operations from the server-retained starting state and forward its `runId`
- reject malformed snapshots and keep the current local state when the resume request is rejected
- document the contract and update the public API surface

## Why

While testing resume after a page refresh or history reload, I found that replay operations were applied to whatever state the resuming client reconstructed. If that state differed from the state that started the run, the conversation could silently diverge.

Closes #5562.

The server half is assistant-ui/assistant-ui-sync-server#1, which retains the run's starting snapshot and rejects mismatched run IDs. The client contract ships first and is the ratified shape the server PR aligns to: the preflight posts `{ threadId }` and receives `{ runId, state }` or `204 No Content` when no run is active (the resume is then skipped without error). A resume request carries `runId` and no `state`, because the server replays from the snapshot it retained; `runId` takes precedence over `body` fields and is re-attached after `prepareSendCommandsRequest` so a rebuilt body cannot drop it, and a retained `null` state is committed locally as-is rather than falling back to the local base. `resumeStateApi` is inert until configured, so shipping the client first affects no existing integration.

## Compatibility

`resumeStateApi` is optional. Existing integrations using only `resumeApi` preserve their current behavior, and the stream format is unchanged.

## Verification

- `pnpm --filter @assistant-ui/react build`
- all assistant-transport tests: 24 passed
- focused drift, malformed snapshot, and rejected-resume regression tests
- oxlint and oxfmt checks
- API surface check
- local end-to-end sync-server stack covering initial state retrieval, matching resume, and mismatched run rejection

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Z3YMTiRZf5siBIytoAJbO8lOna0arf2Ps2VMwn2CALYw9joKbe61MbqLPj4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
