### PR TITLE
fix(react-langchain): isolate stream options per thread

### DIFF
--- a/.changeset/tidy-streams-own.md
+++ b/.changeset/tidy-streams-own.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langchain": patch
+---
+
+fix: isolate LangChain stream options between thread runtimes

--- a/packages/react-langchain/src/useStreamRuntime.test.tsx
+++ b/packages/react-langchain/src/useStreamRuntime.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import type {
+  AssistantRuntime,
+  RemoteThreadListAdapter,
+} from "@assistant-ui/core";
 import { useAui } from "@assistant-ui/store";
 import type { LangChainBaseMessage } from "./types";
 import type { ReactNode } from "react";
@@ -109,6 +113,80 @@ const getText = (aui: ReturnType<typeof useAui>) =>
       .map((part) => part.text)
       .join(""),
   );
+
+const makeThreadListAdapter = (): RemoteThreadListAdapter => ({
+  list: vi.fn(async () => ({
+    threads: [
+      {
+        status: "regular" as const,
+        remoteId: "thread-a",
+        externalId: "thread-a",
+        title: "Thread A",
+      },
+      {
+        status: "regular" as const,
+        remoteId: "thread-b",
+        externalId: "thread-b",
+        title: "Thread B",
+      },
+    ],
+  })),
+  initialize: vi.fn(async () => ({
+    remoteId: "thread-new",
+    externalId: "thread-new",
+  })),
+  rename: vi.fn(async () => {}),
+  archive: vi.fn(async () => {}),
+  unarchive: vi.fn(async () => {}),
+  delete: vi.fn(async () => {}),
+  generateTitle: vi.fn(async () => new ReadableStream()),
+  fetch: vi.fn(async (threadId) => ({
+    status: "regular" as const,
+    remoteId: threadId,
+    externalId: threadId,
+  })),
+});
+
+describe("useStreamRuntime thread options", () => {
+  it("keeps stream options isolated between mounted threads", async () => {
+    mockUseStream.mockReturnValue(createMockStream());
+    const capture: { runtime: AssistantRuntime | null } = { runtime: null };
+    const threadListAdapter = makeThreadListAdapter();
+
+    const TestRuntime = () => {
+      const runtime = useStreamRuntime({
+        apiUrl: "/api",
+        unstable_threadListAdapter: threadListAdapter,
+      } as never);
+      capture.runtime = runtime;
+      return <AssistantRuntimeProvider runtime={runtime} />;
+    };
+
+    const view = render(<TestRuntime />);
+
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("thread-a");
+    });
+
+    const threadAOptions = mockUseStream.mock.calls
+      .map(([options]) => options as { threadId?: string | null })
+      .findLast((options) => options.threadId === "thread-a");
+    expect(threadAOptions).toBeDefined();
+
+    await act(async () => {
+      await capture.runtime!.threads.switchToThread("thread-b");
+    });
+
+    const threadBOptions = mockUseStream.mock.calls
+      .map(([options]) => options as { threadId?: string | null })
+      .findLast((options) => options.threadId === "thread-b");
+    expect(threadBOptions).toBeDefined();
+    expect(threadAOptions).not.toBe(threadBOptions);
+    expect(threadAOptions?.threadId).toBe("thread-a");
+
+    view.unmount();
+  });
+});
 
 describe("useStreamRuntime staged messages", () => {
   it("stages a new user message without submitting when startRun is false", async () => {

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -125,12 +125,9 @@ const useStreamThreadRuntime = (
   const externalId = useAuiState((s) => s.threadListItem.externalId) as
     | string
     | null;
-  // Mutate in place rather than `{ ...options, threadId }`: spreading
-  // `UseStreamOptions` (a discriminated union on `transport`) into an object
-  // literal merges both arms' transport types, breaking arm assignment.
-  options.threadId = externalId;
-
-  const stream = useStream(options);
+  const stream = useStream(
+    Object.assign({}, options, { threadId: externalId }),
+  );
   const [stagedMessages, setStagedMessages] = useState<
     LangChainBaseMessage[] | null
   >(null);

--- a/packages/react-langchain/src/useStreamRuntime.ts
+++ b/packages/react-langchain/src/useStreamRuntime.ts
@@ -125,6 +125,8 @@ const useStreamThreadRuntime = (
   const externalId = useAuiState((s) => s.threadListItem.externalId) as
     | string
     | null;
+  // Object.assign preserves the discriminated transport union; object spread
+  // collapses its arms and no longer satisfies UseStreamOptions.
   const stream = useStream(
     Object.assign({}, options, { threadId: externalId }),
   );


### PR DESCRIPTION
## Summary

- give each mounted LangChain thread runtime its own `useStream` options object
- preserve the caller options and the `UseStreamOptions` transport union
- add a regression test covering two mounted remote threads

## Why

`useRemoteThreadListRuntime` can keep multiple thread runtimes mounted. The adapter previously assigned each runtime's `threadId` onto one shared options object before passing it to `useStream`. Because `@langchain/react` reads those options from effects, a later runtime render could overwrite the ID seen by an earlier runtime.

I reproduced this by mounting threads A and B, then switching the first runtime from A to C. The request for C stayed on A and no hydration ran because B had overwritten the shared options object. This can surface after thread creation or when switching among remote threads.

The fix creates a shallow options object at the per-thread runtime boundary and attaches only that runtime's external ID. Existing option values, callbacks, and transport objects keep their identities.

## Verification

- regression test fails on `main` because both runtimes receive the same object
- `pnpm --filter @assistant-ui/react-langchain test` (107 tests)
- `pnpm --filter @assistant-ui/react-langchain build`
- targeted oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.OaConrFN_MZXSuNppPePltjNSkUlg5DGBUd7eJ_EzXEJcswbFYFXzWfDDaE?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->