### PR TITLE
fix(assistant-stream): accept any Tool instantiation in toToolsJSONSchema

### DIFF
--- a/.changeset/tools-jsonschema-variance.md
+++ b/.changeset/tools-jsonschema-variance.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: accept any Tool instantiation in toToolsJSONSchema via structural ToolSchemaLike parameter

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -11625,7 +11625,7 @@ type ThreadMessageLike = {
 };
 
 type ToToolsJSONSchemaOptions = {
-  filter?: (name: string, tool: Tool) => boolean;
+  filter?: (name: string, tool: ToolSchemaLike) => boolean;
 };
 
 type Tool<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = FrontendTool<TArgs, TResult> | BackendTool<TArgs, TResult> | HumanTool<TArgs, TResult> | ProviderTool<TArgs, TResult> | McpTool | ToolWithoutType<TArgs, TResult>;
@@ -11793,6 +11793,18 @@ type ToolResponseLike<TResult> = {
 type ToolResultStreamOptions = {
   onExecutionStart?: (toolCallId: string, toolName: string) => void;
   onExecutionEnd?: (toolCallId: string, toolName: string) => void;
+};
+
+type ToolSchemaLike = {
+  type?: string | undefined;
+  description?: string | undefined;
+  parameters?: StandardSchemaV1 | JSONSchema7 | undefined;
+  disabled?: boolean | undefined;
+  execute?: ((...args: never[]) => unknown) | undefined;
+  providerOptions?: ProviderOptions | undefined;
+  unstable_backendDefault?: {
+    parameters?: boolean | undefined;
+  } | undefined;
 };
 
 type ToolStreamCallFunction<TArgs extends Record<string, unknown> = Record<string, unknown>, TResult = unknown> = (reader: ToolCallReader<TArgs, TResult>, context: ToolExecutionContext) => void;
@@ -11984,7 +11996,7 @@ declare namespace entry_resumable_exports {
 }
 
 declare namespace entry_root_exports {
-  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, GorpStreamDeltaTracker as AssistantTransportDeltaTracker, AssistantTransportEncoder, AssistantTransportStateOperation, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createObjectStream, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
+  export { AssistantMessage, AssistantMessageAccumulator, AssistantMessageStream, AssistantMessageTiming, AssistantStream, AssistantStreamChunk, AssistantStreamController, AssistantTransportDecoder, GorpStreamDeltaTracker as AssistantTransportDeltaTracker, AssistantTransportEncoder, AssistantTransportStateOperation, DataPart, DataStreamDecoder, DataStreamEncoder, GenericAssistantMessage, GenericFilePart, GenericMessage, GenericSystemMessage, GenericTextPart, GenericToolCallPart, GenericToolMessage, GenericToolResultPart, GenericUserMessage, McpServerConfig, ObjectStreamChunk, ObjectStreamResponse, PlainTextDecoder, PlainTextEncoder, ProviderOptions, TextStreamController, ToToolsJSONSchemaOptions, Tool, ToolCallReader, ToolCallStreamController, ToolCallTiming, ToolDeclaration, ToolExecutionStream, ToolJSONSchema, ToolModelContentPart, ToolModelOutputFunction, ToolResponse, ToolResponseLike, ToolResultStreamOptions, ToolSchemaLike, UIMessageStreamChunk, UIMessageStreamDataChunk, UIMessageStreamDecoder, UIMessageStreamDecoderOptions, createAssistantStream, createAssistantStreamController, createAssistantStreamResponse, createObjectStream, fromObjectStreamResponse, toGenericMessages, toJSONSchema, toPartialJSONSchema, toToolsJSONSchema, createInitialMessage as unstable_createInitialMessage, unstable_runPendingTools, toolResultStream as unstable_toolResultStream };
 }
 
 declare namespace entry_resumable_ioredis_exports {
@@ -12005,7 +12017,7 @@ declare function toJSONSchema(schema: StandardSchemaV1 | JSONSchema7): JSONSchem
 
 declare function toPartialJSONSchema(schema: JSONSchema7): JSONSchema7;
 
-declare function toToolsJSONSchema(tools: Record<string, Tool> | undefined, options?: ToToolsJSONSchemaOptions): Record<string, ToolJSONSchema>;
+declare function toToolsJSONSchema(tools: Record<string, ToolSchemaLike> | undefined, options?: ToToolsJSONSchemaOptions): Record<string, ToolJSONSchema>;
 
 declare function toolResultStream(tools: Record<string, Tool> | (() => Record<string, Tool> | undefined) | undefined, abortSignal: AbortSignal | (() => AbortSignal), human: (toolCallId: string, payload: unknown) => Promise<unknown>, options?: ToolResultStreamOptions): ToolExecutionStream;
 

--- a/packages/assistant-stream/src/core/tool/schema-utils.test.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.test.ts
@@ -425,6 +425,21 @@ describe("toToolsJSONSchema", () => {
     });
   });
 
