### PR TITLE
fix(react): settle assistant transport runs after finish callback errors

### DIFF
--- a/.changeset/quiet-transports-finish.md
+++ b/.changeset/quiet-transports-finish.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: settle assistant transport runs when finish callbacks fail

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/runManager.ts
@@ -9,6 +9,13 @@ export type RunManager = Readonly<{
 
 const disposeReason = Symbol("assistant-transport-dispose");
 
+const reportFinishError = (error: unknown) => {
+  console.error(
+    "[assistant-ui] Assistant transport onFinish callback threw an error",
+    error,
+  );
+};
+
 export function useRunManager(config: {
   onRun: (signal: AbortSignal) => Promise<void>;
   onFinish?: (() => void) | undefined;
@@ -52,7 +59,13 @@ export function useRunManager(config: {
         }
       } finally {
         if (!disposeAborted() && !stateRef.current.disposed) {
-          onFinishRef.current?.();
+          try {
+            void Promise.resolve(onFinishRef.current?.()).catch(
+              reportFinishError,
+            );
+          } catch (error) {
+            reportFinishError(error);
+          }
         }
         if (!stateRef.current.disposed && stateRef.current.pending) {
           startRun();

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/transport-scheduling.test.ts
@@ -146,6 +146,44 @@ describe("assistant transport scheduling contracts", () => {
     expect(seen[0]).toEqual([createMessageCommand("m1")]);
   });
 
+  it("settles the run when onFinish throws", async () => {
+    const error = new Error("telemetry failed");
+    const onFinish = vi.fn<() => void>().mockImplementationOnce(() => {
+      throw error;
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const { result } = renderHook(() =>
+        useTransportSchedulingHarness({ onFinish }),
+      );
+
+      act(() => {
+        result.current.commandQueue.enqueue(createMessageCommand("m1"));
+      });
+
+      await waitFor(() => {
+        expect(result.current.runManager.isRunning).toBe(false);
+      });
+
+      act(() => {
+        result.current.commandQueue.enqueue(createMessageCommand("m2"));
+      });
+
+      await waitFor(() => {
+        expect(result.current.runBatchesRef.current).toHaveLength(2);
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui] Assistant transport onFinish callback threw an error",
+        error,
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it("cancel returns combined in-flight and queued commands", async () => {
     const onCancel = vi.fn();
     const { result } = renderHook(() =>


### PR DESCRIPTION
## Summary

- isolate synchronous throws and rejected promises from `onFinish`
- preserve the existing pending-run and idle cleanup after callback failures
- add a regression test proving a failed finish callback does not block the next run

## Why

Applications commonly use `onFinish` for telemetry or other side effects. It previously ran before the transport manager cleared its active run state. If that callback threw, cleanup was skipped: `isRunning` stayed true, the abort controller remained active, subsequent messages were only marked pending, and the callback error leaked as an unhandled rejection.

Callback failures are now reported without allowing application side effects to interrupt the transport scheduler lifecycle.

## Validation

- reproduced the failure on unchanged `main`: stuck `isRunning: true` plus an unhandled `telemetry failed` rejection
- `pnpm --filter @assistant-ui/react test` (400 tests)
- `pnpm --filter @assistant-ui/react... build`
- focused oxlint and oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.LuyvLZZk8XJtmrt97Di5AVoca1FHfLkvj2Dn2CwuFG6rJfqaTCzgD2ygaXs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->