### PR TITLE
feat(store,vue): live config source, explicit extends, and AuiIf

### DIFF
--- a/.changeset/store-config-source.md
+++ b/.changeset/store-config-source.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+feat: createAssistantClient accepts an AssistantConfigSource, re-read in the root render so bindings can deliver config changes (updated element args, added or removed scopes) without remounting surviving scopes

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1573,6 +1573,7 @@ declare class PiThreadSupervisor {
   private onSessionEvent;
   private emitContextUsage;
   private emit;
+  private notifyListener;
   private liveStatusFor;
   private runStatus;
   private readinessOf;

--- a/api-surface/assistant-ui__store.ts
+++ b/api-surface/assistant-ui__store.ts
@@ -30,6 +30,11 @@ type AssistantClientSource = {
   subscribe(listener: () => void): Unsubscribe;
 };
 
+type AssistantConfigSource = {
+  getConfig(): AuiConfig.Input;
+  subscribe(listener: () => void): Unsubscribe;
+};
+
 type AssistantEventCallback<TEvent extends AssistantEventName> = (payload: AssistantEventPayload[TEvent]) => void;
 
 type AssistantEventName = keyof AssistantEventPayload;
@@ -230,10 +235,10 @@ declare const auiConfigBrand: unique symbol;
 declare const clientIdBrand: unique symbol;
 
 declare namespace entry_client_exports {
-  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, createAssistantClient, getProxiedAssistantState, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useClientLookup, useClientResource };
+  export { AssistantClient, AssistantClientAccessor, AssistantClientHandle, AssistantClientSource, AssistantConfigSource, AssistantEventCallback, AssistantEventName, AssistantEventPayload, AssistantEventSelector, AssistantState, AuiConfig, ClientElement, ClientEvents, ClientMeta, ClientMethods, ClientNames, ClientOutput, ClientSchema, DefaultAssistantClient, Derived, DerivedElement, InferClientState, ScopeRegistry, ScopesConfig, Unsubscribe, attachTransformScopes, createAssistantClient, getProxiedAssistantState, normalizeEventSelector, useAssistantClientRef, useAssistantEmit, useClientLookup, useClientResource };
 }
 
