### PR TITLE
fix(docs): remove double border around PreviewCode previews

### DIFF
--- a/apps/docs/styles/fumadocs.css
+++ b/apps/docs/styles/fumadocs.css
@@ -503,11 +503,11 @@ figure.shiki {
 }
 
 /* PreviewCode component - remove nested SampleFrame styling */
-.preview-code-preview > .not-prose {
+.preview-code-preview > div > .not-prose {
   margin: 0 !important;
 }
 
-.preview-code-preview > .not-prose > div {
+.preview-code-preview > div > .not-prose > div {
   border: none !important;
   border-radius: 0 !important;
   height: auto !important;


### PR DESCRIPTION
## Summary

Every `PreviewCode` preview showed two nested borders, one from the preview shell and one from the `SampleFrame` inside it. Each preview now shows one border.

The stylesheet already contained rules that remove the nested `SampleFrame` border, but the selectors expected `SampleFrame` as a direct child. `PreviewCodeClient` renders a wrapper `div` between the two, thus the rules never matched. The corrected selectors in `fumadocs.css` include the wrapper `div`. The correction applies to the accordion, badge, select, and tabs pages as well.

## Reproduction

Commit `26365f129f5411d8e6a106911f1dbf4034926683` is the `main` commit immediately before this merge. Run these steps:

```bash
git clone https://github.com/assistant-ui/assistant-ui
cd assistant-ui
git checkout 26365f129f5411d8e6a106911f1dbf4034926683
pnpm install
pnpm --filter "@assistant-ui/docs^..." --filter @assistant-ui/next build
cd apps/docs
pnpm generate:type-docs
pnpm generate:source-snapshot
pnpm dev --port 3006
```

Open `http://localhost:3006/docs/ui/badge`. The preview shows two nested borders. The `SampleFrame` inner `div` has a computed `border-top-width` of `1px` inside a shell that also has a `1px` border, and the frame keeps a `24px` margin.

Then apply the two selector changes from this PR to `apps/docs/styles/fumadocs.css:506,510` and reload. The inner `div` has a computed `border-top-width` of `0px`, the frame margin is `0px`, and only the shell border remains.

## Validation

- I measured the computed styles in a browser on the badge page: inner border `1px` and frame margin `24px` before the change, inner border `0px` and frame margin `0px` after the change. The shell border stays at `1px` in the two states.
- The measured checkout carries `fumadocs.css`, `preview-code.tsx`, and `sample-frame.tsx` byte-identical to the pinned commit.
- `@assistant-ui/docs` is a private package, thus no changeset is necessary.

## Evidence

| Claim | Evidence |
| --- | --- |
| `PreviewCodeClient` renders a wrapper `div` between the shell and `SampleFrame` | Browser measurement: `.not-prose` is not a direct child of `.preview-code-preview` |
| The old direct-child selectors never matched | `apps/docs/styles/fumadocs.css:506,510` (pre-fix), inner border stayed `1px` |
| The corrected selectors match and remove the nested border | This PR's diff at `fumadocs.css:506,510`, measured inner border `0px` after the change |
| The double border was visible before the change | Computed `border-top-width: 1px` on the frame inner `div` plus `1px` on the shell, browser measurement at the pinned commit state |
| One border remains after the change | Computed `border-top-width: 0px` on the frame inner `div`, shell border `1px`, browser measurement |