### PR TITLE
fix(tap): guard useResources unmounts with isMounted

### DIFF
--- a/.changeset/tap-useresources-unmount-guard.md
+++ b/.changeset/tap-useresources-unmount-guard.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/tap": patch
+---
+
+fix(tap): guard useResources unmounts with isMounted, so StrictMode/Activity effect replays cannot double-unmount a child fiber

--- a/packages/tap/src/__tests__/react/useResources-activity-replay.test.tsx
+++ b/packages/tap/src/__tests__/react/useResources-activity-replay.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { Activity, StrictMode } from "react";
+import { resource } from "../../core/resource";
+import { withKey } from "../../core/withKey";
+import { useResources } from "../../index";
+import { cleanupAllResources } from "../test-utils";
+
+// React replays effects without an intervening render when an <Activity>
+// boundary is hidden and shown again, and again under StrictMode. The replay's
+// teardown unmounts every child fiber useResources holds; the replay's commit
+// only recommits children that were re-rendered, so children whose deps are
+// unchanged ("skip") stay unmounted. The unmount walk must tolerate that.
+describe("useResources under Activity effect replay", () => {
+  afterEach(() => {
+    cleanupAllResources();
+    cleanup();
+  });
+
+  it("does not double-unmount bailed-out children", async () => {
+    const useItem = (props: { n: number }) => props.n;
+    const Item = resource(useItem);
+
+    function List() {
+      // Constant deps, so every child bails out ("skip") on re-render.
+      useResources([
+        withKey("a", Item({ n: 1 }), []),
+        withKey("b", Item({ n: 2 }), []),
+      ]);
+      return null;
+    }
+
+    function App({ visible }: { visible: boolean }) {
+      return (
+        <Activity mode={visible ? "visible" : "hidden"}>
+          <List />
+        </Activity>
+      );
+    }
+
+    const view = render(
+      <StrictMode>
+        <App visible={true} />
+      </StrictMode>,
+    );
+
+    await act(async () => {
+      view.rerender(
+        <StrictMode>
+          <App visible={false} />
+        </StrictMode>,
+      );
+    });
+
+    await act(async () => {
+      view.rerender(
+        <StrictMode>
+          <App visible={true} />
+        </StrictMode>,
+      );
+    });
+
+    expect(() => view.unmount()).not.toThrow();
+  });
+});

--- a/packages/tap/src/hooks/useResources.ts
+++ b/packages/tap/src/hooks/useResources.ts
@@ -160,7 +160,7 @@ export function useResources<E extends ResourceElement<any>>(
     return () => {
       for (const key of fibers.keys()) {
         const fiber = fibers.get(key)!.fiber;
-        unmountResourceFiber(fiber);
+        if (fiber.isMounted) unmountResourceFiber(fiber);
       }
     };
   }, [fibers]);
@@ -179,7 +179,7 @@ export function useResources<E extends ResourceElement<any>>(
         // Bailed this render: nothing to commit, keep committed deps/value.
       } else {
         if (next.remount) {
-          unmountResourceFiber(state.fiber);
+          if (state.fiber.isMounted) unmountResourceFiber(state.fiber);
           state.fiber = next.remount;
         }
         commitResourceFiber(state.fiber);


### PR DESCRIPTION
## Problem

`unmountResourceFiber` throws `Tried to unmount a fiber that is already unmounted` when handed a fiber with `isMounted === false`. `useResources` already guards for exactly this in the `"delete"` branch of its commit effect, but the teardown walk eight lines above it and the `next.remount` swap three lines below it do not:

https://github.com/assistant-ui/assistant-ui/blob/main/packages/tap/src/hooks/useResources.ts#L159-L184

```ts
  // Cleanup on unmount
  useEffect(() => {
    return () => {
      for (const key of fibers.keys()) {
        const fiber = fibers.get(key)!.fiber;
        unmountResourceFiber(fiber);        // <- no guard
      }
    };
  }, [fibers]);

  useEffect(() => {
    ...
      if (next === "delete") {
        if (state.fiber.isMounted) {        // <- guarded
          unmountResourceFiber(state.fiber);
        }
    ...
        if (next.remount) {
          unmountResourceFiber(state.fiber); // <- no guard
```

## Why the unguarded calls are reachable

`useTapHost` already documents the mechanism:

```ts
// !isMounted: StrictMode/Activity replays effects without a re-render
// after unmounting the fiber; the replay must recommit it.
if (renderCommitted && fiber.isMounted) return;
```

React replays effects without an intervening render under StrictMode and when an `<Activity>` boundary is hidden and shown again. On the replay:

1. the teardown of the cleanup effect sets `isMounted = false` on every fiber in the map;
2. the commit effect re-runs, but children whose deps did not change are sitting on `next === "skip"`, and that branch commits nothing;
3. so those children stay unmounted with no path back to mounted;
4. a later real unmount walks the same map and hits the unguarded `unmountResourceFiber`, which throws.

The bailout is what makes this reachable, so it only shows up with a populated child list. In `@assistant-ui/react` that is a thread with an existing conversation being hidden and shown again by a tab switch. Same error text as #3123.

## Fix

Guard both remaining calls the way the sibling branch is already guarded. One line each, no behavior change on the mounted path.

## Reproduction

Added `packages/tap/src/__tests__/react/useResources-activity-replay.test.tsx`: a keyed `useResources` list with constant deps (so every child bails out), rendered under `<StrictMode>` inside an `<Activity>` boundary, hidden, shown, then unmounted.

Without the fix it fails with the reported error at `useResources.ts:163`:

```
Error: Tried to unmount a fiber that is already unmounted
 ❯ unmountResourceFiber src/core/ResourceFiber.ts:40:11
 ❯ src/hooks/useResources.ts:163:9
 ❯ commitHookEffectListUnmount react-dom-client.development.js:13316:17
 ❯ commitPassiveUnmountEffectsInsideOfDeletedTree_begin ...
```

With the fix the full `@assistant-ui/tap` suite passes: 35 files, 464 tests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.VO6sWbjrhwSQLL0naq-uGxmT-acaxmaoNUpx_JLCnzJPW5UyggoR_1XpTwQ?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->