+  describe("parameter type", () => {
+    it("accepts any Tool instantiation without casts", () => {
+      const tools: Record<string, Tool<any, any>> = {
+        myTool: {
+          type: "frontend",
+          parameters: { type: "object", properties: {} },
+          execute: async () => {},
+        },
+      };
+
+      const result = toToolsJSONSchema(tools);
+      expect(result).toHaveProperty("myTool");
+    });
+  });
+
   describe("output format", () => {
     it("includes description when present", () => {
       const tools: Record<string, Tool> = {

--- a/packages/assistant-stream/src/core/tool/schema-utils.ts
+++ b/packages/assistant-stream/src/core/tool/schema-utils.ts
@@ -1,6 +1,10 @@
 import type { JSONSchema7 } from "json-schema";
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import type { ProviderOptions, Tool } from "./tool-types";
+import type {
+  ProviderOptions,
+  // oxlint-disable-next-line no-unused-vars -- referenced from JSDoc {@link} below
+  Tool,
+} from "./tool-types";
 
 /**
  * Type for a tool definition with JSON Schema parameters.
@@ -11,6 +15,23 @@ export type ToolJSONSchema = {
   providerOptions?: ProviderOptions;
 };
 
+/**
+ * The subset of a {@link Tool} that {@link toToolsJSONSchema} reads.
+ *
+ * Structural on purpose: every `Tool` instantiation (including `Tool<any, any>`
+ * and tools typed against another copy of assistant-stream) is assignable, so
+ * callers never need casts to upload their model context tools.
+ */
+export type ToolSchemaLike = {
+  type?: string | undefined;
+  description?: string | undefined;
+  parameters?: StandardSchemaV1 | JSONSchema7 | undefined;
+  disabled?: boolean | undefined;
+  execute?: ((...args: never[]) => unknown) | undefined;
+  providerOptions?: ProviderOptions | undefined;
+  unstable_backendDefault?: { parameters?: boolean | undefined } | undefined;
+};
+
 export type ToToolsJSONSchemaOptions = {
   /**
    * Filter to determine which tools to include.
@@ -18,7 +39,7 @@ export type ToToolsJSONSchemaOptions = {
    *
    * Tools with backend-default parameters are always excluded.
    */
-  filter?: (name: string, tool: Tool) => boolean;
+  filter?: (name: string, tool: ToolSchemaLike) => boolean;
 };
 
 function isStandardSchema(schema: unknown): schema is StandardSchemaV1 & {
@@ -131,7 +152,7 @@ export function toPartialJSONSchema(schema: JSONSchema7): JSONSchema7 {
   return result;
 }
 
-function defaultToolFilter(_name: string, tool: Tool): boolean {
+function defaultToolFilter(_name: string, tool: ToolSchemaLike): boolean {
   return (
     !tool.disabled &&
     tool.type !== "backend" &&
@@ -140,8 +161,10 @@ function defaultToolFilter(_name: string, tool: Tool): boolean {
 }
 
 function toolHasUploadableParameters(
-  tool: Tool,
-): tool is Tool & { parameters: NonNullable<Tool["parameters"]> } {
+  tool: ToolSchemaLike,
+): tool is ToolSchemaLike & {
+  parameters: NonNullable<ToolSchemaLike["parameters"]>;
+} {
   return (
     tool.parameters !== undefined && !tool.unstable_backendDefault?.parameters
   );
@@ -157,7 +180,7 @@ function toolHasUploadableParameters(
  * different orders.
  */
 export function toToolsJSONSchema(
-  tools: Record<string, Tool> | undefined,
+  tools: Record<string, ToolSchemaLike> | undefined,
   options: ToToolsJSONSchemaOptions = {},
 ): Record<string, ToolJSONSchema> {
   if (!tools) return {};
@@ -172,7 +195,9 @@ export function toToolsJSONSchema(
           entry,
         ): entry is [
           string,
-          Tool & { parameters: NonNullable<Tool["parameters"]> },
+          ToolSchemaLike & {
+            parameters: NonNullable<ToolSchemaLike["parameters"]>;
+          },
         ] => toolHasUploadableParameters(entry[1]),
       )
       .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))

--- a/packages/assistant-stream/src/index.ts
+++ b/packages/assistant-stream/src/index.ts
@@ -56,6 +56,7 @@ export {
   toPartialJSONSchema,
   toToolsJSONSchema,
   type ToolJSONSchema,
+  type ToolSchemaLike,
   type ToToolsJSONSchemaOptions,
 } from "./core/tool/schema-utils";
 


### PR DESCRIPTION
## Problem

`@assistant-ui/core`'s `ModelContext.tools` is `Record<string, Tool<any, any>>`, but `toToolsJSONSchema` required `Record<string, Tool>`. Downstream consumers (harness-sdk, ed08adb there) hit TS2345 and had to bridge with casts.

The assignment only fails when TypeScript cannot shortcut via type identity — concretely when pnpm materializes two peer-variant copies of assistant-stream (it has `ioredis`/`redis` peer deps, so a workspace that also installs Redis gets a second instance). Cross-copy, the structural comparison of `Tool` fails on two members:

- `streamCall`'s `ToolCallReader.args.get` — the generic constraint `TypePath<any>` (`any[]`) is not assignable to `TypePath<Record<string, unknown>>` (a tuple union)
- `ToolResponse`'s `unique symbol` getter, which makes the class nominal across copies

So the full behavioral `Tool` type is effectively unassignable across package instances, even as `Tool<any, any>`.

## Fix

`toToolsJSONSchema` only reads the serializable surface of a tool. Its parameter (and the `filter` callback) is now `ToolSchemaLike` — a structural subset (`type`/`description`/`parameters`/`disabled`/`execute`/`providerOptions`/`unstable_backendDefault`) that every `Tool` instantiation from any copy of the package satisfies. No behavior change; `ToolSchemaLike` is exported from the root entrypoint and the api-surface file is regenerated.

## Verification

- `packages/assistant-stream`: `tsc --noEmit` clean, `vitest` 400 passed (includes a new contract test that `Record<string, Tool<any, any>>` is accepted without casts)
- `turbo build --filter='./packages/*'`: 39/39 packages build against the new signature
- repo `test:types`: failure set byte-identical to origin/main baseline (all pre-existing, none introduced)
- cross-copy repro (two physical copies of the built package, simulating pnpm peer-variant duplication): `toToolsJSONSchema(tools)` with `Record<string, Tool<any, any>>` and `Record<string, Tool>` from the other copy compiles under `--strict --exactOptionalPropertyTypes`; before the fix it produced the exact TS2345 harness-sdk saw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.quXSx1GmTuIM6vopO4MEhLOgKbqgcqVIAhDdQKHYnFoyDhjXW2yOlmhdgqs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->