### PR TITLE
fix(react-mcp): handle server removal failures

### DIFF
--- a/.changeset/calm-mcp-remove-actions.md
+++ b/.changeset/calm-mcp-remove-actions.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: handle rejected MCP server removal actions

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  remove: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock("@assistant-ui/store", () => ({
+  useAui: () => ({ mcpServer: { remove: mocks.remove } }),
+  useAuiState: () => "custom",
+}));
+
+vi.mock("@radix-ui/react-primitive", () => ({
+  Primitive: { button: "button" },
+}));
+
+const { McpServerPrimitiveRemoveButton } =
+  await import("./McpServerRemoveButton");
+
+const renderButton = () =>
+  (
+    McpServerPrimitiveRemoveButton as unknown as {
+      render: (
+        props: Record<string, unknown>,
+        ref: null,
+      ) => {
+        props: {
+          onClick: (event: { defaultPrevented: boolean }) => void;
+        };
+      };
+    }
+  ).render({}, null);
+
+describe("McpServerPrimitiveRemoveButton", () => {
+  beforeEach(() => {
+    mocks.remove.mockReset();
+  });
+
+  it("reports rejected remove actions", async () => {
+    const error = new Error("storage unavailable");
+    mocks.remove.mockRejectedValueOnce(error);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    renderButton().props.onClick({ defaultPrevented: false });
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[assistant-ui/react-mcp] failed to remove MCP server:",
+        error,
+      );
+    });
+    expect(mocks.remove).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.test.tsx
@@ -1,20 +1,36 @@
+import type { AssistantState } from "@assistant-ui/store";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   remove: vi.fn<() => Promise<void>>(),
+  kind: "custom" as "connector" | "custom",
 }));
 
-vi.mock("@assistant-ui/store", () => ({
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
   useAui: () => ({ mcpServer: { remove: mocks.remove } }),
-  useAuiState: () => "custom",
-}));
-
-vi.mock("@radix-ui/react-primitive", () => ({
-  Primitive: { button: "button" },
+  useAuiState: function useAuiState<T>(selector: (state: AssistantState) => T) {
+    return selector({
+      mcpServer: { kind: mocks.kind },
+    } as AssistantState);
+  },
 }));
 
 const { McpServerPrimitiveRemoveButton } =
   await import("./McpServerRemoveButton");
