### PR TITLE
fix(react-pi): isolate initial subscription callbacks

### DIFF
--- a/.changeset/tidy-ravens-smile.md
+++ b/.changeset/tidy-ravens-smile.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-pi": patch
+---
+
+fix: isolate initial subscription callback errors

--- a/packages/react-pi/src/node/ThreadSupervisor.test.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.test.ts
@@ -131,6 +131,39 @@ describe("PiThreadSupervisor", () => {
     expect(session.setThinkingLevel).toHaveBeenCalledTimes(2);
   });
 
+  it("isolates errors from the initial snapshot listener", async () => {
+    const session = {
+      sessionId: "t1",
+      sessionFile: SESSION.path,
+      sessionName: undefined,
+      state: { pendingToolCalls: new Set<string>() },
+      messages: [],
+      model: undefined,
+      thinkingLevel: "off",
+      isStreaming: false,
+      isCompacting: false,
+      isRetrying: false,
+      subscribe: vi.fn(() => () => {}),
+      bindExtensions: vi.fn(async () => {}),
+      getContextUsage: vi.fn(),
+      getSteeringMessages: vi.fn(() => []),
+      getFollowUpMessages: vi.fn(() => []),
+    };
+    sdk.createAgentSession.mockResolvedValue({ session });
+    const supervisor = new PiThreadSupervisor({ workspacePath: "/ws" });
+    const listener = vi.fn((event) => {
+      if (event.type === "snapshot") {
+        throw new Error("snapshot listener failed");
+      }
+    });
+
+    const unsubscribe = supervisor.subscribe("t1", listener);
+
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
+    expect(listener.mock.calls[0]?.[0].type).toBe("snapshot");
+    unsubscribe();
+  });
+
   it("deletes a cold thread and forgets its cached catalog info", async () => {
     const supervisor = new PiThreadSupervisor({ workspacePath: "/ws" });
     await supervisor.getThread("t1"); // primes the per-thread catalog cache

--- a/packages/react-pi/src/node/ThreadSupervisor.ts
+++ b/packages/react-pi/src/node/ThreadSupervisor.ts
@@ -317,7 +317,7 @@ export class PiThreadSupervisor {
         if (options?.includeSnapshot !== false) {
           // Snapshot-first when requested: the authoritative current state,
           // stamped with the record's seq so subsequent live events apply on top.
-          listener({
+          this.notifyListener(listener, {
             type: "snapshot",
             snapshot: this.snapshotOf(r),
             threadId,
@@ -327,7 +327,12 @@ export class PiThreadSupervisor {
       })
       .catch((err) => {
         if (active) {
-          listener({ type: "error", error: errorText(err), threadId, seq: 0 });
+          this.notifyListener(listener, {
+            type: "error",
+            error: errorText(err),
+            threadId,
+            seq: 0,
+          });
         }
       });
     return () => {
@@ -593,11 +598,18 @@ export class PiThreadSupervisor {
       seq: record.seq,
     } as PiClientEvent;
     for (const listener of [...record.listeners]) {
-      try {
-        listener(event);
-      } catch {
-        // A faulty listener must not break delivery to the others.
-      }
+      this.notifyListener(listener, event);
+    }
+  }
+
+  private notifyListener(
+    listener: (event: PiClientEvent) => void,
+    event: PiClientEvent,
+  ): void {
+    try {
+      listener(event);
+    } catch {
+      // A faulty listener must not break delivery to the others.
     }
   }
 


### PR DESCRIPTION
## Summary

- route initial snapshots and connection errors through the same isolated listener delivery used for live events
- prevent a snapshot listener exception from being mistaken for a connection failure
- add a regression test for the duplicate snapshot/error delivery

## Why

The initial snapshot callback ran inside the successful `ensureOpen()` promise handler. If an application subscriber threw while handling that snapshot, the promise chain caught the subscriber error as though opening the Pi session had failed and sent a second, misleading error event to the same subscriber. Subscriber failures are now contained consistently across initial and live delivery.

## Testing

- confirmed the regression test fails on the original path with two listener calls
- `vitest run src/node/ThreadSupervisor.test.ts` (7 tests)
- `aui-build` for `@assistant-ui/react-pi`
- focused oxlint and oxfmt checks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.04m0CroMrc2lh5tRvfHnrVPvFysfZe3-Rb1B8xylN0kzrxfF_rXHDBqdwtw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->