### PR TITLE
feat: framework-neutral store client entry and vue bridge preview

### DIFF
--- a/.changeset/store-neutral-client.md
+++ b/.changeset/store-neutral-client.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: add a framework-neutral client entry with createAssistantClient over a standalone tap root

--- a/.changeset/store-react-peer-optional.md
+++ b/.changeset/store-react-peer-optional.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: make the react peer optional; react-less consumers alias react to @assistant-ui/tap/standalone-shim instead

--- a/.changeset/x-buildutils-react-compiler-gate.md
+++ b/.changeset/x-buildutils-react-compiler-gate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/x-buildutils": patch
+---
+
+fix: only run the react compiler on tap-dependent packages that declare a react peer, so non-React framework bridges do not gain memo caches that run outside any render the compiler understands

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -21,6 +21,15 @@ type AssistantClientAccessor<K extends ClientNames> = ClientSchemas[K]["methods"
   name: K;
 };
 
+type AssistantClientHandle = AssistantClientSource & {
+  destroy(): void;
+};
+
+type AssistantClientSource = {
+  getClient(): AssistantClient;
+  subscribe(listener: () => void): Unsubscribe;
+};
+
 type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
 
 type AssistantEventName = keyof AssistantEventPayload;
@@ -133,6 +142,8 @@ type ClientSchemas = keyof ScopeRegistry extends never ? {
   [K in keyof ScopeRegistry]: ValidateClient<K & string, ScopeRegistry[K]>;
 };
 
+declare const DefaultAssistantClient: AssistantClient;
+
 declare const Derived: <K extends ClientNames>(config: Derived.Props<K>) => DerivedElement<K>;
 
 declare namespace Derived {
@@ -218,6 +229,14 @@ declare const auiConfigBrand: unique symbol;
 
 declare const clientIdBrand: unique symbol;
 
+declare namespace entry_client_exports {
+  export { AssistantClient, AssistantClientHandle, AssistantClientSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, DefaultAssistantClient, Derived, DerivedElement, Unsubscribe, createAssistantClient, getProxiedAssistantState, normalizeEventSelector, useAssistantEmit, useClientResource };
+}
+
+declare const createAssistantClient: (config: AuiConfig.Input, options?: {
+  parent?: AssistantClient | AssistantClientSource | undefined;
+}) => AssistantClientHandle;
+
 declare function forwardTransformScopes(target: Hook, source: Hook): void;
 
 declare const getClientId: (client: object) => getClientId.ClientId;
@@ -227,6 +246,8 @@ declare namespace getClientId {
     readonly [clientIdBrand]: never;
   };
 }
+
+declare const getProxiedAssistantState: (client: AssistantClient) => AssistantState;
 
 declare namespace entry_root_exports {
   export { AssistantClient, AssistantClientAccessor, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventScope, AssistantEventSelector, AssistantState, AuiConfig, AuiIf, AuiProvider, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, Derived, DerivedElement, RenderChildrenWithAccessor, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, forwardTransformScopes, getClientId, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useAui, useAuiEvent, useAuiState, useClientList, useClientLookup, useClientResource };
@@ -296,4 +317,4 @@ declare const useClientResource: <TMethods extends ClientMethods>(element: Resou
   key: string | number | undefined;
 };
 
-export { entry_root_exports as entry_root };
+export { entry_client_exports as entry_client, entry_root_exports as entry_root };

--- a/examples/with-vue/index.html
+++ b/examples/with-vue/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>assistant-ui × Vue</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -15,6 +15,7 @@
     "vue": "^3.5.41"
   },
   "devDependencies": {
+    "@types/react": "^19.2.17",
     "@vitejs/plugin-vue": "^6.0.8",
     "typescript": "^7.0.2",
     "vite": "^8.1.5"

--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "with-vue",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev --port 3000",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "@assistant-ui/store": "workspace:*",
+    "@assistant-ui/tap": "workspace:*",
+    "@assistant-ui/vue": "workspace:*",
+    "vue": "^3.5.41"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.8",
+    "typescript": "^7.0.2",
+    "vite": "^8.1.5"
+  }
+}

--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { useAui, useAuiState } from "@assistant-ui/vue";
+
+const aui = useAui();
+const messages = useAuiState((s) => s.thread.messages);
+const isRunning = useAuiState((s) => s.thread.isRunning);
+const text = useAuiState((s) => s.composer.text);
+
+const send = () => {
+  const value = text.value.trim();
+  if (!value || isRunning.value) return;
+  aui.composer.setText("");
+  aui.thread.append(value);
+};
+</script>
+
+<template>
+  <main class="chat">
+    <h1>assistant-ui × Vue</h1>
+    <ol class="messages">
+      <li
+        v-for="message in messages"
+        :key="message.id"
+        :data-role="message.role"
+      >
+        <span class="role">{{ message.role }}</span>
+        <span>{{ message.text }}</span>
+      </li>
+      <li v-if="isRunning" data-role="assistant">
+        <span class="role">assistant</span>
+        <span>…</span>
+      </li>
+    </ol>
+    <form class="composer" @submit.prevent="send">
+      <input
+        :value="text"
+        name="message"
+        placeholder="Say something"
+        @input="aui.composer.setText(($event.target as HTMLInputElement).value)"
+      />
+      <button type="submit" :disabled="!text.trim() || isRunning">Send</button>
+    </form>
+  </main>
+</template>
+
+<style scoped>
+.chat {
+  max-width: 32rem;
+  margin: 3rem auto;
+  font-family: system-ui, sans-serif;
+}
+.messages {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 12rem;
+}
+.messages li {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: #f2f2f2;
+}
+.messages li[data-role="user"] {
+  background: #e3efff;
+  align-self: flex-end;
+}
+.role {
+  display: block;
+  font-size: 0.7rem;
+  color: #888;
+}
+.composer {
+  display: flex;
+  gap: 0.5rem;
+}
+.composer input {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 0.5rem;
+}
+.composer button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.5rem;
+  background: #111;
+  color: #fff;
+}
+.composer button:disabled {
+  opacity: 0.5;
+}
+</style>

--- a/examples/with-vue/src/Root.vue
+++ b/examples/with-vue/src/Root.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
+import App from "./App.vue";
+import { ComposerScope, ThreadScope } from "./scopes";
+
+const config = AuiConfig({
+  thread: ThreadScope(),
+  composer: ComposerScope(),
+});
+</script>
+
+<template>
+  <AuiProvider :config="config">
+    <App />
+  </AuiProvider>
+</template>

--- a/examples/with-vue/src/env.d.ts
+++ b/examples/with-vue/src/env.d.ts
@@ -1,0 +1,9 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<
+    Record<string, never>,
+    Record<string, never>,
+    unknown
+  >;
+  export default component;
+}

--- a/examples/with-vue/src/main.ts
+++ b/examples/with-vue/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import Root from "./Root.vue";
+
+createApp(Root).mount("#app");

--- a/examples/with-vue/src/scopes.ts
+++ b/examples/with-vue/src/scopes.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { resource } from "@assistant-ui/tap";
+import type {} from "@assistant-ui/store";
 
 export type DemoMessage = {
   id: number;

--- a/examples/with-vue/src/scopes.ts
+++ b/examples/with-vue/src/scopes.ts
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { resource } from "@assistant-ui/tap";
+
+export type DemoMessage = {
+  id: number;
+  role: "user" | "assistant";
+  text: string;
+};
+
+declare module "@assistant-ui/store" {
+  interface ScopeRegistry {
+    thread: {
+      methods: {
+        getState: () => { messages: DemoMessage[]; isRunning: boolean };
+        append: (text: string) => void;
+      };
+    };
+    composer: {
+      methods: {
+        getState: () => { text: string };
+        setText: (text: string) => void;
+      };
+    };
+  }
+}
+
+let nextId = 0;
+
+const useThreadScope = () => {
+  const [messages, setMessages] = useState<DemoMessage[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+
+  return {
+    getState: () => ({ messages, isRunning }),
+    append: (text: string) => {
+      setMessages((prev) => [...prev, { id: nextId++, role: "user", text }]);
+      setIsRunning(true);
+      setTimeout(() => {
+        setMessages((prev) => [
+          ...prev,
+          { id: nextId++, role: "assistant", text: `Echo: ${text}` },
+        ]);
+        setIsRunning(false);
+      }, 600);
+    },
+  };
+};
+export const ThreadScope = resource(useThreadScope);
+
+const useComposerScope = () => {
+  const [text, setText] = useState("");
+  return {
+    getState: () => ({ text }),
+    setText,
+  };
+};
+export const ComposerScope = resource(useComposerScope);

--- a/examples/with-vue/tsconfig.json
+++ b/examples/with-vue/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/with-vue/vite.config.ts
+++ b/examples/with-vue/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+// The assistant-ui runtime is written against react hook imports but runs on
+// @assistant-ui/tap; aliasing react to the standalone shim resolves it with
+// no React installed.
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
+  },
+});

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -7,6 +7,10 @@ Tap-based state container with React Context integration. Bridges `@assistant-ui
 
 `store` powers the runtime layer of assistant-ui. Most users do not install it directly; reach for `@assistant-ui/react` instead.
 
+## Framework-neutral entry
+
+`@assistant-ui/store/client` exposes `createAssistantClient`, which builds the same client inside a standalone tap root with no React renderer. Non-React bindings consume the store through this entry; react-less consumers additionally alias `react` to `@assistant-ui/tap/standalone-shim` in their bundler. The `react` peer dependency is optional for exactly this configuration.
+
 ## Installation
 
 ```bash

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -16,6 +16,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./client": {
+      "types": "./dist/client.d.ts",
+      "default": "./dist/client.js"
     }
   },
   "main": "./dist/index.js",
