### PR TITLE
fix(react-google-adk): isolate runtime event callbacks

### DIFF
--- a/.changeset/tidy-adk-callbacks.md
+++ b/.changeset/tidy-adk-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-google-adk": patch
+---
+
+fix: isolate runtime event callback failures from ADK streams

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -1,6 +1,110 @@
-import { describe, expect, it } from "vitest";
-import { messageToEvent } from "./useAdkMessages";
-import type { AdkMessage } from "./types";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initialize: vi.fn(async () => ({
+    remoteId: "thread-1",
+    externalId: undefined,
+  })),
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAui: () => ({ threadListItem: { initialize: mocks.initialize } }),
+}));
+
+import {
+  invokeAdkRuntimeCallback,
+  messageToEvent,
+  useAdkMessages,
+  type UseAdkMessagesOptions,
+} from "./useAdkMessages";
+import type { AdkEvent, AdkMessage, AdkStreamCallback } from "./types";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ADK runtime callbacks", () => {
+  it.each(["onAgentTransfer", "onCustomEvent", "onError"] as const)(
+    "continues streaming when %s throws",
+    async (callbackName) => {
+      const callbackError = new Error("telemetry failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const callback = vi.fn(() => {
+        throw callbackError;
+      });
+      const eventByCallback: Record<typeof callbackName, AdkEvent> = {
+        onAgentTransfer: {
+          id: "transfer",
+          actions: { transferToAgent: "researcher" },
+        },
+        onCustomEvent: {
+          id: "custom",
+          customMetadata: { progress: 1 },
+        },
+        onError: {
+          id: "error",
+          author: "agent",
+          errorMessage: "recoverable error",
+        },
+      };
+      const stream: AdkStreamCallback = async function* () {
+        yield eventByCallback[callbackName];
+        yield {
+          id: "answer",
+          author: "agent",
+          content: { role: "model", parts: [{ text: "done" }] },
+        };
+      };
+      const eventHandlers = {
+        [callbackName]: callback,
+      } as UseAdkMessagesOptions["eventHandlers"];
+      const { result } = renderHook(() =>
+        useAdkMessages({ stream, eventHandlers }),
+      );
+
+      await act(async () => {
+        await result.current.sendMessage(
+          [{ id: "user", type: "human", content: "hello" }],
+          {},
+        );
+      });
+
+      expect(result.current.messages.at(-1)).toMatchObject({
+        type: "ai",
+        content: [{ type: "text", text: "done" }],
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        `[react-google-adk] ${callbackName} callback threw an error`,
+        callbackError,
+      );
+    },
+  );
+
+  it.each(["onAgentTransfer", "onCustomEvent", "onError"] as const)(
+    "handles rejected %s promises",
+    async (callbackName) => {
+      const callbackError = new Error("async telemetry failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      invokeAdkRuntimeCallback(callbackName, () =>
+        Promise.reject(callbackError),
+      );
+
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          `[react-google-adk] ${callbackName} callback threw an error`,
+          callbackError,
+        );
+      });
+    },
+  );
+});
 
 describe("messageToEvent (contentToParts)", () => {
   it("serializes a file content part as inlineData", () => {

--- a/packages/react-google-adk/src/useAdkMessages.test.ts
+++ b/packages/react-google-adk/src/useAdkMessages.test.ts
@@ -14,7 +14,6 @@ vi.mock("@assistant-ui/store", async (importOriginal) => ({
 }));
 
 import {
-  invokeAdkRuntimeCallback,
   messageToEvent,
   useAdkMessages,
   type UseAdkMessagesOptions,
@@ -84,26 +83,46 @@ describe("ADK runtime callbacks", () => {
     },
   );
 
-  it.each(["onAgentTransfer", "onCustomEvent", "onError"] as const)(
-    "handles rejected %s promises",
-    async (callbackName) => {
-      const callbackError = new Error("async telemetry failed");
-      const consoleError = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+  it("continues streaming when onCustomEvent rejects", async () => {
+    const callbackError = new Error("async telemetry failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const stream: AdkStreamCallback = async function* () {
+      yield { id: "custom", customMetadata: { progress: 1 } };
+      yield {
+        id: "answer",
+        author: "agent",
+        content: { role: "model", parts: [{ text: "done" }] },
+      };
+    };
+    const { result } = renderHook(() =>
+      useAdkMessages({
+        stream,
+        eventHandlers: {
+          onCustomEvent: () => Promise.reject(callbackError),
+        },
+      }),
+    );
 
-      invokeAdkRuntimeCallback(callbackName, () =>
-        Promise.reject(callbackError),
+    await act(async () => {
+      await result.current.sendMessage(
+        [{ id: "user", type: "human", content: "hello" }],
+        {},
       );
+    });
 
-      await vi.waitFor(() => {
-        expect(consoleError).toHaveBeenCalledWith(
-          `[react-google-adk] ${callbackName} callback threw an error`,
-          callbackError,
-        );
-      });
-    },
-  );
+    expect(result.current.messages.at(-1)).toMatchObject({
+      type: "ai",
+      content: [{ type: "text", text: "done" }],
+    });
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[react-google-adk] onCustomEvent callback threw an error",
+        callbackError,
+      );
+    });
+  });
 });
 
 describe("messageToEvent (contentToParts)", () => {

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -32,7 +32,7 @@ const reportCallbackError = (name: AdkRuntimeCallbackName, error: unknown) => {
   console.error(`[react-google-adk] ${name} callback threw an error`, error);
 };
 
-export const invokeAdkRuntimeCallback = <TArgs extends unknown[]>(
+const invokeAdkRuntimeCallback = <TArgs extends unknown[]>(
   name: AdkRuntimeCallbackName,
   callback: ((...args: TArgs) => void | Promise<void>) | undefined,
   ...args: TArgs

--- a/packages/react-google-adk/src/useAdkMessages.ts
+++ b/packages/react-google-adk/src/useAdkMessages.ts
@@ -26,6 +26,28 @@ export type UseAdkMessagesOptions = {
   };
 };
 
+type AdkRuntimeCallbackName = "onError" | "onCustomEvent" | "onAgentTransfer";
+
+const reportCallbackError = (name: AdkRuntimeCallbackName, error: unknown) => {
+  console.error(`[react-google-adk] ${name} callback threw an error`, error);
+};
+
+export const invokeAdkRuntimeCallback = <TArgs extends unknown[]>(
+  name: AdkRuntimeCallbackName,
+  callback: ((...args: TArgs) => void | Promise<void>) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    void Promise.resolve(callback(...args)).catch((error) => {
+      reportCallbackError(name, error);
+    });
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 export const useAdkMessages = ({
   stream,
   eventHandlers,
@@ -160,18 +182,31 @@ export const useAdkMessages = ({
           const transfer = accumulator.getLastTransferToAgent();
           if (transfer && transfer !== lastTransferToAgentRef.current) {
             lastTransferToAgentRef.current = transfer;
-            onAgentTransfer?.(transfer);
+            invokeAdkRuntimeCallback(
+              "onAgentTransfer",
+              onAgentTransfer,
+              transfer,
+            );
           }
 
           // Fire custom event callback for events with customMetadata
           if (event.customMetadata && onCustomEvent) {
             for (const [key, value] of Object.entries(event.customMetadata)) {
-              onCustomEvent(key, value);
+              invokeAdkRuntimeCallback(
+                "onCustomEvent",
+                onCustomEvent,
+                key,
+                value,
+              );
             }
           }
 
           if (event.errorCode || event.errorMessage) {
-            onError?.(event.errorMessage ?? event.errorCode);
+            invokeAdkRuntimeCallback(
+              "onError",
+              onError,
+              event.errorMessage ?? event.errorCode,
+            );
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

- isolate `onAgentTransfer`, `onCustomEvent`, and `onError` callback failures from ADK stream processing
- consume rejected callback promises instead of producing global unhandled rejections
- add regressions proving later stream events still reach the runtime

## Why

Runtime callbacks run inside the ADK event loop. If an application callback used for telemetry, analytics, or UI integration threw synchronously, the surrounding stream loop treated it like an ADK transport failure and stopped processing otherwise healthy events. These callbacks also allow promises, but rejected promises were not handled.

This follows the callback-isolation approach used by the A2A runtime. It is also a client-runtime follow-up to #5598, which isolated the server-side `adkEventStream` error callback.

## Testing

- `pnpm --filter @assistant-ui/react-google-adk test`
- `pnpm --filter @assistant-ui/react-google-adk build`
- `pnpm exec oxlint packages/react-google-adk/src/useAdkMessages.ts packages/react-google-adk/src/useAdkMessages.test.ts`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.CWuBsNoDT9XpKMgC7ocsyTFlcAHYLq7y6zbB6fmopUi27eqSIVetFNqD0c0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->