### PR TITLE
docs(ui): add image preview example

### DIFF
--- a/apps/docs/components/docs/samples/attachment/image-preview.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/image-preview.radix.tsx
@@ -9,34 +9,41 @@ import { UserMessageAttachments } from "@/components/assistant-ui/attachment.rad
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
-)}`;
-
-const MESSAGES: ThreadMessageLike[] = [
-  {
-    role: "user",
-    content: "Check out this photo!",
-    attachments: [
-      {
-        id: "photo-1",
-        type: "image",
-        name: "sunrise.svg",
-        contentType: "image/svg+xml",
-        status: { type: "complete" },
-        content: [{ type: "image", image: IMAGE_SRC }],
-      },
-    ],
-  },
-];
-
 export function AttachmentPreviewSample() {
+  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+  )}`;
+
+  const messages: ThreadMessageLike[] = [
+    {
+      role: "user",
+      content: "Check out this photo!",
+      attachments: [
+        {
+          id: "photo-1",
+          type: "image",
+          name: "sunrise.svg",
+          contentType: "image/svg+xml",
+          status: { type: "complete" },
+          content: [{ type: "image", image: imageSrc }],
+        },
+      ],
+    },
+  ];
+
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
-      <SampleRuntimeProvider messages={MESSAGES}>
+      <SampleRuntimeProvider messages={messages}>
         <div className="flex flex-col items-center gap-4">
           <ThreadPrimitive.Messages>
-            {() => <AttachmentMessage />}
+            {() => (
+              <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
+                <UserMessageAttachments />
+                <div className="bg-muted rounded-xl px-4 py-2 text-sm">
+                  <MessagePrimitive.Parts />
+                </div>
+              </MessagePrimitive.Root>
+            )}
           </ThreadPrimitive.Messages>
           <p className="text-muted-foreground text-xs">
             Select the image to open the preview.
@@ -44,16 +51,5 @@ export function AttachmentPreviewSample() {
         </div>
       </SampleRuntimeProvider>
     </SampleFrame>
-  );
-}
-
-function AttachmentMessage() {
-  return (
-    <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
-      <UserMessageAttachments />
-      <div className="bg-muted rounded-xl px-4 py-2 text-sm">
-        <MessagePrimitive.Parts />
-      </div>
-    </MessagePrimitive.Root>
   );
 }

