### PR TITLE
fix(react): gate composer attachment dropzone on file drags and the attachments capability

### DIFF
--- a/.changeset/composer-dropzone-file-drag-gate.md
+++ b/.changeset/composer-dropzone-file-drag-gate.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: gate ComposerPrimitive.AttachmentDropzone on file drags and the attachments capability

--- a/apps/docs/content/docs/primitives/composer.mdx
+++ b/apps/docs/content/docs/primitives/composer.mdx
@@ -258,7 +258,7 @@ Renders a single attachment at a specific index.
 
 ### AttachmentDropzone
 
-Drag-and-drop zone for file attachments. Sets `data-dragging` when a file is being dragged over it. Renders a `<div>` element unless `asChild` is set.
+Drag-and-drop zone for file attachments. Sets `data-dragging` when a file is being dragged over it and the runtime supports attachments; without the attachments capability the dropzone accepts no files and shows no highlight. Non-file drags (text, links) are ignored. Renders a `<div>` element unless `asChild` is set.
 
 ```tsx
 <ComposerPrimitive.AttachmentDropzone className="rounded-xl border-2 border-dashed data-[dragging]:border-primary data-[dragging]:bg-primary/5">
@@ -507,7 +507,7 @@ Wrap your composer with `AttachmentDropzone` to support dragging files directly 
 </ComposerPrimitive.AttachmentDropzone>
 ```
 
-The dropzone sets `data-dragging` when a file is being dragged over it, so you can style the active state with CSS.
+The dropzone sets `data-dragging` when a file is being dragged over it, so you can style the active state with CSS. It requires the runtime's attachments capability (an attachment adapter); without it the dropzone stays inert.
 
 ### With Voice Input
 

--- a/packages/react/src/primitives/composer/ComposerAttachmentDropzone.test.tsx
+++ b/packages/react/src/primitives/composer/ComposerAttachmentDropzone.test.tsx
@@ -6,7 +6,10 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ComposerPrimitiveAttachmentDropzone } from "./ComposerAttachmentDropzone";
 
-const addAttachment = vi.fn<(file: File) => Promise<void>>();
+const { addAttachment, threadCapabilities } = vi.hoisted(() => ({
+  addAttachment: vi.fn<(file: File) => Promise<void>>(),
+  threadCapabilities: { attachments: true },
+}));
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -18,14 +21,26 @@ vi.mock("@assistant-ui/store", async (importOriginal) => {
       composer: {
         addAttachment,
       },
+      thread: {
+        getState: () => ({ capabilities: threadCapabilities }),
+      },
     }),
   };
 });
 
-const createDropEvent = (files: File[]) => {
+const createDropEvent = (files: File[], types: string[] = ["Files"]) => {
   const event = new Event("drop", { bubbles: true, cancelable: true });
   Object.defineProperty(event, "dataTransfer", {
-    value: { files },
+    value: { files, types },
+    configurable: true,
+  });
+  return event;
+};
+
+const createDragEvent = (type: string, types: string[]) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    value: { files: [], types },
     configurable: true,
   });
   return event;
