### PR TITLE
fix(react): skip add-message commands with no supported parts

### DIFF
--- a/.changeset/skip-empty-add-message.md
+++ b/.changeset/skip-empty-add-message.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: skip add-message commands with no supported parts in assistant transport runtime

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -145,6 +145,32 @@ describe("useAssistantTransportRuntime", () => {
     expect(fetchMock.requests).toHaveLength(1);
   });
 
+  it("skips add-message commands with no supported parts", async () => {
+    const fetchMock = installFetch();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { aui } = mountRuntime();
+    await waitFor(() =>
+      expect(
+        (aui().thread.getState().extras as { sendCommand?: unknown })
+          ?.sendCommand,
+      ).toBeTypeOf("function"),
+    );
+
+    act(() =>
+      aui().thread.append({
+        role: "user",
+        content: [{ type: "audio", audio: { data: "", format: "mp3" } }],
+      }),
+    );
+
+    await act(async () => {});
+    expect(warn).toHaveBeenCalledWith(
+      "[assistant-ui] Skipped add-message command with no supported parts",
+    );
+    expect(fetchMock.requests).toHaveLength(0);
+    warn.mockRestore();
+  });
+
   it("flushes commands enqueued during a resume run in a follow-up run", async () => {
     const fetchMock = installFetch();
     const { aui, sendCommand } = mountRuntime({

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -112,6 +112,7 @@ const mountRuntime = (
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("useAssistantTransportRuntime", () => {
@@ -148,7 +149,7 @@ describe("useAssistantTransportRuntime", () => {
   it("skips add-message commands with no supported parts", async () => {
     const fetchMock = installFetch();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const { aui } = mountRuntime();
+    const { aui, sendCommand } = mountRuntime();
     await waitFor(() =>
       expect(
         (aui().thread.getState().extras as { sendCommand?: unknown })
@@ -168,7 +169,11 @@ describe("useAssistantTransportRuntime", () => {
       "[assistant-ui] Skipped add-message command with no supported parts",
     );
     expect(fetchMock.requests).toHaveLength(0);
-    warn.mockRestore();
+
+    // The skipped message must not leak its parentId into later batches.
+    act(() => sendCommand(createMessageCommand("follow-up")));
+    await waitFor(() => expect(fetchMock.requests).toHaveLength(1));
+    expect(fetchMock.requests[0]!.body).not.toHaveProperty("parentId");
   });
 
   it("flushes commands enqueued during a resume run in a follow-up run", async () => {

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -42,7 +42,7 @@ import type { UserExternalState } from "../../../augmentations";
 
 const convertAppendMessageToCommand = (
   message: AppendMessage,
-): AddMessageCommand => {
+): AddMessageCommand | null => {
   if (message.role !== "user")
     throw new Error("Only user messages are supported");
 
@@ -58,6 +58,8 @@ const convertAppendMessageToCommand = (
       parts.push({ type: "image", image: contentPart.image });
     }
   }
+
+  if (parts.length === 0) return null;
 
   return {
     type: "add-message",
@@ -332,6 +334,12 @@ const useAssistantTransportThreadRuntime = <T>(
     onNew: async (message: AppendMessage): Promise<void> => {
       parentIdRef.current = message.parentId;
       const command = convertAppendMessageToCommand(message);
+      if (!command) {
+        console.warn(
+          "[assistant-ui] Skipped add-message command with no supported parts",
+        );
+        return;
+      }
       commandQueue.enqueue(command, {
         schedule: message.startRun ?? message.role === "user",
       });
@@ -340,6 +348,12 @@ const useAssistantTransportThreadRuntime = <T>(
       onEdit: async (message: AppendMessage): Promise<void> => {
         parentIdRef.current = message.parentId;
         const command = convertAppendMessageToCommand(message);
+        if (!command) {
+          console.warn(
+            "[assistant-ui] Skipped add-message command with no supported parts",
+          );
+          return;
+        }
         commandQueue.enqueue(command, {
           schedule: message.startRun ?? message.role === "user",
         });

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -129,6 +129,20 @@ const useAssistantTransportThreadRuntime = <T>(
     onQueue: () => runManager.schedule(),
   });
 
+  const enqueueAppendMessage = (message: AppendMessage) => {
+    const command = convertAppendMessageToCommand(message);
+    if (!command) {
+      console.warn(
+        "[assistant-ui] Skipped add-message command with no supported parts",
+      );
+      return;
+    }
+    parentIdRef.current = message.parentId;
+    commandQueue.enqueue(command, {
+      schedule: message.startRun ?? message.role === "user",
+    });
+  };
+
   const threadId = useAuiState((s) => s.threadListItem.remoteId);
 
   const runManager = useRunManager({
@@ -331,33 +345,11 @@ const useAssistantTransportThreadRuntime = <T>(
       },
       state: agentStateRef.current as UserExternalState,
     } satisfies AssistantTransportExtras,
-    onNew: async (message: AppendMessage): Promise<void> => {
-      parentIdRef.current = message.parentId;
-      const command = convertAppendMessageToCommand(message);
-      if (!command) {
-        console.warn(
-          "[assistant-ui] Skipped add-message command with no supported parts",
-        );
-        return;
-      }
-      commandQueue.enqueue(command, {
-        schedule: message.startRun ?? message.role === "user",
-      });
-    },
+    onNew: async (message: AppendMessage): Promise<void> =>
+      enqueueAppendMessage(message),
     ...(options.capabilities?.edit && {
-      onEdit: async (message: AppendMessage): Promise<void> => {
-        parentIdRef.current = message.parentId;
-        const command = convertAppendMessageToCommand(message);
-        if (!command) {
-          console.warn(
-            "[assistant-ui] Skipped add-message command with no supported parts",
-          );
-          return;
-        }
-        commandQueue.enqueue(command, {
-          schedule: message.startRun ?? message.role === "user",
-        });
-      },
+      onEdit: async (message: AppendMessage): Promise<void> =>
+        enqueueAppendMessage(message),
     }),
     ...(commandQueue.state.queued.length > 0 && {
       onReload: async (parentId: string | null) => {


### PR DESCRIPTION
## Summary

Upstreams the downstream Athena pnpm patch hunk on `@assistant-ui/react@0.14.24`.

In the assistant-transport runtime, `convertAppendMessageToCommand` built a `parts` array from text/image content parts; when every part was an unsupported type, it still enqueued an `add-message` command with an empty `parts` array. Now it returns `null` when no supported parts remain, and both `onNew` and `onEdit` skip enqueueing with a `console.warn` ("[assistant-ui] Skipped add-message command with no supported parts").

## Changes

- `convertAppendMessageToCommand` returns `null` for empty parts
- `onNew`/`onEdit` warn and return instead of enqueueing on `null`
- Test covering the skip path in `useAssistantTransportRuntime.test.tsx`
- Changeset: patch bump for `@assistant-ui/react`

## Testing

- `vitest run src/legacy-runtime/runtime-cores/assistant-transport`: 22 tests pass
- `tsc --noEmit` in `packages/react`: no new errors (8 pre-existing on main, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.USM8bhunS1MDsE0fOWkb_vwvJpe66bD8LYnlKKG_vo3Rga29fdN6cg33qwk?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->