### PR TITLE
docs: add runtime thread refetch support

### DIFF
--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -224,7 +224,7 @@ function RefetchOnInterrupt({ status }: { status: string }) {
 }
 ```
 
-What the promise means depends on the path, and today it is always the remount one. There it resolves as soon as the replacement runtime attaches, which happens before that runtime's `load()` has started, so awaiting it does not mean the thread is fresh and a failed load cannot reach the caller. Only the in-place path settles with the refetch itself and rejects when it fails, which is why the example above still handles the rejection.
+What the promise means depends on the path. On the remount path, it resolves as soon as the replacement runtime attaches, which happens before that runtime's `load()` has started, so awaiting it does not mean the thread is fresh and a failed load cannot reach the caller. On the in-place path, it settles with the refetch itself and rejects when it fails, which is why the example above still handles the rejection.
 
 A thread that has not been sent yet is left alone because it holds no remote state.
 
@@ -234,7 +234,7 @@ How the refetch happens depends on the runtime, in one of three ways. When it de
 
 `useAuiState((s) => s.thread.capabilities.refetchThread)` reports which of those you would get, in place or not. It is not a signal for whether to offer a refresh at all: it is false on the remount path, where the call still does the work, and false again where the call does nothing.
 
-No adapter registers the capability yet, so today every runtime takes the remount path.
+The LangGraph adapter registers the in-place refetch capability. The Google ADK adapter also registers it when `useAdkRuntime` receives a `load` function. Other remote adapters take the remount path unless they provide the capability themselves.
 
 For an external store runtime, declare it with `onRefetchThread`, which is unrelated to `onReload` (that one re-generates an assistant message):
 

--- a/apps/docs/content/docs/runtimes/concepts/threads.mdx
+++ b/apps/docs/content/docs/runtimes/concepts/threads.mdx
@@ -234,7 +234,7 @@ How the refetch happens depends on the runtime, in one of three ways. When it de
 
 `useAuiState((s) => s.thread.capabilities.refetchThread)` reports which of those you would get, in place or not. It is not a signal for whether to offer a refresh at all: it is false on the remount path, where the call still does the work, and false again where the call does nothing.
 
-The LangGraph adapter registers the in-place refetch capability. The Google ADK adapter also registers it when `useAdkRuntime` receives a `load` function. Other remote adapters take the remount path unless they provide the capability themselves.
+Both the LangGraph and Google ADK adapters register the in-place refetch capability when their runtime hook receives a `load` function; without one they fall back to the remount path. Other remote adapters take the remount path unless they provide the capability themselves.
 
 For an external store runtime, declare it with `onRefetchThread`, which is unrelated to `onReload` (that one re-generates an assistant message):
 


### PR DESCRIPTION
## Summary

- describe the promise behavior for both in-place refetching and the remount fallback
- document that LangGraph and Google ADK support in-place thread refetching when their runtime hook receives a `load` function

## Why

The Threads guide still said every adapter used the remount fallback. That became outdated after the LangGraph support in #5531 and Google ADK support in #5545 landed, which could lead users to expect drafts to be discarded or `reloadMainThread()` to settle before the refetch completes.

## Verification

- verified `onRefetchThread` registration in both adapter implementations and their regression tests
- `git diff --check`
- full docs build was not completed because the fresh worktree dependency install timed out downloading the unrelated `expo-image` package

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.NnF7BFFtgkxhKd8TZzDH5uADgAA70dKl1oPavDYLno-rRw4vBLNnWmGjxIc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->