### PR TITLE
fix(react-a2a): isolate runtime callbacks

### DIFF
--- a/.changeset/calm-a2a-callbacks.md
+++ b/.changeset/calm-a2a-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-a2a": patch
+---
+
+fix: isolate runtime callback failures from A2A stream processing

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -704,46 +704,52 @@ describe("A2AThreadRuntimeCore", () => {
       expect(onArtifactComplete.mock.calls[0]![0].artifactId).toBe("a1");
     });
 
-    it("continues streaming when onArtifactComplete throws", async () => {
-      const callbackError = new Error("artifact callback failed");
-      const consoleError = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const onError = vi.fn();
-      const core = createCore(
-        {
-          streamMessage: vi.fn().mockImplementation(async function* () {
-            yield artifactUpdateEvent("a1", [{ text: "code" }], {
-              lastChunk: true,
-            });
-            yield statusUpdateEvent("completed", "Done");
-          }),
-        },
-        {
-          onArtifactComplete: () => {
-            throw callbackError;
+    it.each(["throws", "rejects"] as const)(
+      "continues streaming when onArtifactComplete %s",
+      async (failureMode) => {
+        const callbackError = new Error("artifact callback failed");
+        const consoleError = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        const onError = vi.fn();
+        const core = createCore(
+          {
+            streamMessage: vi.fn().mockImplementation(async function* () {
+              yield artifactUpdateEvent("a1", [{ text: "code" }], {
+                lastChunk: true,
+              });
+              yield statusUpdateEvent("completed", "Done");
+            }),
           },
-          onError,
-        },
-      );
+          {
+            onArtifactComplete: () => {
+              if (failureMode === "throws") throw callbackError;
+              return Promise.reject(callbackError);
+            },
+            onError,
+          },
+        );
 
-      await expect(
-        core.append(createUserAppendMessage("Go")),
-      ).resolves.toBeUndefined();
+        await expect(
+          core.append(createUserAppendMessage("Go")),
+        ).resolves.toBeUndefined();
 
-      expect(onError).not.toHaveBeenCalled();
-      expect(core.getMessages()[1]!.content).toEqual([
-        { type: "text", text: "Done" },
-      ]);
-      expect(core.getMessages()[1]!.status).toEqual({
-        type: "complete",
-        reason: "stop",
-      });
-      expect(consoleError).toHaveBeenCalledWith(
-        "[react-a2a] onArtifactComplete callback threw an error",
-        callbackError,
-      );
-    });
+        expect(onError).not.toHaveBeenCalled();
+        expect(core.getMessages()[1]!.content).toEqual([
+          { type: "text", text: "Done" },
+        ]);
+        expect(core.getMessages()[1]!.status).toEqual({
+          type: "complete",
+          reason: "stop",
+        });
+        await vi.waitFor(() => {
+          expect(consoleError).toHaveBeenCalledWith(
+            "[react-a2a] onArtifactComplete callback threw an error",
+            callbackError,
+          );
+        });
+      },
+    );
 
     it("resets artifacts on new run", async () => {
       let runCount = 0;
@@ -936,54 +942,60 @@ describe("A2AThreadRuntimeCore", () => {
       expect(cancelTask).not.toHaveBeenCalled();
     });
 
-    it("isolates throwing onCancel callbacks", async () => {
-      const callbackError = new Error("cancel callback failed");
-      const consoleError = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      let signalStreamStarted!: () => void;
-      const streamStarted = new Promise<void>((resolve) => {
-        signalStreamStarted = resolve;
-      });
-      const core = createCore(
-        {
-          streamMessage: vi.fn().mockImplementation(async function* (
-            _message,
-            _configuration,
-            _metadata,
-            signal: AbortSignal,
-          ) {
-            signalStreamStarted();
-            await new Promise<void>((resolve) => {
-              if (signal.aborted) resolve();
-              else
-                signal.addEventListener("abort", () => resolve(), {
-                  once: true,
-                });
-            });
-          }),
-        },
-        {
-          onCancel: () => {
-            throw callbackError;
+    it.each(["throws", "rejects"] as const)(
+      "isolates onCancel callbacks that %s",
+      async (failureMode) => {
+        const callbackError = new Error("cancel callback failed");
+        const consoleError = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        let signalStreamStarted!: () => void;
+        const streamStarted = new Promise<void>((resolve) => {
+          signalStreamStarted = resolve;
+        });
+        const core = createCore(
+          {
+            streamMessage: vi.fn().mockImplementation(async function* (
+              _message,
+              _configuration,
+              _metadata,
+              signal: AbortSignal,
+            ) {
+              signalStreamStarted();
+              await new Promise<void>((resolve) => {
+                if (signal.aborted) resolve();
+                else
+                  signal.addEventListener("abort", () => resolve(), {
+                    once: true,
+                  });
+              });
+            }),
           },
-        },
-      );
+          {
+            onCancel: () => {
+              if (failureMode === "throws") throw callbackError;
+              return Promise.reject(callbackError);
+            },
+          },
+        );
 
-      const appendPromise = core.append(createUserAppendMessage("Go"));
-      await streamStarted;
-      await expect(core.cancel()).resolves.toBeUndefined();
-      await expect(appendPromise).resolves.toBeUndefined();
+        const appendPromise = core.append(createUserAppendMessage("Go"));
+        await streamStarted;
+        await expect(core.cancel()).resolves.toBeUndefined();
+        await expect(appendPromise).resolves.toBeUndefined();
 
-      expect(core.getMessages()[1]!.status).toEqual({
-        type: "incomplete",
-        reason: "cancelled",
-      });
-      expect(consoleError).toHaveBeenCalledWith(
-        "[react-a2a] onCancel callback threw an error",
-        callbackError,
-      );
-    });
+        expect(core.getMessages()[1]!.status).toEqual({
+          type: "incomplete",
+          reason: "cancelled",
+        });
+        await vi.waitFor(() => {
+          expect(consoleError).toHaveBeenCalledWith(
+            "[react-a2a] onCancel callback threw an error",
+            callbackError,
+          );
+        });
+      },
+    );
   });
 
   // --- Error handling ---
@@ -1021,43 +1033,49 @@ describe("A2AThreadRuntimeCore", () => {
       });
     });
 
