### PR TITLE
fix(react-ag-ui): type the runAgent call site against upstream parameters

### DIFF
--- a/.changeset/olive-donkeys-melt.md
+++ b/.changeset/olive-donkeys-melt.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ag-ui": patch
+---
+
+fix: type the runAgent call site against the upstream AG-UI parameters

--- a/.changeset/olive-donkeys-melt.md
+++ b/.changeset/olive-donkeys-melt.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react-ag-ui": patch
 ---
 
-fix: type the runAgent call site against the upstream AG-UI parameters
+fix: send `description: ""` for a tool registered without one, so `RunAgentInput` stays valid against the AG-UI schema. previously the key was dropped from the payload entirely and validating servers rejected the run. also types the `runAgent` call site against the upstream parameters.

--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1573,6 +1573,7 @@ declare class PiThreadSupervisor {
   private onSessionEvent;
   private emitContextUsage;
   private emit;
+  private notifyListener;
   private liveStatusFor;
   private runStatus;
   private readinessOf;

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -1097,9 +1097,8 @@ export class AgUiThreadRuntimeCore {
         } catch {
           // ignore
         }
-        const runAgent = runAgentInstance.runAgent.bind(
-          runAgentInstance,
-        ) as RunAgentWithRunOptions;
+        const runAgent: RunAgentWithRunOptions =
+          runAgentInstance.runAgent.bind(runAgentInstance);
         await runAgent(input, subscriber, { signal: abortSignal });
       }
     } catch (error) {

--- a/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
+++ b/packages/react-ag-ui/src/runtime/AgUiThreadRuntimeCore.ts
@@ -20,7 +20,12 @@ import type {
   ToolCallMessagePart,
 } from "@assistant-ui/core";
 import { MessageRepository } from "@assistant-ui/core/internal";
-import type { AbstractAgent } from "@ag-ui/client";
+import type {
+  AbstractAgent,
+  AgentSubscriber,
+  RunAgentParameters,
+  RunAgentResult,
+} from "@ag-ui/client";
 import jsonpatch, { type Operation } from "fast-json-patch";
 import type { Logger } from "./logger";
 import { readMcpAppResourceUri } from "./mcp-tool-result";
@@ -40,6 +45,15 @@ import {
   toAgUiTools,
 } from "./adapter/conversions";
 import { createAgUiSubscriber } from "./adapter/subscriber";
+
+// AbstractAgent.runAgent declares two parameters. HttpAgent ignores a third and
+// is cancelled through agent.abortRun(); the run options stay for subclasses
+// that inherit the base no-op abortRun and have no other cancellation hook.
+type RunAgentWithRunOptions = (
+  parameters: RunAgentParameters,
+  subscriber: AgentSubscriber,
+  options: { signal: AbortSignal },
+) => Promise<RunAgentResult>;
 
 const optimisticPrefix = "__optimistic__";
 const generateOptimisticId = () => `${optimisticPrefix}${generateId()}`;
@@ -1083,12 +1097,10 @@ export class AgUiThreadRuntimeCore {
         } catch {
           // ignore
         }
-        // HttpAgent ignores this third argument and is cancelled through
-        // agent.abortRun(); it stays for subclasses that inherit the base
-        // no-op abortRun and have no other cancellation hook.
-        await (runAgentInstance as any).runAgent(input, subscriber, {
-          signal: abortSignal,
-        });
+        const runAgent = runAgentInstance.runAgent.bind(
+          runAgentInstance,
+        ) as RunAgentWithRunOptions;
+        await runAgent(input, subscriber, { signal: abortSignal });
       }
     } catch (error) {
       if (!abortSignal.aborted) {

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.tools.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.tools.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { RunAgentParameters } from "@ag-ui/client";
+import { toAgUiTools } from "./conversions";
+
+describe("toAgUiTools", () => {
+  it("normalizes a missing description to an empty string", () => {
+    const tools = toAgUiTools({
+      described: { description: "Has one", parameters: { type: "object" } },
+      undescribed: { parameters: { type: "object" } },
+    });
+
+    expect(tools).toEqual([
+      {
+        name: "described",
+        description: "Has one",
+        parameters: { type: "object" },
+      },
+      { name: "undescribed", description: "", parameters: { type: "object" } },
+    ]);
+  });
+
+  it("produces tools the upstream run parameters accept", () => {
+    const tools = toAgUiTools({
+      search: { description: "Search", parameters: { type: "object" } },
+    });
+
+    expectTypeOf(tools).toExtend<NonNullable<RunAgentParameters["tools"]>>();
+
+    const parameters: RunAgentParameters = { runId: "run-1", tools };
+    expect(parameters.tools).toHaveLength(1);
+  });
+});

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.tools.test.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
-import type { RunAgentParameters } from "@ag-ui/client";
+import { ToolSchema, type RunAgentParameters } from "@ag-ui/client";
 import { toAgUiTools } from "./conversions";
 
 describe("toAgUiTools", () => {
@@ -17,6 +17,14 @@ describe("toAgUiTools", () => {
       },
       { name: "undescribed", description: "", parameters: { type: "object" } },
     ]);
+  });
+
+  it("serializes a description-less tool that upstream still accepts", () => {
+    const [tool] = toAgUiTools({ undescribed: { parameters: {} } });
+
+    expect(ToolSchema.safeParse(JSON.parse(JSON.stringify(tool))).success).toBe(
+      true,
+    );
   });
 
   it("produces tools the upstream run parameters accept", () => {

--- a/packages/react-ag-ui/src/runtime/adapter/conversions.ts
+++ b/packages/react-ag-ui/src/runtime/adapter/conversions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { InputContent } from "@ag-ui/client";
+import type { InputContent, RunAgentParameters } from "@ag-ui/client";
 import type {
   ThreadMessageLike as CoreThreadMessageLike,
   ToolCallMessagePartMcpMetadata,
@@ -915,11 +915,7 @@ export function toAgUiMessages(
   return converted;
 }
 
-type AgUiTool = {
-  name: string;
-  description: string | undefined;
-  parameters: unknown;
-};
+type AgUiTool = NonNullable<RunAgentParameters["tools"]>[number];
 
 export function toAgUiTools(
   tools: Record<string, Tool> | undefined,
@@ -929,7 +925,7 @@ export function toAgUiTools(
   const toolsSchema = toToolsJSONSchema(tools);
   return Object.entries(toolsSchema).map(([name, tool]) => ({
     name,
-    description: tool.description,
+    description: tool.description ?? "",
     parameters: tool.parameters,
   }));
 }

--- a/packages/react-ag-ui/test/conversions.spec.ts
+++ b/packages/react-ag-ui/test/conversions.spec.ts
@@ -561,17 +561,17 @@ describe("adapter conversions", () => {
       expect.arrayContaining([
         {
           name: "jsonTool",
-          description: undefined,
+          description: "",
           parameters: { type: "object" },
         },
         {
           name: "schemaTool",
-          description: undefined,
+          description: "",
           parameters: { type: "string" },
         },
         {
           name: "plain",
-          description: undefined,
+          description: "",
           parameters: { type: "boolean" },
         },
       ]),


### PR DESCRIPTION
Fixes #5659.

## Problem

`AgUiThreadRuntimeCore` called the agent through `(this.agent as any).runAgent(...)`. That cast is why #5621 could ship: a third argument was silently discarded and cancellation never reached the HTTP request. #5622 fixed the cancellation path, but the cast stayed, so nothing checks the argument the dependency actually receives.

Removing the cast does not compile. Our local `AgUiTool` declared `description: string | undefined`, while upstream's `ToolSchema` requires `description: string`; under `exactOptionalPropertyTypes` that is a hard mismatch (`TS2379`).

That mismatch was not only a typing inconvenience. `toAgUiTools` forwarded `description: undefined` for any tool registered without a description, `JSON.stringify` dropped the key, and the resulting `RunAgentInput` violates upstream's own `RunAgentInputSchema`. `@ag-ui/client` does not validate outgoing input, so nothing fails client-side — the invalid payload goes out on the wire and surfaces against servers that do validate (the canonical pydantic-based AG-UI servers):

```
ToolSchema.safeParse({ name: "a", parameters: {} })
// → invalid_type at ["description"]: expected string, received undefined
```

## Approach

- `AgUiTool` is now derived from the dependency rather than restated: `NonNullable<RunAgentParameters["tools"]>[number]`. If upstream changes the tool shape, the converter fails to compile instead of drifting.
- `toAgUiTools` normalizes a missing description to `""`, which is what the AG-UI schema requires. Tools without a description now serialize a valid payload.
- The call site drops `as any`. The run parameters and subscriber are checked against `RunAgentParameters` and `AgentSubscriber`, which is the class of failure #5621 belonged to.

The third argument stays, because #5622 added a test for it: a subclass that inherits the upstream no-op `abortRun()` has the run signal as its only cancellation hook. `AbstractAgent.runAgent` declares two parameters, and TypeScript cannot express a call with an argument the declared signature omits, so that one extension is named in a local `RunAgentWithRunOptions` type with the reason recorded. It is a narrower assertion than `as any`: everything except the extra arity is still compiler-checked.

Worth stating plainly: this delivers a narrower property than #5659 asked for. The issue wanted a call site that would *reject* an argument upstream does not accept; because #5622 deliberately kept that argument (with a test), this PR instead sanctions it by name while making the params and subscriber compiler-checked. Dropping the argument — and the subclass escape hatch with it — remains a separate maintainer call.

`AgUiTool` and `toAgUiTools` are internal to the package (not exported from `src/index.ts`), so the published surface is unchanged; `generate-api-surface` reports no drift.

The adjacent `(agent as any).messages / .threadId / .state` assignments noted in the issue are left alone — reconciling those means reconciling the whole local `AgUiMessage` type against upstream `Message`, which is a separate change.

## Verification

- `pnpm --filter @assistant-ui/react-ag-ui test` — 10 files, 322 tests passing, including the existing subclass-signal cancellation test.
- `pnpm --filter @assistant-ui/react-ag-ui exec tsc --noEmit` — clean.
- `pnpm --filter @assistant-ui/react-ag-ui build` — clean.
- `oxlint packages/react-ag-ui` — only the two pre-existing `exhaustive-deps` warnings in `useAgUiRuntime.ts`, unchanged from `main`. `oxfmt --check` clean.
- `node scripts/generate-api-surface.mjs --filter=@assistant-ui/react-ag-ui` — no changes.

New colocated tests in `src/runtime/adapter/conversions.tools.test.ts` cover the normalization and assert the converter output is assignable to `RunAgentParameters["tools"]`, so the boundary stays typed. Three assertions in `test/conversions.spec.ts` that expected `description: undefined` now expect `""`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.MRxNEnHB_7NAdEkLkmTFOLcdsaYjLBo6-KHHJoIjsXvmSsprBF4QMCJy1c4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->


## Demo

**Before** (`pr3015/main`) — a description-less tool converts to a payload that fails upstream's own `RunAgentInputSchema` after JSON round-trip (`invalid_type` at `["description"]`):


https://github.com/user-attachments/assets/f3fd5137-1a42-488b-a65c-4648873f6497


**After** (this PR) — the identical conversion validates: `success: true`, with `description: ""` on the wire:


https://github.com/user-attachments/assets/ff7b4b54-f52f-4ad7-a29b-9719312be6e4

