### PR TITLE
fix(eve): reconcile staged messages with live session updates and promote staged prefixes on reload

### DIFF
--- a/.changeset/eve-staged-reconciliation.md
+++ b/.changeset/eve-staged-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: reconcile staged messages with live session updates and promote staged prefixes on reload

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 const { mockUseEveAgent } = vi.hoisted(() => ({
@@ -100,5 +100,292 @@ describe("useEveAgentRuntime status forwarding", () => {
     expect(result.current.thread.getState().messages.at(-1)?.status).toEqual({
       type: "running",
     });
+  });
+});
+
+const settledData: EveMessageData = {
+  messages: [
+    { id: "u1", role: "user", parts: [{ type: "text", text: "earlier" }] },
+    {
+      id: "a1",
+      role: "assistant",
+      parts: [{ type: "text", text: "earlier answer" }],
+    },
+  ],
+};
+
+const getText = (runtime: ReturnType<typeof useEveAgentRuntime>) =>
+  runtime.thread
+    .getState()
+    .messages.map((message) =>
+      message.content
+        .flatMap((part) => (part.type === "text" ? [part.text] : []))
+        .join(""),
+    );
+
+const stageMessage = async (
+  runtime: ReturnType<typeof useEveAgentRuntime>,
+  text: string,
+) => {
+  await act(async () => {
+    runtime.thread.append({
+      role: "user",
+      content: [{ type: "text", text }],
+      startRun: false,
+    });
+  });
+};
+
+describe("useEveAgentRuntime staged messages", () => {
+  it("stages a user message without submitting when startRun is false", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "staged draft");
+
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual([
+        "earlier",
+        "earlier answer",
+        "staged draft",
+      ]);
+    });
+    expect(agent.send).not.toHaveBeenCalled();
+  });
+
+  it("renders new turns and refloats staged drafts after a normal send", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result, rerender } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "staged draft");
+
+    await act(async () => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      });
+    });
+    expect(agent.send).toHaveBeenCalledWith({
+      message: "hello",
+    });
+
+    mockUseEveAgent.mockReturnValue(
+      createAgent({
+        data: {
+          messages: [
+            ...settledData.messages,
+            {
+              id: "u2",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            },
+            {
+              id: "a2",
+              role: "assistant",
+              parts: [{ type: "text", text: "hi there" }],
+            },
+          ],
+        },
+        send: agent.send,
+      }) as never,
+    );
+    rerender();
+
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual([
+        "earlier",
+        "earlier answer",
+        "hello",
+        "hi there",
+        "staged draft",
+      ]);
+    });
+  });
+
+  it("keeps both drafts when two appends stage in the same batch", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await act(async () => {
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "first staged" }],
+        startRun: false,
+      });
+      result.current.thread.append({
+        role: "user",
+        content: [{ type: "text", text: "second staged" }],
+        startRun: false,
+      });
+    });
+
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual([
+        "earlier",
+        "earlier answer",
+        "first staged",
+        "second staged",
+      ]);
+    });
+    expect(agent.send).not.toHaveBeenCalled();
+  });
+
+  it("keeps the unsent staged suffix when a promoted send rejects", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("eve session is already processing a turn."),
+      );
+    const agent = createAgent({ data: settledData, send });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "first staged");
+    await stageMessage(result.current, "second staged");
+
+    const secondStagedId = result.current.thread.getState().messages[3]!.id;
+    await expect(
+      Promise.resolve(
+        result.current.thread.startRun({
+          parentId: secondStagedId,
+          sourceId: null,
+          runConfig: {},
+        }),
+      ),
+    ).rejects.toThrow("eve session is already processing a turn.");
+
+    expect(send).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual([
+        "earlier",
+        "earlier answer",
+        "second staged",
+      ]);
+    });
+  });
+
+  it("keeps later staged messages visible after promoting one staged parent", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "first staged");
+    await stageMessage(result.current, "second staged");
+
+    const firstStagedId = result.current.thread.getState().messages[2]!.id;
+    await act(async () => {
+      await result.current.thread.startRun({
+        parentId: firstStagedId,
+        sourceId: null,
+        runConfig: {},
+      });
+    });
+
+    expect(agent.send).toHaveBeenCalledTimes(1);
+    expect(agent.send).toHaveBeenCalledWith({
+      message: "first staged",
+    });
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual([
+        "earlier",
+        "earlier answer",
+        "second staged",
+      ]);
+    });
+  });
+
+  it("promotes the staged prefix sequentially when reloading the last staged message", async () => {
+    let resolveFirstSend!: () => void;
+    const send = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstSend = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const agent = createAgent({ data: settledData, send });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "first staged");
+    await stageMessage(result.current, "second staged");
+
+    const secondStagedId = result.current.thread.getState().messages[3]!.id;
+    act(() => {
+      void result.current.thread.startRun({
+        parentId: secondStagedId,
+        sourceId: null,
+        runConfig: {},
+      });
+    });
+
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    expect(send).toHaveBeenNthCalledWith(1, {
+      message: "first staged",
+    });
+
+    await act(async () => {
+      resolveFirstSend();
+    });
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+    expect(send).toHaveBeenNthCalledWith(2, {
+      message: "second staged",
+    });
+
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual(["earlier", "earlier answer"]);
+    });
+
+    await expect(
+      Promise.resolve(
+        result.current.thread.startRun({
+          parentId: secondStagedId,
+          sourceId: null,
+          runConfig: {},
+        }),
+      ),
+    ).rejects.toThrow("Runtime does not support reloading messages.");
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps staged drafts when the session collapses to empty", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result, rerender } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "staged draft");
+
+    mockUseEveAgent.mockReturnValue(
+      createAgent({ data: { messages: [] }, send: agent.send }) as never,
+    );
+    rerender();
+
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual(["staged draft"]);
+    });
+  });
+
+  it("still rejects reloading a non-staged message", async () => {
+    const agent = createAgent({ data: settledData });
+    mockUseEveAgent.mockReturnValue(agent as never);
+    const { result } = renderHook(() => useEveAgentRuntime());
+
+    await stageMessage(result.current, "staged draft");
+
+    await expect(
+      Promise.resolve(
+        result.current.thread.startRun({
+          parentId: "a1",
+          sourceId: null,
+          runConfig: {},
+        }),
+      ),
+    ).rejects.toThrow("Runtime does not support reloading messages.");
+    expect(agent.send).not.toHaveBeenCalled();
   });
 });

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -233,12 +233,13 @@ describe("useEveAgentRuntime staged messages", () => {
     expect(agent.send).not.toHaveBeenCalled();
   });
 
