### PR TITLE
test(vue): poll for the scheduler flush instead of racing a timer

### DIFF
--- a/packages/vue/src/__tests__/useAuiState.test.ts
+++ b/packages/vue/src/__tests__/useAuiState.test.ts
@@ -67,8 +67,11 @@ describe("useAuiState", () => {
     });
 
     aui.thread.setSelected(1);
-    await new Promise((resolve) => setTimeout(resolve));
-    expect(selected.value).toBe(1);
+    // The tap scheduler flushes on a MessageChannel macrotask whose ordering
+    // against timers is unspecified; poll instead of racing a single timer
+    await vi.waitFor(() => {
+      expect(selected.value).toBe(1);
+    });
 
     unmount();
   });


### PR DESCRIPTION
## summary

- the real-scheduler test in the vue bridge awaited a single `setTimeout(0)` and asserted the tap update had landed; the tap scheduler flushes on a MessageChannel macrotask whose ordering against timers is unspecified, so a loaded runner can fire the timer first and observe the stale value (seen on the Test Changed Packages re-run in #5668, a PR that never touches this code)
- the assertion now polls via `vi.waitFor`, which keeps the test's point (no manual `flushTapSync`, the real scheduler path delivers) without betting on cross-source task ordering

## test plan

### already verified

- [x] `pnpm -C packages/vue test` -> 14/14 green
- [x] `pnpm lint` -> clean

no reviewer steps beyond CI; the change is one assertion

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.4UoZWrvCDnMuZY11LZRVQoRenF2n7iL9Xa6NGjze2au5aro7WwHF6zOyxA4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->