### PR TITLE
docs(examples): make with-eve runnable with an OpenAI API key

### DIFF
--- a/examples/with-eve/.env.example
+++ b/examples/with-eve/.env.example
@@ -1,0 +1,12 @@
+# The agent in agent/agent.ts calls OpenAI directly via `openai("gpt-5.5")`
+# from `@ai-sdk/openai`, so it reads this key.
+OPENAI_API_KEY=
+
+# Point `model` at a different provider and set that provider's key instead.
+# For example `anthropic("claude-...")` from `@ai-sdk/anthropic` reads this one.
+# ANTHROPIC_API_KEY=
+
+# Only needed if `model` is set to a gateway model id string such as
+# "openai/gpt-5.5", which routes through the Vercel AI Gateway rather than
+# calling a provider directly.
+# AI_GATEWAY_API_KEY=

--- a/examples/with-eve/README.md
+++ b/examples/with-eve/README.md
@@ -2,8 +2,18 @@
 
 This example mounts an Eve agent into a Next.js app with `withEve()` from `eve/next`, then adapts Eve's React hook into assistant-ui with `useEveAgentRuntime()`.
 
+## Setup
+
+Copy `.env.example` to `.env.local` and set `OPENAI_API_KEY`:
+
+```bash
+cp .env.example .env.local
+```
+
 ```bash
 pnpm --filter with-eve dev
 ```
+
+The key has to match whichever provider `model` names in `agent/agent.ts`: this example uses `openai("gpt-5.5")` from `@ai-sdk/openai`, so it reads `OPENAI_API_KEY`. Point `model` at another provider and set that provider's key instead.
 
 The Eve channel is served on the same origin as the Next app, so the browser UI does not need a separate agent URL.

--- a/examples/with-eve/agent/agent.ts
+++ b/examples/with-eve/agent/agent.ts
@@ -1,5 +1,6 @@
+import { openai } from "@ai-sdk/openai";
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-4.6",
+  model: openai("gpt-5.5"),
 });

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^4.0.20",
     "@assistant-ui/eve": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1516,6 +1516,9 @@ importers:
 
   examples/with-eve:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.20
+        version: 4.0.20(zod@4.4.3)
       '@assistant-ui/eve':
         specifier: workspace:*
         version: link:../../packages/eve
@@ -5649,6 +5652,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}


### PR DESCRIPTION
## What

Makes `examples/with-eve` runnable out of the box with an OpenAI API key:

- `agent/agent.ts` now uses `openai("gpt-5.5")` from `@ai-sdk/openai` instead of the `"anthropic/claude-sonnet-4.6"` model-id string.
- Adds `examples/with-eve/.env.example` documenting the accepted keys.
- Adds a short Setup section to the README.

## Why

The example shipped with no env documentation and a bare model-id string. In eve, a bare string routes through the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) and needs `AI_GATEWAY_API_KEY` or a Vercel OIDC token — not a provider key. So a reader who cloned this, set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`), and ran `pnpm --filter with-eve dev` got a failed turn with no hint about what was missing.

## How

Per eve's own `agent-config` docs, calling a provider directly means passing a provider-authored `LanguageModel` rather than a string, and installing that provider's AI SDK package. So `@ai-sdk/openai` moves into the example's dependencies (`^4.0.20`, matching the ~10 other examples in the repo that already depend on it) and the agent uses `openai("gpt-5.5")`, which authenticates with `OPENAI_API_KEY`.

`.env.example` keeps the alternatives visible with commented `ANTHROPIC_API_KEY` and `AI_GATEWAY_API_KEY` entries, so the mechanism — the key must match whichever provider `model` names — is legible rather than implied.

## Verification

Ran the example locally with **only** `OPENAI_API_KEY` in the process environment (`ANTHROPIC_API_KEY` and `AI_GATEWAY_API_KEY` explicitly unset).

Before, with the model-id string form, the turn failed in the UI with:

> AI Gateway received no credentials.

After, the same prompt through the browser UI produced a real model response:

- prompt: `In one short sentence, what is 17 times 23? Then say EVE_OPENAI_OK.`
- response: `17 times 23 is 391. EVE_OPENAI_OK`

Boot log:

```
▲ Next.js 16.3.0 (Turbopack)
- Local:         http://localhost:3111
✓ Ready in 288ms
✓ Running next.config.ts took 254ms
[eve:dev] server listening at http://127.0.0.1:52817/
```

`pnpm --filter with-eve build` compiles and typechecks clean; `pnpm lint` reports no new warnings.

No changeset: `with-eve` is `private: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BldHik9jH0-XUhdwiHAJnS1i1YDGWQxEhN0QxeyalzBzVnTsU4Olr747ctM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->