### PR TITLE
chore(python): assistant-stream 0.0.35

### DIFF
--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "assistant-stream"
-version = "0.0.34"
+version = "0.0.35"
 description = ""
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },

--- a/python/assistant-stream/uv.lock
+++ b/python/assistant-stream/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "assistant-stream"
-version = "0.0.34"
+version = "0.0.35"
 source = { editable = "." }
 dependencies = [
     { name = "starlette" },


### PR DESCRIPTION
Releases the public RunController.flush() from #5574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.A56z8MvNNhopbI4RDKuzXxdrKv00r40sdz9zt0QSu1Zw66VNJkP9ubRwvbc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->