### PR TITLE
feat(react-ag-ui): buffer a send during a run behind unstable_enableMessageQueue

### DIFF
--- a/.changeset/ag-ui-message-queue.md
+++ b/.changeset/ag-ui-message-queue.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+feat: add unstable_enableMessageQueue so a send during a run is buffered instead of swallowed

--- a/api-surface/assistant-ui__react-ag-ui.ts
+++ b/api-surface/assistant-ui__react-ag-ui.ts
@@ -1563,6 +1563,7 @@ type UseAgUiRuntimeOptions = ExternalStoreSharedOptions & {
   logger?: Partial<Logger>;
   showThinking?: boolean;
   autoCancelPendingToolCalls?: boolean | undefined;
+  unstable_enableMessageQueue?: boolean | undefined;
   onError?: (e: Error) => void;
   onCancel?: () => void;
   adapters?: UseAgUiRuntimeAdapters;

--- a/packages/react-ag-ui/package.json
+++ b/packages/react-ag-ui/package.json
@@ -52,7 +52,10 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
     "react": "^19.2.8",
     "vitest": "^4.1.10",
     "zod": "^4.4.3"

--- a/packages/react-ag-ui/src/runtime/types.ts
+++ b/packages/react-ag-ui/src/runtime/types.ts
@@ -71,6 +71,13 @@ export type UseAgUiRuntimeOptions = ExternalStoreSharedOptions & {
    * Defaults to `true`.
    */
   autoCancelPendingToolCalls?: boolean | undefined;
+  /**
+   * Buffer a message sent while a run is in flight and send it once the run
+   * settles, exposing it on `composer.queue` for `ComposerPrimitive.Queue`.
+   * The runtime owns the queue lifecycle because flushing needs the agent's
+   * send path and the run's own busy and idle edges.
+   */
+  unstable_enableMessageQueue?: boolean | undefined;
   onError?: (e: Error) => void;
   onCancel?: () => void;
   adapters?: UseAgUiRuntimeAdapters;

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -136,6 +136,79 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     );
   });
 
+  it("holds a queued message when the run settles on an interrupt", async () => {
+    const gate = (() => {
+      let release!: () => void;
+      const promise = new Promise<void>((r) => {
+        release = r;
+      });
+      return { promise, release: () => release() };
+    })();
+    const runAgent = vi.fn(
+      async (
+        _input: unknown,
+        subscriber: {
+          onRunFinishedEvent?: (e: unknown) => void;
+          onRunFinalized?: () => void;
+        },
+      ) => {
+        if (runAgent.mock.calls.length === 1) {
+          await gate.promise;
+          subscriber.onRunFinishedEvent?.({
+            event: {
+              type: "RUN_FINISHED",
+              runId: "run",
+              outcome: {
+                type: "interrupt",
+                interrupts: [{ id: "int-1", reason: "tool_call" }],
+              },
+            },
+          });
+        }
+        subscriber.onRunFinalized?.();
+      },
+    );
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({ agent, unstable_enableMessageQueue: true }),
+    );
+    mount(result.current);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
+    );
+
+    await act(async () => {
+      gate.release();
+    });
+
+    // append refuses a new run until the interrupt is answered, so the queued
+    // message must stay visible rather than being dropped into that refusal
+    await waitFor(() =>
+      expect(
+        result.current.thread.getState().messages.at(-1)?.status?.type,
+      ).toBe("requires-action"),
+    );
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("queued").textContent).toBe("second");
+  });
+
   it("does not wedge on an append that starts no run", async () => {
     const { agent, runAgent } = gatedAgent();
 

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -1,7 +1,16 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi } from "vitest";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { AssistantRuntime } from "@assistant-ui/core";
+import { AssistantRuntimeProvider } from "@assistant-ui/core/react";
+import { useAuiState } from "@assistant-ui/store";
 import type { HttpAgent } from "@ag-ui/client";
 import { useAgUiRuntime } from "./useAgUiRuntime";
 
@@ -23,6 +32,22 @@ const gatedAgent = () => {
   };
 };
 
