### PR TITLE
fix(react-data-stream): isolate lifecycle callbacks

### DIFF
--- a/.changeset/steady-data-stream-callbacks.md
+++ b/.changeset/steady-data-stream-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-data-stream": patch
+---
+
+fix: isolate lifecycle callback failures from stream control flow

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -55,6 +55,7 @@ const runToCompletion = async (
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
@@ -133,6 +134,42 @@ describe("useDataStreamRuntime request errors", () => {
     expect(onResponse).toHaveBeenCalledOnce();
     expect(onError).not.toHaveBeenCalled();
   });
+
+  it.each(["throws", "rejects"] as const)(
+    "preserves stream failures when onError %s",
+    async (failureMode) => {
+      const streamError = new Error("stream failed");
+      const callbackError = new Error("error callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const body = new ReadableStream({
+        start(controller) {
+          controller.error(streamError);
+        },
+      });
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(body)));
+
+      const adapter = createAdapter({
+        api: "/api/chat",
+        protocol: "ui-message-stream",
+        onError: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+      });
+
+      await expect(runToCompletion(adapter, createRunOptions())).rejects.toBe(
+        streamError,
+      );
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-data-stream] onError callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 
   it("reports resolver failures that race with cancellation", async () => {
     const controller = new AbortController();

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -358,6 +358,47 @@ describe("useDataStreamRuntime lifecycle callbacks", () => {
       });
     },
   );
