### PR TITLE
fix(react-mcp): serialize custom server persistence

### DIFF
--- a/.changeset/calm-mcp-storage-writes.md
+++ b/.changeset/calm-mcp-storage-writes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: serialize custom server persistence updates

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -208,3 +208,68 @@ describe("McpManagerResource storage failures", () => {
     }
   });
 });
+
+describe("McpManagerResource storage ordering", () => {
+  it("persists custom server updates in invocation order", async () => {
+    let resolveFirstSave: (() => void) | undefined;
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    let blockNextSave = false;
+    const persistedSnapshots: string[][] = [];
+    const saveCustomServers = vi.fn(async (records: { name: string }[]) => {
+      persistedSnapshots.push(records.map((record) => record.name));
+      if (blockNextSave) {
+        blockNextSave = false;
+        await firstSave;
+      }
+    });
+    const root = mount(
+      [],
+      McpCustomStorage({
+        loadCustomServers: vi.fn(async () => []),
+        saveCustomServers,
+        loadAuthState: vi.fn(async () => null),
+        saveAuthState: vi.fn(async () => {}),
+        clearAuthState: vi.fn(async () => {}),
+      }),
+    );
+
+    try {
+      await vi.waitFor(() =>
+        expect(root.getValue().getState().isHydrated).toBe(true),
+      );
+      await vi.waitFor(() => expect(saveCustomServers).toHaveBeenCalled());
+      saveCustomServers.mockClear();
+      persistedSnapshots.length = 0;
+      blockNextSave = true;
+
+      await root.getValue().addCustomServer({
+        name: "Docs",
+        url: "https://example.com/docs/mcp",
+        auth: { type: "none" },
+      });
+      await vi.waitFor(() =>
+        expect(saveCustomServers).toHaveBeenCalledTimes(1),
+      );
+
+      await root.getValue().addCustomServer({
+        name: "Linear",
+        url: "https://example.com/linear/mcp",
+        auth: { type: "none" },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(saveCustomServers).toHaveBeenCalledTimes(1);
+
+      resolveFirstSave?.();
+      await vi.waitFor(() =>
+        expect(saveCustomServers).toHaveBeenCalledTimes(2),
+      );
+      expect(persistedSnapshots).toEqual([["Docs"], ["Docs", "Linear"]]);
+    } finally {
+      resolveFirstSave?.();
+      root.unmount();
+    }
+  });
+});

--- a/packages/react-mcp/src/resources/McpManagerResource.test.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.test.ts
@@ -1,5 +1,6 @@
-import { createTapRoot, useResource } from "@assistant-ui/tap";
+import { createTapRoot, resource, useResource } from "@assistant-ui/tap";
 import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import { defineConnector } from "../connector";
 import type { MCPConnector } from "../mcp-scope";
 import { assertUniqueServerIds } from "../utils/serverId";
@@ -269,6 +270,47 @@ describe("McpManagerResource storage ordering", () => {
       expect(persistedSnapshots).toEqual([["Docs"], ["Docs", "Linear"]]);
     } finally {
       resolveFirstSave?.();
+      root.unmount();
+    }
+  });
+
+  it("does not persist unchanged servers when inline storage rerenders", async () => {
+    const saveCustomServers = vi.fn(async () => {});
+    let rerender = () => {};
+    const DynamicManager = resource(function useDynamicManager() {
+      const [, setVersion] = useState(0);
+      rerender = () => setVersion((version) => version + 1);
+
+      return useResource(
+        McpManagerResource({
+          connectors: [],
+          storage: McpCustomStorage({
+            loadCustomServers: vi.fn(async () => []),
+            saveCustomServers,
+            loadAuthState: vi.fn(async () => null),
+            saveAuthState: vi.fn(async () => {}),
+            clearAuthState: vi.fn(async () => {}),
+          }),
+          autoConnect: false,
+        }),
+      );
+    });
+    const root = createTapRoot(function Root() {
+      return useResource(DynamicManager());
+    });
+
+    try {
+      await vi.waitFor(() =>
+        expect(root.getValue().getState().isHydrated).toBe(true),
+      );
+      await vi.waitFor(() => expect(saveCustomServers).toHaveBeenCalled());
+      saveCustomServers.mockClear();
+
+      rerender();
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(saveCustomServers).not.toHaveBeenCalled();
+    } finally {
       root.unmount();
     }
   });

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -49,6 +49,17 @@ const reportCustomStorageFailure = (
   );
 };
 