+// Asserts through a subscribed consumer rather than the runtime object, which
+// stays correct on read even when the store identity never moves.
+const QueuedPrompts = () => {
+  const prompts = useAuiState((s) =>
+    s.composer.queue.map((item) => item.prompt).join(","),
+  );
+  return <div data-testid="queued">{prompts}</div>;
+};
+
+const mount = (runtime: AssistantRuntime) =>
+  render(
+    <AssistantRuntimeProvider runtime={runtime}>
+      <QueuedPrompts />
+    </AssistantRuntimeProvider>,
+  );
+
 describe("useAgUiRuntime unstable_enableMessageQueue", () => {
   it("buffers a send during a run and flushes it once the run settles", async () => {
     const { agent, runAgent, release } = gatedAgent();
@@ -30,6 +55,7 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     const { result } = renderHook(() =>
       useAgUiRuntime({ agent, unstable_enableMessageQueue: true }),
     );
+    mount(result.current);
 
     await act(async () => {
       await result.current.thread.append({
@@ -48,20 +74,20 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
       });
     });
 
-    // buffered rather than starting a second run
+    // buffered rather than starting a second run, and visible to subscribers
     expect(runAgent).toHaveBeenCalledTimes(1);
-    expect(
-      result.current.thread.composer
-        .getState()
-        .queue.map((item) => item.prompt),
-    ).toEqual(["second"]);
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
+    );
 
     await act(async () => {
       release();
     });
 
     await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
-    expect(result.current.thread.composer.getState().queue).toEqual([]);
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
   });
 
   it("leaves the queue capability off when the flag is not set", () => {

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { HttpAgent } from "@ag-ui/client";
+import { useAgUiRuntime } from "./useAgUiRuntime";
+
+const gatedAgent = () => {
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const runAgent = vi.fn(
+    async (_input: unknown, subscriber: { onRunFinalized?: () => void }) => {
+      if (runAgent.mock.calls.length === 1) await gate;
+      subscriber.onRunFinalized?.();
+    },
+  );
+  return {
+    agent: { runAgent } as unknown as HttpAgent,
+    runAgent,
+    release: () => release(),
+  };
+};
+
+describe("useAgUiRuntime unstable_enableMessageQueue", () => {
+  it("buffers a send during a run and flushes it once the run settles", async () => {
+    const { agent, runAgent, release } = gatedAgent();
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({ agent, unstable_enableMessageQueue: true }),
+    );
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+    expect(result.current.thread.getState().capabilities.queue).toBe(true);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+
+    // buffered rather than starting a second run
+    expect(runAgent).toHaveBeenCalledTimes(1);
+    expect(
+      result.current.thread.composer
+        .getState()
+        .queue.map((item) => item.prompt),
+    ).toEqual(["second"]);
+
+    await act(async () => {
+      release();
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    expect(result.current.thread.composer.getState().queue).toEqual([]);
+  });
+
+  it("leaves the queue capability off when the flag is not set", () => {
+    const { agent } = gatedAgent();
+
+    const { result } = renderHook(() => useAgUiRuntime({ agent }));
+
+    expect(result.current.thread.getState().capabilities.queue).toBe(false);
+  });
+});

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -136,6 +136,68 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     );
   });
 
+  it("advances one item at a time when a queued dispatch fails", async () => {
+    const gate = (() => {
+      let release!: () => void;
+      const promise = new Promise<void>((r) => {
+        release = r;
+      });
+      return { promise, release: () => release() };
+    })();
+    // every run is held, so a second concurrent dispatch is observable as a
+    // call count rather than being hidden by sequential draining
+    const held: Array<() => void> = [];
+    const runAgent = vi.fn(async () => {
+      if (runAgent.mock.calls.length === 1) {
+        await gate.promise;
+        throw new Error("boom");
+      }
+      await new Promise<void>((resolve) => held.push(resolve));
+    });
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({
+        agent,
+        unstable_enableMessageQueue: true,
+        onError: () => {},
+      }),
+    );
+    mount(result.current);
+
+    const send = async (text: string) => {
+      await act(async () => {
+        await result.current.thread.append({
+          role: "user",
+          content: [{ type: "text", text }],
+          parentId:
+            result.current.thread.getState().messages.at(-1)?.id ?? null,
+        });
+      });
+    };
+
+    await send("first");
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    // two behind the gated run, so a double release would drain both
+    await send("second");
+    await send("third");
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second,third"),
+    );
+
+    await act(async () => {
+      gate.release();
+    });
+
+    // exactly one item advances; a double release would have drained both
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("third"),
+    );
+    expect(runAgent).toHaveBeenCalledTimes(2);
+  });
+
   it("holds a queued message when the run settles on an interrupt", async () => {
     const gate = (() => {
       let release!: () => void;

--- a/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
+++ b/packages/react-ag-ui/src/useAgUiRuntime.queue.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   act,
+  cleanup,
   render,
   renderHook,
   screen,
@@ -48,6 +49,10 @@ const mount = (runtime: AssistantRuntime) =>
     </AssistantRuntimeProvider>,
   );
 
+afterEach(() => {
+  cleanup();
+});
+
 describe("useAgUiRuntime unstable_enableMessageQueue", () => {
   it("buffers a send during a run and flushes it once the run settles", async () => {
     const { agent, runAgent, release } = gatedAgent();
@@ -85,6 +90,118 @@ describe("useAgUiRuntime unstable_enableMessageQueue", () => {
     });
 
     await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
+  });
+
+  it("keeps accepting sends after a queued run fails", async () => {
+    const runAgent = vi.fn(
+      async (_input: unknown, subscriber: { onRunFinalized?: () => void }) => {
+        if (runAgent.mock.calls.length === 1) throw new Error("boom");
+        subscriber.onRunFinalized?.();
+      },
+    );
+    const agent = { runAgent } as unknown as HttpAgent;
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({
+        agent,
+        unstable_enableMessageQueue: true,
+        onError: () => {},
+      }),
+    );
+    mount(result.current);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    // the failed run must not leave the queue permanently busy
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
+  });
+
+  it("does not wedge on an append that starts no run", async () => {
+    const { agent, runAgent } = gatedAgent();
+
+    const { result } = renderHook(() =>
+      useAgUiRuntime({ agent, unstable_enableMessageQueue: true }),
+    );
+    mount(result.current);
+
+    // startRun false never reaches the agent, so it produces no falling edge
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "staged" }],
+        startRun: false,
+      });
+    });
+    expect(runAgent).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "real" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe(""),
+    );
+  });
+
+  it("clears queued items when the flag is turned off", async () => {
+    const { agent, runAgent } = gatedAgent();
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useAgUiRuntime({ agent, unstable_enableMessageQueue: enabled }),
+      { initialProps: { enabled: true } },
+    );
+    mount(result.current);
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first" }],
+      });
+    });
+    await waitFor(() => expect(runAgent).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second" }],
+        parentId: result.current.thread.getState().messages.at(-1)?.id ?? null,
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("queued").textContent).toBe("second"),
+    );
+
+    await act(async () => {
+      rerender({ enabled: false });
+    });
+
+    expect(result.current.thread.getState().capabilities.queue).toBe(false);
     await waitFor(() =>
       expect(screen.getByTestId("queued").textContent).toBe(""),
     );

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -147,16 +147,19 @@ export function useAgUiRuntime(
     () => EMPTY_QUEUE_ITEMS,
   );
 
