### PR TITLE
feat(assistant-stream): public RunController.flush()

### DIFF
--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -76,6 +76,10 @@ class RunController:
         """Append a text delta at a state path using an append-text operation."""
         self._state_manager.append_text(path, text_delta)
 
+    def flush(self) -> None:
+        """Emit any buffered state operations to the stream now."""
+        self._state_manager.flush()
+
     async def add_tool_call(
         self, tool_name: str, tool_call_id: str = None
     ) -> ToolCallController:

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -77,7 +77,7 @@ class RunController:
         self._state_manager.append_text(path, text_delta)
 
     def flush(self) -> None:
-        """Emit any buffered state operations to the stream now."""
+        """Emit buffered state operations ahead of any subsequent stream chunk."""
         self._state_manager.flush()
 
     async def add_tool_call(

--- a/python/assistant-stream/tests/test_state_updates.py
+++ b/python/assistant-stream/tests/test_state_updates.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pytest
@@ -161,4 +162,23 @@ async def test_run_controller_append_state_text() -> None:
     assert operations == [
         {"type": "append-text", "path": ["user", "name"], "value": "Al"},
         {"type": "append-text", "path": ["user", "name"], "value": "ice"},
+    ]
+
+
+@pytest.mark.anyio
+async def test_run_controller_flush_emits_pending_ops() -> None:
+    """RunController.flush() should emit buffered state operations immediately."""
+    queue: asyncio.Queue = asyncio.Queue()
+    controller = RunController(queue, state_data={"user": {"name": ""}})
+
+    controller.state["user"]["name"] = "Alice"
+    assert queue.empty()
+
+    controller.flush()
+    await asyncio.sleep(0)
+
+    chunk = queue.get_nowait()
+    assert chunk.type == "update-state"
+    assert chunk.operations == [
+        {"type": "set", "path": ["user", "name"], "value": "Alice"}
     ]


### PR DESCRIPTION
Exposes the existing state flush as public API: `RunController.flush()` delegates to the internal state manager's flush, forcing buffered state operations to emit now. Hosts embedding assistant-stream (statewire migration in Athena's agora) need this to force emission without reaching into `_state_manager`.

Includes a small test that `flush()` emits pending state ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.rNVwIgpv4TyLDyFLxTANDbeM5iV6fqpr3IMaurDxzzjXZatAY651mH3leys?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->