@@ -39,6 +43,9 @@
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "react": {
       "optional": true
     }
   },

--- a/packages/store/src/client.ts
+++ b/packages/store/src/client.ts
@@ -1,0 +1,31 @@
+// Framework-neutral entry: no module evaluates a React component API, so this
+// graph loads with react installed, or with react aliased to
+// @assistant-ui/tap/standalone-shim, or (types aside) not at all.
+
+export {
+  createAssistantClient,
+  type AssistantClientHandle,
+  type AssistantClientSource,
+} from "./createAssistantClient";
+
+export { DefaultAssistantClient } from "./utils/react-assistant-context";
+export { getProxiedAssistantState } from "./utils/proxied-assistant-state";
+export { useAssistantEmit } from "./utils/tap-assistant-context";
+export { useClientResource } from "./useClientResource";
+
+export { AuiConfig } from "./AuiConfig";
+export { Derived, type DerivedElement } from "./Derived";
+
+export {
+  normalizeEventSelector,
+  type AssistantEventName,
+  type AssistantEventCallback,
+  type AssistantEventSelector,
+  type AssistantEventPayload,
+} from "./types/events";
+
+export type {
+  AssistantClient,
+  AssistantState,
+  Unsubscribe,
+} from "./types/client";

--- a/packages/store/src/createAssistantClient.test.ts
+++ b/packages/store/src/createAssistantClient.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from "vitest";
+import { useEffect, useState } from "react";
+import { flushTapSync, resource } from "@assistant-ui/tap";
+import {
+  createAssistantClient,
+  type AssistantClientHandle,
+} from "./createAssistantClient";
+import { getProxiedAssistantState } from "./utils/proxied-assistant-state";
+import { useAssistantEmit } from "./utils/tap-assistant-context";
+import { useClientResource } from "./useClientResource";
+import { Derived } from "./Derived";
+import type { AssistantClient } from "./types/client";
+
+type AnyClient = Record<string, any>;
+
+const flushEvents = () => new Promise((resolve) => setTimeout(resolve));
+
+const useMessageClient = ({ id }: { id: string }) => {
+  const emit = useAssistantEmit();
+  const [text, setText] = useState("");
+  return {
+    getState: () => ({ id, text }),
+    setText,
+    ping: (value: string) =>
+      emit("message.pinged" as never, { id, value } as never),
+  };
+};
+const MessageClient = resource(useMessageClient);
+
+const useThreadClient = () => {
+  const [selected, setSelected] = useState(0);
+  const m0 = useClientResource(MessageClient({ id: "m0" }));
+  const m1 = useClientResource(MessageClient({ id: "m1" }));
+  const messages = [m0, m1];
+  return {
+    getState: () => ({ selected }),
+    setSelected,
+    message: ({ index }: { index: number }) => messages[index]!.methods,
+  };
+};
+const ThreadClient = resource(useThreadClient);
+
+const messageDerived = () =>
+  Derived({
+    source: "thread",
+    query: {},
+    get: (aui: AnyClient) =>
+      aui.thread.message({ index: aui.thread.getState().selected }),
+  } as never);
+
+const createTestClient = (
+  config: Record<string, unknown>,
+  options?: { parent?: AssistantClient | AssistantClientHandle },
+) =>
+  createAssistantClient(config as never, options as never) as Omit<
+    AssistantClientHandle,
+    "getClient"
+  > & { getClient(): AnyClient };
+
+describe("createAssistantClient", () => {
+  it("hosts scopes without any React renderer", () => {
+    const handle = createTestClient({ thread: ThreadClient() });
+    const aui = handle.getClient();
+
+    expect(aui.thread.getState()).toEqual({ selected: 0 });
+
+    flushTapSync(() => aui.thread.setSelected(1));
+    expect(handle.getClient().thread.getState()).toEqual({ selected: 1 });
+
+    handle.destroy();
+  });
+
+  it("notifies subscribers on value updates and keeps client identity", () => {
+    const handle = createTestClient({ thread: ThreadClient() });
+    const listener = vi.fn();
+    handle.subscribe(listener);
+
+    const before = handle.getClient();
+    flushTapSync(() => before.thread.setSelected(1));
+
+    expect(listener).toHaveBeenCalled();
+    expect(handle.getClient()).toBe(before);
+
+    handle.destroy();
+  });
+
+  it("re-binds derived scopes on structural changes with a new client identity", () => {
+    const handle = createTestClient({
+      thread: ThreadClient(),
+      message: messageDerived(),
+    });
+
+    const before = handle.getClient();
+    expect(before.message.getState().id).toBe("m0");
+
+    flushTapSync(() => before.thread.setSelected(1));
+
+    const after = handle.getClient();
+    expect(after.message.getState().id).toBe("m1");
+    expect(after).not.toBe(before);
+
+    handle.destroy();
+  });
+
+  it("reads state through the proxied assistant state", () => {
+    const handle = createTestClient({ thread: ThreadClient() });
+    const state = getProxiedAssistantState(handle.getClient());
+
+    expect((state as AnyClient).thread.selected).toBe(0);
+    expect((state as AnyClient).optional.missing).toBeUndefined();
+
+    handle.destroy();
+  });
+
+  it("delivers scope-filtered events on a microtask", async () => {
+    const handle = createTestClient({
+      thread: ThreadClient(),
+      message: messageDerived(),
+    });
+    const aui = handle.getClient();
+    const cb = vi.fn();
+    aui.on("message.pinged", cb);
+
+    flushTapSync(() => aui.thread.message({ index: 1 }).ping("other"));
+    await flushEvents();
+    expect(cb).not.toHaveBeenCalled();
+
+    flushTapSync(() => aui.message.ping("bound"));
+    await flushEvents();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith({ id: "m0", value: "bound" });
+
+    handle.destroy();
+  });
+
+  it("extends a parent handle and re-binds across the parent's structural changes", () => {
+    const parent = createTestClient({ thread: ThreadClient() });
+    const child = createTestClient(
+      { message: messageDerived() },
+      { parent: parent as never },
+    );
+
+    expect(child.getClient().message.getState().id).toBe("m0");
+    expect(child.getClient().thread.getState()).toEqual({ selected: 0 });
+
+    flushTapSync(() => parent.getClient().thread.setSelected(1));
+
+    expect(child.getClient().message.getState().id).toBe("m1");
+
+    child.destroy();
+    parent.destroy();
+  });
+
+  it("throws the root scope error for scopes the client does not have", () => {
+    const handle = createTestClient({ thread: ThreadClient() });
+
+    expect(() => handle.getClient().missing.getState()).toThrow(
+      'The current scope does not have a "missing" property.',
+    );
+
+    handle.destroy();
+  });
+
+  it("runs scope effect cleanup on destroy", () => {
+    let cleanups = 0;
+    const useTrackedClient = () => {
+      useEffect(() => {
+        return () => {
+          cleanups++;
+        };
+      }, []);
+      return { getState: () => ({}) };
+    };
+    const TrackedClient = resource(useTrackedClient);
+
+    const handle = createTestClient({ thread: TrackedClient() });
+    handle.getClient();
+
+    const afterCreate = cleanups;
+    handle.destroy();
+    expect(cleanups).toBe(afterCreate + 1);
+  });
+});

