### PR TITLE
fix(eve): map cancelled and failed turns to terminal statuses instead of permanent running

### DIFF
--- a/.changeset/eve-terminal-status-mapping.md
+++ b/.changeset/eve-terminal-status-mapping.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: map cancelled and failed turns to terminal message statuses instead of a permanent running state

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -212,6 +212,7 @@ type ComposerState = ThreadComposerState | EditComposerState;
 
 type ConvertEveMessagesOptions = {
   readonly isRunning?: boolean | undefined;
+  readonly error?: unknown;
   readonly getCreatedAt?: ((message: EveMessage) => Date) | undefined;
 };
 

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -47,9 +47,13 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "eve": "^0.27.6",
+    "jsdom": "^29.1.1",
     "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "vitest": "^4.1.10"
   },
   "publishConfig": {

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { EveMessageData } from "eve/react";
+import { defaultMessageReducer, type EveAgentReducerEvent } from "eve/client";
 import {
   convertEveMessages,
   getEveMessageContent,
@@ -257,6 +258,225 @@ describe("convertEveMessages", () => {
     const [message] = convertEveMessages(data);
 
     expect(message?.content).toEqual([{ type: "text", text: "Done" }]);
+  });
+
+  describe("assistant message status mapping", () => {
+    const withStatus = (
+      status: "streaming" | "complete" | "failed",
+    ): EveMessageData => ({
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          metadata: { status },
+          parts: [{ type: "text", text: "Hi" }],
+        },
+      ],
+    });
+
+    it("maps a running last message to running", () => {
+      const [message] = convertEveMessages(withStatus("streaming"), {
+        isRunning: true,
+      });
+
+      expect(message?.status).toEqual({ type: "running" });
+    });
+
+    it("keeps the legacy running mapping for a streaming marker when liveness is omitted", () => {
+      const [message] = convertEveMessages(withStatus("streaming"));
+
+      expect(message?.status).toEqual({ type: "running" });
+    });
+
+    it("maps a stale streaming marker to cancelled when no longer running", () => {
+      const [message] = convertEveMessages(withStatus("streaming"), {
+        isRunning: false,
+      });
+
+      expect(message?.status).toEqual({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+    });
+
+    it("maps a stale streaming marker to error when the session error is set", () => {
+      const [message] = convertEveMessages(withStatus("streaming"), {
+        isRunning: false,
+        error: new Error("boom"),
+      });
+
+      expect(message?.status).toEqual({
+        type: "incomplete",
+        reason: "error",
+        error: { code: "unknown", message: "boom" },
+      });
+    });
+
+    it("maps a stuck streaming message to cancelled while a newer turn runs", () => {
+      const data = {
+        messages: [
+          {
+            id: "a1",
+            role: "assistant",
+            metadata: { status: "streaming" },
+            parts: [{ type: "text", text: "Interrupted" }],
+          },
+          {
+            id: "u2",
+            role: "user",
+            parts: [{ type: "text", text: "Try again" }],
+          },
+        ],
+      } satisfies EveMessageData;
+
+      const [assistant] = convertEveMessages(data, {
+        isRunning: true,
+        error: new Error("boom"),
+      });
+
+      expect(assistant?.status).toEqual({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+    });
+
+    it("keeps a completed message complete even when the session error is set", () => {
+      const [message] = convertEveMessages(withStatus("complete"), {
+        isRunning: false,
+        error: new Error("boom"),
+      });
+
+      expect(message?.status).toEqual({ type: "complete", reason: "stop" });
+    });
+
+    it("maps an assistant failed marker to an error status", () => {
+      const [message] = convertEveMessages(withStatus("failed"), {
+        isRunning: false,
+      });
+
+      expect(message?.status).toEqual({ type: "incomplete", reason: "error" });
+    });
+
+    it("keeps requires-action for pending approvals when not running", () => {
+      const data = {
+        messages: [
+          {
+            id: "a1",
+            role: "assistant",
+            metadata: { status: "streaming" },
+            parts: [
+              {
+                type: "dynamic-tool",
+                state: "approval-requested",
+                toolCallId: "call_1",
+                toolName: "send_email",
+                input: {},
+                approval: { id: "req_1" },
+              },
+            ],
+          },
+        ],
+      } satisfies EveMessageData;
+
+      const [message] = convertEveMessages(data, { isRunning: false });
+
+      expect(message?.status).toEqual({
+        type: "requires-action",
+        reason: "tool-calls",
+      });
+    });
+
+    describe("contract with eve's default reducer", () => {
+      const replay = (events: readonly EveAgentReducerEvent[]) => {
+        const reducer = defaultMessageReducer();
+        return events.reduce(
+          (state, event) => reducer.reduce(state, event),
+          reducer.initial(),
+        );
+      };
+
+      const midStreamEvents: readonly EveAgentReducerEvent[] = [
+        {
+          type: "client.message.submitted",
+          data: { submissionId: "sub_1", message: "hi", createdAt: 0 },
+        },
+        {
+          type: "turn.started",
+          data: { turnId: "turn_1", sequence: 0 },
+        },
+        {
+          type: "step.started",
+          data: { turnId: "turn_1", stepIndex: 0, sequence: 1 },
+        },
+        {
+          type: "message.appended",
+          data: {
+            turnId: "turn_1",
+            stepIndex: 0,
+            sequence: 2,
+            messageDelta: "Let me th",
+            messageSoFar: "Let me th",
+          },
+        },
+      ];
+
+      it("a locally aborted turn keeps its streaming marker and converts to cancelled", () => {
+        const state = replay(midStreamEvents);
+
+        const assistant = state.messages.find((m) => m.role === "assistant");
+        expect(assistant?.metadata?.status).toBe("streaming");
+
+        const converted = convertEveMessages(state, { isRunning: false });
+        expect(converted.at(-1)?.status).toEqual({
+          type: "incomplete",
+          reason: "cancelled",
+        });
+      });
+
+      it("a failed session keeps its streaming marker and converts to error", () => {
+        const state = replay([
+          ...midStreamEvents,
+          {
+            type: "session.failed",
+            data: { sessionId: "session_1", code: "internal", message: "boom" },
+          },
+        ]);
+
+        const assistant = state.messages.find((m) => m.role === "assistant");
+        expect(assistant?.metadata?.status).toBe("streaming");
+
+        const converted = convertEveMessages(state, {
+          isRunning: false,
+          error: new Error("boom"),
+        });
+        expect(converted.at(-1)?.status).toEqual({
+          type: "incomplete",
+          reason: "error",
+          error: { code: "unknown", message: "boom" },
+        });
+      });
+
+      it("a failed turn converts to cancelled because the store surfaces no error for turn.failed", () => {
+        const state = replay([
+          ...midStreamEvents,
+          {
+            type: "turn.failed",
+            data: {
+              turnId: "turn_1",
+              sequence: 3,
+              code: "internal",
+              message: "boom",
+            },
+          },
+        ]);
+
+        const converted = convertEveMessages(state, { isRunning: false });
+        expect(converted.at(-1)?.status).toEqual({
+          type: "incomplete",
+          reason: "cancelled",
+        });
+      });
+    });
   });
 
   it("uses the supplied message creation time", () => {

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -476,6 +476,35 @@ describe("convertEveMessages", () => {
           reason: "cancelled",
         });
       });
+
+      it("a completed turn terminalizes the streaming marker and converts to complete", () => {
+        const state = replay([
+          ...midStreamEvents,
+          {
+            type: "message.completed",
+            data: {
+              turnId: "turn_1",
+              stepIndex: 0,
+              sequence: 3,
+              finishReason: "stop",
+              message: "Let me think",
+            },
+          },
+          {
+            type: "turn.completed",
+            data: { turnId: "turn_1", sequence: 4 },
+          },
+        ]);
+
+        const assistant = state.messages.find((m) => m.role === "assistant");
+        expect(assistant?.metadata?.status).toBe("complete");
+
+        const converted = convertEveMessages(state, { isRunning: false });
+        expect(converted.at(-1)?.status).toEqual({
+          type: "complete",
+          reason: "stop",
+        });
+      });
     });
   });
 

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -1,5 +1,6 @@
 import {
   fromThreadMessageLike,
+  toAssistantError,
   type AppendMessage,
   type MessageStatus,
   type RespondToToolApprovalOptions,
@@ -29,6 +30,11 @@ const ASSISTANT_RUNNING_STATUS = {
   type: "running",
 } satisfies MessageStatus;
 
+const ASSISTANT_CANCELLED_STATUS = {
+  type: "incomplete",
+  reason: "cancelled",
+} satisfies MessageStatus;
+
 const USER_FALLBACK_STATUS = {
   type: "complete",
   reason: "unknown",
@@ -37,9 +43,15 @@ const USER_FALLBACK_STATUS = {
 export type ConvertEveMessagesOptions = {
   /**
    * Marks the last assistant message as running while Eve is submitting or
-   * streaming.
+   * streaming. When omitted, a message carrying Eve's `"streaming"` marker is
+   * treated as running; pass `false` to settle interrupted messages to a
+   * terminal status.
    */
   readonly isRunning?: boolean | undefined;
+  /**
+   * The Eve session error, mapped onto the assistant message it interrupted.
+   */
+  readonly error?: unknown;
   readonly getCreatedAt?: ((message: EveMessage) => Date) | undefined;
 };
 
@@ -81,11 +93,26 @@ const toMessageStatus = (
     return { type: "incomplete", reason: "error" };
   }
 
-  if (
-    message.metadata?.status === "streaming" ||
-    (options.isRunning === true && index === messages.length - 1)
-  ) {
+  const isLast = index === messages.length - 1;
+  if (isLast && options.isRunning === true) {
     return ASSISTANT_RUNNING_STATUS;
+  }
+
+  // Eve's default reducer never terminalizes the "streaming" marker on
+  // cancellation or turn/session failure, so liveness comes from isRunning and
+  // a leftover marker means the turn was interrupted.
+  if (message.metadata?.status === "streaming") {
+    if (options.isRunning === undefined) {
+      return ASSISTANT_RUNNING_STATUS;
+    }
+    if (isLast && options.error !== undefined) {
+      return {
+        type: "incomplete",
+        reason: "error",
+        error: toAssistantError(options.error),
+      };
+    }
+    return ASSISTANT_CANCELLED_STATUS;
   }
 
   return ASSISTANT_COMPLETE_STATUS;

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseEveAgent } = vi.hoisted(() => ({
+  mockUseEveAgent: vi.fn(),
+}));
+
+vi.mock("eve/react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("eve/react")>()),
+  useEveAgent: mockUseEveAgent,
+}));
+
+import type { EveMessageData } from "eve/react";
+import { useEveAgentRuntime } from "./useEveAgentRuntime";
+
+const stuckStreamingData: EveMessageData = {
+  messages: [
+    { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+    {
+      id: "a1",
+      role: "assistant",
+      metadata: { status: "streaming" },
+      parts: [{ type: "text", text: "Let me th" }],
+    },
+  ],
+};
+
+const createAgent = (overrides: Record<string, unknown>) => ({
+  data: stuckStreamingData,
+  error: undefined,
+  events: [],
+  session: undefined,
+  status: "ready",
+  send: vi.fn(),
+  stop: vi.fn(),
+  reset: vi.fn(),
+  ...overrides,
+});
+
+describe("useEveAgentRuntime status forwarding", () => {
+  it("maps the session error onto the interrupted assistant message", () => {
+    mockUseEveAgent.mockReturnValue(
+      createAgent({ status: "error", error: new Error("boom") }) as never,
+    );
+
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      error: { code: "unknown", message: "boom" },
+    });
+  });
+
+  it("settles an aborted turn to cancelled once the agent is idle", () => {
+    mockUseEveAgent.mockReturnValue(createAgent({ status: "ready" }) as never);
+
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+  });
+
+  it("recomputes statuses when only the session error changes", () => {
+    const idle = createAgent({ status: "ready" });
+    mockUseEveAgent.mockReturnValue(idle as never);
+
+    const { result, rerender } = renderHook(() => useEveAgentRuntime());
+
+    expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "cancelled",
+    });
+
+    mockUseEveAgent.mockReturnValue({
+      ...idle,
+      status: "error",
+      error: new Error("boom"),
+    } as never);
+    rerender();
+
+    expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
+      type: "incomplete",
+      reason: "error",
+      error: { code: "unknown", message: "boom" },
+    });
+  });
+
+  it("keeps the last assistant message running while streaming", () => {
+    mockUseEveAgent.mockReturnValue(
+      createAgent({ status: "streaming" }) as never,
+    );
+
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
+      type: "running",
+    });
+  });
+});

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -117,6 +117,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
 
     return convertEveMessages(agent.data, {
       isRunning,
+      error: agent.error,
       getCreatedAt: (message) => {
         const existing = createdAtByMessageId.get(message.id);
         if (existing) return existing;
@@ -126,7 +127,7 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
         return createdAt;
       },
     });
