### PR TITLE
docs(tap): document hooks support matrix and snapshot-throw divergence

### DIFF
--- a/apps/docs/content/tap-docs/tap/api-reference.mdx
+++ b/apps/docs/content/tap-docs/tap/api-reference.mdx
@@ -86,10 +86,13 @@ only — promises are not supported). They follow React's rules of Hooks, with a
 few [differences](/tap/docs/tap/differences-from-react). Hooks compiled by
 React Compiler also work: tap implements the compiler's memo-cache primitive.
 
-The remaining React hooks are not supported: `useId`, `useTransition`,
-`useDeferredValue`, `useImperativeHandle`, `useOptimistic`, and
-`useActionState`. Calling one inside a resource throws a `TypeError` naming the
-hook, for example `useId is not a function`.
+The remaining React hooks are not supported inside a resource body: `useId`,
+`useTransition`, `useDeferredValue`, `useImperativeHandle`, `useOptimistic`,
+and `useActionState`. Calling one inside a resource throws a `TypeError` naming
+the hook, for example `useId is not a function`. This restricts only the
+resource body itself: a React component hosting a resource can still wrap
+`useResource` in concurrent features like `useDeferredValue`
+([lifecycle](/tap/docs/tap/lifecycle)).
 
 The Hooks below are exported by tap.
 

--- a/apps/docs/content/tap-docs/tap/api-reference.mdx
+++ b/apps/docs/content/tap-docs/tap/api-reference.mdx
@@ -80,10 +80,16 @@ rendering again. State updates and context changes still render it.
 
 Inside a resource body you use React's own hooks, imported from `"react"`:
 `useState`, `useReducer`, `useEffect`, `useMemo`, `useCallback`, `useRef`,
-`useLayoutEffect`, `useEffectEvent`, `useSyncExternalStore`, `useDebugValue`,
-`useContext`, and `use` (tap contexts only — promises are not supported). They
-follow React's rules of Hooks, with a few
-[differences](/tap/docs/tap/differences-from-react).
+`useLayoutEffect`, `useInsertionEffect`, `useEffectEvent`,
+`useSyncExternalStore`, `useDebugValue`, `useContext`, and `use` (tap contexts
+only — promises are not supported). They follow React's rules of Hooks, with a
+few [differences](/tap/docs/tap/differences-from-react). Hooks compiled by
+React Compiler also work: tap implements the compiler's memo-cache primitive.
+
+The remaining React hooks are not supported: `useId`, `useTransition`,
+`useDeferredValue`, `useImperativeHandle`, `useOptimistic`, and
+`useActionState`. Calling one inside a resource throws a `TypeError` naming the
+hook, for example `useId is not a function`.
 
 The Hooks below are exported by tap.
 

--- a/apps/docs/content/tap-docs/tap/differences-from-react.mdx
+++ b/apps/docs/content/tap-docs/tap/differences-from-react.mdx
@@ -52,7 +52,16 @@ breaks this chain by creating a new root with its own scheduler. Everything
 below it re-renders independently, and the parent does not re-render when that
 root updates.
 
-## `useLayoutEffect` collapses onto `useEffect`
+## `useLayoutEffect` and `useInsertionEffect` collapse onto `useEffect`
 
-tap has a single effect primitive. `useLayoutEffect` is accepted (so React code
-ports cleanly) but behaves like `useEffect` inside a resource.
+tap has a single effect primitive. `useLayoutEffect` and `useInsertionEffect`
+are accepted (so React code ports cleanly) but behave like `useEffect` inside a
+resource.
+
+## A throwing snapshot keeps the committed value
+
+In React, when a store notifies `useSyncExternalStore` and `getSnapshot`
+throws, React re-renders and the error surfaces during that render. In tap, the
+resource keeps its last committed value and skips the re-render; the throw is
+swallowed for that notification only, and the next notification whose snapshot
+succeeds and differs re-renders as usual. This may change in a future release.


### PR DESCRIPTION
## What

Docs-only update to two tap pages: adds `useInsertionEffect` to the supported hooks list, notes that React Compiler compiled hooks work inside resources, lists the six unsupported hooks with their throw symptom, and documents the `useSyncExternalStore` snapshot-throw divergence on the differences page.

## Why

While re-checking the tap docs against the current dispatcher  found four support-matrix facts stated nowhere: `useInsertionEffect` works (it collapses onto `useEffect`), compiled hooks work since #5182 gave the dispatcher a memo cache, six hooks throw an opaque `TypeError` when called in a resource, and since #5274 a throwing snapshot keeps the committed value instead of surfacing. The #5402 docs revision covered the type-level drift but not these.

## Impact

Docs only, no code change. Someone hitting `useId is not a function` inside a resource now finds the answer in the API reference.

## Scope 

- Every claim is traced to source: the dispatcher hook map, `useMemoCache` (the compiler `c()` cache), and the `useSyncExternalStore` catch path.
- The `useMemoCache` barrel export stays undocumented on purpose: it is `@deprecated` internal, so the docs state the compiler capability, not the export.
- The throw example quotes only the stable tail (`useId is not a function`), not the React-internals prefix, which varies by React version.
- The snapshot-throw section ends with "may change in a future release" because the source TODO marks the behavior provisional.
- The renamed heading on the differences page has no inbound anchor links.
- Tests: none, docs only; the docs app build is the gate.
- Changeset: none, private package (`@assistant-ui/docs`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.eQxd6z2oJNNWfxNEV45AwJB68b8ay3esDiJ7ugzejzdUhUaj6iXjt-vb8Fo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->