### PR TITLE
chore(react-pi): regenerate the api surface after notifyListener

### DIFF
--- a/api-surface/assistant-ui__react-pi.ts
+++ b/api-surface/assistant-ui__react-pi.ts
@@ -1573,6 +1573,7 @@ declare class PiThreadSupervisor {
   private onSessionEvent;
   private emitContextUsage;
   private emit;
+  private notifyListener;
   private liveStatusFor;
   private runStatus;
   private readinessOf;


### PR DESCRIPTION
## What

Regenerates `api-surface/assistant-ui__react-pi.ts` so it matches the source, adding the one line the generator emits for `PiThreadSupervisor.notifyListener`.

## Why

#5682 added `private notifyListener` to `packages/react-pi/src/node/ThreadSupervisor.ts` without regenerating the surface. Nothing on `main` catches that, so the file has been stale since it merged.

The cost falls on unrelated PRs. autofix.ci regenerates the surface on every PR, so any PR that triggers it picks this line up and carries it in its own diff, where a reviewer reasonably asks why an AG-UI change is touching react-pi. It came up on #5684 for exactly that reason. Stripping it there does not help, because the next push re-adds it; the drift has to be closed at the source.

## Verification

`node scripts/generate-api-surface.mjs --filter=@assistant-ui/react-pi` against a freshly built `@assistant-ui/react-pi` produces exactly this diff and nothing else. No package source changes, so no changeset.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.do_X8FQl12Hq-CNQ8_5TPjxhO3Aswfws2ADcSjz4qpoDGfKkk9cIcQTgCQU?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->