--- a/packages/store/src/createAssistantClient.ts
+++ b/packages/store/src/createAssistantClient.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { createTapRoot, flushTapSync } from "@assistant-ui/tap";
+import { useSyncExternalStore } from "react";
+
+import type { AssistantClient, Unsubscribe } from "./types/client";
+import type { AuiConfig } from "./AuiConfig";
+import { DefaultAssistantClient } from "./utils/react-assistant-context";
+import { createNotificationManager } from "./utils/NotificationManager";
+import {
+  applyTransformScopes,
+  useAuiRoot,
+  type ClientRef,
+  type ScopeEntry,
+} from "./useAui";
+
+/**
+ * A live view onto an `AssistantClient` whose identity may change over time.
+ *
+ * `getClient` returns the current client; `subscribe` fires after every state
+ * or structural update. An {@link AssistantClientHandle} is itself a source,
+ * so handles nest directly as the `parent` of another handle.
+ */
+export type AssistantClientSource = {
+  getClient(): AssistantClient;
+  subscribe(listener: () => void): Unsubscribe;
+};
+
+export type AssistantClientHandle = AssistantClientSource & {
+  destroy(): void;
+};
+
+// A client (including the sentinel proxies, whose property reads all resolve)
+// always carries `on`; a source or handle never does, so its absence is the
+// discriminator
+const isClientSource = (
+  parent: AssistantClient | AssistantClientSource,
+): parent is AssistantClientSource =>
+  typeof (parent as AssistantClientSource).getClient === "function" &&
+  !("on" in parent);
+
+const toClientSource = (
+  parent: AssistantClient | AssistantClientSource,
+): AssistantClientSource =>
+  isClientSource(parent)
+    ? parent
+    : {
+        getClient: () => parent as AssistantClient,
+        subscribe: (parent as AssistantClient).subscribe,
+      };
+
+/**
+ * Creates an `AssistantClient` outside any UI framework.
+ *
+ * The client's scopes run as tap resources inside a standalone tap root; no
+ * React renderer is involved. This is the construction seam for non-React
+ * bindings: a framework bridge creates the handle, reads the current client
+ * with `getClient`, re-reads it whenever `subscribe` fires (a structural
+ * change produces a new client object, a value-only update keeps its
+ * identity), and calls `destroy` on teardown.
+ *
+ * The parent may be a plain client or another source/handle. Passing a source
+ * keeps the child bound to the parent's current client across the parent's
+ * structural changes without remounting the child's scopes.
+ *
+ * The config is captured at creation; create a new handle to change the scope
+ * set.
+ */
+export const createAssistantClient = (
+  config: AuiConfig.Input,
+  options?: {
+    parent?: AssistantClient | AssistantClientSource | undefined;
+  },
+): AssistantClientHandle => {
+  const parentSource = toClientSource(
+    options?.parent ?? DefaultAssistantClient,
+  );
+
+  const clientRef: ClientRef = {
+    parent: parentSource.getClient(),
+    current: null,
+  };
+  const notifications = createNotificationManager();
+
+  const root = createTapRoot(function AssistantClientRoot() {
+    const parent = useSyncExternalStore(
+      parentSource.subscribe,
+      parentSource.getClient,
+      parentSource.getClient,
+    );
+    const entries = Object.entries(
+      applyTransformScopes(config, parent),
+    ) as ScopeEntry[];
+    return useAuiRoot({ parent, entries, clientRef, notifications });
+  });
+  clientRef.current = root.getValue().client;
+
+  // flushTapSync makes structural rebinds triggered by a notification land
+  // before the notification returns
+  const notify = () => {
+    clientRef.parent = parentSource.getClient();
+    clientRef.current = root.getValue().client;
+    flushTapSync(notifications.notifySubscribers);
+  };
+  const unsubscribeRoot = root.subscribe(notify);
+  const unsubscribeParent = parentSource.subscribe(notify);
+
+  return {
+    getClient: () => root.getValue().client,
+    subscribe: notifications.subscribe,
+    destroy: () => {
+      unsubscribeRoot();
+      unsubscribeParent();
+      root.unmount();
+    },
+  };
+};

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -54,17 +54,20 @@ const isDevelopment =
   typeof process !== "undefined" &&
   (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");
 
-type ClientRef = { parent: AssistantClient; current: AssistantClient | null };
+export type ClientRef = {
+  parent: AssistantClient;
+  current: AssistantClient | null;
+};
 
 type ScopeElement = ResourceElement<ClientMethods>;
-type ScopeEntry = [name: ClientNames, element: ScopeElement];
+export type ScopeEntry = [name: ClientNames, element: ScopeElement];
 type ScopeMeta = {
   source: ClientNames | "root";
   query: Record<string, unknown>;
 };
 type ScopeAccessor = AssistantClientAccessor<ClientNames>;
 
-const applyTransformScopes = (
+export const applyTransformScopes = (
   clients: useAui.Props,
   parent: AssistantClient,
 ): Record<string, ScopeElement> => {
@@ -243,7 +246,7 @@ const useCommittedClient = (
   return cell.client!;
 };
 
-const useAuiRoot = ({
+export const useAuiRoot = ({
   parent,
   entries,
   clientRef,

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -25,89 +25,91 @@ export type NotificationManager = {
   notifySubscribers(): void;
 };
 
+export const createNotificationManager = (): NotificationManager => {
+  const listeners = new Map<string, Set<InternalCallback>>();
+  const wildcardListeners = new Set<InternalCallback>();
+  const subscribers = new Set<() => void>();
+
+  return {
+    on(event, callback) {
+      const cb = callback as InternalCallback;
+      if (event === "*") {
+        wildcardListeners.add(cb);
+        return () => wildcardListeners.delete(cb);
+      }
+
+      let set = listeners.get(event);
+      if (!set) {
+        set = new Set();
+        listeners.set(event, set);
+      }
+      set.add(cb);
+
+      return () => {
+        set!.delete(cb);
+        if (set!.size === 0) listeners.delete(event);
+      };
+    },
+
+    emit(event, payload, clientStack) {
+      const eventListeners = listeners.get(event);
+      if (!eventListeners && wildcardListeners.size === 0) return;
+
+      queueMicrotask(() => {
+        const errors = [];
+        if (eventListeners) {
+          for (const cb of eventListeners) {
+            try {
+              cb(payload, clientStack);
+            } catch (e) {
+              errors.push(e);
+            }
+          }
+        }
+        if (wildcardListeners.size > 0) {
+          const wrapped = { event, payload };
+          for (const cb of wildcardListeners) {
+            try {
+              cb(wrapped, clientStack);
+            } catch (e) {
+              errors.push(e);
+            }
+          }
+        }
+
+        if (errors.length > 0) {
+          if (errors.length === 1) {
+            throw errors[0];
+          } else {
+            for (const error of errors) {
+              console.error(error);
+            }
+            throw new AggregateError(
+              errors,
+              "Errors occurred during event emission",
+            );
+          }
+        }
+      });
+    },
+
+    subscribe(callback) {
+      subscribers.add(callback);
+      return () => subscribers.delete(callback);
+    },
+
+    notifySubscribers() {
+      for (const cb of subscribers) {
+        try {
+          cb();
+        } catch (e) {
+          console.error("NotificationManager: subscriber callback error", e);
+        }
+      }
+    },
+  };
+};
+
 export const useNotificationManager = (): NotificationManager => {
-  return useState<NotificationManager>(() => {
-    const listeners = new Map<string, Set<InternalCallback>>();
-    const wildcardListeners = new Set<InternalCallback>();
-    const subscribers = new Set<() => void>();
-
-    return {
-      on(event, callback) {
-        const cb = callback as InternalCallback;
-        if (event === "*") {
-          wildcardListeners.add(cb);
-          return () => wildcardListeners.delete(cb);
-        }
-
-        let set = listeners.get(event);
-        if (!set) {
-          set = new Set();
-          listeners.set(event, set);
-        }
-        set.add(cb);
-
-        return () => {
-          set!.delete(cb);
-          if (set!.size === 0) listeners.delete(event);
-        };
-      },
-
-      emit(event, payload, clientStack) {
-        const eventListeners = listeners.get(event);
-        if (!eventListeners && wildcardListeners.size === 0) return;
-
-        queueMicrotask(() => {
-          const errors = [];
-          if (eventListeners) {
-            for (const cb of eventListeners) {
-              try {
-                cb(payload, clientStack);
-              } catch (e) {
-                errors.push(e);
-              }
-            }
-          }
-          if (wildcardListeners.size > 0) {
-            const wrapped = { event, payload };
-            for (const cb of wildcardListeners) {
-              try {
-                cb(wrapped, clientStack);
-              } catch (e) {
-                errors.push(e);
-              }
-            }
-          }
-
-          if (errors.length > 0) {
-            if (errors.length === 1) {
-              throw errors[0];
-            } else {
-              for (const error of errors) {
-                console.error(error);
-              }
-              throw new AggregateError(
-                errors,
-                "Errors occurred during event emission",
-              );
-            }
-          }
-        });
-      },
-
-      subscribe(callback) {
-        subscribers.add(callback);
-        return () => subscribers.delete(callback);
-      },
-
-      notifySubscribers() {
-        for (const cb of subscribers) {
-          try {
-            cb();
-          } catch (e) {
-            console.error("NotificationManager: subscriber callback error", e);
-          }
-        }
-      },
-    };
-  })[0];
+  return useState(createNotificationManager)[0];
 };

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -21,8 +21,24 @@ export default defineConfig({
 ## Usage
 
 ```vue
+<!-- Root.vue -->
 <script setup lang="ts">
-import { AuiProvider, AuiConfig, useAui, useAuiState } from "@assistant-ui/vue";
+import { AuiProvider, AuiConfig } from "@assistant-ui/vue";
+import Composer from "./Composer.vue";
+import { ThreadScope } from "./scopes";
+
+const config = AuiConfig({ thread: ThreadScope() });
+</script>
+
+<template>
+  <AuiProvider :config="config"><Composer /></AuiProvider>
+</template>
+```
+
+```vue
+<!-- Composer.vue -->
+<script setup lang="ts">
+import { useAui, useAuiState } from "@assistant-ui/vue";
 
 const aui = useAui();
 const isRunning = useAuiState((s) => s.thread.isRunning);

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -25,9 +25,12 @@ export default defineConfig({
 <script setup lang="ts">
 import { AuiProvider, AuiConfig } from "@assistant-ui/vue";
 import Composer from "./Composer.vue";
-import { ThreadScope } from "./scopes";
+import { ComposerScope, ThreadScope } from "./scopes";
 
-const config = AuiConfig({ thread: ThreadScope() });
+const config = AuiConfig({
+  thread: ThreadScope(),
+  composer: ComposerScope(),
+});
 </script>
 
 <template>

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,38 @@
+# `@assistant-ui/vue`
+
+> Not published yet. This package is the in-repo preview of the Vue bridge and stays private until the Vue integration is complete.
+
+Vue bindings for assistant-ui. Bridges the framework-neutral `@assistant-ui/store` client into Vue via `<AuiProvider>`, `useAui`, `useAuiState`, and `useAuiEvent`.
+
+The runtime layer runs on `@assistant-ui/tap`, a headless hooks runtime that needs no React renderer. Alias `react` to `@assistant-ui/tap/standalone-shim` in your bundler so the shared runtime code resolves without React installed:
+
+```ts
+// vite.config.ts
+export default defineConfig({
+  resolve: {
+    alias: {
+      "react/compiler-runtime": "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      react: "@assistant-ui/tap/standalone-shim",
+    },
+  },
+});
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { AuiProvider, AuiConfig, useAui, useAuiState } from "@assistant-ui/vue";
+
+const aui = useAui();
+const isRunning = useAuiState((s) => s.thread.isRunning);
+</script>
+
+<template>
+  <button :disabled="isRunning" @click="aui.composer.send()">Send</button>
+</template>
+```
+
+`useAui` returns a stable client whose scope accessors always resolve to the provider's current client. `useAuiState` returns a computed ref that updates when the selected slice changes by `Object.is`. `useAuiEvent` subscribes to assistant events for the lifetime of the current effect scope.
+
+See `examples/with-vue` in the repository for a complete Vite setup.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@assistant-ui/vue",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Vue bindings for assistant-ui",
+  "keywords": [
+    "vue",
+    "assistant-ui",
+    "store",
+    "tap",
+    "state-management"
+  ],
+  "author": "AgentbaseAI Inc.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "aui-build",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@assistant-ui/store": "^0.3.3",
+    "@assistant-ui/tap": "^0.9.9"
+  },
+  "peerDependencies": {
+    "vue": "^3.5.0"
+  },
+  "devDependencies": {
+    "@assistant-ui/x-buildutils": "workspace:*",
+    "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.10",
+    "vue": "^3.5.41"
+  },
+  "homepage": "https://www.assistant-ui.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/assistant-ui/assistant-ui.git",
+    "directory": "packages/vue"
+  },
+  "bugs": {
+    "url": "https://github.com/assistant-ui/assistant-ui/issues"
+  }
+}

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -1,0 +1,69 @@
+import {
+  defineComponent,
+  inject,
+  onScopeDispose,
+  provide,
+  watch,
+  type PropType,
+  type SlotsType,
+} from "vue";
+import {
+  createAssistantClient,
+  type AuiConfig,
+} from "@assistant-ui/store/client";
+import { auiInjectionKey, createClientFacade } from "./context";
+
+const isDevelopment =
+  typeof process !== "undefined" &&
+  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");
+
+/**
+ * Creates an `AssistantClient` from the given config and provides it to the
+ * subtree. Nested providers extend the nearest ancestor's client; scopes the
+ * config does not define resolve through the parent chain.
+ *
+ * The config is captured when the provider mounts; swapping the `config` prop
+ * afterwards is not supported. Remount the provider (for example with a
+ * `key`) to change the scope set.
+ */
+export const AuiProvider = defineComponent({
+  name: "AuiProvider",
+  props: {
+    config: {
+      type: Object as PropType<AuiConfig>,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const parent = inject(auiInjectionKey, null);
+
+    const handle = createAssistantClient(
+      props.config,
+      parent ? { parent: parent.source } : undefined,
+    );
+    onScopeDispose(() => handle.destroy());
+
+    const source = {
+      getClient: handle.getClient,
+      subscribe: handle.subscribe,
+    };
+    provide(auiInjectionKey, {
+      source,
+      aui: createClientFacade(source),
+    });
+
+    if (isDevelopment) {
+      watch(
+        () => props.config,
+        () => {
+          console.warn(
+            "[assistant-ui] AuiProvider does not support swapping `config` after mount; remount the provider with a `key` to change the scope set.",
+          );
+        },
+      );
+    }
+
+    return () => slots.default?.();
+  },
+});

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -3,7 +3,6 @@ import {
   inject,
   onScopeDispose,
   provide,
-  watch,
   type PropType,
   type SlotsType,
 } from "vue";
@@ -12,10 +11,6 @@ import {
   type AuiConfig,
 } from "@assistant-ui/store/client";
 import { auiInjectionKey, createClientFacade } from "./context";
-
-const isDevelopment =
-  typeof process !== "undefined" &&
-  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");
 
 /**
  * Creates an `AssistantClient` from the given config and provides it to the
@@ -52,17 +47,6 @@ export const AuiProvider = defineComponent({
       source,
       aui: createClientFacade(source),
     });
-
-    if (isDevelopment) {
-      watch(
-        () => props.config,
-        () => {
-          console.warn(
-            "[assistant-ui] AuiProvider does not support swapping `config` after mount; remount the provider with a `key` to change the scope set.",
-          );
-        },
-      );
-    }
 
     return () => slots.default?.();
   },

--- a/packages/vue/src/__tests__/AuiProvider.test.ts
+++ b/packages/vue/src/__tests__/AuiProvider.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig, type AssistantClient } from "@assistant-ui/store/client";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import {
+  ThreadClient,
+  messageDerived,
+  trackers,
+  type AnyClient,
+} from "./fixtures";
+
+const mountApp = (root: Component) => {
+  const app = createApp(root);
+  const el = document.createElement("div");
+  app.mount(el);
+  return { app, unmount: () => app.unmount() };
+};
+
+const captureAui = () => {
+  let aui!: AnyClient;
+  const Probe = defineComponent({
+    setup() {
+      aui = useAui() as AnyClient;
+      return () => null;
+    },
+  });
+  return { Probe, getAui: () => aui };
+};
+
+describe("AuiProvider", () => {
+  it("provides a client built from the config", () => {
+    const { Probe, getAui } = captureAui();
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({ thread: ThreadClient() } as never) },
+            { default: () => h(Probe) },
+          ),
+      }),
+    );
+
+    expect(getAui().thread.getState()).toEqual({ selected: 0 });
+
+    flushTapSync(() => getAui().thread.setSelected(1));
+    expect(getAui().thread.getState()).toEqual({ selected: 1 });
+
+    unmount();
+  });
+
+  it("keeps the facade stable across structural changes", () => {
+    const { Probe, getAui } = captureAui();
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            {
+              config: AuiConfig({
+                thread: ThreadClient(),
+                message: messageDerived(),
+              } as never),
+            },
+            { default: () => h(Probe) },
+          ),
+      }),
+    );
+
+    const aui = getAui();
+    expect(aui.message.getState().id).toBe("m0");
+
+    flushTapSync(() => aui.thread.setSelected(1));
+
+    expect(getAui()).toBe(aui);
+    expect(aui.message.getState().id).toBe("m1");
+
+    unmount();
+  });
+
+  it("extends the parent provider's client in nested providers", () => {
+    const { Probe, getAui } = captureAui();
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({ thread: ThreadClient() } as never) },
+            {
+              default: () =>
+                h(
+                  AuiProvider,
+                  { config: AuiConfig({ message: messageDerived() } as never) },
+                  { default: () => h(Probe) },
+                ),
+            },
+          ),
+      }),
+    );
+
+    const aui = getAui();
+    expect(aui.message.getState().id).toBe("m0");
+    expect(aui.thread.getState()).toEqual({ selected: 0 });
+
+    flushTapSync(() => aui.thread.setSelected(1));
+    expect(aui.message.getState().id).toBe("m1");
+
+    unmount();
+  });
+
+  it("destroys the client on unmount", () => {
+    const before = trackers.threadCleanups;
+    const { Probe } = captureAui();
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({ thread: ThreadClient() } as never) },
+            { default: () => h(Probe) },
+          ),
+      }),
+    );
+
+    const afterMount = trackers.threadCleanups;
+    unmount();
+    expect(trackers.threadCleanups).toBe(afterMount + 1);
+    expect(afterMount).toBeGreaterThanOrEqual(before);
+  });
+
+  it("returns the throwing default client outside a provider", () => {
+    let aui!: AssistantClient;
+    const { unmount } = mountApp(
+      defineComponent({
+        setup() {
+          aui = useAui();
+          return () => null;
+        },
+      }),
+    );
+
+    expect(() => (aui as AnyClient).thread.getState()).toThrow(
+      "Wrap your component in an <AuiProvider> component.",
+    );
+
+    unmount();
+  });
+});

--- a/packages/vue/src/__tests__/dist-graph.test.ts
+++ b/packages/vue/src/__tests__/dist-graph.test.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const DIST_DIR = resolve(__dirname, "../../dist");
+const DIST_ENTRY = resolve(DIST_DIR, "index.js");
+
+describe("@assistant-ui/vue dist graph", () => {
+  it.skipIf(!existsSync(DIST_ENTRY))(
+    "contains no react, react-shim, or compiler-runtime references",
+    () => {
+      const visited = new Set<string>();
+      const pending = [DIST_ENTRY];
+      const violations: string[] = [];
+
+      while (pending.length > 0) {
+        const file = pending.pop()!;
+        if (visited.has(file)) continue;
+        visited.add(file);
+
+        const source = readFileSync(file, "utf8");
+        for (const match of source.matchAll(
+          /(?:from\s+|import\s+)["']([^"']+)["']/g,
+        )) {
+          const specifier = match[1]!;
+          if (
+            specifier === "react" ||
+            specifier.startsWith("react/") ||
+            specifier.includes("react-shim") ||
+            specifier.includes("compiler-runtime")
+          ) {
+            violations.push(`${relative(DIST_DIR, file)} -> ${specifier}`);
+            continue;
+          }
+          if (specifier.startsWith(".")) {
+            pending.push(resolve(dirname(file), specifier));
+          }
+        }
+      }
+
+      expect(
+        violations,
+        `The vue bridge must build without the react compiler: aui-build's compiler gate requires a react peer, and this package must never declare one. Violations:\n` +
+          violations.map((v) => `  - ${v}`).join("\n"),
+      ).toEqual([]);
+    },
+  );
+});

--- a/packages/vue/src/__tests__/fixtures.ts
+++ b/packages/vue/src/__tests__/fixtures.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { resource } from "@assistant-ui/tap";
+import {
+  Derived,
+  useAssistantEmit,
+  useClientResource,
+} from "@assistant-ui/store/client";
+
+export type AnyClient = Record<string, any>;
+
+export const flushEvents = () => new Promise((resolve) => setTimeout(resolve));
+
+export const trackers = { threadCleanups: 0 };
+
+const useMessageClient = ({ id }: { id: string }) => {
+  const emit = useAssistantEmit();
+  const [text, setText] = useState("");
+  return {
+    getState: () => ({ id, text }),
+    setText,
+    ping: (value: string) =>
+      emit("message.pinged" as never, { id, value } as never),
+  };
+};
+const MessageClient = resource(useMessageClient);
+
+const useThreadClient = () => {
+  const [selected, setSelected] = useState(0);
+  const m0 = useClientResource(MessageClient({ id: "m0" }));
+  const m1 = useClientResource(MessageClient({ id: "m1" }));
+  const messages = [m0, m1];
+  useEffect(() => {
+    return () => {
+      trackers.threadCleanups++;
+    };
+  }, []);
+  return {
+    getState: () => ({ selected }),
+    setSelected,
+    message: ({ index }: { index: number }) => messages[index]!.methods,
+  };
+};
+export const ThreadClient = resource(useThreadClient);
+
+export const messageDerived = () =>
+  Derived({
+    source: "thread",
+    query: {},
+    get: (aui: AnyClient) =>
+      aui.thread.message({ index: aui.thread.getState().selected }),
+  } as never);

--- a/packages/vue/src/__tests__/useAuiEvent.test.ts
+++ b/packages/vue/src/__tests__/useAuiEvent.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { useAuiEvent } from "../useAuiEvent";
+import {
+  ThreadClient,
+  flushEvents,
+  messageDerived,
+  type AnyClient,
+} from "./fixtures";
+
+const mountWithProvider = (setup: () => void) => {
+  const Probe = defineComponent({
+    setup() {
+      setup();
+      return () => null;
+    },
+  });
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              thread: ThreadClient(),
+              message: messageDerived(),
+            } as never),
+          },
+          { default: () => h(Probe) },
+        ),
+    }) as Component,
+  );
+  app.mount(document.createElement("div"));
+  return { unmount: () => app.unmount() };
+};
+
+describe("useAuiEvent", () => {
+  it("delivers scope-filtered events on a microtask", async () => {
+    let aui!: AnyClient;
+    const cb = vi.fn();
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      useAuiEvent("message.pinged" as never, cb as never);
+    });
+
+    flushTapSync(() => aui.thread.message({ index: 1 }).ping("other"));
+    await flushEvents();
+    expect(cb).not.toHaveBeenCalled();
+
+    flushTapSync(() => aui.message.ping("bound"));
+    await flushEvents();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith({ id: "m0", value: "bound" });
+
+    unmount();
+  });
+
+  it("follows the client across structural changes", async () => {
+    let aui!: AnyClient;
+    const cb = vi.fn();
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      useAuiEvent("message.pinged" as never, cb as never);
+    });
+
+    flushTapSync(() => aui.thread.setSelected(1));
+
+    flushTapSync(() => aui.message.ping("after-rebind"));
+    await flushEvents();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb).toHaveBeenCalledWith({ id: "m1", value: "after-rebind" });
+
+    unmount();
+  });
+
+  it("stops delivering after unmount", async () => {
+    let aui!: AnyClient;
+    const cb = vi.fn();
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      useAuiEvent("message.pinged" as never, cb as never);
+    });
+
+    unmount();
+
+    flushTapSync(() => aui.thread.message({ index: 0 }).ping("late"));
+    await flushEvents();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vue/src/__tests__/useAuiState.test.ts
+++ b/packages/vue/src/__tests__/useAuiState.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  watch,
+  type Component,
+  type ComputedRef,
+} from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+import { ThreadClient, messageDerived, type AnyClient } from "./fixtures";
+
+const mountWithProvider = (setup: () => void) => {
+  const Probe = defineComponent({
+    setup() {
+      setup();
+      return () => null;
+    },
+  });
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              thread: ThreadClient(),
+              message: messageDerived(),
+            } as never),
+          },
+          { default: () => h(Probe) },
+        ),
+    }) as Component,
+  );
+  app.mount(document.createElement("div"));
+  return { unmount: () => app.unmount() };
+};
+
+describe("useAuiState", () => {
+  it("selects state and updates when the store notifies", () => {
+    let aui!: AnyClient;
+    let selected!: ComputedRef<number>;
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      selected = useAuiState((s) => (s as AnyClient).thread.selected);
+    });
+
+    expect(selected.value).toBe(0);
+
+    flushTapSync(() => aui.thread.setSelected(1));
+    expect(selected.value).toBe(1);
+
+    unmount();
+  });
+
+  it("updates through the real scheduler without a manual flush", async () => {
+    let aui!: AnyClient;
+    let selected!: ComputedRef<number>;
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      selected = useAuiState((s) => (s as AnyClient).thread.selected);
+    });
+
+    aui.thread.setSelected(1);
+    await new Promise((resolve) => setTimeout(resolve));
+    expect(selected.value).toBe(1);
+
+    unmount();
+  });
+
+  it("re-runs watchers only when the slice changes by Object.is", async () => {
+    let aui!: AnyClient;
+    let id!: ComputedRef<string>;
+    const watcher = vi.fn();
+    const { unmount } = mountWithProvider(() => {
+      aui = useAui() as AnyClient;
+      id = useAuiState((s) => (s as AnyClient).message.id);
+      watch(id, watcher);
+    });
+
+    flushTapSync(() => aui.thread.message({ index: 0 }).setText("hello"));
+    await nextTick();
+    expect(watcher).not.toHaveBeenCalled();
+
+    flushTapSync(() => aui.thread.setSelected(1));
+    await nextTick();
+    expect(watcher).toHaveBeenCalledTimes(1);
+    expect(id.value).toBe("m1");
+
+    unmount();
+  });
+
+  it("throws when the selector returns the whole state", () => {
+    let state!: ComputedRef<unknown>;
+    const { unmount } = mountWithProvider(() => {
+      state = useAuiState((s) => s);
+    });
+
+    expect(() => state.value).toThrow(
+      "You tried to return the entire AssistantState.",
+    );
+
+    unmount();
+  });
+
+  it("resolves unavailable scopes to undefined via optional", () => {
+    let missing!: ComputedRef<unknown>;
+    const { unmount } = mountWithProvider(() => {
+      missing = useAuiState((s) => (s.optional as AnyClient).missing);
+    });
+
+    expect(missing.value).toBeUndefined();
+
+    unmount();
+  });
+});

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -35,7 +35,12 @@ export const createClientFacade = (
   new Proxy({} as AssistantClient, {
     get: (_target, prop) => Reflect.get(source.getClient(), prop),
     has: (_target, prop) => prop in source.getClient(),
-    ownKeys: () => Reflect.ownKeys(source.getClient()),
+    ownKeys: () => {
+      const client = source.getClient();
+      const keys = new Set<string | symbol>(Reflect.ownKeys(client));
+      for (const key in client) keys.add(key);
+      return [...keys];
+    },
     getOwnPropertyDescriptor: (_target, prop) => {
       const client = source.getClient();
       if (!(prop in client)) return undefined;

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -1,0 +1,48 @@
+import { inject, type InjectionKey } from "vue";
+import {
+  DefaultAssistantClient,
+  type AssistantClient,
+  type AssistantClientSource,
+} from "@assistant-ui/store/client";
+
+export type AuiContext = {
+  source: AssistantClientSource;
+  aui: AssistantClient;
+};
+
+export const auiInjectionKey: InjectionKey<AuiContext> = Symbol(
+  "assistant-ui.vue.aui",
+);
+
+const NO_OP_SUBSCRIBE = () => () => {};
+
+const defaultContext: AuiContext = {
+  source: {
+    getClient: () => DefaultAssistantClient,
+    subscribe: NO_OP_SUBSCRIBE,
+  },
+  aui: DefaultAssistantClient,
+};
+
+export const useAuiContext = (): AuiContext =>
+  inject(auiInjectionKey, defaultContext);
+
+// The client object changes identity on structural updates; the facade keeps
+// one stable object per provider that always forwards to the current client
+export const createClientFacade = (
+  source: AssistantClientSource,
+): AssistantClient =>
+  new Proxy({} as AssistantClient, {
+    get: (_target, prop) => Reflect.get(source.getClient(), prop),
+    has: (_target, prop) => prop in source.getClient(),
+    ownKeys: () => Reflect.ownKeys(source.getClient()),
+    getOwnPropertyDescriptor: (_target, prop) => {
+      const client = source.getClient();
+      if (!(prop in client)) return undefined;
+      return {
+        configurable: true,
+        enumerable: true,
+        value: Reflect.get(client, prop),
+      };
+    },
+  });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,18 @@
+export { AuiProvider } from "./AuiProvider";
+export { useAui } from "./useAui";
+export { useAuiState } from "./useAuiState";
+export { useAuiEvent } from "./useAuiEvent";
+
+export {
+  AuiConfig,
+  Derived,
+  createAssistantClient,
+  type AssistantClient,
+  type AssistantClientHandle,
+  type AssistantClientSource,
+  type AssistantState,
+  type AssistantEventCallback,
+  type AssistantEventName,
+  type AssistantEventSelector,
+  type Unsubscribe,
+} from "@assistant-ui/store/client";

--- a/packages/vue/src/useAui.ts
+++ b/packages/vue/src/useAui.ts
@@ -1,0 +1,18 @@
+import type { AssistantClient } from "@assistant-ui/store/client";
+import { useAuiContext } from "./context";
+
+/**
+ * Returns the `AssistantClient` provided by the nearest {@link AuiProvider}.
+ *
+ * The returned object is stable for the lifetime of the provider and always
+ * forwards to the provider's current client, so it can be captured once and
+ * used in event handlers: `aui.composer.send()`, `aui.thread.cancelRun()`.
+ * Pair with {@link useAuiState} to read reactive state and
+ * {@link useAuiEvent} to subscribe to events.
+ *
+ * Called outside a provider, the returned client's scope accessors throw a
+ * descriptive error whenever they are used.
+ */
+export const useAui = (): AssistantClient => {
+  return useAuiContext().aui;
+};

--- a/packages/vue/src/useAuiEvent.ts
+++ b/packages/vue/src/useAuiEvent.ts
@@ -1,0 +1,53 @@
+import { onScopeDispose } from "vue";
+import {
+  normalizeEventSelector,
+  type AssistantClient,
+  type AssistantEventCallback,
+  type AssistantEventName,
+  type AssistantEventSelector,
+  type Unsubscribe,
+} from "@assistant-ui/store/client";
+import { useAuiContext } from "./context";
+
+/**
+ * Subscribes to an assistant event for the lifetime of the current effect
+ * scope.
+ *
+ * The subscription follows the provider's current client across structural
+ * changes. Use `scope: "*"` to receive emissions from any descendant scope.
+ *
+ * @example
+ * ```ts
+ * useAuiEvent("thread.modelContextUpdate", ({ threadId }) => {
+ *   analytics.track("model_context_update", { threadId });
+ * });
+ * ```
+ */
+export const useAuiEvent = <TEvent extends AssistantEventName>(
+  selector: AssistantEventSelector<TEvent>,
+  callback: AssistantEventCallback<TEvent>,
+): void => {
+  const { source } = useAuiContext();
+  const { scope, event } = normalizeEventSelector(selector);
+
+  let bound: AssistantClient | undefined;
+  let off: Unsubscribe | undefined;
+
+  const bind = () => {
+    const client = source.getClient();
+    if (client === bound) return;
+    off?.();
+    bound = client;
+    off = client.on(
+      { scope, event } as AssistantEventSelector<TEvent>,
+      callback,
+    );
+  };
+
+  bind();
+  const unsubscribe = source.subscribe(bind);
+  onScopeDispose(() => {
+    unsubscribe();
+    off?.();
+  });
+};

--- a/packages/vue/src/useAuiState.ts
+++ b/packages/vue/src/useAuiState.ts
@@ -1,0 +1,55 @@
+import { computed, onScopeDispose, shallowRef, type ComputedRef } from "vue";
+import {
+  getProxiedAssistantState,
+  type AssistantState,
+} from "@assistant-ui/store/client";
+import { useAuiContext } from "./context";
+
+/**
+ * Subscribes to a slice of `AssistantState` and returns it as a computed ref.
+ *
+ * The `selector` runs on every store update; dependents re-run only when the
+ * selected slice changes by `Object.is`. Returning the entire state object is
+ * not supported and throws — select a specific field instead, or compose
+ * multiple `useAuiState` calls. Returning a fresh object or array literal
+ * re-triggers dependents on every update; select primitives or a memoized
+ * reference.
+ *
+ * Scopes that may be unavailable can be read via `s.optional.<scope>`, which
+ * resolves to `undefined` instead of throwing.
+ *
+ * @example
+ * ```ts
+ * const isRunning = useAuiState((s) => s.thread.isRunning);
+ * // template: <button :disabled="isRunning">…</button>
+ * ```
+ */
+export const useAuiState = <T>(
+  selector: (state: AssistantState) => T,
+): ComputedRef<T> => {
+  const { source } = useAuiContext();
+
+  const version = shallowRef(0);
+  const unsubscribe = source.subscribe(() => {
+    version.value++;
+  });
+  onScopeDispose(unsubscribe);
+
+  return computed(() => {
+    void version.value;
+    const state = getProxiedAssistantState(source.getClient());
+    const slice = selector(state);
+
+    if (
+      typeof slice === "object" &&
+      slice !== null &&
+      ((slice as unknown) === state || (slice as unknown) === state.optional)
+    ) {
+      throw new Error(
+        "You tried to return the entire AssistantState. This is not supported due to technical limitations.",
+      );
+    }
+
+    return slice;
+  });
+};

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@assistant-ui/x-buildutils/ts/base",
+  "include": ["src"]
+}

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+
+// `react` resolves to tap's standalone shim, so this suite is the
+// react-less integration proof for the whole chain: tap standalone shim,
+// the store client entry (dist), and the Vue bridge.
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^react\/compiler-runtime$/,
+        replacement: "@assistant-ui/tap/standalone-shim/compiler-runtime",
+      },
+      { find: /^react$/, replacement: "@assistant-ui/tap/standalone-shim" },
+    ],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+  },
+});

