### PR TITLE
fix(react-ag-ui): reload keyed history adapters

### DIFF
--- a/.changeset/calm-agui-history-scopes.md
+++ b/.changeset/calm-agui-history-scopes.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: reload AG-UI history when its keyed adapter scope changes

--- a/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
+++ b/apps/docs/content/docs/integrations/persistence/custom-adapter.mdx
@@ -589,7 +589,7 @@ export const threadListAdapter: RemoteThreadListAdapter = {
 
 The top-level `load`/`append` on the history adapter are required by the type but unused by `useChatRuntime`. The AI SDK code path always goes through `withFormat`.
 
-If one mounted runtime can switch between accounts or workspaces, set the adapter's optional `key` to that persistence scope. Keep it stable for the same scope and change it when the backing history changes; `useLocalRuntime` and the AI SDK runtimes then clear the previous scope, reload the new history, and ignore stale load responses. Adapters without a key retain the existing load-once behavior. React A2A and AG-UI runtimes currently require a remount when the backing history scope changes.
+If one mounted runtime can switch between accounts or workspaces, set the adapter's optional `key` to that persistence scope. Keep it stable for the same scope and change it when the backing history changes; `useLocalRuntime`, the AI SDK runtimes, and AG-UI then clear the previous scope, reload the new history, and ignore stale load responses. Adapters without a key retain the existing load-once behavior. React A2A currently requires a remount when the backing history scope changes.
 
 `undefined` is a distinct keyless scope. If the account or workspace ID is loaded asynchronously, wait to provide the history adapter or mount the runtime until the key is known; changing from `undefined` to a concrete key clears and reloads the thread.
 

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -52,8 +52,12 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
     "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "vitest": "^4.1.10",
     "zod": "^4.4.3"
   },

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -295,6 +295,10 @@ export class AgUiThreadRuntimeCore {
       key,
       promise: Promise.resolve(),
     };
+    const historyScopeGeneration = this.historyScopeGeneration;
+    const isCurrentRequest = () =>
+      this._loadRequest === request &&
+      historyScopeGeneration === this.historyScopeGeneration;
     this._loadRequest = request;
     this.lastHistoryAdapterKey = key;
 
