### PR TITLE
fix(docs): show registry install path in PreviewCode imports

### DIFF
--- a/apps/docs/components/docs/preview-code.server.tsx
+++ b/apps/docs/components/docs/preview-code.server.tsx
@@ -195,9 +195,7 @@ function cleanupImports(imports: string[]): string[] {
   return imports
     .filter((imp) => !imp.includes("SampleFrame"))
     .map((imp) =>
-      imp
-        .replace(/@\/components\/assistant-ui\//g, "@/components/ui/")
-        .replace(/(@\/components\/[\w-]+\/[\w.-]+?)\.radix(["'])/g, "$1$2"),
+      imp.replace(/(@\/components\/[\w-]+\/[\w.-]+?)\.radix(["'])/g, "$1$2"),
     );
 }
 


### PR DESCRIPTION
The code tab of every `PreviewCode` example showed imports from `@/components/ui/`, but the registry installs the components to `components/assistant-ui/` (see the `path` fields in `apps/registry/dist/*.json`). A reader who copied the snippet got an import that does not resolve in a fresh install. `cleanupImports` no longer rewrites `@/components/assistant-ui/` to `@/components/ui/`, so the displayed imports match the installed path and the usage snippets on the same pages. The rewrite that removes the `.radix` suffix stays unchanged.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.g17l68ieQMuIh8L6OFnusZ4yFf-AoKDw_E1Pf58ToiRVs96dlmx52Tkg5DM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->