### PR TITLE
fix(react-markdown): pass the raw fence language instead of unknown

### DIFF
--- a/.changeset/markdown-empty-language.md
+++ b/.changeset/markdown-empty-language.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-markdown": patch
+---
+
+fix: pass the raw fence language to custom highlighters instead of "unknown"

--- a/packages/react-markdown/src/overrides/CodeBlock.tsx
+++ b/packages/react-markdown/src/overrides/CodeBlock.tsx
@@ -6,7 +6,6 @@ import type {
   PreComponent,
   SyntaxHighlighterProps,
 } from "./types";
-import { DefaultCodeBlockContent } from "./defaultComponents";
 import type { Element } from "hast";
 
 export type CodeBlockProps = {
@@ -29,15 +28,13 @@ export const DefaultCodeBlock: FC<CodeBlockProps> = ({
 }) => {
   const components = useMemo(() => ({ Pre, Code }), [Pre, Code]);
 
-  const SH = language ? SyntaxHighlighter : DefaultCodeBlockContent;
-
   return (
     <>
       <CodeHeader node={node} language={language} code={code} />
-      <SH
+      <SyntaxHighlighter
         node={node}
         components={components}
-        language={language ?? "unknown"}
+        language={language}
         code={code}
       />
     </>

--- a/packages/react-markdown/src/overrides/CodeOverride.test.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.test.tsx
@@ -5,6 +5,7 @@ import { CodeOverride } from "./CodeOverride";
 import { PreContext } from "./PreOverride";
 import type {
   CodeComponent,
+  CodeHeaderProps,
   PreComponent,
   SyntaxHighlighterProps,
 } from "./types";
@@ -29,6 +30,7 @@ const render = (
     string,
     { SyntaxHighlighter?: FC<SyntaxHighlighterProps> }
   >,
+  CodeHeader: FC<CodeHeaderProps> = () => null,
 ) =>
   renderToStaticMarkup(
     <PreContext.Provider value={{}}>
@@ -36,7 +38,7 @@ const render = (
         components={{
           Pre,
           Code,
-          CodeHeader: () => null,
+          CodeHeader,
           SyntaxHighlighter: FallbackHighlighter,
         }}
         componentsByLanguage={componentsByLanguage}
@@ -73,9 +75,17 @@ describe("CodeOverride language extraction", () => {
     expect(html).toContain(`data-language="c++"`);
   });
 
-  it("falls back to unknown when no language class is present", () => {
+  it("passes an empty language to the fallback highlighter when no language class is present", () => {
     const html = render("");
     expect(html).toContain(`data-testid="fallback"`);
-    expect(html).toContain(`data-language="unknown"`);
+    expect(html).toContain(`data-language=""`);
+  });
+
+  it("passes an empty language to the code header when no language class is present", () => {
+    const CodeHeader: FC<CodeHeaderProps> = ({ language }) => (
+      <div data-testid="header" data-language={language} />
+    );
+    const html = render("", undefined, CodeHeader);
+    expect(html).toContain(`data-testid="header" data-language=""`);
   });
 });

--- a/packages/react-markdown/src/overrides/CodeOverride.tsx
+++ b/packages/react-markdown/src/overrides/CodeOverride.tsx
@@ -71,7 +71,7 @@ const CodeBlockOverride: FC<CodeOverrideProps> = ({
         SyntaxHighlighter,
         CodeHeader,
       }}
-      language={language || "unknown"}
+      language={language}
       code={children}
     />
   );


### PR DESCRIPTION
## What

`CodeOverride` now forwards the extracted fence language as-is instead of substituting `"unknown"` when a code block has no language, and the now-dead `language ? SyntaxHighlighter : DefaultCodeBlockContent` branch in `CodeBlock.tsx` is removed.

## Why

While pinning behavior for #5673 I noticed language-less fences call the user's `SyntaxHighlighter` and `CodeHeader` with the literal id `"unknown"`: a shiki-based highlighter tries to load a language named "unknown", and the default registry code header renders "unknown" as the label. react-streamdown already passes the raw language through (`""` when none), so this aligns the two packages, same as the parent PR did for the regex.

## Impact

- Custom `SyntaxHighlighter` and `CodeHeader` components now receive `""` instead of `"unknown"` for language-less fences, matching react-streamdown.
- Default UI without a custom highlighter is unchanged (`MarkdownTextPrimitive` falls back to the plain code block, which ignores `language`).
- The registry code header stops showing a literal "unknown" label on plain fences.

## Scope 

- Was stacked on #5673; parent merged, so the branch is rebased onto main and is now a single commit carrying only this change. Flips one assertion of the parent's merged `CodeOverride.test.tsx`.
- The removed branch in `CodeBlock.tsx` was unreachable: its only caller always passed a truthy string, and `language ?? "unknown"` was dead under `language: string`. `DefaultCodeBlock` is not exported from the package, so no public surface changes.
- `"unknown"` is not a documented contract anywhere in docs or code; only a consumer string-matching `language === "unknown"` would notice, and streamdown never emitted it.
- `componentsByLanguage` dispatch already used the raw language, so component selection is unchanged; only the forwarded id changes.
- Kept `DefaultCodeBlock` as a wrapper rather than inlining its single caller, to keep the diff minimal.
- Tests: language-less fence pinned on both the highlighter and the code header receiving `""`; existing c++/objective-c/f#/tsx dispatch tests unchanged.
- Changeset: patch (`@assistant-ui/react-markdown`).

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Wd9xazWGHgBI88hq8RTULBBBb5HjLMmnGQgWxrfoV8OmYB3p0j72xyZcEFc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->