### PR TITLE
fix(react-langgraph): isolate stream event callbacks

### DIFF
--- a/.changeset/calm-lobsters-listen.md
+++ b/.changeset/calm-lobsters-listen.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: isolate stream event callback errors

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, onTestFinished, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 
 import { useLangGraphMessages } from "./useLangGraphMessages";
@@ -3642,6 +3642,80 @@ describe("useLangGraphMessages", {}, () => {
         langgraph_node: "tools",
         namespace: "tools:tc-1",
       });
+    });
+  });
+
+  it("continues processing after an event callback throws", async () => {
+    const callbackError = new Error("values callback failed");
+    const onCustomEvent = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const mockStreamCallback = mockStreamCallbackFactory([
+      { event: "values", data: { messages: [] } },
+      { event: "after-values", data: { ok: true } },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: {
+          onValues: () => {
+            throw callbackError;
+          },
+          onCustomEvent,
+        },
+      }),
+    );
+
+    await act(() =>
+      result.current.sendMessage([{ type: "human", content: "hi" }], {}),
+    );
+
+    expect(onCustomEvent).toHaveBeenCalledWith("after-values", { ok: true });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[react-langgraph] onValues callback threw an error",
+      callbackError,
+    );
+  });
+
+  it("handles rejected event callback promises", async () => {
+    const callbackError = new Error("custom callback failed");
+    const onMetadata = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    onTestFinished(() => consoleError.mockRestore());
+    const mockStreamCallback = mockStreamCallbackFactory([
+      { event: "custom-event", data: { value: 1 } },
+      { event: "metadata", data: { run_id: "run-1" } },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+        eventHandlers: {
+          onCustomEvent: async () => {
+            throw callbackError;
+          },
+          onMetadata,
+        },
+      }),
+    );
+
+    await act(() =>
+      result.current.sendMessage([{ type: "human", content: "hi" }], {}),
+    );
+
+    expect(onMetadata).toHaveBeenCalledWith({ run_id: "run-1" });
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[react-langgraph] onCustomEvent callback threw an error",
+        callbackError,
+      );
     });
   });
 });

--- a/packages/react-langgraph/src/useLangGraphMessages.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.ts
@@ -25,6 +25,41 @@ import { normalizeLangGraphTupleMessage } from "./normalizeLangGraphTupleMessage
 
 const DEFAULT_UI_STATE_KEY = "ui";
 
+type LangGraphEventCallbackName =
+  | "onMessageChunk"
+  | "onValues"
+  | "onUpdates"
+  | "onSubgraphValues"
+  | "onSubgraphUpdates"
+  | "onMetadata"
+  | "onInfo"
+  | "onError"
+  | "onSubgraphError"
+  | "onCustomEvent";
+
+const reportCallbackError = (
+  name: LangGraphEventCallbackName,
+  error: unknown,
+) => {
+  console.error(`[react-langgraph] ${name} callback threw an error`, error);
+};
+
+const invokeEventCallback = <TArgs extends unknown[]>(
+  name: LangGraphEventCallbackName,
+  callback: ((...args: TArgs) => void | Promise<void>) | undefined,
+  ...args: TArgs
+) => {
+  if (!callback) return;
+
+  try {
+    void Promise.resolve(callback(...args)).catch((error) => {
+      reportCallbackError(name, error);
+    });
+  } catch (error) {
+    reportCallbackError(name, error);
+  }
+};
+
 const parseEventType = (
   event: string,
 ): { type: string; namespace: string | undefined } => {
@@ -284,9 +319,14 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               break;
             case LangGraphKnownEventTypes.Updates: {
               if (eventNamespace) {
-                onSubgraphUpdates?.(eventNamespace, chunk.data);
+                invokeEventCallback(
+                  "onSubgraphUpdates",
+                  onSubgraphUpdates,
+                  eventNamespace,
+                  chunk.data,
+                );
               } else {
-                onUpdates?.(chunk.data);
+                invokeEventCallback("onUpdates", onUpdates, chunk.data);
               }
               const extracted = extractMessagesFromUpdates<TMessage>(
                 chunk.data,
@@ -303,11 +343,16 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
             }
             case LangGraphKnownEventTypes.Values:
               if (eventNamespace) {
-                onSubgraphValues?.(eventNamespace, chunk.data);
+                invokeEventCallback(
+                  "onSubgraphValues",
+                  onSubgraphValues,
+                  eventNamespace,
+                  chunk.data,
+                );
                 break;
               }
               setValues(chunk.data as Record<string, unknown>);
-              onValues?.(chunk.data);
+              invokeEventCallback("onValues", onValues, chunk.data);
               if (Array.isArray(chunk.data?.messages)) {
                 lastValuesMessages = chunk.data.messages;
                 if (hasTupleMessageEvents) {
@@ -359,7 +404,9 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
                   : undefined;
 
               if (normalizedTupleMessage.kind === "chunk") {
-                onMessageChunk?.(
+                invokeEventCallback(
+                  "onMessageChunk",
+                  onMessageChunk,
                   normalizedTupleMessage.message,
                   tupleMetadataWithNamespace ?? {},
                 );
@@ -379,13 +426,13 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
               break;
             }
             case LangGraphKnownEventTypes.Metadata:
-              onMetadata?.(chunk.data);
+              invokeEventCallback("onMetadata", onMetadata, chunk.data);
               break;
             case LangGraphKnownEventTypes.Info:
-              onInfo?.(chunk.data);
+              invokeEventCallback("onInfo", onInfo, chunk.data);
               break;
             case LangGraphKnownEventTypes.Error: {
-              onError?.(chunk.data);
+              invokeEventCallback("onError", onError, chunk.data);
               // namespaced errors come from subgraphs, which the parent may recover from
               if (!eventNamespace) {
                 const messages = accumulator.getMessages();
@@ -405,7 +452,12 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
                   setMessagesImmediate(accumulator.addMessages([errorMessage]));
                 }
               } else {
-                onSubgraphError?.(eventNamespace, chunk.data);
+                invokeEventCallback(
+                  "onSubgraphError",
+                  onSubgraphError,
+                  eventNamespace,
+                  chunk.data,
+                );
               }
               break;
             }
@@ -416,7 +468,12 @@ export const useLangGraphMessages = <TMessage extends { id?: string }>({
                 break;
               }
               if (onCustomEvent) {
-                onCustomEvent(eventType, chunk.data);
+                invokeEventCallback(
+                  "onCustomEvent",
+                  onCustomEvent,
+                  eventType,
+                  chunk.data,
+                );
               } else {
                 console.warn(
                   "Unhandled event received:",


### PR DESCRIPTION
## Summary

- isolate synchronous errors from LangGraph stream event callbacks
- consume rejected callback promises so they do not become unhandled rejections
- continue processing later stream events after an application callback fails

## Why

LangGraph event handlers support both synchronous and async callbacks. A telemetry or application callback that threw could terminate an otherwise healthy stream, while a rejected callback promise was previously left unhandled. Callback failures are now reported with callback context without changing the stream result.

## Testing

- `vitest run src/useLangGraphMessages.test.ts` (67 tests)
- `aui-build` for `@assistant-ui/react-langgraph`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.G2WNc_O8W586pVtpkobE2KFdQ_WZRxxDC3FgamI0hrE1pmdPPZtHsO55uT4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->