### PR TITLE
fix(react-o11y): tolerate cyclic span parents

### DIFF
--- a/.changeset/tidy-span-cycles.md
+++ b/.changeset/tidy-span-cycles.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-o11y": patch
+---
+
+fix: prevent cyclic span parent links from crashing observability trees

--- a/packages/react-o11y/src/resources/SpanResource.test.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import * as SpanPrimitive from "../primitives/span";
+import { SpanResource, type SpanData } from "./SpanResource";
+
+const createSpan = (id: string, parentSpanId: string | null): SpanData => ({
+  id,
+  parentSpanId,
+  name: id,
+  type: "test",
+  status: "completed",
+  startedAt: 0,
+  endedAt: 1,
+  latencyMs: 1,
+});
+
+const SpanFixture = ({ spans }: { spans: SpanData[] }) => {
+  const aui = useAui({ span: SpanResource({ spans }) });
+
+  return (
+    <AuiProvider value={aui}>
+      <SpanPrimitive.Children>
+        {({ span }) => (
+          <span data-span-id={span.id} data-span-depth={span.depth} />
+        )}
+      </SpanPrimitive.Children>
+    </AuiProvider>
+  );
+};
+
+const renderSpans = (spans: SpanData[]) =>
+  renderToStaticMarkup(<SpanFixture spans={spans} />);
+
+describe("SpanResource", () => {
+  it("preserves valid parent hierarchies", () => {
+    const html = renderSpans([
+      createSpan("root", null),
+      createSpan("child", "root"),
+    ]);
+
+    expect(html).toContain('data-span-id="root" data-span-depth="0"');
+    expect(html).toContain('data-span-id="child" data-span-depth="1"');
+  });
+
+  it("renders cyclic parent hierarchies without recursing indefinitely", () => {
+    const html = renderSpans([
+      createSpan("first", "second"),
+      createSpan("second", "first"),
+    ]);
+
+    expect(html.match(/data-span-id=/g)).toHaveLength(2);
+    expect(html).toContain('data-span-id="first" data-span-depth="0"');
+    expect(html).toContain('data-span-id="second" data-span-depth="1"');
+  });
+
+  it("renders self-parented and orphaned spans as roots", () => {
+    const html = renderSpans([
+      createSpan("self", "self"),
+      createSpan("orphan", "missing"),
+    ]);
+
+    expect(html.match(/data-span-id=/g)).toHaveLength(2);
+    expect(html).toContain('data-span-id="self" data-span-depth="0"');
+    expect(html).toContain('data-span-id="orphan" data-span-depth="0"');
+  });
+});