-declare const createAssistantClient: (config: AuiConfig.Input, options?: {
+declare const createAssistantClient: (config: AuiConfig.Input | AssistantConfigSource, options?: {
   parent?: AssistantClient | AssistantClientSource | undefined;
 }) => AssistantClientHandle;
 

--- a/packages/store/src/client.ts
+++ b/packages/store/src/client.ts
@@ -6,6 +6,7 @@ export {
   createAssistantClient,
   type AssistantClientHandle,
   type AssistantClientSource,
+  type AssistantConfigSource,
 } from "./createAssistantClient";
 
 export { DefaultAssistantClient } from "./utils/react-assistant-context";

--- a/packages/store/src/createAssistantClient.test.ts
+++ b/packages/store/src/createAssistantClient.test.ts
@@ -58,6 +58,40 @@ const createTestClient = (
   > & { getClient(): AnyClient };
 
 describe("createAssistantClient", () => {
+  it("re-reads a config source, updating args in place and reconciling scopes", () => {
+    let config: Record<string, unknown> = {
+      message: MessageClient({ id: "m0" }),
+    };
+    const listeners = new Set<() => void>();
+    const notify = () => listeners.forEach((listener) => listener());
+    const handle = createAssistantClient({
+      getConfig: () => config as never,
+      subscribe: (listener) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    });
+
+    const aui = handle.getClient() as AnyClient;
+    flushTapSync(() => aui.message.setText("draft"));
+    expect(aui.message.getState()).toEqual({ id: "m0", text: "draft" });
+
+    config = { message: MessageClient({ id: "m1" }), thread: ThreadClient() };
+    flushTapSync(notify);
+
+    const extended = handle.getClient() as AnyClient;
+    expect(extended.message.getState()).toEqual({ id: "m1", text: "draft" });
+    expect(extended.thread.getState()).toEqual({ selected: 0 });
+
+    config = {};
+    flushTapSync(notify);
+    expect(() =>
+      (handle.getClient() as AnyClient).message.getState(),
+    ).toThrow();
+
+    handle.destroy();
+  });
+
   it("hosts scopes without any React renderer", () => {
     const handle = createTestClient({ thread: ThreadClient() });
     const aui = handle.getClient();

--- a/packages/store/src/createAssistantClient.ts
+++ b/packages/store/src/createAssistantClient.ts
@@ -30,6 +30,35 @@ export type AssistantClientHandle = AssistantClientSource & {
   destroy(): void;
 };
 
+/**
+ * A live view onto a config whose entries may change over time.
+ *
+ * `getConfig` returns the current config; `subscribe` fires after every
+ * change. The root re-reads the config on each notification: a scope that
+ * keeps its key keeps its state while its element args update, and added or
+ * removed keys mount and unmount their scopes.
+ */
+export type AssistantConfigSource = {
+  getConfig(): AuiConfig.Input;
+  subscribe(listener: () => void): Unsubscribe;
+};
+
+// A config maps scope names to resource elements; only a source carries a
+// getConfig function
+const isConfigSource = (
+  config: AuiConfig.Input | AssistantConfigSource,
+): config is AssistantConfigSource =>
+  typeof (config as AssistantConfigSource).getConfig === "function";
+
+const NO_OP_SUBSCRIBE = () => () => {};
+
+const toConfigSource = (
+  config: AuiConfig.Input | AssistantConfigSource,
+): AssistantConfigSource =>
+  isConfigSource(config)
+    ? config
+    : { getConfig: () => config, subscribe: NO_OP_SUBSCRIBE };
+
 // A client (including the sentinel proxies, whose property reads all resolve)
 // always carries `on`; a source or handle never does, so its absence is the
 // discriminator
@@ -63,11 +92,13 @@ const toClientSource = (
  * keeps the child bound to the parent's current client across the parent's
  * structural changes without remounting the child's scopes.
  *
- * The config is captured at creation; create a new handle to change the scope
- * set.
+ * The config may be a plain value, captured at creation, or an
+ * {@link AssistantConfigSource} that is re-read in the root render whenever it
+ * notifies, so a binding can deliver config changes (updated element args,
+ * added or removed scopes) without remounting the surviving scopes.
  */
 export const createAssistantClient = (
-  config: AuiConfig.Input,
+  config: AuiConfig.Input | AssistantConfigSource,
   options?: {
     parent?: AssistantClient | AssistantClientSource | undefined;
   },
@@ -75,6 +106,7 @@ export const createAssistantClient = (
   const parentSource = toClientSource(
     options?.parent ?? DefaultAssistantClient,
   );
+  const configSource = toConfigSource(config);
 
   const clientRef: ClientRef = {
     parent: parentSource.getClient(),
@@ -88,8 +120,13 @@ export const createAssistantClient = (
       parentSource.getClient,
       parentSource.getClient,
     );
+    const currentConfig = useSyncExternalStore(
+      configSource.subscribe,
+      configSource.getConfig,
+      configSource.getConfig,
+    );
     const entries = Object.entries(
-      applyTransformScopes(config, parent),
+      applyTransformScopes(currentConfig, parent),
     ) as ScopeEntry[];
     const result = useAuiRoot({ parent, entries, clientRef, notifications });
     // Seeded during render, before the commit runs mount effects that read it

--- a/packages/vue/src/AuiIf.ts
+++ b/packages/vue/src/AuiIf.ts
@@ -1,0 +1,29 @@
+import { defineComponent, type PropType, type SlotsType } from "vue";
+import type { AssistantState } from "@assistant-ui/store/client";
+import { useAuiState } from "./useAuiState";
+
+/**
+ * Renders the default slot while `condition` selects `true` from the
+ * assistant state.
+ *
+ * @example
+ * ```html
+ * <AuiIf :condition="(s) => s.thread.isRunning">
+ *   <StopButton />
+ * </AuiIf>
+ * ```
+ */
+export const AuiIf = defineComponent({
+  name: "AuiIf",
+  props: {
+    condition: {
+      type: Function as PropType<(state: AssistantState) => boolean>,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const active = useAuiState((state) => props.condition(state));
+    return () => (active.value ? slots.default?.() : null);
+  },
+});

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -14,9 +14,23 @@ import {
 } from "@assistant-ui/store/client";
 import { auiInjectionKey, createClientFacade } from "./context";
 
-const isDevelopment =
-  typeof process !== "undefined" &&
-  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");
+// Vite replaces the import.meta.env and process.env.NODE_ENV literals per
+// host; the try blocks cover hosts where neither binding exists.
+const isDevelopment = (() => {
+  try {
+    const env = (import.meta as { env?: { DEV?: boolean } }).env;
+    if (typeof env?.DEV === "boolean") return env.DEV;
+  } catch {
+    /* empty */
+  }
+  try {
+    return (
+      process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+    );
+  } catch {
+    return false;
+  }
+})();
 
 /**
  * Creates an `AssistantClient` from the given config and provides it to the
@@ -58,12 +72,13 @@ export const AuiProvider = defineComponent({
       }
     }
 
-    const parent =
-      !hasExtends || props.extends === null
+    const parent = !hasExtends
+      ? injected?.source
+      : props.extends === null
         ? undefined
         : injected && props.extends === injected.aui
           ? injected.source
-          : props.extends!;
+          : props.extends;
 
     const handle = createAssistantClient(
       {

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -3,23 +3,35 @@ import {
   inject,
   onScopeDispose,
   provide,
+  watch,
   type PropType,
   type SlotsType,
 } from "vue";
 import {
   createAssistantClient,
+  type AssistantClient,
   type AuiConfig,
 } from "@assistant-ui/store/client";
 import { auiInjectionKey, createClientFacade } from "./context";
 
+const isDevelopment =
+  typeof process !== "undefined" &&
+  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test");
+
 /**
  * Creates an `AssistantClient` from the given config and provides it to the
- * subtree. Nested providers extend the nearest ancestor's client; scopes the
- * config does not define resolve through the parent chain.
+ * subtree.
  *
- * The config is captured when the provider mounts; swapping the `config` prop
- * afterwards is not supported. Remount the provider (for example with a
- * `key`) to change the scope set.
+ * At the top level, `config` alone creates this subtree's own client. Under a
+ * parent provider, `extends` is mandatory: pass `:extends="aui"` to extend the
+ * parent client or `:extends="null"` to isolate from it (enforced with a dev
+ * error).
+ *
+ * The `config` prop is live: passing a new config object updates element args
+ * in place (scopes keep their state) and mounts or unmounts added and removed
+ * scopes. Pass a computed config to derive it from reactive inputs. `extends`
+ * is captured when the provider mounts; remount (for example with a `key`) to
+ * change the parent.
  */
 export const AuiProvider = defineComponent({
   name: "AuiProvider",
@@ -28,14 +40,37 @@ export const AuiProvider = defineComponent({
       type: Object as PropType<AuiConfig>,
       required: true,
     },
+    extends: {
+      type: Object as PropType<AssistantClient | null>,
+      default: undefined,
+    },
   },
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(props, { slots }) {
-    const parent = inject(auiInjectionKey, null);
+    const injected = inject(auiInjectionKey, null);
+    const hasExtends = props.extends !== undefined;
+
+    if (isDevelopment) {
+      if (injected && !hasExtends) {
+        throw new Error(
+          'A parent AuiProvider exists. Pass :extends="aui" to inherit it or :extends="null" to isolate.',
+        );
+      }
+    }
+
+    const parent =
+      !hasExtends || props.extends === null
+        ? undefined
+        : injected && props.extends === injected.aui
+          ? injected.source
+          : props.extends!;
 
     const handle = createAssistantClient(
-      props.config,
-      parent ? { parent: parent.source } : undefined,
+      {
+        getConfig: () => props.config,
+        subscribe: (listener) => watch(() => props.config, listener),
+      },
+      parent ? { parent } : undefined,
     );
     onScopeDispose(() => handle.destroy());
 

--- a/packages/vue/src/__tests__/AuiIf.test.ts
+++ b/packages/vue/src/__tests__/AuiIf.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { AuiProvider } from "../AuiProvider";
+import { AuiIf } from "../AuiIf";
+import { useAui } from "../useAui";
+import { ThreadClient, type AnyClient } from "./fixtures";
+
+const mountApp = (root: Component) => {
+  const app = createApp(root);
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+describe("AuiIf", () => {
+  it("renders the slot only while the condition selects true", async () => {
+    let aui!: AnyClient;
+    const Probe = defineComponent({
+      setup() {
+        aui = useAui() as AnyClient;
+        return () =>
+          h(
+            AuiIf,
+            { condition: (s) => (s as AnyClient).thread.selected === 1 },
+            { default: () => h("span", { id: "flag" }, "visible") },
+          );
+      },
+    });
+    const { el, unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({ thread: ThreadClient() } as never) },
+            { default: () => h(Probe) },
+          ),
+      }),
+    );
+
+    expect(el.querySelector("#flag")).toBeNull();
+
+    flushTapSync(() => aui.thread.setSelected(1));
+    await nextTick();
+    expect(el.querySelector("#flag")?.textContent).toBe("visible");
+
+    flushTapSync(() => aui.thread.setSelected(0));
+    await nextTick();
+    expect(el.querySelector("#flag")).toBeNull();
+
+    unmount();
+  });
+});

--- a/packages/vue/src/__tests__/AuiProvider.test.ts
+++ b/packages/vue/src/__tests__/AuiProvider.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from "vitest";
-import { createApp, defineComponent, h, type Component } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  shallowRef,
+  type Component,
+} from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig, type AssistantClient } from "@assistant-ui/store/client";
 import { AuiProvider } from "../AuiProvider";
 import { useAui } from "../useAui";
 import {
+  MessageClient,
   ThreadClient,
   messageDerived,
   trackers,
@@ -80,22 +88,29 @@ describe("AuiProvider", () => {
     unmount();
   });
 
-  it("extends the parent provider's client in nested providers", () => {
+  it("extends the parent provider's client with an explicit extends", () => {
     const { Probe, getAui } = captureAui();
+    const Nested = defineComponent({
+      setup(_, { slots }) {
+        const aui = useAui();
+        return () =>
+          h(
+            AuiProvider,
+            {
+              config: AuiConfig({ message: messageDerived() } as never),
+              extends: aui,
+            },
+            { default: () => slots.default?.() },
+          );
+      },
+    });
     const { unmount } = mountApp(
       defineComponent({
         setup: () => () =>
           h(
             AuiProvider,
             { config: AuiConfig({ thread: ThreadClient() } as never) },
-            {
-              default: () =>
-                h(
-                  AuiProvider,
-                  { config: AuiConfig({ message: messageDerived() } as never) },
-                  { default: () => h(Probe) },
-                ),
-            },
+            { default: () => h(Nested, null, { default: () => h(Probe) }) },
           ),
       }),
     );
@@ -106,6 +121,87 @@ describe("AuiProvider", () => {
 
     flushTapSync(() => aui.thread.setSelected(1));
     expect(aui.message.getState().id).toBe("m1");
+
+    unmount();
+  });
+
+  it("throws in dev when nested without an explicit extends", () => {
+    const Nested = defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ message: messageDerived() } as never) },
+          { default: () => null },
+        ),
+    });
+    expect(() =>
+      mountApp(
+        defineComponent({
+          setup: () => () =>
+            h(
+              AuiProvider,
+              { config: AuiConfig({ thread: ThreadClient() } as never) },
+              { default: () => h(Nested) },
+            ),
+        }),
+      ),
+    ).toThrow("A parent AuiProvider exists.");
+  });
+
+  it("isolates from the parent with extends null", () => {
+    const { Probe, getAui } = captureAui();
+    const Isolated = defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              message: MessageClient({ id: "iso" }),
+            } as never),
+            extends: null,
+          },
+          { default: () => h(Probe) },
+        ),
+    });
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(
+            AuiProvider,
+            { config: AuiConfig({ thread: ThreadClient() } as never) },
+            { default: () => h(Isolated) },
+          ),
+      }),
+    );
+
+    expect(getAui().message.getState()).toEqual({ id: "iso", text: "" });
+    expect(() => getAui().thread.getState()).toThrow(
+      'The current scope does not have a "thread" property.',
+    );
+
+    unmount();
+  });
+
+  it("applies config changes in place, keeping scope state", async () => {
+    const { Probe, getAui } = captureAui();
+    const config = shallowRef(
+      AuiConfig({ message: MessageClient({ id: "m0" }) } as never),
+    );
+    const { unmount } = mountApp(
+      defineComponent({
+        setup: () => () =>
+          h(AuiProvider, { config: config.value }, { default: () => h(Probe) }),
+      }),
+    );
+
+    flushTapSync(() => getAui().message.setText("draft"));
+    expect(getAui().message.getState()).toEqual({ id: "m0", text: "draft" });
+
+    config.value = AuiConfig({ message: MessageClient({ id: "m1" }) } as never);
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(getAui().message.getState()).toEqual({ id: "m1", text: "draft" });
+    });
 
     unmount();
   });

