### PR TITLE
fix(assistant-stream): await resumable reader cleanup

### DIFF
--- a/.changeset/calm-readers-clean.md
+++ b/.changeset/calm-readers-clean.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: await resumable reader cleanup during cancellation

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -167,6 +167,58 @@ describe("createResumableStreamContext", () => {
     expect(await collect(replay!)).toBe("chunk0;chunk1;chunk2;chunk3;chunk4;");
   });
 
+  it("waits for store iterator cleanup when a consumer cancels", async () => {
+    let releaseCleanup!: () => void;
+    const cleanupGate = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const iterator = {
+      next: vi.fn(
+        () =>
+          new Promise<IteratorResult<{ cursor: string; chunk: Uint8Array }>>(
+            () => undefined,
+          ),
+      ),
+      return: vi.fn(async () => {
+        await cleanupGate;
+        return { done: true as const, value: undefined };
+      }),
+    };
+    const ctx = createResumableStreamContext({
+      store: {
+        async acquire() {
+          return "consumer";
+        },
+        async append() {},
+        async finalize() {},
+        read() {
+          return {
+            [Symbol.asyncIterator]: () => iterator,
+          };
+        },
+        async status() {
+          return "streaming";
+        },
+        async delete() {},
+      },
+    });
+
+    const stream = await ctx.run("a", () => {
+      throw new Error("consumer must not create a producer stream");
+    });
+    let cancelSettled = false;
+    const cancelPromise = stream.cancel().then(() => {
+      cancelSettled = true;
+    });
+
+    await vi.waitFor(() => expect(iterator.return).toHaveBeenCalledOnce());
+    expect(cancelSettled).toBe(false);
+
+    releaseCleanup();
+    await cancelPromise;
+    expect(cancelSettled).toBe(true);
+  });
+
   it("propagates producer errors to consumers", async () => {
     const ctx = createResumableStreamContext({
       store: createInMemoryResumableStreamStore(),

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.test.ts
@@ -219,6 +219,34 @@ describe("createResumableStreamContext", () => {
     expect(cancelSettled).toBe(true);
   });
 
+  it("cancels a parked in-memory store reader", async () => {
+    const store = createInMemoryResumableStreamStore();
+    await store.acquire("a");
+    const read = store.read.bind(store);
+    let markReadStarted!: () => void;
+    const readStarted = new Promise<void>((resolve) => {
+      markReadStarted = resolve;
+    });
+    vi.spyOn(store, "read").mockImplementation(async function* (...args) {
+      markReadStarted();
+      yield* read(...args);
+    });
+    const ctx = createResumableStreamContext({ store });
+
+    const stream = await ctx.run("a", () => {
+      throw new Error("consumer must not create a producer stream");
+    });
+    const reader = stream.getReader();
+    const readPromise = reader.read();
+    await readStarted;
+
+    await expect(reader.cancel()).resolves.toBeUndefined();
+    await expect(readPromise).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
   it("propagates producer errors to consumers", async () => {
     const ctx = createResumableStreamContext({
       store: createInMemoryResumableStreamStore(),

--- a/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
+++ b/packages/assistant-stream/src/resumable/ResumableStreamContext.ts
@@ -206,9 +206,11 @@ function readFromStore(
         controller.error(err);
       }
     },
-    cancel() {
+    async cancel() {
       ac.abort();
-      iterator?.return?.().catch(() => {});
+      try {
+        await iterator?.return?.();
+      } catch {}
     },
   });
 }


### PR DESCRIPTION
## Summary

- await asynchronous store iterator cleanup when a resumable stream consumer cancels
- preserve the existing abort-first behavior and cleanup error handling
- add a regression test proving cancellation stays pending until iterator teardown finishes

## Why

`ResumableStreamStore.read()` supports custom asynchronous iterators, including database and remote-store readers that may release cursors, subscriptions, or connections in `return()`.

Previously, cancellation aborted the signal but started `iterator.return()` without returning its promise. As a result, `await reader.cancel()` could resolve while storage cleanup was still running. Callers could then dispose request or storage resources under the assumption that teardown had completed.

Returning the cleanup promise aligns the adapter with the Web Streams cancellation contract. It only waits for the local consumer iterator; the producer continues writing and remains resumable.

## Testing

- `pnpm --filter assistant-stream test` (400 passed, 20 skipped)
- `pnpm --filter assistant-stream exec tsc --noEmit`
- `pnpm --filter assistant-stream build`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.IldxtoJ3zhpzqgMXBdqlyWOlrNP68zI_iox0BCCjfmOC81GX93gk4yh-DEM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->