### PR TITLE
fix(react-streamdown): merge user rehypePlugins after the security hardening pipeline

### DIFF
--- a/.changeset/streamdown-merge-user-rehype-plugins.md
+++ b/.changeset/streamdown-merge-user-rehype-plugins.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-streamdown": patch
+---
+
+fix: merge user rehypePlugins after the security hardening pipeline instead of dropping it

--- a/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
+++ b/packages/react-streamdown/src/__tests__/StreamdownText.test.tsx
@@ -4,6 +4,7 @@ import { TextMessagePartProvider } from "@assistant-ui/react";
 import { StreamdownTextPrimitive } from "../primitives/StreamdownText";
 import type {
   StreamdownTextComponents,
+  StreamdownProps,
   SyntaxHighlighterProps,
   CodeHeaderProps,
 } from "../types";
@@ -111,6 +112,94 @@ describe("StreamdownTextPrimitive", () => {
     expect(
       container.querySelector("[data-status]")?.getAttribute("data-status"),
     ).toBe("complete");
+  });
+
+  describe("security and user rehypePlugins", () => {
+    type HastNode = {
+      tagName?: string;
+      properties?: Record<string, unknown>;
+      children?: HastNode[];
+    };
+
+    const stampAnchors = () => (tree: HastNode) => {
+      const walk = (node: HastNode) => {
+        if (node.tagName === "a") {
+          node.properties = { ...node.properties, dataUserPlugin: "true" };
+        }
+        node.children?.forEach(walk);
+      };
+      walk(tree);
+    };
+    const userRehypePlugins = [stampAnchors] as unknown as NonNullable<
+      StreamdownProps["rehypePlugins"]
+    >;
+
+    const markdown =
+      "[good](https://trusted.example.com/page) and [evil](https://evil.example.com)";
+    const security = {
+      allowedLinkPrefixes: ["https://trusted.example.com"],
+      defaultOrigin: "https://trusted.example.com",
+      blockedLinkClass: "blocked-link",
+    };
+
+    it("applies both the hardening pipeline and user rehypePlugins", async () => {
+      const { container } = render(
+        <TextMessagePartProvider text={markdown} isRunning={false}>
+          <StreamdownTextPrimitive
+            security={security}
+            rehypePlugins={userRehypePlugins}
+            linkSafety={{ enabled: false }}
+          />
+        </TextMessagePartProvider>,
+      );
+
+      expect(await screen.findByText(/\[blocked\]/)).toBeTruthy();
+      expect(
+        container.querySelector('a[href^="https://evil.example.com"]'),
+      ).toBeNull();
+
+      const goodAnchor = container.querySelector(
+        'a[href="https://trusted.example.com/page"]',
+      );
+      expect(goodAnchor).not.toBeNull();
+      expect(goodAnchor!.getAttribute("data-user-plugin")).toBe("true");
+    });
+
+    it("hardens URLs when only security is set", async () => {
+      const { container } = render(
+        <TextMessagePartProvider text={markdown} isRunning={false}>
+          <StreamdownTextPrimitive
+            security={security}
+            linkSafety={{ enabled: false }}
+          />
+        </TextMessagePartProvider>,
+      );
+
+      expect(await screen.findByText(/\[blocked\]/)).toBeTruthy();
+      expect(
+        container.querySelector('a[href^="https://evil.example.com"]'),
+      ).toBeNull();
+      expect(
+        container.querySelector('a[href="https://trusted.example.com/page"]'),
+      ).not.toBeNull();
+    });
+
+    it("passes user rehypePlugins through when security is not set", async () => {
+      const { container } = render(
+        <TextMessagePartProvider text={markdown} isRunning={false}>
+          <StreamdownTextPrimitive
+            rehypePlugins={userRehypePlugins}
+            linkSafety={{ enabled: false }}
+          />
+        </TextMessagePartProvider>,
+      );
+
+      const evilAnchor = container.querySelector(
+        'a[href^="https://evil.example.com"]',
+      );
+      expect(evilAnchor).not.toBeNull();
+      expect(evilAnchor!.getAttribute("data-user-plugin")).toBe("true");
+    });
   });
 
   describe("code adapter with custom components", () => {

--- a/packages/react-streamdown/src/primitives/StreamdownText.tsx
+++ b/packages/react-streamdown/src/primitives/StreamdownText.tsx
@@ -109,6 +109,7 @@ export const StreamdownTextPrimitive = forwardRef<
       parseIncompleteMarkdown,
       allowedTags,
       remarkRehypeOptions,
+      rehypePlugins: userRehypePlugins,
       security,
       BlockComponent,
       parseMarkdownIntoBlocksFn,
@@ -183,10 +184,13 @@ export const StreamdownTextPrimitive = forwardRef<
       return classes || undefined;
     }, [containerClassName, containerProps?.className]);
 
-    const rehypePlugins = useMemo(
-      () => (security ? buildSecurityRehypePlugins(security) : undefined),
-      [security],
-    );
+    const rehypePlugins = useMemo(() => {
+      if (!security) return userRehypePlugins;
+      return [
+        ...buildSecurityRehypePlugins(security),
+        ...(userRehypePlugins ?? []),
+      ];
+    }, [security, userRehypePlugins]);
 
     const optionalProps = {
       ...(className && { className }),

--- a/packages/react-streamdown/src/types.ts
+++ b/packages/react-streamdown/src/types.ts
@@ -404,6 +404,8 @@ export type StreamdownTextPrimitiveProps = Omit<
   /**
    * Security configuration for URL/image validation.
    * Overrides streamdown's default (allow-all) policy via rehype-harden.
+   * When `rehypePlugins` is also provided, those plugins run after this
+   * hardening pipeline.
    *
    * @example
    * // Restrict links to trusted domains only


### PR DESCRIPTION
Closes #5611
## What

`StreamdownTextPrimitive` now merges a user-passed `rehypePlugins` after the `security` hardening pipeline instead of letting it silently replace the pipeline. When `security` is not set, user plugins pass through unchanged.

## Why

While validating the `security` prop I found that adding any `rehypePlugins` alongside it renders blocked URLs as live links: the prop rode the rest spread, which spreads after the internally built pipeline and overwrote it wholesale, with no warning. 

## Impact

- Anyone combining `security` with a custom rehype plugin gets URL hardening back; previously it was dropped silently.
- All other prop combinations are unchanged (verified for each row of the security x rehypePlugins matrix).

## Scope 

- Merge order is `[raw, sanitize, harden, ...userPlugins]`, mirroring streamdown's own default pipeline shape, so a plugin behaves the same with or without `security`.
- Passing `rehypePlugins` without `security` still replaces streamdown's internal defaults; that is streamdown's documented default-parameter semantic, intentionally untouched.
- When neither prop is set the component keeps passing `undefined`, so streamdown's built-in pipeline still applies.
- Tests disable `linkSafety` because streamdown renders safe links as buttons by default; the assertions need real anchors.
- Tests: security+plugins (the bug), security alone, plugins alone; the bug case fails without the fix.
- Additive only, no exports removed or reshaped; one JSDoc sentence added to the `security` prop documenting the interaction.
- Changeset: patch (`@assistant-ui/react-streamdown`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7ZPMgGaC0l7VpNOGxoZQhgcltKVNlm7HxVlCuJq7-qD5XHngeXqf6uSLp9Q?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->