--- a/packages/react-o11y/src/resources/SpanResource.test.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.test.tsx
@@ -22,7 +22,11 @@ const SpanFixture = ({ spans }: { spans: SpanData[] }) => {
     <AuiProvider value={aui}>
       <SpanPrimitive.Children>
         {({ span }) => (
-          <span data-span-id={span.id} data-span-depth={span.depth} />
+          <span
+            data-span-id={span.id}
+            data-parent-span-id={span.parentSpanId ?? "root"}
+            data-span-depth={span.depth}
+          />
         )}
       </SpanPrimitive.Children>
     </AuiProvider>
@@ -39,8 +43,12 @@ describe("SpanResource", () => {
       createSpan("child", "root"),
     ]);
 
-    expect(html).toContain('data-span-id="root" data-span-depth="0"');
-    expect(html).toContain('data-span-id="child" data-span-depth="1"');
+    expect(html).toContain(
+      'data-span-id="root" data-parent-span-id="root" data-span-depth="0"',
+    );
+    expect(html).toContain(
+      'data-span-id="child" data-parent-span-id="root" data-span-depth="1"',
+    );
   });
 
   it("renders cyclic parent hierarchies without recursing indefinitely", () => {
@@ -50,8 +58,35 @@ describe("SpanResource", () => {
     ]);
 
     expect(html.match(/data-span-id=/g)).toHaveLength(2);
-    expect(html).toContain('data-span-id="first" data-span-depth="0"');
-    expect(html).toContain('data-span-id="second" data-span-depth="1"');
+    expect(html).toContain(
+      'data-span-id="first" data-parent-span-id="root" data-span-depth="0"',
+    );
+    expect(html).toContain(
+      'data-span-id="second" data-parent-span-id="first" data-span-depth="1"',
+    );
+  });
+
+  it("renders every span when a parent chain enters a longer cycle", () => {
+    const html = renderSpans([
+      createSpan("branch", "first"),
+      createSpan("first", "second"),
+      createSpan("second", "third"),
+      createSpan("third", "first"),
+    ]);
+
+    expect(html.match(/data-span-id=/g)).toHaveLength(4);
+    expect(html).toContain(
+      'data-span-id="first" data-parent-span-id="root" data-span-depth="0"',
+    );
+    expect(html).toContain(
+      'data-span-id="third" data-parent-span-id="first" data-span-depth="1"',
+    );
+    expect(html).toContain(
+      'data-span-id="second" data-parent-span-id="third" data-span-depth="2"',
+    );
+    expect(html).toContain(
+      'data-span-id="branch" data-parent-span-id="first" data-span-depth="1"',
+    );
   });
 
   it("renders self-parented and orphaned spans as roots", () => {
@@ -61,7 +96,11 @@ describe("SpanResource", () => {
     ]);
 
     expect(html.match(/data-span-id=/g)).toHaveLength(2);
-    expect(html).toContain('data-span-id="self" data-span-depth="0"');
-    expect(html).toContain('data-span-id="orphan" data-span-depth="0"');
+    expect(html).toContain(
+      'data-span-id="self" data-parent-span-id="root" data-span-depth="0"',
+    );
+    expect(html).toContain(
+      'data-span-id="orphan" data-parent-span-id="root" data-span-depth="0"',
+    );
   });
 });

