### PR TITLE
fix(react-google-adk): isolate stream error callbacks

### DIFF
--- a/.changeset/steady-adk-stream-errors.md
+++ b/.changeset/steady-adk-stream-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: keep ADK stream error events reliable when error callbacks fail

--- a/packages/react-google-adk/src/server/adkEventStream.test.ts
+++ b/packages/react-google-adk/src/server/adkEventStream.test.ts
@@ -73,4 +73,40 @@ describe("adkEventStream", () => {
     await readSSE(response);
     expect(onError).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    [
+      "throws",
+      () => {
+        throw new Error("callback failed");
+      },
+    ],
+    [
+      "rejects",
+      async () => {
+        throw new Error("callback failed");
+      },
+    ],
+  ])(
+    "still emits the stream error when onError %s",
+    async (_behavior, onError) => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      async function* throwingGen() {
+        throw new Error("stream failed");
+      }
+
+      const response = adkEventStream(throwingGen() as any, { onError });
+      const text = await readSSE(response);
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
+
+      const lines = text.split("\n\n").filter((l) => l.startsWith("data: "));
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0]!.slice(6))).toMatchObject({
+        errorCode: "STREAM_ERROR",
+        errorMessage: "stream failed",
+      });
+
+      errorSpy.mockRestore();
+    },
+  );
 });

--- a/packages/react-google-adk/src/server/adkEventStream.test.ts
+++ b/packages/react-google-adk/src/server/adkEventStream.test.ts
@@ -95,18 +95,20 @@ describe("adkEventStream", () => {
         throw new Error("stream failed");
       }
 
-      const response = adkEventStream(throwingGen() as any, { onError });
-      const text = await readSSE(response);
-      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
+      try {
+        const response = adkEventStream(throwingGen() as any, { onError });
+        const text = await readSSE(response);
+        await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
 
-      const lines = text.split("\n\n").filter((l) => l.startsWith("data: "));
-      expect(lines).toHaveLength(1);
-      expect(JSON.parse(lines[0]!.slice(6))).toMatchObject({
-        errorCode: "STREAM_ERROR",
-        errorMessage: "stream failed",
-      });
-
-      errorSpy.mockRestore();
+        const lines = text.split("\n\n").filter((l) => l.startsWith("data: "));
+        expect(lines).toHaveLength(1);
+        expect(JSON.parse(lines[0]!.slice(6))).toMatchObject({
+          errorCode: "STREAM_ERROR",
+          errorMessage: "stream failed",
+        });
+      } finally {
+        errorSpy.mockRestore();
+      }
     },
   );
 });

--- a/packages/react-google-adk/src/server/adkEventStream.ts
+++ b/packages/react-google-adk/src/server/adkEventStream.ts
@@ -101,6 +101,21 @@ export type AdkEventStreamOptions = {
   onError?: (error: unknown) => void;
 };
 
+const reportCallbackError = (error: unknown) => {
+  console.error("[react-google-adk] onError callback threw an error", error);
+};
+
+const notifyError = (
+  callback: AdkEventStreamOptions["onError"],
+  error: unknown,
+) => {
+  try {
+    void Promise.resolve(callback?.(error)).catch(reportCallbackError);
+  } catch (callbackError) {
+    reportCallbackError(callbackError);
+  }
+};
+
 /**
  * Converts an AsyncGenerator of ADK SDK Events into an SSE Response.
  *
@@ -131,7 +146,7 @@ export const adkEventStream = (
         }
       } catch (e) {
         if (!cancelled) {
-          options?.onError?.(e);
+          notifyError(options?.onError, e);
           const errorEvent: AdkEvent = {
             id: "",
             errorCode: "STREAM_ERROR",


### PR DESCRIPTION
## Summary

- isolate synchronous throws and async rejections from the ADK `onError` callback
- preserve the structured `STREAM_ERROR` event for the client
- add regression coverage for both callback failure modes

## Why

An application may use `onError` for telemetry or logging. If that callback fails while the ADK generator is already failing, it must not replace the original stream failure or prevent the client from receiving its error event. Without this isolation, the client can observe only a closed or blank stream.

## Verification

- `pnpm --filter @assistant-ui/react-google-adk exec vitest run src/server/adkEventStream.test.ts`
- `pnpm --filter @assistant-ui/react-google-adk build`
- `pnpm exec oxlint packages/react-google-adk/src/server/adkEventStream.ts packages/react-google-adk/src/server/adkEventStream.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5pzM0dX9Rky_hpYQ4anFUzT8V4x_NvPV_DFdNDkMa1hGxXF8ZnmDlCFwr_M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->