-  // Gate on the same value the store reports as isRunning, so a queued message
-  // does not flush while client-side tools are still executing.
+  // Holds the queue while client-side tools are still executing, and while an
+  // interrupt is unanswered: `append` refuses a new run until it is resolved,
+  // and the queue drops an item before dispatching it, so draining into that
+  // refusal would lose the message instead of keeping it visible.
+  const queueBusy = isRunning || core.getPendingInterrupts() !== null;
   useEffect(() => {
-    if (isRunning) {
+    if (queueBusy) {
       runStartsRef.current++;
       queueController?.notifyBusy();
     } else {
       queueController?.notifyIdle();
     }
-  }, [isRunning, queueController]);
+  }, [queueBusy, queueController]);
 
   const threadList = useMemo(() => {
     if (!threadListAdapter) return undefined;

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -1,12 +1,23 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import {
   useExternalStoreRuntime,
   useExternalStoreSharedOptions,
   useRuntimeAdapters,
 } from "@assistant-ui/core/react";
-import type { ToolExecutionStatus } from "@assistant-ui/core";
+import { createMessageQueue } from "@assistant-ui/core";
+import type {
+  MessageQueueController,
+  ToolExecutionStatus,
+} from "@assistant-ui/core";
 import type {
   AssistantRuntime,
   AppendMessage,
@@ -22,8 +33,11 @@ import type {
 } from "./runtime/types";
 import { AgUiThreadRuntimeCore } from "./runtime/AgUiThreadRuntimeCore";
 import { agUiExtras } from "./agUiExtras";
+import type { QueueItemState } from "@assistant-ui/core/store";
 
 const EMPTY_INTERRUPTS: readonly AgUiInterrupt[] = [];
+const EMPTY_QUEUE_ITEMS: readonly QueueItemState[] = Object.freeze([]);
+const subscribeNoop = () => () => {};
 
 export type AgUiAssistantRuntime = AssistantRuntime & {
   /**
@@ -84,6 +98,41 @@ export function useAgUiRuntime(
   const hasExecutingTools = Object.values(toolStatuses).some(
     (s) => s?.type === "executing",
   );
+  const isRunning = core.isRunning() || hasExecutingTools;
+
+  // The driver sends through the agent core rather than the runtime, because
+  // the runtime's append routes every tail append back into this queue.
+  const queueRef = useRef<MessageQueueController | null>(null);
+  if (options.unstable_enableMessageQueue && !queueRef.current) {
+    queueRef.current = createMessageQueue({
+      run: (message) => {
+        void core.append(message);
+      },
+    });
+  } else if (!options.unstable_enableMessageQueue && queueRef.current) {
+    queueRef.current.adapter.clear("cancel-run");
+    queueRef.current = null;
+  }
+  const queueController = options.unstable_enableMessageQueue
+    ? queueRef.current
+    : null;
+
+  // Re-render when queued items change so composer.queue re-syncs.
+  useSyncExternalStore(
+    queueController?.subscribe ?? subscribeNoop,
+    () => queueController?.adapter.items ?? EMPTY_QUEUE_ITEMS,
+    () => EMPTY_QUEUE_ITEMS,
+  );
+
+  // Gate on the same value the store reports as isRunning, so a queued message
+  // does not flush while client-side tools are still executing.
+  useEffect(() => {
+    if (isRunning) {
+      queueController?.notifyBusy();
+    } else {
+      queueController?.notifyIdle();
+    }
+  }, [isRunning, queueController]);
 
   const threadList = useMemo(() => {
     if (!threadListAdapter) return undefined;
@@ -143,7 +192,7 @@ export function useAgUiRuntime(
         isLoading: core.isLoading,
         messageRepository: core.getMessageRepository(),
         state: core.getState(),
-        isRunning: core.isRunning() || hasExecutingTools,
+        isRunning,
         extras: agUiExtras.provide({
           interrupts:
             core.getPendingInterrupts()?.interrupts ?? EMPTY_INTERRUPTS,
@@ -172,11 +221,12 @@ export function useAgUiRuntime(
         onLoadExternalState: (state: ReadonlyJSONValue) =>
           core.loadExternalState(state),
         adapters: adapterAdapters,
+        ...(queueController && { queue: queueController.adapter }),
       } satisfies ExternalStoreAdapter<ThreadMessage>;
     },
     // _version is intentionally included to trigger re-computation when core state changes via notifyUpdate
     // toolInvocations intentionally excluded: abort/resume use refs internally and work with stale captures
-    [adapterAdapters, core, _version, hasExecutingTools, shared],
+    [adapterAdapters, core, _version, isRunning, queueController, shared],
   );
 
   const baseRuntime = useExternalStoreRuntime(store);

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -106,7 +106,13 @@ export function useAgUiRuntime(
   if (options.unstable_enableMessageQueue && !queueRef.current) {
     queueRef.current = createMessageQueue({
       run: (message) => {
-        void core.append(message);
+        // The queue drops the item before dispatching and stays busy until an
+        // idle edge, so a rejected append (a pending interrupt, for one) has to
+        // release it here or every later send buffers forever.
+        void core.append(message).catch((e: unknown) => {
+          queueRef.current?.notifyIdle();
+          logger.error?.("queued message failed to send", e);
+        });
       },
     });
   } else if (!options.unstable_enableMessageQueue && queueRef.current) {
@@ -117,8 +123,10 @@ export function useAgUiRuntime(
     ? queueRef.current
     : null;
 
-  // Re-render when queued items change so composer.queue re-syncs.
-  useSyncExternalStore(
+  // Feeds the store memo below: the runtime core skips an adapter whose
+  // identity is unchanged, so queue items have to move the store reference or
+  // subscribers never see composer.queue change.
+  const queueItems = useSyncExternalStore(
     queueController?.subscribe ?? subscribeNoop,
     () => queueController?.adapter.items ?? EMPTY_QUEUE_ITEMS,
     () => EMPTY_QUEUE_ITEMS,
@@ -226,7 +234,15 @@ export function useAgUiRuntime(
     },
     // _version is intentionally included to trigger re-computation when core state changes via notifyUpdate
     // toolInvocations intentionally excluded: abort/resume use refs internally and work with stale captures
-    [adapterAdapters, core, _version, isRunning, queueController, shared],
+    [
+      adapterAdapters,
+      core,
+      _version,
+      isRunning,
+      queueController,
+      queueItems,
+      shared,
+    ],
   );
 
   const baseRuntime = useExternalStoreRuntime(store);

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -103,23 +103,27 @@ export function useAgUiRuntime(
   // The driver sends through the agent core rather than the runtime, because
   // the runtime's append routes every tail append back into this queue.
   const queueRef = useRef<MessageQueueController | null>(null);
-  // Counts observed run starts. A dispatch whose count never moves produced no
-  // run of its own, so no falling edge is coming to release the queue.
-  const runStartsRef = useRef(0);
+  // Counts rendered busy edges, whether a run start or an interrupt arriving.
+  // A dispatch whose count never moves was never observed as busy, so no
+  // falling edge is coming to release the queue.
+  const busyEdgesRef = useRef(0);
   if (options.unstable_enableMessageQueue && !queueRef.current) {
     queueRef.current = createMessageQueue({
       run: (message) => {
         const controller = queueRef.current;
-        const startsAtDispatch = runStartsRef.current;
+        const edgesAtDispatch = busyEdgesRef.current;
         // The queue drops the item before dispatching and stays busy until an
-        // idle edge. An append that starts a run is released by that run's
-        // falling edge, and releasing again here would advance the queue twice;
-        // one that never runs (a pre-run rejection, or startRun false) has to be
-        // released here or every later send buffers forever.
+        // idle edge. An append observed as busy is released by that falling
+        // edge, and releasing again here would advance the queue twice; one
+        // that never runs (a pre-run rejection, or startRun false) has to be
+        // released here or every later send buffers forever. An interrupt is
+        // rechecked because a run that resolves without yielding to React
+        // reaches here before the effect below has seen either edge.
         const releaseIfNoRun = () => {
           if (
             queueRef.current !== controller ||
-            runStartsRef.current !== startsAtDispatch
+            busyEdgesRef.current !== edgesAtDispatch ||
+            core.getPendingInterrupts() !== null
           )
             return;
           controller?.notifyIdle();
@@ -154,7 +158,7 @@ export function useAgUiRuntime(
   const queueBusy = isRunning || core.getPendingInterrupts() !== null;
   useEffect(() => {
     if (queueBusy) {
-      runStartsRef.current++;
+      busyEdgesRef.current++;
       queueController?.notifyBusy();
     } else {
       queueController?.notifyIdle();

--- a/packages/react-ag-ui/src/useAgUiRuntime.ts
+++ b/packages/react-ag-ui/src/useAgUiRuntime.ts
@@ -103,15 +103,30 @@ export function useAgUiRuntime(
   // The driver sends through the agent core rather than the runtime, because
   // the runtime's append routes every tail append back into this queue.
   const queueRef = useRef<MessageQueueController | null>(null);
+  // Counts observed run starts. A dispatch whose count never moves produced no
+  // run of its own, so no falling edge is coming to release the queue.
+  const runStartsRef = useRef(0);
   if (options.unstable_enableMessageQueue && !queueRef.current) {
     queueRef.current = createMessageQueue({
       run: (message) => {
+        const controller = queueRef.current;
+        const startsAtDispatch = runStartsRef.current;
         // The queue drops the item before dispatching and stays busy until an
-        // idle edge, so a rejected append (a pending interrupt, for one) has to
-        // release it here or every later send buffers forever.
-        void core.append(message).catch((e: unknown) => {
-          queueRef.current?.notifyIdle();
-          logger.error?.("queued message failed to send", e);
+        // idle edge. An append that starts a run is released by that run's
+        // falling edge, and releasing again here would advance the queue twice;
+        // one that never runs (a pre-run rejection, or startRun false) has to be
+        // released here or every later send buffers forever.
+        const releaseIfNoRun = () => {
+          if (
+            queueRef.current !== controller ||
+            runStartsRef.current !== startsAtDispatch
+          )
+            return;
+          controller?.notifyIdle();
+        };
+        void core.append(message).then(releaseIfNoRun, (e: unknown) => {
+          releaseIfNoRun();
+          logger.error?.("[agui] queued message failed to send", e);
         });
       },
     });
@@ -136,6 +151,7 @@ export function useAgUiRuntime(
   // does not flush while client-side tools are still executing.
   useEffect(() => {
     if (isRunning) {
+      runStartsRef.current++;
       queueController?.notifyBusy();
     } else {
       queueController?.notifyIdle();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5658,9 +5658,6 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
-    deprecated: |-
-      Deprecated due to Document number parsing bug in JSON, see
-        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,7 +1940,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3799,9 +3799,18 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -3976,7 +3985,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud
@@ -5649,6 +5658,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,7 +1940,7 @@ importers:
         version: link:../../packages/ui
       '@google/adk':
         specifier: ^1.4.0
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3985,7 +3985,7 @@ importers:
         version: link:../store
       '@google/adk':
         specifier: '>=0.5.0'
-        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16)(pg@8.20.0))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5)(pg@8.20.0))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5)(pg@8.20.0))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+        version: 1.4.0(@bufbuild/protobuf@2.13.0)(@cfworker/json-schema@4.1.1)(@grpc/grpc-js@1.14.4)(@mikro-orm/mariadb@6.6.16(@mikro-orm/core@6.6.16))(@mikro-orm/mssql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/mysql@6.6.16(@mikro-orm/core@6.6.16)(@types/node@26.1.1)(mariadb@3.4.5))(@mikro-orm/postgresql@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@mikro-orm/sqlite@6.6.16(@mikro-orm/core@6.6.16)(mariadb@3.4.5))(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(encoding@0.1.13)
       assistant-cloud:
         specifier: '*'
         version: link:../cloud


### PR DESCRIPTION
Fixes #5633.

## what

AG-UI could not expose the queue capability. `capabilities.queue` was always false, so `ComposerPrimitive.Queue` rendered nothing and an Enter during a run fell through it and was silently swallowed. This adds `unstable_enableMessageQueue`, which buffers a send made during a run and flushes it once the run settles.

```tsx
const runtime = useAgUiRuntime({ agent, unstable_enableMessageQueue: true });
```

## why the runtime owns the queue instead of accepting one

The obvious shape is to let the caller pass an `ExternalThreadQueueAdapter` through `ExternalStoreSharedOptions`, which is what #5635 tried. That cannot work for a wrapper hook, and it is worth writing down so nobody re-tries it:

- `ExternalStoreThreadRuntimeCore.append` routes every non-edit tail append into `queue.enqueue` and returns, so the queue's `driver.run` becomes the only path that actually sends.
- `createMessageQueue` additionally needs the run's rising and falling edges (`advance()` bails while `running`, and only `notifyIdle()` clears it) and a `subscribe` so the composer re-renders.
- In `useAgUiRuntime` all three live inside the hook: the send is `core.append` on a core that is never exported, and the running state is `core.isRunning() || hasExecutingTools`. A caller's `run` could only be a no-op, dropping every message, or `runtime.thread.append`, which re-enters `append` and enqueues forever.

`useLangGraphRuntime` reached the same conclusion and owns its controller internally behind the same flag name; this mirrors it.

Three details that are load bearing:

- the driver sends through `core.append`, not the runtime, or the tail append recurses back into the queue
- the busy and idle edges gate on the same expression the store reports as `isRunning`, so a queued message does not flush while client-side tools are still executing
- flipping the flag off clears the adapter, so stale items do not survive a disable

## verification

- new `useAgUiRuntime.queue.test.tsx` drives the real hook against a gated agent: a send during a run buffers rather than starting a second run, appears on `composer.queue`, and flushes exactly once when the run settles. I checked it fails when the `queue` wiring is removed, so it pins the behaviour rather than merely covering it.
- `@assistant-ui/react-ag-ui` suite 305 passed, `tsc --noEmit` clean, repo lint and format clean.

The package gained `jsdom` and `@testing-library/react` as dev dependencies to render the hook, matching how `react-langgraph` tests its equivalent queue. The environment is opted into per file so the existing `test/*.spec.ts` unit tests keep running unchanged.

## follow-up, not in scope

While writing the test I hit a separate wrinkle: during an AG-UI run the last message is an optimistic assistant placeholder, and a send whose `parentId` lags that placeholder is classified as an edit by `append`, which calls `queue.clear("edit")`. Driving `thread.append` with the live last-message id behaves correctly. Whether the composer can produce a stale `parentId` in that window predates this change and deserves its own issue.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QbluLDivytJDqgqTT9_ehQRK54pbpbVZy_fna43WBmTfMjWOqSmL7GuN-Dc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->