### PR TITLE
docs(examples): make with-eve runnable with an OpenAI API key

### DIFF
--- a/examples/with-eve/.env.example
+++ b/examples/with-eve/.env.example
@@ -1,0 +1,12 @@
+# The agent in agent/agent.ts calls OpenAI directly via `openai("gpt-5.5")`
+# from `@ai-sdk/openai`, so it reads this key.
+OPENAI_API_KEY=
+
+# Point `model` at a different provider and set that provider's key instead.
+# For example `anthropic("claude-...")` from `@ai-sdk/anthropic` reads this one.
+# ANTHROPIC_API_KEY=
+
+# Only needed if `model` is set to a gateway model id string such as
+# "openai/gpt-5.5", which routes through the Vercel AI Gateway rather than
+# calling a provider directly.
+# AI_GATEWAY_API_KEY=

--- a/examples/with-eve/README.md
+++ b/examples/with-eve/README.md
@@ -2,8 +2,18 @@
 
 This example mounts an Eve agent into a Next.js app with `withEve()` from `eve/next`, then adapts Eve's React hook into assistant-ui with `useEveAgentRuntime()`.
 
+## Setup
+
+Copy `.env.example` to `.env.local` and set `OPENAI_API_KEY`:
+
+```bash
+cp .env.example .env.local
+```
+
 ```bash
 pnpm --filter with-eve dev
 ```
+
+The key has to match whichever provider `model` names in `agent/agent.ts`: this example uses `openai("gpt-5.5")` from `@ai-sdk/openai`, so it reads `OPENAI_API_KEY`. Point `model` at another provider and set that provider's key instead.
 
 The Eve channel is served on the same origin as the Next app, so the browser UI does not need a separate agent URL.

--- a/examples/with-eve/agent/agent.ts
+++ b/examples/with-eve/agent/agent.ts
@@ -1,5 +1,6 @@
+import { openai } from "@ai-sdk/openai";
 import { defineAgent } from "eve";
 
 export default defineAgent({
-  model: "anthropic/claude-sonnet-4.6",
+  model: openai("gpt-5.5"),
 });

--- a/examples/with-eve/package.json
+++ b/examples/with-eve/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^4.0.20",
     "@assistant-ui/eve": "workspace:*",
     "@assistant-ui/react": "workspace:*",
     "@assistant-ui/react-markdown": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1516,6 +1516,9 @@ importers:
 
   examples/with-eve:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^4.0.20
+        version: 4.0.20(zod@4.4.3)
       '@assistant-ui/eve':
         specifier: workspace:*
         version: link:../../packages/eve
@@ -5649,6 +5652,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}


### PR DESCRIPTION
## What

`examples/with-eve` did not run out of the box. Its agent pointed at the bare model-id string `"anthropic/claude-sonnet-4.6"`, and the example shipped no env documentation at all.

This switches the agent to eve's direct-provider form — `openai("gpt-5.5")` from `@ai-sdk/openai` — and documents the required key in a new `.env.example` plus a README setup section.

## Why

In eve, a bare model-id string is a Vercel AI Gateway route: it authenticates with `AI_GATEWAY_API_KEY` or a Vercel OIDC token, not with a provider key. So a user who cloned the repo, set `ANTHROPIC_API_KEY` (the obvious guess given the model name), and ran `pnpm --filter with-eve dev` got an auth failure with nothing in the example to explain it.

Passing a provider model instance instead makes the auth path explicit and conventional: the agent calls OpenAI directly and reads `OPENAI_API_KEY`, which is the same key every other example in `examples/` already asks for. The new `.env.example` also documents the two alternatives (another provider's key, or `AI_GATEWAY_API_KEY` if you deliberately switch `model` back to a gateway id string), so the relationship between `model` and the key is written down rather than inferred.

## How

- `agent/agent.ts`: `model: openai("gpt-5.5")` from `@ai-sdk/openai`.
- `package.json`: adds `@ai-sdk/openai` at `^4.0.20`, matching the pin every other example and template in the repo already uses.
- `.env.example` (new): `OPENAI_API_KEY`, with commented alternatives.
- `README.md`: a Setup section covering `cp .env.example .env.local`, and a note that the key must match whichever provider `model` names.

No changeset — `with-eve` is a private package.

## Verification

Ran `next dev` for the example against a real `OPENAI_API_KEY`:

- The app boots and the eve channel comes up on the same origin: `GET /eve/v1/health` returns `{"ok":true,"status":"ready",...}`, and `GET /eve/v1/info` reports the agent resolving to `openai/gpt-5.5` with `routing: {"kind":"external","provider":"openai"}` — i.e. calling OpenAI directly, not the gateway, which is the point of the change.
- One chat turn round-trips end to end. `POST /eve/v1/session` opens a session, and its NDJSON stream carries the full sequence: `session.started` → `turn.started` → `message.received` → streamed `message.appended` deltas → `message.completed` with `finishReason: "stop"` and real token usage → `turn.completed`. The model returned the requested text.
- The UI route renders: `GET /` returns 200 with the example's suggestion content in the HTML.
- `tsc --noEmit` passes for the example.

Note for anyone reproducing: eve 0.27.6 requires Node >= 24, so the dev server needs a Node 24+ runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.sbh6mIRWxiU2Q8ZSQmqVBjFErzq9MWjfHFLMZnmxhKTQsv3RvSIf99Kq6jg?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->