### PR TITLE
feat(assistant-stream): opt-in heartbeat for DataStreamResponse

### DIFF
--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_stream_response.py
@@ -1,7 +1,7 @@
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 from assistant_stream.serialization.heartbeat import (
     HeartbeatOption,
-    add_sse_heartbeat,
+    add_keepalive,
     resolve_heartbeat_interval,
 )
 from assistant_stream.serialization.stream_encoder import StreamEncoder
@@ -12,11 +12,11 @@ from starlette.responses import StreamingResponse
 
 class AssistantStreamResponse(StreamingResponse):
     """
-    Streams an encoded assistant stream. For text/event-stream encoders, SSE
-    comment heartbeats are emitted while the stream is idle (15s interval by
-    default) to keep proxies from timing out the connection. Pass
-    `heartbeat=<seconds>` to change the interval, or `heartbeat=False` to
-    disable heartbeats.
+    Streams an encoded assistant stream. Encoders that declare a keepalive
+    token (SSE comment lines for event streams, blank lines for data streams)
+    emit it while the stream is idle (15s interval by default) to keep proxies
+    from timing out the connection. Pass `heartbeat=<seconds>` to change the
+    interval, or `heartbeat=False` to disable heartbeats.
     """
 
     def __init__(
@@ -26,12 +26,10 @@ class AssistantStreamResponse(StreamingResponse):
         heartbeat: HeartbeatOption = True,
     ):
         heartbeat_interval = resolve_heartbeat_interval(heartbeat)
+        keepalive_token = stream_encoder.get_keepalive_token()
         body = stream_encoder.encode_stream(stream)