-  it("keeps the unsent staged suffix when a promoted send rejects", async () => {
+  it("restores staged drafts when a promoted send rejects and promotes them all on retry", async () => {
     const send = vi
       .fn()
       .mockRejectedValueOnce(
         new Error("eve session is already processing a turn."),
-      );
+      )
+      .mockResolvedValue(undefined);
     const agent = createAgent({ data: settledData, send });
     mockUseEveAgent.mockReturnValue(agent as never);
     const { result } = renderHook(() => useEveAgentRuntime());
@@ -262,8 +263,24 @@ describe("useEveAgentRuntime staged messages", () => {
       expect(getText(result.current)).toEqual([
         "earlier",
         "earlier answer",
+        "first staged",
         "second staged",
       ]);
+    });
+
+    await act(async () => {
+      await result.current.thread.startRun({
+        parentId: secondStagedId,
+        sourceId: null,
+        runConfig: {},
+      });
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenNthCalledWith(2, { message: "first staged" });
+    expect(send).toHaveBeenNthCalledWith(3, { message: "second staged" });
+    await waitFor(() => {
+      expect(getText(result.current)).toEqual(["earlier", "earlier answer"]);
     });
   });
 

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -137,10 +137,13 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
 
   const getStagedRun = (parentId: string | null) => {
     if (!parentId || !stagedInputsRef.current.has(parentId)) return null;
-    const staged: { id: string; message: AppendMessage }[] = [];
+    const staged: {
+      message: ThreadMessage;
+      input: { message: AppendMessage; runConfig: AppendMessage["runConfig"] };
+    }[] = [];
     for (const message of messagesRef.current) {
-      const entry = stagedInputsRef.current.get(message.id);
-      if (entry) staged.push({ id: message.id, message: entry.message });
+      const input = stagedInputsRef.current.get(message.id);
+      if (input) staged.push({ message, input });
       if (message.id === parentId) break;
     }
     return staged;
@@ -187,18 +190,26 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
             const stagedRun = getStagedRun(parentId);
             if (!stagedRun)
               throw new Error("Runtime does not support reloading messages.");
-            for (const entry of stagedRun) {
-              stagedInputsRef.current.delete(entry.id);
-              const nextMessages = messagesRef.current.filter(
-                (message) => message.id !== entry.id,
+            for (const { message: stagedMessage, input } of stagedRun) {
+              const previousMessages = messagesRef.current;
+              stagedInputsRef.current.delete(stagedMessage.id);
+              const nextMessages = previousMessages.filter(
+                (message) => message.id !== stagedMessage.id,
               );
               messagesRef.current = nextMessages;
               setStagedMessages(
                 stagedInputsRef.current.size > 0 ? nextMessages : null,
               );
-              await agent.send({
-                message: getEveMessageContent(entry.message),
-              });
+              try {
+                await agent.send({
+                  message: getEveMessageContent(input.message),
+                });
+              } catch (error) {
+                stagedInputsRef.current.set(stagedMessage.id, input);
+                messagesRef.current = previousMessages;
+                setStagedMessages(previousMessages);
+                throw error;
+              }
             }
           },
         }

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   fromThreadMessageLike,
   generateId,
@@ -34,16 +34,6 @@ const USER_STAGED_STATUS = {
   type: "complete",
   reason: "unknown",
 } as const;
-
-const truncateThreadMessages = (
-  messages: readonly ThreadMessage[],
-  parentId: string | null,
-) => {
-  if (parentId === null) return [];
-  const parentIndex = messages.findIndex((message) => message.id === parentId);
-  if (parentIndex === -1) return [];
-  return messages.slice(0, parentIndex + 1);
-};
 
 export type UseEveAgentRuntimeOptions = Omit<
   UseEveAgentOptions<EveMessageData>,
@@ -133,6 +123,29 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
 
+  useEffect(() => {
+    if (stagedInputsRef.current.size === 0) return;
+    const baseIds = new Set(convertedMessages.map((message) => message.id));
+    const remaining = messagesRef.current.filter(
+      (message) =>
+        stagedInputsRef.current.has(message.id) && !baseIds.has(message.id),
+    );
+    setStagedMessages(
+      remaining.length > 0 ? [...convertedMessages, ...remaining] : null,
+    );
+  }, [convertedMessages]);
+
+  const getStagedRun = (parentId: string | null) => {
+    if (!parentId || !stagedInputsRef.current.has(parentId)) return null;
+    const staged: { id: string; message: AppendMessage }[] = [];
+    for (const message of messagesRef.current) {
+      const entry = stagedInputsRef.current.get(message.id);
+      if (entry) staged.push({ id: message.id, message: entry.message });
+      if (message.id === parentId) break;
+    }
+    return staged;
+  };
+
   const stageUserMessage = (message: AppendMessage) => {
     const threadMessage = fromThreadMessageLike(
       message,
@@ -143,10 +156,9 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
       message,
       runConfig: message.runConfig,
     });
-    setStagedMessages([
-      ...truncateThreadMessages(messagesRef.current, message.parentId),
-      threadMessage,
-    ]);
+    const nextMessages = [...messagesRef.current, threadMessage];
+    messagesRef.current = nextMessages;
+    setStagedMessages(nextMessages);
   };
 
   return useExternalStoreRuntime({
@@ -172,14 +184,22 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     ...(stagedMessages
       ? {
           onReload: async (parentId: string | null) => {
-            const staged = parentId
-              ? stagedInputsRef.current.get(parentId)
-              : null;
-            if (!staged)
+            const stagedRun = getStagedRun(parentId);
+            if (!stagedRun)
               throw new Error("Runtime does not support reloading messages.");
-            stagedInputsRef.current.delete(parentId!);
-            setStagedMessages(null);
-            await agent.send({ message: getEveMessageContent(staged.message) });
+            for (const entry of stagedRun) {
+              stagedInputsRef.current.delete(entry.id);
+              const nextMessages = messagesRef.current.filter(
+                (message) => message.id !== entry.id,
+              );
+              messagesRef.current = nextMessages;
+              setStagedMessages(
+                stagedInputsRef.current.size > 0 ? nextMessages : null,
+              );
+              await agent.send({
+                message: getEveMessageContent(entry.message),
+              });
+            }
           },
         }
       : {}),


### PR DESCRIPTION
Closes #5651

## What

- Adds the reconciliation effect the eve runtime was missing: whenever converted messages change while drafts are staged, the view rebuilds as live base plus staged tail instead of staying pinned to a stale snapshot.
- `onReload` now promotes the staged prefix up to the reloaded message (each sent as its own turn, sequentially) and keeps later staged messages visible instead of discarding them.
- Promoted entries are removed from the staged-input map, closing the leak where entries survived every path except an exact-id reload.

## Why

While auditing the staged flow I hit a hard freeze: a normal send while a draft was staged ran the turn server-side but the UI never updated again, and reloading one of several staged messages silently discarded the rest. #4591 gave react-langchain the reconciliation effect and multi-staged promotion but eve only received the staging entry point, so this is a port of the sibling shape.

## Impact

- Sending while a draft is staged now renders the new turn with the draft floating below it, instead of freezing the thread until remount.
- Promoting one of several staged drafts keeps the others staged and visible.
- No public surface change.

## Scope 

- runConfig forwarding on staged sends is intentionally out of scope: #5629 (open) owns the runConfig-to-clientContext mapping end to end, including the reload precedence; duplicating it here would create a semantic conflict.
- Staging appends at the current view tail and advances the visible ref synchronously, so two appends in the same batch cannot orphan a draft; the parentId truncation helper became dead code with this and is removed (core routes every non-tail-parentId append to `onEdit`, which eve does not expose).
- Promotion deletes each entry and rebuilds the view right before its own send: a rejected send (only the concurrent-turn guard throws) keeps the unsent suffix staged and retryable, and later drafts stay visible while earlier turns run.
- No frozen-base ref (langchain's `stagedBaseMessagesRef`): eve staging is tail-only per the onEdit routing above, so there is no truncated base to preserve.
- Sends are sequential because eve is one message per turn; eve's `send` resolves when the turn completes even if the turn fails, so the loop cannot abort mid-prefix on a turn failure. Whether a failed turn should stop the remaining sends is deferred to the concurrent-send guard work, where an agent ref makes live status readable.
- Staged drafts deliberately survive a session collapse (reset): they are unsent user input, not session state; a test pins this.
- Expected textual conflicts with open #5629/#5630/#5626 (same file); whoever merges second rebases.
- Tests: staging without submit, same-batch double staging, freeze repro flipped green, promote-first-of-two, sequential whole-prefix promotion plus reload capability dropping afterwards,rejected-send restore plus full-prefix retry, reset survival, non-staged reload rejection.
- Changeset: patch (`@assistant-ui/eve`).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nBEHNjS8TJ73MnYW-T2pq8XfgEe_f4AwkFf9Ng6wtnLLfqyTXf1dB1R3fcM?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->