+
+  it.each(["throws", "rejects"] as const)(
+    "keeps streams healthy when onData %s",
+    async (failureMode) => {
+      const callbackError = new Error("data callback failed");
+      const onError = vi.fn();
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const events = [
+        { type: "start", messageId: "assistant" },
+        { type: "data-weather", data: { temperature: 72 } },
+        { type: "finish", finishReason: "stop" },
+      ];
+      const body = `${events
+        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+        .join("")}data: [DONE]\n\n`;
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(body)));
+      const adapter = createAdapter({
+        api: "/api/chat",
+        protocol: "ui-message-stream",
+        onData: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+        onError,
+      });
+
+      await expect(
+        runToCompletion(adapter, createRunOptions()),
+      ).resolves.toBeUndefined();
+
+      expect(onError).not.toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-data-stream] onData callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 });
 
 const createAssistantMessage = (

--- a/packages/react-data-stream/src/useDataStreamRuntime.test.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.test.ts
@@ -46,6 +46,13 @@ const createAdapter = (options: UseDataStreamRuntimeOptions) => {
 const runOnce = (adapter: ChatModelAdapter, options: ChatModelRunOptions) =>
   (adapter.run(options) as AsyncGenerator).next();
 
+const runToCompletion = async (
+  adapter: ChatModelAdapter,
+  options: ChatModelRunOptions,
+) => {
+  for await (const _ of adapter.run(options)) void _;
+};
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
@@ -83,6 +90,36 @@ describe("useDataStreamRuntime request errors", () => {
     await expect(runOnce(adapter, createRunOptions())).rejects.toBe(error);
     expect(onError).toHaveBeenCalledExactlyOnceWith(error);
   });
+
+  it.each(["throws", "rejects"] as const)(
+    "preserves request failures when onError %s",
+    async (failureMode) => {
+      const requestError = new TypeError("Failed to fetch");
+      const callbackError = new Error("error callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(requestError));
+
+      const adapter = createAdapter({
+        api: "/api/chat",
+        onError: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+      });
+
+      await expect(runOnce(adapter, createRunOptions())).rejects.toBe(
+        requestError,
+      );
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-data-stream] onError callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 
   it("keeps response callback failures separate from request errors", async () => {
     const error = new Error("response callback failed");
@@ -204,6 +241,86 @@ describe("useDataStreamRuntime request errors", () => {
     expect(onCancel).toHaveBeenCalledOnce();
     expect(onError).not.toHaveBeenCalled();
   });
+
+  it.each(["throws", "rejects"] as const)(
+    "keeps cancellation settled when onCancel %s",
+    async (failureMode) => {
+      const controller = new AbortController();
+      const abortError = new DOMException("Cancelled", "AbortError");
+      const callbackError = new Error("cancel callback failed");
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+          return new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(init.signal?.reason),
+              { once: true },
+            );
+          });
+        }),
+      );
+      const adapter = createAdapter({
+        api: "/api/chat",
+        onCancel: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+      });
+      const result = runOnce(adapter, createRunOptions(controller.signal));
+
+      controller.abort(abortError);
+
+      await expect(result).rejects.toBe(abortError);
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-data-stream] onCancel callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
+});
+
+describe("useDataStreamRuntime lifecycle callbacks", () => {
+  it.each(["throws", "rejects"] as const)(
+    "keeps successful responses successful when onFinish %s",
+    async (failureMode) => {
+      const callbackError = new Error("finish callback failed");
+      const onError = vi.fn();
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(new Response("data: [DONE]\n\n")),
+      );
+      const adapter = createAdapter({
+        api: "/api/chat",
+        protocol: "ui-message-stream",
+        onFinish: () => {
+          if (failureMode === "throws") throw callbackError;
+          return Promise.reject(callbackError);
+        },
+        onError,
+      });
+
+      await expect(
+        runToCompletion(adapter, createRunOptions()),
+      ).resolves.toBeUndefined();
+
+      expect(onError).not.toHaveBeenCalled();
+      await vi.waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          "[react-data-stream] onFinish callback threw an error",
+          callbackError,
+        );
+      });
+    },
+  );
 });
 
 const createAssistantMessage = (

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -24,7 +24,11 @@ import { asAsyncIterableStream } from "assistant-stream/utils";
 
 type HeadersValue = Record<string, string> | Headers;
 
-type DataStreamRuntimeCallbackName = "onFinish" | "onError" | "onCancel";
+type DataStreamRuntimeCallbackName =
+  | "onFinish"
+  | "onError"
+  | "onCancel"
+  | "onData";
 
 const reportCallbackError = (
   name: DataStreamRuntimeCallbackName,
@@ -211,7 +215,17 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
       const decoder =
         protocol === "ui-message-stream"
           ? new UIMessageStreamDecoder(
-              this.options.onData ? { onData: this.options.onData } : {},
+              this.options.onData
+                ? {
+                    onData: (data) => {
+                      invokeRuntimeCallback(
+                        "onData",
+                        this.options.onData,
+                        data,
+                      );
+                    },
+                  }
+                : {},
             )
           : new DataStreamDecoder();
 

--- a/packages/react-data-stream/src/useDataStreamRuntime.ts
+++ b/packages/react-data-stream/src/useDataStreamRuntime.ts
@@ -24,6 +24,39 @@ import { asAsyncIterableStream } from "assistant-stream/utils";
 
 type HeadersValue = Record<string, string> | Headers;
 
+type DataStreamRuntimeCallbackName = "onFinish" | "onError" | "onCancel";
+
+const reportCallbackError = (
+  name: DataStreamRuntimeCallbackName,
+  error: unknown,
+) => {
+  console.error(`[react-data-stream] ${name} callback threw an error`, error);
+};
+
+const invokeRuntimeCallback = <TArgs extends unknown[]>(
+  name: DataStreamRuntimeCallbackName,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    const result = callback(...args) as unknown;
+    if (
+      result !== null &&
+      (typeof result === "object" || typeof result === "function") &&
+      "then" in result &&
+      typeof result.then === "function"
+    ) {
+      void Promise.resolve(result).catch((error) => {
+        reportCallbackError(name, error);
+      });
+    }
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 export type { DataStreamProtocol } from "./protocol";
 
 let didWarnProtocolFallback = false;
@@ -80,7 +113,9 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     unstable_getMessage,
   }: ChatModelRunOptions) {
     const handleAbort = () => {
-      if (!abortSignal.reason?.detach) this.options.onCancel?.();
+      if (!abortSignal.reason?.detach) {
+        invokeRuntimeCallback("onCancel", this.options.onCancel);
+      }
     };
 
     if (abortSignal.aborted) {
@@ -135,7 +170,9 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
     } catch (error: unknown) {
       abortSignal.removeEventListener("abort", handleAbort);
       if (!(error instanceof Error && error.name === "AbortError")) {
-        this.options.onError?.(
+        invokeRuntimeCallback(
+          "onError",
+          this.options.onError,
           error instanceof Error ? error : new Error(String(error)),
         );
       }
@@ -191,9 +228,13 @@ class DataStreamRuntimeAdapter implements ChatModelAdapter {
 
       yield* asAsyncIterableStream(stream);
 
-      this.options.onFinish?.(unstable_getMessage());
+      invokeRuntimeCallback(
+        "onFinish",
+        this.options.onFinish,
+        unstable_getMessage(),
+      );
     } catch (error: unknown) {
-      this.options.onError?.(error as Error);
+      invokeRuntimeCallback("onError", this.options.onError, error as Error);
       throw error;
     } finally {
       abortSignal.removeEventListener("abort", handleAbort);


### PR DESCRIPTION
## Summary

- isolate `onFinish`, `onError`, `onCancel`, and `onData` failures from stream control flow
- preserve successful completion when application observers throw or reject
- preserve original request/stream errors and cancellation when observer callbacks fail

## Why

In `@assistant-ui/react-data-stream` 0.12.24, these application observers run directly inside request, stream, decoder, and abort paths. A telemetry or UI callback failure can turn a successful response into a failed run, replace the real transport error, terminate a healthy `data-*` stream, or throw from cancellation.

`onResponse` remains awaited because its failure intentionally controls request setup. Open PR #5586 independently handles response-body cleanup for that path.

## Reproduction

The regression can be reproduced from this branch by restoring only the main-branch runtime implementation while keeping the new tests:

```bash
git clone https://github.com/assistant-ui/assistant-ui.git
cd assistant-ui
git checkout fix/data-stream-lifecycle-callback-errors
pnpm install --frozen-lockfile
git checkout "$(git merge-base HEAD origin/main)" -- packages/react-data-stream/src/useDataStreamRuntime.ts
pnpm --filter @assistant-ui/react-data-stream test -- src/useDataStreamRuntime.test.ts
```

Without the fix, callback errors replace request and stream failures, cancellation can throw, `onFinish` can fail a completed response, and `onData` can terminate a valid stream. Restoring the branch implementation makes the focused suite pass.

## Testing

- `node node_modules/vitest/vitest.mjs run src/useDataStreamRuntime.test.ts` (`22` tests)
- `aui-build` for `@assistant-ui/react-data-stream`
- focused formatting and lint checks