-        if (
-            heartbeat_interval is not None
-            and stream_encoder.get_media_type() == "text/event-stream"
-        ):
-            body = add_sse_heartbeat(body, heartbeat_interval)
+        if heartbeat_interval is not None and keepalive_token is not None:
+            body = add_keepalive(body, heartbeat_interval, keepalive_token)
         super().__init__(
             body,
             media_type=stream_encoder.get_media_type(),

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -14,7 +14,10 @@ from assistant_stream.assistant_stream_chunk import (
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
-from assistant_stream.serialization.heartbeat import HeartbeatOption
+from assistant_stream.serialization.heartbeat import (
+    SSE_HEARTBEAT_LINE,
+    HeartbeatOption,
+)
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
 from typing import AsyncGenerator, Any
@@ -244,6 +247,9 @@ class AssistantTransportEncoder(StreamEncoder):
 
     def get_media_type(self) -> str:
         return "text/event-stream"
+
+    def get_keepalive_token(self) -> str:
+        return SSE_HEARTBEAT_LINE
 
     async def encode_stream(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -6,6 +6,10 @@ from typing import AsyncGenerator, Any
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
+from assistant_stream.serialization.heartbeat import (
+    DATA_STREAM_KEEPALIVE_LINE,
+    HeartbeatOption,
+)
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 from assistant_stream.state_proxy import StateProxy
 
@@ -85,6 +89,9 @@ class DataStreamEncoder(StreamEncoder):
     def get_media_type(self) -> str:
         return "text/plain"
 
+    def get_keepalive_token(self) -> str:
+        return DATA_STREAM_KEEPALIVE_LINE
+
     async def encode_stream(
         self, stream: AsyncGenerator[AssistantStreamChunk, None]
     ) -> AsyncGenerator[str, None]:
@@ -99,5 +106,6 @@ class DataStreamResponse(AssistantStreamResponse):
     def __init__(
         self,
         stream: AsyncGenerator[AssistantStreamChunk, None],
+        heartbeat: HeartbeatOption = False,
     ):
-        super().__init__(stream, DataStreamEncoder())
+        super().__init__(stream, DataStreamEncoder(), heartbeat=heartbeat)

--- a/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
@@ -6,6 +6,8 @@ DEFAULT_HEARTBEAT_INTERVAL = 15.0
 
 SSE_HEARTBEAT_LINE = ": heartbeat\n\n"
 
+DATA_STREAM_KEEPALIVE_LINE = "\n"
+
 HeartbeatOption = Union[float, int, bool, None]
 
 
@@ -28,12 +30,13 @@ def resolve_heartbeat_interval(
     return interval
 
 
-async def add_sse_heartbeat(
+async def add_keepalive(
     stream: AsyncGenerator[str, None],
     interval: float,
+    token: str,
 ) -> AsyncGenerator[str, None]:
     """
-    Yield SSE comment heartbeats whenever the encoded stream is idle for
+    Yield `token` as a keepalive whenever the encoded stream is idle for
     `interval` seconds. Any real chunk resets the timer.
     """
     task: Optional[asyncio.Task] = None
@@ -43,7 +46,7 @@ async def add_sse_heartbeat(
                 task = asyncio.create_task(stream.__anext__())
             done, _ = await asyncio.wait({task}, timeout=interval)
             if not done:
-                yield SSE_HEARTBEAT_LINE
+                yield token
                 continue
             try:
                 item = task.result()

--- a/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/heartbeat.py
@@ -62,3 +62,14 @@ async def add_keepalive(
             if not task.cancelled():
                 task.exception()  # retrieve the outcome so asyncio does not log "Task exception was never retrieved"
         await stream.aclose()
+
+
+def add_sse_heartbeat(
+    stream: AsyncGenerator[str, None],
+    interval: float,
+) -> AsyncGenerator[str, None]:
+    """
+    Deprecated alias for `add_keepalive` with the SSE comment token,
+    kept for compatibility with assistant-stream <= 0.0.35.
+    """
+    return add_keepalive(stream, interval, SSE_HEARTBEAT_LINE)

--- a/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/openai_stream.py
@@ -7,7 +7,10 @@ from typing import AsyncGenerator
 from assistant_stream.serialization.assistant_stream_response import (
     AssistantStreamResponse,
 )
-from assistant_stream.serialization.heartbeat import HeartbeatOption
+from assistant_stream.serialization.heartbeat import (
+    SSE_HEARTBEAT_LINE,
+    HeartbeatOption,
+)
 from assistant_stream.serialization.stream_encoder import StreamEncoder
 
 
@@ -27,6 +30,9 @@ class OpenAIStreamEncoder(StreamEncoder):
 
     def get_media_type(self) -> str:
         return "text/event-stream"
+
+    def get_keepalive_token(self) -> str:
+        return SSE_HEARTBEAT_LINE
 
     def _create_chunk(self, delta={}, finish_reason=None):
         response = {

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Optional
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
 
 
@@ -14,6 +14,13 @@ class StreamEncoder(ABC):
         Returns the MIME type of the stream.
         """
         pass
+
+    def get_keepalive_token(self) -> Optional[str]:
+        """
+        Returns the chunk emitted as a keepalive while the stream is idle,
+        or None if the format has no benign keepalive token.
+        """
+        return None
 
     @abstractmethod
     async def encode_stream(

--- a/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/stream_encoder.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, Optional
 from assistant_stream.assistant_stream_chunk import AssistantStreamChunk
+from assistant_stream.serialization.heartbeat import SSE_HEARTBEAT_LINE
 
 
 class StreamEncoder(ABC):
@@ -18,8 +19,12 @@ class StreamEncoder(ABC):
     def get_keepalive_token(self) -> Optional[str]:
         """
         Returns the chunk emitted as a keepalive while the stream is idle,
-        or None if the format has no benign keepalive token.
+        or None if the format has no benign keepalive token. Defaults to an
+        SSE comment line for text/event-stream encoders and None otherwise;
+        override to declare a format-specific token or to disable keepalives.
         """
+        if self.get_media_type() == "text/event-stream":
+            return SSE_HEARTBEAT_LINE
         return None
 
     @abstractmethod

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -20,8 +20,11 @@ from assistant_stream.serialization.heartbeat import (
     DEFAULT_HEARTBEAT_INTERVAL,
     SSE_HEARTBEAT_LINE,
     add_keepalive,
+    add_sse_heartbeat,
     resolve_heartbeat_interval,
 )
+from assistant_stream.serialization.openai_stream import OpenAIStreamResponse
+from assistant_stream.serialization.stream_encoder import StreamEncoder
 
 
 def test_resolve_heartbeat_interval():
@@ -132,6 +135,86 @@ async def test_data_stream_response_heartbeat_opt_in():
     lines = [line async for line in response.body_iterator]
 
     assert DATA_STREAM_KEEPALIVE_LINE in lines
+
+
+class _PassthroughEncoder(StreamEncoder):
+    def __init__(self, media_type):
+        self._media_type = media_type
+
+    def get_media_type(self):
+        return self._media_type
+
+    async def encode_stream(self, stream):
+        async for chunk in stream:
+            yield f"data: {chunk.text_delta}\n\n"
+
+
+def test_default_keepalive_token_derives_from_media_type():
+    assert (
+        _PassthroughEncoder("text/event-stream").get_keepalive_token()
+        == SSE_HEARTBEAT_LINE
+    )
+    assert _PassthroughEncoder("application/json").get_keepalive_token() is None
+
+
+@pytest.mark.anyio
+async def test_custom_sse_encoder_inherits_comment_heartbeats():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = AssistantStreamResponse(
+        stream(), _PassthroughEncoder("text/event-stream"), heartbeat=0.05
+    )
+    lines = [line async for line in response.body_iterator]
+
+    assert SSE_HEARTBEAT_LINE in lines
+
+
+@pytest.mark.anyio
+async def test_tokenless_encoder_never_emits_keepalives():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = AssistantStreamResponse(
+        stream(), _PassthroughEncoder("application/json"), heartbeat=0.05
+    )
+    lines = [line async for line in response.body_iterator]
+
+    assert lines == ["data: hello\n\n", "data: world\n\n"]
+
+
+@pytest.mark.anyio
+async def test_openai_stream_response_emits_comment_heartbeats():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = OpenAIStreamResponse(stream(), heartbeat=0.05)
+    lines = [line async for line in response.body_iterator]
+
+    assert SSE_HEARTBEAT_LINE in lines
+    assert lines[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_add_sse_heartbeat_compat_wrapper():
+    async def stream():
+        yield "data: 1\n\n"
+        await asyncio.sleep(0.18)
+        yield "data: 2\n\n"
+
+    lines = [line async for line in add_sse_heartbeat(stream(), 0.05)]
+
+    assert SSE_HEARTBEAT_LINE in lines
+    assert [line for line in lines if line != SSE_HEARTBEAT_LINE] == [
+        "data: 1\n\n",
+        "data: 2\n\n",
+    ]
 
 
 @pytest.mark.anyio

--- a/python/assistant-stream/tests/test_heartbeat.py
+++ b/python/assistant-stream/tests/test_heartbeat.py
@@ -11,11 +11,15 @@ from assistant_stream.serialization.assistant_transport import (
     AssistantTransportEncoder,
     AssistantTransportResponse,
 )
-from assistant_stream.serialization.data_stream import DataStreamEncoder
+from assistant_stream.serialization.data_stream import (
+    DataStreamEncoder,
+    DataStreamResponse,
+)
 from assistant_stream.serialization.heartbeat import (
+    DATA_STREAM_KEEPALIVE_LINE,
     DEFAULT_HEARTBEAT_INTERVAL,
     SSE_HEARTBEAT_LINE,
-    add_sse_heartbeat,
+    add_keepalive,
     resolve_heartbeat_interval,
 )
 
@@ -87,7 +91,7 @@ async def test_subclass_forwards_heartbeat_kwarg():
 
 
 @pytest.mark.anyio
-async def test_non_sse_response_unaffected():
+async def test_data_stream_emits_blank_line_keepalives_when_idle():
     async def stream():
         yield TextDeltaChunk(text_delta="hello")
         await asyncio.sleep(0.18)
@@ -96,7 +100,38 @@ async def test_non_sse_response_unaffected():
     response = AssistantStreamResponse(stream(), DataStreamEncoder(), heartbeat=0.05)
     lines = [line async for line in response.body_iterator]
 
-    assert SSE_HEARTBEAT_LINE not in lines
+    keepalives = [line for line in lines if line == DATA_STREAM_KEEPALIVE_LINE]
+    assert len(keepalives) >= 2
+    data_lines = [line for line in lines if line != DATA_STREAM_KEEPALIVE_LINE]
+    assert data_lines == ['0:"hello"\n', '0:"world"\n']
+    assert lines.index('0:"hello"\n') < lines.index(keepalives[0])
+    assert lines.index(keepalives[0]) < lines.index('0:"world"\n')
+
+
+@pytest.mark.anyio
+async def test_data_stream_response_defaults_to_no_keepalives():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.15)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = DataStreamResponse(stream())
+    lines = [line async for line in response.body_iterator]
+
+    assert lines == ['0:"hello"\n', '0:"world"\n']
+
+
+@pytest.mark.anyio
+async def test_data_stream_response_heartbeat_opt_in():
+    async def stream():
+        yield TextDeltaChunk(text_delta="hello")
+        await asyncio.sleep(0.18)
+        yield TextDeltaChunk(text_delta="world")
+
+    response = DataStreamResponse(stream(), heartbeat=0.05)
+    lines = [line async for line in response.body_iterator]
+
+    assert DATA_STREAM_KEEPALIVE_LINE in lines
 
 
 @pytest.mark.anyio
@@ -115,7 +150,7 @@ async def test_real_chunk_resets_heartbeat_timer():
 
 
 @pytest.mark.anyio
-async def test_add_sse_heartbeat_cancels_pending_read_on_close():
+async def test_add_keepalive_cancels_pending_read_on_close():
     cancelled = asyncio.Event()
 
     async def stream():
@@ -126,7 +161,7 @@ async def test_add_sse_heartbeat_cancels_pending_read_on_close():
             cancelled.set()
             raise
 
-    gen = add_sse_heartbeat(stream(), 0.05)
+    gen = add_keepalive(stream(), 0.05, SSE_HEARTBEAT_LINE)
     assert await gen.__anext__() == "data: 1\n\n"
     assert await gen.__anext__() == SSE_HEARTBEAT_LINE
     await gen.aclose()
@@ -134,7 +169,7 @@ async def test_add_sse_heartbeat_cancels_pending_read_on_close():
 
 
 @pytest.mark.anyio
-async def test_add_sse_heartbeat_closes_upstream_when_no_read_pending():
+async def test_add_keepalive_closes_upstream_when_no_read_pending():
     closed = asyncio.Event()
 
     async def stream():
@@ -144,7 +179,7 @@ async def test_add_sse_heartbeat_closes_upstream_when_no_read_pending():
         finally:
             closed.set()
 
-    gen = add_sse_heartbeat(stream(), 10)
+    gen = add_keepalive(stream(), 10, SSE_HEARTBEAT_LINE)
     assert await gen.__anext__() == "data: 1\n\n"
     await gen.aclose()
     assert closed.is_set()


### PR DESCRIPTION
## What

Makes heartbeats opt-in for `DataStreamResponse` and moves keepalive dispatch onto the encoder.

- `DataStreamResponse(stream, heartbeat: HeartbeatOption = False)` — heartbeats are off by default for the data stream protocol. Opt in with `heartbeat=True` (15s default interval) or a number of seconds. The keepalive token is a bare `"\n"`, which the data stream line protocol ignores.
- SSE response classes are unchanged: `: heartbeat` comment keepalives remain on by default.
- Dispatch is now encoder-declared: `StreamEncoder.get_keepalive_token()` (default `None`) replaces the hardcoded `text/event-stream` media-type check in `AssistantStreamResponse`. SSE encoders return the comment line, `DataStreamEncoder` returns `"\n"`, encoders without a benign token return `None` and never emit keepalives.

## Why

The previous media-type check silently excluded non-SSE formats from keepalives even when the format has a safe idle token, and coupled the response class to a specific wire format. Each encoder knows whether its format tolerates a keepalive and what that token is.

## Tests

Contract tests in `python/assistant-stream/tests/test_heartbeat.py`: default-off for `DataStreamResponse`, opt-in emission of blank-line keepalives between real chunks (ordering asserted), and the existing SSE comment-heartbeat path. `uv run --extra dev --extra langgraph pytest`: 143 passed, 7 skipped (redis-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.mOSq0f7jTHIJHN1YAMaezK_9cvIpNpQ5R_J80iFTYHd06LI3xEQHz_kobXA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->