### PR TITLE
fix(cli): stop project writes after download timeout

### DIFF
--- a/.changeset/quiet-downloads-stage.md
+++ b/.changeset/quiet-downloads-stage.md
@@ -1,0 +1,5 @@
+---
+"assistant-ui": patch
+---
+
+fix: prevent timed-out project downloads from writing to the destination

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -111,16 +111,40 @@ export async function downloadProject(
   // namespaces. Temporarily unsetting it targets the root cause.
   const origDebug = process.env.DEBUG;
   delete process.env.DEBUG;
+  const absoluteDestDir = path.resolve(destDir);
+  fs.mkdirSync(path.dirname(absoluteDestDir), { recursive: true });
+  const stagingDir = fs.mkdtempSync(
+    path.join(path.dirname(absoluteDestDir), ".assistant-ui-download-"),
+  );
+  const cleanupStagingDir = () => {
+    process.removeListener("exit", cleanupStagingDir);
+    try {
+      fs.rmSync(stagingDir, { recursive: true, force: true });
+    } catch (error) {
+      logger.warn(
+        `Could not remove temporary download directory ${stagingDir}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+  process.once("exit", cleanupStagingDir);
+
   try {
     const authToken = resolveGitHubAuthToken();
-    const downloadPromise = downloadTemplate(source, {
-      dir: destDir,
-      force: true,
-      silent: true,
-      ...(authToken ? { auth: authToken } : {}),
-    });
+    let downloadSettled = false;
+    const downloadPromise = Promise.resolve()
+      .then(() =>
+        downloadTemplate(source, {
+          dir: stagingDir,
+          force: true,
+          silent: true,
+          ...(authToken ? { auth: authToken } : {}),
+        }),
+      )
+      .finally(() => {
+        downloadSettled = true;
+      });
 
-    let timer: ReturnType<typeof setTimeout>;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(
         () =>
@@ -135,8 +159,17 @@ export async function downloadProject(
 
     try {
       await Promise.race([downloadPromise, timeoutPromise]);
+      fs.cpSync(stagingDir, absoluteDestDir, {
+        recursive: true,
+        force: true,
+      });
     } finally {
-      clearTimeout(timer!);
+      if (timer !== undefined) clearTimeout(timer);
+      if (downloadSettled) {
+        cleanupStagingDir();
+      } else {
+        void downloadPromise.then(cleanupStagingDir, cleanupStagingDir);
+      }
     }
   } finally {
     if (origDebug !== undefined) {

--- a/packages/cli/test/lib/create-project.test.ts
+++ b/packages/cli/test/lib/create-project.test.ts
@@ -75,6 +75,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   fs.rmSync(testDir, { recursive: true, force: true });
   for (const key of GITHUB_AUTH_ENV_KEYS) {
     const value = originalGitHubAuthEnv[key];
@@ -143,45 +144,121 @@ describe("resolveLatestReleaseRef", () => {
 
 describe("downloadProject", () => {
   it("passes ref in giget source when provided", async () => {
-    await downloadProject("templates/default", "/tmp/dest", "v1.0.0");
+    const destDir = path.join(testDir, "dest");
+    await downloadProject("templates/default", destDir, "v1.0.0");
 
     expect(downloadTemplate).toHaveBeenCalledWith(
       "gh:assistant-ui/assistant-ui/templates/default#v1.0.0",
-      expect.objectContaining({ dir: "/tmp/dest", force: true, silent: true }),
+      expect.objectContaining({
+        dir: expect.stringContaining(".assistant-ui-download-"),
+        force: true,
+        silent: true,
+      }),
     );
   });
 
   it("omits ref from giget source when not provided", async () => {
-    await downloadProject("examples/with-tanstack", "/tmp/dest");
+    const destDir = path.join(testDir, "dest");
+    await downloadProject("examples/with-tanstack", destDir);
 
     expect(downloadTemplate).toHaveBeenCalledWith(
       "gh:assistant-ui/assistant-ui/examples/with-tanstack",
-      expect.objectContaining({ dir: "/tmp/dest", force: true, silent: true }),
+      expect.objectContaining({
+        dir: expect.stringContaining(".assistant-ui-download-"),
+        force: true,
+        silent: true,
+      }),
     );
   });
 
   it("passes auth to giget when a GitHub token is configured", async () => {
     process.env.GH_TOKEN = "ghs_test-token";
 
-    await downloadProject("templates/default", "/tmp/dest", "v1.0.0");
+    const destDir = path.join(testDir, "dest");
+    await downloadProject("templates/default", destDir, "v1.0.0");
 
     expect(downloadTemplate).toHaveBeenCalledWith(
       "gh:assistant-ui/assistant-ui/templates/default#v1.0.0",
       expect.objectContaining({ auth: "ghs_test-token" }),
     );
   });
+
+  it("publishes a completed staged download", async () => {
+    const destDir = path.join(testDir, "dest");
+    (downloadTemplate as Mock).mockImplementationOnce(
+      async (_source, options: { dir: string }) => {
+        fs.writeFileSync(path.join(options.dir, "package.json"), "{}");
+        return {};
+      },
+    );
+
+    await downloadProject("templates/default", destDir);
+
+    expect(fs.readFileSync(path.join(destDir, "package.json"), "utf8")).toBe(
+      "{}",
+    );
+    expect(
+      fs
+        .readdirSync(testDir)
+        .filter((entry) => entry.startsWith(".assistant-ui-download-")),
+    ).toEqual([]);
+  });
+
+  it("does not publish a download that completes after the timeout", async () => {
+    vi.useFakeTimers();
+    const destDir = path.join(testDir, "dest");
+    let finishDownload!: () => void;
+    const downloadGate = new Promise<void>((resolve) => {
+      finishDownload = resolve;
+    });
+    let lateDownload!: Promise<unknown>;
+    (downloadTemplate as Mock).mockImplementationOnce(
+      (_source, options: { dir: string }) => {
+        lateDownload = (async () => {
+          await downloadGate;
+          fs.writeFileSync(path.join(options.dir, "package.json"), "{}");
+          return {};
+        })();
+        return lateDownload;
+      },
+    );
+
+    const result = downloadProject("templates/default", destDir);
+    const rejection = expect(result).rejects.toThrow("Download timed out");
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
+
+    expect(fs.existsSync(destDir)).toBe(false);
+
+    finishDownload();
+    await lateDownload;
+
+    expect(fs.existsSync(destDir)).toBe(false);
+    await vi.waitFor(() => {
+      expect(
+        fs
+          .readdirSync(testDir)
+          .filter((entry) => entry.startsWith(".assistant-ui-download-")),
+      ).toEqual([]);
+    });
+  });
 });
 
 describe("scaffoldProject", () => {
   it("downloads from GitHub sources", async () => {
-    await scaffoldProject("templates/default", "/tmp/dest", {
+    const destDir = path.join(testDir, "dest");
+    await scaffoldProject("templates/default", destDir, {
       kind: "github",
       ref: "v1.0.0",
     });
 
     expect(downloadTemplate).toHaveBeenCalledWith(
       "gh:assistant-ui/assistant-ui/templates/default#v1.0.0",
-      expect.objectContaining({ dir: "/tmp/dest", force: true, silent: true }),
+      expect.objectContaining({
+        dir: expect.stringContaining(".assistant-ui-download-"),
+        force: true,
+        silent: true,
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary

- download GitHub templates into a sibling staging directory
- publish staged files to the requested project directory only after the download completes within the timeout
- clean up staging directories after success, failure, late completion, or process exit

## Why

`Promise.race()` reports a timeout after 30 seconds, but `giget` does not expose cancellation and its `downloadTemplate()` promise can continue extracting files. The create command then removes the partial destination, so a late download could write back into that directory after the CLI already reported failure. Retrying immediately could also overlap with those writes.

Staging isolates the continuing work from the user-visible destination. A timely download is copied into place; a timed-out download can finish only inside its temporary directory, which is then removed.

## Testing

- `vitest run` in `packages/cli` (22 files, 257 tests)
- focused timeout regression confirming late completion never creates the destination
- `aui-build` in `packages/cli`
- targeted `oxlint` and `oxfmt`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EfFr6DA8izcQkRgjdEjQI96RlMFtjMATPIiAjCqSMtNf4l8KWy5_TqGaTSw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->