-  }, [agent.data, isRunning]);
+  }, [agent.data, agent.error, isRunning]);
 
   const messages = stagedMessages ?? convertedMessages;
   const messagesRef = useRef(messages);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3507,15 +3507,27 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
       eve:
         specifier: ^0.27.6
         version: 0.27.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.37(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION

Closes #5579
## What

The eve converter no longer treats eve's `metadata.status === "streaming"` marker as proof a message is still running. Liveness now comes from the store's `isRunning`; a message left with the stale marker maps to `incomplete`/`cancelled`, or `incomplete`/`error` (via `toAssistantError`) when the session error interrupted it. `useEveAgentRuntime` passes `agent.error` through to the converter.

## Why

While validating the adapter against eve 0.27.6 I replayed real event sequences through eve's own `defaultMessageReducer`: it never clears the streaming marker on cancel or failure (`stop()` only aborts the local fetch, and `turn.failed`/`session.failed` are literal no-op arms), so the stop button left a spinner forever and an HTTP 500 rendered no error state at all.

## Impact

- Cancelling a turn now settles the message to `incomplete`/`cancelled` (the core-wide cancel status) instead of a permanent spinner.
- Session failures and transport errors (for example an HTTP 500) now show `incomplete`/`error` with the error message; previously they were invisible.
- Behavior change only for interrupted turns; completed turns render exactly as before.

## Scope 

- Error attribution is deliberately narrow: only the last, still-streaming message can carry the error, so a successful earlier message can never get mislabeled. Session-level errors (failure before any assistant message exists, or after the final text completed) are a follow-up extras surface, not this PR.
- The assistant `"failed"` branch stays although eve's default reducer never sets it on assistant messages: it is correct and cheap for custom reducers.
- eve's store derives `error` only from `session.failed` events and thrown transport errors; a bare `turn.failed` carries no error object upstream, so it settles as `cancelled` rather than `error`. That is a stated gap pinned by a contract test; richer turn-failure surfacing is an upstream/extras follow-up.
- An `authorization.required` suspension leaves the streaming marker set the same way (eve's server skips `turn.completed` there), so it now settles as `cancelled` instead of the previous permanent spinner. The honest `requires-action` mapping, plus rendering the authorization part at all, is #5613.
- One contract test imports eve's `defaultMessageReducer` on purpose: it pins the coupling this fix depends on (the reducer never terminalizes cancelled or failed turns), so the upcoming 0.28/0.29 validation trips loudly if upstream changes it.
- Tests: full status matrix (running, cancelled, error, stuck-while-newer-turn-runs, complete-wins-over-error, failed marker, pending approval), two reducer-replay contract tests, and three hook-level tests (`renderHook` with a mocked `useEveAgent`, the sibling-adapter pattern) verifying `agent.error` and liveness actually reach the rendered messages.
- Omitting `isRunning` keeps the legacy mapping (a streaming marker renders as running), so direct converter callers see no behavior change; only an explicit `false` settles interrupted messages. The hook always passes a boolean.
- Additive only: one optional `error` field on `ConvertEveMessagesOptions`, no exports removed or reshaped.
- Changeset: patch (`@assistant-ui/eve`).

