### PR TITLE
fix(react): route only thread-composer sends into the queue adapter

### DIFF
--- a/.changeset/edit-composer-queue-routing.md
+++ b/.changeset/edit-composer-queue-routing.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix(react): route only thread-composer sends into the queue adapter

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -672,7 +672,8 @@ const useComposerClientResource = ({
             custom: { ...(currentQuote ? { quote: currentQuote } : {}) },
           },
         };
-        if (queue) {
+        // edit sends carry a sourceId contract; only thread sends queue
+        if (queue && type === "thread") {
           if (opts?.steer ?? canCancel) queue.steer(composedMessage);
           else queue.enqueue(composedMessage);
         } else {

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -279,6 +279,49 @@ describe("ExternalThread composer", () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
+  it("routes edit-composer sends to onEdit with sourceId, bypassing the queue", async () => {
+    const onEdit = vi.fn();
+    const enqueue = vi.fn();
+    const steer = vi.fn();
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: false,
+      onEdit,
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue,
+        steer,
+        move: vi.fn(),
+        edit: vi.fn(),
+        remove: vi.fn(),
+      },
+    });
+
+    const composer = () => aui().thread.message({ id: "u1" }).composer();
+    composer().beginEdit();
+    await waitFor(() => expect(composer().getState().isEditing).toBe(true));
+    composer().setText("edited");
+    composer().send();
+
+    await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1));
+    expect(onEdit.mock.calls[0]![0]).toMatchObject({
+      sourceId: "u1",
+      content: [{ type: "text", text: "edited" }],
+    });
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(steer).not.toHaveBeenCalled();
+  });
+
   it("still refuses to send an empty composer synchronously after a send", async () => {
     const onNew = vi.fn();
     const { aui } = renderThread({ messages: [], isRunning: false, onNew });


### PR DESCRIPTION
## Root cause

After #5650 (two-lane, placement-aware message queue), `ExternalThread`'s shared composer send path routed every send into the queue adapter whenever one was configured. Edit-composer sends took that path too, so the `sourceId` stamped by `handleSendEdit` (the id of the message being edited) was lost — edits arrived as plain enqueued/steered messages instead of reaching `onEdit`.

## Fix

Only `type === "thread"` sends enter the queue adapter; edit-composer sends always dispatch through `onSend`, preserving the `sourceId` contract.

## Test

`external-thread-parity.test.tsx`: with a queue adapter configured, an edit-composer send calls `onEdit` with `sourceId` set to the edited message's id and calls neither `enqueue` nor `steer`. Fails without the fix.

Full react suite: 413 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._IAJdQKPtEamJYWiiRihLv6oeGI475YBZ1MMw3TdvDodjjnK7SeIiawfg9s?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->