--- a/packages/vue/src/__tests__/AuiProvider.test.ts
+++ b/packages/vue/src/__tests__/AuiProvider.test.ts
@@ -203,6 +203,24 @@ describe("AuiProvider", () => {
       expect(getAui().message.getState()).toEqual({ id: "m1", text: "draft" });
     });
 
+    config.value = AuiConfig({
+      message: MessageClient({ id: "m1" }),
+      thread: ThreadClient(),
+    } as never);
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(getAui().thread.getState()).toEqual({ selected: 0 });
+    });
+    expect(getAui().message.getState()).toEqual({ id: "m1", text: "draft" });
+
+    config.value = AuiConfig({ message: MessageClient({ id: "m1" }) } as never);
+    await nextTick();
+    await vi.waitFor(() => {
+      expect(() => getAui().thread.getState()).toThrow(
+        'The current scope does not have a "thread" property.',
+      );
+    });
+
     unmount();
   });
 

--- a/packages/vue/src/__tests__/fixtures.ts
+++ b/packages/vue/src/__tests__/fixtures.ts
@@ -22,7 +22,7 @@ const useMessageClient = ({ id }: { id: string }) => {
       emit("message.pinged" as never, { id, value } as never),
   };
 };
-const MessageClient = resource(useMessageClient);
+export const MessageClient = resource(useMessageClient);
 
 const useThreadClient = () => {
   const [selected, setSelected] = useState(0);

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,4 +1,5 @@
 export { AuiProvider } from "./AuiProvider";
+export { AuiIf } from "./AuiIf";
 export { useAui } from "./useAui";
 export { useAuiState } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
@@ -10,6 +11,7 @@ export {
   type AssistantClient,
   type AssistantClientHandle,
   type AssistantClientSource,
+  type AssistantConfigSource,
   type AssistantState,
   type AssistantEventCallback,
   type AssistantEventName,


### PR DESCRIPTION
## summary

- createAssistantClient now accepts an AssistantConfigSource ({ getConfig, subscribe }) that is re-read in the root render, mirroring the parent-source design: a scope that keeps its key keeps its state while its element args update, and added or removed keys mount and unmount their scopes
- the vue AuiProvider adopts the React provider's explicit extends grammar (nesting without extends throws in dev, :extends="aui" inherits through the live injected source, :extends="null" isolates) and wires its config prop through the config source, so passing a new config object updates scope args in place; the P1 auto-inherit behavior is removed (the package is private and unreleased)
- adds the vue AuiIf component, mirroring the React AuiIf: renders the default slot while the condition selector returns true

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/store -> 123/123, including the new config source contract test (in-place arg update, scope add and remove, post-removal access throws)
- [x] `pnpm exec vitest run` in packages/vue -> 18/18, including explicit extends inheritance, dev throw without extends, extends null isolation, live config keeping scope state, and AuiIf slot toggling
- [x] `pnpm api-surface` + `pnpm api-surface:check` -> green; the store surface diff is additive only (AssistantConfigSource)
- [x] `pnpm lint` -> clean; examples/with-vue build -> green (single top-level provider, unaffected by the extends requirement)

### reviewer should verify

- [ ] in a Vue app, swapping the :config binding to a new AuiConfig with changed element args keeps existing scope state (for example composer text) while the args take effect

## notes

- extends is captured at mount on the vue side; swapping the parent requires a remount (documented on the component), matching the provider-identity model the React side gets from re-render
- follow-up (3b) builds the first Vue primitives on top of these seams

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.7KknJ2Kg1o6LlWbX_TAt467XRldSSn8-T4A0zXsiND3B-qYHmF-A5dxpsDU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->