--- a/packages/x-buildutils/src/index.ts
+++ b/packages/x-buildutils/src/index.ts
@@ -66,12 +66,15 @@ await build({
   sourcemap: true,
   watch: isDev,
   ...(onSuccess ? { onSuccess } : {}),
-  // React Compiler shares the dependency gate: compiled output's memo cache only
-  // works inside tap renders through the shimmed `react/compiler-runtime`, and
-  // tap itself (which implements the hooks the compiler output runs on) must
-  // never be compiled.
+  // React Compiler shares the dependency gate, narrowed to packages that
+  // declare a react peer: compiled output's memo cache only works inside tap
+  // renders through the shimmed `react/compiler-runtime`. Tap itself (which
+  // implements the hooks the compiler output runs on) must never be compiled,
+  // and neither must a non-React framework bridge, whose use-prefixed
+  // composables would otherwise gain memo caches that run outside any render
+  // the compiler understands.
   plugins: [
-    ...(dependsOnTap ? [reactCompiler()] : []),
+    ...(dependsOnTap && pkg.peerDependencies?.react ? [reactCompiler()] : []),
     preserveReferenceDirectives(),
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3272,6 +3272,9 @@ importers:
         specifier: ^3.5.41
         version: 3.5.41(typescript@7.0.2)
     devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: 0.82.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.1)(zod@4.4.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@modelcontextprotocol/client':
         specifier: ^2.0.0
         version: 2.0.0
@@ -215,7 +215,7 @@ importers:
         version: 5.4.2(@sinclair/typebox@0.27.12)(@standard-schema/spec@1.1.0)(ajv@8.20.0)(react-hook-form@7.83.0(react@19.2.8))(valibot@1.4.2(typescript@7.0.2))(zod@4.4.3)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@modelcontextprotocol/server':
         specifier: ^2.0.0
         version: 2.0.0
@@ -233,10 +233,10 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       ai:
         specifier: ^7.0.37
         version: 7.0.37(zod@4.4.3)
@@ -2193,10 +2193,10 @@ importers:
         version: link:../../packages/ui
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2266,10 +2266,10 @@ importers:
         version: link:../../packages/ui
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3257,6 +3257,31 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  examples/with-vue:
+    dependencies:
+      '@assistant-ui/store':
+        specifier: workspace:*
+        version: link:../../packages/store
+      '@assistant-ui/tap':
+        specifier: workspace:*
+        version: link:../../packages/tap
+      '@assistant-ui/vue':
+        specifier: workspace:*
+        version: link:../../packages/vue
+      vue:
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@7.0.2)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.8
+        version: 6.0.8(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.5
+        version: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
   packages/agent-launcher:
     dependencies:
       cross-spawn:
@@ -4170,10 +4195,10 @@ importers:
         version: 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -4213,7 +4238,7 @@ importers:
         version: link:../x-buildutils
       '@langchain/langgraph-sdk':
         specifier: ^1.9.28
-        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -4828,6 +4853,31 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  packages/vue:
+    dependencies:
+      '@assistant-ui/store':
+        specifier: ^0.3.3
+        version: link:../store
+      '@assistant-ui/tap':
+        specifier: ^0.9.9
+        version: link:../tap
+    devDependencies:
+      '@assistant-ui/x-buildutils':
+        specifier: workspace:*
+        version: link:../x-buildutils
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+      vue:
+        specifier: ^3.5.41
+        version: 3.5.41(typescript@7.0.2)
+
   packages/x-buildutils:
     dependencies:
       '@babel/core':
@@ -5249,10 +5299,10 @@ importers:
         version: 1.5.2(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
       '@langchain/langgraph':
         specifier: ^1.4.8
-        version: 1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        version: 1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
       '@langchain/react':
         specifier: ^1.0.29
-        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -5295,7 +5345,7 @@ importers:
         version: 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/langgraph-cli':
         specifier: ^1.4.3
-        version: 1.4.3(94b95f4182030aa6c89acfaa05f846f1)
+        version: 1.4.3(0de05fe9d7a3a34b0f6f89a2600697d8)
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -5658,6 +5708,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.61':
     resolution: {integrity: sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==}
@@ -5928,6 +5981,11 @@ packages:
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -6231,6 +6289,10 @@ packages:
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.4':
@@ -10751,6 +10813,13 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitejs/plugin-vue@6.0.8':
+    resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
   '@vitest/coverage-v8@4.1.10':
     resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
     peerDependencies:
@@ -10793,6 +10862,33 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@vue/compiler-core@3.5.41':
+    resolution: {integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==}
+
+  '@vue/compiler-dom@3.5.41':
+    resolution: {integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==}
+
+  '@vue/compiler-sfc@3.5.41':
+    resolution: {integrity: sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==}
+
+  '@vue/compiler-ssr@3.5.41':
+    resolution: {integrity: sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==}
+
+  '@vue/reactivity@3.5.41':
+    resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
+
+  '@vue/runtime-core@3.5.41':
+    resolution: {integrity: sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==}
+
+  '@vue/runtime-dom@3.5.41':
+    resolution: {integrity: sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==}
+
+  '@vue/server-renderer@3.5.41':
+    resolution: {integrity: sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==}
+
+  '@vue/shared@3.5.41':
+    resolution: {integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==}
 
   '@workflow/serde@4.1.0':
     resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
@@ -12532,6 +12628,9 @@ packages:
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -17738,6 +17837,14 @@ packages:
   vscode-languageserver-types@3.18.0:
     resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
 
+  vue@3.5.41:
+    resolution: {integrity: sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -18574,10 +18681,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
       '@babel/helpers': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -18589,8 +18696,8 @@ snapshots:
 
   '@babel/generator@7.29.7':
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -18654,14 +18761,14 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -18676,7 +18783,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.29.7':
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/helper-plugin-utils@7.29.7': {}
 
@@ -18719,18 +18826,22 @@ snapshots:
     dependencies:
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
 
   '@babel/parser@8.0.4':
     dependencies:
@@ -19058,8 +19169,8 @@ snapshots:
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/template@8.0.0':
     dependencies:
@@ -19072,9 +19183,9 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
       '@babel/helper-globals': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -19090,6 +19201,11 @@ snapshots:
       obug: 2.1.4
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -20641,14 +20757,14 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-api@1.4.3(94b95f4182030aa6c89acfaa05f846f1)':
+  '@langchain/langgraph-api@1.4.3(0de05fe9d7a3a34b0f6f89a2600697d8)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@hono/node-server': 1.19.15(hono@4.12.32)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.15(hono@4.12.32))(hono@4.12.32)
       '@hono/zod-validator': 0.7.6(hono@4.12.32)(zod@4.4.3)
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
-      '@langchain/langgraph': 1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      '@langchain/langgraph': 1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
       '@langchain/langgraph-ui': 1.4.3
       '@langchain/protocol': 0.0.18
@@ -20669,7 +20785,7 @@ snapshots:
       winston-console-format: 1.0.8
       zod: 4.4.3
     optionalDependencies:
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -20685,11 +20801,11 @@ snapshots:
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
 
-  '@langchain/langgraph-cli@1.4.3(94b95f4182030aa6c89acfaa05f846f1)':
+  '@langchain/langgraph-cli@1.4.3(0de05fe9d7a3a34b0f6f89a2600697d8)':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@commander-js/extra-typings': 13.1.0(commander@13.1.0)
-      '@langchain/langgraph-api': 1.4.3(94b95f4182030aa6c89acfaa05f846f1)
+      '@langchain/langgraph-api': 1.4.3(0de05fe9d7a3a34b0f6f89a2600697d8)
       chokidar: 4.0.3
       commander: 13.1.0
       create-langgraph: 1.1.5
@@ -20725,7 +20841,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/protocol': 0.0.18
@@ -20735,8 +20851,9 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      vue: 3.5.41(typescript@7.0.2)
 
-  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/protocol': 0.0.18
@@ -20746,6 +20863,7 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
+      vue: 3.5.41(typescript@7.0.2)
 
   '@langchain/langgraph-ui@1.4.3':
     dependencies:
@@ -20755,11 +20873,11 @@ snapshots:
       esbuild-plugin-tailwindcss: 2.2.0
       zod: 4.4.3
 
-  '@langchain/langgraph@1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)':
+  '@langchain/langgraph@1.4.8(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
       '@langchain/langgraph-checkpoint': 1.1.3(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       '@langchain/protocol': 0.0.18
       '@standard-schema/spec': 1.1.0
       zod: 4.4.3
@@ -20771,20 +20889,20 @@ snapshots:
 
   '@langchain/protocol@0.0.18': {}
 
-  '@langchain/react@1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@langchain/react@1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.0)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.0))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       react: 19.2.8
     transitivePeerDependencies:
       - react-dom
       - svelte
       - vue
 
-  '@langchain/react@1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@langchain/react@1.0.29(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     dependencies:
       '@langchain/core': 1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1)
-      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.3(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.49.0(@aws-sdk/credential-provider-node@3.972.72)(@smithy/signature-v4@5.6.10)(ws@8.21.1)(zod@4.4.3))(ws@8.21.1))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))
       react: 19.2.8
     transitivePeerDependencies:
       - react-dom
@@ -24426,17 +24544,19 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.8
 
-  '@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/analytics@2.0.1(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     optionalDependencies:
       next: 16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
+      vue: 3.5.41(typescript@7.0.2)
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(vue@3.5.41(typescript@7.0.2))':
     optionalDependencies:
       next: 16.3.0(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
+      vue: 3.5.41(typescript@7.0.2)
 
   '@vitejs/plugin-react@6.0.4(babel-plugin-react-compiler@1.0.0)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
@@ -24444,6 +24564,12 @@ snapshots:
       vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+      vue: 3.5.41(typescript@7.0.2)
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -24510,6 +24636,60 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@vue/compiler-core@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.41
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.41':
+    dependencies:
+      '@vue/compiler-core': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/compiler-sfc@3.5.41':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.41
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/shared': 3.5.41
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.23
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.41':
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/reactivity@3.5.41':
+    dependencies:
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-core@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/runtime-dom@3.5.41':
+    dependencies:
+      '@vue/reactivity': 3.5.41
+      '@vue/runtime-core': 3.5.41
+      '@vue/shared': 3.5.41
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.41':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/shared': 3.5.41
+
+  '@vue/shared@3.5.41': {}
 
   '@workflow/serde@4.1.0': {}
 
@@ -24900,7 +25080,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
 
   babel-plugin-react-native-web@0.21.2: {}
 
@@ -26157,6 +26337,8 @@ snapshots:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -28456,8 +28638,8 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-dir@2.1.0:
@@ -28911,10 +29093,10 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.7
       '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/types': 7.29.8
       accepts: 2.0.0
       ci-info: 2.0.0
       connect: 3.7.0
@@ -32543,6 +32725,16 @@ snapshots:
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.18.0: {}
+
+  vue@3.5.41(typescript@7.0.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.41
+      '@vue/compiler-sfc': 3.5.41
+      '@vue/runtime-dom': 3.5.41
+      '@vue/server-renderer': 3.5.41
+      '@vue/shared': 3.5.41
+    optionalDependencies:
+      typescript: 7.0.2
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## summary

- new `@assistant-ui/store/client` subpath: `createAssistantClient(config, { parent? })` builds an `AssistantClient` inside a standalone tap root with no React renderer; the returned handle (`getClient`/`subscribe`/`destroy`) is itself a source, so handles nest as the parent of another handle, and a source parent is re-read live so the child's scope fibers survive the parent's structural changes; the entry's module graph deliberately avoids every module-scope React component API, and the store `react` peer becomes optional
- new private `@assistant-ui/vue` package (not published yet, deliberately: the Vue line is incomplete): `<AuiProvider>` creates the client from the neutral entry and provides it, `useAui` returns a stable facade that always forwards to the provider's current client, `useAuiState` returns a computed ref with `Object.is` change semantics, `useAuiEvent` follows the client across structural rebinds; its vitest suite aliases `react` to `@assistant-ui/tap/standalone-shim` and consumes the store dist, making it the react-less integration proof for the whole chain
- new `examples/with-vue`: vite + vue single page that demos the documented bundler alias, a proper `declare module "@assistant-ui/store"` ScopeRegistry augmentation, and the composables end to end
- fix in `@assistant-ui/x-buildutils`, found by the example: the react compiler gate was "depends on tap", which compiled the vue package's use-prefixed composables and injected memo caches that throw outside any render the compiler understands; the gate now also requires a declared react peer (verified: `@assistant-ui/vue` is the only tap-dependent package without one, so shipped react packages are byte-identical)

## test plan

### already verified

- [x] `pnpm -C packages/store test` -> 122/122 green, including the eight new `createAssistantClient` contract tests (no-renderer hosting, value-update identity, structural rebinds, proxied state, microtask event filtering, handle nesting across parent structural changes, root error messages, destroy cleanup)
- [x] `pnpm -C packages/vue test` -> 13/13 green with `react` aliased to the tap standalone shim dist and the store consumed from dist (real react is never resolved)
- [x] `pnpm exec turbo run build --filter=with-vue` -> green; browser smoke via vite preview: sending a message renders the user bubble, the fake run streams in the assistant echo, the composer clears and re-disables, console clean
- [x] `pnpm check:resource-memo` -> 18/18 and `pnpm -C packages/store test:react-compiler` -> green after the x-buildutils gate change
- [x] `node scripts/generate-api-surface.mjs --filter='@assistant-ui/store'` -> snapshot regenerated and committed (the private vue package is excluded by the generator)
- [x] `pnpm lint` -> oxlint and oxfmt clean

### reviewer should verify

- [ ] `cd examples/with-vue && pnpm dev`, send a message, and confirm the echo reply renders; the app resolves no react because vite aliases it to the standalone shim

## notes

- known v1 divergences from the React bindings, all deliberate: the provider captures `config` at mount (remount with a `key` to change the scope set; React recomputes entries per render), nested providers inherit the parent through inject with no explicit `extends` grammar yet, and `AuiIf`/`useAuiToolOverride` are deferred until the core react entry concepts they need are ported
- the vue package stays private until the Vue integration (runtime adapter, primitives) is complete; flipping it to publishable later is a one-line change plus a changeset

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.nkGyCxOUUlsOdSwyz33-NGKhjSjfU0qF3ZSDUjTJ62ygrJGJJrKZenNGe5M?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->