@@ -304,7 +308,7 @@ export class AgUiThreadRuntimeCore {
     request.promise = Promise.resolve()
       .then(() => history?.load() ?? null)
       .then(async (repo) => {
-        if (this._loadRequest !== request || !repo) return;
+        if (!isCurrentRequest() || !repo) return;
 
         this.applyExternalMessageRepository(repo);
 
@@ -324,14 +328,14 @@ export class AgUiThreadRuntimeCore {
         }
       })
       .catch((error) => {
-        if (this._loadRequest !== request) return;
+        if (!isCurrentRequest()) return;
         this.logger.error?.("[agui] failed to load history", error);
         this.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       })
       .finally(() => {
-        if (this._loadRequest !== request) return;
+        if (!isCurrentRequest()) return;
         this._isLoading = false;
         this.notifyUpdate();
       });

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -280,6 +280,7 @@ export class AgUiThreadRuntimeCore {
       this.lastHistoryAdapterKey !== undefined &&
       !Object.is(this.lastHistoryAdapterKey, key);
     if (replacingHistory) {
+      this.historyScopeGeneration += 1;
       void this.cancel();
       this.clearRepository();
       this.stateSnapshot = undefined;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -74,6 +74,11 @@ type CoreOptions = {
   notifyUpdate: () => void;
 };
 
+const DEFAULT_HISTORY_ADAPTER_KEY = Symbol("history-adapter");
+type HistoryAdapterKey =
+  | NonNullable<ThreadHistoryAdapter["key"]>
+  | typeof DEFAULT_HISTORY_ADAPTER_KEY;
+
 const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
 export class AgUiThreadRuntimeCore {
@@ -96,8 +101,15 @@ export class AgUiThreadRuntimeCore {
   private lastRunConfig: RunConfig | undefined;
   private readonly assistantHistoryParents = new Map<string, string | null>();
   private readonly recordedHistoryIds = new Set<string>();
+  private historyScopeGeneration = 0;
   private _isLoading = false;
-  private _loadPromise: Promise<void> | undefined;
+  private _loadRequest:
+    | {
+        key: HistoryAdapterKey;
+        promise: Promise<void>;
+      }
+    | undefined;
+  private lastHistoryAdapterKey: HistoryAdapterKey | undefined;
   private pendingResumeMessageId: string | null = null;
   private pendingA2uiResume = false;
   private pendingA2uiAction: Record<string, unknown> | undefined;
@@ -240,15 +252,42 @@ export class AgUiThreadRuntimeCore {
   }
 
   __internal_load(): Promise<void> {
-    if (this._loadPromise) return this._loadPromise;
+    const history = this.history;
+    const key = history?.key ?? DEFAULT_HISTORY_ADAPTER_KEY;
+    const activeLoadRequest = this._loadRequest;
+    if (activeLoadRequest && Object.is(activeLoadRequest.key, key)) {
+      return activeLoadRequest.promise;
+    }
 
-    const promise = this.history?.load() ?? Promise.resolve(null);
+    const replacingHistory =
+      this.lastHistoryAdapterKey !== undefined &&
+      !Object.is(this.lastHistoryAdapterKey, key);
+    if (replacingHistory) {
+      this.historyScopeGeneration += 1;
+      void this.cancel();
+      this.clearRepository();
+      this.stateSnapshot = undefined;
+      this.assistantHistoryParents.clear();
+      this.recordedHistoryIds.clear();
+      this.pendingResumeMessageId = null;
+      this.pendingA2uiResume = false;
+      this.pendingA2uiAction = undefined;
+    }
+
+    const request = {
+      key,
+      promise: Promise.resolve(),
+    };
+    this._loadRequest = request;
+    this.lastHistoryAdapterKey = key;
 
     this._isLoading = true;
+    this.notifyUpdate();
 
-    this._loadPromise = promise
+    request.promise = Promise.resolve()
+      .then(() => history?.load() ?? null)
       .then(async (repo) => {
-        if (!repo) return;
+        if (this._loadRequest !== request || !repo) return;
 
         this.applyExternalMessageRepository(repo);
 
@@ -258,7 +297,7 @@ export class AgUiThreadRuntimeCore {
 
         if (repo.unstable_resume) {
           const parentId = repo.headId ?? this.repository.headId;
-          const resumeStream = this.history?.resume?.bind(this.history);
+          const resumeStream = history?.resume?.bind(history);
           await this.startRun(
             parentId,
             this.lastRunConfig,
@@ -268,18 +307,19 @@ export class AgUiThreadRuntimeCore {
         }
       })
       .catch((error) => {
+        if (this._loadRequest !== request) return;
         this.logger.error?.("[agui] failed to load history", error);
         this.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
       })
       .finally(() => {
+        if (this._loadRequest !== request) return;
         this._isLoading = false;
         this.notifyUpdate();
       });
 
-    this.notifyUpdate();
-    return this._loadPromise;
+    return request.promise;
   }
 
   async append(message: AppendMessage): Promise<void> {
@@ -1685,9 +1725,12 @@ export class AgUiThreadRuntimeCore {
   }
 
   private appendHistoryItem(parentId: string | null, message: ThreadMessage) {
-    if (!this.history || this.recordedHistoryIds.has(message.id)) return;
+    const history = this.history;
+    if (!history || this.recordedHistoryIds.has(message.id)) return;
+    const historyScopeGeneration = this.historyScopeGeneration;
     this.recordedHistoryIds.add(message.id);
-    void this.history.append({ parentId, message }).catch((error) => {
+    void history.append({ parentId, message }).catch((error) => {
+      if (historyScopeGeneration !== this.historyScopeGeneration) return;
       this.recordedHistoryIds.delete(message.id);
       this.logger.error?.("[agui] failed to append history entry", error);
     });

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -115,6 +115,7 @@ export class AgUiThreadRuntimeCore {
   private _loadRequest:
     | {
         key: HistoryAdapterKey;
+        historyScopeGeneration: number;
         promise: Promise<void>;
       }
     | undefined;
@@ -272,7 +273,11 @@ export class AgUiThreadRuntimeCore {
     const history = this.history;
     const key = getHistoryAdapterKey(history);
     const activeLoadRequest = this._loadRequest;
-    if (activeLoadRequest && Object.is(activeLoadRequest.key, key)) {
+    if (
+      activeLoadRequest &&
+      Object.is(activeLoadRequest.key, key) &&
+      activeLoadRequest.historyScopeGeneration === this.historyScopeGeneration
+    ) {
       return activeLoadRequest.promise;
     }
 
@@ -293,12 +298,12 @@ export class AgUiThreadRuntimeCore {
 
     const request = {
       key,
+      historyScopeGeneration: this.historyScopeGeneration,
       promise: Promise.resolve(),
     };
-    const historyScopeGeneration = this.historyScopeGeneration;
     const isCurrentRequest = () =>
       this._loadRequest === request &&
-      historyScopeGeneration === this.historyScopeGeneration;
+      request.historyScopeGeneration === this.historyScopeGeneration;
     this._loadRequest = request;
     this.lastHistoryAdapterKey = key;
 

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -70,14 +70,23 @@ type CoreOptions = {
   autoCancelPendingToolCalls?: boolean | undefined;
   onError?: (error: Error) => void;
   onCancel?: () => void;
-  history?: ThreadHistoryAdapter;
+  history?: ThreadHistoryAdapter | undefined;
   notifyUpdate: () => void;
 };
 
 const DEFAULT_HISTORY_ADAPTER_KEY = Symbol("history-adapter");
+const NO_HISTORY_ADAPTER_KEY = Symbol("no-history-adapter");
 type HistoryAdapterKey =
   | NonNullable<ThreadHistoryAdapter["key"]>
-  | typeof DEFAULT_HISTORY_ADAPTER_KEY;
+  | typeof DEFAULT_HISTORY_ADAPTER_KEY
+  | typeof NO_HISTORY_ADAPTER_KEY;
+
+const getHistoryAdapterKey = (
+  history: ThreadHistoryAdapter | undefined,
+): HistoryAdapterKey =>
+  history
+    ? (history.key ?? DEFAULT_HISTORY_ADAPTER_KEY)
+    : NO_HISTORY_ADAPTER_KEY;
 
 const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
@@ -133,6 +142,14 @@ export class AgUiThreadRuntimeCore {
     this.autoCancelPendingToolCalls = options.autoCancelPendingToolCalls;
     this.onError = options.onError;
     this.onCancel = options.onCancel;
+    if (
+      !Object.is(
+        getHistoryAdapterKey(this.history),
+        getHistoryAdapterKey(options.history),
+      )
+    ) {
+      this.historyScopeGeneration += 1;
+    }
     this.history = options.history;
     this.installResumeShim();
   }
@@ -253,7 +270,7 @@ export class AgUiThreadRuntimeCore {
 
   __internal_load(): Promise<void> {
     const history = this.history;
-    const key = history?.key ?? DEFAULT_HISTORY_ADAPTER_KEY;
+    const key = getHistoryAdapterKey(history);
     const activeLoadRequest = this._loadRequest;
     if (activeLoadRequest && Object.is(activeLoadRequest.key, key)) {
       return activeLoadRequest.promise;
@@ -263,7 +280,6 @@ export class AgUiThreadRuntimeCore {
       this.lastHistoryAdapterKey !== undefined &&
       !Object.is(this.lastHistoryAdapterKey, key);
     if (replacingHistory) {
-      this.historyScopeGeneration += 1;
       void this.cancel();
       this.clearRepository();
       this.stateSnapshot = undefined;
@@ -945,6 +961,9 @@ export class AgUiThreadRuntimeCore {
     resume?: AgUiResumeEntry[],
     resumeStream?: ResumeStream,
   ): Promise<void> {
+    const historyScopeGeneration = this.historyScopeGeneration;
+    const isCurrentHistoryScope = () =>
+      historyScopeGeneration === this.historyScopeGeneration;
     const normalizedRunConfig = runConfig ?? {};
     this.lastRunConfig = normalizedRunConfig;
     const parent = parentId === null ? undefined : this.tryGetMessage(parentId);
@@ -987,6 +1006,7 @@ export class AgUiThreadRuntimeCore {
     if (shouldEagerlyInsertAssistant) ensureAssistant();
 
     const applyUpdate = (update: ChatModelRunResult) => {
+      if (!isCurrentHistoryScope()) return;
       const hasContent =
         Array.isArray(update.content) && update.content.length > 0;
       const resolved = this.updateAssistantMessage(
@@ -1003,6 +1023,7 @@ export class AgUiThreadRuntimeCore {
       logger: this.logger,
       emit: applyUpdate,
       onServerMessageId: (serverId) => {
+        if (!isCurrentHistoryScope()) return;
         const placeholder = ensureAssistant(true);
         if (placeholder === serverId) return;
         if (this.reassignAssistantId(placeholder, serverId)) {
@@ -1012,8 +1033,10 @@ export class AgUiThreadRuntimeCore {
         }
       },
     });
-    const dispatch = (event: AgUiEvent) =>
+    const dispatch = (event: AgUiEvent) => {
+      if (!isCurrentHistoryScope()) return;
       this.handleEvent(aggregator, event, assistantMessageId);
+    };
 
     const abortController = new AbortController();
     const abortSignal = abortController.signal;
@@ -1061,6 +1084,7 @@ export class AgUiThreadRuntimeCore {
           runId,
           logger: this.logger,
           onRunFailed: (error) => {
+            if (!isCurrentHistoryScope()) return;
             this.pendingError = error;
             this.onError?.(error);
           },
@@ -1077,7 +1101,7 @@ export class AgUiThreadRuntimeCore {
         });
       }
     } catch (error) {
-      if (!abortSignal.aborted) {
+      if (!abortSignal.aborted && isCurrentHistoryScope()) {
         const err = error instanceof Error ? error : new Error(String(error));
         dispatch({ type: "RUN_ERROR", message: err.message });
         this.onError?.(err);
@@ -1086,6 +1110,8 @@ export class AgUiThreadRuntimeCore {
     } finally {
       this.finishRun(abortController);
     }
+
+    if (!isCurrentHistoryScope()) return;
 
     if (this.pendingError) {
       const err = this.pendingError;
@@ -1255,9 +1281,8 @@ export class AgUiThreadRuntimeCore {
   }
 
   private finishRun(controller: AbortController | null) {
-    if (this.abortController === controller) {
-      this.abortController = null;
-    }
+    if (this.abortController !== controller) return;
+    this.abortController = null;
     this.setRunning(false);
   }
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -74,7 +74,7 @@ export function useAgUiRuntime(
     autoCancelPendingToolCalls: options.autoCancelPendingToolCalls,
     ...(options.onError && { onError: options.onError }),
     ...(options.onCancel && { onCancel: options.onCancel }),
-    ...(historyAdapter && { history: historyAdapter }),
+    history: historyAdapter,
   });
 
   const [toolStatuses, setToolStatuses] = useState<
@@ -197,10 +197,11 @@ export function useAgUiRuntime(
     };
   }, [core, runtime]);
 
+  const hasHistoryAdapter = historyAdapter !== undefined;
   const historyAdapterKey = historyAdapter?.key;
   useEffect(() => {
     core.__internal_load();
-  }, [core, historyAdapterKey]);
+  }, [core, hasHistoryAdapter, historyAdapterKey]);
 
   return runtime;
 }

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -197,9 +197,10 @@ export function useAgUiRuntime(
     };
   }, [core, runtime]);
 
+  const historyAdapterKey = historyAdapter?.key;
   useEffect(() => {
     core.__internal_load();
-  }, [core]);
+  }, [core, historyAdapterKey]);
 
   return runtime;
 }

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1920,6 +1920,12 @@ describe("AGUIThreadRuntimeCore", () => {
             resolveFirstLoad = resolve;
           }),
       ),
+      resume: vi.fn(async function* () {
+        yield {
+          content: [{ type: "text", text: "stale resume" }],
+          status: { type: "complete", reason: "unknown" },
+        };
+      }),
       append: vi.fn().mockResolvedValue(undefined),
     };
     const secondHistory: ThreadHistoryAdapter = {
@@ -1938,20 +1944,47 @@ describe("AGUIThreadRuntimeCore", () => {
 
     core.applyExternalMessages([
       {
-        id: "message-a",
+        id: "current-message",
         role: "user",
-        content: [{ type: "text", text: "workspace a" }],
+        content: [{ type: "text", text: "current workspace" }],
         createdAt: new Date(),
         metadata: { custom: {} },
       },
     ]);
-    core.loadExternalState({ workspace: "a" });
+    core.loadExternalState({ workspace: "current" });
     core.updateOptions({
       agent,
       logger: noopLogger,
       showThinking: true,
       history: secondHistory,
     });
+
+    resolveFirstLoad({
+      headId: "stale-message-a",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "stale-message-a",
+            role: "user",
+            content: [{ type: "text", text: "stale workspace a" }],
+            createdAt: new Date(),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+      state: { workspace: "stale-a" },
+      unstable_resume: true,
+    });
+    await firstRequest;
+
+    expect(core.getMessages().map((message) => message.id)).toEqual([
+      "current-message",
+    ]);
+    expect(core.getState()).toEqual({ workspace: "current" });
+    expect(firstHistory.resume).not.toHaveBeenCalled();
+    expect(core.isLoading).toBe(true);
+
     const secondRequest = core.__internal_load();
     await vi.waitFor(() => expect(secondHistory.load).toHaveBeenCalledOnce());
 
@@ -1976,24 +2009,6 @@ describe("AGUIThreadRuntimeCore", () => {
       state: { workspace: "b" },
     });
     await secondRequest;
-
-    resolveFirstLoad({
-      headId: "message-a",
-      messages: [
-        {
-          parentId: null,
-          message: {
-            id: "message-a",
-            role: "user",
-            content: [{ type: "text", text: "workspace a" }],
-            createdAt: new Date(),
-            metadata: { custom: {} },
-          },
-        },
-      ],
-      state: { workspace: "a" },
-    });
-    await firstRequest;
 
     expect(core.getMessages().map((message) => message.id)).toEqual([
       "message-b",

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2033,6 +2033,163 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(secondHistory.append).toHaveBeenCalledTimes(1);
   });
 
+  it("isolates an active run when keyed history changes", async () => {
+    let releaseFirstRun!: () => void;
+    const firstRun = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve;
+    });
+    let releaseResume!: () => void;
+    const resumedRun = new Promise<void>((resolve) => {
+      releaseResume = resolve;
+    });
+    let markResumeStarted!: () => void;
+    const resumeStarted = new Promise<void>((resolve) => {
+      markResumeStarted = resolve;
+    });
+    const agent = {
+      runAgent: vi.fn(async (_input, subscriber) => {
+        subscriber.onTextMessageStartEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_START",
+            messageId: "assistant-a",
+            role: "assistant",
+          },
+        });
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: "assistant-a",
+            delta: "workspace a",
+          },
+        });
+        await firstRun;
+        subscriber.onTextMessageContentEvent?.({
+          event: {
+            type: "TEXT_MESSAGE_CONTENT",
+            messageId: "assistant-a",
+            delta: " late",
+          },
+        });
+        subscriber.onRunFinalized?.();
+      }),
+    } as unknown as HttpAgent;
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      key: "workspace-b",
+      load: vi.fn().mockResolvedValue({
+        headId: "message-b",
+        messages: [
+          {
+            parentId: null,
+            message: {
+              id: "message-b",
+              role: "user",
+              content: [{ type: "text", text: "workspace b" }],
+              createdAt: new Date(),
+              metadata: { custom: {} },
+            },
+          },
+        ],
+        unstable_resume: true,
+      }),
+      resume: vi.fn(async function* () {
+        markResumeStarted();
+        await resumedRun;
+        yield {
+          content: [{ type: "text", text: "resumed workspace b" }],
+          status: { type: "complete", reason: "unknown" },
+        };
+      }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, { history: firstHistory });
+    await core.__internal_load();
+
+    const oldRun = core.append(createAppendMessage());
+    await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledOnce());
+
+    core.updateOptions({
+      agent,
+      logger: noopLogger,
+      showThinking: true,
+      history: secondHistory,
+    });
+    const replacementLoad = core.__internal_load();
+    await resumeStarted;
+
+    expect(core.isRunning()).toBe(true);
+    expect(secondHistory.append).not.toHaveBeenCalled();
+
+    releaseFirstRun();
+    await oldRun;
+
+    expect(core.isRunning()).toBe(true);
+    expect(secondHistory.append).not.toHaveBeenCalled();
+    expect(
+      core.getMessages().some((message) => message.id === "assistant-a"),
+    ).toBe(false);
+
+    releaseResume();
+    await replacementLoad;
+
+    expect(core.isRunning()).toBe(false);
+    expect(secondHistory.append).toHaveBeenCalledTimes(1);
+    expect(core.getMessages().map((message) => message.id)).not.toContain(
+      "assistant-a",
+    );
+  });
+
+  it("ignores append failures from a previous history scope", async () => {
+    let rejectFirstAppend!: (error: Error) => void;
+    const firstAppend = new Promise<void>((_resolve, reject) => {
+      rejectFirstAppend = reject;
+    });
+    const loggerError = vi.fn();
+    const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn(() => firstAppend),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      key: "workspace-b",
+      load: vi.fn(),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, {
+      history: firstHistory,
+      logger: makeLogger({ error: loggerError }),
+    });
+    await core.__internal_load();
+    await core.append(createAppendMessage({ startRun: false }));
+    const sharedMessage = core.getMessages()[0]!;
+    vi.mocked(secondHistory.load).mockResolvedValue({
+      headId: sharedMessage.id,
+      messages: [{ parentId: null, message: sharedMessage }],
+    });
+
+    core.updateOptions({
+      agent,
+      logger: makeLogger({ error: loggerError }),
+      showThinking: true,
+      history: secondHistory,
+    });
+    await core.__internal_load();
+
+    rejectFirstAppend(new Error("workspace a unavailable"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const recordedHistoryIds = (
+      core as unknown as { recordedHistoryIds: Set<string> }
+    ).recordedHistoryIds;
+    expect(recordedHistoryIds.has(sharedMessage.id)).toBe(true);
+    expect(loggerError).not.toHaveBeenCalled();
+  });
+
   it("handles missing history adapter gracefully", async () => {
     const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
     const core = createCore(agent);

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1908,6 +1908,51 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(historyAdapter.load).toHaveBeenCalledTimes(1);
   });
 
+  it("does not reuse a load invalidated by an intervening scope", async () => {
+    const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
+    let resolveFirstLoad!: (repo: ExportedMessageRepository) => void;
+    const firstLoad = new Promise<ExportedMessageRepository>((resolve) => {
+      resolveFirstLoad = resolve;
+    });
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi
+        .fn()
+        .mockImplementationOnce(() => firstLoad)
+        .mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      key: "workspace-b",
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, { history: firstHistory });
+    const staleRequest = core.__internal_load();
+    await vi.waitFor(() => expect(firstHistory.load).toHaveBeenCalledOnce());
+
+    core.updateOptions({
+      agent,
+      logger: noopLogger,
+      showThinking: true,
+      history: secondHistory,
+    });
+    core.updateOptions({
+      agent,
+      logger: noopLogger,
+      showThinking: true,
+      history: firstHistory,
+    });
+    const currentRequest = core.__internal_load();
+
+    expect(currentRequest).not.toBe(staleRequest);
+    await currentRequest;
+    expect(firstHistory.load).toHaveBeenCalledTimes(2);
+
+    resolveFirstLoad({ messages: [] });
+    await staleRequest;
+  });
+
   it("reloads keyed history and ignores stale responses", async () => {
     const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
     let resolveFirstLoad!: (repo: ExportedMessageRepository) => void;

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1908,6 +1908,131 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(historyAdapter.load).toHaveBeenCalledTimes(1);
   });
 
+  it("reloads keyed history and ignores stale responses", async () => {
+    const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
+    let resolveFirstLoad!: (repo: ExportedMessageRepository) => void;
+    let resolveSecondLoad!: (repo: ExportedMessageRepository) => void;
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstLoad = resolve;
+          }),
+      ),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      key: "workspace-b",
+      load: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolveSecondLoad = resolve;
+          }),
+      ),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, { history: firstHistory });
+    const firstRequest = core.__internal_load();
+    await vi.waitFor(() => expect(firstHistory.load).toHaveBeenCalledOnce());
+
+    core.applyExternalMessages([
+      {
+        id: "message-a",
+        role: "user",
+        content: [{ type: "text", text: "workspace a" }],
+        createdAt: new Date(),
+        metadata: { custom: {} },
+      },
+    ]);
+    core.loadExternalState({ workspace: "a" });
+    core.updateOptions({
+      agent,
+      logger: noopLogger,
+      showThinking: true,
+      history: secondHistory,
+    });
+    const secondRequest = core.__internal_load();
+    await vi.waitFor(() => expect(secondHistory.load).toHaveBeenCalledOnce());
+
+    expect(core.getMessages()).toEqual([]);
+    expect(core.getState()).toBeUndefined();
+    expect(core.isLoading).toBe(true);
+
+    resolveSecondLoad({
+      headId: "message-b",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "message-b",
+            role: "user",
+            content: [{ type: "text", text: "workspace b" }],
+            createdAt: new Date(),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+      state: { workspace: "b" },
+    });
+    await secondRequest;
+
+    resolveFirstLoad({
+      headId: "message-a",
+      messages: [
+        {
+          parentId: null,
+          message: {
+            id: "message-a",
+            role: "user",
+            content: [{ type: "text", text: "workspace a" }],
+            createdAt: new Date(),
+            metadata: { custom: {} },
+          },
+        },
+      ],
+      state: { workspace: "a" },
+    });
+    await firstRequest;
+
+    expect(core.getMessages().map((message) => message.id)).toEqual([
+      "message-b",
+    ]);
+    expect(core.getState()).toEqual({ workspace: "b" });
+    expect(core.isLoading).toBe(false);
+  });
+
+  it("does not reload replacement history adapters with the same key", async () => {
+    const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn().mockResolvedValue({ messages: [] }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const core = createCore(agent, { history: firstHistory });
+
+    const firstRequest = core.__internal_load();
+    await firstRequest;
+    core.updateOptions({
+      agent,
+      logger: noopLogger,
+      showThinking: true,
+      history: secondHistory,
+    });
+
+    expect(core.__internal_load()).toBe(firstRequest);
+    expect(secondHistory.load).not.toHaveBeenCalled();
+
+    await core.append(createAppendMessage({ startRun: false }));
+    expect(firstHistory.append).not.toHaveBeenCalled();
+    expect(secondHistory.append).toHaveBeenCalledTimes(1);
+  });
+
   it("handles missing history adapter gracefully", async () => {
     const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
     const core = createCore(agent);

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -2073,29 +2073,28 @@ describe("AGUIThreadRuntimeCore", () => {
         subscriber.onRunFinalized?.();
       }),
     } as unknown as HttpAgent;
-    const firstHistory: ThreadHistoryAdapter = {
+    const historyAdapter: ThreadHistoryAdapter = {
       key: "workspace-a",
-      load: vi.fn().mockResolvedValue({ messages: [] }),
-      append: vi.fn().mockResolvedValue(undefined),
-    };
-    const secondHistory: ThreadHistoryAdapter = {
-      key: "workspace-b",
-      load: vi.fn().mockResolvedValue({
-        headId: "message-b",
-        messages: [
-          {
-            parentId: null,
-            message: {
-              id: "message-b",
-              role: "user",
-              content: [{ type: "text", text: "workspace b" }],
-              createdAt: new Date(),
-              metadata: { custom: {} },
+      load: vi.fn(async () =>
+        historyAdapter.key === "workspace-a"
+          ? { messages: [] }
+          : {
+              headId: "message-b",
+              messages: [
+                {
+                  parentId: null,
+                  message: {
+                    id: "message-b",
+                    role: "user" as const,
+                    content: [{ type: "text" as const, text: "workspace b" }],
+                    createdAt: new Date(),
+                    metadata: { custom: {} },
+                  },
+                },
+              ],
+              unstable_resume: true,
             },
-          },
-        ],
-        unstable_resume: true,
-      }),
+      ),
       resume: vi.fn(async function* () {
         markResumeStarted();
         await resumedRun;
@@ -2106,29 +2105,31 @@ describe("AGUIThreadRuntimeCore", () => {
       }),
       append: vi.fn().mockResolvedValue(undefined),
     };
-    const core = createCore(agent, { history: firstHistory });
+    const core = createCore(agent, { history: historyAdapter });
     await core.__internal_load();
 
     const oldRun = core.append(createAppendMessage());
     await vi.waitFor(() => expect(agent.runAgent).toHaveBeenCalledOnce());
+    vi.mocked(historyAdapter.append).mockClear();
 
+    historyAdapter.key = "workspace-b";
     core.updateOptions({
       agent,
       logger: noopLogger,
       showThinking: true,
-      history: secondHistory,
+      history: historyAdapter,
     });
     const replacementLoad = core.__internal_load();
     await resumeStarted;
 
     expect(core.isRunning()).toBe(true);
-    expect(secondHistory.append).not.toHaveBeenCalled();
+    expect(historyAdapter.append).not.toHaveBeenCalled();
 
     releaseFirstRun();
     await oldRun;
 
     expect(core.isRunning()).toBe(true);
-    expect(secondHistory.append).not.toHaveBeenCalled();
+    expect(historyAdapter.append).not.toHaveBeenCalled();
     expect(
       core.getMessages().some((message) => message.id === "assistant-a"),
     ).toBe(false);
@@ -2137,7 +2138,7 @@ describe("AGUIThreadRuntimeCore", () => {
     await replacementLoad;
 
     expect(core.isRunning()).toBe(false);
-    expect(secondHistory.append).toHaveBeenCalledTimes(1);
+    expect(historyAdapter.append).toHaveBeenCalledTimes(1);
     expect(core.getMessages().map((message) => message.id)).not.toContain(
       "assistant-a",
     );

--- a/packages/react-ag-ui/test/useAgUiRuntime.spec.tsx
+++ b/packages/react-ag-ui/test/useAgUiRuntime.spec.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ThreadHistoryAdapter, ThreadMessage } from "@assistant-ui/core";
+import type { HttpAgent } from "@ag-ui/client";
+import { describe, expect, it, vi } from "vitest";
+import { useAgUiRuntime } from "../src/useAgUiRuntime";
+
+const storedMessage = (id: string, text: string): ThreadMessage => ({
+  id,
+  role: "user",
+  content: [{ type: "text", text }],
+  createdAt: new Date(),
+  metadata: { custom: {} },
+});
+
+describe("useAgUiRuntime", () => {
+  it("clears removed history and loads a newly added unkeyed adapter", async () => {
+    const agent = { runAgent: vi.fn() } as unknown as HttpAgent;
+    const firstHistory: ThreadHistoryAdapter = {
+      key: "workspace-a",
+      load: vi.fn().mockResolvedValue({
+        headId: "message-a",
+        messages: [
+          {
+            parentId: null,
+            message: storedMessage("message-a", "workspace a"),
+          },
+        ],
+      }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const secondHistory: ThreadHistoryAdapter = {
+      load: vi.fn().mockResolvedValue({
+        headId: "message-b",
+        messages: [
+          {
+            parentId: null,
+            message: storedMessage("message-b", "workspace b"),
+          },
+        ],
+      }),
+      append: vi.fn().mockResolvedValue(undefined),
+    };
+    const { result, rerender } = renderHook(
+      ({ history }: { history: ThreadHistoryAdapter | undefined }) =>
+        useAgUiRuntime({
+          agent,
+          adapters: history ? { history } : {},
+        }),
+      {
+        initialProps: {
+          history: firstHistory as ThreadHistoryAdapter | undefined,
+        },
+      },
+    );
+
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.map((message) => message.id),
+      ).toEqual(["message-a"]),
+    );
+
+    rerender({ history: undefined });
+
+    await waitFor(() =>
+      expect(result.current.thread.getState().messages).toEqual([]),
+    );
+
+    rerender({ history: secondHistory });
+
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.map((message) => message.id),
+      ).toEqual(["message-b"]),
+    );
+    expect(firstHistory.load).toHaveBeenCalledOnce();
+    expect(secondHistory.load).toHaveBeenCalledOnce();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3883,12 +3883,24 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- rerun AG-UI history loading when the adapter scope key changes
- clear the previous scope and cancel its active run before loading the replacement
- ignore stale load completions and stale append failures from the previous scope
- keep replacement adapters with the same key load-free while routing new writes through the latest adapter

## Why

This is a follow-up to #5481 and depends on that PR landing first. #5481 introduces `ThreadHistoryAdapter.key` and adds account/workspace switching support to core and React AI SDK runtimes, while AG-UI still caches its first history load forever. Without this follow-up, changing an account, tenant, or workspace can leave AG-UI showing history from the previous scope and allow a delayed old load to overwrite the new one.

This PR is stacked on `fix/ai-sdk-history-adapter-switch` so its diff contains only the AG-UI parity work. It can be rebased and retargeted to `main` after #5481 merges.

## Verification

- `pnpm --filter @assistant-ui/react-ag-ui test` (9 files, 309 tests)
- `pnpm --filter @assistant-ui/react-ag-ui build`
- `pnpm exec oxlint packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts packages/react-ag-ui/src/useAgUiRuntime.ts packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts packages/react-ag-ui/test/useAgUiRuntime.spec.tsx`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

