### PR TITLE
fix(ui): keep attachment thumb image square

### DIFF
--- a/packages/ui/src/components/assistant-ui/attachment.radix.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.radix.tsx
@@ -125,7 +125,7 @@ const AttachmentThumb: FC = () => {
       <AvatarImage
         src={src}
         alt="Attachment preview"
-        className="aui-attachment-tile-image object-cover"
+        className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
         <FileText className="aui-attachment-tile-fallback-icon text-muted-foreground/80 size-6 stroke-[1.5]" />

--- a/packages/ui/src/components/assistant-ui/attachment.tsx
+++ b/packages/ui/src/components/assistant-ui/attachment.tsx
@@ -126,7 +126,7 @@ const AttachmentThumb: FC = () => {
       <AvatarImage
         src={src}
         alt="Attachment preview"
-        className="aui-attachment-tile-image object-cover"
+        className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
         <FileText className="aui-attachment-tile-fallback-icon text-muted-foreground/80 size-6 stroke-[1.5]" />

--- a/templates/minimal/components/assistant-ui/attachment.tsx
+++ b/templates/minimal/components/assistant-ui/attachment.tsx
@@ -126,7 +126,7 @@ const AttachmentThumb: FC = () => {
       <AvatarImage
         src={src}
         alt="Attachment preview"
-        className="aui-attachment-tile-image object-cover"
+        className="aui-attachment-tile-image rounded-none object-cover"
       />
       <AvatarFallback>
         <FileText className="aui-attachment-tile-fallback-icon text-muted-foreground/80 size-6 stroke-[1.5]" />


### PR DESCRIPTION
## Summary

Image attachment thumbs rendered as circles inside the square attachment tile in the Base UI flavor. The thumb image now fills the tile with square corners in the two flavors.

The Base UI avatar primitive sets `rounded-full` on its image element. `AttachmentThumb` overrode the radius only on the Avatar root. The root clip cannot remove the radius of the child image. `AttachmentThumb` now passes `rounded-none` to `AvatarImage`, and tailwind-merge removes `rounded-full` because the two classes are in the same group. The Radix avatar does not round its image, thus the class has no effect there and only keeps the image line identical across the two flavors. `pnpm sync-templates --write` copied the change to the minimal template.

## Reproduction

Commit `5552ee016ac5b293e3c9b5a6e6af0f31a55000e8` (the head of assistant-ui/assistant-ui#5647) contains a live docs composer example that seeds an image attachment against the pre-fix attachment source. I ran these exact steps:

```bash
git clone https://github.com/assistant-ui/assistant-ui
cd assistant-ui
git fetch origin refs/pull/5647/head
git checkout 5552ee016ac5b293e3c9b5a6e6af0f31a55000e8
pnpm install
pnpm --filter "@assistant-ui/docs^..." --filter @assistant-ui/next build
cd apps/docs
pnpm generate:type-docs
pnpm generate:source-snapshot
pnpm dev --port 3006
```

Open `http://localhost:3006/docs/ui/attachment` and go to the `Composer` example. The seeded image tile shows a circular thumb. The computed `border-radius` of the tile `<img>` is `3.35544e+07px`, because `rounded-full` from `AvatarImage` stays on the element.

Then apply the one-line change from this PR to `packages/ui/src/components/assistant-ui/attachment.tsx:129`. After hot reload, the same `<img>` has a computed `border-radius` of `0px` and fills the tile.

## Validation

- I measured the computed `border-radius` of the seeded composer thumb in a browser: `3.35544e+07px` before the change, `0px` after the change.
- The class list of the rendered `<img>` shows the mechanism: `rounded-full` is gone when the caller passes `rounded-none` in the same group.
- The Radix flavor shows no change, because its avatar image carries no radius class.
- The minimal template copy is byte-equal with the canonical source. `@assistant-ui/ui` and the minimal template are private packages, thus no changeset is necessary.

## Evidence

| Claim | Evidence |
| --- | --- |
| The Base UI avatar sets `rounded-full` on the image element | `packages/ui/src/components/ui/base/avatar.tsx:33` |
| The pre-fix thumb overrode only the Avatar root | `packages/ui/src/components/assistant-ui/attachment.tsx:125` (root), pre-fix `:129` (image, no radius class) |
| The fix adds `rounded-none` on the image in the two flavors | `packages/ui/src/components/assistant-ui/attachment.tsx:129`, `packages/ui/src/components/assistant-ui/attachment.radix.tsx:128` |
| The template copy carries the same change | `templates/minimal/components/assistant-ui/attachment.tsx:129` |
| The Radix avatar image carries no radius class | `packages/ui/src/components/ui/radix/avatar.tsx:35` |
| Bug measured as a circle before the change | Computed `border-radius: 3.35544e+07px` at commit `5552ee0`, browser measurement |
| Fix measured as square after the change | Computed `border-radius: 0px` with only this PR's image class applied, browser measurement |