### PR TITLE
feat: add the elements design gallery and component family

### DIFF
--- a/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
+++ b/apps/docs/app/(home)/elements/(detail)/[slug]/page.tsx
@@ -1,0 +1,227 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mono } from "@/components/elements/surfaces";
+import { createOgMetadata } from "@/lib/og";
+import {
+  highlightElementSource,
+  readElementSource,
+} from "@/lib/element-source";
+import { CopyButton } from "@/components/elements/copy-button";
+import { demoCanvasClass } from "@/components/elements/canvas";
+import { DemoStage } from "@/components/elements/demo-stage";
+import { DemoVariants } from "@/components/elements/demo-variants";
+import { InstallCommand } from "@/components/elements/install-command";
+import { ELEMENT_DOCS } from "@/components/elements/element-docs";
+import {
+  ELEMENT_COUNT,
+  ELEMENTS,
+  getElement,
+} from "@/components/elements/registry";
+
+export function generateStaticParams() {
+  return ELEMENTS.map((element) => ({ slug: element.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const element = getElement(slug);
+  if (!element) return {};
+  const title = `${element.title} | Elements`;
+  return {
+    title,
+    description: element.description,
+    ...createOgMetadata(element.title, element.description),
+  };
+}
+
+function SectionHeading({
+  title,
+  meta,
+  copyText,
+}: {
+  title: string;
+  meta?: string;
+  copyText?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <h2 className="text-sm font-medium">{title}</h2>
+      {meta !== undefined && (
+        <span className={cn(mono, "text-foreground/35")}>{meta}</span>
+      )}
+      {copyText !== undefined && (
+        <CopyButton text={copyText} className="ms-auto" />
+      )}
+    </div>
+  );
+}
+
+function CodeSurface({ html }: { html: string }) {
+  return (
+    <div
+      className="bg-foreground/[0.025] dark:bg-foreground/[0.04] mt-4 overflow-hidden rounded-2xl [&_pre]:overflow-x-auto [&_pre]:bg-transparent! [&_pre]:p-5 [&_pre]:font-mono [&_pre]:text-[12.5px] [&_pre]:leading-[1.7] md:[&_pre]:p-6"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+export default async function ElementPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const element = getElement(slug);
+  if (!element) notFound();
+
+  const doc = ELEMENT_DOCS[slug];
+  const registryName = `elements-${element.installName ?? element.slug}`;
+  const source = await readElementSource(element.file);
+  const highlightedSource = await highlightElementSource(source);
+  const highlightedUsage = doc ? await highlightElementSource(doc.usage) : null;
+
+  const previous = ELEMENTS[element.index - 2];
+  const next = ELEMENTS[element.index];
+
+  return (
+    <>
+      <header className="mt-8 lg:mt-0">
+        <p className={cn(mono, "text-foreground/35 tabular-nums")}>
+          {String(element.index).padStart(2, "0")} /{" "}
+          {String(ELEMENT_COUNT).padStart(2, "0")} · {element.section}
+        </p>
+        <h1 className="mt-3 text-2xl font-medium tracking-tight md:text-3xl">
+          {element.title}
+        </h1>
+        <p className="text-foreground/55 mt-3 max-w-lg text-[15px] leading-relaxed">
+          {element.description}
+        </p>
+      </header>
+
+      {element.variants ? (
+        <DemoVariants
+          variants={element.variants}
+          replay={element.replay !== false}
+        />
+      ) : (
+        <div className={cn(demoCanvasClass, "mt-8 h-[400px]")}>
+          <DemoStage replay={element.replay !== false}>
+            <element.Component />
+          </DemoStage>
+        </div>
+      )}
+
+      <section className="mt-12">
+        <InstallCommand registryName={registryName} />
+      </section>
+
+      {doc && highlightedUsage && (
+        <section className="mt-12">
+          <SectionHeading title="Usage" copyText={doc.usage} />
+          <CodeSurface html={highlightedUsage} />
+        </section>
+      )}
+
+      {doc && doc.props.length > 0 && (
+        <section className="mt-12">
+          <SectionHeading title="Props" />
+          {doc.props.map((table) => (
+            <div key={table.component} className="mt-4">
+              {doc.props.length > 1 && (
+                <p className={cn(mono, "text-foreground/40 mb-2")}>
+                  {table.component}
+                </p>
+              )}
+              <div className="bg-foreground/[0.025] dark:bg-foreground/[0.04] overflow-hidden rounded-2xl">
+                <div
+                  className={cn(
+                    mono,
+                    "text-foreground/35 hidden items-baseline gap-4 px-5 pt-3.5 pb-2 md:flex",
+                  )}
+                >
+                  <span className="w-36 shrink-0">Prop</span>
+                  <span className="w-40 shrink-0">Type</span>
+                  <span className="hidden w-20 shrink-0 md:block">Default</span>
+                  <span className="flex-1">Description</span>
+                </div>
+                <div className="bg-foreground/[0.06] mx-5 hidden h-px md:block" />
+                {table.rows.map((row) => (
+                  <div
+                    key={row.name}
+                    className="hover:bg-foreground/[0.02] flex flex-col gap-1 px-5 py-3 text-[13px] transition-colors md:flex-row md:items-baseline md:gap-4"
+                  >
+                    <span className="shrink-0 font-mono text-[12.5px] font-medium md:w-36">
+                      {row.name}
+                      {row.required && (
+                        <span
+                          className="ms-0.5 text-blue-500 dark:text-blue-400"
+                          title="Required"
+                        >
+                          *
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-foreground/45 shrink-0 font-mono text-[12px] break-words md:w-40">
+                      {row.type}
+                    </span>
+                    <span className="text-foreground/35 hidden w-20 shrink-0 font-mono text-[12px] md:block">
+                      {row.defaultValue ?? "–"}
+                    </span>
+                    <span className="text-foreground/55 flex-1 leading-relaxed">
+                      {row.description}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      <section className="mt-12">
+        <SectionHeading title="Source" meta={element.file} copyText={source} />
+        <CodeSurface html={highlightedSource} />
+      </section>
+
+      <nav className="border-foreground/10 mt-16 flex items-center justify-between gap-4 border-t border-dashed pt-6">
+        {previous ? (
+          <Link
+            href={`/elements/${previous.slug}`}
+            scroll={false}
+            className="group text-foreground/45 hover:text-foreground/90 flex items-center gap-2 text-[13px] transition-colors"
+          >
+            <ArrowLeftIcon className="size-3.5 transition-transform group-hover:-translate-x-0.5" />
+            <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+              {String(previous.index).padStart(2, "0")}
+            </span>
+            {previous.title}
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link
+            href={`/elements/${next.slug}`}
+            scroll={false}
+            className="group text-foreground/45 hover:text-foreground/90 flex items-center gap-2 text-[13px] transition-colors"
+          >
+            <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+              {String(next.index).padStart(2, "0")}
+            </span>
+            {next.title}
+            <ArrowRightIcon className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </>
+  );
+}

--- a/apps/docs/app/(home)/elements/(detail)/layout.tsx
+++ b/apps/docs/app/(home)/elements/(detail)/layout.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { ArrowLeftIcon } from "lucide-react";
+import { ElementsSidebar } from "@/components/elements/elements-sidebar";
+import { ScrollReset } from "@/components/elements/scroll-reset";
+
+export default function ElementDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-20 pb-32 md:pt-24">
+      <ScrollReset />
+      <div className="lg:grid lg:grid-cols-[210px_minmax(0,1fr)] lg:gap-14">
+        <ElementsSidebar />
+        <article className="min-w-0">
+          <Link
+            href="/elements"
+            className="text-foreground/45 hover:text-foreground/90 inline-flex items-center gap-1.5 text-[13px] transition-colors lg:hidden"
+          >
+            <ArrowLeftIcon className="size-3.5" />
+            Elements
+          </Link>
+          {children}
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/app/(home)/elements/page.tsx
+++ b/apps/docs/app/(home)/elements/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from "next";
+import { createOgMetadata } from "@/lib/og";
+import { DemoCard } from "@/components/elements/demo-card";
+import {
+  ELEMENT_COUNT,
+  ELEMENT_SECTIONS,
+} from "@/components/elements/registry";
+
+const title = "Elements";
+const description = `${ELEMENT_COUNT} interface pieces for AI products: reasoning, tool calls, approvals, artifacts, and the composer itself. Every demo is live, every element ships its source.`;
+
+export const metadata: Metadata = {
+  title,
+  description,
+  ...createOgMetadata(title, description),
+};
+
+export default function ElementsPage() {
+  let runningIndex = 0;
+
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 pt-24 pb-32 md:pt-32">
+      <header className="max-w-xl">
+        <p className="text-foreground/35 font-mono text-[11px] tracking-tight">
+          Elements
+        </p>
+        <h1 className="mt-4 text-3xl font-medium tracking-tight text-balance md:text-4xl">
+          Every state an assistant can be in.
+        </h1>
+        <p className="text-foreground/55 mt-4 max-w-md text-[15px] leading-relaxed">
+          {ELEMENT_COUNT} interface pieces for AI products: reasoning, tool
+          calls, approvals, artifacts, and the composer itself. Every demo is
+          live; open any element for its source.
+        </p>
+      </header>
+
+      <div className="mt-20 flex flex-col gap-20 md:mt-24">
+        {ELEMENT_SECTIONS.map((section, sectionIndex) => (
+          <section
+            key={section.label}
+            className="border-foreground/10 border-t border-dashed pt-8"
+          >
+            <div className="flex items-baseline gap-3">
+              <span className="text-foreground/30 font-mono text-[11px] tracking-tight tabular-nums">
+                {String(sectionIndex + 1).padStart(2, "0")}
+              </span>
+              <h2 className="text-sm font-medium">{section.label}</h2>
+              <span className="text-foreground/35 ms-auto font-mono text-[11px] tracking-tight tabular-nums">
+                {section.elements.length} elements
+              </span>
+            </div>
+            <div className="mt-8 grid gap-x-8 gap-y-14 md:grid-cols-2">
+              {section.elements.map((element) => {
+                runningIndex += 1;
+                return (
+                  <DemoCard
+                    key={element.slug}
+                    href={`/elements/${element.slug}`}
+                    index={runningIndex}
+                    title={element.title}
+                    description={element.description}
+                    {...(element.wide ? { wide: true } : {})}
+                  >
+                    <element.Component />
+                  </DemoCard>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import { source, getTapDocsPages, blog, examples, careers } from "@/lib/source";
+import { ELEMENTS } from "@/components/elements/registry";
 import { DEMOS } from "@/lib/demos";
 import { GALLERY_TEMPLATES } from "@/lib/gallery-templates";
 import { BASE_URL, PRODUCTS } from "@/lib/constants";
@@ -11,6 +12,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: `${BASE_URL}/careers`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${BASE_URL}/pricing`, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE_URL}/showcase`, changeFrequency: "weekly", priority: 0.7 },
+    {
+      url: `${BASE_URL}/elements`,
+      changeFrequency: "weekly",
+      priority: 0.7,
+    },
     { url: `${BASE_URL}/gallery`, changeFrequency: "weekly", priority: 0.7 },
     {
       url: `${BASE_URL}/gallery/components`,
@@ -68,6 +74,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     }));
 
+  const elementPages: MetadataRoute.Sitemap = ELEMENTS.map((element) => ({
+    url: `${BASE_URL}/elements/${element.slug}`,
+    changeFrequency: "weekly" as const,
+    priority: 0.6,
+  }));
+
   const demoPages: MetadataRoute.Sitemap = DEMOS.map((demo) => ({
     url: `${BASE_URL}/demos/${demo.slug}`,
     changeFrequency: "monthly" as const,
@@ -96,6 +108,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...tapDocsPages,
     ...blogPages,
     ...examplePages,
+    ...elementPages,
     ...demoPages,
     ...galleryPages,
     ...careerPages,

--- a/apps/docs/components/elements/agent-plan-demo.tsx
+++ b/apps/docs/components/elements/agent-plan-demo.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { AgentPlan } from "@/components/elements/agent-plan";
+import { useStoryPhases } from "./use-demo";
+
+const STEPS = [
+  "Read existing composer state",
+  "Design the draft store",
+  "Wire runtime persistence",
+  "Add regression tests",
+  "Update the docs",
+] as const;
+
+const PHASES = [1900, 1900, 1900, 1900, 1900, 2400] as const;
+
+export function AgentPlanDemo() {
+  const { phase } = useStoryPhases(PHASES);
+
+  return <AgentPlan steps={STEPS} activeIndex={phase} />;
+}

--- a/apps/docs/components/elements/agent-status-demo.tsx
+++ b/apps/docs/components/elements/agent-status-demo.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import {
+  AgentStatus,
+  type StatusStep,
+} from "@/components/elements/agent-status";
+import { formatSeconds, useElapsed, useStoryPhases } from "./use-demo";
+
+const PHASES = [3200, 2400, 2600, 3000] as const;
+const STEPS: StatusStep[] = [
+  { state: "working", label: "Refactoring composer" },
+  { state: "waiting", label: "Waiting for approval" },
+  { state: "working", label: "Running tests" },
+  { state: "done", label: "Finished, 2 files changed" },
+];
+
+export function AgentStatusDemo() {
+  const { phase, running } = useStoryPhases(PHASES);
+  const step = STEPS[phase]!;
+  const elapsed = useElapsed(running && step.state !== "done");
+
+  return (
+    <AgentStatus
+      state={step.state}
+      label={step.label}
+      elapsed={formatSeconds(elapsed)}
+    />
+  );
+}

--- a/apps/docs/components/elements/approval-card-demo.tsx
+++ b/apps/docs/components/elements/approval-card-demo.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ApprovalCard,
+  type ApprovalState,
+} from "@/components/elements/approval-card";
+
+export function ApprovalCardDemo() {
+  const [state, setState] = useState<ApprovalState>("request");
+
+  useEffect(() => {
+    if (state === "request") return;
+    const delay = state === "running" ? 1800 : state === "done" ? 2400 : 1600;
+    const id = setTimeout(() => {
+      setState(state === "running" ? "done" : "request");
+    }, delay);
+    return () => clearTimeout(id);
+  }, [state]);
+
+  return (
+    <ApprovalCard
+      state={state}
+      command="pnpm vitest run --changed"
+      title="Run command"
+      subtitle="The agent wants to run a shell command"
+      onAllowOnce={() => setState("running")}
+      onAlwaysAllow={() => setState("running")}
+      onDeny={() => setState("denied")}
+    />
+  );
+}

--- a/apps/docs/components/elements/artifact-card-demo.tsx
+++ b/apps/docs/components/elements/artifact-card-demo.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ArtifactCard } from "@/components/elements/artifact-card";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const PHASES = [3200, 2800] as const;
+const MAX_WORDS = 214;
+
+export function ArtifactCardDemo() {
+  const { phase } = useStoryPhases(PHASES);
+  const generating = phase === 0;
+  const tenths = useElapsed(generating);
+  const words = Math.min(MAX_WORDS, Math.floor((tenths * MAX_WORDS) / 32));
+
+  return (
+    <ArtifactCard
+      title="Draft persistence RFC"
+      meta="Document · v3 · just now"
+      generating={generating}
+      words={words}
+    />
+  );
+}

--- a/apps/docs/components/elements/canvas.ts
+++ b/apps/docs/components/elements/canvas.ts
@@ -1,0 +1,2 @@
+export const demoCanvasClass =
+  "bg-foreground/[0.025] dark:bg-foreground/[0.04] flex items-center justify-center overflow-hidden rounded-[24px] p-6 md:p-10";

--- a/apps/docs/components/elements/chat-panel-demo.tsx
+++ b/apps/docs/components/elements/chat-panel-demo.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ChatPanel } from "@/components/elements/chat-panel";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const USER_MESSAGE = "Why did my draft disappear?";
+const REPLY =
+  "Drafts were living in component state, so switching threads reset them. The runtime now keys every draft by thread id and restores it when you come back.";
+const PHASES = [1400, 1500, 3400, 2800] as const;
+
+export function ChatPanelDemo() {
+  const { phase, running } = useStoryPhases(PHASES);
+  const streamTenths = useElapsed(running && phase === 2);
+  const words = REPLY.split(" ");
+  const visibleWords =
+    phase < 2
+      ? 0
+      : phase === 2
+        ? Math.min(Math.floor(streamTenths * 0.9), words.length)
+        : words.length;
+
+  return (
+    <ChatPanel
+      userMessage={USER_MESSAGE}
+      reply={REPLY}
+      showUserMessage
+      typing={running && phase === 1}
+      visibleWords={visibleWords}
+      streaming={running && phase === 2 && visibleWords < words.length}
+    />
+  );
+}

--- a/apps/docs/components/elements/code-diff-demo.tsx
+++ b/apps/docs/components/elements/code-diff-demo.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { CodeDiff, type DiffLine } from "@/components/elements/code-diff";
+
+const LINES: DiffLine[] = [
+  { kind: "context", text: "export function Composer() {" },
+  { kind: "context", text: "  const threadId = useThreadId();" },
+  { kind: "context", text: "  const composer = useComposer();" },
+  { kind: "removed", text: '  const [draft, setDraft] = useState("");' },
+  { kind: "added", text: "  const draft = useDraft(threadId);" },
+  {
+    kind: "added",
+    text: "  useEffect(() => hydrate(draft), [threadId]);",
+  },
+  { kind: "context", text: "  return (" },
+  { kind: "context", text: "    <form onSubmit={composer.send}>" },
+  { kind: "context", text: "      {/* … */}" },
+];
+
+export function CodeDiffDemo() {
+  return (
+    <CodeDiff
+      filename="composer.tsx"
+      additions={2}
+      deletions={1}
+      lines={LINES}
+      cycle={0}
+    />
+  );
+}

--- a/apps/docs/components/elements/composer-attachments-demo.tsx
+++ b/apps/docs/components/elements/composer-attachments-demo.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Composer,
+  type ComposerAttachment,
+} from "@/components/elements/composer";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const PHASES = [2400, 2400, 3000, 0] as const;
+
+export function ComposerAttachmentsDemo() {
+  const { phase, running } = useStoryPhases(PHASES);
+  const [value, setValue] = useState("");
+  const [removed, setRemoved] = useState<string[]>([]);
+  const tenths = useElapsed(running && phase < 2);
+
+  const progressA = Math.min(96, tenths * 4.5);
+  const progressB = Math.min(96, Math.max(0, (tenths - 24) * 4.5));
+
+  const attachments: ComposerAttachment[] = [
+    {
+      name: "design-review.pdf",
+      meta: phase === 0 ? "Uploading" : "2.4 MB",
+      state: phase === 0 ? ("uploading" as const) : ("done" as const),
+      progress: progressA,
+      kind: "text" as const,
+    },
+    ...(phase >= 1
+      ? [
+          {
+            name: "screens.zip",
+            meta: phase === 1 ? "Uploading" : "18 MB",
+            state: phase === 1 ? ("uploading" as const) : ("done" as const),
+            progress: progressB,
+            kind: "archive" as const,
+          },
+        ]
+      : []),
+  ].filter((a) => !removed.includes(a.name));
+
+  return (
+    <Composer
+      value={value}
+      onValueChange={setValue}
+      onSend={() => setValue("")}
+      placeholder="Add a note for the review"
+      attachments={attachments}
+      {...(phase >= 2
+        ? {
+            onRemoveAttachment: (name: string) =>
+              setRemoved((r) => [...r, name]),
+          }
+        : {})}
+    />
+  );
+}

--- a/apps/docs/components/elements/composer-context-demo.tsx
+++ b/apps/docs/components/elements/composer-context-demo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+import { Composer } from "@/components/elements/composer";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const PHASES = [6000, 0] as const;
+
+export function ComposerContextDemo() {
+  const { phase, running } = useStoryPhases(PHASES);
+  const [value, setValue] = useState("");
+  const tenths = useElapsed(running && phase === 0);
+  const messages =
+    phase >= 1 ? 158 : Math.min(158, 4 + Math.round(tenths * 2.6));
+
+  return (
+    <Composer
+      value={value}
+      onValueChange={setValue}
+      onSend={() => setValue("")}
+      placeholder="Hover the ring for the breakdown"
+      usage={{ system: 12, tools: 8, messages, total: 200 }}
+    />
+  );
+}

--- a/apps/docs/components/elements/composer-demo.tsx
+++ b/apps/docs/components/elements/composer-demo.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  BookOpenIcon,
+  GitBranchIcon,
+  SearchIcon,
+  SparklesIcon,
+} from "lucide-react";
+import {
+  Composer,
+  type ComposerAttachment,
+  type ComposerCommand,
+  type ComposerModel,
+  type ComposerPerson,
+} from "@/components/elements/composer";
+import { useElapsed } from "./use-demo";
+
+const COMMANDS: ComposerCommand[] = [
+  { name: "review", description: "Review the current diff", icon: SearchIcon },
+  { name: "explain", description: "Explain the selection", icon: BookOpenIcon },
+  { name: "branch", description: "Start a new branch", icon: GitBranchIcon },
+  { name: "improve", description: "Suggest improvements", icon: SparklesIcon },
+];
+
+const PEOPLE: ComposerPerson[] = [
+  { name: "Mara", role: "human" },
+  { name: "Max", role: "agent" },
+  { name: "Aiden", role: "agent" },
+  { name: "Ana", role: "human" },
+];
+
+const MODELS: ComposerModel[] = [
+  { name: "Fable 5", meta: "1M ctx" },
+  { name: "Opus 5", meta: "400k ctx" },
+  { name: "Haiku 4.5", meta: "200k ctx" },
+];
+
+const TRANSCRIPT = "Summarize the review threads from this week";
+
+export function ComposerDemo() {
+  const [value, setValue] = useState("");
+  const [model, setModel] = useState("Fable 5");
+  const [removed, setRemoved] = useState<string[]>([]);
+  const [voice, setVoice] = useState<"idle" | "recording" | "transcribing">(
+    "idle",
+  );
+  const elapsedTenths = useElapsed(voice === "recording");
+  const settle = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(settle.current), []);
+
+  const attachments: ComposerAttachment[] = [
+    {
+      name: "screenshot.png",
+      meta: "128 KB",
+      state: "done" as const,
+      kind: "image" as const,
+    },
+  ].filter((a) => !removed.includes(a.name));
+
+  return (
+    <div className="flex w-full max-w-lg flex-col">
+      <div aria-hidden className="h-40" />
+      <Composer
+        value={value}
+        onValueChange={setValue}
+        onSend={() => setValue("")}
+        attachments={attachments}
+        onRemoveAttachment={(name) => setRemoved((r) => [...r, name])}
+        commands={COMMANDS}
+        people={PEOPLE}
+        models={MODELS}
+        model={model}
+        onModelChange={setModel}
+        usage={{ system: 12, tools: 8, messages: 54, total: 200 }}
+        recording={voice === "recording"}
+        transcribing={voice === "transcribing"}
+        recordingSeconds={Math.floor(elapsedTenths / 10)}
+        onVoiceStart={() => setVoice("recording")}
+        onVoiceStop={() => {
+          setVoice("transcribing");
+          settle.current = setTimeout(() => {
+            setVoice("idle");
+            setValue((v) => (v ? `${v} ${TRANSCRIPT}` : TRANSCRIPT));
+          }, 1400);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/composer-mentions-demo.tsx
+++ b/apps/docs/components/elements/composer-mentions-demo.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { Composer, type ComposerPerson } from "@/components/elements/composer";
+
+const PEOPLE: ComposerPerson[] = [
+  { name: "Mara", role: "human" },
+  { name: "Max", role: "agent" },
+  { name: "Aiden", role: "agent" },
+  { name: "Ana", role: "human" },
+];
+
+export function ComposerMentionsDemo() {
+  const [value, setValue] = useState("Ask @");
+
+  return (
+    <div className="flex w-full max-w-lg flex-col">
+      <div aria-hidden className="h-44" />
+      <Composer
+        value={value}
+        onValueChange={setValue}
+        onSend={() => setValue("")}
+        placeholder="Type @ to mention"
+        people={PEOPLE}
+      />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/composer-models-demo.tsx
+++ b/apps/docs/components/elements/composer-models-demo.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { Composer, type ComposerModel } from "@/components/elements/composer";
+
+const MODELS: ComposerModel[] = [
+  { name: "Fable 5", meta: "1M ctx" },
+  { name: "Opus 5", meta: "400k ctx" },
+  { name: "Haiku 4.5", meta: "200k ctx" },
+];
+
+export function ComposerModelsDemo() {
+  const [value, setValue] = useState("");
+  const [model, setModel] = useState("Fable 5");
+
+  return (
+    <div className="flex w-full max-w-lg flex-col">
+      <div aria-hidden className="h-40" />
+      <Composer
+        value={value}
+        onValueChange={setValue}
+        onSend={() => setValue("")}
+        models={MODELS}
+        model={model}
+        onModelChange={setModel}
+        defaultModelMenuOpen
+      />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/composer-slash-demo.tsx
+++ b/apps/docs/components/elements/composer-slash-demo.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import {
+  BookOpenIcon,
+  GitBranchIcon,
+  SearchIcon,
+  SparklesIcon,
+} from "lucide-react";
+import { Composer, type ComposerCommand } from "@/components/elements/composer";
+
+const COMMANDS: ComposerCommand[] = [
+  { name: "review", description: "Review the current diff", icon: SearchIcon },
+  { name: "explain", description: "Explain the selection", icon: BookOpenIcon },
+  { name: "branch", description: "Start a new branch", icon: GitBranchIcon },
+  { name: "improve", description: "Suggest improvements", icon: SparklesIcon },
+];
+
+export function ComposerSlashDemo() {
+  const [value, setValue] = useState("/");
+
+  return (
+    <div className="flex w-full max-w-lg flex-col">
+      <div aria-hidden className="h-44" />
+      <Composer
+        value={value}
+        onValueChange={setValue}
+        onSend={() => setValue("")}
+        placeholder="Type / for commands"
+        commands={COMMANDS}
+      />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/composer-voice-demo.tsx
+++ b/apps/docs/components/elements/composer-voice-demo.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Composer } from "@/components/elements/composer";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const PHASES = [1400, 3600, 1600, 3000, 0] as const;
+const TRANSCRIPT = "Add a regression test for draft restore";
+
+export function ComposerVoiceDemo() {
+  const { phase, running, takeOver } = useStoryPhases(PHASES);
+  const [value, setValue] = useState("");
+  const elapsedTenths = useElapsed(running && phase === 1);
+
+  useEffect(() => {
+    if (phase >= 3) setValue(TRANSCRIPT);
+  }, [phase]);
+
+  return (
+    <Composer
+      value={value}
+      onValueChange={(v) => {
+        takeOver();
+        setValue(v);
+      }}
+      onSend={() => setValue("")}
+      recording={running && phase === 1}
+      transcribing={running && phase === 2}
+      recordingSeconds={Math.floor(elapsedTenths / 10)}
+      onVoiceStart={takeOver}
+      onVoiceStop={takeOver}
+    />
+  );
+}

--- a/apps/docs/components/elements/copy-button.tsx
+++ b/apps/docs/components/elements/copy-button.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  ghostButton,
+  iconSwap,
+  iconSwapIn,
+  iconSwapOut,
+} from "@/components/elements/surfaces";
+
+export function CopyButton({
+  text,
+  className,
+}: {
+  text: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const id = setTimeout(() => setCopied(false), 1600);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  return (
+    <button
+      type="button"
+      aria-label={copied ? "Copied" : "Copy source"}
+      onClick={() => {
+        void navigator.clipboard.writeText(text);
+        setCopied(true);
+      }}
+      className={cn(
+        ghostButton,
+        "grid size-7 place-items-center",
+        copied && "text-emerald-500",
+        className,
+      )}
+    >
+      <CopyIcon
+        className={cn(iconSwap, "size-3.5", copied ? iconSwapOut : iconSwapIn)}
+      />
+      <CheckIcon
+        className={cn(iconSwap, "size-3.5", copied ? iconSwapIn : iconSwapOut)}
+      />
+    </button>
+  );
+}

--- a/apps/docs/components/elements/data-table-demo.tsx
+++ b/apps/docs/components/elements/data-table-demo.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { DataTable, type ModelUsage } from "@/components/elements/data-table";
+
+const MODEL_USAGE = [
+  { name: "Sonnet 4.5", context: "200k", cost: "$3.00" },
+  { name: "GPT-5", context: "400k", cost: "$5.00" },
+  { name: "Haiku 4.5", context: "200k", cost: "$0.80" },
+] as const satisfies readonly ModelUsage[];
+
+export function DataTableDemo() {
+  return <DataTable rows={MODEL_USAGE} cycle={0} />;
+}

--- a/apps/docs/components/elements/demo-card.tsx
+++ b/apps/docs/components/elements/demo-card.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { ArrowUpRightIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { inkButton, mono } from "@/components/elements/surfaces";
+
+export function DemoCard({
+  href,
+  index,
+  title,
+  description,
+  wide = false,
+  children,
+}: {
+  href: string;
+  index: number;
+  title: string;
+  description: string;
+  wide?: boolean;
+  children: React.ReactNode;
+}) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setMounted(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "240px 0px" },
+    );
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn("group flex flex-col", wide && "md:col-span-2")}
+    >
+      <div className="group/canvas bg-foreground/[0.025] dark:bg-foreground/[0.04] relative flex h-[360px] items-center justify-center overflow-hidden rounded-[20px] p-6 md:p-10">
+        {mounted ? (
+          <div className="flex h-full w-full items-center justify-center">
+            {children}
+          </div>
+        ) : null}
+        <Link
+          href={href}
+          aria-hidden
+          tabIndex={-1}
+          className="absolute inset-0 z-[5] pointer-fine:hidden"
+        />
+        <div className="bg-background/55 pointer-events-none absolute inset-0 z-10 flex items-center justify-center opacity-0 backdrop-blur-[2px] transition-opacity duration-200 group-focus-within/canvas:opacity-100 group-hover/canvas:opacity-100 motion-reduce:transition-none">
+          <Link
+            href={href}
+            aria-label={`View ${title}`}
+            className={cn(
+              inkButton,
+              "pointer-events-auto flex h-8 scale-[0.96] items-center gap-1.5 rounded-full px-4 text-[12.5px] font-medium group-hover/canvas:scale-100",
+            )}
+          >
+            View
+            <ArrowUpRightIcon className="size-3.5" />
+          </Link>
+        </div>
+      </div>
+      <Link href={href} className="group/link mt-4 flex items-baseline gap-2.5">
+        <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+          {String(index).padStart(2, "0")}
+        </span>
+        <h3 className="text-[13.5px] font-medium group-hover/link:underline group-hover/link:underline-offset-4">
+          {title}
+        </h3>
+      </Link>
+      <p className="text-foreground/50 mt-1 text-[13px] leading-relaxed">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/apps/docs/components/elements/demo-stage.tsx
+++ b/apps/docs/components/elements/demo-stage.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { createContext, useCallback, useMemo, useState } from "react";
+import { PauseIcon, RotateCcwIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  ghostButton,
+  iconSwap,
+  iconSwapIn,
+  iconSwapOut,
+} from "@/components/elements/surfaces";
+
+export interface DemoStageControls {
+  stopped: boolean;
+  setPlaying: (playing: boolean) => void;
+}
+
+export const DemoStageContext = createContext<DemoStageControls | null>(null);
+
+export function DemoStage({
+  replay = true,
+  children,
+}: {
+  replay?: boolean;
+  children: React.ReactNode;
+}) {
+  const [epoch, setEpoch] = useState(0);
+  const [stopped, setStopped] = useState(false);
+  const [playing, setPlaying] = useState(true);
+
+  const report = useCallback((next: boolean) => setPlaying(next), []);
+  const controls = useMemo(
+    () => ({ stopped, setPlaying: report }),
+    [stopped, report],
+  );
+
+  if (!replay) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        {children}
+      </div>
+    );
+  }
+
+  const showPause = playing && !stopped;
+
+  return (
+    <div className="relative flex h-full w-full items-center justify-center">
+      <DemoStageContext.Provider value={controls}>
+        <div
+          key={epoch}
+          className="flex h-full w-full items-center justify-center"
+        >
+          {children}
+        </div>
+      </DemoStageContext.Provider>
+      <button
+        type="button"
+        aria-label={showPause ? "Pause animation" : "Replay animation"}
+        onClick={() => {
+          if (showPause) {
+            setStopped(true);
+          } else {
+            setEpoch((e) => e + 1);
+            setStopped(false);
+            setPlaying(true);
+          }
+        }}
+        className={cn(
+          ghostButton,
+          "absolute -end-3 -top-3 grid size-7 place-items-center md:-end-7 md:-top-7",
+        )}
+      >
+        <PauseIcon
+          className={cn(
+            iconSwap,
+            "size-3.5",
+            showPause ? iconSwapIn : iconSwapOut,
+          )}
+        />
+        <RotateCcwIcon
+          className={cn(
+            iconSwap,
+            "size-3.5",
+            showPause ? iconSwapOut : iconSwapIn,
+          )}
+        />
+      </button>
+    </div>
+  );
+}

--- a/apps/docs/components/elements/demo-variants.tsx
+++ b/apps/docs/components/elements/demo-variants.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { demoCanvasClass } from "./canvas";
+import { DemoStage } from "./demo-stage";
+import type { ElementVariant } from "./registry";
+
+export function DemoVariants({
+  variants,
+  replay,
+}: {
+  variants: ElementVariant[];
+  replay: boolean;
+}) {
+  const [key, setKey] = useState(variants[0]!.key);
+  const active =
+    variants.find((variant) => variant.key === key) ?? variants[0]!;
+
+  return (
+    <div className={cn(demoCanvasClass, "mt-8 h-[400px] flex-col")}>
+      <div className="flex min-h-0 w-full flex-1 items-center justify-center">
+        <DemoStage key={active.key} replay={replay}>
+          <active.Component />
+        </DemoStage>
+      </div>
+      <div className="-mb-3 flex flex-wrap justify-center gap-1 pt-4 md:-mb-7">
+        {variants.map((variant) => {
+          const selected = variant.key === active.key;
+          return (
+            <button
+              key={variant.key}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => setKey(variant.key)}
+              className={cn(
+                "h-7 rounded-full px-3 text-[12.5px] transition-[color,background-color,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] motion-reduce:transition-none",
+                selected
+                  ? "bg-foreground/[0.05] text-foreground dark:bg-foreground/[0.08] font-medium"
+                  : "text-foreground/45 hover:text-foreground/90",
+              )}
+            >
+              {variant.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/elements/element-docs.ts
+++ b/apps/docs/components/elements/element-docs.ts
@@ -1,0 +1,2008 @@
+export interface ElementPropRow {
+  name: string;
+  type: string;
+  required?: boolean;
+  defaultValue?: string;
+  description: string;
+}
+
+export interface ElementPropsTable {
+  component: string;
+  rows: ElementPropRow[];
+}
+
+export interface ElementDoc {
+  usage: string;
+  props: ElementPropsTable[];
+}
+
+export const ELEMENT_DOCS: Record<string, ElementDoc> = {
+  "loading-state": {
+    usage: `import { GenerationLoader } from "@/components/elements/loading-state";
+
+<GenerationLoader label="Generating" tick={24} />`,
+    props: [
+      {
+        component: "GenerationLoader",
+        rows: [
+          {
+            name: "label",
+            type: "string",
+            required: true,
+            description:
+              "Status copy shown under the pixel grid while the model has nothing else to show.",
+          },
+          {
+            name: "tick",
+            type: "number",
+            required: true,
+            description:
+              "Animation clock that advances the pixel pattern and the elapsed seconds counter.",
+          },
+          {
+            name: "variant",
+            type: '"dots" | "squares" | "rounded"',
+            defaultValue: '"dots"',
+            description: "Cell shape of the pixel matrix.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "thinking-indicator": {
+    usage: `import { ThinkingIndicator } from "@/components/elements/thinking-indicator";
+
+<ThinkingIndicator label="Reading thread.tsx" elapsed="12s" />`,
+    props: [
+      {
+        component: "ThinkingIndicator",
+        rows: [
+          {
+            name: "label",
+            type: "string",
+            required: true,
+            description:
+              "What the agent is doing right now. Swapping it replays the entrance animation.",
+          },
+          {
+            name: "elapsed",
+            type: "string",
+            description:
+              "Elapsed time rendered in mono next to the label. Omit to hide the timer.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root row.",
+          },
+        ],
+      },
+    ],
+  },
+  "reasoning-panel": {
+    usage: `import { ReasoningPanel } from "@/components/elements/reasoning-panel";
+
+<ReasoningPanel
+  steps={[{ title: "Scope", body: "Find the failing path." }]}
+  visibleSteps={1}
+  streaming
+  open
+  onOpenChange={setOpen}
+  restingLabel="Reasoned for 4s"
+  elapsed="2s"
+/>`,
+    props: [
+      {
+        component: "ReasoningPanel",
+        rows: [
+          {
+            name: "steps",
+            type: "ReasoningStep[]",
+            required: true,
+            description: "Full list of reasoning steps available to reveal.",
+          },
+          {
+            name: "visibleSteps",
+            type: "number",
+            required: true,
+            description:
+              "How many steps from the start are currently shown on the timeline.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the trigger shows a shimmering Thinking label and the active step pulses.",
+          },
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description: "Whether the collapsible step list is expanded.",
+          },
+          {
+            name: "onOpenChange",
+            type: "(open: boolean) => void",
+            required: true,
+            description: "Called when the user expands or collapses the panel.",
+          },
+          {
+            name: "restingLabel",
+            type: "string",
+            required: true,
+            description:
+              "Trigger label once streaming finishes, for example a summary of how long it thought.",
+          },
+          {
+            name: "elapsed",
+            type: "string",
+            description:
+              "Elapsed timer shown next to Thinking while streaming. Omit to hide it.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "streaming-text": {
+    usage: `import { StreamingText } from "@/components/elements/streaming-text";
+
+<StreamingText
+  segments={[{ text: "Hello world" }, { text: "thread.tsx", mono: true }]}
+  count={3}
+  streaming
+/>`,
+    props: [
+      {
+        component: "StreamingText",
+        rows: [
+          {
+            name: "segments",
+            type: "Segment[]",
+            required: true,
+            description:
+              "Text chunks to stream, optionally marked mono for inline code chips.",
+          },
+          {
+            name: "count",
+            type: "number",
+            required: true,
+            description:
+              "How many words from the flattened segments are visible.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the newest words tint blue and a caret blinks at the end.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "typing-indicator": {
+    usage: `import { TypingIndicator } from "@/components/elements/typing-indicator";
+
+<TypingIndicator />`,
+    props: [
+      {
+        component: "TypingIndicator",
+        rows: [
+          {
+            name: "variant",
+            type: '"bubble" | "bare"',
+            defaultValue: '"bubble"',
+            description:
+              "bubble wraps the dots in a pill; bare renders only the three dots.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "message-pair": {
+    usage: `import { MessagePair } from "@/components/elements/message-pair";
+
+<MessagePair
+  userMessage="Explain the composer."
+  words={["Here", "is", "a", "short", "reply."]}
+  visibleWords={5}
+  streaming={false}
+/>`,
+    props: [
+      {
+        component: "MessagePair",
+        rows: [
+          {
+            name: "userMessage",
+            type: "string",
+            required: true,
+            description: "Text shown in the user bubble on the right.",
+          },
+          {
+            name: "words",
+            type: "readonly string[]",
+            required: true,
+            description: "Assistant reply broken into words for streaming.",
+          },
+          {
+            name: "visibleWords",
+            type: "number",
+            required: true,
+            description: "How many assistant words are currently visible.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the newest assistant words tint blue as they arrive.",
+          },
+          {
+            name: "variant",
+            type: '"bubble" | "flat"',
+            defaultValue: '"bubble"',
+            description:
+              "bubble wraps the user message in a surface; flat renders it as plain right-aligned text.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "message-branches": {
+    usage: `import { MessageBranches } from "@/components/elements/message-branches";
+
+<MessageBranches
+  variants={["First answer.", "Second answer."]}
+  index={0}
+  onIndexChange={setIndex}
+/>`,
+    props: [
+      {
+        component: "MessageBranches",
+        rows: [
+          {
+            name: "variants",
+            type: "readonly string[]",
+            required: true,
+            description:
+              "Alternate regenerated answers the user can step through.",
+          },
+          {
+            name: "index",
+            type: "number",
+            required: true,
+            description: "Which variant is currently displayed.",
+          },
+          {
+            name: "onIndexChange",
+            type: "(index: number) => void",
+            required: true,
+            description:
+              "Called when the previous or next branch control is pressed.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "message-actions": {
+    usage: `import { MessageActions } from "@/components/elements/message-actions";
+
+<MessageActions
+  copied={false}
+  reaction={null}
+  regenerating={false}
+  onCopy={() => {}}
+  onReactionChange={setReaction}
+  onRegenerate={() => {}}
+  onMore={() => {}}
+/>`,
+    props: [
+      {
+        component: "MessageActions",
+        rows: [
+          {
+            name: "copied",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the copy button shows a green check confirmation.",
+          },
+          {
+            name: "reaction",
+            type: "Reaction",
+            required: true,
+            description:
+              "Active thumbs reaction, or null when none is selected.",
+          },
+          {
+            name: "regenerating",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the regenerate icon spins to show work in progress.",
+          },
+          {
+            name: "onCopy",
+            type: "() => void",
+            required: true,
+            description: "Called when the copy control is pressed.",
+          },
+          {
+            name: "onReactionChange",
+            type: "(reaction: Reaction) => void",
+            required: true,
+            description:
+              "Called when the user toggles thumbs up or thumbs down.",
+          },
+          {
+            name: "onRegenerate",
+            type: "() => void",
+            required: true,
+            description: "Called when the regenerate control is pressed.",
+          },
+          {
+            name: "onMore",
+            type: "() => void",
+            required: true,
+            description: "Called when the overflow menu control is pressed.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  suggestions: {
+    usage: `import { Suggestions } from "@/components/elements/suggestions";
+
+<Suggestions
+  suggestions={["Explain more", "Show an example"]}
+  selectedSuggestion={null}
+  cycle={0}
+  onSuggestion={setSelected}
+/>`,
+    props: [
+      {
+        component: "Suggestions",
+        rows: [
+          {
+            name: "suggestions",
+            type: "readonly string[]",
+            required: true,
+            description: "Follow-up prompt pills rendered in order.",
+          },
+          {
+            name: "selectedSuggestion",
+            type: "string | null",
+            required: true,
+            description:
+              "The pill currently pressed, or null when none is selected.",
+          },
+          {
+            name: "cycle",
+            type: "number",
+            required: true,
+            description:
+              "Identity key that remounts the row so the stagger entrance can replay.",
+          },
+          {
+            name: "variant",
+            type: '"pills" | "list"',
+            defaultValue: '"pills"',
+            description:
+              "pills wraps suggestions into a centered row; list stacks them as full-width rows.",
+          },
+          {
+            name: "onSuggestion",
+            type: "(suggestion: string) => void",
+            required: true,
+            description: "Called when a suggestion pill is pressed.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "error-state": {
+    usage: `import { ErrorState } from "@/components/elements/error-state";
+
+<ErrorState
+  title="Request failed"
+  detail="The model timed out."
+  retrying={false}
+  onRetry={() => {}}
+/>`,
+    props: [
+      {
+        component: "ErrorState",
+        rows: [
+          {
+            name: "title",
+            type: "string",
+            required: true,
+            description: "Primary failure headline shown in the banner.",
+          },
+          {
+            name: "detail",
+            type: "string",
+            required: true,
+            description:
+              "Supporting detail under the title explaining what went wrong.",
+          },
+          {
+            name: "retrying",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the banner swaps to a spinning Retrying status instead of the error.",
+          },
+          {
+            name: "onRetry",
+            type: "() => void",
+            required: true,
+            description: "Called when the retry control is pressed.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "tool-call": {
+    usage: `import { ToolCall } from "@/components/elements/tool-call";
+
+<ToolCall
+  label="Searched"
+  activeLabel="Searching"
+  query="composer props"
+  request='{"q":"composer"}'
+  result='{"hits":2}'
+  running={false}
+  open
+  onOpenChange={setOpen}
+/>`,
+    props: [
+      {
+        component: "ToolCall",
+        rows: [
+          {
+            name: "activeLabel",
+            type: "string",
+            required: true,
+            description:
+              "Verb shown with a shimmer while the tool is running, for example Searching the docs.",
+          },
+          {
+            name: "label",
+            type: "string",
+            required: true,
+            description: "Tool name shown on the collapsed trigger row.",
+          },
+          {
+            name: "query",
+            type: "string",
+            required: true,
+            description:
+              "Short chip next to the label summarizing the call target.",
+          },
+          {
+            name: "request",
+            type: "string",
+            required: true,
+            description:
+              "Request payload shown inside the expanded disclosure.",
+          },
+          {
+            name: "result",
+            type: "string",
+            required: true,
+            description:
+              "Result payload shown once the call is no longer running.",
+          },
+          {
+            name: "running",
+            type: "boolean",
+            required: true,
+            description:
+              "When true a spinner replaces the success check on the trigger.",
+          },
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description: "Whether the request and result panel is expanded.",
+          },
+          {
+            name: "onOpenChange",
+            type: "(open: boolean) => void",
+            required: true,
+            description: "Called when the user expands or collapses the call.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "tool-timeline": {
+    usage: `import { FileSearchIcon } from "lucide-react";
+import { ToolTimeline } from "@/components/elements/tool-timeline";
+
+<ToolTimeline
+  steps={[{ verb: "Read", chip: "thread.tsx", icon: FileSearchIcon }]}
+  visibleSteps={1}
+  streaming
+  open
+  onOpenChange={setOpen}
+  restingLabel="Worked for 12s"
+  activeLabel="Working for 12s"
+  stats={[{ file: "thread.tsx", added: 4, removed: 1 }]}
+/>`,
+    props: [
+      {
+        component: "ToolTimeline",
+        rows: [
+          {
+            name: "steps",
+            type: "readonly TimelineStep[]",
+            required: true,
+            description:
+              "Working-session verbs, chips, and icons to reveal over time.",
+          },
+          {
+            name: "visibleSteps",
+            type: "number",
+            required: true,
+            description: "How many steps from the start are currently shown.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the trigger shows Working with a shimmer and elapsed timer.",
+          },
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description: "Whether the collapsible timeline body is expanded.",
+          },
+          {
+            name: "onOpenChange",
+            type: "(open: boolean) => void",
+            required: true,
+            description:
+              "Called when the user expands or collapses the timeline.",
+          },
+          {
+            name: "restingLabel",
+            type: "string",
+            required: true,
+            description: "Trigger label once streaming finishes.",
+          },
+          {
+            name: "activeLabel",
+            type: "string",
+            required: true,
+            description:
+              "Full-size live label while streaming, for example Working for 12s.",
+          },
+          {
+            name: "stats",
+            type: "TimelineStat[]",
+            required: true,
+            description:
+              "Per-file addition and removal counts listed under the steps.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "terminal-block": {
+    usage: `import { TerminalBlock } from "@/components/elements/terminal-block";
+
+<TerminalBlock
+  command="pnpm test"
+  lines={["PASS  thread.test.ts", "Tests: 2 passed"]}
+  visibleCount={2}
+  done
+/>`,
+    props: [
+      {
+        component: "TerminalBlock",
+        rows: [
+          {
+            name: "command",
+            type: "string",
+            required: true,
+            description: "Command string shown in the terminal header.",
+          },
+          {
+            name: "lines",
+            type: "readonly string[]",
+            required: true,
+            description: "Output lines available to stream into the body.",
+          },
+          {
+            name: "visibleCount",
+            type: "number",
+            required: true,
+            description:
+              "How many output lines from the start are currently shown.",
+          },
+          {
+            name: "variant",
+            type: '"paper" | "ink"',
+            defaultValue: '"paper"',
+            description:
+              "paper matches the surrounding surfaces; ink renders the classic dark terminal slab.",
+          },
+          {
+            name: "done",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the header shows exit 0; otherwise a spinner keeps spinning.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "code-diff": {
+    usage: `import { CodeDiff } from "@/components/elements/code-diff";
+
+<CodeDiff
+  filename="thread.tsx"
+  additions={2}
+  deletions={1}
+  lines={[
+    { kind: "removed", text: "const x = 1" },
+    { kind: "added", text: "const x = 2" },
+  ]}
+  cycle={0}
+/>`,
+    props: [
+      {
+        component: "CodeDiff",
+        rows: [
+          {
+            name: "filename",
+            type: "string",
+            required: true,
+            description: "File path shown in the diff header.",
+          },
+          {
+            name: "additions",
+            type: "number",
+            required: true,
+            description:
+              "Addition count rendered in green next to the filename.",
+          },
+          {
+            name: "deletions",
+            type: "number",
+            required: true,
+            description: "Deletion count rendered in red next to the filename.",
+          },
+          {
+            name: "lines",
+            type: "readonly DiffLine[]",
+            required: true,
+            description:
+              "Unified diff lines with context, added, or removed kind.",
+          },
+          {
+            name: "cycle",
+            type: "number",
+            required: true,
+            description:
+              "Identity key that remounts the body so entrance animation can replay.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "web-search": {
+    usage: `import { WebSearch } from "@/components/elements/web-search";
+
+<WebSearch
+  query="assistant-ui composer"
+  results={[{ title: "Composer guide", domain: "docs.example.com" }]}
+  visibleResults={1}
+  searching={false}
+  cycle={0}
+/>`,
+    props: [
+      {
+        component: "WebSearch",
+        rows: [
+          {
+            name: "query",
+            type: "string",
+            required: true,
+            description: "Search query shown in the query pill.",
+          },
+          {
+            name: "results",
+            type: "readonly WebSearchResult[]",
+            required: true,
+            description: "Result cards available to reveal one by one.",
+          },
+          {
+            name: "visibleResults",
+            type: "number",
+            required: true,
+            description: "How many results from the start are currently shown.",
+          },
+          {
+            name: "searching",
+            type: "boolean",
+            required: true,
+            description:
+              "When true a shimmering Searching label replaces the result count.",
+          },
+          {
+            name: "cycle",
+            type: "number",
+            required: true,
+            description:
+              "Identity key that remounts the list so entrance animation can replay.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  sources: {
+    usage: `import { Sources } from "@/components/elements/sources";
+
+<Sources
+  sources={[{ domain: "docs.example.com", title: "Composer guide" }]}
+  open
+  onOpenChange={setOpen}
+/>`,
+    props: [
+      {
+        component: "Sources",
+        rows: [
+          {
+            name: "sources",
+            type: "readonly Source[]",
+            required: true,
+            description:
+              "Citation cards revealed when the sources pill expands.",
+          },
+          {
+            name: "open",
+            type: "boolean",
+            required: true,
+            description: "Whether the source list is expanded under the pill.",
+          },
+          {
+            name: "onOpenChange",
+            type: "(open: boolean) => void",
+            required: true,
+            description:
+              "Called when the user expands or collapses the sources.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "inline-citation": {
+    usage: `import { InlineCitation } from "@/components/elements/inline-citation";
+
+<InlineCitation
+  sources={[
+    {
+      domain: "docs.example.com",
+      title: "Optimistic updates",
+      snippet: "Confirm writes after paint.",
+    },
+  ]}
+  openIndex={0}
+  onOpenIndexChange={setOpenIndex}
+/>`,
+    props: [
+      {
+        component: "InlineCitation",
+        rows: [
+          {
+            name: "sources",
+            type: "Source[]",
+            required: true,
+            description:
+              "Sources attached to the numbered reference markers in the sentence.",
+          },
+          {
+            name: "openIndex",
+            type: "number | null",
+            required: true,
+            description:
+              "Which citation preview is open, or null when none is open.",
+          },
+          {
+            name: "onOpenIndexChange",
+            type: "(index: number | null) => void",
+            required: true,
+            description:
+              "Called when a citation marker opens or closes its preview.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "image-generation": {
+    usage: `import { ImageGeneration } from "@/components/elements/image-generation";
+
+<ImageGeneration prompt="A calm blue abstract" generating={false} />`,
+    props: [
+      {
+        component: "ImageGeneration",
+        rows: [
+          {
+            name: "prompt",
+            type: "string",
+            required: true,
+            description: "Prompt text shown under the image frame.",
+          },
+          {
+            name: "generating",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the frame holds a pulsing dot grid; otherwise the image resolves.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "data-table": {
+    usage: `import { DataTable } from "@/components/elements/data-table";
+
+<DataTable
+  rows={[{ name: "Sonnet", context: "200k", cost: "$3" }]}
+  cycle={0}
+/>`,
+    props: [
+      {
+        component: "DataTable",
+        rows: [
+          {
+            name: "rows",
+            type: "readonly ModelUsage[]",
+            required: true,
+            description:
+              "Table rows with model name, context window, and cost.",
+          },
+          {
+            name: "cycle",
+            type: "number",
+            required: true,
+            description:
+              "Identity key that remounts the body so row entrance can replay.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "number-ticker": {
+    usage: `import { NumberTicker } from "@/components/elements/number-ticker";
+
+<NumberTicker value={1284} label="tokens / sec" />`,
+    props: [
+      {
+        component: "NumberTicker",
+        rows: [
+          {
+            name: "value",
+            type: "number",
+            required: true,
+            description:
+              "Numeric value whose digits roll into place as it changes.",
+          },
+          {
+            name: "label",
+            type: "string",
+            required: true,
+            description: "Mono caption rendered under the rolling number.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "agent-plan": {
+    usage: `import { AgentPlan } from "@/components/elements/agent-plan";
+
+<AgentPlan
+  steps={["Read the file", "Draft the fix", "Run tests"]}
+  activeIndex={1}
+/>`,
+    props: [
+      {
+        component: "AgentPlan",
+        rows: [
+          {
+            name: "steps",
+            type: "readonly string[]",
+            required: true,
+            description: "Checklist items the agent works through in order.",
+          },
+          {
+            name: "activeIndex",
+            type: "number",
+            required: true,
+            description:
+              "Index of the step currently running. Values past the end mark every step done.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "subagent-list": {
+    usage: `import { SubagentList } from "@/components/elements/subagent-list";
+
+<SubagentList
+  agents={[{ name: "Researcher", model: "Sonnet" }]}
+  completedCount={0}
+  progress={[40]}
+  showSummary={false}
+  summaryAgent={{ name: "Summarizer", model: "Haiku" }}
+/>`,
+    props: [
+      {
+        component: "SubagentList",
+        rows: [
+          {
+            name: "agents",
+            type: "readonly SubagentItem[]",
+            required: true,
+            description: "Parallel workers shown as cards with name and model.",
+          },
+          {
+            name: "completedCount",
+            type: "number",
+            required: true,
+            description: "How many agents from the start are marked complete.",
+          },
+          {
+            name: "progress",
+            type: "readonly number[]",
+            required: true,
+            description:
+              "Per-agent progress widths used while a worker is still running.",
+          },
+          {
+            name: "showSummary",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the summary agent card is revealed under the list.",
+          },
+          {
+            name: "summaryAgent",
+            type: "SubagentItem",
+            required: true,
+            description:
+              "Agent shown in the summary card once showSummary is true.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "agent-status": {
+    usage: `import { AgentStatus } from "@/components/elements/agent-status";
+
+<AgentStatus state="working" label="Editing composer.tsx" elapsed="8s" />`,
+    props: [
+      {
+        component: "AgentStatus",
+        rows: [
+          {
+            name: "state",
+            type: "AgentState",
+            required: true,
+            description:
+              "Visual mode of the pill: working, waiting, or done with a check.",
+          },
+          {
+            name: "label",
+            type: "string",
+            required: true,
+            description:
+              "Short status line describing what the agent is doing.",
+          },
+          {
+            name: "elapsed",
+            type: "string",
+            description: "Elapsed time shown in mono when provided.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "approval-card": {
+    usage: `import { ApprovalCard } from "@/components/elements/approval-card";
+
+<ApprovalCard
+  state="request"
+  command="pnpm db:migrate"
+  title="Run migration"
+  subtitle="Needs your approval"
+  onAllowOnce={() => approve()}
+  onDeny={() => deny()}
+/>`,
+    props: [
+      {
+        component: "ApprovalCard",
+        rows: [
+          {
+            name: "state",
+            type: '"request" | "running" | "done" | "denied"',
+            required: true,
+            description:
+              "Lifecycle of the card: request with actions, running spinner, done check, or denied.",
+          },
+          {
+            name: "command",
+            type: "string",
+            required: true,
+            description:
+              "Command shown in the mono field the agent wants to run.",
+          },
+          {
+            name: "title",
+            type: "string",
+            required: true,
+            description: "Headline naming the action that needs approval.",
+          },
+          {
+            name: "subtitle",
+            type: "string",
+            required: true,
+            description:
+              "Supporting line under the title explaining the request.",
+          },
+          {
+            name: "onAllowOnce",
+            type: "() => void",
+            description: "Called when the user clicks Allow once.",
+          },
+          {
+            name: "onAlwaysAllow",
+            type: "() => void",
+            description: "Called when the user clicks Always allow.",
+          },
+          {
+            name: "onDeny",
+            type: "() => void",
+            description: "Called when the user clicks Deny.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "recommendation-card": {
+    usage: `import { RecommendationCard } from "@/components/elements/recommendation-card";
+
+<RecommendationCard
+  state="idle"
+  question="Enable draft autosave?"
+  confidenceLabel="high confidence"
+  acceptedLabel="Enabled for every thread"
+  onAccept={() => accept()}
+>
+  Wire{" "}
+  <span className="bg-foreground/[0.06] text-foreground/70 rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+    runtime.drafts
+  </span>{" "}
+  with three lines.
+</RecommendationCard>`,
+    props: [
+      {
+        component: "RecommendationCard",
+        rows: [
+          {
+            name: "state",
+            type: "RecommendationState",
+            required: true,
+            description:
+              "idle shows accept controls; accepted swaps in a confirmation row.",
+          },
+          {
+            name: "question",
+            type: "string",
+            required: true,
+            description:
+              "Proposal headline the agent is asking the user about.",
+          },
+          {
+            name: "children",
+            type: "ReactNode",
+            required: true,
+            description: "Supporting body explaining the recommendation.",
+          },
+          {
+            name: "confidenceLabel",
+            type: "string",
+            required: true,
+            description:
+              "Confidence copy shown next to the bar meter while idle.",
+          },
+          {
+            name: "acceptedLabel",
+            type: "string",
+            required: true,
+            description:
+              "Confirmation copy shown once the proposal is accepted.",
+          },
+          {
+            name: "onAccept",
+            type: "() => void",
+            description: "Called when the user clicks Accept.",
+          },
+          {
+            name: "onAlternatives",
+            type: "() => void",
+            description: "Called when the user clicks Alternatives.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "artifact-card": {
+    usage: `import { ArtifactCard } from "@/components/elements/artifact-card";
+
+<ArtifactCard
+  title="Draft persistence RFC"
+  meta="Document · v3 · just now"
+  generating={isWriting}
+  words={wordCount}
+/>`,
+    props: [
+      {
+        component: "ArtifactCard",
+        rows: [
+          {
+            name: "title",
+            type: "string",
+            required: true,
+            description: "Name of the generated artifact.",
+          },
+          {
+            name: "meta",
+            type: "string",
+            required: true,
+            description:
+              "Resting meta line shown once generation finishes, for example kind, version, and recency.",
+          },
+          {
+            name: "generating",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "While true the icon pulses and the meta line shows a live word count with a shimmer.",
+          },
+          {
+            name: "words",
+            type: "number",
+            defaultValue: "0",
+            description: "Live word count shown while generating.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the card.",
+          },
+        ],
+      },
+    ],
+  },
+  composer: {
+    usage: `import { Composer } from "@/components/elements/composer";
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  onSend={send}
+  attachments={[{ name: "notes.md", meta: "12 KB", state: "done" }]}
+  commands={[{ name: "review", description: "Review the diff", icon: SearchIcon }]}
+  people={[{ name: "Mara", role: "human" }]}
+  models={[{ name: "Fable 5", meta: "1M ctx" }]}
+  model={model}
+  onModelChange={setModel}
+  usage={{ system: 12, tools: 8, messages: 54, total: 200 }}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "value",
+            type: "string",
+            required: true,
+            description: "Current draft text in the input field.",
+          },
+          {
+            name: "onValueChange",
+            type: "(value: string) => void",
+            required: true,
+            description: "Called as the user types.",
+          },
+          {
+            name: "onSend",
+            type: "() => void",
+            description: "Called on Enter or the send button.",
+          },
+          {
+            name: "onStop",
+            type: "() => void",
+            description: "Called by the stop button while streaming.",
+          },
+          {
+            name: "placeholder",
+            type: "string",
+            defaultValue: '"Ask anything"',
+            description: "Placeholder shown when the value is empty.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "When true the send control cross-fades into a stop button.",
+          },
+          {
+            name: "attachments",
+            type: "ComposerAttachment[]",
+            description:
+              "Staged files rendered as tiles above the field, with per-file progress.",
+          },
+          {
+            name: "onRemoveAttachment",
+            type: "(name: string) => void",
+            description:
+              "Enables a remove control on attachments that finished uploading.",
+          },
+          {
+            name: "dragActive",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Tints the surface while a file hovers over it.",
+          },
+          {
+            name: "commands",
+            type: "ComposerCommand[]",
+            description:
+              "Enables the slash menu: it floats above the input while the value starts with /.",
+          },
+          {
+            name: "onCommand",
+            type: "(command: ComposerCommand) => void",
+            description: "Called when a slash command is picked.",
+          },
+          {
+            name: "people",
+            type: "ComposerPerson[]",
+            description:
+              "Enables the mention menu: it opens while the value ends in an @ token.",
+          },
+          {
+            name: "onMention",
+            type: "(person: ComposerPerson) => void",
+            description:
+              "Called when a person is picked; the token is replaced with their name.",
+          },
+          {
+            name: "models",
+            type: "ComposerModel[]",
+            description: "Enables the model picker in the composer rail.",
+          },
+          {
+            name: "model",
+            type: "string",
+            description: "Name of the active model shown on the rail control.",
+          },
+          {
+            name: "onModelChange",
+            type: "(name: string) => void",
+            description: "Called when a model is picked from the menu.",
+          },
+          {
+            name: "defaultModelMenuOpen",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Opens the model menu on mount.",
+          },
+          {
+            name: "usage",
+            type: "ComposerUsage",
+            description:
+              "Shows a context ring next to the send button; hovering it reveals the breakdown.",
+          },
+          {
+            name: "recording",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Replaces the input with a live waveform and elapsed timer.",
+          },
+          {
+            name: "transcribing",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Shows the transcribing state after recording stops.",
+          },
+          {
+            name: "recordingSeconds",
+            type: "number",
+            defaultValue: "0",
+            description: "Elapsed seconds shown next to the waveform.",
+          },
+          {
+            name: "onVoiceStart",
+            type: "() => void",
+            description:
+              "Shows the mic button in the rail and is called when it is pressed.",
+          },
+          {
+            name: "onVoiceStop",
+            type: "() => void",
+            description: "Called by the stop control while voice is active.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-slash-commands": {
+    usage: `import { Composer, type ComposerCommand } from "@/components/elements/composer";
+
+const commands: ComposerCommand[] = [
+  { name: "review", description: "Review the current diff", icon: SearchIcon },
+  { name: "explain", description: "Explain the selection", icon: BookOpenIcon },
+];
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  commands={commands}
+  onCommand={(command) => run(command.name)}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "commands",
+            type: "ComposerCommand[]",
+            required: true,
+            description:
+              "Available commands. The menu floats above the input while the value starts with / and filters on the text after it.",
+          },
+          {
+            name: "onCommand",
+            type: "(command: ComposerCommand) => void",
+            description:
+              "Called when a command is picked; the input clears afterwards.",
+          },
+        ],
+      },
+      {
+        component: "ComposerCommand",
+        rows: [
+          {
+            name: "name",
+            type: "string",
+            required: true,
+            description: "Command name matched against the typed filter.",
+          },
+          {
+            name: "description",
+            type: "string",
+            required: true,
+            description: "One-line explanation shown next to the name.",
+          },
+          {
+            name: "icon",
+            type: "LucideIcon",
+            required: true,
+            description: "Icon rendered at the start of the row.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-mentions": {
+    usage: `import { Composer, type ComposerPerson } from "@/components/elements/composer";
+
+const people: ComposerPerson[] = [
+  { name: "Mara", role: "human" },
+  { name: "Max", role: "agent" },
+];
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  people={people}
+  onMention={(person) => notify(person.name)}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "people",
+            type: "ComposerPerson[]",
+            required: true,
+            description:
+              "People and agents available to mention. The menu opens while the value ends in an @ token.",
+          },
+          {
+            name: "onMention",
+            type: "(person: ComposerPerson) => void",
+            description:
+              "Called when a person is picked; the @ token is replaced with their name.",
+          },
+        ],
+      },
+      {
+        component: "ComposerPerson",
+        rows: [
+          {
+            name: "name",
+            type: "string",
+            required: true,
+            description: "Display name matched against the typed filter.",
+          },
+          {
+            name: "role",
+            type: '"agent" | "human"',
+            required: true,
+            description: "Role tag shown at the end of the row.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-attachments": {
+    usage: `import { Composer } from "@/components/elements/composer";
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  attachments={[
+    { name: "design-review.pdf", meta: "2.4 MB", state: "done", kind: "text" },
+    { name: "screens.zip", meta: "Uploading", state: "uploading", progress: 60, kind: "archive" },
+  ]}
+  onRemoveAttachment={(name) => remove(name)}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "attachments",
+            type: "ComposerAttachment[]",
+            required: true,
+            description: "Files staged above the input field.",
+          },
+          {
+            name: "onRemoveAttachment",
+            type: "(name: string) => void",
+            description:
+              "Enables a remove control on attachments that finished uploading.",
+          },
+          {
+            name: "dragActive",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Tints the surface while a file hovers over it.",
+          },
+        ],
+      },
+      {
+        component: "ComposerAttachment",
+        rows: [
+          {
+            name: "name",
+            type: "string",
+            required: true,
+            description: "File name shown on the tile.",
+          },
+          {
+            name: "meta",
+            type: "string",
+            required: true,
+            description: "Secondary line: size, status, or an error message.",
+          },
+          {
+            name: "state",
+            type: '"uploading" | "done" | "error"',
+            required: true,
+            description: "Drives the progress bar, check, or error styling.",
+          },
+          {
+            name: "progress",
+            type: "number",
+            description: "Upload percentage for the bottom progress line.",
+          },
+          {
+            name: "kind",
+            type: '"image" | "text" | "archive"',
+            defaultValue: '"text"',
+            description: "Picks the file icon.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-model-picker": {
+    usage: `import { Composer, type ComposerModel } from "@/components/elements/composer";
+
+const models: ComposerModel[] = [
+  { name: "Fable 5", meta: "1M ctx" },
+  { name: "Haiku 4.5", meta: "200k ctx" },
+];
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  models={models}
+  model={model}
+  onModelChange={setModel}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "models",
+            type: "ComposerModel[]",
+            required: true,
+            description:
+              "Available models listed in the menu above the rail control.",
+          },
+          {
+            name: "model",
+            type: "string",
+            required: true,
+            description:
+              "Active model name; shown on the rail control and checked in the menu.",
+          },
+          {
+            name: "onModelChange",
+            type: "(name: string) => void",
+            description:
+              "Called when a model is picked; the menu closes afterwards.",
+          },
+          {
+            name: "defaultModelMenuOpen",
+            type: "boolean",
+            defaultValue: "false",
+            description: "Opens the model menu on mount.",
+          },
+        ],
+      },
+      {
+        component: "ComposerModel",
+        rows: [
+          {
+            name: "name",
+            type: "string",
+            required: true,
+            description: "Model name shown in the row.",
+          },
+          {
+            name: "meta",
+            type: "string",
+            required: true,
+            description: "Context size or speed note at the end of the row.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-voice": {
+    usage: `import { Composer } from "@/components/elements/composer";
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  recording={recording}
+  transcribing={transcribing}
+  recordingSeconds={seconds}
+  onVoiceStart={startRecording}
+  onVoiceStop={stopRecording}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "recording",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Replaces the input with a live waveform and elapsed timer.",
+          },
+          {
+            name: "transcribing",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Holds the waveform in a settling state after recording stops.",
+          },
+          {
+            name: "recordingSeconds",
+            type: "number",
+            defaultValue: "0",
+            description:
+              "Elapsed seconds shown next to the waveform; also animates the bars.",
+          },
+          {
+            name: "onVoiceStart",
+            type: "() => void",
+            description:
+              "Shows the mic button in the rail and is called when it is pressed.",
+          },
+          {
+            name: "onVoiceStop",
+            type: "() => void",
+            description: "Called by the stop control while voice is active.",
+          },
+        ],
+      },
+    ],
+  },
+  "composer-context": {
+    usage: `import { Composer } from "@/components/elements/composer";
+
+<Composer
+  value={value}
+  onValueChange={setValue}
+  usage={{ system: 24, tools: 12, messages: 142, total: 200 }}
+/>`,
+    props: [
+      {
+        component: "Composer",
+        rows: [
+          {
+            name: "usage",
+            type: "ComposerUsage",
+            required: true,
+            description:
+              "Renders a ring next to the send button. The numbers stay hidden until hover, which reveals the segmented breakdown; everything turns red past 85% of the window.",
+          },
+        ],
+      },
+      {
+        component: "ComposerUsage",
+        rows: [
+          {
+            name: "system",
+            type: "number",
+            required: true,
+            description: "Tokens held by the system prompt, in thousands.",
+          },
+          {
+            name: "tools",
+            type: "number",
+            required: true,
+            description: "Tokens held by tool definitions, in thousands.",
+          },
+          {
+            name: "messages",
+            type: "number",
+            required: true,
+            description: "Tokens held by the conversation, in thousands.",
+          },
+          {
+            name: "total",
+            type: "number",
+            required: true,
+            description: "Context window size, in thousands.",
+          },
+        ],
+      },
+    ],
+  },
+
+  "chat-panel": {
+    usage: `import { ChatPanel } from "@/components/elements/chat-panel";
+
+<ChatPanel
+  userMessage="What is a runtime?"
+  reply="A runtime owns thread state and tools."
+  showUserMessage
+  typing={false}
+  visibleWords={6}
+  streaming
+/>`,
+    props: [
+      {
+        component: "ChatPanel",
+        rows: [
+          {
+            name: "userMessage",
+            type: "string",
+            required: true,
+            description: "User bubble text shown when showUserMessage is true.",
+          },
+          {
+            name: "reply",
+            type: "string",
+            required: true,
+            description:
+              "Full assistant reply that is sliced into streaming words.",
+          },
+          {
+            name: "showUserMessage",
+            type: "boolean",
+            required: true,
+            description: "Whether the user bubble is visible yet.",
+          },
+          {
+            name: "typing",
+            type: "boolean",
+            required: true,
+            description:
+              "When true a typing row is shown before the reply starts.",
+          },
+          {
+            name: "visibleWords",
+            type: "number",
+            required: true,
+            description: "How many words of the reply are currently visible.",
+          },
+          {
+            name: "streaming",
+            type: "boolean",
+            required: true,
+            description:
+              "When true the newest reply words tint as they arrive.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "empty-state": {
+    usage: `import { EmptyState } from "@/components/elements/empty-state";
+
+<EmptyState
+  greeting="What are we working on?"
+  suggestions={["Draft an RFC", "Debug a test"]}
+/>`,
+    props: [
+      {
+        component: "EmptyState",
+        rows: [
+          {
+            name: "greeting",
+            type: "string",
+            required: true,
+            description: "Centered headline shown above the suggestion chips.",
+          },
+          {
+            name: "suggestions",
+            type: "readonly string[]",
+            required: true,
+            description: "Starter chips that offer ways into the first turn.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "thread-list": {
+    usage: `import { ThreadList } from "@/components/elements/thread-list";
+
+<ThreadList
+  threads={[
+    { title: "Composer polish", time: "2m", unread: true },
+    { title: "Runtime migration", time: "1h" },
+  ]}
+  activeIndex={activeIndex}
+  onActiveIndexChange={setActiveIndex}
+/>`,
+    props: [
+      {
+        component: "ThreadList",
+        rows: [
+          {
+            name: "threads",
+            type: "readonly ThreadItem[]",
+            required: true,
+            description:
+              "Conversation rows with title, time, and optional unread mark.",
+          },
+          {
+            name: "activeIndex",
+            type: "number",
+            required: true,
+            description: "Index of the currently selected thread.",
+          },
+          {
+            name: "onActiveIndexChange",
+            type: "(index: number) => void",
+            description: "Called when the user clicks a thread row.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+  "scroll-anchor": {
+    usage: `import { ScrollAnchor } from "@/components/elements/scroll-anchor";
+
+<ScrollAnchor
+  messages={[
+    { role: "user", text: "Keep scrolling pinned?" },
+    { role: "assistant", text: "Only when you are already at the bottom." },
+  ]}
+/>`,
+    props: [
+      {
+        component: "ScrollAnchor",
+        rows: [
+          {
+            name: "messages",
+            type: "ScrollAnchorMessage[]",
+            required: true,
+            description:
+              "Conversation messages appended over time inside the scroll viewport.",
+          },
+          {
+            name: "paused",
+            type: "boolean",
+            defaultValue: "false",
+            description:
+              "Freezes the scene where it is; replay happens by remounting.",
+          },
+          {
+            name: "onSettled",
+            type: "() => void",
+            description:
+              "Called once every message has landed and the viewport is pinned.",
+          },
+          {
+            name: "className",
+            type: "string",
+            description: "Extra classes merged onto the root.",
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/apps/docs/components/elements/elements-sidebar.tsx
+++ b/apps/docs/components/elements/elements-sidebar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { mono } from "@/components/elements/surfaces";
+import { ELEMENT_COUNT, ELEMENT_SECTIONS, ELEMENTS } from "./registry";
+
+export function ElementsSidebar() {
+  const pathname = usePathname();
+  const current = pathname.split("/").filter(Boolean).at(-1) ?? "";
+  const indexBySlug = new Map(ELEMENTS.map((e) => [e.slug, e.index]));
+
+  return (
+    <aside className="hidden lg:block">
+      <nav className="sticky top-36 -ms-2 max-h-[calc(100vh-10rem)] overflow-y-auto overscroll-contain ps-2 pe-3 pb-8">
+        <Link
+          href="/elements"
+          className="hover:text-foreground/70 flex items-baseline justify-between text-[13px] font-medium transition-colors"
+        >
+          Elements
+          <span className={cn(mono, "text-foreground/35 tabular-nums")}>
+            {ELEMENT_COUNT}
+          </span>
+        </Link>
+        {ELEMENT_SECTIONS.map((section) => (
+          <div key={section.label} className="mt-6">
+            <p className={cn(mono, "text-foreground/35")}>{section.label}</p>
+            <ul className="mt-2 flex flex-col gap-0.5">
+              {section.elements.map((element) => {
+                const active = element.slug === current;
+                return (
+                  <li key={element.slug}>
+                    <Link
+                      href={`/elements/${element.slug}`}
+                      scroll={false}
+                      aria-current={active ? "page" : undefined}
+                      className={cn(
+                        "-mx-2 flex items-baseline gap-2 rounded-md px-2 py-1 text-[13px] transition-colors",
+                        active
+                          ? "bg-foreground/[0.05] text-foreground dark:bg-foreground/[0.08] font-medium"
+                          : "text-foreground/45 hover:bg-foreground/[0.03] hover:text-foreground/90",
+                      )}
+                    >
+                      <span
+                        className={cn(mono, "text-foreground/30 tabular-nums")}
+                      >
+                        {String(indexBySlug.get(element.slug) ?? 0).padStart(
+                          2,
+                          "0",
+                        )}
+                      </span>
+                      <span className="truncate">{element.title}</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/apps/docs/components/elements/empty-state-demo.tsx
+++ b/apps/docs/components/elements/empty-state-demo.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { EmptyState } from "@/components/elements/empty-state";
+
+const SUGGESTIONS = [
+  "Explain the runtime layers",
+  "Draft a migration plan",
+  "Review my composer code",
+];
+
+export function EmptyStateDemo() {
+  return (
+    <div className="flex w-full justify-center">
+      <EmptyState greeting="Where should we start?" suggestions={SUGGESTIONS} />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/error-state-demo.tsx
+++ b/apps/docs/components/elements/error-state-demo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ErrorState } from "@/components/elements/error-state";
+
+export function ErrorStateDemo() {
+  const [retrying, setRetrying] = useState(false);
+
+  useEffect(() => {
+    if (!retrying) return undefined;
+    const id = setTimeout(() => setRetrying(false), 1600);
+    return () => clearTimeout(id);
+  }, [retrying]);
+
+  return (
+    <div className="flex min-h-[4.75rem] w-full max-w-sm items-center">
+      <ErrorState
+        title="Generation stopped"
+        detail="The model hit the output limit after 4,096 tokens."
+        retrying={retrying}
+        onRetry={() => setRetrying(true)}
+      />
+    </div>
+  );
+}

--- a/apps/docs/components/elements/image-generation-demo.tsx
+++ b/apps/docs/components/elements/image-generation-demo.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ImageGeneration } from "@/components/elements/image-generation";
+import { useStoryPhases } from "./use-demo";
+
+const PHASES = [3600, 4000] as const;
+
+export function ImageGenerationDemo() {
+  const { phase } = useStoryPhases(PHASES);
+  return (
+    <ImageGeneration
+      prompt="A calm mountain lake at dawn"
+      generating={phase === 0}
+    />
+  );
+}

--- a/apps/docs/components/elements/inline-citation-demo.tsx
+++ b/apps/docs/components/elements/inline-citation-demo.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import {
+  InlineCitation,
+  type Source,
+} from "@/components/elements/inline-citation";
+
+const SOURCES: Source[] = [
+  {
+    domain: "assistant-ui.com",
+    title: "Optimistic updates in the runtime",
+    snippet:
+      "The runtime applies local edits immediately and reconciles them once the server acknowledges the write.",
+  },
+  {
+    domain: "react.dev",
+    title: "useSyncExternalStore reference",
+    snippet:
+      "Subscribes a component to an external store, re-rendering on every store change with a consistent snapshot.",
+  },
+];
+
+export function InlineCitationDemo() {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <InlineCitation
+      sources={SOURCES}
+      openIndex={openIndex}
+      onOpenIndexChange={setOpenIndex}
+    />
+  );
+}

--- a/apps/docs/components/elements/install-command.tsx
+++ b/apps/docs/components/elements/install-command.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { mono } from "@/components/elements/surfaces";
+import { CopyButton } from "./copy-button";
+
+const MANAGERS = [
+  { key: "npm", runner: "npx" },
+  { key: "pnpm", runner: "pnpm dlx" },
+  { key: "yarn", runner: "yarn dlx" },
+  { key: "bun", runner: "bunx --bun" },
+] as const;
+
+type ManagerKey = (typeof MANAGERS)[number]["key"];
+
+const STORAGE_KEY = "aui-elements-pm";
+
+export function InstallCommand({ registryName }: { registryName: string }) {
+  const [manager, setManager] = useState<ManagerKey>("npm");
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (MANAGERS.some((entry) => entry.key === stored)) {
+      setManager(stored as ManagerKey);
+    }
+  }, []);
+
+  const active = MANAGERS.find((entry) => entry.key === manager)!;
+  const command = `${active.runner} shadcn@latest add "@assistant-ui/${registryName}"`;
+
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <h2 className="text-sm font-medium">Installation</h2>
+        <div className="ms-auto flex items-center gap-0.5">
+          {MANAGERS.map((entry) => {
+            const selected = entry.key === manager;
+            return (
+              <button
+                key={entry.key}
+                type="button"
+                aria-pressed={selected}
+                onClick={() => {
+                  setManager(entry.key);
+                  localStorage.setItem(STORAGE_KEY, entry.key);
+                }}
+                className={cn(
+                  mono,
+                  "h-6 rounded-full px-2.5 transition-[color,background-color] duration-150 motion-reduce:transition-none",
+                  selected
+                    ? "bg-foreground/[0.05] text-foreground dark:bg-foreground/[0.08]"
+                    : "text-foreground/40 hover:text-foreground/90",
+                )}
+              >
+                {entry.key}
+              </button>
+            );
+          })}
+        </div>
+        <CopyButton text={command} />
+      </div>
+      <div className="bg-foreground/[0.025] text-foreground/70 dark:bg-foreground/[0.04] mt-4 flex items-center overflow-x-auto rounded-2xl px-5 py-3.5 font-mono text-[12.5px] whitespace-nowrap">
+        {command}
+      </div>
+    </>
+  );
+}

--- a/apps/docs/components/elements/loading-state-demo.tsx
+++ b/apps/docs/components/elements/loading-state-demo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import {
+  GenerationLoader,
+  type GenerationLoaderVariant,
+} from "@/components/elements/loading-state";
+import { useElapsed } from "./use-demo";
+
+function LoadingDemo({ variant }: { variant: GenerationLoaderVariant }) {
+  const tick = useElapsed(true);
+
+  return <GenerationLoader label="Generating" tick={tick} variant={variant} />;
+}
+
+export function GenerationLoaderDemo() {
+  return <LoadingDemo variant="dots" />;
+}
+
+export function GenerationLoaderSquaresDemo() {
+  return <LoadingDemo variant="squares" />;
+}
+
+export function GenerationLoaderRoundedDemo() {
+  return <LoadingDemo variant="rounded" />;
+}

--- a/apps/docs/components/elements/message-actions-demo.tsx
+++ b/apps/docs/components/elements/message-actions-demo.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  MessageActions,
+  type Reaction,
+} from "@/components/elements/message-actions";
+
+export function MessageActionsDemo() {
+  const [copied, setCopied] = useState(false);
+  const [reaction, setReaction] = useState<Reaction>(null);
+  const [regenerating, setRegenerating] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return undefined;
+    const id = setTimeout(() => setCopied(false), 1400);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  useEffect(() => {
+    if (!regenerating) return undefined;
+    const id = setTimeout(() => setRegenerating(false), 900);
+    return () => clearTimeout(id);
+  }, [regenerating]);
+
+  return (
+    <MessageActions
+      copied={copied}
+      reaction={reaction}
+      regenerating={regenerating}
+      onCopy={() => setCopied(true)}
+      onReactionChange={setReaction}
+      onRegenerate={() => setRegenerating(true)}
+      onMore={() => {}}
+    />
+  );
+}

--- a/apps/docs/components/elements/message-branches-demo.tsx
+++ b/apps/docs/components/elements/message-branches-demo.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useState } from "react";
+import { MessageBranches } from "@/components/elements/message-branches";
+
+const VARIANTS = [
+  "Persist the composer draft in the runtime with the thread id as its key. When the active thread changes, read that value back into the composer.",
+  "Keep drafts in a thread keyed runtime map, then hydrate the composer whenever a new thread becomes active. Delete the matching entry only after a successful send.",
+  "Treat each draft as thread state instead of component state. Restoring it on thread selection keeps the composer stable without adding a second store.",
+];
+
+export function MessageBranchesDemo() {
+  const [index, setIndex] = useState(0);
+
+  return (
+    <MessageBranches
+      variants={VARIANTS}
+      index={index}
+      onIndexChange={setIndex}
+    />
+  );
+}

--- a/apps/docs/components/elements/message-pair-demo.tsx
+++ b/apps/docs/components/elements/message-pair-demo.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { MessagePair } from "@/components/elements/message-pair";
+import { useWordStream } from "./use-demo";
+
+const USER_MESSAGE = "How do I persist composer drafts across threads?";
+const ASSISTANT_MESSAGE =
+  "Key the draft by thread id inside the runtime, hydrate the composer when a thread becomes active, and drop the entry after the message sends.";
+
+function MessagePairStory({ variant }: { variant: "bubble" | "flat" }) {
+  const { words, count, streaming } = useWordStream(ASSISTANT_MESSAGE, {
+    interval: 82,
+  });
+
+  return (
+    <MessagePair
+      userMessage={USER_MESSAGE}
+      words={words}
+      visibleWords={count}
+      streaming={streaming}
+      variant={variant}
+    />
+  );
+}
+
+export function MessagePairDemo() {
+  return <MessagePairStory variant="bubble" />;
+}
+
+export function MessagePairFlatDemo() {
+  return <MessagePairStory variant="flat" />;
+}

--- a/apps/docs/components/elements/number-ticker-demo.tsx
+++ b/apps/docs/components/elements/number-ticker-demo.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { NumberTicker } from "@/components/elements/number-ticker";
+import { useStoryPhases } from "./use-demo";
+
+const VALUES = [12847, 14211, 15108, 17318, 17776] as const;
+const PHASES = [900, 900, 900, 900, 0] as const;
+
+export function NumberTickerDemo() {
+  const { phase } = useStoryPhases(PHASES);
+
+  return (
+    <NumberTicker value={VALUES[phase] ?? VALUES[0]} label="tokens generated" />
+  );
+}

--- a/apps/docs/components/elements/reasoning-panel-demo.tsx
+++ b/apps/docs/components/elements/reasoning-panel-demo.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ReasoningPanel,
+  type ReasoningStep,
+} from "@/components/elements/reasoning-panel";
+import { useStoryPhases } from "./use-demo";
+
+const STEPS: ReasoningStep[] = [
+  {
+    title: "Reading the request",
+    body: "The user wants drafts restored per thread, so the composer state has to move out of component state.",
+  },
+  {
+    title: "Locating the seam",
+    body: "Draft state already flows through the runtime; persisting it per thread id avoids a parallel store.",
+  },
+  {
+    title: "Settling on an approach",
+    body: "Keep a map keyed by thread id, hydrate on switch, and clear the entry once a message is sent.",
+  },
+];
+
+const PHASES = [1700, 1900, 1800, 1600, 0] as const;
+
+export function ReasoningPanelDemo() {
+  const { phase, running, takeOver } = useStoryPhases(PHASES);
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+
+  const streaming = running && phase < STEPS.length;
+  const open = running ? phase < STEPS.length + 1 : (userOpen ?? false);
+  const visibleSteps = streaming ? phase + 1 : STEPS.length;
+
+  return (
+    <ReasoningPanel
+      steps={STEPS}
+      visibleSteps={visibleSteps}
+      streaming={streaming}
+      open={open}
+      onOpenChange={(next) => {
+        takeOver();
+        setUserOpen(next);
+      }}
+      restingLabel="Thought for 5s"
+    />
+  );
+}

--- a/apps/docs/components/elements/recommendation-card-demo.tsx
+++ b/apps/docs/components/elements/recommendation-card-demo.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  RecommendationCard,
+  type RecommendationState,
+} from "@/components/elements/recommendation-card";
+
+export function RecommendationCardDemo() {
+  const [state, setState] = useState<RecommendationState>("idle");
+
+  useEffect(() => {
+    if (state !== "accepted") return;
+    const id = setTimeout(() => setState("idle"), 2600);
+    return () => clearTimeout(id);
+  }, [state]);
+
+  return (
+    <RecommendationCard
+      state={state}
+      question="Enable draft autosave?"
+      confidenceLabel="high confidence"
+      acceptedLabel="Enabled for every thread"
+      onAccept={() => setState("accepted")}
+    >
+      Threads lose their draft on switch. Wiring{" "}
+      <span className="bg-foreground/[0.06] text-foreground/70 rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+        runtime.drafts
+      </span>{" "}
+      fixes it with{" "}
+      <span className="bg-foreground/[0.06] text-foreground/70 rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+        3 lines
+      </span>{" "}
+      and no migration.
+    </RecommendationCard>
+  );
+}

--- a/apps/docs/components/elements/registry.tsx
+++ b/apps/docs/components/elements/registry.tsx
@@ -1,0 +1,488 @@
+import type { ComponentType } from "react";
+import {
+  GenerationLoaderDemo,
+  GenerationLoaderRoundedDemo,
+  GenerationLoaderSquaresDemo,
+} from "./loading-state-demo";
+import { DataTableDemo } from "./data-table-demo";
+import { RecommendationCardDemo } from "./recommendation-card-demo";
+import { NumberTickerDemo } from "./number-ticker-demo";
+import { ChatPanelDemo } from "./chat-panel-demo";
+import { ThinkingIndicatorDemo } from "./thinking-indicator-demo";
+import { ReasoningPanelDemo } from "./reasoning-panel-demo";
+import { StreamingTextDemo } from "./streaming-text-demo";
+import {
+  TypingIndicatorBareDemo,
+  TypingIndicatorDemo,
+} from "./typing-indicator-demo";
+import { MessagePairDemo, MessagePairFlatDemo } from "./message-pair-demo";
+import { MessageBranchesDemo } from "./message-branches-demo";
+import { MessageActionsDemo } from "./message-actions-demo";
+import { SuggestionsDemo, SuggestionsListDemo } from "./suggestions-demo";
+import { ErrorStateDemo } from "./error-state-demo";
+import { ToolCallDemo } from "./tool-call-demo";
+import { ToolTimelineDemo } from "./tool-timeline-demo";
+import { TerminalBlockDemo, TerminalBlockInkDemo } from "./terminal-block-demo";
+import { CodeDiffDemo } from "./code-diff-demo";
+import { WebSearchDemo } from "./web-search-demo";
+import { SourcesDemo } from "./sources-demo";
+import { InlineCitationDemo } from "./inline-citation-demo";
+import { ImageGenerationDemo } from "./image-generation-demo";
+import { AgentPlanDemo } from "./agent-plan-demo";
+import { SubagentListDemo } from "./subagent-list-demo";
+import { AgentStatusDemo } from "./agent-status-demo";
+import { ApprovalCardDemo } from "./approval-card-demo";
+import { ArtifactCardDemo } from "./artifact-card-demo";
+import { ComposerDemo } from "./composer-demo";
+import { ComposerSlashDemo } from "./composer-slash-demo";
+import { ComposerMentionsDemo } from "./composer-mentions-demo";
+import { ComposerAttachmentsDemo } from "./composer-attachments-demo";
+import { ComposerModelsDemo } from "./composer-models-demo";
+import { ComposerVoiceDemo } from "./composer-voice-demo";
+import { ComposerContextDemo } from "./composer-context-demo";
+import { EmptyStateDemo } from "./empty-state-demo";
+import { ThreadListDemo } from "./thread-list-demo";
+import { ScrollAnchorDemo } from "./scroll-anchor-demo";
+
+export interface ElementVariant {
+  key: string;
+  label: string;
+  Component: ComponentType;
+}
+
+export interface ElementEntry {
+  slug: string;
+  title: string;
+  description: string;
+  file: string;
+  installName?: string;
+  wide?: boolean;
+  replay?: boolean;
+  Component: ComponentType;
+  variants?: ElementVariant[];
+}
+
+export interface ElementSection {
+  label: string;
+  description: string;
+  elements: ElementEntry[];
+}
+
+export const ELEMENT_SECTIONS: ElementSection[] = [
+  {
+    label: "Reasoning",
+    description: "What the model shows while it thinks.",
+    elements: [
+      {
+        slug: "loading-state",
+        replay: false,
+        title: "Loading state",
+        description:
+          "A pixel matrix that keeps time while the model has nothing to show yet.",
+        file: "loading-state.tsx",
+        Component: GenerationLoaderDemo,
+        variants: [
+          { key: "dots", label: "Dots", Component: GenerationLoaderDemo },
+          {
+            key: "squares",
+            label: "Squares",
+            Component: GenerationLoaderSquaresDemo,
+          },
+          {
+            key: "rounded",
+            label: "Rounded",
+            Component: GenerationLoaderRoundedDemo,
+          },
+        ],
+      },
+      {
+        slug: "thinking-indicator",
+        title: "Thinking indicator",
+        description:
+          "A live status line that names what the agent is doing right now, with elapsed time.",
+        file: "thinking-indicator.tsx",
+        Component: ThinkingIndicatorDemo,
+      },
+      {
+        slug: "reasoning-panel",
+        title: "Reasoning panel",
+        description:
+          "A collapsible trace that streams reasoning steps along a timeline, then settles into a summary.",
+        file: "reasoning-panel.tsx",
+        Component: ReasoningPanelDemo,
+      },
+      {
+        slug: "streaming-text",
+        title: "Streaming text",
+        description:
+          "Tokens arrive softly: the newest words land in blue and settle into ink.",
+        file: "streaming-text.tsx",
+        Component: StreamingTextDemo,
+      },
+      {
+        slug: "typing-indicator",
+        replay: false,
+        title: "Typing indicator",
+        description:
+          "The classic three dots, tuned to read as presence rather than noise.",
+        file: "typing-indicator.tsx",
+        Component: TypingIndicatorDemo,
+        variants: [
+          {
+            key: "bubble",
+            label: "Bubble",
+            Component: TypingIndicatorDemo,
+          },
+          { key: "bare", label: "Bare", Component: TypingIndicatorBareDemo },
+        ],
+      },
+    ],
+  },
+  {
+    label: "Messages",
+    description: "The conversation surface itself.",
+    elements: [
+      {
+        slug: "message-pair",
+        title: "Message pair",
+        description:
+          "A user bubble and a streaming assistant reply, with actions that appear on hover.",
+        file: "message-pair.tsx",
+        Component: MessagePairDemo,
+        variants: [
+          { key: "bubble", label: "Bubble", Component: MessagePairDemo },
+          { key: "flat", label: "Flat", Component: MessagePairFlatDemo },
+        ],
+      },
+      {
+        slug: "message-branches",
+        replay: false,
+        title: "Message branches",
+        description:
+          "Navigate between regenerated versions of the same answer without losing your place.",
+        file: "message-branches.tsx",
+        Component: MessageBranchesDemo,
+      },
+      {
+        slug: "message-actions",
+        replay: false,
+        title: "Message actions",
+        description:
+          "Copy, rate, and regenerate. Each action confirms itself with a small state change.",
+        file: "message-actions.tsx",
+        Component: MessageActionsDemo,
+      },
+      {
+        slug: "suggestions",
+        replay: false,
+        title: "Follow-up suggestions",
+        description:
+          "Prompt pills that stagger in after a reply and invite the next turn.",
+        file: "suggestions.tsx",
+        Component: SuggestionsDemo,
+        variants: [
+          { key: "pills", label: "Pills", Component: SuggestionsDemo },
+          { key: "list", label: "List", Component: SuggestionsListDemo },
+        ],
+      },
+      {
+        slug: "error-state",
+        replay: false,
+        title: "Error state",
+        description:
+          "A quiet failure banner with a retry path, not a modal in your face.",
+        file: "error-state.tsx",
+        Component: ErrorStateDemo,
+      },
+    ],
+  },
+  {
+    label: "Tool use",
+    description: "Agent work, made legible.",
+    elements: [
+      {
+        slug: "tool-call",
+        title: "Tool call",
+        description:
+          "One tool invocation with its request and result tucked behind a disclosure.",
+        file: "tool-call.tsx",
+        Component: ToolCallDemo,
+      },
+      {
+        slug: "tool-timeline",
+        title: "Tool timeline",
+        description:
+          "A whole working session summarized as verbs, targets, and file stats.",
+        file: "tool-timeline.tsx",
+        Component: ToolTimelineDemo,
+      },
+      {
+        slug: "terminal-block",
+        title: "Terminal block",
+        description:
+          "Command output that streams line by line and ends with an exit status.",
+        file: "terminal-block.tsx",
+        Component: TerminalBlockDemo,
+        variants: [
+          { key: "paper", label: "Paper", Component: TerminalBlockDemo },
+          { key: "ink", label: "Ink", Component: TerminalBlockInkDemo },
+        ],
+      },
+      {
+        slug: "code-diff",
+        title: "Code diff",
+        description:
+          "A unified diff with tinted additions and removals, sized for chat.",
+        file: "code-diff.tsx",
+        Component: CodeDiffDemo,
+      },
+    ],
+  },
+  {
+    label: "Knowledge",
+    description: "Where answers come from.",
+    elements: [
+      {
+        slug: "web-search",
+        title: "Web search",
+        description:
+          "A search query and its results landing one by one as the agent reads.",
+        file: "web-search.tsx",
+        Component: WebSearchDemo,
+      },
+      {
+        slug: "sources",
+        replay: false,
+        title: "Sources",
+        description:
+          "Citations collapsed into a pill, expanding into scannable source cards.",
+        file: "sources.tsx",
+        Component: SourcesDemo,
+      },
+      {
+        slug: "inline-citation",
+        replay: false,
+        title: "Inline citation",
+        description:
+          "Numbered references inside a sentence, each with a hover preview of its source.",
+        file: "inline-citation.tsx",
+        Component: InlineCitationDemo,
+      },
+      {
+        slug: "image-generation",
+        title: "Image generation",
+        description:
+          "A dot grid holds the frame while the image resolves out of a blur.",
+        file: "image-generation.tsx",
+        Component: ImageGenerationDemo,
+      },
+    ],
+  },
+  {
+    label: "Structured output",
+    description: "Answers with shape: tables, diffs, and counts.",
+    elements: [
+      {
+        slug: "data-table",
+        title: "Data table",
+        description:
+          "A small comparison table the model can answer with directly.",
+        file: "data-table.tsx",
+        Component: DataTableDemo,
+      },
+      {
+        slug: "number-ticker",
+        title: "Number ticker",
+        description:
+          "Digits that roll into place as a count updates in real time.",
+        file: "number-ticker.tsx",
+        Component: NumberTickerDemo,
+      },
+    ],
+  },
+  {
+    label: "Agents",
+    description: "Long-running work you can supervise.",
+    elements: [
+      {
+        slug: "agent-plan",
+        title: "Agent plan",
+        description:
+          "A checklist the agent works through, with progress you can glance.",
+        file: "agent-plan.tsx",
+        Component: AgentPlanDemo,
+      },
+      {
+        slug: "subagent-list",
+        title: "Subagent list",
+        description:
+          "Parallel workers with their own progress, models, and completions.",
+        file: "subagent-list.tsx",
+        Component: SubagentListDemo,
+      },
+      {
+        slug: "agent-status",
+        title: "Agent status",
+        description:
+          "One pill that always answers: what is it doing, and for how long.",
+        file: "agent-status.tsx",
+        Component: AgentStatusDemo,
+      },
+      {
+        slug: "approval-card",
+        replay: false,
+        title: "Approval card",
+        description:
+          "Human in the loop: the agent asks before it runs anything with side effects.",
+        file: "approval-card.tsx",
+        Component: ApprovalCardDemo,
+      },
+      {
+        slug: "recommendation-card",
+        replay: false,
+        title: "Recommendation card",
+        description:
+          "The agent proposes a change with its confidence, and waits for a yes.",
+        file: "recommendation-card.tsx",
+        Component: RecommendationCardDemo,
+      },
+      {
+        slug: "artifact-card",
+        title: "Artifact card",
+        description:
+          "A generated document as a tangible object, written live and versioned.",
+        file: "artifact-card.tsx",
+        Component: ArtifactCardDemo,
+      },
+    ],
+  },
+  {
+    label: "Composer",
+    description: "One input, every capability built in.",
+    elements: [
+      {
+        slug: "composer",
+        replay: false,
+        title: "Composer",
+        description:
+          "The unified input: attachments, commands, mentions, models, voice, and context in one surface.",
+        file: "composer.tsx",
+        wide: true,
+        Component: ComposerDemo,
+      },
+      {
+        slug: "composer-slash-commands",
+        replay: false,
+        title: "Slash commands",
+        description:
+          "Type a slash and the command menu floats above the input, filtering as you continue.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerSlashDemo,
+      },
+      {
+        slug: "composer-mentions",
+        replay: false,
+        title: "Mentions",
+        description:
+          "Type @ to pull people and agents into the conversation, filtered as you go.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerMentionsDemo,
+      },
+      {
+        slug: "composer-attachments",
+        title: "Attachments",
+        description:
+          "Files stage inside the composer with per-file progress before the message sends.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerAttachmentsDemo,
+      },
+      {
+        slug: "composer-model-picker",
+        replay: false,
+        title: "Model picker",
+        description:
+          "The model lives in the composer rail, one tap away with context at a glance.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerModelsDemo,
+      },
+      {
+        slug: "composer-voice",
+        title: "Voice",
+        description:
+          "The mic morphs the input into a live waveform, then lands the transcript as text.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerVoiceDemo,
+      },
+      {
+        slug: "composer-context",
+        title: "Context",
+        description:
+          "A token ring in the rail fills as the conversation grows, warning near the limit.",
+        file: "composer.tsx",
+        installName: "composer",
+        Component: ComposerContextDemo,
+      },
+    ],
+  },
+  {
+    label: "Thread",
+    description: "Everything around the conversation.",
+    elements: [
+      {
+        slug: "chat-panel",
+        title: "Chat panel",
+        description:
+          "The whole family working together: a message, a pause, a streamed reply.",
+        file: "chat-panel.tsx",
+        wide: true,
+        Component: ChatPanelDemo,
+      },
+      {
+        slug: "empty-state",
+        title: "Empty state",
+        description:
+          "The first screen: a greeting, three ways in, and the composer front and center.",
+        file: "empty-state.tsx",
+        wide: true,
+        Component: EmptyStateDemo,
+      },
+      {
+        slug: "thread-list",
+        replay: false,
+        title: "Thread list",
+        description:
+          "Conversation history with unread marks and actions that wait for hover.",
+        file: "thread-list.tsx",
+        Component: ThreadListDemo,
+      },
+      {
+        slug: "scroll-anchor",
+        title: "Scroll anchor",
+        description:
+          "Streaming never steals your scroll position; a pill offers the way back down.",
+        file: "scroll-anchor.tsx",
+        Component: ScrollAnchorDemo,
+      },
+    ],
+  },
+];
+
+export interface FlatElement extends ElementEntry {
+  section: string;
+  index: number;
+}
+
+export const ELEMENTS: FlatElement[] = ELEMENT_SECTIONS.flatMap((section) =>
+  section.elements.map((element) => ({ ...element, section: section.label })),
+).map((element, i) => ({ ...element, index: i + 1 }));
+
+export const ELEMENT_COUNT = ELEMENTS.length;
+
+export function getElement(slug: string): FlatElement | undefined {
+  return ELEMENTS.find((element) => element.slug === slug);
+}

--- a/apps/docs/components/elements/scroll-anchor-demo.tsx
+++ b/apps/docs/components/elements/scroll-anchor-demo.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useContext } from "react";
+import {
+  ScrollAnchor,
+  type ScrollAnchorMessage,
+} from "@/components/elements/scroll-anchor";
+import { DemoStageContext } from "./demo-stage";
+
+const MESSAGES: ScrollAnchorMessage[] = [
+  { role: "user", text: "Why does the thread jump while streaming?" },
+  {
+    role: "assistant",
+    text: "The viewport pins to the bottom only while you are already there, so mid-stream layout shifts never steal your position.",
+  },
+  { role: "user", text: "And when I scroll up to reread something?" },
+  {
+    role: "assistant",
+    text: "Pinning pauses. New tokens keep arriving below without moving your scroll position at all.",
+  },
+  { role: "user", text: "How do I get back down quickly?" },
+  {
+    role: "assistant",
+    text: "A jump pill appears once content lands out of view. One click resumes the pinned follow.",
+  },
+  {
+    role: "assistant",
+    text: "That is also exactly what the ScrollToBottom primitive wires up for you.",
+  },
+];
+
+export function ScrollAnchorDemo() {
+  const stage = useContext(DemoStageContext);
+  const handleSettled = useCallback(() => stage?.setPlaying(false), [stage]);
+
+  return (
+    <ScrollAnchor
+      messages={MESSAGES}
+      paused={stage?.stopped ?? false}
+      onSettled={handleSettled}
+    />
+  );
+}

--- a/apps/docs/components/elements/scroll-reset.tsx
+++ b/apps/docs/components/elements/scroll-reset.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+export function ScrollReset() {
+  const pathname = usePathname();
+  const restored = useRef(false);
+
+  useEffect(() => {
+    const onPop = () => {
+      restored.current = true;
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (restored.current) {
+      restored.current = false;
+      return;
+    }
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/docs/components/elements/sources-demo.tsx
+++ b/apps/docs/components/elements/sources-demo.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import { Sources, type Source } from "@/components/elements/sources";
+
+const SOURCES: Source[] = [
+  {
+    domain: "assistant-ui.com",
+    title: "Runtime drafts API",
+  },
+  {
+    domain: "react.dev",
+    title: "You might not need an effect",
+  },
+  {
+    domain: "patterns.dev",
+    title: "Optimistic UI updates",
+  },
+  {
+    domain: "github.com",
+    title: "assistant-ui #5321 draft restore",
+  },
+];
+
+export function SourcesDemo() {
+  const [open, setOpen] = useState(false);
+
+  return <Sources sources={SOURCES} open={open} onOpenChange={setOpen} />;
+}

--- a/apps/docs/components/elements/streaming-text-demo.tsx
+++ b/apps/docs/components/elements/streaming-text-demo.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  StreamingText,
+  type Segment,
+} from "@/components/elements/streaming-text";
+import { useWordStream } from "./use-demo";
+
+const SEGMENTS: Segment[] = [
+  { text: "Here is what changed in the latest release: the composer now" },
+  { text: "restores drafts per thread, tool calls stream partial arguments" },
+  { text: "through" },
+  { text: "useAuiState", mono: true },
+  { text: "selectors, and reasoning traces collapse on their own the moment" },
+  { text: "a reply starts streaming." },
+];
+
+export function StreamingTextDemo() {
+  const text = useMemo(
+    () => SEGMENTS.map((segment) => segment.text).join(" "),
+    [],
+  );
+  const { count, streaming } = useWordStream(text, {
+    interval: 88,
+  });
+
+  return (
+    <StreamingText segments={SEGMENTS} count={count} streaming={streaming} />
+  );
+}

--- a/apps/docs/components/elements/subagent-list-demo.tsx
+++ b/apps/docs/components/elements/subagent-list-demo.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  SubagentList,
+  type SubagentItem,
+} from "@/components/elements/subagent-list";
+import { useStoryPhases } from "./use-demo";
+
+const AGENTS: readonly SubagentItem[] = [
+  { name: "Explore the runtime", model: "haiku" },
+  { name: "Fix composer types", model: "sonnet" },
+  { name: "Write regression tests", model: "sonnet" },
+];
+
+const SUMMARY_AGENT: SubagentItem = {
+  name: "Summarize findings",
+  model: "haiku",
+};
+const PHASES = [1800, 1800, 2800] as const;
+const PROGRESS = [
+  [68, 44, 22],
+  [100, 68, 44],
+  [100, 100, 68],
+] as const;
+
+export function SubagentListDemo() {
+  const { phase } = useStoryPhases(PHASES);
+  const completedCount = phase === 0 ? 0 : phase === 1 ? 1 : 2;
+  const progress =
+    phase === 0 ? PROGRESS[0] : phase === 1 ? PROGRESS[1] : PROGRESS[2];
+
+  return (
+    <SubagentList
+      agents={AGENTS}
+      completedCount={completedCount}
+      progress={progress}
+      showSummary={phase === 2}
+      summaryAgent={SUMMARY_AGENT}
+    />
+  );
+}

--- a/apps/docs/components/elements/suggestions-demo.tsx
+++ b/apps/docs/components/elements/suggestions-demo.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+import { Suggestions } from "@/components/elements/suggestions";
+
+const SUGGESTIONS = [
+  "Add optimistic updates",
+  "Show me the diff",
+  "Why not React context?",
+  "Write a regression test",
+];
+
+function SuggestionsStory({ variant }: { variant: "pills" | "list" }) {
+  const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(
+    null,
+  );
+
+  return (
+    <Suggestions
+      suggestions={SUGGESTIONS}
+      selectedSuggestion={selectedSuggestion}
+      cycle={0}
+      onSuggestion={setSelectedSuggestion}
+      variant={variant}
+    />
+  );
+}
+
+export function SuggestionsDemo() {
+  return <SuggestionsStory variant="pills" />;
+}
+
+export function SuggestionsListDemo() {
+  return <SuggestionsStory variant="list" />;
+}

--- a/apps/docs/components/elements/terminal-block-demo.tsx
+++ b/apps/docs/components/elements/terminal-block-demo.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { TerminalBlock } from "@/components/elements/terminal-block";
+import { useStoryPhases } from "./use-demo";
+
+const LINES = [
+  "RUN v4.0.5 /apps/docs",
+  "✓ composer restores draft on switch (12ms)",
+  "✓ composer clears draft after send (9ms)",
+  "✓ composer keeps attachments per thread (11ms)",
+  "Tests 3 passed (3)",
+] as const;
+
+const PHASES = [700, 700, 700, 700, 700, 2500] as const;
+
+function TerminalBlockStory({ variant }: { variant: "paper" | "ink" }) {
+  const { phase } = useStoryPhases(PHASES);
+  const done = phase >= LINES.length;
+  const visibleCount = Math.min(phase + 1, LINES.length);
+
+  return (
+    <TerminalBlock
+      command="pnpm vitest run composer"
+      lines={LINES}
+      visibleCount={visibleCount}
+      done={done}
+      variant={variant}
+    />
+  );
+}
+
+export function TerminalBlockDemo() {
+  return <TerminalBlockStory variant="paper" />;
+}
+
+export function TerminalBlockInkDemo() {
+  return <TerminalBlockStory variant="ink" />;
+}

--- a/apps/docs/components/elements/thinking-indicator-demo.tsx
+++ b/apps/docs/components/elements/thinking-indicator-demo.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ThinkingIndicator } from "@/components/elements/thinking-indicator";
+import { useStoryPhases } from "./use-demo";
+
+const STATUSES = [
+  "Thinking",
+  "Reading thread.tsx",
+  "Searching the docs",
+  "Drafting a reply",
+];
+
+const PHASES = [2400, 2400, 2400, 0] as const;
+
+export function ThinkingIndicatorDemo() {
+  const { phase } = useStoryPhases(PHASES);
+
+  return <ThinkingIndicator label={STATUSES[phase]!} />;
+}

--- a/apps/docs/components/elements/thread-list-demo.tsx
+++ b/apps/docs/components/elements/thread-list-demo.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import { ThreadList, type ThreadItem } from "@/components/elements/thread-list";
+
+const THREADS: ThreadItem[] = [
+  { title: "Draft persistence design", time: "2m" },
+  { title: "Streaming tool arguments", time: "1h", unread: true },
+  { title: "Migrate thread list to tap", time: "3h" },
+  { title: "Fix scroll pinning race", time: "1d" },
+];
+
+export function ThreadListDemo() {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <ThreadList
+      threads={THREADS}
+      activeIndex={activeIndex}
+      onActiveIndexChange={setActiveIndex}
+    />
+  );
+}

--- a/apps/docs/components/elements/tool-call-demo.tsx
+++ b/apps/docs/components/elements/tool-call-demo.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+import { ToolCall } from "@/components/elements/tool-call";
+import { useStoryPhases } from "./use-demo";
+
+const PHASES = [2200, 1400, 3000, 0] as const;
+
+export function ToolCallDemo() {
+  const { phase, running, takeOver } = useStoryPhases(PHASES);
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+
+  const open = running ? phase === 2 : (userOpen ?? false);
+
+  return (
+    <ToolCall
+      label="Searched the docs"
+      activeLabel="Searching the docs"
+      query="draft persistence"
+      request={'{"query": "draft persistence"}'}
+      result="3 matches, best hit /docs/runtime/drafts"
+      running={running && phase === 0}
+      open={open}
+      onOpenChange={(next) => {
+        takeOver();
+        setUserOpen(next);
+      }}
+    />
+  );
+}

--- a/apps/docs/components/elements/tool-timeline-demo.tsx
+++ b/apps/docs/components/elements/tool-timeline-demo.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import {
+  FileSearchIcon,
+  PenLineIcon,
+  SparklesIcon,
+  TerminalIcon,
+} from "lucide-react";
+import {
+  ToolTimeline,
+  type TimelineStat,
+  type TimelineStep,
+} from "@/components/elements/tool-timeline";
+import { useElapsed, useStoryPhases } from "./use-demo";
+
+const STEPS: TimelineStep[] = [
+  {
+    verb: "Thinking",
+    chip: "planning the change",
+    icon: SparklesIcon,
+  },
+  {
+    verb: "Read",
+    chip: "thread.tsx",
+    icon: FileSearchIcon,
+  },
+  {
+    verb: "Ran",
+    chip: "pnpm vitest",
+    icon: TerminalIcon,
+  },
+  {
+    verb: "Edited",
+    chip: "composer.tsx",
+    icon: PenLineIcon,
+  },
+];
+
+const STATS: TimelineStat[] = [
+  { file: "composer.tsx", added: 14, removed: 3 },
+  { file: "use-draft.ts", added: 42 },
+];
+
+const PHASES = [1000, 1000, 1000, 1000, 2400, 0] as const;
+
+export function ToolTimelineDemo() {
+  const { phase, running, takeOver } = useStoryPhases(PHASES);
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+
+  const streaming = running && phase < STEPS.length;
+  const elapsed = useElapsed(streaming);
+  const open = running ? phase !== PHASES.length - 1 : (userOpen ?? false);
+  const visibleSteps = streaming ? phase + 1 : STEPS.length;
+
+  return (
+    <ToolTimeline
+      steps={STEPS}
+      visibleSteps={visibleSteps}
+      streaming={streaming}
+      open={open}
+      onOpenChange={(next) => {
+        takeOver();
+        setUserOpen(next);
+      }}
+      restingLabel="4 steps · 2 files changed"
+      activeLabel={`Working for ${Math.floor(elapsed / 10)}s`}
+      stats={STATS}
+    />
+  );
+}

--- a/apps/docs/components/elements/typing-indicator-demo.tsx
+++ b/apps/docs/components/elements/typing-indicator-demo.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { TypingIndicator } from "@/components/elements/typing-indicator";
+
+export function TypingIndicatorDemo() {
+  return <TypingIndicator variant="bubble" />;
+}
+
+export function TypingIndicatorBareDemo() {
+  return <TypingIndicator variant="bare" />;
+}

--- a/apps/docs/components/elements/use-demo.ts
+++ b/apps/docs/components/elements/use-demo.ts
@@ -1,0 +1,211 @@
+"use client";
+
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { DemoStageContext } from "./demo-stage";
+
+/** Cycles 0..length-1 on a fixed interval. Pass a stable length. */
+export function useCycle(length: number, ms: number): number {
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setIndex((i) => (i + 1) % length), ms);
+    return () => clearInterval(id);
+  }, [length, ms]);
+  return index;
+}
+
+/**
+ * Steps through phases with per-phase durations in ms, looping forever.
+ * Pass a module-level constant so the array identity is stable.
+ */
+export function usePhases(durations: readonly number[]): number {
+  const [phase, setPhase] = useState(0);
+  useEffect(() => {
+    let index = 0;
+    let id: ReturnType<typeof setTimeout>;
+    const next = () => {
+      id = setTimeout(() => {
+        index = (index + 1) % durations.length;
+        setPhase(index);
+        next();
+      }, durations[index]);
+    };
+    next();
+    return () => clearTimeout(id);
+  }, [durations]);
+  return phase;
+}
+
+export interface StoryPhases {
+  phase: number;
+  running: boolean;
+  takeOver: () => void;
+  replay: () => void;
+}
+
+/**
+ * Play-once phases for animated demos: advances through the phases a single
+ * time and stops on the final one, which is the resting state. The user can
+ * stop the script early (`takeOver`); `replay` restarts it from the top.
+ * Demos are replayed wholesale by remounting, so `replay` mostly serves
+ * in-component takeover flows.
+ */
+export function useStoryPhases(durations: readonly number[]): StoryPhases {
+  const stage = useContext(DemoStageContext);
+  const [phase, setPhase] = useState(0);
+  const [running, setRunning] = useState(true);
+  const [epoch, setEpoch] = useState(0);
+
+  useEffect(() => {
+    if (stage?.stopped) setRunning(false);
+  }, [stage?.stopped]);
+
+  useEffect(() => {
+    stage?.setPlaying(running);
+  }, [stage, running]);
+
+  useEffect(() => {
+    if (!running) return;
+    setPhase(0);
+    let index = 0;
+    let id: ReturnType<typeof setTimeout>;
+    const next = () => {
+      id = setTimeout(() => {
+        index += 1;
+        setPhase(index);
+        if (index >= durations.length - 1) {
+          setRunning(false);
+          return;
+        }
+        next();
+      }, durations[index]);
+    };
+    if (durations.length <= 1) {
+      setRunning(false);
+      return;
+    }
+    next();
+    return () => clearTimeout(id);
+  }, [durations, running, epoch]);
+
+  const takeOver = useCallback(() => setRunning(false), []);
+  const replay = useCallback(() => {
+    setRunning(true);
+    setEpoch((e) => e + 1);
+  }, []);
+
+  return { phase, running, takeOver, replay };
+}
+
+/** Elapsed tenths of a second while `running`, reset on each rising edge. */
+export function useElapsed(running: boolean): number {
+  const [tenths, setTenths] = useState(0);
+  useEffect(() => {
+    if (!running) return;
+    setTenths(0);
+    const id = setInterval(() => setTenths((t) => t + 1), 100);
+    return () => clearInterval(id);
+  }, [running]);
+  return tenths;
+}
+
+export interface WordStream {
+  words: string[];
+  /** Number of words currently revealed. */
+  count: number;
+  streaming: boolean;
+}
+
+/**
+ * Reveals `text` word by word and stops when finished (replay happens by
+ * remounting the demo). Word delays are jittered deterministically so the
+ * rhythm reads as generation rather than a metronome.
+ */
+export function useWordStream(
+  text: string,
+  {
+    interval = 70,
+    startDelay = 600,
+  }: { interval?: number; startDelay?: number } = {},
+): WordStream {
+  const stage = useContext(DemoStageContext);
+  const stopped = stage?.stopped ?? false;
+  const words = useMemo(() => text.split(" "), [text]);
+  const [count, setCount] = useState(0);
+  const countRef = useRef(0);
+
+  useEffect(() => {
+    stage?.setPlaying(!stopped && count < words.length);
+  }, [stage, stopped, count, words.length]);
+
+  useEffect(() => {
+    if (stopped) return;
+    let id: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      const current = countRef.current;
+      if (current >= words.length) {
+        return;
+      }
+      const jitter = ((current * 7919) % 5) / 4;
+      id = setTimeout(
+        () => {
+          countRef.current = current + 1;
+          setCount(current + 1);
+          tick();
+        },
+        interval * (0.6 + jitter),
+      );
+    };
+    id = setTimeout(tick, startDelay);
+    return () => clearTimeout(id);
+  }, [words, interval, startDelay, stopped]);
+
+  return { words, count, streaming: !stopped && count < words.length };
+}
+
+/** Types `text` character by character, clears, and restarts. */
+export function useTypedText(
+  text: string,
+  {
+    interval = 38,
+    holdDelay = 1800,
+    startDelay = 800,
+  }: { interval?: number; holdDelay?: number; startDelay?: number } = {},
+): { typed: string; done: boolean } {
+  const [length, setLength] = useState(0);
+  const lengthRef = useRef(0);
+
+  useEffect(() => {
+    let id: ReturnType<typeof setTimeout>;
+    const tick = () => {
+      const current = lengthRef.current;
+      if (current >= text.length) {
+        id = setTimeout(() => {
+          lengthRef.current = 0;
+          setLength(0);
+          id = setTimeout(tick, startDelay);
+        }, holdDelay);
+        return;
+      }
+      id = setTimeout(() => {
+        lengthRef.current = current + 1;
+        setLength(current + 1);
+        tick();
+      }, interval);
+    };
+    id = setTimeout(tick, startDelay);
+    return () => clearTimeout(id);
+  }, [text, interval, holdDelay, startDelay]);
+
+  return { typed: text.slice(0, length), done: length >= text.length };
+}
+
+export function formatSeconds(tenths: number): string {
+  return `${Math.floor(tenths / 10)}s`;
+}

--- a/apps/docs/components/elements/web-search-demo.tsx
+++ b/apps/docs/components/elements/web-search-demo.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import {
+  WebSearch,
+  type WebSearchResult,
+} from "@/components/elements/web-search";
+import { useStoryPhases } from "./use-demo";
+
+const QUERY = "assistant-ui draft persistence";
+const RESULTS: readonly WebSearchResult[] = [
+  {
+    title: "Persisting composer state across threads",
+    domain: "assistant-ui.com",
+  },
+  {
+    title: "Draft autosave patterns in chat UIs",
+    domain: "patterns.dev",
+  },
+  {
+    title: "useSyncExternalStore and derived state",
+    domain: "react.dev",
+  },
+];
+
+const PHASES = [1800, 500, 500, 500, 3000] as const;
+
+export function WebSearchDemo() {
+  const { phase } = useStoryPhases(PHASES);
+  const visibleResults = Math.min(phase, RESULTS.length);
+  const searching = phase < RESULTS.length + 1;
+
+  return (
+    <WebSearch
+      query={QUERY}
+      results={RESULTS}
+      visibleResults={visibleResults}
+      searching={searching}
+      cycle={0}
+    />
+  );
+}

--- a/apps/docs/lib/constants.ts
+++ b/apps/docs/lib/constants.ts
@@ -110,6 +110,7 @@ export type NavItem =
 
 export const NAV_ITEMS: NavItem[] = [
   { type: "link", label: "Docs", href: "/docs" },
+  { type: "link", label: "Elements", href: "/elements" },
   {
     type: "mega",
     label: "Resources",

--- a/apps/docs/lib/element-source.ts
+++ b/apps/docs/lib/element-source.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { codeToHtml } from "shiki";
+
+const SOURCE_ROOTS = [
+  ["..", "..", "packages", "ui", "src", "components", "elements"],
+  ["components", "elements"],
+] as const;
+
+export async function readElementSource(file: string): Promise<string> {
+  for (const root of SOURCE_ROOTS) {
+    try {
+      const source = await fs.readFile(
+        path.join(process.cwd(), ...root, file),
+        "utf8",
+      );
+      return source.trimEnd();
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(`Element source not found: ${file}`);
+}
+
+export async function highlightElementSource(code: string): Promise<string> {
+  return codeToHtml(code, {
+    lang: "tsx",
+    themes: { light: "github-light", dark: "github-dark" },
+    defaultColor: "light-dark()",
+  });
+}

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -61,6 +61,12 @@ const config: NextConfig = {
   transpilePackages: ["@assistant-ui/ui", "shiki"],
   serverExternalPackages: ["just-bash"],
   skipTrailingSlashRedirect: true,
+  outputFileTracingIncludes: {
+    "/elements/[slug]": [
+      "./components/elements/*.tsx",
+      "../../packages/ui/src/components/elements/*.tsx",
+    ],
+  },
   headers: async () => [
     {
       source: "/(.*)",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -16,6 +16,10 @@
       "@/components/assistant-ui/*": [
         "../../packages/ui/src/components/assistant-ui/*"
       ],
+      "@/components/elements/*": [
+        "../../packages/ui/src/components/elements/*",
+        "./components/elements/*"
+      ],
       "@/*": ["./*"],
       "@assistant-ui/ui/*": ["../../packages/ui/src/*"],
       "fumadocs-mdx:collections/*": ["./.source/*"],

--- a/apps/registry/src/registry.ts
+++ b/apps/registry/src/registry.ts
@@ -42,7 +42,301 @@ const accordionKeyframesCss = {
   },
 };
 
+type ElementRegistryEntry = {
+  slug: string;
+  title: string;
+  description: string;
+  file: string;
+  dependencies?: string[];
+  usesCollapsible?: boolean;
+};
+
+const createElementRegistryItem = (
+  entry: ElementRegistryEntry,
+): RegistryItem => ({
+  name: `elements-${entry.slug}`,
+  type: "registry:component",
+  title: entry.title,
+  description: entry.description,
+  files: [
+    {
+      type: "registry:component",
+      path: `components/elements/${entry.file}`,
+      sourcePath: `../../packages/ui/src/components/elements/${entry.file}`,
+    },
+  ],
+  registryDependencies: [
+    "https://r.assistant-ui.com/elements-surfaces.json",
+    ...(entry.usesCollapsible ? ["collapsible"] : []),
+  ],
+  ...(entry.dependencies ? { dependencies: entry.dependencies } : {}),
+});
+
+const elementsRegistryItems: RegistryItem[] = [
+  {
+    name: "elements-surfaces",
+    type: "registry:component",
+    title: "Elements Surfaces",
+    description:
+      "Shared design language for the elements family: surface, ink, and motion class recipes plus the shimmer utility.",
+    files: [
+      {
+        type: "registry:lib",
+        path: "components/elements/surfaces.tsx",
+        sourcePath: "../../packages/ui/src/components/elements/surfaces.tsx",
+      },
+    ],
+    dependencies: ["tw-shimmer"],
+    css: {
+      '@import "tw-shimmer"': {},
+    },
+  },
+  createElementRegistryItem({
+    slug: "loading-state",
+    title: "Loading state",
+    description:
+      "A pixel matrix that keeps time while the model has nothing to show yet.",
+    file: "loading-state.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "thinking-indicator",
+    title: "Thinking indicator",
+    description:
+      "A live status line that names what the agent is doing right now, with elapsed time.",
+    file: "thinking-indicator.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "reasoning-panel",
+    title: "Reasoning panel",
+    description:
+      "A collapsible trace that streams reasoning steps along a timeline, then settles into a summary.",
+    file: "reasoning-panel.tsx",
+    dependencies: ["lucide-react"],
+    usesCollapsible: true,
+  }),
+  createElementRegistryItem({
+    slug: "streaming-text",
+    title: "Streaming text",
+    description:
+      "Tokens arrive softly: the newest words land in blue and settle into ink.",
+    file: "streaming-text.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "typing-indicator",
+    title: "Typing indicator",
+    description:
+      "The classic three dots, tuned to read as presence rather than noise.",
+    file: "typing-indicator.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "message-pair",
+    title: "Message pair",
+    description:
+      "A user bubble and a streaming assistant reply, with actions that appear on hover.",
+    file: "message-pair.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "message-branches",
+    title: "Message branches",
+    description:
+      "Navigate between regenerated versions of the same answer without losing your place.",
+    file: "message-branches.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "message-actions",
+    title: "Message actions",
+    description:
+      "Copy, rate, and regenerate. Each action confirms itself with a small state change.",
+    file: "message-actions.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "suggestions",
+    title: "Follow-up suggestions",
+    description:
+      "Prompt pills that stagger in after a reply and invite the next turn.",
+    file: "suggestions.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "error-state",
+    title: "Error state",
+    description:
+      "A quiet failure banner with a retry path, not a modal in your face.",
+    file: "error-state.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "tool-call",
+    title: "Tool call",
+    description:
+      "One tool invocation with its request and result tucked behind a disclosure.",
+    file: "tool-call.tsx",
+    dependencies: ["lucide-react"],
+    usesCollapsible: true,
+  }),
+  createElementRegistryItem({
+    slug: "tool-timeline",
+    title: "Tool timeline",
+    description:
+      "A whole working session summarized as verbs, targets, and file stats.",
+    file: "tool-timeline.tsx",
+    dependencies: ["lucide-react"],
+    usesCollapsible: true,
+  }),
+  createElementRegistryItem({
+    slug: "terminal-block",
+    title: "Terminal block",
+    description:
+      "Command output that streams line by line and ends with an exit status.",
+    file: "terminal-block.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "code-diff",
+    title: "Code diff",
+    description:
+      "A unified diff with tinted additions and removals, sized for chat.",
+    file: "code-diff.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "web-search",
+    title: "Web search",
+    description:
+      "A search query and its results landing one by one as the agent reads.",
+    file: "web-search.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "sources",
+    title: "Sources",
+    description:
+      "Citations collapsed into a pill, expanding into scannable source cards.",
+    file: "sources.tsx",
+    dependencies: ["lucide-react"],
+    usesCollapsible: true,
+  }),
+  createElementRegistryItem({
+    slug: "inline-citation",
+    title: "Inline citation",
+    description:
+      "Numbered references inside a sentence, each with a hover preview of its source.",
+    file: "inline-citation.tsx",
+    dependencies: ["@base-ui/react"],
+  }),
+  createElementRegistryItem({
+    slug: "image-generation",
+    title: "Image generation",
+    description:
+      "A dot grid holds the frame while the image resolves out of a blur.",
+    file: "image-generation.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "data-table",
+    title: "Data table",
+    description: "A small comparison table the model can answer with directly.",
+    file: "data-table.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "number-ticker",
+    title: "Number ticker",
+    description: "Digits that roll into place as a count updates in real time.",
+    file: "number-ticker.tsx",
+  }),
+  createElementRegistryItem({
+    slug: "agent-plan",
+    title: "Agent plan",
+    description:
+      "A checklist the agent works through, with progress you can glance.",
+    file: "agent-plan.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "subagent-list",
+    title: "Subagent list",
+    description:
+      "Parallel workers with their own progress, models, and completions.",
+    file: "subagent-list.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "agent-status",
+    title: "Agent status",
+    description:
+      "One pill that always answers: what is it doing, and for how long.",
+    file: "agent-status.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "approval-card",
+    title: "Approval card",
+    description:
+      "Human in the loop: the agent asks before it runs anything with side effects.",
+    file: "approval-card.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "recommendation-card",
+    title: "Recommendation card",
+    description:
+      "The agent proposes a change with its confidence, and waits for a yes.",
+    file: "recommendation-card.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "artifact-card",
+    title: "Artifact card",
+    description:
+      "A generated document as a tangible object, written live and versioned.",
+    file: "artifact-card.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "composer",
+    title: "Composer",
+    description:
+      "The unified input: attachments, commands, mentions, models, voice, and context in one surface.",
+    file: "composer.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "chat-panel",
+    title: "Chat panel",
+    description:
+      "The whole family working together: a message, a pause, a streamed reply.",
+    file: "chat-panel.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "empty-state",
+    title: "Empty state",
+    description:
+      "The first screen: a greeting, three ways in, and the composer front and center.",
+    file: "empty-state.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "thread-list",
+    title: "Thread list",
+    description:
+      "Conversation history with unread marks and actions that wait for hover.",
+    file: "thread-list.tsx",
+    dependencies: ["lucide-react"],
+  }),
+  createElementRegistryItem({
+    slug: "scroll-anchor",
+    title: "Scroll anchor",
+    description:
+      "Streaming never steals your scroll position; a pill offers the way back down.",
+    file: "scroll-anchor.tsx",
+    dependencies: ["lucide-react"],
+  }),
+];
+
 export const registry: RegistryItem[] = [
+  ...elementsRegistryItems,
   {
     name: "shimmer-style",
     type: "registry:style",

--- a/packages/ui/src/components/elements/agent-plan.tsx
+++ b/packages/ui/src/components/elements/agent-plan.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { CheckIcon, Loader2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mono } from "./surfaces";
+
+export function AgentPlan({
+  steps,
+  activeIndex,
+  className,
+}: {
+  steps: readonly string[];
+  activeIndex: number;
+  className?: string;
+}) {
+  const total = steps.length;
+  const allDone = activeIndex >= total;
+  const completed = allDone ? total : activeIndex;
+  const progress = total === 0 ? 0 : (completed / total) * 100;
+
+  return (
+    <div className={cn("flex w-full max-w-sm flex-col gap-3", className)}>
+      <div className="flex items-center justify-between">
+        <span className="text-[13.5px] font-medium">Plan</span>
+        <span className={cn(mono, "text-foreground/35 tabular-nums")}>
+          {completed} of {total}
+        </span>
+      </div>
+      <div className="bg-foreground/[0.06] h-[3px] w-full overflow-hidden rounded-full">
+        <span
+          className="bg-foreground/80 block h-full rounded-full transition-[width] duration-500"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <ul className="flex flex-col gap-2.5">
+        {steps.map((step, i) => {
+          const done = allDone || i < activeIndex;
+          const active = !allDone && i === activeIndex;
+          return (
+            <li key={step} className="flex items-center gap-2.5 text-[13.5px]">
+              <span className="flex size-4 shrink-0 items-center justify-center">
+                {done ? (
+                  <CheckIcon className="text-foreground/35 size-3.5" />
+                ) : active ? (
+                  <Loader2Icon className="text-foreground/90 size-3.5 animate-spin motion-reduce:animate-none" />
+                ) : (
+                  <span
+                    aria-hidden
+                    className="bg-foreground/15 size-1.5 rounded-full"
+                  />
+                )}
+              </span>
+              <span
+                className={cn(
+                  done && "text-foreground/40",
+                  active && "text-foreground/90",
+                  !done && !active && "text-foreground/35",
+                )}
+              >
+                {step}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/agent-status.tsx
+++ b/packages/ui/src/components/elements/agent-status.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { CheckIcon, PauseIcon, RotateCcwIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ghostButton, mono, paper } from "./surfaces";
+
+export type AgentState = "working" | "waiting" | "done";
+
+export interface StatusStep {
+  state: AgentState;
+  label: string;
+}
+
+export function AgentStatus({
+  state,
+  label,
+  elapsed,
+  className,
+}: {
+  state: AgentState;
+  label: string;
+  elapsed?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "flex items-center gap-2.5 rounded-full py-1.5 ps-3.5 pe-1.5",
+        className,
+      )}
+    >
+      {state === "done" ? (
+        <CheckIcon aria-hidden className="size-3 shrink-0 text-emerald-500" />
+      ) : (
+        <span
+          aria-hidden
+          className={cn(
+            "size-1.5 shrink-0 rounded-full motion-reduce:animate-none",
+            state === "working"
+              ? "animate-pulse bg-blue-500 dark:bg-blue-400"
+              : "bg-foreground/25 animate-pulse",
+          )}
+        />
+      )}
+      <span
+        key={label}
+        className="fade-in blur-in-[2px] animate-in max-w-44 truncate text-xs duration-300 motion-reduce:animate-none"
+      >
+        {label}
+      </span>
+      {elapsed !== undefined && state !== "done" && (
+        <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+          {elapsed}
+        </span>
+      )}
+      <button
+        type="button"
+        aria-label={state === "done" ? "Run again" : "Pause agent"}
+        className={cn(ghostButton, "size-6")}
+      >
+        {state === "done" ? (
+          <RotateCcwIcon className="size-3" />
+        ) : (
+          <PauseIcon className="size-3" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/approval-card.tsx
+++ b/packages/ui/src/components/elements/approval-card.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { CheckIcon, Loader2Icon, TerminalIcon, XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { field, inkButton, paper } from "./surfaces";
+
+export type ApprovalState = "request" | "running" | "done" | "denied";
+
+export function ApprovalCard({
+  state,
+  command,
+  title,
+  subtitle,
+  onAllowOnce,
+  onAlwaysAllow,
+  onDeny,
+  className,
+}: {
+  state: ApprovalState;
+  command: string;
+  title: string;
+  subtitle: string;
+  onAllowOnce?: () => void;
+  onAlwaysAllow?: () => void;
+  onDeny?: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "flex w-full max-w-sm flex-col gap-3.5 rounded-[20px] p-4",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <span className="bg-foreground/[0.05] text-foreground/45 flex size-9 shrink-0 items-center justify-center rounded-xl">
+          <TerminalIcon className="size-4" />
+        </span>
+        <div className="flex flex-col">
+          <p className="text-[13.5px] font-medium">{title}</p>
+          <p className="text-foreground/45 text-xs">{subtitle}</p>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          field,
+          "text-foreground/70 rounded-xl px-3.5 py-2.5 font-mono text-xs",
+        )}
+      >
+        {command}
+      </div>
+
+      <div className="flex h-8 items-center justify-end gap-2">
+        {state === "request" ? (
+          <>
+            <button
+              type="button"
+              onClick={onDeny}
+              className="text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 h-8 rounded-full px-3.5 text-xs font-medium transition-[background-color,color,scale] duration-150 active:scale-[0.96]"
+            >
+              Deny
+            </button>
+            <button
+              type="button"
+              onClick={onAlwaysAllow}
+              className="text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 h-8 rounded-full px-3.5 text-xs font-medium transition-[background-color,color,scale] duration-150 active:scale-[0.96]"
+            >
+              Always allow
+            </button>
+            <button
+              type="button"
+              onClick={onAllowOnce}
+              className={cn(
+                inkButton,
+                "flex h-8 items-center rounded-full px-3.5 text-xs font-medium",
+              )}
+            >
+              Allow once
+            </button>
+          </>
+        ) : (
+          <div
+            key={state}
+            className="fade-in animate-in text-foreground/55 flex items-center gap-2 text-xs duration-300"
+          >
+            {state === "running" ? (
+              <>
+                <Loader2Icon className="text-foreground/45 size-3.5 animate-spin" />
+                Approved, running
+              </>
+            ) : state === "denied" ? (
+              <>
+                <XIcon className="text-foreground/45 size-3.5" />
+                Denied
+              </>
+            ) : (
+              <>
+                <CheckIcon className="size-3.5 text-emerald-500" />
+                Finished with exit 0
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/artifact-card.tsx
+++ b/packages/ui/src/components/elements/artifact-card.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { ArrowUpRightIcon, FileTextIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mono, paper } from "./surfaces";
+
+export function ArtifactCard({
+  title,
+  meta,
+  generating = false,
+  words = 0,
+  className,
+}: {
+  title: string;
+  meta: string;
+  generating?: boolean;
+  words?: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "group flex w-full max-w-xs cursor-pointer items-center gap-3 rounded-[20px] p-3.5 transition-transform duration-150 hover:-translate-y-px active:scale-[0.98]",
+        className,
+      )}
+    >
+      <span className="bg-foreground/[0.05] text-foreground/45 flex size-9 shrink-0 items-center justify-center rounded-xl">
+        <FileTextIcon
+          className={cn(
+            "size-4",
+            generating && "animate-pulse motion-reduce:animate-none",
+          )}
+        />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-[13.5px] font-medium">{title}</p>
+        {generating ? (
+          <p className={cn(mono, "text-foreground/40 flex items-center gap-1")}>
+            <span className="relative inline-block leading-none">
+              <span>Writing</span>
+              <span
+                aria-hidden
+                className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+              >
+                Writing
+              </span>
+            </span>
+            <span>·</span>
+            <span className="tabular-nums">{words} words</span>
+          </p>
+        ) : (
+          <p
+            className={cn(
+              mono,
+              "fade-in blur-in-[2px] animate-in text-foreground/40 duration-300 motion-reduce:animate-none",
+            )}
+          >
+            {meta}
+          </p>
+        )}
+      </div>
+      <ArrowUpRightIcon className="text-foreground/35 size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/chat-panel.tsx
+++ b/packages/ui/src/components/elements/chat-panel.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { ArrowUpIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { field, inkButton, paper } from "./surfaces";
+
+export interface ChatPanelProps {
+  userMessage: string;
+  reply: string;
+  showUserMessage: boolean;
+  typing: boolean;
+  visibleWords: number;
+  streaming: boolean;
+  className?: string;
+}
+
+export function ChatPanel({
+  userMessage,
+  reply,
+  showUserMessage,
+  typing,
+  visibleWords,
+  streaming,
+  className,
+}: ChatPanelProps) {
+  const words = reply.split(" ");
+
+  return (
+    <div
+      className={cn(
+        paper,
+        "flex h-[270px] w-full max-w-md flex-col overflow-hidden rounded-[24px]",
+        className,
+      )}
+    >
+      <div className="flex flex-1 flex-col justify-end gap-2.5 overflow-hidden p-4">
+        {showUserMessage && (
+          <div
+            className={cn(
+              field,
+              "fade-in slide-in-from-bottom-1 animate-in self-end rounded-2xl px-3 py-1.5 text-xs duration-300",
+            )}
+          >
+            {userMessage}
+          </div>
+        )}
+        {typing && (
+          <div className="fade-in animate-in flex gap-1 self-start px-1 duration-300">
+            {["-0.32s", "-0.16s", "0s"].map((delay) => (
+              <span
+                key={delay}
+                aria-hidden
+                className="bg-foreground/40 size-1 animate-bounce rounded-full motion-reduce:animate-none"
+                style={{ animationDelay: delay, animationDuration: "1.1s" }}
+              />
+            ))}
+          </div>
+        )}
+        {visibleWords > 0 && (
+          <p className="text-foreground/70 max-w-[85%] self-start text-xs leading-relaxed">
+            {words.slice(0, visibleWords).map((word, i) => {
+              const fresh = streaming && visibleWords - 1 - i < 2;
+              return (
+                <span
+                  key={i}
+                  className="fade-in animate-in fill-mode-both duration-500 motion-reduce:animate-none"
+                >
+                  <span
+                    className={cn(
+                      "transition-colors duration-700 motion-reduce:transition-none",
+                      fresh && "text-blue-500 dark:text-blue-400",
+                    )}
+                  >
+                    {word}
+                  </span>{" "}
+                </span>
+              );
+            })}
+            {streaming && (
+              <span
+                aria-hidden
+                className="-mb-0.5 ml-0.5 inline-block h-3 w-0.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+              />
+            )}
+          </p>
+        )}
+      </div>
+      <div
+        className={cn(
+          field,
+          "mx-3 mb-3 flex h-10 shrink-0 items-center justify-between rounded-full py-1.5 ps-4 pe-1.5",
+        )}
+      >
+        <span className="text-foreground/35 text-[13px]">Message</span>
+        <span
+          className={cn(
+            inkButton,
+            "flex size-7 items-center justify-center rounded-full",
+          )}
+        >
+          <ArrowUpIcon className="size-3.5" />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/code-diff.tsx
+++ b/packages/ui/src/components/elements/code-diff.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { mono, paper } from "./surfaces";
+
+export type DiffKind = "context" | "added" | "removed";
+
+export interface DiffLine {
+  kind: DiffKind;
+  text: string;
+}
+
+const GUTTER: Record<DiffKind, string> = {
+  context: "",
+  added: "+",
+  removed: "−",
+};
+
+export function CodeDiff({
+  filename,
+  additions,
+  deletions,
+  lines,
+  cycle,
+  className,
+}: {
+  filename: string;
+  additions: number;
+  deletions: number;
+  lines: readonly DiffLine[];
+  cycle: number;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "w-full max-w-md overflow-hidden rounded-2xl font-mono text-xs",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between px-4 pt-3 pb-2">
+        <span className="text-foreground/90">{filename}</span>
+        <span className={cn(mono, "tabular-nums")}>
+          <span className="text-emerald-600 dark:text-emerald-400">
+            +{additions}
+          </span>{" "}
+          <span className="text-red-600 dark:text-red-400">−{deletions}</span>
+        </span>
+      </div>
+      <div>
+        {lines.map((line, i) => (
+          <div
+            key={`${cycle}-${i}-${line.text}`}
+            className={cn(
+              "fade-in animate-in fill-mode-both flex px-4 py-0.5 leading-relaxed whitespace-pre duration-300",
+              line.kind === "context" && "text-foreground/45",
+              line.kind === "added" &&
+                "bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-300",
+              line.kind === "removed" &&
+                "bg-red-500/10 text-red-700 dark:text-red-300",
+            )}
+            style={{ animationDelay: `${i * 60}ms` }}
+          >
+            <span className="w-4 shrink-0 select-none">
+              {GUTTER[line.kind]}
+            </span>
+            <span>{line.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/composer.tsx
+++ b/packages/ui/src/components/elements/composer.tsx
@@ -1,0 +1,613 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  ArrowUpIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  FileArchiveIcon,
+  FileImageIcon,
+  FileTextIcon,
+  Loader2Icon,
+  MicIcon,
+  PlusIcon,
+  SquareIcon,
+  XIcon,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  field,
+  floating,
+  ghostButton,
+  iconSwap,
+  iconSwapIn,
+  iconSwapOut,
+  inkButton,
+  mono,
+  paper,
+} from "./surfaces";
+
+export interface ComposerAttachment {
+  name: string;
+  meta: string;
+  state: "uploading" | "done" | "error";
+  progress?: number;
+  kind?: "image" | "text" | "archive";
+}
+
+export interface ComposerCommand {
+  name: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export interface ComposerPerson {
+  name: string;
+  role: "agent" | "human";
+}
+
+export interface ComposerModel {
+  name: string;
+  meta: string;
+}
+
+export interface ComposerUsage {
+  system: number;
+  tools: number;
+  messages: number;
+  total: number;
+}
+
+export interface ComposerProps {
+  value: string;
+  onValueChange: (value: string) => void;
+  onSend?: () => void;
+  onStop?: () => void;
+  placeholder?: string;
+  streaming?: boolean;
+  attachments?: ComposerAttachment[];
+  onRemoveAttachment?: (name: string) => void;
+  dragActive?: boolean;
+  commands?: ComposerCommand[];
+  onCommand?: (command: ComposerCommand) => void;
+  people?: ComposerPerson[];
+  onMention?: (person: ComposerPerson) => void;
+  models?: ComposerModel[];
+  model?: string;
+  onModelChange?: (name: string) => void;
+  defaultModelMenuOpen?: boolean;
+  usage?: ComposerUsage;
+  recording?: boolean;
+  transcribing?: boolean;
+  recordingSeconds?: number;
+  onVoiceStart?: () => void;
+  onVoiceStop?: () => void;
+  className?: string;
+}
+
+const ATTACHMENT_ICONS: Record<
+  NonNullable<ComposerAttachment["kind"]>,
+  LucideIcon
+> = {
+  image: FileImageIcon,
+  text: FileTextIcon,
+  archive: FileArchiveIcon,
+};
+
+const BARS = Array.from({ length: 14 }, (_, i) => i);
+
+function barHeight(bar: number, tick: number): number {
+  return 5 + Math.abs(Math.sin(bar * 1.35 + tick * 0.55)) * 13;
+}
+
+function MenuSurface({
+  open,
+  align = "start",
+  children,
+}: {
+  open: boolean;
+  align?: "start" | "end";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        floating,
+        "absolute bottom-full z-10 mb-2 flex w-72 flex-col gap-0.5 rounded-2xl p-1.5",
+        align === "start"
+          ? "start-0 origin-bottom-left"
+          : "end-0 origin-bottom-right",
+        "transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+        open
+          ? "scale-100 opacity-100"
+          : "pointer-events-none scale-[0.97] opacity-0",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Composer({
+  value,
+  onValueChange,
+  onSend,
+  onStop,
+  placeholder = "Ask anything",
+  streaming = false,
+  attachments,
+  onRemoveAttachment,
+  dragActive = false,
+  commands,
+  onCommand,
+  people,
+  onMention,
+  models,
+  model,
+  onModelChange,
+  defaultModelMenuOpen = false,
+  usage,
+  recording = false,
+  transcribing = false,
+  recordingSeconds = 0,
+  onVoiceStart,
+  onVoiceStop,
+  className,
+}: ComposerProps) {
+  const [modelMenuOpen, setModelMenuOpen] = useState(defaultModelMenuOpen);
+
+  const slashQuery = useMemo(() => {
+    if (!commands || !value.startsWith("/")) return null;
+    return value.slice(1).toLowerCase();
+  }, [commands, value]);
+  const slashMatches = useMemo(
+    () =>
+      slashQuery === null
+        ? []
+        : (commands ?? []).filter((c) => c.name.startsWith(slashQuery)),
+    [commands, slashQuery],
+  );
+
+  const mentionQuery = useMemo(() => {
+    if (!people) return null;
+    const match = /@([\w]*)$/.exec(value);
+    return match ? (match[1]?.toLowerCase() ?? "") : null;
+  }, [people, value]);
+  const mentionMatches = useMemo(
+    () =>
+      mentionQuery === null
+        ? []
+        : (people ?? []).filter((p) =>
+            p.name.toLowerCase().startsWith(mentionQuery),
+          ),
+    [people, mentionQuery],
+  );
+
+  const voiceActive = recording || transcribing;
+  const empty = value.length === 0;
+  const timer = `0:${String(recordingSeconds).padStart(2, "0")}`;
+  const usageUsed = usage ? usage.system + usage.tools + usage.messages : 0;
+  const usageFraction = usage ? usageUsed / usage.total : 0;
+  const usageWarn = usageFraction > 0.85;
+  const circumference = 2 * Math.PI * 6;
+  const usageSegments = usage
+    ? [
+        { label: "System", value: usage.system, className: "bg-foreground/25" },
+        { label: "Tools", value: usage.tools, className: "bg-foreground/45" },
+        {
+          label: "Messages",
+          value: usage.messages,
+          className: "bg-foreground/80",
+        },
+      ]
+    : [];
+
+  return (
+    <div className={cn("relative w-full max-w-lg", className)}>
+      <MenuSurface open={slashMatches.length > 0}>
+        {slashMatches.map((command, i) => (
+          <button
+            key={command.name}
+            type="button"
+            onClick={() => {
+              onCommand?.(command);
+              onValueChange(`/${command.name} `);
+            }}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
+              i === 0 ? field : "hover:bg-foreground/[0.04]",
+            )}
+          >
+            <command.icon className="text-foreground/35 size-3.5 shrink-0" />
+            <span className="font-medium">/{command.name}</span>
+            <span className="text-foreground/45 flex-1 truncate text-start text-xs">
+              {command.description}
+            </span>
+            {i === 0 && (
+              <kbd className="bg-foreground/[0.06] text-foreground/45 rounded px-1 font-mono text-[10px]">
+                ↵
+              </kbd>
+            )}
+          </button>
+        ))}
+      </MenuSurface>
+
+      <MenuSurface open={mentionMatches.length > 0}>
+        {mentionMatches.map((person, i) => (
+          <button
+            key={person.name}
+            type="button"
+            onClick={() => {
+              onMention?.(person);
+              onValueChange(value.replace(/@[\w]*$/, `@${person.name} `));
+            }}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
+              i === 0 ? field : "hover:bg-foreground/[0.04]",
+            )}
+          >
+            <span className="bg-foreground/[0.06] text-foreground/45 flex size-5 shrink-0 items-center justify-center rounded-full text-[9px] font-medium">
+              {person.name[0]}
+            </span>
+            <span className="flex-1 truncate text-start">{person.name}</span>
+            <span className={cn(mono, "text-foreground/35")}>
+              {person.role}
+            </span>
+          </button>
+        ))}
+      </MenuSurface>
+
+      <div
+        className={cn(
+          paper,
+          "flex w-full flex-col gap-2 rounded-[24px] p-2.5 transition-colors",
+          dragActive && "bg-blue-500/[0.04] dark:bg-blue-500/10",
+        )}
+      >
+        {attachments && attachments.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {attachments.map((attachment) => {
+              const Icon = ATTACHMENT_ICONS[attachment.kind ?? "text"];
+              return (
+                <div
+                  key={attachment.name}
+                  className={cn(
+                    field,
+                    "relative flex items-center gap-2.5 overflow-hidden rounded-[14px] py-1.5 ps-1.5 pe-2.5",
+                  )}
+                >
+                  <span className="bg-background text-foreground/45 flex size-8 shrink-0 items-center justify-center rounded-[10px] shadow-[0_1px_2px_rgba(0,0,0,0.06)] dark:bg-white/10 dark:shadow-none">
+                    <Icon className="size-4" />
+                  </span>
+                  <span className="flex flex-col">
+                    <span className="max-w-36 truncate text-xs font-medium">
+                      {attachment.name}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-[11px]",
+                        attachment.state === "error"
+                          ? "text-red-600/80 dark:text-red-400/80"
+                          : "text-foreground/40",
+                      )}
+                    >
+                      {attachment.meta}
+                    </span>
+                  </span>
+                  <span className="ms-1 flex w-5 items-center justify-end">
+                    {attachment.state === "uploading" ? (
+                      <Loader2Icon className="text-foreground/35 size-3.5 animate-spin motion-reduce:animate-none" />
+                    ) : attachment.state === "done" && onRemoveAttachment ? (
+                      <button
+                        type="button"
+                        aria-label={`Remove ${attachment.name}`}
+                        onClick={() => onRemoveAttachment(attachment.name)}
+                        className={cn(ghostButton, "size-5 [&_svg]:size-3")}
+                      >
+                        <XIcon />
+                      </button>
+                    ) : attachment.state === "done" ? (
+                      <CheckIcon className="size-3.5 text-emerald-500" />
+                    ) : null}
+                  </span>
+                  {attachment.state === "uploading" && (
+                    <span
+                      aria-hidden
+                      className="absolute inset-x-0 bottom-0 h-0.5 bg-blue-500/70 transition-[width] duration-300 dark:bg-blue-400/70"
+                      style={{ width: `${attachment.progress ?? 0}%` }}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {voiceActive ? (
+          <div className="flex min-h-11 items-center gap-3 ps-3">
+            {recording && (
+              <span
+                aria-hidden
+                className="size-1.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+              />
+            )}
+            <div className="flex h-6 items-center gap-[3px]" aria-hidden>
+              {BARS.map((bar) => (
+                <span
+                  key={bar}
+                  className={cn(
+                    "w-0.5 rounded-full transition-[height,background-color] duration-150 motion-reduce:transition-none",
+                    recording ? "bg-foreground/50" : "bg-foreground/25",
+                  )}
+                  style={{
+                    height: recording
+                      ? barHeight(bar, recordingSeconds * 10)
+                      : 3,
+                  }}
+                />
+              ))}
+            </div>
+            {recording ? (
+              <span className={cn(mono, "text-foreground/40 tabular-nums")}>
+                {timer}
+              </span>
+            ) : (
+              <span className="text-foreground/55 relative text-[13px]">
+                <span>Transcribing</span>
+                <span
+                  aria-hidden
+                  className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+                >
+                  Transcribing
+                </span>
+              </span>
+            )}
+          </div>
+        ) : (
+          <input
+            value={value}
+            onChange={(event) => onValueChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !empty && !streaming) onSend?.();
+            }}
+            placeholder={placeholder}
+            className="placeholder:text-foreground/35 min-h-11 w-full bg-transparent px-3 text-[15px] caret-blue-500 outline-none dark:caret-blue-400"
+          />
+        )}
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              aria-label="Add attachment"
+              className={cn(ghostButton, "size-8")}
+            >
+              <PlusIcon className="size-4" />
+            </button>
+            {models && model !== undefined && (
+              <div className="relative">
+                <MenuSurface open={modelMenuOpen}>
+                  <p
+                    className={cn(
+                      mono,
+                      "text-foreground/35 px-2.5 pt-2 pb-1.5",
+                    )}
+                  >
+                    Models
+                  </p>
+                  {models.map((entry) => {
+                    const selected = entry.name === model;
+                    return (
+                      <button
+                        key={entry.name}
+                        type="button"
+                        onClick={() => {
+                          onModelChange?.(entry.name);
+                          setModelMenuOpen(false);
+                        }}
+                        className={cn(
+                          "flex w-full items-center gap-2.5 rounded-[10px] px-2.5 py-2 text-[13.5px] transition-colors",
+                          selected ? field : "hover:bg-foreground/[0.04]",
+                        )}
+                      >
+                        <span className="flex-1 text-start">{entry.name}</span>
+                        <span
+                          className={cn(
+                            mono,
+                            "text-foreground/35 tabular-nums",
+                          )}
+                        >
+                          {entry.meta}
+                        </span>
+                        <span className="flex w-4 justify-end">
+                          {selected && (
+                            <CheckIcon className="fade-in zoom-in-90 animate-in size-3.5 duration-200" />
+                          )}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </MenuSurface>
+                <button
+                  type="button"
+                  aria-expanded={modelMenuOpen}
+                  onClick={() => setModelMenuOpen((open) => !open)}
+                  className="text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 dark:hover:bg-foreground/[0.09] flex h-8 items-center gap-1.5 rounded-full px-3 text-[12.5px] transition-colors"
+                >
+                  {model}
+                  <ChevronDownIcon className="size-3 opacity-60" />
+                </button>
+              </div>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5">
+            {usage && (
+              <div className="group/ctx relative">
+                <div
+                  className={cn(
+                    floating,
+                    "absolute end-0 bottom-full z-10 mb-2 flex w-60 origin-bottom-right flex-col gap-3.5 rounded-2xl p-4",
+                    "transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+                    "pointer-events-none scale-[0.97] opacity-0",
+                    "group-hover/ctx:pointer-events-auto group-hover/ctx:scale-100 group-hover/ctx:opacity-100",
+                    "group-focus-within/ctx:pointer-events-auto group-focus-within/ctx:scale-100 group-focus-within/ctx:opacity-100",
+                  )}
+                >
+                  <div className="flex items-baseline justify-between">
+                    <p className="text-[13.5px] font-medium">Context</p>
+                    <p
+                      className={cn(
+                        mono,
+                        "tabular-nums",
+                        usageWarn
+                          ? "text-red-500 dark:text-red-400"
+                          : "text-foreground/35",
+                      )}
+                    >
+                      {Math.round(usageFraction * 100)}%
+                    </p>
+                  </div>
+                  <div className="bg-foreground/[0.06] flex h-[5px] w-full gap-px overflow-hidden rounded-full">
+                    {usageSegments.map((segment) => (
+                      <span
+                        key={segment.label}
+                        className={cn(
+                          "h-full transition-[width] duration-700 motion-reduce:transition-none",
+                          segment.className,
+                        )}
+                        style={{
+                          width: `${(segment.value / usage.total) * 100}%`,
+                        }}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {usageSegments.map((segment) => (
+                      <div
+                        key={segment.label}
+                        className="text-foreground/55 flex items-center gap-2.5 text-[13px]"
+                      >
+                        <span
+                          aria-hidden
+                          className={cn(
+                            "size-1.5 rounded-full",
+                            segment.className,
+                          )}
+                        />
+                        <span className="flex-1">{segment.label}</span>
+                        <span
+                          className={cn(
+                            mono,
+                            "text-foreground/40 tabular-nums",
+                          )}
+                        >
+                          {segment.value}k
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="bg-foreground/[0.06] h-px" />
+                  <div className="text-foreground/55 flex items-center justify-between text-[13px]">
+                    <span>Total</span>
+                    <span
+                      className={cn(mono, "text-foreground/40 tabular-nums")}
+                    >
+                      {usageUsed}k / {usage.total}k
+                    </span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  aria-label="Context usage"
+                  className={cn(
+                    ghostButton,
+                    "size-8",
+                    usageWarn && "text-red-500 dark:text-red-400",
+                  )}
+                >
+                  <svg
+                    viewBox="0 0 16 16"
+                    className="size-4 -rotate-90"
+                    aria-hidden
+                  >
+                    <circle
+                      cx="8"
+                      cy="8"
+                      r="6"
+                      fill="none"
+                      strokeWidth="2.5"
+                      className="stroke-foreground/10"
+                    />
+                    <circle
+                      cx="8"
+                      cy="8"
+                      r="6"
+                      fill="none"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      className="stroke-current transition-[stroke-dashoffset] duration-700 motion-reduce:transition-none"
+                      strokeDasharray={circumference}
+                      strokeDashoffset={
+                        circumference * (1 - Math.min(usageFraction, 1))
+                      }
+                    />
+                  </svg>
+                </button>
+              </div>
+            )}
+            {(onVoiceStart || voiceActive) && (
+              <button
+                type="button"
+                aria-label={
+                  voiceActive ? "Stop recording" : "Start voice input"
+                }
+                onClick={voiceActive ? onVoiceStop : onVoiceStart}
+                className={cn(
+                  voiceActive
+                    ? cn(
+                        inkButton,
+                        "flex size-8 items-center justify-center rounded-full",
+                      )
+                    : cn(ghostButton, "size-8"),
+                )}
+              >
+                {voiceActive ? (
+                  <SquareIcon className="size-3 fill-current" />
+                ) : (
+                  <MicIcon className="size-4" />
+                )}
+              </button>
+            )}
+            <button
+              type="button"
+              aria-label={streaming ? "Stop generating" : "Send message"}
+              onClick={streaming ? onStop : onSend}
+              className={cn(
+                "grid size-8 place-items-center rounded-full",
+                streaming || !empty
+                  ? inkButton
+                  : "bg-foreground/[0.06] text-foreground/30 dark:bg-foreground/[0.09] transition-colors",
+              )}
+            >
+              <ArrowUpIcon
+                className={cn(
+                  iconSwap,
+                  "size-4",
+                  streaming ? iconSwapOut : iconSwapIn,
+                )}
+              />
+              <SquareIcon
+                className={cn(
+                  iconSwap,
+                  "size-3 fill-current",
+                  streaming ? iconSwapIn : iconSwapOut,
+                )}
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/data-table.tsx
+++ b/packages/ui/src/components/elements/data-table.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { mono, paper } from "./surfaces";
+
+export interface ModelUsage {
+  name: string;
+  context: string;
+  cost: string;
+}
+
+export interface DataTableProps {
+  rows: readonly ModelUsage[];
+  cycle: number;
+  className?: string;
+}
+
+export function DataTable({ rows, cycle, className }: DataTableProps) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "w-full max-w-sm overflow-hidden rounded-2xl text-[13px]",
+        className,
+      )}
+    >
+      <div className="flex items-center px-4 pt-3 pb-2">
+        <span className={cn(mono, "text-foreground/35 flex-1")}>Model</span>
+        <span className={cn(mono, "text-foreground/35 w-16 text-end")}>
+          Context
+        </span>
+        <span className={cn(mono, "text-foreground/35 w-16 text-end")}>
+          Cost
+        </span>
+      </div>
+      <div className="bg-foreground/[0.06] mx-4 h-px" />
+      <div key={cycle}>
+        {rows.map((row, index) => (
+          <div
+            key={row.name}
+            className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both hover:bg-foreground/[0.03] flex items-center gap-2.5 px-4 py-2.5 transition-colors duration-300"
+            style={{ animationDelay: `${index * 80}ms` }}
+          >
+            <span className="bg-foreground/[0.06] text-foreground/45 flex size-5 shrink-0 items-center justify-center rounded-md text-[9px] font-medium">
+              {row.name[0]!}
+            </span>
+            <span className="text-foreground/90 flex-1 truncate">
+              {row.name}
+            </span>
+            <span
+              className={cn(
+                mono,
+                "text-foreground/55 w-16 text-end tabular-nums",
+              )}
+            >
+              {row.context}
+            </span>
+            <span
+              className={cn(
+                mono,
+                "text-foreground/55 w-16 text-end tabular-nums",
+              )}
+            >
+              {row.cost}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/empty-state.tsx
+++ b/packages/ui/src/components/elements/empty-state.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ArrowUpIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { inkButton, paper } from "./surfaces";
+
+export interface EmptyStateProps {
+  greeting: string;
+  suggestions: readonly string[];
+  className?: string;
+}
+
+export function EmptyState({
+  greeting,
+  suggestions,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex w-full max-w-md flex-col items-center gap-7",
+        className,
+      )}
+    >
+      <h2 className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-center text-2xl font-medium tracking-tight duration-500 motion-reduce:animate-none">
+        {greeting}
+      </h2>
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {suggestions.map((suggestion, i) => (
+          <button
+            key={suggestion}
+            type="button"
+            className={cn(
+              paper,
+              "fade-in slide-in-from-bottom-2 animate-in fill-mode-both focus-visible:ring-foreground/20 rounded-full px-4 py-2 text-[13px] transition-transform duration-500 outline-none hover:-translate-y-px focus-visible:ring-2 active:scale-[0.96] motion-reduce:animate-none",
+            )}
+            style={{ animationDelay: `${120 + i * 70}ms` }}
+          >
+            {suggestion}
+          </button>
+        ))}
+      </div>
+
+      <div
+        className={cn(
+          paper,
+          "fade-in slide-in-from-bottom-2 animate-in fill-mode-both flex h-13 w-full items-center justify-between rounded-full py-2 ps-5 pe-2.5 duration-500 motion-reduce:animate-none",
+        )}
+        style={{ animationDelay: "360ms" }}
+      >
+        <span className="text-foreground/35 text-[15px]">Ask anything</span>
+        <span
+          className={cn(
+            inkButton,
+            "flex size-8 items-center justify-center rounded-full",
+          )}
+        >
+          <ArrowUpIcon className="size-4" />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/error-state.tsx
+++ b/packages/ui/src/components/elements/error-state.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { CircleAlertIcon, RefreshCwIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface ErrorStateProps {
+  title: string;
+  detail: string;
+  retrying: boolean;
+  onRetry: () => void;
+  className?: string;
+}
+
+export function ErrorState({
+  title,
+  detail,
+  retrying,
+  onRetry,
+  className,
+}: ErrorStateProps) {
+  if (retrying) {
+    return (
+      <div
+        key="retrying"
+        role="status"
+        className={cn(
+          "fade-in animate-in flex w-full max-w-sm items-center gap-2.5 text-sm duration-300 motion-reduce:animate-none",
+          className,
+        )}
+      >
+        <RefreshCwIcon className="text-foreground/45 size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
+        <span className="text-foreground/55 relative inline-block">
+          <span>Retrying</span>
+          <span
+            aria-hidden
+            className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+          >
+            Retrying
+          </span>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      key="error"
+      role="alert"
+      className={cn(
+        "fade-in animate-in flex w-full max-w-sm items-start gap-2.5 rounded-2xl bg-red-500/[0.06] px-4 py-3 text-sm duration-300 motion-reduce:animate-none dark:bg-red-500/10",
+        className,
+      )}
+    >
+      <CircleAlertIcon className="mt-0.5 size-4 shrink-0 text-red-500/80" />
+      <div>
+        <p className="font-medium text-red-600 dark:text-red-400">{title}</p>
+        <p className="mt-0.5 text-[13px] leading-snug text-red-600/60 dark:text-red-400/60">
+          {detail}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="ms-auto flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-500/10 dark:text-red-400"
+      >
+        <RefreshCwIcon className="size-3" />
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/image-generation.tsx
+++ b/packages/ui/src/components/elements/image-generation.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { RefreshCwIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ghostButton, mono, paper } from "./surfaces";
+
+const DOTS = Array.from({ length: 64 }, (_, i) => i);
+
+export function ImageGeneration({
+  prompt,
+  generating,
+  className,
+}: {
+  prompt: string;
+  generating: boolean;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex w-52 flex-col gap-2.5", className)}>
+      <div
+        className={cn(
+          paper,
+          "relative aspect-square w-full overflow-hidden rounded-2xl",
+        )}
+      >
+        <div
+          className="absolute inset-0 grid grid-cols-8 place-items-center p-6"
+          aria-hidden
+        >
+          {DOTS.map((dot) => {
+            const row = Math.floor(dot / 8);
+            const col = dot % 8;
+            return (
+              <span
+                key={dot}
+                className={cn(
+                  "bg-foreground/20 size-1 rounded-full transition-opacity duration-500",
+                  generating
+                    ? "animate-pulse motion-reduce:animate-none"
+                    : "opacity-0",
+                )}
+                style={{ animationDelay: `${(row + col) * 90}ms` }}
+              />
+            );
+          })}
+        </div>
+        <div
+          aria-hidden
+          className={cn(
+            "absolute inset-0 transition-[opacity,filter] duration-1000 ease-out motion-reduce:transition-none",
+            generating ? "opacity-0 blur-xl" : "blur-0 opacity-100",
+          )}
+          style={{
+            background:
+              "radial-gradient(120% 90% at 20% 100%, oklch(0.45 0.09 265) 0%, transparent 55%), radial-gradient(110% 80% at 85% 90%, oklch(0.62 0.1 300 / 0.8) 0%, transparent 60%), radial-gradient(130% 100% at 60% 0%, oklch(0.88 0.06 60) 0%, oklch(0.74 0.09 25 / 0.9) 45%, transparent 75%), linear-gradient(to top, oklch(0.35 0.06 275), oklch(0.82 0.07 50))",
+          }}
+        />
+        <span
+          className={cn(
+            mono,
+            "absolute end-2.5 top-2.5 tabular-nums",
+            generating ? "text-foreground/35" : "text-white/70",
+          )}
+        >
+          1024 × 1024
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-foreground/45 min-w-0 flex-1 truncate text-xs">
+          {generating ? (
+            <span className="relative">
+              <span>Generating</span>
+              <span
+                aria-hidden
+                className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+              >
+                Generating
+              </span>
+            </span>
+          ) : (
+            prompt
+          )}
+        </p>
+        <button
+          type="button"
+          aria-label="Regenerate image"
+          className={cn(
+            ghostButton,
+            "size-6 shrink-0",
+            generating && "pointer-events-none opacity-0",
+          )}
+        >
+          <RefreshCwIcon className="size-3" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/inline-citation.tsx
+++ b/packages/ui/src/components/elements/inline-citation.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { PreviewCard } from "@base-ui/react/preview-card";
+import { cn } from "@/lib/utils";
+import { floating, mono } from "./surfaces";
+
+export interface Source {
+  domain: string;
+  title: string;
+  snippet: string;
+}
+
+interface CitationProps {
+  index: number;
+  source: Source;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function Citation({ index, source, open, onOpenChange }: CitationProps) {
+  return (
+    <PreviewCard.Root open={open} onOpenChange={onOpenChange}>
+      <PreviewCard.Trigger
+        delay={0}
+        render={<button type="button" />}
+        className={cn(
+          "mx-0.5 inline-flex h-4 min-w-4 translate-y-[-2px] cursor-default items-center justify-center rounded-[5px] px-1 align-middle font-mono text-[10px] font-medium tabular-nums transition-colors",
+          open
+            ? "bg-foreground text-background"
+            : "bg-foreground/[0.06] text-foreground/45 hover:text-foreground/90",
+        )}
+      >
+        {index + 1}
+      </PreviewCard.Trigger>
+      <PreviewCard.Portal>
+        <PreviewCard.Positioner side="top" sideOffset={8}>
+          <PreviewCard.Popup
+            className={cn(
+              floating,
+              "z-50 w-64 origin-(--transform-origin) rounded-2xl p-3.5 outline-none",
+              "transition-[opacity,scale] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+              "data-[starting-style]:scale-[0.97] data-[starting-style]:opacity-0",
+              "data-[ending-style]:scale-[0.97] data-[ending-style]:opacity-0",
+            )}
+          >
+            <div className="flex items-center gap-1.5">
+              <span className="bg-foreground/[0.06] text-foreground/45 flex size-4 items-center justify-center rounded text-[9px] font-medium">
+                {source.domain[0]?.toUpperCase()}
+              </span>
+              <span className={cn(mono, "text-foreground/40")}>
+                {source.domain}
+              </span>
+            </div>
+            <p className="mt-2 text-[13px] leading-snug font-medium">
+              {source.title}
+            </p>
+            <p className="text-foreground/50 mt-1 text-[13px] leading-relaxed">
+              {source.snippet}
+            </p>
+          </PreviewCard.Popup>
+        </PreviewCard.Positioner>
+      </PreviewCard.Portal>
+    </PreviewCard.Root>
+  );
+}
+
+export interface InlineCitationProps {
+  sources: Source[];
+  openIndex: number | null;
+  onOpenIndexChange: (index: number | null) => void;
+  className?: string;
+}
+
+export function InlineCitation({
+  sources,
+  openIndex,
+  onOpenIndexChange,
+  className,
+}: InlineCitationProps) {
+  return (
+    <p
+      className={cn(
+        "text-foreground/90 max-w-sm text-sm leading-relaxed",
+        className,
+      )}
+    >
+      Optimistic updates keep the thread responsive while the server confirms
+      the write
+      {sources[0] && (
+        <Citation
+          index={0}
+          source={sources[0]}
+          open={openIndex === 0}
+          onOpenChange={(open) => onOpenIndexChange(open ? 0 : null)}
+        />
+      )}
+      . The store already exposes a consistent snapshot for every subscriber
+      {sources[1] && (
+        <Citation
+          index={1}
+          source={sources[1]}
+          open={openIndex === 1}
+          onOpenChange={(open) => onOpenIndexChange(open ? 1 : null)}
+        />
+      )}
+      , so no extra reconciliation pass is needed.
+    </p>
+  );
+}

--- a/packages/ui/src/components/elements/loading-state.tsx
+++ b/packages/ui/src/components/elements/loading-state.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type GenerationLoaderVariant = "dots" | "squares" | "rounded";
+
+export interface GenerationLoaderProps {
+  label: string;
+  tick: number;
+  variant?: GenerationLoaderVariant;
+  className?: string;
+}
+
+const CELL_SHAPES: Record<GenerationLoaderVariant, string> = {
+  dots: "rounded-full",
+  squares: "rounded-[1px]",
+  rounded: "rounded-[3px]",
+};
+
+export function GenerationLoader({
+  label,
+  tick,
+  variant = "dots",
+  className,
+}: GenerationLoaderProps) {
+  const pixelOffset = Math.floor(tick / 3);
+
+  return (
+    <div className={cn("flex flex-col items-center gap-4", className)}>
+      <div aria-hidden className="grid grid-cols-3 gap-1">
+        {Array.from({ length: 9 }, (_, index) => {
+          const active = (index * 2 + pixelOffset) % 9 < 3;
+
+          return (
+            <span
+              key={index}
+              className={cn(
+                "bg-foreground size-2 transition-opacity duration-300 motion-reduce:transition-none",
+                CELL_SHAPES[variant],
+                active ? "opacity-90" : "opacity-15",
+              )}
+            />
+          );
+        })}
+      </div>
+      <span className="text-foreground/55 relative inline-block text-sm">
+        <span>{label}</span>
+        <span
+          aria-hidden
+          className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+        >
+          {label}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/message-actions.tsx
+++ b/packages/ui/src/components/elements/message-actions.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  CheckIcon,
+  CopyIcon,
+  EllipsisIcon,
+  RefreshCwIcon,
+  ThumbsDownIcon,
+  ThumbsUpIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ghostButton, iconSwap, iconSwapIn, iconSwapOut } from "./surfaces";
+
+export type Reaction = "up" | "down" | null;
+
+export interface MessageActionsProps {
+  copied: boolean;
+  reaction: Reaction;
+  regenerating: boolean;
+  onCopy: () => void;
+  onReactionChange: (reaction: Reaction) => void;
+  onRegenerate: () => void;
+  onMore: () => void;
+  className?: string;
+}
+
+export function MessageActions({
+  copied,
+  reaction,
+  regenerating,
+  onCopy,
+  onReactionChange,
+  onRegenerate,
+  onMore,
+  className,
+}: MessageActionsProps) {
+  const buttonClassName = cn(ghostButton, "size-7");
+
+  return (
+    <div className={cn("flex items-center gap-1", className)}>
+      <button
+        type="button"
+        aria-label={copied ? "Copied response" : "Copy response"}
+        onClick={onCopy}
+        className={cn(
+          buttonClassName,
+          "grid place-items-center",
+          copied && "text-emerald-500",
+        )}
+      >
+        <CopyIcon
+          className={cn(
+            iconSwap,
+            "size-3.5",
+            copied ? iconSwapOut : iconSwapIn,
+          )}
+        />
+        <CheckIcon
+          className={cn(
+            iconSwap,
+            "size-3.5",
+            copied ? iconSwapIn : iconSwapOut,
+          )}
+        />
+      </button>
+      <button
+        type="button"
+        aria-label="Mark response helpful"
+        aria-pressed={reaction === "up"}
+        onClick={() => onReactionChange(reaction === "up" ? null : "up")}
+        className={cn(
+          buttonClassName,
+          reaction === "up" &&
+            "bg-foreground/[0.06] text-foreground/90 dark:bg-foreground/[0.09]",
+        )}
+      >
+        <ThumbsUpIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Mark response unhelpful"
+        aria-pressed={reaction === "down"}
+        onClick={() => onReactionChange(reaction === "down" ? null : "down")}
+        className={cn(
+          buttonClassName,
+          reaction === "down" &&
+            "bg-foreground/[0.06] text-foreground/90 dark:bg-foreground/[0.09]",
+        )}
+      >
+        <ThumbsDownIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Regenerate response"
+        onClick={onRegenerate}
+        className={buttonClassName}
+      >
+        <RefreshCwIcon
+          className={cn(
+            "size-3.5",
+            regenerating && "animate-spin motion-reduce:animate-none",
+          )}
+        />
+      </button>
+      <button
+        type="button"
+        aria-label="More response actions"
+        onClick={onMore}
+        className={buttonClassName}
+      >
+        <EllipsisIcon className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/message-branches.tsx
+++ b/packages/ui/src/components/elements/message-branches.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ghostButton, mono } from "./surfaces";
+
+export interface MessageBranchesProps {
+  variants: readonly string[];
+  index: number;
+  onIndexChange: (index: number) => void;
+  className?: string;
+}
+
+export function MessageBranches({
+  variants,
+  index,
+  onIndexChange,
+  className,
+}: MessageBranchesProps) {
+  const message = variants[index] ?? variants[0] ?? "";
+  const hasNavigation = variants.length > 1;
+
+  const goPrevious = () => {
+    if (!hasNavigation) return;
+    onIndexChange(index === 0 ? variants.length - 1 : index - 1);
+  };
+  const goNext = () => {
+    if (!hasNavigation) return;
+    onIndexChange(index === variants.length - 1 ? 0 : index + 1);
+  };
+
+  return (
+    <div className={cn("flex max-w-sm flex-col gap-2", className)}>
+      <p
+        key={index}
+        className="fade-in slide-in-from-bottom-1 animate-in text-foreground/90 min-h-[4.25rem] text-sm leading-relaxed duration-300 motion-reduce:animate-none"
+      >
+        {message}
+      </p>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          aria-label="Show previous response"
+          disabled={!hasNavigation}
+          onClick={goPrevious}
+          className={cn(ghostButton, "size-6")}
+        >
+          <ChevronLeftIcon className="size-3.5" />
+        </button>
+        <span className={cn(mono, "text-foreground/35 tabular-nums")}>
+          {variants.length === 0
+            ? "0 / 0"
+            : `${index + 1} / ${variants.length}`}
+        </span>
+        <button
+          type="button"
+          aria-label="Show next response"
+          disabled={!hasNavigation}
+          onClick={goNext}
+          className={cn(ghostButton, "size-6")}
+        >
+          <ChevronRightIcon className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/message-pair.tsx
+++ b/packages/ui/src/components/elements/message-pair.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { CopyIcon, RefreshCwIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ghostButton, paper } from "./surfaces";
+
+export interface MessagePairProps {
+  userMessage: string;
+  words: readonly string[];
+  visibleWords: number;
+  streaming: boolean;
+  variant?: "bubble" | "flat";
+  className?: string;
+}
+
+export function MessagePair({
+  userMessage,
+  words,
+  visibleWords,
+  streaming,
+  variant = "bubble",
+  className,
+}: MessagePairProps) {
+  return (
+    <div className={cn("flex w-full max-w-sm flex-col gap-5", className)}>
+      <p
+        className={cn(
+          "max-w-[85%] self-end text-sm",
+          variant === "bubble"
+            ? cn(paper, "rounded-2xl px-3.5 py-2")
+            : "text-foreground/90 text-end",
+        )}
+      >
+        {userMessage}
+      </p>
+      <div className="group/message flex flex-col items-start">
+        <p className="min-h-[4.25rem] text-sm leading-relaxed">
+          {words.slice(0, visibleWords).map((word, index) => {
+            const fresh = streaming && visibleWords - 1 - index < 2;
+
+            return (
+              <span
+                key={`${word}-${index}`}
+                className="fade-in animate-in fill-mode-both duration-500 motion-reduce:animate-none"
+              >
+                <span
+                  className={cn(
+                    "transition-colors duration-700 motion-reduce:transition-none",
+                    fresh && "text-blue-500 dark:text-blue-400",
+                  )}
+                >
+                  {word}
+                </span>{" "}
+              </span>
+            );
+          })}
+          {streaming && visibleWords > 0 && (
+            <span
+              aria-hidden
+              className="-mb-0.5 ml-0.5 inline-block h-4 w-0.5 animate-pulse rounded-full bg-blue-500 motion-reduce:animate-none dark:bg-blue-400"
+            />
+          )}
+        </p>
+        <div className="flex items-center gap-1 pt-1 opacity-0 transition-opacity group-focus-within/message:opacity-100 group-hover/message:opacity-100 motion-reduce:transition-none">
+          <button
+            type="button"
+            aria-label="Copy response"
+            className={cn(ghostButton, "size-7")}
+          >
+            <CopyIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            aria-label="Regenerate response"
+            className={cn(ghostButton, "size-7")}
+          >
+            <RefreshCwIcon className="size-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/number-ticker.tsx
+++ b/packages/ui/src/components/elements/number-ticker.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { mono } from "./surfaces";
+
+function RollingDigit({ digit }: { digit: number }) {
+  return (
+    <span className="inline-flex h-[1.15em] overflow-hidden">
+      <span
+        className="flex flex-col transition-transform duration-500 ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none"
+        style={{ transform: `translateY(-${digit * 1.15}em)` }}
+      >
+        {Array.from({ length: 10 }, (_, i) => (
+          <span key={i} className="h-[1.15em] leading-[1.15]">
+            {i}
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}
+
+export function NumberTicker({
+  value,
+  label,
+  className,
+}: {
+  value: number;
+  label: string;
+  className?: string;
+}) {
+  const formatted = value.toLocaleString("en-US");
+
+  return (
+    <div className={cn("flex flex-col items-center gap-2.5", className)}>
+      <span
+        className="flex text-3xl font-medium tracking-tight tabular-nums"
+        aria-label={formatted}
+      >
+        {formatted.split("").map((char, i) =>
+          /\d/.test(char) ? (
+            <RollingDigit key={i} digit={Number(char)} />
+          ) : (
+            <span key={i} className="h-[1.15em] leading-[1.15]">
+              {char}
+            </span>
+          ),
+        )}
+      </span>
+      <span className={cn(mono, "text-foreground/35")}>{label}</span>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/reasoning-panel.tsx
+++ b/packages/ui/src/components/elements/reasoning-panel.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { ChevronDownIcon } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { collapsePanel, mono, SwapLabel } from "./surfaces";
+
+export interface ReasoningStep {
+  title: string;
+  body: string;
+}
+
+export interface ReasoningPanelProps {
+  steps: ReasoningStep[];
+  visibleSteps: number;
+  streaming: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restingLabel: string;
+  elapsed?: string;
+  className?: string;
+}
+
+export function ReasoningPanel({
+  steps,
+  visibleSteps,
+  streaming,
+  open,
+  onOpenChange,
+  restingLabel,
+  elapsed,
+  className,
+}: ReasoningPanelProps) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn("w-full max-w-sm", className)}
+    >
+      <CollapsibleTrigger className="group/trigger text-foreground/55 hover:text-foreground/90 flex items-center gap-1.5 py-1 text-[13.5px] transition-[color,scale] outline-none active:scale-[0.98]">
+        <SwapLabel active={streaming ? 0 : 1} className="text-start">
+          <>
+            <span className="relative inline-block leading-none">
+              <span>Thinking</span>
+              <span
+                aria-hidden
+                className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+              >
+                Thinking
+              </span>
+            </span>
+            {elapsed !== undefined && (
+              <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+                {elapsed}
+              </span>
+            )}
+          </>
+          <>{restingLabel}</>
+        </SwapLabel>
+        <ChevronDownIcon className="size-3.5 shrink-0 opacity-60 transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-open/trigger:rotate-180 group-data-panel-open/trigger:rotate-180 motion-reduce:transition-none" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
+        <ol className="flex flex-col gap-4 pt-3 pb-1">
+          {steps.slice(0, visibleSteps).map((step, i) => {
+            const active = streaming && i === visibleSteps - 1;
+            return (
+              <li
+                key={step.title}
+                className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex gap-3 duration-300"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    "mt-[7px] size-[5px] shrink-0 rounded-full transition-colors duration-300",
+                    active
+                      ? "animate-pulse bg-blue-500 dark:bg-blue-400"
+                      : "bg-foreground/20",
+                  )}
+                />
+                <span className="flex flex-col">
+                  <p className="text-foreground/90 text-[13.5px] font-medium">
+                    {step.title}
+                  </p>
+                  <p className="text-foreground/50 mt-0.5 text-[13px] leading-relaxed">
+                    {step.body}
+                  </p>
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/ui/src/components/elements/recommendation-card.tsx
+++ b/packages/ui/src/components/elements/recommendation-card.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { CheckIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { inkButton, mono, paper } from "./surfaces";
+
+export type RecommendationState = "idle" | "accepted";
+
+const CONFIDENCE_BARS = [0, 1, 2];
+
+export function RecommendationCard({
+  state,
+  question,
+  children,
+  confidenceLabel,
+  acceptedLabel,
+  onAccept,
+  onAlternatives,
+  className,
+}: {
+  state: RecommendationState;
+  question: string;
+  children: ReactNode;
+  confidenceLabel: string;
+  acceptedLabel: string;
+  onAccept?: () => void;
+  onAlternatives?: () => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        paper,
+        "flex w-full max-w-sm flex-col gap-3 rounded-[20px] p-4",
+        className,
+      )}
+    >
+      <p className="text-sm font-medium">{question}</p>
+      <p className="text-foreground/55 text-[13px] leading-relaxed">
+        {children}
+      </p>
+
+      <div className="flex h-8 items-center justify-between">
+        {state === "idle" ? (
+          <>
+            <div className="flex items-center gap-2">
+              <span className="flex items-end gap-0.5" aria-hidden>
+                {CONFIDENCE_BARS.map((bar) => (
+                  <span
+                    key={bar}
+                    className="w-1 rounded-full bg-emerald-500/70"
+                    style={{ height: 6 + bar * 3 }}
+                  />
+                ))}
+              </span>
+              <span className={cn(mono, "text-foreground/40")}>
+                {confidenceLabel}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onAlternatives}
+                className="text-foreground/55 hover:bg-foreground/[0.06] hover:text-foreground/90 h-8 rounded-full px-3.5 text-xs font-medium transition-[background-color,color,scale] duration-150 active:scale-[0.96]"
+              >
+                Alternatives
+              </button>
+              <button
+                type="button"
+                onClick={onAccept}
+                className={cn(
+                  inkButton,
+                  "flex h-8 items-center rounded-full px-3.5 text-xs font-medium",
+                )}
+              >
+                Accept
+              </button>
+            </div>
+          </>
+        ) : (
+          <div
+            key="accepted"
+            className="fade-in animate-in text-foreground/55 flex items-center gap-2 text-xs duration-300"
+          >
+            <CheckIcon className="size-3.5 text-emerald-500" />
+            {acceptedLabel}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/scroll-anchor.tsx
+++ b/packages/ui/src/components/elements/scroll-anchor.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowDownIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { field, floating, paper } from "./surfaces";
+
+export interface ScrollAnchorMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
+const INITIAL_COUNT = 3;
+const APPEND_MS = 1300;
+
+export function ScrollAnchor({
+  messages,
+  paused = false,
+  onSettled,
+  className,
+}: {
+  messages: ScrollAnchorMessage[];
+  paused?: boolean;
+  onSettled?: () => void;
+  className?: string;
+}) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [count, setCount] = useState(INITIAL_COUNT);
+  const [pinned, setPinned] = useState(true);
+  const [seenCount, setSeenCount] = useState(INITIAL_COUNT);
+
+  useEffect(() => {
+    if (paused) return;
+    const id = setInterval(() => {
+      setCount((current) => {
+        if (current >= messages.length) return current;
+        return current + 1;
+      });
+    }, APPEND_MS);
+    return () => clearInterval(id);
+  }, [messages.length, paused]);
+
+  useEffect(() => {
+    if (count >= messages.length && pinned) onSettled?.();
+  }, [count, pinned, messages.length, onSettled]);
+
+  useEffect(() => {
+    if (count === INITIAL_COUNT + 1) {
+      setPinned(false);
+      const viewport = viewportRef.current;
+      if (viewport) viewport.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, [count]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    if (pinned) {
+      viewport.scrollTo({ top: viewport.scrollHeight });
+      setSeenCount(count);
+    }
+  }, [count, pinned]);
+
+  const jump = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (viewport) {
+      viewport.scrollTo({ top: viewport.scrollHeight, behavior: "smooth" });
+    }
+    setPinned(true);
+    setSeenCount(count);
+  }, [count]);
+
+  useEffect(() => {
+    if (paused || pinned || count - seenCount < 2) return;
+    const id = setTimeout(jump, 2400);
+    return () => clearTimeout(id);
+  }, [paused, pinned, count, seenCount, jump]);
+
+  const newCount = count - seenCount;
+
+  return (
+    <div
+      className={cn(
+        paper,
+        "relative h-64 w-full max-w-sm overflow-hidden rounded-2xl",
+        className,
+      )}
+    >
+      <div
+        ref={viewportRef}
+        className="flex h-full flex-col gap-2.5 overflow-y-hidden scroll-smooth p-4"
+      >
+        {messages.slice(0, count).map((message, i) => (
+          <div
+            key={i}
+            className={cn(
+              "fade-in slide-in-from-bottom-1 animate-in max-w-[85%] text-xs leading-relaxed duration-300 motion-reduce:animate-none",
+              message.role === "user"
+                ? cn(field, "self-end rounded-2xl px-3 py-1.5")
+                : "text-foreground/55 self-start",
+            )}
+          >
+            {message.text}
+          </div>
+        ))}
+      </div>
+      <div
+        aria-hidden
+        className="from-background dark:from-popover pointer-events-none absolute inset-x-0 top-0 h-6 bg-gradient-to-b to-transparent"
+      />
+      {!pinned && newCount > 0 && (
+        <button
+          type="button"
+          onClick={jump}
+          className={cn(
+            floating,
+            "fade-in slide-in-from-bottom-2 animate-in absolute inset-x-0 bottom-3 mx-auto flex w-fit items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs transition-transform duration-200 hover:-translate-y-px",
+          )}
+        >
+          <ArrowDownIcon className="size-3 opacity-60" />
+          {newCount} new {newCount === 1 ? "message" : "messages"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/sources.tsx
+++ b/packages/ui/src/components/elements/sources.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { ChevronDownIcon } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { collapsePanel, fieldInteractive, mono, paper } from "./surfaces";
+
+export interface Source {
+  domain: string;
+  title: string;
+}
+
+export interface SourcesProps {
+  sources: readonly Source[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+}
+
+export function Sources({
+  sources,
+  open,
+  onOpenChange,
+  className,
+}: SourcesProps) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn("w-full max-w-sm", className)}
+    >
+      <CollapsibleTrigger
+        className={cn(
+          fieldInteractive,
+          "group/trigger text-foreground/60 hover:text-foreground/90 inline-flex w-fit items-center gap-1.5 rounded-full px-3.5 py-2 text-xs outline-none",
+        )}
+      >
+        <span>Sources</span>
+        <span className={cn(mono, "text-foreground/35 tabular-nums")}>
+          {sources.length}
+        </span>
+        <ChevronDownIcon className="size-3 opacity-60 transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-open/trigger:rotate-180 group-data-panel-open/trigger:rotate-180 motion-reduce:transition-none" />
+      </CollapsibleTrigger>
+      <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
+        <div className="grid grid-cols-2 gap-2 pt-2.5">
+          {sources.map((source) => (
+            <div
+              key={source.domain}
+              className={cn(
+                paper,
+                "flex flex-col gap-1.5 rounded-2xl p-3 transition-transform hover:-translate-y-px",
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="bg-foreground/[0.06] text-foreground/45 flex size-4 shrink-0 items-center justify-center rounded text-[9px] font-medium">
+                  {source.domain.charAt(0).toUpperCase()}
+                </span>
+                <span className={cn(mono, "text-foreground/40 truncate")}>
+                  {source.domain}
+                </span>
+              </div>
+              <span className="text-foreground/90 line-clamp-2 text-[13px] leading-snug font-medium">
+                {source.title}
+              </span>
+            </div>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/ui/src/components/elements/streaming-text.tsx
+++ b/packages/ui/src/components/elements/streaming-text.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+
+export interface Segment {
+  text: string;
+  mono?: boolean;
+}
+
+export function StreamingText({
+  segments,
+  count,
+  streaming,
+  className,
+}: {
+  segments: Segment[];
+  count: number;
+  streaming: boolean;
+  className?: string;
+}) {
+  const words = useMemo(
+    () =>
+      segments.flatMap((segment) =>
+        segment.text
+          .split(" ")
+          .map((word) => ({ word, mono: segment.mono ?? false })),
+      ),
+    [segments],
+  );
+
+  return (
+    <p
+      className={cn(
+        "min-h-[8.5rem] max-w-sm text-sm leading-relaxed text-pretty",
+        className,
+      )}
+    >
+      {words.slice(0, count).map(({ word, mono: isMono }, i) => {
+        const fresh = streaming && count - 1 - i < 2;
+        return (
+          <span
+            key={i}
+            className="fade-in animate-in fill-mode-both duration-500 motion-reduce:animate-none"
+          >
+            <span
+              className={cn(
+                "transition-colors duration-700 motion-reduce:transition-none",
+                fresh && "text-blue-500 dark:text-blue-400",
+                isMono &&
+                  "bg-foreground/[0.06] rounded-md px-1.5 py-0.5 font-mono text-[0.85em]",
+              )}
+            >
+              {word}
+            </span>{" "}
+          </span>
+        );
+      })}
+      {streaming && count > 0 && (
+        <span
+          aria-hidden
+          className="-mb-0.5 ml-0.5 inline-block h-4 w-0.5 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400"
+        />
+      )}
+    </p>
+  );
+}

--- a/packages/ui/src/components/elements/subagent-list.tsx
+++ b/packages/ui/src/components/elements/subagent-list.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { CheckIcon, Loader2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mono, paper } from "./surfaces";
+
+export interface SubagentItem {
+  name: string;
+  model: string;
+}
+
+export function SubagentList({
+  agents,
+  completedCount,
+  progress,
+  showSummary,
+  summaryAgent,
+  className,
+}: {
+  agents: readonly SubagentItem[];
+  completedCount: number;
+  progress: readonly number[];
+  showSummary: boolean;
+  summaryAgent: SubagentItem;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[14.5rem] w-full max-w-xs flex-col gap-2",
+        className,
+      )}
+    >
+      {agents.map((agent, index) => {
+        const done = index < completedCount;
+        const width = progress[index] ?? 0;
+
+        return (
+          <div
+            key={agent.name}
+            className={cn(
+              paper,
+              "flex flex-col gap-2 rounded-2xl px-3.5 py-2.5",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              {done ? (
+                <CheckIcon className="fade-in zoom-in-90 animate-in size-3.5 shrink-0 text-emerald-500 duration-200" />
+              ) : (
+                <Loader2Icon className="text-foreground/35 size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
+              )}
+              <span className="flex-1 truncate text-[13.5px]">
+                {agent.name}
+              </span>
+              <span className={cn(mono, "text-foreground/35")}>
+                {agent.model}
+              </span>
+            </div>
+            <span className="bg-foreground/[0.06] h-[3px] w-full overflow-hidden rounded-full">
+              <span
+                className={cn(
+                  "block h-full rounded-full transition-[width] duration-700",
+                  done ? "bg-emerald-500/70" : "bg-foreground/60",
+                )}
+                style={{ width: `${width}%` }}
+              />
+            </span>
+          </div>
+        );
+      })}
+      {showSummary && (
+        <div
+          className={cn(
+            paper,
+            "fade-in slide-in-from-bottom-2 animate-in flex flex-col gap-2 rounded-2xl px-3.5 py-2.5 duration-300",
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Loader2Icon className="text-foreground/35 size-3.5 shrink-0 animate-spin motion-reduce:animate-none" />
+            <span className="flex-1 truncate text-[13.5px]">
+              {summaryAgent.name}
+            </span>
+            <span className={cn(mono, "text-foreground/35")}>
+              {summaryAgent.model}
+            </span>
+          </div>
+          <span className="bg-foreground/[0.06] h-[3px] w-full overflow-hidden rounded-full">
+            <span
+              className="bg-foreground/60 block h-full rounded-full transition-[width] duration-700"
+              style={{ width: "42%" }}
+            />
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/suggestions.tsx
+++ b/packages/ui/src/components/elements/suggestions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { paper } from "./surfaces";
+
+export interface SuggestionsProps {
+  suggestions: readonly string[];
+  selectedSuggestion: string | null;
+  cycle: number;
+  onSuggestion: (suggestion: string) => void;
+  variant?: "pills" | "list";
+  className?: string;
+}
+
+export function Suggestions({
+  suggestions,
+  selectedSuggestion,
+  cycle,
+  onSuggestion,
+  variant = "pills",
+  className,
+}: SuggestionsProps) {
+  const list = variant === "list";
+
+  return (
+    <div
+      key={cycle}
+      className={cn(
+        list
+          ? "flex w-full max-w-sm flex-col gap-2"
+          : "flex max-w-md flex-wrap justify-center gap-2",
+        className,
+      )}
+    >
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={suggestion}
+          type="button"
+          aria-pressed={selectedSuggestion === suggestion}
+          onClick={() => onSuggestion(suggestion)}
+          className={cn(
+            paper,
+            "fade-in slide-in-from-bottom-2 animate-in fill-mode-both flex cursor-pointer items-center text-[13px] transition-transform duration-300 hover:-translate-y-px active:scale-[0.96] motion-reduce:animate-none",
+            list
+              ? "w-full rounded-2xl px-4 py-2.5 text-start"
+              : "rounded-full px-4 py-2",
+            selectedSuggestion === suggestion &&
+              "bg-foreground text-background",
+          )}
+          style={{ animationDelay: `${index * 70}ms` }}
+        >
+          {suggestion}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/surfaces.tsx
+++ b/packages/ui/src/components/elements/surfaces.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export const paper =
+  "bg-background shadow-[0_1px_2px_rgba(0,0,0,0.04),0_12px_32px_-16px_rgba(0,0,0,0.12)] dark:bg-popover dark:shadow-none";
+
+export const floating =
+  "bg-background shadow-[0_2px_8px_rgba(0,0,0,0.05),0_20px_48px_-16px_rgba(0,0,0,0.18)] dark:bg-popover dark:shadow-[0_20px_48px_-16px_rgba(0,0,0,0.55)]";
+
+export const field = "bg-foreground/[0.04] dark:bg-foreground/[0.06]";
+
+export const fieldInteractive =
+  "bg-foreground/[0.04] transition-colors hover:bg-foreground/[0.07] dark:bg-foreground/[0.06] dark:hover:bg-foreground/[0.09]";
+
+export const pressable =
+  "transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.96] motion-reduce:transition-none";
+
+export const ghostButton =
+  "flex items-center justify-center rounded-full text-foreground/45 outline-none transition-[background-color,color,scale] duration-150 hover:bg-foreground/[0.06] hover:text-foreground/90 active:scale-[0.96] focus-visible:ring-2 focus-visible:ring-foreground/20 motion-reduce:transition-none dark:hover:bg-foreground/[0.09]";
+
+export const inkButton =
+  "bg-foreground text-background transition-[opacity,scale] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:opacity-90 active:scale-[0.96] motion-reduce:transition-none";
+
+export const iconSwap =
+  "[grid-area:1/1] transition-[opacity,scale,filter] duration-200 ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none";
+
+export const iconSwapIn = "scale-100 opacity-100 blur-none";
+
+export const iconSwapOut = "scale-[0.25] opacity-0 blur-[4px]";
+
+export const labelSwap =
+  "col-start-1 row-start-1 flex w-max items-center gap-1.5 leading-none transition-[opacity,filter] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none";
+
+export const labelSwapIn = "opacity-100 blur-none";
+
+export const labelSwapOut = "pointer-events-none opacity-0 blur-[2px]";
+
+export const collapsePanel =
+  "h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] data-[ending-style]:h-0 data-[starting-style]:h-0 motion-reduce:transition-none";
+
+export const live = "text-blue-500 dark:text-blue-400";
+
+export const mono = "font-mono text-[11px] tracking-tight";
+
+export function SwapLabel({
+  active,
+  children,
+  className,
+}: {
+  active: 0 | 1;
+  children: [React.ReactNode, React.ReactNode];
+  className?: string;
+}) {
+  const layers = [useRef<HTMLSpanElement>(null), useRef<HTMLSpanElement>(null)];
+  const [width, setWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const target = layers[active]?.current;
+    if (!target) return undefined;
+    const measure = () =>
+      setWidth(Math.ceil(target.getBoundingClientRect().width));
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [active]);
+
+  return (
+    <span
+      style={width === null ? undefined : { width }}
+      className={cn(
+        "grid overflow-x-clip transition-[width] duration-300 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+        className,
+      )}
+    >
+      {children.map((layer, index) => (
+        <span
+          key={index}
+          ref={layers[index]}
+          aria-hidden={active !== index}
+          className={cn(
+            labelSwap,
+            active === index ? labelSwapIn : labelSwapOut,
+          )}
+        >
+          {layer}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/packages/ui/src/components/elements/terminal-block.tsx
+++ b/packages/ui/src/components/elements/terminal-block.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { CheckIcon, Loader2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { mono, paper } from "./surfaces";
+
+export function TerminalBlock({
+  command,
+  lines,
+  visibleCount,
+  done,
+  variant = "paper",
+  className,
+}: {
+  command: string;
+  lines: readonly string[];
+  visibleCount: number;
+  done: boolean;
+  variant?: "paper" | "ink";
+  className?: string;
+}) {
+  const ink = variant === "ink";
+
+  return (
+    <div
+      className={cn(
+        ink
+          ? "bg-foreground dark:bg-popover shadow-[0_12px_32px_-16px_rgba(0,0,0,0.35)] dark:shadow-none"
+          : paper,
+        "w-full max-w-md overflow-hidden rounded-2xl font-mono text-xs",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between px-4 pt-3 pb-1.5">
+        <span
+          className={cn(
+            ink
+              ? "text-background/90 dark:text-foreground/90"
+              : "text-foreground/90",
+          )}
+        >
+          {command}
+        </span>
+        {done ? (
+          <div className="flex items-center gap-1">
+            <CheckIcon className="size-3 text-emerald-500" />
+            <span
+              className={cn(
+                mono,
+                ink
+                  ? "text-background/40 dark:text-foreground/40"
+                  : "text-foreground/40",
+              )}
+            >
+              exit 0
+            </span>
+          </div>
+        ) : (
+          <Loader2Icon
+            className={cn(
+              "size-3 animate-spin motion-reduce:animate-none",
+              ink
+                ? "text-background/35 dark:text-foreground/35"
+                : "text-foreground/35",
+            )}
+          />
+        )}
+      </div>
+      <div
+        className={cn(
+          "flex min-h-[8.5rem] flex-col gap-1 px-4 pt-1 pb-3.5",
+          ink
+            ? "text-background/55 dark:text-foreground/50"
+            : "text-foreground/50",
+        )}
+      >
+        {lines.slice(0, visibleCount).map((line, i) => {
+          const isLast = i === lines.length - 1;
+          return (
+            <div
+              key={`${i}-${line}`}
+              className={cn(
+                "fade-in animate-in fill-mode-both duration-300",
+                isLast &&
+                  (ink
+                    ? "text-background/90 dark:text-foreground/90"
+                    : "text-foreground/90"),
+              )}
+            >
+              {line}
+            </div>
+          );
+        })}
+        {!done && (
+          <span
+            aria-hidden
+            className="inline-block h-3 w-1.5 animate-pulse bg-blue-500/70 motion-reduce:animate-none dark:bg-blue-400/70"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/thinking-indicator.tsx
+++ b/packages/ui/src/components/elements/thinking-indicator.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { mono } from "./surfaces";
+
+export function ThinkingIndicator({
+  label,
+  elapsed,
+  className,
+}: {
+  label: string;
+  elapsed?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "text-foreground/55 flex items-center gap-2.5 text-sm",
+        className,
+      )}
+    >
+      <span
+        aria-hidden
+        className="size-1.5 shrink-0 animate-pulse rounded-full bg-blue-500 motion-reduce:animate-none dark:bg-blue-400"
+      />
+      <span
+        key={label}
+        className="fade-in slide-in-from-bottom-1 animate-in relative inline-block leading-none duration-300"
+      >
+        <span>{label}</span>
+        <span
+          aria-hidden
+          className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+        >
+          {label}
+        </span>
+      </span>
+      {elapsed !== undefined && (
+        <span className={cn(mono, "text-foreground/30 tabular-nums")}>
+          {elapsed}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/thread-list.tsx
+++ b/packages/ui/src/components/elements/thread-list.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { PencilIcon, Trash2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { field, mono } from "./surfaces";
+
+export interface ThreadItem {
+  title: string;
+  time: string;
+  unread?: boolean;
+}
+
+export function ThreadList({
+  threads,
+  activeIndex,
+  onActiveIndexChange,
+  className,
+}: {
+  threads: readonly ThreadItem[];
+  activeIndex: number;
+  onActiveIndexChange?: (index: number) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn("flex w-full max-w-[240px] flex-col gap-0.5", className)}
+    >
+      <div className={cn(mono, "text-foreground/35 px-3 pb-1.5")}>Today</div>
+      {threads.map((thread, i) => {
+        const active = i === activeIndex;
+        return (
+          <button
+            key={thread.title}
+            type="button"
+            onClick={() => onActiveIndexChange?.(i)}
+            className={cn(
+              "group flex w-full items-center justify-between gap-2 rounded-xl px-3 py-2 text-start text-[13.5px] transition-colors",
+              active ? field : "hover:bg-foreground/[0.03]",
+            )}
+          >
+            <span className="flex-1 truncate">{thread.title}</span>
+            <span
+              className={cn(
+                mono,
+                "text-foreground/35 flex items-center gap-1.5 tabular-nums group-hover:hidden",
+              )}
+            >
+              {thread.unread && !active && (
+                <span
+                  aria-hidden
+                  className="size-1.5 rounded-full bg-blue-500 dark:bg-blue-400"
+                />
+              )}
+              {thread.time}
+            </span>
+            <span className="hidden items-center gap-0.5 group-hover:flex">
+              <span className="text-foreground/45 hover:bg-foreground/[0.06] hover:text-foreground/90 rounded-full p-1">
+                <PencilIcon className="size-3" />
+              </span>
+              <span className="text-foreground/45 hover:bg-foreground/[0.06] hover:text-foreground/90 rounded-full p-1">
+                <Trash2Icon className="size-3" />
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/tool-call.tsx
+++ b/packages/ui/src/components/elements/tool-call.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { collapsePanel, field, mono, SwapLabel } from "./surfaces";
+
+export interface ToolCallProps {
+  label: string;
+  activeLabel: string;
+  query: string;
+  request: string;
+  result: string;
+  running: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  className?: string;
+}
+
+export function ToolCall({
+  label,
+  activeLabel,
+  query,
+  request,
+  result,
+  running,
+  open,
+  onOpenChange,
+  className,
+}: ToolCallProps) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn("w-full max-w-sm", className)}
+    >
+      <CollapsibleTrigger className="group/trigger text-foreground/55 hover:text-foreground/90 flex items-center gap-2 rounded-md py-1 text-[13.5px] transition-colors outline-none">
+        <ChevronRightIcon className="size-3.5 shrink-0 opacity-60 transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-open/trigger:rotate-90 group-data-panel-open/trigger:rotate-90 motion-reduce:transition-none" />
+        <SwapLabel active={running ? 0 : 1} className="text-start">
+          <span className="relative inline-block leading-none">
+            <span>{activeLabel}</span>
+            <span
+              aria-hidden
+              className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {activeLabel}
+            </span>
+          </span>
+          <>{label}</>
+        </SwapLabel>
+        <span
+          className={cn(
+            mono,
+            "bg-foreground/[0.06] text-foreground/70 rounded-md px-1.5 py-0.5",
+          )}
+        >
+          {query}
+        </span>
+        <span className="ms-auto flex w-4 items-center justify-end">
+          {!running && (
+            <CheckIcon className="fade-in zoom-in-90 animate-in size-3.5 text-emerald-500 duration-200" />
+          )}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
+        <div className={cn(field, "mt-2 overflow-hidden rounded-2xl text-xs")}>
+          <div className="px-3.5 pt-2.5 pb-2">
+            <p className={cn(mono, "text-foreground/35 mb-1")}>Request</p>
+            <p className="text-foreground/55 font-mono">{request}</p>
+          </div>
+          <div className="bg-foreground/[0.06] mx-3.5 h-px" />
+          <div className="px-3.5 pt-2 pb-2.5">
+            <p className={cn(mono, "text-foreground/35 mb-1")}>Result</p>
+            <p className="text-foreground/90">{result}</p>
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/ui/src/components/elements/tool-timeline.tsx
+++ b/packages/ui/src/components/elements/tool-timeline.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { ChevronRightIcon, type LucideIcon } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { collapsePanel, SwapLabel } from "./surfaces";
+
+export interface TimelineStep {
+  verb: string;
+  chip: string;
+  icon: LucideIcon;
+}
+
+export interface TimelineStat {
+  file: string;
+  added?: number;
+  removed?: number;
+}
+
+export interface ToolTimelineProps {
+  steps: readonly TimelineStep[];
+  visibleSteps: number;
+  streaming: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restingLabel: string;
+  activeLabel: string;
+  stats: TimelineStat[];
+  className?: string;
+}
+
+export function ToolTimeline({
+  steps,
+  visibleSteps,
+  streaming,
+  open,
+  onOpenChange,
+  restingLabel,
+  activeLabel,
+  stats,
+  className,
+}: ToolTimelineProps) {
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={onOpenChange}
+      className={cn("w-full max-w-sm", className)}
+    >
+      <CollapsibleTrigger className="group/trigger text-foreground/55 hover:text-foreground/90 flex items-center gap-1.5 rounded-md py-1 text-[13.5px] transition-colors outline-none">
+        <ChevronRightIcon className="size-3.5 shrink-0 opacity-60 transition-transform duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] group-data-open/trigger:rotate-90 group-data-panel-open/trigger:rotate-90 motion-reduce:transition-none" />
+        <SwapLabel
+          active={streaming ? 0 : 1}
+          className="text-start tabular-nums"
+        >
+          <span className="relative inline-block leading-none">
+            <span>{activeLabel}</span>
+            <span
+              aria-hidden
+              className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              {activeLabel}
+            </span>
+          </span>
+          <>{restingLabel}</>
+        </SwapLabel>
+      </CollapsibleTrigger>
+      <CollapsibleContent className={cn(collapsePanel, "outline-none")}>
+        <div className="flex flex-col gap-2.5 ps-4 pt-2.5">
+          {steps.slice(0, visibleSteps).map((step, index) => {
+            const Icon = step.icon;
+            const active = streaming && index === visibleSteps - 1;
+
+            return (
+              <div
+                key={step.chip}
+                className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both text-foreground/55 flex items-center gap-2 text-[13.5px] duration-300"
+              >
+                <Icon className="text-foreground/35 size-3.5 shrink-0" />
+                <span className="relative inline-block leading-none">
+                  <span>{step.verb}</span>
+                  {active && (
+                    <span
+                      aria-hidden
+                      className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+                    >
+                      {step.verb}
+                    </span>
+                  )}
+                </span>
+                <span className="bg-foreground/[0.06] text-foreground/70 rounded-md px-1.5 py-0.5 font-mono text-[11px]">
+                  {step.chip}
+                </span>
+              </div>
+            );
+          })}
+          {stats.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {stats.map((stat) => (
+                <span
+                  key={stat.file}
+                  className="bg-foreground/[0.06] text-foreground/70 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 font-mono text-[11px]"
+                >
+                  <span>{stat.file}</span>
+                  {stat.added !== undefined && (
+                    <span className="text-emerald-600 dark:text-emerald-400">
+                      +{stat.added}
+                    </span>
+                  )}
+                  {stat.removed !== undefined && (
+                    <span className="text-red-600 dark:text-red-400">
+                      −{stat.removed}
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/packages/ui/src/components/elements/typing-indicator.tsx
+++ b/packages/ui/src/components/elements/typing-indicator.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { paper } from "./surfaces";
+
+const DOT_DELAYS = ["-0.32s", "-0.16s", "0s"];
+
+export function TypingIndicator({
+  variant = "bubble",
+  className,
+}: {
+  variant?: "bubble" | "bare";
+  className?: string;
+}) {
+  const dots = (
+    <div
+      role="status"
+      aria-label="Assistant is typing"
+      className={cn("flex gap-1", variant === "bare" && className)}
+    >
+      {DOT_DELAYS.map((delay) => (
+        <span
+          key={delay}
+          aria-hidden
+          className="bg-foreground/40 size-1.5 animate-bounce rounded-full motion-reduce:animate-none"
+          style={{ animationDelay: delay, animationDuration: "1.1s" }}
+        />
+      ))}
+    </div>
+  );
+
+  if (variant === "bare") {
+    return dots;
+  }
+
+  return (
+    <div className={cn(paper, "w-fit rounded-full px-4 py-3.5", className)}>
+      {dots}
+    </div>
+  );
+}

--- a/packages/ui/src/components/elements/web-search.tsx
+++ b/packages/ui/src/components/elements/web-search.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { field, mono } from "./surfaces";
+
+export interface WebSearchResult {
+  title: string;
+  domain: string;
+}
+
+export function WebSearch({
+  query,
+  results,
+  visibleResults,
+  searching,
+  cycle,
+  className,
+}: {
+  query: string;
+  results: readonly WebSearchResult[];
+  visibleResults: number;
+  searching: boolean;
+  cycle: number;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex w-full max-w-sm flex-col gap-2.5", className)}>
+      <span
+        className={cn(
+          field,
+          "text-foreground/70 inline-flex w-fit items-center gap-1.5 rounded-full px-3.5 py-2 text-xs",
+        )}
+      >
+        <SearchIcon className="text-foreground/40 size-3" />
+        {query}
+      </span>
+      <div className="text-foreground/45 text-xs">
+        {searching ? (
+          <span className="relative inline-block leading-none">
+            <span>Searching</span>
+            <span
+              aria-hidden
+              className="shimmer pointer-events-none absolute inset-0 motion-reduce:animate-none"
+            >
+              Searching
+            </span>
+          </span>
+        ) : (
+          <span className="fade-in animate-in duration-300">
+            Read 3 sources
+          </span>
+        )}
+      </div>
+      <div className="flex min-h-[5.75rem] flex-col">
+        {results.slice(0, visibleResults).map((result) => (
+          <div
+            key={`${cycle}-${result.domain}`}
+            className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both hover:bg-foreground/[0.03] -mx-2.5 flex items-center gap-2.5 rounded-xl px-2.5 py-1.5 transition-colors duration-300"
+          >
+            <span className="bg-foreground/[0.06] text-foreground/45 flex size-4 shrink-0 items-center justify-center rounded text-[9px] font-medium">
+              {result.domain.charAt(0).toUpperCase()}
+            </span>
+            <span className="text-foreground/90 min-w-0 flex-1 truncate text-[13.5px]">
+              {result.title}
+            </span>
+            <span className={cn(mono, "text-foreground/35 shrink-0")}>
+              {result.domain}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## summary

- adds an Elements surface to the docs: `/elements` with 37 live AI interface pieces across 8 sections (reasoning, messages, tool use, knowledge, structured output, agents, composer, thread), each with a detail page carrying a live demo, installation, usage, full props tables, and the component source
- the components themselves live in `packages/ui/src/components/elements` on a dedicated borderless design language (`surfaces.tsx`: paper/field surfaces, ink opacity ladder, shimmer labels, icon and label cross-fades, height-transition collapsibles)
- the composer is one unified component: slash commands, mentions, attachments, model picker, voice, and a hover context breakdown are prop-gated capabilities of a single `Composer`, presented as one element plus six variant pages that share the same install
- every element installs via the shadcn CLI (`npx shadcn@latest add "@assistant-ui/elements-<name>"`); items are declared in apps/registry with a shared `elements-surfaces` item that carries the tw-shimmer dependency and CSS import
- demos auto-play once and rest; detail canvases get a pause/replay control, index cards get a hover veil with a view action (full-card tap on touch); five elements ship skin variants (loading-state, typing-indicator, message-pair, suggestions, terminal-block) behind an in-canvas switcher

## test plan

### already verified

- [x] `tsc --noEmit` on apps/docs green
- [x] `pnpm build` + `pnpm test` in apps/registry green (32 elements items in both trees, registry item contents spot-checked)
- [x] `pnpm lint:fix` clean at repo root
- [x] browser pass on desktop and 390px mobile emulation: no horizontal overflow, props tables stack on mobile, composer menus anchor correctly, sidebar scroll persists across detail navigation

### reviewer should verify

- [ ] open `/elements`, hover a card for the view overlay, open a detail page, switch variants on loading state, and install one item via the printed shadcn command

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.kWN6ejs-sff7sbauuVR_r_z11FZIG9Dz4DpCRGfrITRovmnnYtAO3QneUlM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->