### PR TITLE
fix(core): preserve falsy tool results

### DIFF
--- a/.changeset/calm-tools-complete.md
+++ b/.changeset/calm-tools-complete.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: preserve falsy tool results

--- a/packages/core/src/runtime/api/message-runtime.test.ts
+++ b/packages/core/src/runtime/api/message-runtime.test.ts
@@ -173,6 +173,31 @@ describe("toMessagePartStatus", () => {
     });
   });
 
+  it.each([
+    ["false", false],
+    ["zero", 0],
+    ["an empty string", ""],
+    ["null", null],
+  ])("treats %s tool results as complete", (_label, result) => {
+    const message = createAssistantMessage(
+      [
+        {
+          type: "tool-call",
+          toolCallId: "call-1",
+          toolName: "weather",
+          args: {},
+          argsText: "{}",
+          result,
+        },
+      ],
+      { type: "running" },
+    );
+
+    expect(toMessagePartStatus(message, 0, message.content[0]!)).toEqual({
+      type: "complete",
+    });
+  });
+
   it("normalizes supplied upstream statuses", () => {
     const upstreamComplete = {
       type: "text",

--- a/packages/core/src/runtime/api/message-runtime.ts
+++ b/packages/core/src/runtime/api/message-runtime.ts
@@ -44,7 +44,7 @@ export const toMessagePartStatus = (
   if (message.role !== "assistant") return COMPLETE_STATUS;
 
   if (part.type === "tool-call") {
-    if (!part.result) {
+    if (part.result === undefined) {
       return message.status as ToolCallMessagePartStatus;
     } else {
       return COMPLETE_STATUS;

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.test.ts
@@ -958,6 +958,49 @@ describe("LocalThreadRuntimeCore tool approval persistence", () => {
     });
   });
 
+  it("does not persist an existing falsy tool result again", async () => {
+    const { history, updated } = createHistory();
+    const twoHumanTools: ChatModelRunResult = {
+      content: [
+        {
+          ...toolCallPart("send_email"),
+          toolCallId: "call-1",
+        },
+        {
+          ...toolCallPart("send_email"),
+          toolCallId: "call-2",
+        },
+      ],
+      status: { type: "requires-action", reason: "tool-calls" },
+    };
+    const thread = createThread(
+      {
+        async run() {
+          return twoHumanTools;
+        },
+      },
+      { history },
+    );
+
+    await thread.append(userMessage("send two emails"));
+    await flush();
+
+    const options = {
+      messageId: thread.messages.at(-1)!.id,
+      toolName: "send_email",
+      toolCallId: "call-1",
+      result: false,
+      isError: false,
+    };
+    thread.addToolResult(options);
+    await flush();
+    expect(updated).toHaveLength(1);
+
+    thread.addToolResult(options);
+    await flush();
+    expect(updated).toHaveLength(1);
+  });
+
   it("persists a multi-step run once instead of writing intermediate steps", async () => {
     const { history, appended, updated } = createHistory();
     const runs: ChatModelRunOptions[] = [];

--- a/packages/core/src/runtimes/local/local-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/local/local-thread-runtime-core.ts
@@ -681,7 +681,7 @@ export class LocalThreadRuntimeCore
       if (c.type !== "tool-call") return c;
       if (c.toolCallId !== toolCallId) return c;
       found = true;
-      if (!c.result) added = true;
+      if (c.result === undefined) added = true;
       return {
         ...c,
         result,


### PR DESCRIPTION
## Summary

- treat only `undefined` as a missing tool result when deriving part status
- avoid persisting an already-recorded falsy result as though it were newly added
- cover `false`, `0`, an empty string, and `null` with regression tests

## Why

While testing a human-in-the-loop tool locally, a valid `false` result remained in a running state because the runtime used a truthiness check to detect whether the result existed. The same check also classified an existing falsy result as newly added, causing a redundant paused-history update when another tool call was still pending.

Tool results are typed as unknown, so falsy values are valid results. `undefined` is the runtime sentinel for a result that has not arrived yet, consistent with the existing continuation and tool-invocation checks.

## Validation

- `pnpm --filter @assistant-ui/core exec vitest run src/runtime/api/message-runtime.test.ts src/runtimes/local/local-thread-runtime-core.test.ts`
- `pnpm --filter @assistant-ui/core test`
- `pnpm --filter @assistant-ui/core build`
- targeted `oxlint` and `oxfmt --check` on changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jekAI4-UIVjQvYJ7oL9BHXCsUXIpjx_uN1YiRRkfuDNxV3q8zJpwA-BYm9M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->