+
+const captureUnhandledRejections = async (callback: () => void) => {
+  const reasons: unknown[] = [];
+  const listener = (reason: unknown) => reasons.push(reason);
+  process.on("unhandledRejection", listener);
+  try {
+    callback();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    return reasons;
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+};
 
 const renderButton = () =>
   (
@@ -33,23 +49,23 @@ const renderButton = () =>
 describe("McpServerPrimitiveRemoveButton", () => {
   beforeEach(() => {
     mocks.remove.mockReset();
+    mocks.kind = "custom";
   });
 
-  it("reports rejected remove actions", async () => {
-    const error = new Error("storage unavailable");
-    mocks.remove.mockRejectedValueOnce(error);
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => undefined);
+  it("does not render for connectors", () => {
+    mocks.kind = "connector";
 
-    renderButton().props.onClick({ defaultPrevented: false });
+    expect(renderButton()).toBeNull();
+  });
 
-    await vi.waitFor(() => {
-      expect(consoleError).toHaveBeenCalledWith(
-        "[assistant-ui/react-mcp] failed to remove MCP server:",
-        error,
-      );
+  it("handles rejected custom server remove actions", async () => {
+    mocks.remove.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    const unhandledRejections = await captureUnhandledRejections(() => {
+      renderButton().props.onClick({ defaultPrevented: false });
     });
+
     expect(mocks.remove).toHaveBeenCalledOnce();
+    expect(unhandledRejections).toEqual([]);
   });
 });

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
@@ -26,7 +26,12 @@ export const McpServerPrimitiveRemoveButton = forwardRef<
       onClick={(e) => {
         props.onClick?.(e);
         if (e.defaultPrevented) return;
-        void aui.mcpServer.remove();
+        void aui.mcpServer.remove().catch((error) => {
+          console.error(
+            "[assistant-ui/react-mcp] failed to remove MCP server:",
+            error,
+          );
+        });
       }}
     />
   );

--- a/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
+++ b/packages/react-mcp/src/primitives/server/McpServerRemoveButton.tsx
@@ -26,12 +26,7 @@ export const McpServerPrimitiveRemoveButton = forwardRef<
       onClick={(e) => {
         props.onClick?.(e);
         if (e.defaultPrevented) return;
-        void aui.mcpServer.remove().catch((error) => {
-          console.error(
-            "[assistant-ui/react-mcp] failed to remove MCP server:",
-            error,
-          );
-        });
+        void aui.mcpServer.remove().catch(() => undefined);
       }}
     />
   );

--- a/packages/react-mcp/src/resources/McpServerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.test.ts
@@ -150,6 +150,9 @@ const mount = (
     connectionTimeout?: number | undefined;
     cache?: { readonly defaultTtlMs?: number } | undefined;
     elicitation?: boolean | undefined;
+    kind?: "connector" | "custom" | undefined;
+    storage?: MCPStorage | undefined;
+    onRemove?: (() => Promise<void>) | undefined;
   },
   onMount?: (server: ClientOutput<"mcpServer">) => void,
 ) => {
@@ -160,11 +163,11 @@ const mount = (
     const server = useResource(
       McpServerResource({
         id: "docs",
-        kind: "connector",
+        kind: props?.kind ?? "connector",
         name: "Docs",
         url: "https://example.com/mcp",
         auth: props?.auth ?? { type: "none" },
-        storage: createStorage(),
+        storage: props?.storage ?? createStorage(),
         redirectUri: "https://example.com/callback",
         autoConnect: false,
         connectionTimeout,
@@ -172,7 +175,7 @@ const mount = (
         ...(props?.elicitation !== undefined
           ? { elicitation: props.elicitation }
           : {}),
-        onRemove: vi.fn(async () => {}),
+        onRemove: props?.onRemove ?? vi.fn(async () => {}),
       }),
     );
     useEffect(() => {
@@ -1194,6 +1197,37 @@ describe("McpServerResource tools listChanged", () => {
 
       const options = mocks.Client.mock.calls[0]?.[1];
       expect(options).not.toHaveProperty("defaultCacheTtlMs");
+    } finally {
+      root.unmount();
+    }
+  });
+});
+
+describe("McpServerResource removal", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("exposes auth storage failures and preserves the server", async () => {
+    const error = new Error("storage unavailable");
+    const storage = createStorage();
+    vi.mocked(storage.clearAuthState).mockRejectedValueOnce(error);
+    const onRemove = vi.fn(async () => {});
+    const root = mount({ kind: "custom", storage, onRemove });
+
+    try {
+      await expect(root.getValue().remove()).rejects.toBe(error);
+      await waitForResourceUpdate(
+        () =>
+          root.getValue().getState().lastError?.message ===
+          "storage unavailable",
+      );
+
+      expect(root.getValue().getState()).toMatchObject({
+        connectionState: "disconnected",
+        lastError: { message: "storage unavailable" },
+      });
+      expect(onRemove).not.toHaveBeenCalled();
     } finally {
       root.unmount();
     }

--- a/packages/react-mcp/src/resources/McpServerResource.ts
+++ b/packages/react-mcp/src/resources/McpServerResource.ts
@@ -539,8 +539,15 @@ const useMcpServerResource = (
     disconnect: doDisconnect,
     remove: async () => {
       await doDisconnect();
-      await props.storage.clearAuthState(props.id);
-      await props.onRemove();
+      try {
+        await props.storage.clearAuthState(props.id);
+        await props.onRemove();
+      } catch (err) {
+        setLastError({
+          message: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
     },
     callTool: async (name, args) => {
       const client = clientRef.current;


### PR DESCRIPTION
## Summary

- handle rejected MCP server removal actions without leaking a global unhandled rejection
- publish removal failures through the server's existing `lastError` state so `McpServerPrimitive.Error` can render them
- preserve rejection behavior for callers that await `mcpServer.remove()` and keep the failed server available for retry
- add focused button and resource regression coverage plus a patch changeset

## Why

Custom MCP storage may use IndexedDB or a remote service. If `clearAuthState()` rejects while a user clicks `McpServerPrimitive.RemoveButton`, `remove()` rejects, but the primitive previously discarded that promise with `void`. The failure escaped as a global `unhandledrejection`, and the built-in MCP UI had no useful error state to show.

The resource now records the original failure in `lastError` and rethrows it for programmatic callers. The button consumes that already-reported rejection so the UI action does not leak globally. The server remains listed after failed persistence cleanup, allowing the user to see the error and retry. Successful removal behavior is unchanged.

## Reproduction

Against `@assistant-ui/react-mcp@0.1.3`, configure custom storage whose auth cleanup rejects:

```tsx
const storage = McpCustomStorage({
  loadCustomServers: async () => [],
  saveCustomServers: async () => {},
  loadAuthState: async () => null,
  saveAuthState: async () => {},
  clearAuthState: async () => {
    throw new Error("storage unavailable");
  },
});
```

Add a custom server and click its `McpServerPrimitive.RemoveButton`. Before this change, the click emits a global `unhandledrejection`, leaves the server in place, and provides no error through `McpServerPrimitive.Error`. With this change, no global rejection is emitted, the error primitive receives `storage unavailable`, and an explicitly awaited `mcpServer.remove()` still rejects with the original error.

## Verification

- `pnpm --filter @assistant-ui/react-mcp test` (101 tests passed)
- `pnpm --filter @assistant-ui/react-mcp... build`
- `pnpm lint`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Pe4YhzR78vuGoRhIc40kEZUIXF9W_DPzk9ltO05HCPWcY2p6FnYKqfuWUl0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