--- a/packages/react-o11y/src/resources/SpanResource.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.tsx
@@ -115,7 +115,13 @@ function enrichSpans(rawSpans: SpanData[]): {
   for (const span of rawSpans) {
     const depth = calculateDepth(span.id, parents, depthCache);
     const hasChildren = (childrenCount.get(span.id) ?? 0) > 0;
-    allSpans.set(span.id, { ...span, depth, hasChildren, isCollapsed: false });
+    allSpans.set(span.id, {
+      ...span,
+      parentSpanId: parents.get(span.id) ?? null,
+      depth,
+      hasChildren,
+      isCollapsed: false,
+    });
 
     if (span.startedAt < min) min = span.startedAt;
     const end = span.endedAt ?? Date.now();

--- a/packages/react-o11y/src/resources/SpanResource.tsx
+++ b/packages/react-o11y/src/resources/SpanResource.tsx
@@ -18,25 +18,76 @@ export type SpanData = {
 
 function calculateDepth(
   spanId: string,
-  spanMap: Map<string, SpanData>,
+  parents: Map<string, string | null>,
   cache: Map<string, number>,
 ): number {
   const cached = cache.get(spanId);
   if (cached !== undefined) return cached;
 
-  const span = spanMap.get(spanId);
-  if (!span?.parentSpanId) {
-    cache.set(spanId, 0);
-    return 0;
+  const path: string[] = [];
+  let current: string | null = spanId;
+  let depth = -1;
+
+  while (current !== null) {
+    const currentDepth = cache.get(current);
+    if (currentDepth !== undefined) {
+      depth = currentDepth;
+      break;
+    }
+
+    path.push(current);
+    current = parents.get(current) ?? null;
   }
 
-  const depth = calculateDepth(span.parentSpanId, spanMap, cache) + 1;
-  cache.set(spanId, depth);
+  for (let index = path.length - 1; index >= 0; index--) {
+    depth += 1;
+    cache.set(path[index]!, depth);
+  }
+
   return depth;
+}
+
+function normalizeSpanParents(
+  spanMap: Map<string, SpanData>,
+): Map<string, string | null> {
+  const parents = new Map<string, string | null>();
+  for (const span of spanMap.values()) {
+    parents.set(
+      span.id,
+      span.parentSpanId && spanMap.has(span.parentSpanId)
+        ? span.parentSpanId
+        : null,
+    );
+  }
+
+  const resolved = new Set<string>();
+  for (const spanId of spanMap.keys()) {
+    if (resolved.has(spanId)) continue;
+
+    const path: string[] = [];
+    const pathIds = new Set<string>();
+    let current: string | null = spanId;
+
+    while (current !== null && !resolved.has(current)) {
+      if (pathIds.has(current)) {
+        parents.set(current, null);
+        break;
+      }
+
+      path.push(current);
+      pathIds.add(current);
+      current = parents.get(current) ?? null;
+    }
+
+    for (const id of path) resolved.add(id);
+  }
+
+  return parents;
 }
 
 function enrichSpans(rawSpans: SpanData[]): {
   allSpans: Map<string, SpanItemState>;
+  parents: Map<string, string | null>;
   timeRange: { min: number; max: number };
 } {
   const spanMap = new Map<string, SpanData>();
@@ -44,13 +95,15 @@ function enrichSpans(rawSpans: SpanData[]): {
     spanMap.set(span.id, span);
   }
 
+  const parents = normalizeSpanParents(spanMap);
   const depthCache = new Map<string, number>();
   const childrenCount = new Map<string, number>();
   for (const span of rawSpans) {
-    if (span.parentSpanId) {
+    const parentSpanId = parents.get(span.id);
+    if (parentSpanId) {
       childrenCount.set(
-        span.parentSpanId,
-        (childrenCount.get(span.parentSpanId) ?? 0) + 1,
+        parentSpanId,
+        (childrenCount.get(parentSpanId) ?? 0) + 1,
       );
     }
   }
@@ -60,7 +113,7 @@ function enrichSpans(rawSpans: SpanData[]): {
   let max = -Infinity;
 
   for (const span of rawSpans) {
-    const depth = calculateDepth(span.id, spanMap, depthCache);
+    const depth = calculateDepth(span.id, parents, depthCache);
     const hasChildren = (childrenCount.get(span.id) ?? 0) > 0;
     allSpans.set(span.id, { ...span, depth, hasChildren, isCollapsed: false });
 
@@ -73,16 +126,17 @@ function enrichSpans(rawSpans: SpanData[]): {
   if (max === -Infinity) max = Date.now();
   if (max === min) max = min + 100;
 
-  return { allSpans, timeRange: { min, max } };
+  return { allSpans, parents, timeRange: { min, max } };
 }
 
 function buildFlatList(
   allSpans: Map<string, SpanItemState>,
+  parents: Map<string, string | null>,
   collapsedIds: Set<string>,
 ): SpanItemState[] {
   const children = new Map<string | null, SpanItemState[]>();
   for (const span of allSpans.values()) {
-    const parent = span.parentSpanId ?? null;
+    const parent = parents.get(span.id) ?? null;
     let group = children.get(parent);
     if (!group) {
       group = [];
@@ -142,15 +196,18 @@ const useSpanResource = ({
 }: {
   spans: SpanData[];
 }): ClientOutput<"span"> => {
-  const { allSpans, timeRange } = useMemo(() => enrichSpans(spans), [spans]);
+  const { allSpans, parents, timeRange } = useMemo(
+    () => enrichSpans(spans),
+    [spans],
+  );
 
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(
     () => new Set(),
   );
 
   const visibleSpans = useMemo(
-    () => buildFlatList(allSpans, collapsedIds),
-    [allSpans, collapsedIds],
+    () => buildFlatList(allSpans, parents, collapsedIds),
+    [allSpans, parents, collapsedIds],
   );
 
   const toggleCollapse = (spanId: string) => {


### PR DESCRIPTION
## Summary

- normalize cyclic, self-referencing, and missing span parent links into a safe render hierarchy
- expose the normalized parent relationship through `SpanState` and calculate depths without recursive traversal
- add regressions covering valid trees, direct cycles, and chains entering longer cycles

## Why

Observability data can be partial or malformed, including two spans that reference each other as parents. `SpanResource` previously followed those links recursively and crashed the observability UI with `RangeError: Maximum call stack size exceeded`. Breaking one invalid edge keeps every span visible and gives downstream consumers a cycle-free hierarchy.

## Testing

- `pnpm --filter @assistant-ui/react-o11y test`
- `pnpm --filter @assistant-ui/react-o11y build`
- `pnpm lint`