### PR TITLE
fix(react): clear replay state after stream errors

### DIFF
--- a/.changeset/calm-streams-recover.md
+++ b/.changeset/calm-streams-recover.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: clear assistant transport replay state when response streams fail

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts
@@ -290,6 +290,30 @@ describe("createReplayBoundaryStream", () => {
     expect(setReplaying).toHaveBeenLastCalledWith(false);
   });
 
+  it("clears replaying when the source stream errors before the boundary", async () => {
+    const { waitForRender, releaseNext } = createRenderWait();
+    const setReplaying = vi.fn();
+    const sourceError = new Error("connection lost");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(sourceError);
+      },
+    });
+    const streamPromise = createReplayBoundaryStream(
+      new Response(body, { headers: { [REPLAY_CONTENT_LENGTH_HEADER]: "10" } }),
+      { setReplaying, waitForRender },
+    );
+
+    await releaseNext();
+    const stream = await streamPromise;
+    const reader = stream.getReader();
+
+    await expect(reader.read()).rejects.toBe(sourceError);
+    expect(setReplaying).toHaveBeenNthCalledWith(1, true);
+    expect(setReplaying).toHaveBeenNthCalledWith(2, false);
+    expect(setReplaying).toHaveBeenCalledTimes(2);
+  });
+
   it("clears replaying when the gated stream is cancelled", async () => {
     const { waitForRender, releaseNext } = createRenderWait();
     const setReplaying = vi.fn();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts
@@ -103,7 +103,18 @@ export const createReplayBoundaryStream = async (
 
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
-      const { done, value } = await reader.read();
+      let result: ReadableStreamReadResult<Uint8Array>;
+      try {
+        result = await reader.read();
+      } catch (error) {
+        if (!replayFinished) {
+          replayFinished = true;
+          setReplaying(false);
+        }
+        throw error;
+      }
+
+      const { done, value } = result;
 
       if (done) {
         await finishReplay();


### PR DESCRIPTION
## Summary

- clear assistant-transport replay state when the underlying response body errors before the replay boundary
- preserve and rethrow the original stream error for existing downstream error handling
- cover the failure with a focused replay-boundary regression test

## Why

The replay wrapper sets `isReplaying` before consuming the replay prefix. If the response body fails during that read, such as after a network disconnect or truncated resumable response, the returned stream rejects but replay state previously remained `true`. That could leave replay/loading UI stuck until the runtime remounted.

The failure path now marks replay complete and clears the replay flag before rethrowing the same source error. Normal completion, cancellation, replay gating, and chunk ordering are unchanged.

## Testing

- `pnpm exec turbo build --filter=@assistant-ui/react`
- `pnpm --filter @assistant-ui/react test` (48 files, 386 tests)
- `pnpm --filter @assistant-ui/react test --run src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts` (11 tests)
- `pnpm exec oxlint packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts`
- `pnpm exec oxfmt --check packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.ts packages/react/src/legacy-runtime/runtime-cores/assistant-transport/replayBoundaryStream.test.ts .changeset/calm-streams-recover.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-3UvMmCUTeVH2cS50E2yuPQ65AW5qXIGZPp99cTkTIdm-zsW1u-FbaB8uz8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->