### PR TITLE
fix(react-a2a): preserve replacement run state

### DIFF
--- a/.changeset/bright-a2a-runs.md
+++ b/.changeset/bright-a2a-runs.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: preserve replacement run state when an aborted run settles late

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -987,6 +987,41 @@ describe("A2AThreadRuntimeCore", () => {
       // Second run should have completed
       expect(core.isRunning()).toBe(false);
     });
+
+    it("stays running when an aborted run settles after its replacement starts", async () => {
+      let resolveFirst!: () => void;
+      let resolveSecond!: () => void;
+      const firstPending = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const secondPending = new Promise<void>((resolve) => {
+        resolveSecond = resolve;
+      });
+      const streamMessage = vi.fn().mockImplementation(() => {
+        const pending =
+          streamMessage.mock.calls.length === 1 ? firstPending : secondPending;
+        return (async function* () {
+          await pending;
+        })();
+      });
+      const core = createCore({ streamMessage });
+
+      const first = core.append(createUserAppendMessage("First"));
+      await vi.waitFor(() => expect(streamMessage).toHaveBeenCalledTimes(1));
+
+      const second = core.append(createUserAppendMessage("Second"));
+      await vi.waitFor(() => expect(streamMessage).toHaveBeenCalledTimes(2));
+      expect(core.isRunning()).toBe(true);
+
+      resolveFirst();
+      await first;
+
+      expect(core.isRunning()).toBe(true);
+
+      resolveSecond();
+      await second;
+      expect(core.isRunning()).toBe(false);
+    });
   });
 
   // --- applyExternalMessages ---

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -746,9 +746,8 @@ export class A2AThreadRuntimeCore {
   }
 
   private finishRun(controller: AbortController | null) {
-    if (this.abortController === controller) {
-      this.abortController = null;
-    }
+    if (this.abortController !== controller) return;
+    this.abortController = null;
     this.setRunning(false);
   }
 


### PR DESCRIPTION
## Summary

- let only the active A2A run clear the runtime running state
- ignore delayed finalization from an aborted run after its replacement starts
- add a regression test that keeps the replacement stream pending while the old stream settles

## Why

While testing overlapping A2A sends, I found that replacing run A with run B could briefly leave the runtime reporting `isRunning: false` even though B was still active. Run A’s transport may not stop immediately when its signal is aborted. When that older stream eventually settles, its unconditional finalizer cleared the shared running flag owned by B.

This can make loading and cancel controls disappear early and expose an idle composer while the replacement request is still running. The finalizer now clears state only when its abort controller is still the active controller.

## Validation

- reproduced the failure before the fix with an abort-delayed stream
- `pnpm --filter @assistant-ui/react-a2a test` (189 tests)
- `pnpm --filter @assistant-ui/react-a2a build`
- targeted `oxlint` and `oxfmt --check`

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Z_6b4Fl0LtiYeDRX2hTdSt2G64ob7IowFVfUnVv8VtbGdc-n8AwKHga_08U?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

