### PR TITLE
fix(react-ag-ui): isolate runtime callbacks

### DIFF
--- a/.changeset/quiet-ag-ui-callbacks.md
+++ b/.changeset/quiet-ag-ui-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: isolate runtime lifecycle callback failures

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -76,6 +76,36 @@ type CoreOptions = {
 
 const FALLBACK_USER_STATUS = { type: "complete", reason: "unknown" } as const;
 
+type AgUiRuntimeCallbackName = "onError" | "onCancel";
+
+const reportCallbackError = (name: AgUiRuntimeCallbackName, error: unknown) => {
+  console.error(`[react-ag-ui] ${name} callback threw an error`, error);
+};
+
+const invokeRuntimeCallback = <TArgs extends unknown[]>(
+  name: AgUiRuntimeCallbackName,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 export class AgUiThreadRuntimeCore {
   private agent: AbstractAgent;
   private logger: Logger;
@@ -272,7 +302,9 @@ export class AgUiThreadRuntimeCore {
       })
       .catch((error) => {
         this.logger.error?.("[agui] failed to load history", error);
-        this.onError?.(
+        invokeRuntimeCallback(
+          "onError",
+          this.onError,
           error instanceof Error ? error : new Error(String(error)),
         );
       })
@@ -366,7 +398,7 @@ export class AgUiThreadRuntimeCore {
         "[agui] unstable_resume requires a ThreadHistoryAdapter with a resume() method; skipping resume after thread switch",
       );
       this.logger.error?.(error.message);
-      this.onError?.(error);
+      invokeRuntimeCallback("onError", this.onError, error);
       return;
     }
     const parentId = messages.at(-1)?.id ?? null;
@@ -773,7 +805,11 @@ export class AgUiThreadRuntimeCore {
 
   private startResumeRun(messageId: string): void {
     void this.startRun(messageId, this.lastRunConfig).catch((error) => {
-      this.onError?.(error instanceof Error ? error : new Error(String(error)));
+      invokeRuntimeCallback(
+        "onError",
+        this.onError,
+        error instanceof Error ? error : new Error(String(error)),
+      );
     });
   }
 
@@ -999,7 +1035,7 @@ export class AgUiThreadRuntimeCore {
       () => {
         cancelRun();
         this.finishRun(abortController);
-        this.onCancel?.();
+        invokeRuntimeCallback("onCancel", this.onCancel);
       },
       { once: true },
     );
@@ -1037,7 +1073,7 @@ export class AgUiThreadRuntimeCore {
           onRunFailed: (error) => {
             if (abortSignal.aborted) return;
             this.pendingError = error;
-            this.onError?.(error);
+            invokeRuntimeCallback("onError", this.onError, error);
           },
         });
         try {
@@ -1058,7 +1094,7 @@ export class AgUiThreadRuntimeCore {
       if (!abortSignal.aborted) {
         const err = error instanceof Error ? error : new Error(String(error));
         dispatch({ type: "RUN_ERROR", message: err.message });
-        this.onError?.(err);
+        invokeRuntimeCallback("onError", this.onError, err);
         this.pendingError = this.pendingError ?? err;
       }
     } finally {
@@ -1160,7 +1196,7 @@ export class AgUiThreadRuntimeCore {
       ctx.applyUpdate({
         status: { type: "incomplete", reason: "error", error: err.message },
       });
-      this.onError?.(err);
+      invokeRuntimeCallback("onError", this.onError, err);
       this.pendingError = this.pendingError ?? err;
       return;
     }

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -606,6 +606,51 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(agent.abortRun).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["throws", "rejects"] as const)(
+    "keeps cancellation settled when onCancel %s",
+    async (failureMode) => {
+      const callbackError = new Error("cancel callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      let rejectRun!: (error: Error) => void;
+      const agent = {
+        runAgent: vi.fn(
+          () =>
+            new Promise((_, reject) => {
+              rejectRun = reject;
+            }),
+        ),
+        abortRun: vi.fn(() => {
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          rejectRun(error);
+        }),
+      } as unknown as HttpAgent;
+      const core = createCore(agent, {
+        onCancel: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+      });
+
+      const appendPromise = core.append(createAppendMessage());
+      await expect(core.cancel()).resolves.toBeUndefined();
+      await expect(appendPromise).resolves.toBeUndefined();
+
+      expect(core.getMessages().at(-1)?.status).toMatchObject({
+        type: "incomplete",
+        reason: "cancelled",
+      });
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-ag-ui] onCancel callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
+
   it("aborts the agent run before the local abort fires onCancel", async () => {
     const order: string[] = [];
     let rejectRun!: (error: Error) => void;
@@ -791,6 +836,40 @@ describe("AGUIThreadRuntimeCore", () => {
     });
     expect(onError).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["throws", "rejects"] as const)(
+    "preserves the run error when onError %s",
+    async (failureMode) => {
+      const runError = new Error("run failed");
+      const callbackError = new Error("error callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const agent = {
+        runAgent: vi.fn().mockRejectedValue(runError),
+      } as unknown as HttpAgent;
+      const core = createCore(agent, {
+        onError: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+      });
+
+      await expect(core.append(createAppendMessage())).rejects.toBe(runError);
+
+      expect(core.getMessages().at(-1)?.status).toMatchObject({
+        type: "incomplete",
+        reason: "error",
+        error: "run failed",
+      });
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-ag-ui] onError callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 
   it("updates tool call result entries", () => {
     const agent = {
@@ -2134,6 +2213,31 @@ describe("AGUIThreadRuntimeCore", () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
     expect(onError.mock.calls[0][0].message).toBe("load failed");
     expect(core.isLoading).toBe(false);
+  });
+
+  it("settles history loading when onError throws", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const callbackError = new Error("error callback failed");
+    const historyAdapter: ThreadHistoryAdapter = {
+      load: vi.fn().mockRejectedValue(new Error("load failed")),
+      append: vi.fn(),
+    };
+    const core = createCore({ runAgent: vi.fn() } as unknown as HttpAgent, {
+      history: historyAdapter,
+      onError: () => {
+        throw callbackError;
+      },
+    });
+
+    await expect(core.__internal_load()).resolves.toBeUndefined();
+
+    expect(core.isLoading).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith(
+      "[react-ag-ui] onError callback threw an error",
+      callbackError,
+    );
   });
 
   it("resets isLoading to false when history.load() throws", async () => {

--- a/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
+++ b/packages/react-ag-ui/test/ag-ui-thread-runtime-core.spec.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ExportedMessageRepository } from "@assistant-ui/core";
 import type {
   AppendMessage,
@@ -59,6 +59,10 @@ const assistantText = (message: ThreadMessage | undefined): string => {
   }
   return "";
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("AGUIThreadRuntimeCore", () => {
   it("streams assistant output into thread messages", async () => {


### PR DESCRIPTION
## Summary

- isolate `onError` and `onCancel` callback failures from AG-UI runtime control flow
- preserve the original run error when an error observer throws or rejects
- keep cancellation and history loading settled when lifecycle callbacks fail

## Why

In `@assistant-ui/react-ag-ui` 0.0.51, these application observers run directly inside run, resume, history, and abort control paths. A telemetry or UI callback failure can replace the real agent error, throw from cancellation, or reject an otherwise settled history load.

The fix guards observer invocation using the same behavior as the A2A and Google ADK runtimes: callback failures are reported without changing runtime settlement.

## Reproduction

The regression can be reproduced from this branch by restoring only the main-branch runtime implementation while keeping the new tests:

```bash
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git checkout fix/ag-ui-runtime-callback-errors
pnpm install --frozen-lockfile
git checkout "$(git merge-base HEAD origin/main)" -- packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
pnpm --filter @assistant-ui/react-ag-ui test -- test/ag-ui-thread-runtime-core.spec.ts
```

Without the fix, the callback error replaces `run failed`, cancellation produces an uncaught `cancel callback failed`, and history loading rejects. Restoring the branch implementation makes the focused suite pass.

## Testing

- `node node_modules/vitest/vitest.mjs run test/ag-ui-thread-runtime-core.spec.ts` (`126` tests)
- `aui-build` for `@assistant-ui/react-ag-ui`
- focused formatting and lint checks
