### PR TITLE
fix(react-data-stream): cancel responses after callback failures

### DIFF
--- a/.changeset/clean-stream-responses.md
+++ b/.changeset/clean-stream-responses.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: cancel response streams when response callbacks fail

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -86,15 +86,26 @@ describe("useDataStreamRuntime request errors", () => {
 
   it("keeps response callback failures separate from request errors", async () => {
     const error = new Error("response callback failed");
+    const cancel = vi.fn().mockRejectedValue(new Error("cancel failed"));
     const onResponse = vi.fn().mockRejectedValue(error);
     const onError = vi.fn();
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response()));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream({
+            cancel,
+          }),
+        ),
+      ),
+    );
 
     const adapter = createAdapter({ api: "/api/chat", onResponse, onError });
 
     await expect(runOnce(adapter, createRunOptions())).rejects.toBe(error);
     expect(onResponse).toHaveBeenCalledOnce();
     expect(onError).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("reports resolver failures that race with cancellation", async () => {

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -145,6 +145,11 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     try {
       await this.options.onResponse?.(result);
     } catch (error: unknown) {
+      try {
+        await result.body?.cancel(error);
+      } catch {
+        // Preserve the response callback error when body cancellation fails.
+      }
       abortSignal.removeEventListener("abort", handleAbort);
       throw error;
     }

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -145,12 +145,8 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     try {
       await this.options.onResponse?.(result);
     } catch (error: unknown) {
-      try {
-        await result.body?.cancel(error);
-      } catch {
-        // Preserve the response callback error when body cancellation fails.
-      }
       abortSignal.removeEventListener("abort", handleAbort);
+      void result.body?.cancel().catch(() => undefined);
       throw error;
     }
 


### PR DESCRIPTION
## Summary

- cancel the fetched response body when `onResponse` rejects
- preserve the original callback error if response cancellation also fails
- cover the cleanup path with a cancellable streaming response regression test

## Why

`onResponse` is commonly used to validate response headers or perform application-side setup before decoding begins. If an asynchronous callback rejected after `fetch()` returned, the runtime rethrew the callback error without consuming or cancelling the response body. The server or model could therefore continue generating and transmitting a response that no consumer would read.

The response stream is now cancelled before the callback error is rethrown. Callback failures remain separate from request and decoding errors, so the existing `onError` behavior does not change.

## Validation

- reproduced the failure on unchanged `main`: the response body's `cancel()` hook was called zero times
- `pnpm --filter @assistant-ui/react-data-stream test` (22 tests)
- `pnpm --filter @assistant-ui/react-data-stream build`
- `pnpm --filter @assistant-ui/react-data-stream exec tsc --noEmit`
- focused oxlint and oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.bjXk3hnofEthoE2VX1ZCrR7UevtkwUyki6qPfRw50iGsUev2T-t7ugcOYoo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->