--- a/apps/docs/components/docs/samples/attachment/image-preview.radix.tsx
+++ b/apps/docs/components/docs/samples/attachment/image-preview.radix.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  MessagePrimitive,
+  ThreadPrimitive,
+  type ThreadMessageLike,
+} from "@assistant-ui/react";
+import { UserMessageAttachments } from "@/components/assistant-ui/attachment.radix";
+import { SampleFrame } from "../sample-frame";
+import { SampleRuntimeProvider } from "../sample-runtime-provider";
+
+const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
+)}`;
+
+const MESSAGES: ThreadMessageLike[] = [
+  {
+    role: "user",
+    content: "Check out this photo!",
+    attachments: [
+      {
+        id: "photo-1",
+        type: "image",
+        name: "sunrise.svg",
+        contentType: "image/svg+xml",
+        status: { type: "complete" },
+        content: [{ type: "image", image: IMAGE_SRC }],
+      },
+    ],
+  },
+];
+
+export function AttachmentPreviewSample() {
+  return (
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+      <SampleRuntimeProvider messages={MESSAGES}>
+        <div className="flex flex-col items-center gap-4">
+          <ThreadPrimitive.Messages>
+            {() => <AttachmentMessage />}
+          </ThreadPrimitive.Messages>
+          <p className="text-muted-foreground text-xs">
+            Select the image to open the preview.
+          </p>
+        </div>
+      </SampleRuntimeProvider>
+    </SampleFrame>
+  );
+}
+
+function AttachmentMessage() {
+  return (
+    <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <UserMessageAttachments />
+      <div className="bg-muted rounded-xl px-4 py-2 text-sm">
+        <MessagePrimitive.Parts />
+      </div>
+    </MessagePrimitive.Root>
+  );
+}

--- a/apps/docs/components/docs/samples/attachment/image-preview.tsx
+++ b/apps/docs/components/docs/samples/attachment/image-preview.tsx
@@ -9,34 +9,41 @@ import { UserMessageAttachments } from "@/components/assistant-ui/attachment";
 import { SampleFrame } from "../sample-frame";
 import { SampleRuntimeProvider } from "../sample-runtime-provider";
 
-const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
-)}`;
-
-const MESSAGES: ThreadMessageLike[] = [
-  {
-    role: "user",
-    content: "Check out this photo!",
-    attachments: [
-      {
-        id: "photo-1",
-        type: "image",
-        name: "sunrise.svg",
-        contentType: "image/svg+xml",
-        status: { type: "complete" },
-        content: [{ type: "image", image: IMAGE_SRC }],
-      },
-    ],
-  },
-];
-
 export function AttachmentPreviewSample() {
+  const imageSrc = `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><rect width="400" height="300" fill="#6366f1"/><circle cx="320" cy="72" r="36" fill="#fde68a"/></svg>',
+  )}`;
+
+  const messages: ThreadMessageLike[] = [
+    {
+      role: "user",
+      content: "Check out this photo!",
+      attachments: [
+        {
+          id: "photo-1",
+          type: "image",
+          name: "sunrise.svg",
+          contentType: "image/svg+xml",
+          status: { type: "complete" },
+          content: [{ type: "image", image: imageSrc }],
+        },
+      ],
+    },
+  ];
+
   return (
     <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
-      <SampleRuntimeProvider messages={MESSAGES}>
+      <SampleRuntimeProvider messages={messages}>
         <div className="flex flex-col items-center gap-4">
           <ThreadPrimitive.Messages>
-            {() => <AttachmentMessage />}
+            {() => (
+              <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
+                <UserMessageAttachments />
+                <div className="bg-muted rounded-xl px-4 py-2 text-sm">
+                  <MessagePrimitive.Parts />
+                </div>
+              </MessagePrimitive.Root>
+            )}
           </ThreadPrimitive.Messages>
           <p className="text-muted-foreground text-xs">
             Select the image to open the preview.
@@ -44,16 +51,5 @@ export function AttachmentPreviewSample() {
         </div>
       </SampleRuntimeProvider>
     </SampleFrame>
-  );
-}
-
-function AttachmentMessage() {
-  return (
-    <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
-      <UserMessageAttachments />
-      <div className="bg-muted rounded-xl px-4 py-2 text-sm">
-        <MessagePrimitive.Parts />
-      </div>
-    </MessagePrimitive.Root>
   );
 }

--- a/apps/docs/components/docs/samples/attachment/image-preview.tsx
+++ b/apps/docs/components/docs/samples/attachment/image-preview.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  MessagePrimitive,
+  ThreadPrimitive,
+  type ThreadMessageLike,
+} from "@assistant-ui/react";
+import { UserMessageAttachments } from "@/components/assistant-ui/attachment";
+import { SampleFrame } from "../sample-frame";
+import { SampleRuntimeProvider } from "../sample-runtime-provider";
+
+const IMAGE_SRC = `data:image/svg+xml,${encodeURIComponent(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#6366f1"/><stop offset="1" stop-color="#0ea5e9"/></linearGradient></defs><rect width="400" height="300" fill="url(#g)"/><circle cx="320" cy="72" r="36" fill="#fff" opacity="0.85"/><path d="M0 300 140 160 230 250 310 180 400 270v30z" fill="#fff" opacity="0.4"/></svg>',
+)}`;
+
+const MESSAGES: ThreadMessageLike[] = [
+  {
+    role: "user",
+    content: "Check out this photo!",
+    attachments: [
+      {
+        id: "photo-1",
+        type: "image",
+        name: "sunrise.svg",
+        contentType: "image/svg+xml",
+        status: { type: "complete" },
+        content: [{ type: "image", image: IMAGE_SRC }],
+      },
+    ],
+  },
+];
+
+export function AttachmentPreviewSample() {
+  return (
+    <SampleFrame className="bg-background flex h-auto min-h-48 items-center justify-center p-6">
+      <SampleRuntimeProvider messages={MESSAGES}>
+        <div className="flex flex-col items-center gap-4">
+          <ThreadPrimitive.Messages>
+            {() => <AttachmentMessage />}
+          </ThreadPrimitive.Messages>
+          <p className="text-muted-foreground text-xs">
+            Select the image to open the preview.
+          </p>
+        </div>
+      </SampleRuntimeProvider>
+    </SampleFrame>
+  );
+}
+
+function AttachmentMessage() {
+  return (
+    <MessagePrimitive.Root className="flex w-full max-w-lg flex-col items-end gap-2 [--composer-padding:8px] [--composer-radius:1.5rem]">
+      <UserMessageAttachments />
+      <div className="bg-muted rounded-xl px-4 py-2 text-sm">
+        <MessagePrimitive.Parts />
+      </div>
+    </MessagePrimitive.Root>
+  );
+}

--- a/apps/docs/content/docs/ui/attachment.mdx
+++ b/apps/docs/content/docs/ui/attachment.mdx
@@ -14,6 +14,8 @@ import { AttachmentMessageContextSample } from "@/components/docs/samples/attach
 import * as AttachmentMessageRadixSample from "@/components/docs/samples/attachment/message-attachments.radix";
 import { AttachmentTypesSample } from "@/components/docs/samples/attachment/types";
 import * as AttachmentTypesRadixSample from "@/components/docs/samples/attachment/types.radix";
+import { AttachmentPreviewSample } from "@/components/docs/samples/attachment/image-preview";
+import * as AttachmentPreviewRadixSample from "@/components/docs/samples/attachment/image-preview.radix";
 
 <FlavorSwitcher />
 
@@ -117,6 +119,14 @@ This example shows the image tile, the document tile, and the generic fallback t
 
 <PreviewCode file="components/docs/samples/attachment/types" name="AttachmentTypesSample" base={<AttachmentTypesSample />}>
   <AttachmentTypesRadixSample.AttachmentTypesSample />
+</PreviewCode>
+
+### Image Preview
+
+When you click an image tile or activate it with the keyboard, a full-size preview dialog opens.
+
+<PreviewCode file="components/docs/samples/attachment/image-preview" name="AttachmentPreviewSample" base={<AttachmentPreviewSample />}>
+  <AttachmentPreviewRadixSample.AttachmentPreviewSample />
 </PreviewCode>
 
 ## API Reference


### PR DESCRIPTION
The attachment component opens a full-size preview dialog for image attachments, but the page did not show this behavior. The `Examples` section gets an `Image Preview` example with one complete image attachment in a sent user message. A click on the tile opens the real dialog, and the Enter key opens it as well. A short instruction under the tile tells the reader to select the image. The Base UI file and the Radix twin are identical except the component import. This PR merges last in the example stack, after assistant-ui/assistant-ui#5646, and completes the example set.

Related: #5643

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.-hkHysxHlljWshEFVYqJyc3fs-OqqJ9eSDSCwybRfLCppKTp0xYyizKUHyw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->