### PR TITLE
fix(react-mcp): isolate oauth lifecycle callbacks

### DIFF
--- a/.changeset/calm-oauth-callbacks.md
+++ b/.changeset/calm-oauth-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-mcp": patch
+---
+
+fix: isolate OAuth lifecycle callback failures from authentication state

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -51,7 +51,10 @@
   },
   "devDependencies": {
     "@assistant-ui/x-buildutils": "workspace:*",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
+    "jsdom": "^29.1.1",
     "react": "^19.2.8",
     "vitest": "^4.1.10"
   },

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -1,5 +1,34 @@
-import { describe, expect, it } from "vitest";
-import { createMcpOAuthCallbackError } from "./useMcpOAuthCallback";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMcpOAuthCallbackError,
+  invokeMcpOAuthCallback,
+} from "./useMcpOAuthCallback";
+
+describe("invokeMcpOAuthCallback", () => {
+  it.each([
+    { name: "onComplete", mode: "throws" },
+    { name: "onComplete", mode: "rejects" },
+    { name: "onError", mode: "throws" },
+    { name: "onError", mode: "rejects" },
+  ] as const)("isolates $name callbacks that $mode", async ({ name, mode }) => {
+    const callbackError = new Error("telemetry failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const callback = vi.fn(() => {
+      if (mode === "throws") throw callbackError;
+      return Promise.reject(callbackError);
+    });
+
+    expect(() => invokeMcpOAuthCallback(name, callback)).not.toThrow();
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        `[react-mcp] ${name} callback threw an error`,
+        callbackError,
+      );
+    });
+  });
+});
 
 describe("createMcpOAuthCallbackError", () => {
   it("adds MCP OAuth callback context without a server id", () => {

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -1,33 +1,103 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  createMcpOAuthCallbackError,
-  invokeMcpOAuthCallback,
-} from "./useMcpOAuthCallback";
+// @vitest-environment jsdom
 
-describe("invokeMcpOAuthCallback", () => {
-  it.each([
-    { name: "onComplete", mode: "throws" },
-    { name: "onComplete", mode: "rejects" },
-    { name: "onError", mode: "throws" },
-    { name: "onError", mode: "rejects" },
-  ] as const)("isolates $name callbacks that $mode", async ({ name, mode }) => {
-    const callbackError = new Error("telemetry failed");
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    const callback = vi.fn(() => {
-      if (mode === "throws") throw callbackError;
-      return Promise.reject(callbackError);
-    });
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-    expect(() => invokeMcpOAuthCallback(name, callback)).not.toThrow();
-    await vi.waitFor(() => {
-      expect(consoleError).toHaveBeenCalledWith(
-        `[react-mcp] ${name} callback threw an error`,
-        callbackError,
+const mocks = vi.hoisted(() => {
+  const completeAuth = vi.fn<(url: string) => Promise<void>>();
+  const server = vi.fn(() => ({ completeAuth }));
+  return {
+    completeAuth,
+    server,
+    aui: { mcp: { server } },
+  };
+});
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => mocks.aui,
+}));
+
+const { createMcpOAuthCallbackError, useMcpOAuthCallback } =
+  await import("./useMcpOAuthCallback");
+
+const callbackUrl =
+  "https://app.example.com/oauth/callback?state=aui-mcp%3AZG9jcw.nonce";
+
+beforeEach(() => {
+  mocks.completeAuth.mockReset();
+  mocks.server.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useMcpOAuthCallback", () => {
+  it.each(["throws", "rejects"] as const)(
+    "keeps successful authentication done when onComplete $mode",
+    async (mode) => {
+      const callbackError = new Error("telemetry failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onComplete = vi.fn(() => {
+        if (mode === "throws") throw callbackError;
+        return Promise.reject(callbackError);
+      });
+      mocks.completeAuth.mockResolvedValueOnce();
+
+      const { result } = renderHook(() =>
+        useMcpOAuthCallback({ url: callbackUrl, onComplete }),
       );
-    });
-  });
+
+      await waitFor(() => expect(result.current.status).toBe("done"));
+      expect(result.current).toEqual({
+        status: "done",
+        serverId: "docs",
+        error: null,
+      });
+      await waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-mcp] onComplete callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
+
+  it.each(["throws", "rejects"] as const)(
+    "preserves authentication errors when onError $mode",
+    async (mode) => {
+      const authError = new Error("invalid_grant");
+      const callbackError = new Error("telemetry failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const onError = vi.fn(() => {
+        if (mode === "throws") throw callbackError;
+        return Promise.reject(callbackError);
+      });
+      mocks.completeAuth.mockRejectedValueOnce(authError);
+
+      const { result } = renderHook(() =>
+        useMcpOAuthCallback({ url: callbackUrl, onError }),
+      );
+
+      await waitFor(() => expect(result.current.status).toBe("error"));
+      expect(result.current.serverId).toBe("docs");
+      expect(result.current.error).toMatchObject({
+        message: 'MCP OAuth callback for server "docs" failed: invalid_grant',
+        cause: authError,
+      });
+      await waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-mcp] onError callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 });
 
 describe("createMcpOAuthCallbackError", () => {

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe("useMcpOAuthCallback", () => {
   it.each(["throws", "rejects"] as const)(
-    "keeps successful authentication done when onComplete $mode",
+    "keeps successful authentication done when onComplete %s",
     async (mode) => {
       const callbackError = new Error("telemetry failed");
       const consoleError = vi
@@ -67,7 +67,7 @@ describe("useMcpOAuthCallback", () => {
   );
 
   it.each(["throws", "rejects"] as const)(
-    "preserves authentication errors when onError $mode",
+    "preserves authentication errors when onError %s",
     async (mode) => {
       const authError = new Error("invalid_grant");
       const callbackError = new Error("telemetry failed");

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -2,6 +2,36 @@ import { type FC, type ReactNode, useEffect, useRef, useState } from "react";
 import { useAui } from "@assistant-ui/store";
 import { decodeServerIdFromState } from "../auth/createOAuthProvider";
 
+type McpOAuthCallbackName = "onComplete" | "onError";
+
+const reportCallbackError = (name: McpOAuthCallbackName, error: unknown) => {
+  console.error(`[react-mcp] ${name} callback threw an error`, error);
+};
+
+export const invokeMcpOAuthCallback = <TArgs extends unknown[]>(
+  name: McpOAuthCallbackName,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 export const createMcpOAuthCallbackError = (
   err: unknown,
   serverId: string | null,
@@ -52,7 +82,7 @@ export function useMcpOAuthCallback(
     if (startedRef.current === url) return;
     startedRef.current = url;
 
-    (async () => {
+    void (async () => {
       let serverId: string | null = null;
       try {
         const parsed = new URL(url);
@@ -71,12 +101,18 @@ export function useMcpOAuthCallback(
         setResult({ status: "running", serverId, error: null });
         await aui.mcp.server({ id: serverId }).completeAuth(url);
         setResult({ status: "done", serverId, error: null });
-        optsRef.current.onComplete?.(serverId);
       } catch (err) {
-        const e = createMcpOAuthCallbackError(err, serverId);
-        setResult({ status: "error", serverId, error: e });
-        optsRef.current.onError?.(e);
+        const error = createMcpOAuthCallbackError(err, serverId);
+        setResult({ status: "error", serverId, error });
+        invokeMcpOAuthCallback("onError", optsRef.current.onError, error);
+        return;
       }
+
+      invokeMcpOAuthCallback(
+        "onComplete",
+        optsRef.current.onComplete,
+        serverId,
+      );
     })();
   }, [aui, opts.url]);
 

--- a/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
+++ b/packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx
@@ -8,7 +8,7 @@ const reportCallbackError = (name: McpOAuthCallbackName, error: unknown) => {
   console.error(`[react-mcp] ${name} callback threw an error`, error);
 };
 
-export const invokeMcpOAuthCallback = <TArgs extends unknown[]>(
+const invokeMcpOAuthCallback = <TArgs extends unknown[]>(
   name: McpOAuthCallbackName,
   callback: ((...args: TArgs) => void) | undefined,
   ...args: TArgs

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4343,9 +4343,18 @@ importers:
       '@assistant-ui/x-buildutils':
         specifier: workspace:*
         version: link:../x-buildutils
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       react:
         specifier: ^19.2.8
         version: 19.2.8


### PR DESCRIPTION
## Summary

- keep successful MCP OAuth callbacks in the `done` state when `onComplete` throws or rejects
- preserve the original authentication error when `onError` itself fails
- report lifecycle callback failures without creating unhandled rejections

## Why

The hook previously invoked `onComplete` inside the authentication `try` block. An application callback used for navigation, analytics, or telemetry could therefore turn a completed OAuth exchange into an error state. A rejected `onError` callback could also escape the fire-and-forget effect as an unhandled rejection.

This keeps authentication state tied to the OAuth operation itself while isolating both synchronous and asynchronous consumer callback failures.

## Reproduction

With `@assistant-ui/react-mcp@0.1.3`, configure an OAuth MCP server with ID `docs`, complete its redirect, and mount:

```tsx
const result = useMcpOAuthCallback({
  onComplete: () => {
    throw new Error("telemetry failed");
  },
});
```

Before this change, `completeAuth()` resolves but the callback exception is caught as an authentication failure, changing `result.status` from `"done"` to `"error"`. After this change, the OAuth result remains `"done"` and the callback error is reported separately.

For the failure path, make `completeAuth()` reject and use an `onError` callback that throws or returns a rejected promise. Previously that callback failure escaped as an unhandled rejection. After this change, `result.status` remains `"error"`, `result.error` retains the original authentication failure, and the callback failure is reported separately. The hook-level regression tests exercise both flows with synchronous throws and rejected promises.

## Scope

Callback isolation remains package-local in this focused fix because the adapters have package-specific callback types and logging. Extracting a shared internal primitive can be evaluated separately without coupling it to this behavior change.

## Testing

- `pnpm --filter @assistant-ui/react-mcp test`
- `pnpm --filter @assistant-ui/react-mcp build`
- `pnpm exec oxlint packages/react-mcp/src/hooks/useMcpOAuthCallback.tsx packages/react-mcp/src/hooks/useMcpOAuthCallback.test.ts`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jk92fm--vRACyPBrnKS4Sg8FmrZVdqq1eoi1YtIgFMVgi-fHCWN-LpUXclo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->