### PR TITLE
chore(python): assistant-stream 0.0.36

### DIFF
--- a/python/assistant-stream/pyproject.toml
+++ b/python/assistant-stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "assistant-stream"
-version = "0.0.35"
+version = "0.0.36"
 description = ""
 authors = [
   { name="Simon Farshid", email="simon@assistant-ui.com" },

--- a/python/assistant-stream/uv.lock
+++ b/python/assistant-stream/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "assistant-stream"
-version = "0.0.35"
+version = "0.0.36"
 source = { editable = "." }
 dependencies = [
     { name = "starlette" },


### PR DESCRIPTION
Releases the opt-in heartbeat support from #5592 (`DataStreamResponse(heartbeat=...)`, encoder-declared keepalive tokens, `add_sse_heartbeat` compat wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.JoEf-CkevW4LpXs4LGJP5klVy3iOhZ06i_PHgHNCYiF0H1MwSWm_zYxVa7o?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->