### PR TITLE
chore(eve): widen eve peer range to cover 0.28/0.29 and export toEveInputResponse

### DIFF
--- a/.changeset/eve-widen-peer-range.md
+++ b/.changeset/eve-widen-peer-range.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+chore: validate against eve 0.28/0.29, widen the eve peer to >=0.27.6 <0.30.0, and export toEveInputResponse

--- a/api-surface/assistant-ui__eve.ts
+++ b/api-surface/assistant-ui__eve.ts
@@ -1,6 +1,6 @@
 import { StandardSchemaV1 } from "@standard-schema/spec";
 
-import { SendTurnPayload } from "eve/client";
+import { InputResponse, SendTurnPayload } from "eve/client";
 
 import { EveMessage, EveMessageData, UseEveAgentOptions } from "eve/react";
 
@@ -1484,8 +1484,10 @@ declare global {
 }
 
 declare namespace entry_root_exports {
-  export { ConvertEveMessagesOptions, UseEveAgentRuntimeOptions, convertEveMessage, convertEveMessages, getEveMessageContent, useEveAgentRuntime };
+  export { ConvertEveMessagesOptions, UseEveAgentRuntimeOptions, convertEveMessage, convertEveMessages, getEveMessageContent, toEveInputResponse, useEveAgentRuntime };
 }
+
+declare const toEveInputResponse: (response: RespondToToolApprovalOptions) => InputResponse;
 
 declare const useEveAgentRuntime: (options?: UseEveAgentRuntimeOptions) => AssistantRuntime;
 

--- a/apps/docs/content/docs/(reference)/api-reference/integrations/eve.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/integrations/eve.mdx
@@ -39,6 +39,14 @@ Eve's `send` API.
 const getEveMessageContent: (message: AppendMessage) => NonNullable<SendTurnPayload["message"]>;
 ```
 
+### toEveInputResponse
+
+Converts an assistant-ui tool approval response into an Eve input response.
+
+```ts
+const toEveInputResponse: (response: RespondToToolApprovalOptions) => InputResponse;
+```
+
 ### useEveAgentRuntime
 
 Connects Eve's `useEveAgent` hook to assistant-ui's runtime contract.

--- a/packages/eve/package.json
+++ b/packages/eve/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@types/react": "*",
-    "eve": "^0.27.6",
+    "eve": ">=0.27.6 <0.30.0",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
     "@types/react": "^19.2.17",
-    "eve": "^0.27.6",
+    "eve": "^0.29.5",
     "react": "^19.2.8",
     "vitest": "^4.1.10"
   },

--- a/packages/eve/src/index.ts
+++ b/packages/eve/src/index.ts
@@ -4,6 +4,7 @@ export {
   convertEveMessage,
   convertEveMessages,
   getEveMessageContent,
+  toEveInputResponse,
 } from "./convertEveMessages";
 export type { ConvertEveMessagesOptions } from "./convertEveMessages";
 export { useEveAgentRuntime } from "./useEveAgentRuntime";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3511,8 +3511,8 @@ importers:
         specifier: ^19.2.17
         version: 19.2.17
       eve:
-        specifier: ^0.27.6
-        version: 0.27.6(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.37(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: ^0.29.5
+        version: 0.29.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.37(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -12539,6 +12539,26 @@ packages:
       microsandbox:
         optional: true
 
+  eve@0.29.5:
+    resolution: {integrity: sha512-XiIJHANIgT7LQAZ3e2MyQG4N+B9dPYwdFk0rAzSGYSBjgavCbCtX/tXDlqasjIfEH726uxFdYrLGnlGvIZ38vg==}
+    engines: {node: '>=24'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+      ai: ^7.0.38
+      braintrust: ^3.0.0
+      just-bash: ^3.0.0
+      microsandbox: ^0.5.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      braintrust:
+        optional: true
+      just-bash:
+        optional: true
+      microsandbox:
+        optional: true
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -17296,6 +17316,10 @@ packages:
 
   undici@8.5.0:
     resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -26237,6 +26261,54 @@ snapshots:
       - xml2js
       - zephyr-agent
 
+  eve@0.29.5(@azure/identity@4.13.1)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(ai@7.0.37(zod@4.4.3))(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.1.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      ai: 7.0.37(zod@4.4.3)
+      nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@upstash/redis@1.38.0)(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(mysql2@3.20.0(@types/node@26.1.1))(sqlite3@5.1.7)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      undici: 8.9.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      just-bash: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - dotenv
+      - drizzle-orm
+      - giget
+      - idb-keyval
+      - ioredis
+      - jiti
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - rollup
+      - sqlite3
+      - uploadthing
+      - vite
+      - wrangler
+      - xml2js
+      - zephyr-agent
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -32159,6 +32231,8 @@ snapshots:
   undici@7.29.0: {}
 
   undici@8.5.0: {}
+
+  undici@8.9.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## What

Widens the `eve` peer range from `^0.27.6` to `>=0.27.6 <0.30.0`, bumps the test pin to `^0.29.5`, and exports the already-shipped `toEveInputResponse` helper from the package barrel. The api-surface snapshot and generated api-reference page are regenerated for the new export.

## Why

Upstream shipped 0.28.0 and 0.29.0 on 07-30, so every consumer on a current eve gets an unmet-peer warning from our 0.27-only caret. I ran the package build, typecheck, and full test suite against both 0.28.0 (the release with the type changes: required stream-event meta, input-request `kind` discriminator) and 0.29.5, green on each, so the widen is validated rather than advertised.

## Impact

- Consumers on eve 0.28.x or 0.29.x stop getting unmet-peer warnings; consumers on 0.27.x are unaffected.
- `toEveInputResponse` becomes importable for custom approval flows; it was already implemented, documented, and tested.
- No runtime behavior change.

## Scope & caveats

- 0.30.x is deliberately excluded: all seven 0.30 patches shipped 2026-08-04 and were younger than the repo's 24h `minimumReleaseAge` at validation time, so that leg could not be resolved or tested in CI; widening to 0.30 is a follow-up once it ages and validates.
- The workspace now exercises both ends of the range: `examples/with-eve` builds at the 0.27.6 floor, the package tests run at 0.29.5.
- `examples/with-eve` is intentionally untouched; the open dependency chore #5561 owns example bumps.
- Install logs a non-gating unmet-peer WARN: eve 0.29.5 peers on `ai@^7.0.38` while the workspace resolves 7.0.37; that peer belongs to the host app, not this package.
- Additive only: no exports removed or reshaped; the barrel export is append-only and api-surface plus api-reference are regenerated in this PR.
- Tests: the existing converter suite already covers `toEveInputResponse` both ways; no new tests because there is no new behavior.
- Changeset: patch (`@assistant-ui/eve`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IjVzGcAD7l35w_EF_cPdrMgnRKlLxWKGV377meRO1kpuvJrYqEe0hnvfkQU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->