### PR TITLE
docs(ui): add composer attachments example

### DIFF
--- a/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
@@ -18,7 +18,7 @@ import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
 export function ComposerWithAttachments() {
   return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3">
       <ComposerAttachments />
       <ComposerPrimitive.Input
         aria-label="Message input"
@@ -38,7 +38,7 @@ const imageSrc = `data:image/svg+xml,${encodeURIComponent(
 
 export function AttachmentComposerSample() {
   return (
-    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6 [--composer-padding:8px] [--composer-radius:1.5rem]">
       <SampleRuntimeProvider
         messages={[]}
         adapters={{

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
 import {
   ComposerPrimitive,
   CompositeAttachmentAdapter,
   SimpleImageAttachmentAdapter,
   SimpleTextAttachmentAdapter,
-  useAui,
 } from "@assistant-ui/react";
 import {
   ComposerAddAttachment,
@@ -15,57 +13,47 @@ import {
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-const ADAPTER = new CompositeAttachmentAdapter([
-  new SimpleImageAttachmentAdapter(),
-  new SimpleTextAttachmentAdapter(),
-]);
-
-const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
-)}`;
-
 export function AttachmentComposerSample() {
+  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+  )}`;
+
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
-      <SampleRuntimeProvider messages={[]} adapters={{ attachments: ADAPTER }}>
-        <ComposerWithAttachments />
+      <SampleRuntimeProvider
+        messages={[]}
+        adapters={{
+          attachments: new CompositeAttachmentAdapter([
+            new SimpleImageAttachmentAdapter(),
+            new SimpleTextAttachmentAdapter(),
+          ]),
+        }}
+        initialAttachments={[
+          {
+            name: "meeting-notes.txt",
+            contentType: "text/plain",
+            content: [{ type: "text", text: "Meeting notes" }],
+          },
+          {
+            name: "sunrise.svg",
+            type: "image",
+            contentType: "image/svg+xml",
+            content: [{ type: "image", image: imageSrc }],
+          },
+        ]}
+      >
+        <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+          <ComposerAttachments />
+          <ComposerPrimitive.Input
+            aria-label="Message input"
+            placeholder="Send a message..."
+            className="min-h-10 resize-none bg-transparent px-2 outline-none"
+          />
+          <div className="flex items-center">
+            <ComposerAddAttachment />
+          </div>
+        </ComposerPrimitive.Root>
       </SampleRuntimeProvider>
     </SampleFrame>
   );
-}
-
-function ComposerWithAttachments() {
-  useDemoAttachments();
-
-  return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
-      <ComposerAttachments />
-      <ComposerPrimitive.Input
-        aria-label="Message input"
-        placeholder="Send a message..."
-        className="min-h-10 resize-none bg-transparent px-2 outline-none"
-      />
-      <div className="flex items-center">
-        <ComposerAddAttachment />
-      </div>
-    </ComposerPrimitive.Root>
-  );
-}
-
-function useDemoAttachments() {
-  const aui = useAui();
-  useEffect(() => {
-    void aui.composer.addAttachment({
-      name: "meeting-notes.txt",
-      contentType: "text/plain",
-      content: [{ type: "text", text: "Meeting notes" }],
-    });
-    void aui.composer.addAttachment({
-      name: "sunrise.svg",
-      type: "image",
-      contentType: "image/svg+xml",
-      content: [{ type: "image", image: IMAGE_SRC }],
-    });
-    return () => void aui.composer.clearAttachments();
-  }, [aui]);
 }

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { ComposerPrimitive } from "@assistant-ui/react";
+// Separate statement: the Code tab keeps an import whenever any one of its
+// names is used, so grouping these with ComposerPrimitive would show adapter
+// wiring the extracted snippet never calls.
 import {
-  ComposerPrimitive,
   CompositeAttachmentAdapter,
   SimpleImageAttachmentAdapter,
   SimpleTextAttachmentAdapter,
@@ -13,11 +16,27 @@ import {
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-export function AttachmentComposerSample() {
-  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
-  )}`;
+export function ComposerWithAttachments() {
+  return (
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <ComposerAttachments />
+      <ComposerPrimitive.Input
+        aria-label="Message input"
+        placeholder="Send a message..."
+        className="min-h-10 resize-none bg-transparent px-2 outline-none"
+      />
+      <div className="flex items-center">
+        <ComposerAddAttachment />
+      </div>
+    </ComposerPrimitive.Root>
+  );
+}
 
