### PR TITLE
fix(eve): convert inbound eve file parts instead of dropping them

### DIFF
--- a/.changeset/eve-inbound-file-parts.md
+++ b/.changeset/eve-inbound-file-parts.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: convert inbound eve file parts instead of dropping them

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -195,7 +195,7 @@ describe("convertEveMessages", () => {
     expect(message?.metadata).not.toHaveProperty("isOptimistic");
   });
 
-  it("falls back to an empty text part for user messages without convertible parts", () => {
+  it("falls back to an empty text part for user messages with only url-less file parts", () => {
     const data = {
       messages: [
         {
@@ -209,9 +209,10 @@ describe("convertEveMessages", () => {
     const [message] = convertEveMessages(data);
 
     expect(message?.content).toEqual([{ type: "text", text: "" }]);
+    expect(message?.attachments).toEqual([]);
   });
 
-  it("drops non-convertible user parts without triggering the fallback", () => {
+  it("drops url-less user file parts without triggering the fallback", () => {
     const data = {
       messages: [
         {
@@ -228,6 +229,213 @@ describe("convertEveMessages", () => {
     const [message] = convertEveMessages(data);
 
     expect(message?.content).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("converts a user file part into content and a file attachment", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            { type: "text", text: "See the report" },
+            {
+              type: "file",
+              url: "https://example.com/report.pdf",
+              mediaType: "application/pdf",
+              filename: "report.pdf",
+              size: 1024,
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "See the report" },
+      {
+        type: "file",
+        data: "https://example.com/report.pdf",
+        mimeType: "application/pdf",
+        filename: "report.pdf",
+        sourceType: "url",
+      },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "file",
+        name: "report.pdf",
+        content: [
+          {
+            type: "file",
+            data: "https://example.com/report.pdf",
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+            sourceType: "url",
+          },
+        ],
+        contentType: "application/pdf",
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
+  it("converts a user image file part into an image attachment", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "https://example.com/photo.png",
+              mediaType: "image/png",
+              filename: "photo.png",
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([
+      {
+        type: "file",
+        data: "https://example.com/photo.png",
+        mimeType: "image/png",
+        filename: "photo.png",
+        sourceType: "url",
+      },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "image",
+        name: "photo.png",
+        content: [
+          {
+            type: "image",
+            image: "https://example.com/photo.png",
+            filename: "photo.png",
+          },
+        ],
+        contentType: "image/png",
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
+  it("omits sourceType and falls back to a generic name for data url file parts", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "data:application/pdf;base64,QUJD",
+              mediaType: "application/pdf",
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([
+      {
+        type: "file",
+        data: "data:application/pdf;base64,QUJD",
+        mimeType: "application/pdf",
+      },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "file",
+        name: "file",
+        content: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,QUJD",
+            mimeType: "application/pdf",
+          },
+        ],
+        contentType: "application/pdf",
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
+  it("assigns sequential attachment ids across multiple file parts", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "https://example.com/a.pdf",
+              mediaType: "application/pdf",
+            },
+            { type: "file", mediaType: "image/png" },
+            {
+              type: "file",
+              url: "https://example.com/b.png",
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.attachments?.map((a) => [a.id, a.type])).toEqual([
+      ["0", "file"],
+      ["1", "image"],
+    ]);
+  });
+
+  it("converts an assistant file part into a file content part", () => {
+    const data = {
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            { type: "text", text: "Here you go" },
+            {
+              type: "file",
+              url: "https://example.com/result.csv",
+              mediaType: "text/csv",
+              filename: "result.csv",
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([
+      { type: "text", text: "Here you go" },
+      {
+        type: "file",
+        data: "https://example.com/result.csv",
+        mimeType: "text/csv",
+        filename: "result.csv",
+        sourceType: "url",
+      },
+    ]);
   });
 
   it("drops non-convertible part types instead of throwing", () => {
@@ -365,6 +573,66 @@ describe("getEveMessageContent", () => {
         type: "file",
         data: "https://cdn.example.com/memo.mp3",
         mediaType: "audio/mp3",
+      },
+    ]);
+  });
+
+  it("round-trips a sent file attachment through the eve echo shape", () => {
+    const message = {
+      ...baseAppendMessage,
+      content: [],
+      attachments: [
+        {
+          id: "1",
+          type: "file",
+          name: "report.pdf",
+          content: [
+            {
+              type: "file",
+              data: "https://example.com/report.pdf",
+              mimeType: "application/pdf",
+              filename: "report.pdf",
+            },
+          ],
+          status: { type: "complete" },
+        },
+      ],
+    } as unknown as AppendMessage;
+
+    expect(getEveMessageContent(message)).toEqual([
+      {
+        type: "file",
+        data: "https://example.com/report.pdf",
+        mediaType: "application/pdf",
+        filename: "report.pdf",
+      },
+    ]);
+
+    const [echoed] = convertEveMessages({
+      messages: [
+        {
+          id: "t1:user",
+          role: "user",
+          metadata: { status: "complete", turnId: "t1" },
+          parts: [
+            {
+              type: "file",
+              url: "https://example.com/report.pdf",
+              mediaType: "application/pdf",
+              filename: "report.pdf",
+            },
+          ],
+        },
+      ],
+    } satisfies EveMessageData);
+
+    expect(echoed?.content).toEqual([
+      {
+        type: "file",
+        data: "https://example.com/report.pdf",
+        mimeType: "application/pdf",
+        filename: "report.pdf",
+        sourceType: "url",
       },
     ]);
   });

--- a/packages/eve/src/convertEveMessages.test.ts
+++ b/packages/eve/src/convertEveMessages.test.ts
@@ -405,6 +405,46 @@ describe("convertEveMessages", () => {
     ]);
   });
 
+  it("defaults a file part with a missing mediaType to unknown/unknown", () => {
+    const data = {
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          parts: [{ type: "file", url: "https://example.com/blob" }],
+        },
+      ],
+    } as unknown as EveMessageData;
+
+    const [message] = convertEveMessages(data);
+
+    expect(message?.content).toEqual([
+      {
+        type: "file",
+        data: "https://example.com/blob",
+        mimeType: "unknown/unknown",
+        sourceType: "url",
+      },
+    ]);
+    expect(message?.attachments).toEqual([
+      {
+        id: "0",
+        type: "file",
+        name: "file",
+        content: [
+          {
+            type: "file",
+            data: "https://example.com/blob",
+            mimeType: "unknown/unknown",
+            sourceType: "url",
+          },
+        ],
+        contentType: "unknown/unknown",
+        status: { type: "complete" },
+      },
+    ]);
+  });
+
   it("converts an assistant file part into a file content part", () => {
     const data = {
       messages: [

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -1,6 +1,8 @@
 import {
   fromThreadMessageLike,
   type AppendMessage,
+  type CompleteAttachment,
+  type FileMessagePart,
   type MessageStatus,
   type RespondToToolApprovalOptions,
   type ThreadAssistantMessagePart,
@@ -176,6 +178,19 @@ const convertDynamicToolPart = (
   }
 };
 
+const convertFilePart = (
+  part: Extract<EveMessagePart, { type: "file" }>,
+): FileMessagePart | null => {
+  if (part.url === undefined) return null;
+  return {
+    type: "file",
+    data: part.url,
+    mimeType: part.mediaType,
+    ...(part.filename && { filename: part.filename }),
+    ...(httpUrlPattern.test(part.url) && { sourceType: "url" as const }),
+  };
+};
+
 const convertAssistantPart = (
   part: EveMessagePart,
 ): ThreadAssistantMessagePart | null => {
@@ -190,6 +205,9 @@ const convertAssistantPart = (
     case "dynamic-tool":
       return convertDynamicToolPart(part);
 
+    case "file":
+      return convertFilePart(part);
+
     default:
       return null;
   }
@@ -202,6 +220,9 @@ const convertUserPart = (
     case "text":
       return { type: "text", text: part.text };
 
+    case "file":
+      return convertFilePart(part);
+
     default:
       return null;
   }
@@ -212,6 +233,35 @@ const toUserContent = (
 ): readonly ThreadUserMessagePart[] => {
   const content = parts.map(convertUserPart).filter((part) => part !== null);
   return content.length > 0 ? content : [{ type: "text", text: "" }];
+};
+
+const toUserAttachments = (
+  parts: readonly EveMessagePart[],
+): CompleteAttachment[] => {
+  const attachments: CompleteAttachment[] = [];
+  for (const part of parts) {
+    if (part.type !== "file") continue;
+    const file = convertFilePart(part);
+    if (file === null) continue;
+    const isImage = part.mediaType.startsWith("image/");
+    attachments.push({
+      id: String(attachments.length),
+      type: isImage ? "image" : "file",
+      name: part.filename ?? "file",
+      content: [
+        isImage
+          ? {
+              type: "image",
+              image: file.data,
+              ...(part.filename && { filename: part.filename }),
+            }
+          : file,
+      ],
+      contentType: part.mediaType,
+      status: { type: "complete" },
+    });
+  }
+  return attachments;
 };
 
 /**
@@ -238,7 +288,7 @@ export const convertEveMessage = (
           id: message.id,
           createdAt,
           content: toUserContent(message.parts),
-          attachments: [],
+          attachments: toUserAttachments(message.parts),
           metadata,
         }
       : {

--- a/packages/eve/src/convertEveMessages.ts
+++ b/packages/eve/src/convertEveMessages.ts
@@ -185,7 +185,7 @@ const convertFilePart = (
   return {
     type: "file",
     data: part.url,
-    mimeType: part.mediaType,
+    mimeType: part.mediaType ?? "unknown/unknown",
     ...(part.filename && { filename: part.filename }),
     ...(httpUrlPattern.test(part.url) && { sourceType: "url" as const }),
   };
@@ -243,7 +243,7 @@ const toUserAttachments = (
     if (part.type !== "file") continue;
     const file = convertFilePart(part);
     if (file === null) continue;
-    const isImage = part.mediaType.startsWith("image/");
+    const isImage = file.mimeType.startsWith("image/");
     attachments.push({
       id: String(attachments.length),
       type: isImage ? "image" : "file",
@@ -257,7 +257,7 @@ const toUserAttachments = (
             }
           : file,
       ],
-      contentType: part.mediaType,
+      contentType: file.mimeType,
       status: { type: "complete" },
     });
   }


### PR DESCRIPTION
Closes #5583
## What
`convertEveMessages` now converts inbound eve `file` parts instead of dropping them: a shared `convertFilePart` maps them to core `FileMessagePart` in both role arms, and user messages additionally get their attachments rebuilt from file parts in the same shape `react-ai-sdk` uses.

## Why
While validating the eve adapter, found that sending an attachment worked outbound, but the server echo (`message.received`) came back with the file part silently dropped, so the sent attachment rendered as an empty bubble and vanished entirely when resuming a session via `initialEvents`. 

## Impact
- User attachments echoed by eve now survive: they render through `UserMessageAttachments` and stay in history across session resume.
- Assistant file parts convert too (forward compat, eve 0.27's reducer only emits file parts on user messages today).
- No change for messages without file parts.

## Scope 
- User file parts land in both content and reconstructed attachments, mirroring `react-ai-sdk` (`convertMessage.ts:326-333`, `:403-429`); same class of fix as the a2a one in #5547.
- `sourceType: "url"` is set only for http(s) urls: core documents omitted as "inferred (http -> url, else base64)", so stamping it on a `data:` url would mislabel inline payloads to runtimes that honor the field.
- Url-less file parts (metadata only) are still dropped: core `FileMessagePart.data` is required and there is nothing renderable; pinned by tests.
- `size` has no core slot and is dropped; `stepIndex` is dropped like every other arm.
- Overlaps files with #5580 but not hunks (it touches status mapping, this touches part arms); independent, mergeable in either order.
- Tests: both directions, http vs data urls, image vs file attachments, url-less fallback, attachment id scheme, and an outbound-to-echo round trip; not covered: live server echo, exercised via the reducer-shape fixtures instead.
- Additive only, no exports added or reshaped.
- Changeset: patch (`@assistant-ui/eve`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.wmFXNFejaqBBxZ4cgqQpherCYLJnsgP6gA3JXE5BWT0vMsRtBYDeBFEmhRg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->