### PR TITLE
test(mcp-docs-server): assert docs index frontmatter instead of a brand string

### DIFF
--- a/packages/mcp-docs-server/src/tools/tests/docs.test.ts
+++ b/packages/mcp-docs-server/src/tools/tests/docs.test.ts
@@ -42,7 +42,7 @@ describe("assistantUIDocs", () => {
     expect(result.found).toBe(true);
     expect(result.type).toBe("file");
     expect(result.content).toBeDefined();
-    expect(result.content).toContain("assistant-ui");
+    expect(result.content).toContain("title: Documentation");
   });
 
   it("should handle non-existent paths", async () => {
@@ -88,7 +88,7 @@ describe("assistantUIDocs", () => {
 
     expect(result.content).toBeDefined();
     expect(result.content).toContain("title:");
-    expect(result.content).toContain("assistant-ui");
+    expect(result.content).toContain("description:");
   });
 
   it("includes title and excerpt on a file response", async () => {


### PR DESCRIPTION
## summary

- the docs index test asserted the fetched `(docs)/index` content contains the literal string `assistant-ui`; the docs landing rewrite made the page component-driven and it now contains zero occurrences, so the assertion is stale
- the failure is latent because mcp-docs-server only enters the changed set on repo-wide changes; the first PR to sweep it (a devDependency change) turned Test Changed Packages red on content that PR never touched
- the assertions now target what the tests actually mean: file retrieval pins the stable frontmatter `title: Documentation`, and the frontmatter parsing test checks both `title:` and `description:` keys instead of a brand string

## test plan

### already verified

- [x] `pnpm -C packages/mcp-docs-server test` -> 100/100 green (was 98 passed, 2 failed on unmodified main content)
- [x] `pnpm lint` -> clean

no reviewer steps beyond CI; the change is two assertion strings

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.cHdW3rZqCuylRcPmxtzuXG7eDCWn5AtTX_P-8vv1_v_FgNawnBJgaGZUQho?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->