### PR TITLE
fix(react-markdown): extract full fence language for non-word ids 

### DIFF
--- a/.changeset/markdown-language-regex.md
+++ b/.changeset/markdown-language-regex.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+fix: extract full fence language for ids with non-word characters (c++, objective-c, f#)

--- a/packages/react-markdown/src/overrides/CodeOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { FC } from "react";
+import { CodeOverride } from "./CodeOverride";
+import { PreContext } from "./PreOverride";
+import type {
+  CodeComponent,
+  PreComponent,
+  SyntaxHighlighterProps,
+} from "./types";
+
+const Pre: PreComponent = ({ node: _, ...props }) => <pre {...props} />;
+const Code: CodeComponent = ({ node: _, ...props }) => <code {...props} />;
+const FallbackHighlighter: FC<SyntaxHighlighterProps> = ({
+  language,
+  code,
+}) => <div data-testid="fallback" data-language={language} data-code={code} />;
+
+const makeHighlighter = (id: string): FC<SyntaxHighlighterProps> => {
+  const Highlighter: FC<SyntaxHighlighterProps> = ({ language }) => (
+    <div data-testid={id} data-language={language} />
+  );
+  return Highlighter;
+};
+
+const render = (
+  className: string,
+  componentsByLanguage?: Record<
+    string,
+    { SyntaxHighlighter?: FC<SyntaxHighlighterProps> }
+  >,
+) =>
+  renderToStaticMarkup(
+    <PreContext.Provider value={{}}>
+      <CodeOverride
+        components={{
+          Pre,
+          Code,
+          CodeHeader: () => null,
+          SyntaxHighlighter: FallbackHighlighter,
+        }}
+        componentsByLanguage={componentsByLanguage}
+        className={className}
+      >
+        test code
+      </CodeOverride>
+    </PreContext.Provider>,
+  );
+
+describe("CodeOverride language extraction", () => {
+  it.each(["c++", "objective-c", "f#"])(
+    "dispatches componentsByLanguage for %s",
+    (lang) => {
+      const html = render(`language-${lang}`, {
+        [lang]: { SyntaxHighlighter: makeHighlighter("custom") },
+      });
+      expect(html).toContain(`data-testid="custom"`);
+      expect(html).toContain(`data-language="${lang}"`);
+    },
+  );
+
+  it("dispatches componentsByLanguage for word-character ids", () => {
+    const html = render("language-tsx", {
+      tsx: { SyntaxHighlighter: makeHighlighter("custom") },
+    });
+    expect(html).toContain(`data-testid="custom"`);
+    expect(html).toContain(`data-language="tsx"`);
+  });
+
+  it("passes the full language id to the fallback highlighter", () => {
+    const html = render("language-c++");
+    expect(html).toContain(`data-testid="fallback"`);
+    expect(html).toContain(`data-language="c++"`);
+  });
+
+  it("falls back to unknown when no language class is present", () => {
+    const html = render("");
+    expect(html).toContain(`data-testid="fallback"`);
+    expect(html).toContain(`data-language="unknown"`);
+  });
+});

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -41,7 +41,8 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
     <Code {...getCodeProps(props)} />
   ));
 
-  const language = /language-(\w+)/.exec(codeProps.className || "")?.[1] ?? "";
+  const language =
+    /language-([^\s]+)/.exec(codeProps.className || "")?.[1] ?? "";
 
   // if the code content is not string (due to rehype plugins), return a default code block
   if (typeof children !== "string") {


### PR DESCRIPTION
Closes #5672

## What

Align react-markdown's fence-language regex to react-streamdown's `/language-([^\s]+)/` so language ids with non-word characters survive extraction, and add a colocated test for `CodeOverride`.

## Why

While testing `componentsByLanguage` with a `c++` fence, the override silently never fired: `\w+` stops at the first non-word character, so `c++` extracts as `c`, `objective-c` as `objective`, and `f#` as `f`. streamdown already uses the wider regex for the same job, so the two packages disagreed on identical input. 

## Impact

- `componentsByLanguage["c++"]` (and any non-word id) now dispatches; previously it was silently ignored.
- The fallback `SyntaxHighlighter`/`CodeHeader` now receive the full id instead of a truncated one.
- Word-character ids (`tsx`, `mermaid`, `diff`) extract exactly as before.

## Scope 

- The regex is byte-for-byte streamdown's `LANGUAGE_REGEX` (`code-adapter.tsx:17`); intentionally not extracted into a shared module, a one-line regex does not justify a cross-package dependency.
- These are the only two copies of this extraction in the repo; streamdown's side is already correct and untouched.
- `language || "unknown"` at `CodeOverride.tsx` makes `CodeBlock`'s no-language branch unreachable; pre-existing, tracked separately as a follow-up.
- The regex matching `language-` as a substring (e.g. `not-language-x`) is pre-existing and identical in both packages before and after.
- Tests: c++ / objective-c / f# dispatch, a `tsx` control, full-id fallback, and the no-language `unknown` path; the memoization wrapper is already covered by `memoization.test.ts`.
- Regex-only change, no exports touched.
- Changeset: patch (`@assistant-ui/react-markdown`).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.225fLHgy6N5_dYFRQYjFfRm_OShtGpHDjI4oHB8gOUREWIJAblYPtX_E0MA?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->