### PR TITLE
chore: sync versions after manual npm release

### DIFF
--- a/packages/react-mcp/CHANGELOG.md
+++ b/packages/react-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @assistant-ui/react-mcp
 
+## 0.1.6
+
+### Patch Changes
+
+- Fix broken 0.1.5 publish that shipped unresolved workspace: dependency ranges.
+
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/react-mcp/package.json
+++ b/packages/react-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-mcp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "MCP server configuration and connection primitives for @assistant-ui",
   "keywords": [
     "mcp",

--- a/packages/react-o11y/CHANGELOG.md
+++ b/packages/react-o11y/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @assistant-ui/react-o11y
 
+## 0.0.36
+
+### Patch Changes
+
+- Fix broken 0.0.35 publish that shipped unresolved workspace: dependency ranges.
+
+
 ## 0.0.35
 
 ### Patch Changes

--- a/packages/react-o11y/package.json
+++ b/packages/react-o11y/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react-o11y",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Observability primitives for @assistant-ui",
   "keywords": [
     "observability",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @assistant-ui/react
 
+## 0.15.8
+
+### Patch Changes
+
+- Republish of 0.15.6 (registry staged-version conflicts blocked 0.15.6 and 0.15.7; contents identical).
+
+
 ## 0.15.6
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/react",
-  "version": "0.15.6",
+  "version": "0.15.8",
   "description": "Open-source TypeScript/React library for building production-grade AI chat experiences",
   "keywords": [
     "ai",

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @assistant-ui/store
 
+## 0.3.6
+
+### Patch Changes
+
+- Republish of 0.3.5 (registry staged-version conflict blocked the original publish; contents identical).
+
+
 ## 0.3.5
 
 ### Patch Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@assistant-ui/store",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Tap-based state management for @assistant-ui",
   "keywords": [
     "state-management",


### PR DESCRIPTION
GitHub Actions was down, so the release commit 6d155db was published to npm manually. This syncs the repo with what actually landed on the registry:

- **react 0.15.8**, **store 0.3.6** — the original 0.15.6/0.3.5 (and an intermediate 0.15.7) got wedged in npm's staged-publishing hold; bumped past them. 0.15.7 later cleared and is also live; `latest` points at 0.15.8.
- **react-mcp 0.1.6**, **react-o11y 0.0.36** — 0.1.5/0.0.35 were published via raw `npm publish`, which does not rewrite `workspace:*` ranges, making them uninstallable. Republished from pnpm-packed tarballs and deprecated the broken versions.

Without this sync the next changesets release would collide with the versions already on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjgzND7cyD7NmYTAy74JJN

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