@@ -37,6 +52,7 @@ describe("ComposerPrimitiveAttachmentDropzone", () => {
 
   beforeEach(async () => {
     addAttachment.mockReset();
+    threadCapabilities.attachments = true;
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -122,5 +138,89 @@ describe("ComposerPrimitiveAttachmentDropzone", () => {
     expect(addAttachment).toHaveBeenCalledTimes(3);
     expect(errorSpy).not.toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+
+  it("highlights on file drags", async () => {
+    const dropzone = container.querySelector("[data-testid='dropzone']");
+    expect(dropzone).not.toBeNull();
+
+    const event = createDragEvent("dragenter", ["Files"]);
+    await act(async () => {
+      dropzone!.dispatchEvent(event);
+    });
+
+    expect(dropzone!.getAttribute("data-dragging")).toBe("true");
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores non-file drags", async () => {
+    const dropzone = container.querySelector("[data-testid='dropzone']");
+    expect(dropzone).not.toBeNull();
+
+    const enter = createDragEvent("dragenter", ["text/plain"]);
+    const over = createDragEvent("dragover", ["text/plain"]);
+    await act(async () => {
+      dropzone!.dispatchEvent(enter);
+      dropzone!.dispatchEvent(over);
+    });
+
+    expect(dropzone!.hasAttribute("data-dragging")).toBe(false);
+    expect(enter.defaultPrevented).toBe(false);
+    expect(over.defaultPrevented).toBe(false);
+  });
+
+  it("claims file drags without highlighting when the runtime does not support attachments", async () => {
+    threadCapabilities.attachments = false;
+    const dropzone = container.querySelector("[data-testid='dropzone']");
+    expect(dropzone).not.toBeNull();
+
+    const enter = createDragEvent("dragenter", ["Files"]);
+    const drop = createDropEvent([
+      new File(["a"], "first.txt", { type: "text/plain" }),
+    ]);
+    await act(async () => {
+      dropzone!.dispatchEvent(enter);
+      dropzone!.dispatchEvent(drop);
+    });
+
+    expect(dropzone!.hasAttribute("data-dragging")).toBe(false);
+    expect(enter.defaultPrevented).toBe(true);
+    expect((enter as unknown as DragEvent).dataTransfer!.dropEffect).toBe(
+      "none",
+    );
+    expect(drop.defaultPrevented).toBe(true);
+    expect(addAttachment).not.toHaveBeenCalled();
+  });
+
+  it("clears the highlight and keeps a file drop claimed when it yields no files", async () => {
+    const dropzone = container.querySelector("[data-testid='dropzone']");
+    expect(dropzone).not.toBeNull();
+
+    await act(async () => {
+      dropzone!.dispatchEvent(createDragEvent("dragenter", ["Files"]));
+    });
+    expect(dropzone!.getAttribute("data-dragging")).toBe("true");
+
+    const drop = createDropEvent([], ["Files"]);
+    await act(async () => {
+      dropzone!.dispatchEvent(drop);
+    });
+
+    expect(dropzone!.hasAttribute("data-dragging")).toBe(false);
+    expect(drop.defaultPrevented).toBe(true);
+    expect(addAttachment).not.toHaveBeenCalled();
+  });
+
+  it("lets non-file drops pass through", async () => {
+    const dropzone = container.querySelector("[data-testid='dropzone']");
+    expect(dropzone).not.toBeNull();
+
+    const drop = createDropEvent([], []);
+    await act(async () => {
+      dropzone!.dispatchEvent(drop);
+    });
+
+    expect(drop.defaultPrevented).toBe(false);
+    expect(addAttachment).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/primitives/composer/ComposerAttachmentDropzone.tsx
+++ b/packages/react/src/primitives/composer/ComposerAttachmentDropzone.tsx
@@ -30,22 +30,34 @@ export const ComposerPrimitiveAttachmentDropzone = forwardRef<
   const [isDragging, setIsDragging] = useState(false);
   const aui = useAui();
 
+  // An unprevented file drop navigates the tab to the file, so file drags are
+  // claimed via preventDefault even when the runtime does not support attachments.
   const handleDragEnterCapture = useCallback(
     (e: React.DragEvent) => {
       if (disabled) return;
+      if (!e.dataTransfer.types.includes("Files")) return;
       e.preventDefault();
+      if (!aui.thread.getState().capabilities.attachments) {
+        e.dataTransfer.dropEffect = "none";
+        return;
+      }
       setIsDragging(true);
     },
-    [disabled],
+    [disabled, aui],
   );
 
   const handleDragOverCapture = useCallback(
     (e: React.DragEvent) => {
       if (disabled) return;
+      if (!e.dataTransfer.types.includes("Files")) return;
       e.preventDefault();
+      if (!aui.thread.getState().capabilities.attachments) {
+        e.dataTransfer.dropEffect = "none";
+        return;
+      }
       if (!isDragging) setIsDragging(true);
     },
-    [disabled, isDragging],
+    [disabled, isDragging, aui],
   );
 
   const handleDragLeaveCapture = useCallback(
@@ -64,9 +76,12 @@ export const ComposerPrimitiveAttachmentDropzone = forwardRef<
   const handleDrop = useCallback(
     async (e: React.DragEvent) => {
       if (disabled) return;
-      e.preventDefault();
       setIsDragging(false);
+      if (!e.dataTransfer.types.includes("Files")) return;
+      e.preventDefault();
       const files = Array.from(e.dataTransfer.files);
+      if (!aui.thread.getState().capabilities.attachments || files.length === 0)
+        return;
       await Promise.all(
         files.map(async (file) => {
           try {


### PR DESCRIPTION
## What

`ComposerPrimitive.AttachmentDropzone` now only reacts to actual file drags in runtimes with the attachments capability:

- dragenter/dragover/drop bail on non-file drags (`e.dataTransfer.types.includes("Files")`), so text and link drags pass through to native browser behavior
- file drags are always claimed with `preventDefault` (an unprevented file drop navigates the tab to the file); the capability only gates the `data-dragging` highlight and `addAttachment`
- when the capability is off, dragenter/dragover also set `dropEffect = "none"` so the cursor shows the native no-drop state while the drag stays claimed
- the drag highlight always clears on drop, so it can't stick when a drop yields no files

## Why

While validating this, dragging a text selection over the shipped Thread flipped the whole composer shell into its `data-dragging` styling, and the unconditional `preventDefault` on dragover also blocked dropping that text into the textarea. The docs already describe the intended behavior ("sets `data-dragging` when a file is being dragged over it"), so this brings the code in line with them, using the same capability gate the paste path in `ComposerInput` already merged.

## Repro

pre-fix, with the shipped Thread on any runtime: drag a text selection over the composer and the shell flips into its `data-dragging` styling, and dropping that text into the textarea is swallowed by the unconditional `preventDefault`. on a runtime without an attachment adapter, dragging a file highlights the composer and the drop is silently discarded.

minimal snippet, no adapter needed (matches `examples/with-external-store`):

```tsx
<ComposerPrimitive.AttachmentDropzone>
  <ComposerPrimitive.Root>
    <ComposerPrimitive.Input />
  </ComposerPrimitive.Root>
</ComposerPrimitive.AttachmentDropzone>
```

drag selected text over it: `data-dragging="true"` appears pre-fix and stays absent post-fix. the failure returns without this diff: the new test cases fail on main with the source change reverted (the highlight and defaultPrevented assertions flip), and I verified the behavior in headless chromium against with-external-store (no adapter: file drag claimed, no highlight, no navigation) and with-ai-sdk-v7 (default adapter: highlight shows, drop attaches).

## Impact

- non-file drags now pass through to native browser behavior instead of highlighting and being swallowed
- dropzones in runtimes without attachment support show no highlight and a no-drop cursor, and discard the drop without handing it to the browser (an unclaimed file drop would navigate the tab away)
- file drags in attachment-capable runtimes behave exactly as before

## Scope

- dragleave is intentionally untouched: it has no default action, and clearing an unset `isDragging` is a bailed update, so gating it would be dead code.
- Gating the highlight (not just the drop) on the capability is deliberate: highlighting and then silently discarding the drop is worse than staying inert.
- The capability read uses `getState()` inside the handlers, matching the paste path in `ComposerInput.tsx`; no subscription needed since it's an event-time read.
- The primitives doc gains one sentence noting the capability requirement; the api-reference page is generated from unchanged types.
- Tests: file drag highlights, non-file drag ignored, capability-off claims the drag with a no-drop cursor and no highlight or addAttachment, empty-files drop clears the highlight while staying claimed, non-file drop passes through; the two pre-existing drop tests still pass.
- Additive behavior gating only, no exports or props changed.
- Changeset: patch (`@assistant-ui/react`).