+const persistCustomServers = async (
+  storage: MCPStorage,
+  records: MCPCustomServerRecord[],
+) => {
+  try {
+    await storage.saveCustomServers(records);
+  } catch (error) {
+    reportCustomStorageFailure("save", error);
+  }
+};
+
 const useMcpManagerResource = (
   props: McpManagerResourceProps,
 ): ClientOutput<"mcp"> => {
@@ -67,8 +78,11 @@ const useMcpManagerResource = (
 
   const hydratedRef = useRef(false);
   const storageRef = useRef(storage);
-  storageRef.current = storage;
   const persistenceQueueRef = useRef(Promise.resolve());
+
+  useEffect(() => {
+    storageRef.current = storage;
+  }, [storage]);
 
   const hydrate = useEffectEvent(async (signal: { cancelled: boolean }) => {
     const markHydrated = () => {
@@ -108,16 +122,6 @@ const useMcpManagerResource = (
       signal.cancelled = true;
     };
   }, []);
-
-  const persistCustomServers = useEffectEvent(
-    async (targetStorage: MCPStorage, records: MCPCustomServerRecord[]) => {
-      try {
-        await targetStorage.saveCustomServers(records);
-      } catch (error) {
-        reportCustomStorageFailure("save", error);
-      }
-    },
-  );
 
   useEffect(() => {
     if (!hydratedRef.current) return;

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -10,7 +10,7 @@ import { ModelContext } from "@assistant-ui/core/store";
 import type { Tool } from "assistant-stream";
 import { McpServerResource } from "./McpServerResource";
 import { McpLocalStorage } from "./storage/McpLocalStorage";
-import type { MCPStorageElement } from "./storage/types";
+import type { MCPStorage, MCPStorageElement } from "./storage/types";
 import { assertUniqueServerIds } from "../utils/serverId";
 import type {
   MCPAuthConfig,
@@ -66,6 +66,7 @@ const useMcpManagerResource = (
   const [isHydrated, setIsHydrated] = useState(false);
 
   const hydratedRef = useRef(false);
+  const persistenceQueueRef = useRef(Promise.resolve());
 
   const hydrate = useEffectEvent(async (signal: { cancelled: boolean }) => {
     const markHydrated = () => {
@@ -107,10 +108,9 @@ const useMcpManagerResource = (
   }, []);
 
   const persistCustomServers = useEffectEvent(
-    async (records: MCPCustomServerRecord[]) => {
-      if (!hydratedRef.current) return;
+    async (targetStorage: MCPStorage, records: MCPCustomServerRecord[]) => {
       try {
-        await storage.saveCustomServers(records);
+        await targetStorage.saveCustomServers(records);
       } catch (error) {
         reportCustomStorageFailure("save", error);
       }
@@ -118,8 +118,11 @@ const useMcpManagerResource = (
   );
 
   useEffect(() => {
-    void persistCustomServers(customServers);
-  }, [customServers]);
+    if (!hydratedRef.current) return;
+    persistenceQueueRef.current = persistenceQueueRef.current.then(() =>
+      persistCustomServers(storage, customServers),
+    );
+  }, [customServers, storage]);
 
   const serverElements = useMemo(() => {
     assertUniqueServerIds([

--- a/packages/react-mcp/src/resources/McpManagerResource.ts
+++ b/packages/react-mcp/src/resources/McpManagerResource.ts
@@ -66,6 +66,8 @@ const useMcpManagerResource = (
   const [isHydrated, setIsHydrated] = useState(false);
 
   const hydratedRef = useRef(false);
+  const storageRef = useRef(storage);
+  storageRef.current = storage;
   const persistenceQueueRef = useRef(Promise.resolve());
 
   const hydrate = useEffectEvent(async (signal: { cancelled: boolean }) => {
@@ -119,10 +121,11 @@ const useMcpManagerResource = (
 
   useEffect(() => {
     if (!hydratedRef.current) return;
+    const targetStorage = storageRef.current;
     persistenceQueueRef.current = persistenceQueueRef.current.then(() =>
-      persistCustomServers(storage, customServers),
+      persistCustomServers(targetStorage, customServers),
     );
-  }, [customServers, storage]);
+  }, [customServers]);
 
   const serverElements = useMemo(() => {
     assertUniqueServerIds([


### PR DESCRIPTION
## Summary

- serialize custom MCP server storage writes in state-update order
- capture the storage instance and server snapshot for each queued write
- add regression coverage for overlapping asynchronous saves

## Why

`MCPStorage.saveCustomServers()` is asynchronous so apps can persist custom servers through IndexedDB or a remote store. Previously, each state update started a save independently. If a user added Docs and then Linear while the first save was slow, the newer `[Docs, Linear]` write could finish first and the older `[Docs]` write could finish last. Reloading would then lose the Linear server.

The manager now waits for each save to settle before starting the next snapshot. Existing save-error handling remains inside the queue, so a failed write is reported without preventing later updates from being persisted.

## Verification

- reproduced the race with a deferred first save: the second save was invoked while the first remained pending
- confirmed the regression test fails before the implementation and passes after it
- `pnpm --filter @assistant-ui/react-mcp test` (102 tests)
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm exec oxlint packages/react-mcp/src/resources/McpManagerResource.ts packages/react-mcp/src/resources/McpManagerResource.test.ts`
- `pnpm exec oxfmt --check packages/react-mcp/src/resources/McpManagerResource.ts packages/react-mcp/src/resources/McpManagerResource.test.ts .changeset/calm-mcp-storage-writes.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.H5Yb4Gb72v8_3vxpKra1W0G3bs5oTXeAltLyAIx3JQv8drgeTrgvy9fK9PA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->