### PR TITLE
fix(cloud): scope persisted message ids by thread

### DIFF
--- a/.changeset/deduplicate-cloud-child-appends.md
+++ b/.changeset/deduplicate-cloud-child-appends.md
@@ -1,0 +1,5 @@
+---
+"assistant-cloud": patch
+---
+
+fix: deduplicate concurrent child message appends while parent persistence is pending

--- a/.changeset/tidy-cloud-message-ids.md
+++ b/.changeset/tidy-cloud-message-ids.md
@@ -1,0 +1,7 @@
+---
+"assistant-cloud": patch
+"@assistant-ui/cloud-ai-sdk": patch
+"@assistant-ui/core": patch
+---
+
+fix: scope persisted Cloud message ID mappings by thread

--- a/.changeset/tidy-cloud-message-ids.md
+++ b/.changeset/tidy-cloud-message-ids.md
@@ -1,6 +1,5 @@
 ---
 "assistant-cloud": patch
-"@assistant-ui/cloud-ai-sdk": patch
 "@assistant-ui/core": patch
 ---
 

--- a/api-surface/assistant-cloud.ts
+++ b/api-surface/assistant-cloud.ts
@@ -318,12 +318,15 @@ declare class CloudMessagePersistence {
   private getCloud;
   constructor(cloud: AssistantCloud);
   constructor(getCloud: () => AssistantCloud);
+  private getThreadMapping;
   append(threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject): Promise<void>;
   update(threadId: string, messageId: string, _format: string, content: ReadonlyJSONObject): Promise<void>;
   isPersisted(messageId: string): boolean;
+  isPersisted(threadId: string, messageId: string): boolean;
   getRemoteId(messageId: string): Promise<string | undefined>;
+  getRemoteId(threadId: string, messageId: string): Promise<string | undefined>;
   load(threadId: string, format?: string): Promise<CloudMessage[]>;
-  reset(): void;
+  reset(threadId?: string): void;
 }
 
 declare class CloudResponseError extends Error {
@@ -488,7 +491,7 @@ type ToolModelContentPart = {
 declare const createFormattedPersistence: <TMessage, TStorageFormat>(persistence: {
   append: (threadId: string, messageId: string, parentId: string | null, format: string, content: ReadonlyJSONObject) => Promise<void>;
   load: (threadId: string, format?: string) => Promise<any[]>;
-  isPersisted: (messageId: string) => boolean;
+  isPersisted: (threadIdOrMessageId: string, messageId?: string) => boolean;
   update?: (threadId: string, messageId: string, format: string, content: ReadonlyJSONObject) => Promise<void>;
 }, adapter: MessageFormatAdapter<TMessage, TStorageFormat>) => {
   append: (threadId: string, item: {
@@ -505,7 +508,7 @@ declare const createFormattedPersistence: <TMessage, TStorageFormat>(persistence
       message: TMessage;
     }[];
   }>;
-  isPersisted: (messageId: string) => boolean;
+  isPersisted: (threadIdOrMessageId: string, messageId?: string) => boolean;
 };
 
 declare function createSamplingCollector(): {

--- a/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
+++ b/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
@@ -79,7 +79,7 @@ export class MessagePersistence {
 
     const appendTasks = messages.map((msg, idx) => {
       if (roles && !roles.includes(msg.role)) return null;
-      if (formatted.isPersisted(msg.id)) return null;
+      if (formatted.isPersisted(threadId, msg.id)) return null;
 
       const parentId = idx > 0 ? messages[idx - 1]!.id : null;
 

--- a/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
+++ b/packages/cloud-ai-sdk/src/chat/MessagePersistence.ts
@@ -79,7 +79,7 @@ export class MessagePersistence {
 
     const appendTasks = messages.map((msg, idx) => {
       if (roles && !roles.includes(msg.role)) return null;
-      if (formatted.isPersisted(threadId, msg.id)) return null;
+      if (formatted.isPersisted(msg.id)) return null;
 
       const parentId = idx > 0 ? messages[idx - 1]!.id : null;
 

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -70,7 +70,7 @@ export class CloudMessagePersistence {
         // Only delete if we're still the active task (avoids clobbering a retry)
         if (mapping.get(messageId) === task) {
           mapping.delete(messageId);
-          if (mapping.size === 0) {
+          if (mapping.size === 0 && this.idMapping.get(threadId) === mapping) {
             this.idMapping.delete(threadId);
           }
         }

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -13,13 +13,24 @@ import type { AssistantCloud } from "./AssistantCloud";
  * to get its remote ID before creating B.
  */
 export class CloudMessagePersistence {
-  private idMapping: Record<string, string | Promise<string>> = {};
+  private idMapping = new Map<string, Map<string, string | Promise<string>>>();
   private getCloud: () => AssistantCloud;
 
   constructor(cloud: AssistantCloud);
   constructor(getCloud: () => AssistantCloud);
   constructor(cloud: AssistantCloud | (() => AssistantCloud)) {
     this.getCloud = typeof cloud === "function" ? cloud : () => cloud;
+  }
+
+  private getThreadMapping(
+    threadId: string,
+  ): Map<string, string | Promise<string>> {
+    let mapping = this.idMapping.get(threadId);
+    if (!mapping) {
+      mapping = new Map();
+      this.idMapping.set(threadId, mapping);
+    }
+    return mapping;
   }
 
   /**
@@ -39,9 +50,10 @@ export class CloudMessagePersistence {
     content: ReadonlyJSONObject,
   ): Promise<void> {
     const cloud = this.getCloud();
+    const mapping = this.getThreadMapping(threadId);
     // Resolve parent's remote ID if it exists (may be a promise if concurrent)
     const resolvedParentId = parentId
-      ? ((await this.idMapping[parentId]) ?? parentId)
+      ? ((await mapping.get(parentId)) ?? parentId)
       : null;
 
     const task = cloud.threads.messages
@@ -51,19 +63,22 @@ export class CloudMessagePersistence {
         content,
       })
       .then(({ message_id }) => {
-        this.idMapping[messageId] = message_id;
+        mapping.set(messageId, message_id);
         return message_id;
       })
       .catch((err) => {
         // Only delete if we're still the active task (avoids clobbering a retry)
-        if (this.idMapping[messageId] === task) {
-          delete this.idMapping[messageId];
+        if (mapping.get(messageId) === task) {
+          mapping.delete(messageId);
+          if (mapping.size === 0) {
+            this.idMapping.delete(threadId);
+          }
         }
         throw err;
       });
 
     // Store the promise immediately so concurrent appends can await it
-    this.idMapping[messageId] = task;
+    mapping.set(messageId, task);
     return task.then(() => {});
   }
 
@@ -77,7 +92,7 @@ export class CloudMessagePersistence {
     content: ReadonlyJSONObject,
   ): Promise<void> {
     const cloud = this.getCloud();
-    const remoteId = await this.getRemoteId(messageId);
+    const remoteId = await this.getRemoteId(threadId, messageId);
     if (!remoteId) {
       console.warn(
         `Skipping update for message ${messageId}: no remote id is mapped.`,
@@ -89,17 +104,45 @@ export class CloudMessagePersistence {
 
   /**
    * Check if a message has been persisted (or is currently being persisted).
+   * Pass a thread ID to disambiguate local IDs reused across threads.
    */
-  isPersisted(messageId: string): boolean {
-    return messageId in this.idMapping;
+  isPersisted(messageId: string): boolean;
+  isPersisted(threadId: string, messageId: string): boolean;
+  isPersisted(threadIdOrMessageId: string, messageId?: string): boolean {
+    if (messageId !== undefined) {
+      return this.idMapping.get(threadIdOrMessageId)?.has(messageId) ?? false;
+    }
+
+    for (const mapping of this.idMapping.values()) {
+      if (mapping.has(threadIdOrMessageId)) return true;
+    }
+    return false;
   }
 
   /**
    * Get the remote ID for a local message ID (resolved).
+   * Pass a thread ID to disambiguate local IDs reused across threads.
    * Returns undefined if not persisted.
    */
-  async getRemoteId(messageId: string): Promise<string | undefined> {
-    const entry = this.idMapping[messageId];
+  async getRemoteId(messageId: string): Promise<string | undefined>;
+  async getRemoteId(
+    threadId: string,
+    messageId: string,
+  ): Promise<string | undefined>;
+  async getRemoteId(
+    threadIdOrMessageId: string,
+    messageId?: string,
+  ): Promise<string | undefined> {
+    let entry: string | Promise<string> | undefined;
+    if (messageId !== undefined) {
+      entry = this.idMapping.get(threadIdOrMessageId)?.get(messageId);
+    } else {
+      for (const mapping of this.idMapping.values()) {
+        entry = mapping.get(threadIdOrMessageId);
+        if (entry) break;
+      }
+    }
+
     if (!entry) return undefined;
     return entry;
   }
@@ -121,16 +164,21 @@ export class CloudMessagePersistence {
       format ? { format } : undefined,
     );
     // Populate ID mapping so isPersisted() recognizes loaded messages
+    const mapping = this.getThreadMapping(threadId);
     for (const m of messages) {
-      this.idMapping[m.id] = m.id;
+      mapping.set(m.id, m.id);
     }
     return messages;
   }
 
   /**
-   * Reset the ID mapping (call when switching threads).
+   * Reset one thread's ID mapping, or all mappings when no thread is provided.
    */
-  reset() {
-    this.idMapping = {};
+  reset(threadId?: string) {
+    if (threadId !== undefined) {
+      this.idMapping.delete(threadId);
+    } else {
+      this.idMapping.clear();
+    }
   }
 }

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -51,32 +51,36 @@ export class CloudMessagePersistence {
   ): Promise<void> {
     const cloud = this.getCloud();
     const mapping = this.getThreadMapping(threadId);
-    // Resolve parent's remote ID if it exists (may be a promise if concurrent)
-    const resolvedParentId = parentId
-      ? ((await mapping.get(parentId)) ?? parentId)
-      : null;
+    const existing = mapping.get(messageId);
+    if (existing instanceof Promise) {
+      await existing;
+      return;
+    }
 
-    const task = cloud.threads.messages
-      .create(threadId, {
+    const task = (async () => {
+      const resolvedParentId = parentId
+        ? ((await mapping.get(parentId)) ?? parentId)
+        : null;
+      const { message_id } = await cloud.threads.messages.create(threadId, {
         parent_id: resolvedParentId,
         format,
         content,
-      })
-      .then(({ message_id }) => {
-        mapping.set(messageId, message_id);
-        return message_id;
-      })
-      .catch((err) => {
-        // Only delete if we're still the active task (avoids clobbering a retry)
-        if (mapping.get(messageId) === task) {
-          mapping.delete(messageId);
-        }
-        throw err;
       });
+      return message_id;
+    })();
 
-    // Store the promise immediately so concurrent appends can await it
     mapping.set(messageId, task);
-    return task.then(() => {});
+    try {
+      const remoteId = await task;
+      if (mapping.get(messageId) === task) {
+        mapping.set(messageId, remoteId);
+      }
+    } catch (err) {
+      if (mapping.get(messageId) === task) {
+        mapping.delete(messageId);
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/cloud/src/CloudMessagePersistence.ts
+++ b/packages/cloud/src/CloudMessagePersistence.ts
@@ -70,9 +70,6 @@ export class CloudMessagePersistence {
         // Only delete if we're still the active task (avoids clobbering a retry)
         if (mapping.get(messageId) === task) {
           mapping.delete(messageId);
-          if (mapping.size === 0 && this.idMapping.get(threadId) === mapping) {
-            this.idMapping.delete(threadId);
-          }
         }
         throw err;
       });

--- a/packages/cloud/src/FormattedCloudPersistence.ts
+++ b/packages/cloud/src/FormattedCloudPersistence.ts
@@ -37,7 +37,7 @@ export const createFormattedPersistence = <TMessage, TStorageFormat>(
       content: ReadonlyJSONObject,
     ) => Promise<void>;
     load: (threadId: string, format?: string) => Promise<any[]>;
-    isPersisted: (messageId: string) => boolean;
+    isPersisted: (threadIdOrMessageId: string, messageId?: string) => boolean;
     update?: (
       threadId: string,
       messageId: string,
@@ -92,5 +92,8 @@ export const createFormattedPersistence = <TMessage, TStorageFormat>(
         .reverse(),
     };
   },
-  isPersisted: (messageId: string) => persistence.isPersisted(messageId),
+  isPersisted: (threadIdOrMessageId: string, messageId?: string) =>
+    messageId === undefined
+      ? persistence.isPersisted(threadIdOrMessageId)
+      : persistence.isPersisted(threadIdOrMessageId, messageId),
 });

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -148,6 +148,39 @@ describe("CloudMessagePersistence", () => {
     );
   });
 
+  it("keeps mappings for duplicate local message IDs scoped to their thread", async () => {
+    vi.mocked(cloud.threads.messages.create)
+      .mockResolvedValueOnce({ message_id: "remote-a" })
+      .mockResolvedValueOnce({ message_id: "remote-b" });
+    vi.mocked(cloud.threads.messages.update).mockResolvedValue(undefined);
+
+    await persistence.append("thread-a", "local-1", null, "aui/v0", {
+      text: "thread a",
+    });
+    await persistence.append("thread-b", "local-1", null, "aui/v0", {
+      text: "thread b",
+    });
+
+    expect(persistence.isPersisted("thread-a", "local-1")).toBe(true);
+    expect(persistence.isPersisted("thread-b", "local-1")).toBe(true);
+    expect(await persistence.getRemoteId("thread-a", "local-1")).toBe(
+      "remote-a",
+    );
+    expect(await persistence.getRemoteId("thread-b", "local-1")).toBe(
+      "remote-b",
+    );
+
+    await persistence.update("thread-a", "local-1", "aui/v0", {
+      text: "updated",
+    });
+
+    expect(cloud.threads.messages.update).toHaveBeenCalledWith(
+      "thread-a",
+      "remote-a",
+      { content: { text: "updated" } },
+    );
+  });
+
   it("warns and skips update when no remote id is mapped", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -108,6 +108,59 @@ describe("CloudMessagePersistence", () => {
     });
   });
 
+  it("deduplicates concurrent child appends while the parent is pending", async () => {
+    let resolveParent!: (value: { message_id: string }) => void;
+    vi.mocked(cloud.threads.messages.create)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveParent = resolve;
+          }),
+      )
+      .mockResolvedValue({ message_id: "remote-child" });
+
+    const parent = persistence.append("thread-1", "parent", null, "aui/v0", {
+      text: "parent",
+    });
+    const firstChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+    const secondChild = persistence.append(
+      "thread-1",
+      "child",
+      "parent",
+      "aui/v0",
+      { text: "child" },
+    );
+
+    resolveParent({ message_id: "remote-parent" });
+    await Promise.all([parent, firstChild, secondChild]);
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-appends messages whose mapping has already resolved", async () => {
+    vi.mocked(cloud.threads.messages.create)
+      .mockResolvedValueOnce({ message_id: "remote-1" })
+      .mockResolvedValueOnce({ message_id: "remote-2" });
+
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "first",
+    });
+    await persistence.append("thread-1", "local-1", null, "aui/v0", {
+      text: "second",
+    });
+
+    expect(cloud.threads.messages.create).toHaveBeenCalledTimes(2);
+    expect(await persistence.getRemoteId("thread-1", "local-1")).toBe(
+      "remote-2",
+    );
+  });
+
   it("loaded messages are marked as persisted and not re-created", async () => {
     vi.mocked(cloud.threads.messages.list).mockResolvedValue({
       messages: [

--- a/packages/cloud/src/tests/CloudMessagePersistence.test.ts
+++ b/packages/cloud/src/tests/CloudMessagePersistence.test.ts
@@ -150,8 +150,10 @@ describe("CloudMessagePersistence", () => {
 
   it("keeps mappings for duplicate local message IDs scoped to their thread", async () => {
     vi.mocked(cloud.threads.messages.create)
-      .mockResolvedValueOnce({ message_id: "remote-a" })
-      .mockResolvedValueOnce({ message_id: "remote-b" });
+      .mockResolvedValueOnce({ message_id: "remote-a-parent" })
+      .mockResolvedValueOnce({ message_id: "remote-b-parent" })
+      .mockResolvedValueOnce({ message_id: "remote-a-child" })
+      .mockResolvedValueOnce({ message_id: "remote-b-child" });
     vi.mocked(cloud.threads.messages.update).mockResolvedValue(undefined);
 
     await persistence.append("thread-a", "local-1", null, "aui/v0", {
@@ -160,14 +162,30 @@ describe("CloudMessagePersistence", () => {
     await persistence.append("thread-b", "local-1", null, "aui/v0", {
       text: "thread b",
     });
+    await persistence.append("thread-a", "child", "local-1", "aui/v0", {
+      text: "thread a child",
+    });
+    await persistence.append("thread-b", "child", "local-1", "aui/v0", {
+      text: "thread b child",
+    });
 
     expect(persistence.isPersisted("thread-a", "local-1")).toBe(true);
     expect(persistence.isPersisted("thread-b", "local-1")).toBe(true);
     expect(await persistence.getRemoteId("thread-a", "local-1")).toBe(
-      "remote-a",
+      "remote-a-parent",
     );
     expect(await persistence.getRemoteId("thread-b", "local-1")).toBe(
-      "remote-b",
+      "remote-b-parent",
+    );
+    expect(cloud.threads.messages.create).toHaveBeenNthCalledWith(
+      3,
+      "thread-a",
+      expect.objectContaining({ parent_id: "remote-a-parent" }),
+    );
+    expect(cloud.threads.messages.create).toHaveBeenNthCalledWith(
+      4,
+      "thread-b",
+      expect.objectContaining({ parent_id: "remote-b-parent" }),
     );
 
     await persistence.update("thread-a", "local-1", "aui/v0", {
@@ -176,8 +194,40 @@ describe("CloudMessagePersistence", () => {
 
     expect(cloud.threads.messages.update).toHaveBeenCalledWith(
       "thread-a",
-      "remote-a",
+      "remote-a-parent",
       { content: { text: "updated" } },
+    );
+  });
+
+  it("does not let a failed pre-reset append clear replacement mappings", async () => {
+    let rejectOldAppend!: (error: Error) => void;
+    vi.mocked(cloud.threads.messages.create)
+      .mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectOldAppend = reject;
+          }),
+      )
+      .mockResolvedValueOnce({ message_id: "remote-new" });
+
+    const oldAppend = persistence.append(
+      "thread-1",
+      "old-message",
+      null,
+      "aui/v0",
+      { text: "old" },
+    );
+    persistence.reset("thread-1");
+    await persistence.append("thread-1", "new-message", null, "aui/v0", {
+      text: "new",
+    });
+
+    rejectOldAppend(new Error("old append failed"));
+    await expect(oldAppend).rejects.toThrow("old append failed");
+
+    expect(persistence.isPersisted("thread-1", "new-message")).toBe(true);
+    expect(await persistence.getRemoteId("thread-1", "new-message")).toBe(
+      "remote-new",
     );
   });
 

--- a/packages/cloud/src/tests/FormattedCloudPersistence.test.ts
+++ b/packages/cloud/src/tests/FormattedCloudPersistence.test.ts
@@ -106,6 +106,9 @@ describe("createFormattedPersistence", () => {
     persistence.isPersisted.mockReturnValue(true);
     const formatted = createFormattedPersistence(persistence, adapter);
 
+    expect(formatted.isPersisted("thread-1", "msg-1")).toBe(true);
+    expect(persistence.isPersisted).toHaveBeenCalledWith("thread-1", "msg-1");
+
     expect(formatted.isPersisted("msg-1")).toBe(true);
     expect(persistence.isPersisted).toHaveBeenCalledWith("msg-1");
   });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -1,15 +1,17 @@
 // @vitest-environment jsdom
 
 import { renderHook } from "@testing-library/react";
-import type { AssistantCloud } from "assistant-cloud";
+import { CloudMessagePersistence, type AssistantCloud } from "assistant-cloud";
 import { describe, expect, it, vi } from "vitest";
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
+import { ExportedMessageRepository } from "../../../runtime/utils/message-repository";
 
 const mocks = vi.hoisted(() => {
   const makeClient = (remoteId: string) =>
     ({
       threadListItem: {
         getState: () => ({ remoteId }),
+        initialize: vi.fn().mockResolvedValue({ remoteId }),
       },
     }) as unknown as import("@assistant-ui/store").AssistantClient;
 
@@ -26,9 +28,12 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 
 const makeCloud = () =>
   ({
+    telemetry: { enabled: false },
     threads: {
       messages: {
+        create: vi.fn().mockResolvedValue({ message_id: "remote-message-1" }),
         list: vi.fn().mockResolvedValue({ messages: [] }),
+        update: vi.fn().mockResolvedValue(undefined),
       },
     },
   }) as unknown as AssistantCloud;
@@ -90,5 +95,30 @@ describe("useAssistantCloudThreadHistoryAdapter", () => {
     expect(cloud.threads.messages.list).toHaveBeenCalledWith("thread-2", {
       format: "aui/v0",
     });
+  });
+
+  it("checks persisted messages within the current remote thread", async () => {
+    mocks.aui = mocks.makeClient("thread-1");
+    const cloud = makeCloud();
+    const cloudRef = { current: cloud };
+    const isPersisted = vi.spyOn(
+      CloudMessagePersistence.prototype,
+      "isPersisted",
+    );
+    const { result } = renderHook(() =>
+      useAssistantCloudThreadHistoryAdapter(cloudRef),
+    );
+    const [item] = ExportedMessageRepository.fromArray([
+      {
+        id: "local-message-1",
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      },
+    ]).messages;
+
+    await result.current.append(item!);
+    await result.current.update(item!);
+
+    expect(isPersisted).toHaveBeenCalledWith("thread-1", "local-message-1");
   });
 });

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx
@@ -2,7 +2,7 @@
 
 import { renderHook } from "@testing-library/react";
 import { CloudMessagePersistence, type AssistantCloud } from "assistant-cloud";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAssistantCloudThreadHistoryAdapter } from "./AssistantCloudThreadHistoryAdapter";
 import { ExportedMessageRepository } from "../../../runtime/utils/message-repository";
 
@@ -37,6 +37,10 @@ const makeCloud = () =>
       },
     },
   }) as unknown as AssistantCloud;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("useAssistantCloudThreadHistoryAdapter", () => {
   it("refreshes formatted persistence when the Cloud client changes", async () => {

--- a/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
+++ b/packages/core/src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.ts
@@ -112,12 +112,11 @@ class AssistantCloudThreadHistoryAdapter implements ThreadHistoryAdapter {
   }
 
   async update(item: ExportedMessageRepositoryItem) {
-    if (!this._persistence.isPersisted(item.message.id)) {
-      return this.append(item);
-    }
     const { message } = item;
     const remoteId = this.aui.threadListItem.getState().remoteId;
-    if (!remoteId) return;
+    if (!remoteId || !this._persistence.isPersisted(remoteId, message.id)) {
+      return this.append(item);
+    }
     const encoded = auiV0Encode(message);
     await this._persistence.update(remoteId, message.id, "aui/v0", encoded);
 


### PR DESCRIPTION
## Summary

- scope local-to-remote Cloud message ID mappings by thread
- use the scoped mapping for parent resolution, updates, loads, and persistence checks
- preserve the existing one-argument lookup methods for compatibility while migrating internal callers to the unambiguous thread-aware form

## Why

`CloudMessagePersistence` is exported publicly and its methods accept a `threadId`, so direct consumers can use one instance across multiple threads. In that supported shape, duplicate local IDs collide: persisting `msg-1` in thread B overwrites thread A's mapping, and a later direct update for thread A can target thread B's remote message ID.

The built-in core and Cloud AI SDK paths currently isolate persistence instances per thread, so this is a correctness fix for direct consumers and future shared-instance use rather than a currently reachable cross-thread bug in those runtimes. Scoping mappings by thread makes the exported class behave consistently with its API.

## Minimal reproduction

Using `assistant-cloud@0.1.38`:

```bash
pnpm init
pnpm add assistant-cloud@0.1.38
pnpm add -D tsx
```

```ts
// repro.ts
import { CloudMessagePersistence } from "assistant-cloud";

const remoteIds = ["remote-a", "remote-b"];
const updates: unknown[][] = [];
const cloud = {
  threads: {
    messages: {
      create: async () => ({ message_id: remoteIds.shift()! }),
      update: async (...args: unknown[]) => {
        updates.push(args);
      },
      list: async () => ({ messages: [] }),
    },
  },
} as any;

const persistence = new CloudMessagePersistence(cloud);
await persistence.append("thread-a", "msg-1", null, "aui/v0", {});
await persistence.append("thread-b", "msg-1", null, "aui/v0", {});
await persistence.update("thread-a", "msg-1", "aui/v0", {});

console.log(updates[0]);
// Before: ["thread-a", "remote-b", ...]
// Expected: ["thread-a", "remote-a", ...]
```

Run with `pnpm tsx repro.ts`.

## Testing

- added a regression that persists the same local ID in two threads and verifies thread A updates its own remote message
- `pnpm --filter assistant-cloud test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/core exec vitest run src/react/runtimes/cloud/AssistantCloudThreadHistoryAdapter.test.tsx`
- built `@assistant-ui/core`, `assistant-cloud`, and `@assistant-ui/cloud-ai-sdk`
- `pnpm lint`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.GGdNIOVJeiQ-YJCXeBRLTnbVtbwESKs3dQV4c9WymCpNcS6H4Y5EphW1_Kg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->