+const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+)}`;
+
+export function AttachmentComposerSample() {
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
       <SampleRuntimeProvider
@@ -42,17 +61,7 @@ export function AttachmentComposerSample() {
           },
         ]}
       >
-        <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
-          <ComposerAttachments />
-          <ComposerPrimitive.Input
-            aria-label="Message input"
-            placeholder="Send a message..."
-            className="min-h-10 resize-none bg-transparent px-2 outline-none"
-          />
-          <div className="flex items-center">
-            <ComposerAddAttachment />
-          </div>
-        </ComposerPrimitive.Root>
+        <ComposerWithAttachments />
       </SampleRuntimeProvider>
     </SampleFrame>
   );

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
@@ -18,7 +18,7 @@ import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
 export function ComposerWithAttachments() {
   return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3">
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-(--composer-radius) border p-(--composer-padding)">
       <ComposerAttachments />
       <ComposerPrimitive.Input
         aria-label="Message input"

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.radix.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  ComposerPrimitive,
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+  useAui,
+} from "@assistant-ui/react";
+import {
+  ComposerAddAttachment,
+  ComposerAttachments,
+} from "@/components/assistant-ui/attachment.radix";
+import { SampleFrame } from "../sample-frame";
+import { SampleRuntimeProvider } from "../sample-runtime-provider";
+
+const ADAPTER = new CompositeAttachmentAdapter([
+  new SimpleImageAttachmentAdapter(),
+  new SimpleTextAttachmentAdapter(),
+]);
+
+const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
+)}`;
+
+export function AttachmentComposerSample() {
+  return (
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+      <SampleRuntimeProvider messages={[]} adapters={{ attachments: ADAPTER }}>
+        <ComposerWithAttachments />
+      </SampleRuntimeProvider>
+    </SampleFrame>
+  );
+}
+
+function ComposerWithAttachments() {
+  useDemoAttachments();
+
+  return (
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <ComposerAttachments />
+      <ComposerPrimitive.Input
+        aria-label="Message input"
+        placeholder="Send a message..."
+        className="min-h-10 resize-none bg-transparent px-2 outline-none"
+      />
+      <div className="flex items-center">
+        <ComposerAddAttachment />
+      </div>
+    </ComposerPrimitive.Root>
+  );
+}
+
+function useDemoAttachments() {
+  const aui = useAui();
+  useEffect(() => {
+    void aui.composer.addAttachment({
+      name: "meeting-notes.txt",
+      contentType: "text/plain",
+      content: [{ type: "text", text: "Meeting notes" }],
+    });
+    void aui.composer.addAttachment({
+      name: "sunrise.svg",
+      type: "image",
+      contentType: "image/svg+xml",
+      content: [{ type: "image", image: IMAGE_SRC }],
+    });
+    return () => void aui.composer.clearAttachments();
+  }, [aui]);
+}

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect } from "react";
+import {
+  ComposerPrimitive,
+  CompositeAttachmentAdapter,
+  SimpleImageAttachmentAdapter,
+  SimpleTextAttachmentAdapter,
+  useAui,
+} from "@assistant-ui/react";
+import {
+  ComposerAddAttachment,
+  ComposerAttachments,
+} from "@/components/assistant-ui/attachment";
+import { SampleFrame } from "../sample-frame";
+import { SampleRuntimeProvider } from "../sample-runtime-provider";
+
+const ADAPTER = new CompositeAttachmentAdapter([
+  new SimpleImageAttachmentAdapter(),
+  new SimpleTextAttachmentAdapter(),
+]);
+
+const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
+)}`;
+
+export function AttachmentComposerSample() {
+  return (
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+      <SampleRuntimeProvider messages={[]} adapters={{ attachments: ADAPTER }}>
+        <ComposerWithAttachments />
+      </SampleRuntimeProvider>
+    </SampleFrame>
+  );
+}
+
+function ComposerWithAttachments() {
+  useDemoAttachments();
+
+  return (
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <ComposerAttachments />
+      <ComposerPrimitive.Input
+        aria-label="Message input"
+        placeholder="Send a message..."
+        className="min-h-10 resize-none bg-transparent px-2 outline-none"
+      />
+      <div className="flex items-center">
+        <ComposerAddAttachment />
+      </div>
+    </ComposerPrimitive.Root>
+  );
+}
+
+function useDemoAttachments() {
+  const aui = useAui();
+  useEffect(() => {
+    void aui.composer.addAttachment({
+      name: "meeting-notes.txt",
+      contentType: "text/plain",
+      content: [{ type: "text", text: "Meeting notes" }],
+    });
+    void aui.composer.addAttachment({
+      name: "sunrise.svg",
+      type: "image",
+      contentType: "image/svg+xml",
+      content: [{ type: "image", image: IMAGE_SRC }],
+    });
+    return () => void aui.composer.clearAttachments();
+  }, [aui]);
+}

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
@@ -18,7 +18,7 @@ import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
 export function ComposerWithAttachments() {
   return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3">
       <ComposerAttachments />
       <ComposerPrimitive.Input
         aria-label="Message input"
@@ -38,7 +38,7 @@ const imageSrc = `data:image/svg+xml,${encodeURIComponent(
 
 export function AttachmentComposerSample() {
   return (
-    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6 [--composer-padding:8px] [--composer-radius:1.5rem]">
       <SampleRuntimeProvider
         messages={[]}
         adapters={{

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
 import {
   ComposerPrimitive,
   CompositeAttachmentAdapter,
   SimpleImageAttachmentAdapter,
   SimpleTextAttachmentAdapter,
-  useAui,
 } from "@assistant-ui/react";
 import {
   ComposerAddAttachment,
@@ -15,57 +13,47 @@ import {
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-const ADAPTER = new CompositeAttachmentAdapter([
-  new SimpleImageAttachmentAdapter(),
-  new SimpleTextAttachmentAdapter(),
-]);
-
-const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
-)}`;
-
 export function AttachmentComposerSample() {
+  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+  )}`;
+
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
-      <SampleRuntimeProvider messages={[]} adapters={{ attachments: ADAPTER }}>
-        <ComposerWithAttachments />
+      <SampleRuntimeProvider
+        messages={[]}
+        adapters={{
+          attachments: new CompositeAttachmentAdapter([
+            new SimpleImageAttachmentAdapter(),
+            new SimpleTextAttachmentAdapter(),
+          ]),
+        }}
+        initialAttachments={[
+          {
+            name: "meeting-notes.txt",
+            contentType: "text/plain",
+            content: [{ type: "text", text: "Meeting notes" }],
+          },
+          {
+            name: "sunrise.svg",
+            type: "image",
+            contentType: "image/svg+xml",
+            content: [{ type: "image", image: imageSrc }],
+          },
+        ]}
+      >
+        <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+          <ComposerAttachments />
+          <ComposerPrimitive.Input
+            aria-label="Message input"
+            placeholder="Send a message..."
+            className="min-h-10 resize-none bg-transparent px-2 outline-none"
+          />
+          <div className="flex items-center">
+            <ComposerAddAttachment />
+          </div>
+        </ComposerPrimitive.Root>
       </SampleRuntimeProvider>
     </SampleFrame>
   );
-}
-
-function ComposerWithAttachments() {
-  useDemoAttachments();
-
-  return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
-      <ComposerAttachments />
-      <ComposerPrimitive.Input
-        aria-label="Message input"
-        placeholder="Send a message..."
-        className="min-h-10 resize-none bg-transparent px-2 outline-none"
-      />
-      <div className="flex items-center">
-        <ComposerAddAttachment />
-      </div>
-    </ComposerPrimitive.Root>
-  );
-}
-
-function useDemoAttachments() {
-  const aui = useAui();
-  useEffect(() => {
-    void aui.composer.addAttachment({
-      name: "meeting-notes.txt",
-      contentType: "text/plain",
-      content: [{ type: "text", text: "Meeting notes" }],
-    });
-    void aui.composer.addAttachment({
-      name: "sunrise.svg",
-      type: "image",
-      contentType: "image/svg+xml",
-      content: [{ type: "image", image: IMAGE_SRC }],
-    });
-    return () => void aui.composer.clearAttachments();
-  }, [aui]);
 }

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { ComposerPrimitive } from "@assistant-ui/react";
+// Separate statement: the Code tab keeps an import whenever any one of its
+// names is used, so grouping these with ComposerPrimitive would show adapter
+// wiring the extracted snippet never calls.
 import {
-  ComposerPrimitive,
   CompositeAttachmentAdapter,
   SimpleImageAttachmentAdapter,
   SimpleTextAttachmentAdapter,
@@ -13,11 +16,27 @@ import {
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-export function AttachmentComposerSample() {
-  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
-  )}`;
+export function ComposerWithAttachments() {
+  return (
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <ComposerAttachments />
+      <ComposerPrimitive.Input
+        aria-label="Message input"
+        placeholder="Send a message..."
+        className="min-h-10 resize-none bg-transparent px-2 outline-none"
+      />
+      <div className="flex items-center">
+        <ComposerAddAttachment />
+      </div>
+    </ComposerPrimitive.Root>
+  );
+}
 
+const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+)}`;
+
+export function AttachmentComposerSample() {
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
       <SampleRuntimeProvider
@@ -42,17 +61,7 @@ export function AttachmentComposerSample() {
           },
         ]}
       >
-        <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3 [--composer-padding:8px] [--composer-radius:1.5rem]">
-          <ComposerAttachments />
-          <ComposerPrimitive.Input
-            aria-label="Message input"
-            placeholder="Send a message..."
-            className="min-h-10 resize-none bg-transparent px-2 outline-none"
-          />
-          <div className="flex items-center">
-            <ComposerAddAttachment />
-          </div>
-        </ComposerPrimitive.Root>
+        <ComposerWithAttachments />
       </SampleRuntimeProvider>
     </SampleFrame>
   );

--- a/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
+++ b/apps/docs/components/docs/samples/attachment/composer-attachments.tsx
@@ -18,7 +18,7 @@ import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
 export function ComposerWithAttachments() {
   return (
-    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-3xl border p-3">
+    <ComposerPrimitive.Root className="border-border bg-muted flex w-full max-w-lg flex-col gap-2 rounded-(--composer-radius) border p-(--composer-padding)">
       <ComposerAttachments />
       <ComposerPrimitive.Input
         aria-label="Message input"

--- a/apps/docs/components/docs/samples/sample-runtime-provider.tsx
+++ b/apps/docs/components/docs/samples/sample-runtime-provider.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import {
   AssistantRuntimeProvider,
+  useAui,
   useLocalRuntime,
   type ChatModelAdapter,
+  type CreateAttachment,
   type LocalRuntimeOptions,
   type ThreadMessageLike,
 } from "@assistant-ui/react";
@@ -24,13 +26,33 @@ const defaultMessages: ThreadMessageLike[] = [
   },
 ];
 
+function useSeedAttachments(attachments: CreateAttachment[]) {
+  const aui = useAui();
+  const initialAttachments = useRef(attachments).current;
+  useEffect(() => {
+    for (const attachment of initialAttachments) {
+      aui.composer.addAttachment(attachment).catch(console.error);
+    }
+    return () => {
+      aui.composer.clearAttachments().catch(console.error);
+    };
+  }, [aui, initialAttachments]);
+}
+
+function SeedAttachments({ attachments }: { attachments: CreateAttachment[] }) {
+  useSeedAttachments(attachments);
+  return null;
+}
+
 export function SampleRuntimeProvider({
   messages = defaultMessages,
   adapters,
+  initialAttachments,
   children,
 }: {
   messages?: ThreadMessageLike[];
   adapters?: LocalRuntimeOptions["adapters"];
+  initialAttachments?: CreateAttachment[];
   children: ReactNode;
 }) {
   const runtime = useLocalRuntime(noOpAdapter, {
@@ -39,6 +61,9 @@ export function SampleRuntimeProvider({
   });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      {initialAttachments && (
+        <SeedAttachments attachments={initialAttachments} />
+      )}
       {children}
     </AssistantRuntimeProvider>
   );

--- a/apps/docs/components/docs/samples/sample-runtime-provider.tsx
+++ b/apps/docs/components/docs/samples/sample-runtime-provider.tsx
@@ -5,6 +5,7 @@ import {
   AssistantRuntimeProvider,
   useLocalRuntime,
   type ChatModelAdapter,
+  type LocalRuntimeOptions,
   type ThreadMessageLike,
 } from "@assistant-ui/react";
 
@@ -25,12 +26,17 @@ const defaultMessages: ThreadMessageLike[] = [
 
 export function SampleRuntimeProvider({
   messages = defaultMessages,
+  adapters,
   children,
 }: {
   messages?: ThreadMessageLike[];
+  adapters?: LocalRuntimeOptions["adapters"];
   children: ReactNode;
 }) {
-  const runtime = useLocalRuntime(noOpAdapter, { initialMessages: messages });
+  const runtime = useLocalRuntime(noOpAdapter, {
+    initialMessages: messages,
+    adapters,
+  });
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       {children}

--- a/apps/docs/content/docs/ui/attachment.mdx
+++ b/apps/docs/content/docs/ui/attachment.mdx
@@ -95,7 +95,7 @@ const UserMessage: FC = () => {
 
 In the composer, each attachment tile shows a remove button that deletes the attachment from the composer. Use the plus button to add your own files.
 
-<PreviewCode file="components/docs/samples/attachment/composer-attachments" name="AttachmentComposerSample" base={<AttachmentComposerSample />}>
+<PreviewCode file="components/docs/samples/attachment/composer-attachments" name="ComposerWithAttachments" base={<AttachmentComposerSample />}>
   <AttachmentComposerRadixSample.AttachmentComposerSample />
 </PreviewCode>
 

--- a/apps/docs/content/docs/ui/attachment.mdx
+++ b/apps/docs/content/docs/ui/attachment.mdx
@@ -7,6 +7,9 @@ platforms: ["react"]
 import { AttachmentSample } from "@/components/docs/samples/attachment";
 import * as AttachmentRadixSamples from "@/components/docs/samples/attachment.radix";
 import { Flavored, FlavorSwitcher } from "@/components/docs/contexts/flavor.server";
+import { PreviewCode } from "@/components/docs/preview-code.server";
+import { AttachmentComposerSample } from "@/components/docs/samples/attachment/composer-attachments";
+import * as AttachmentComposerRadixSample from "@/components/docs/samples/attachment/composer-attachments.radix";
 
 <FlavorSwitcher />
 
@@ -35,6 +38,8 @@ This adds a `/components/assistant-ui/attachment.tsx` file to your project, whic
 
 ### Use in your application
 
+Add `ComposerAttachments` and `ComposerAddAttachment` to your composer:
+
 ```tsx title="/components/assistant-ui/thread.tsx" {1-4,9-10}
 import {
   ComposerAttachments,
@@ -59,6 +64,8 @@ const Composer: FC = () => {
 };
 ```
 
+Add `UserMessageAttachments` to your user message:
+
 ```tsx title="/components/assistant-ui/thread.tsx" {1,8}
 import { UserMessageAttachments } from "@/components/assistant-ui/attachment";
 
@@ -81,6 +88,16 @@ const UserMessage: FC = () => {
 
   </Step>
 </Steps>
+
+## Examples
+
+### Composer
+
+In the composer, each attachment tile shows a remove button that deletes the attachment from the composer. Use the plus button to add your own files.
+
+<PreviewCode file="components/docs/samples/attachment/composer-attachments" name="AttachmentComposerSample" base={<AttachmentComposerSample />}>
+  <AttachmentComposerRadixSample.AttachmentComposerSample />
+</PreviewCode>
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

The Attachment page showed one static composer mock, thus a reader could not try the runtime behavior of the component. The page gets an `Examples` section with a live composer example. The example seeds two attachments into real composer state on mount. The remove button on each tile deletes the attachment. The plus button opens the file picker through an attachment adapter.

`SampleRuntimeProvider` gets two optional props. The `adapters` prop passes an attachment adapter to the local runtime, because the file picker path does not operate without an `AttachmentAdapter`. The `initialAttachments` prop seeds the composer once per mount, with the initial array captured in a ref, thus a re-render does not reseed removed tiles. Each `addAttachment` call carries a `.catch`, because the runtime rejects attachments that do not match the adapter accept list.

The exported sample function contains the adapter, the fixture, and the composer markup, because `PreviewCode` extracts only the named export. The code tab therefore shows one complete snippet with no unresolved identifiers. The Base UI file and the Radix twin differ only in the attachment import. The code tab shows one flavor-neutral snippet, because `cleanupImports` removes the `.radix` suffix from import paths by design.

The tile radius comes from the `--composer-radius` and `--composer-padding` variables, which only `thread.tsx` sets, thus the example sets the two variables on the composer root. Two lead-in sentences in Getting Started identify the target of each `thread.tsx` code block, because the two blocks change the same file. Three sibling PRs with the other examples come after this one.

Related: #5643

## Validation

- I ran the real `buildPreviewCode` pipeline against the two sample files. The emitted snippets contain the adapter, the fixture, and the composer markup, with no unresolved identifiers.
- I loaded the page in a browser. The composer seeds two tiles on mount, the remove button deletes a tile, and the rendered code tab contains the full snippet.
- `tsc`, `oxlint`, and `oxfmt` pass on the changed files. `@assistant-ui/docs` is private, thus no changeset is necessary.