-    it("preserves the stream error when onError throws", async () => {
-      const streamError = new Error("Network error");
-      const callbackError = new Error("error callback failed");
-      const consoleError = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const core = createCore(
-        {
-          streamMessage: vi.fn().mockImplementation(() => ({
-            async next() {
-              throw streamError;
-            },
-            [Symbol.asyncIterator]() {
-              return this;
-            },
-          })),
-        },
-        {
-          onError: () => {
-            throw callbackError;
+    it.each(["throws", "rejects"] as const)(
+      "preserves the stream error when onError %s",
+      async (failureMode) => {
+        const streamError = new Error("Network error");
+        const callbackError = new Error("error callback failed");
+        const consoleError = vi
+          .spyOn(console, "error")
+          .mockImplementation(() => {});
+        const core = createCore(
+          {
+            streamMessage: vi.fn().mockImplementation(() => ({
+              async next() {
+                throw streamError;
+              },
+              [Symbol.asyncIterator]() {
+                return this;
+              },
+            })),
           },
-        },
-      );
+          {
+            onError: () => {
+              if (failureMode === "throws") throw callbackError;
+              return Promise.reject(callbackError);
+            },
+          },
+        );
 
-      await expect(core.append(createUserAppendMessage("Go"))).rejects.toBe(
-        streamError,
-      );
+        await expect(core.append(createUserAppendMessage("Go"))).rejects.toBe(
+          streamError,
+        );
 
-      expect(core.getMessages()[1]!.status).toEqual({
-        type: "incomplete",
-        reason: "error",
-      });
-      expect(consoleError).toHaveBeenCalledWith(
-        "[react-a2a] onError callback threw an error",
-        callbackError,
-      );
-    });
+        expect(core.getMessages()[1]!.status).toEqual({
+          type: "incomplete",
+          reason: "error",
+        });
+        await vi.waitFor(() => {
+          expect(consoleError).toHaveBeenCalledWith(
+            "[react-a2a] onError callback threw an error",
+            callbackError,
+          );
+        });
+      },
+    );
 
     it("marks complete when stream ends without terminal status", async () => {
       const core = createCore({

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { A2AThreadRuntimeCore } from "./A2AThreadRuntimeCore";
 import type { A2AClient } from "./A2AClient";
 import type { A2AMessage, A2AStreamEvent, A2ATask } from "./types";
@@ -133,6 +133,10 @@ describe("A2AThreadRuntimeCore", () => {
 
   beforeEach(() => {
     notifyUpdate = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   function createCore(
@@ -700,6 +704,47 @@ describe("A2AThreadRuntimeCore", () => {
       expect(onArtifactComplete.mock.calls[0]![0].artifactId).toBe("a1");
     });
 
+    it("continues streaming when onArtifactComplete throws", async () => {
+      const callbackError = new Error("artifact callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onError = vi.fn();
+      const core = createCore(
+        {
+          streamMessage: vi.fn().mockImplementation(async function* () {
+            yield artifactUpdateEvent("a1", [{ text: "code" }], {
+              lastChunk: true,
+            });
+            yield statusUpdateEvent("completed", "Done");
+          }),
+        },
+        {
+          onArtifactComplete: () => {
+            throw callbackError;
+          },
+          onError,
+        },
+      );
+
+      await expect(
+        core.append(createUserAppendMessage("Go")),
+      ).resolves.toBeUndefined();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(core.getMessages()[1]!.content).toEqual([
+        { type: "text", text: "Done" },
+      ]);
+      expect(core.getMessages()[1]!.status).toEqual({
+        type: "complete",
+        reason: "stop",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[react-a2a] onArtifactComplete callback threw an error",
+        callbackError,
+      );
+    });
+
     it("resets artifacts on new run", async () => {
       let runCount = 0;
 
@@ -890,6 +935,55 @@ describe("A2AThreadRuntimeCore", () => {
 
       expect(cancelTask).not.toHaveBeenCalled();
     });
+
+    it("isolates throwing onCancel callbacks", async () => {
+      const callbackError = new Error("cancel callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      let signalStreamStarted!: () => void;
+      const streamStarted = new Promise<void>((resolve) => {
+        signalStreamStarted = resolve;
+      });
+      const core = createCore(
+        {
+          streamMessage: vi.fn().mockImplementation(async function* (
+            _message,
+            _configuration,
+            _metadata,
+            signal: AbortSignal,
+          ) {
+            signalStreamStarted();
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) resolve();
+              else
+                signal.addEventListener("abort", () => resolve(), {
+                  once: true,
+                });
+            });
+          }),
+        },
+        {
+          onCancel: () => {
+            throw callbackError;
+          },
+        },
+      );
+
+      const appendPromise = core.append(createUserAppendMessage("Go"));
+      await streamStarted;
+      await expect(core.cancel()).resolves.toBeUndefined();
+      await expect(appendPromise).resolves.toBeUndefined();
+
+      expect(core.getMessages()[1]!.status).toEqual({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[react-a2a] onCancel callback threw an error",
+        callbackError,
+      );
+    });
   });
 
   // --- Error handling ---
@@ -925,6 +1019,44 @@ describe("A2AThreadRuntimeCore", () => {
         type: "incomplete",
         reason: "error",
       });
+    });
+
+    it("preserves the stream error when onError throws", async () => {
+      const streamError = new Error("Network error");
+      const callbackError = new Error("error callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const core = createCore(
+        {
+          streamMessage: vi.fn().mockImplementation(() => ({
+            async next() {
+              throw streamError;
+            },
+            [Symbol.asyncIterator]() {
+              return this;
+            },
+          })),
+        },
+        {
+          onError: () => {
+            throw callbackError;
+          },
+        },
+      );
+
+      await expect(core.append(createUserAppendMessage("Go"))).rejects.toBe(
+        streamError,
+      );
+
+      expect(core.getMessages()[1]!.status).toEqual({
+        type: "incomplete",
+        reason: "error",
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[react-a2a] onError callback threw an error",
+        callbackError,
+      );
     });
 
     it("marks complete when stream ends without terminal status", async () => {

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -46,6 +46,28 @@ const FALLBACK_USER_STATUS = {
   reason: "unknown",
 } as const;
 
+type A2ARuntimeCallbackName = "onError" | "onCancel" | "onArtifactComplete";
+
+const reportCallbackError = (name: A2ARuntimeCallbackName, error: unknown) => {
+  console.error(`[react-a2a] ${name} callback threw an error`, error);
+};
+
+const invokeRuntimeCallback = <TArgs extends unknown[]>(
+  name: A2ARuntimeCallbackName,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    void Promise.resolve(callback(...args)).catch((error) => {
+      reportCallbackError(name, error);
+    });
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 export class A2AThreadRuntimeCore {
   private client: A2AClient;
   private contextId: string | undefined;
@@ -216,7 +238,9 @@ export class A2AThreadRuntimeCore {
         }
       })
       .catch((error) => {
-        this.onError?.(
+        invokeRuntimeCallback(
+          "onError",
+          this.onError,
           error instanceof Error ? error : new Error(String(error)),
         );
       })
@@ -444,7 +468,7 @@ export class A2AThreadRuntimeCore {
           reason: "cancelled",
         });
         this.finishRun(abortController);
-        this.onCancel?.();
+        invokeRuntimeCallback("onCancel", this.onCancel);
       },
       { once: true },
     );
@@ -468,7 +492,7 @@ export class A2AThreadRuntimeCore {
           type: "incomplete",
           reason: "error",
         });
-        this.onError?.(err);
+        invokeRuntimeCallback("onError", this.onError, err);
         this.pendingError = this.pendingError ?? err;
       }
     } finally {
@@ -615,7 +639,11 @@ export class A2AThreadRuntimeCore {
     }
 
     if (lastChunk) {
-      this.onArtifactComplete?.(updated);
+      invokeRuntimeCallback(
+        "onArtifactComplete",
+        this.onArtifactComplete,
+        updated,
+      );
     }
 
     this.notifyUpdate();

--- a/packages/react-a2a/src/A2AThreadRuntimeCore.ts
+++ b/packages/react-a2a/src/A2AThreadRuntimeCore.ts
@@ -60,9 +60,17 @@ const invokeRuntimeCallback = <TArgs extends unknown[]>(
   if (!callback) return;
 
   try {
-    void Promise.resolve(callback(...args)).catch((error) => {
-      reportCallbackError(name, error);
-    });
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
   } catch (error) {
     reportCallbackError(name, error);
   }


### PR DESCRIPTION
## Summary

- isolate `onArtifactComplete`, `onError`, and `onCancel` failures from A2A runtime processing
- continue processing healthy stream events after an artifact callback fails
- preserve the original transport error when the error callback itself fails
- report both synchronous throws and rejected callback promises without producing unhandled rejections

## Why

Runtime callbacks are commonly used for telemetry or application side effects. A failure in that consumer code should not turn a successful A2A response into an incomplete message, stop later stream events, replace the original network error, or escape from cancellation handling.

On `31a427a6b`, focused regressions reproduced all three cases:

- a throwing `onArtifactComplete` rejected `append()`, marked the response incomplete, and skipped the later completed status event
- a throwing `onCancel` escaped as an uncaught exception
- a throwing `onError` replaced the original stream error

## Testing

- `pnpm --filter @assistant-ui/react-a2a exec vitest run src/A2AThreadRuntimeCore.test.ts` (48 tests)
- `pnpm --filter @assistant-ui/react-a2a test` (204 tests)
- `pnpm exec turbo build --filter=@assistant-ui/react-a2a... --concurrency=4`
- `pnpm lint`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.P9XD3ja25g1ipXA9YcYeadaFsSUK8AelftWM__O-ifaxQVpg3S0eMlJWEPg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->