### PR TITLE
feat(vue): viewport, message parts, and branch picker primitives

### DIFF
--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -13,6 +13,7 @@
     "@assistant-ui/store": "workspace:*",
     "@assistant-ui/tap": "workspace:*",
     "@assistant-ui/vue": "workspace:*",
+    "lucide-vue-next": "^1.0.0",
     "vue": "^3.5.41"
   },
   "devDependencies": {

--- a/examples/with-vue/package.json
+++ b/examples/with-vue/package.json
@@ -13,7 +13,7 @@
     "@assistant-ui/store": "workspace:*",
     "@assistant-ui/tap": "workspace:*",
     "@assistant-ui/vue": "workspace:*",
-    "lucide-vue-next": "^1.0.0",
+    "@lucide/vue": "^1.26.0",
     "vue": "^3.5.41"
   },
   "devDependencies": {

--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -8,7 +8,7 @@ import {
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
-import { ArrowUpIcon, SquareIcon } from "lucide-vue-next";
+import { ArrowUpIcon, SquareIcon } from "@lucide/vue";
 import Message from "./Message.vue";
 </script>
 

--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -5,39 +5,59 @@ import {
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
   ThreadPrimitiveMessages,
+  ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
+import { ArrowUpIcon, SquareIcon } from "lucide-vue-next";
 import Message from "./Message.vue";
 </script>
 
 <template>
-  <main class="mx-auto mt-12 max-w-lg px-4 font-sans">
-    <h1 class="mb-4 text-xl font-semibold">assistant-ui × Vue</h1>
-    <ol class="flex min-h-48 flex-col gap-2">
-      <ThreadPrimitiveMessages>
-        <Message />
-      </ThreadPrimitiveMessages>
-    </ol>
-    <div class="mt-4 flex gap-2">
-      <ComposerPrimitiveInput
-        class="flex-1 resize-none rounded-xl border border-neutral-300 px-3 py-2 outline-none"
-        placeholder="Say something"
-        rows="1"
-      />
-      <AuiIf :condition="(s) => !s.thread.isRunning">
-        <ComposerPrimitiveSend
-          class="rounded-xl bg-neutral-900 px-4 py-2 text-white disabled:opacity-50"
-        >
-          Send
-        </ComposerPrimitiveSend>
-      </AuiIf>
-      <AuiIf :condition="(s) => s.thread.isRunning">
-        <ComposerPrimitiveCancel
-          class="rounded-xl bg-neutral-200 px-4 py-2 text-neutral-900 disabled:opacity-50"
-        >
-          Stop
-        </ComposerPrimitiveCancel>
-      </AuiIf>
+  <div class="bg-background flex h-full flex-col">
+    <ThreadPrimitiveViewport
+      class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+    >
+      <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+        <AuiIf :condition="(s) => s.thread.messages.length === 0">
+          <div class="flex flex-1 flex-col items-center justify-center pb-24">
+            <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+          </div>
+        </AuiIf>
+        <ol class="mb-14 flex flex-col gap-y-6 empty:hidden">
+          <ThreadPrimitiveMessages>
+            <Message />
+          </ThreadPrimitiveMessages>
+        </ol>
+      </div>
+    </ThreadPrimitiveViewport>
+    <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+      <div
+        class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+      >
+        <ComposerPrimitiveInput
+          class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+          placeholder="Send a message..."
+          rows="1"
+        />
+        <div class="flex items-center justify-end">
+          <AuiIf :condition="(s) => !s.thread.isRunning">
+            <ComposerPrimitiveSend
+              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+              aria-label="Send"
+            >
+              <ArrowUpIcon class="size-4.5" />
+            </ComposerPrimitiveSend>
+          </AuiIf>
+          <AuiIf :condition="(s) => s.thread.isRunning">
+            <ComposerPrimitiveCancel
+              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+              aria-label="Stop"
+            >
+              <SquareIcon class="size-3.5 fill-current" />
+            </ComposerPrimitiveCancel>
+          </AuiIf>
+        </div>
+      </div>
     </div>
-  </main>
+  </div>
 </template>

--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -11,7 +11,7 @@ const pulsing = useAuiState(
 <template>
   <li v-if="role === 'user'" data-role="user" class="flex justify-end px-2">
     <div
-      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word whitespace-pre-line"
+      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word"
     >
       <MessagePrimitiveParts />
     </div>
@@ -19,7 +19,7 @@ const pulsing = useAuiState(
   <li
     v-else
     data-role="assistant"
-    class="text-foreground px-2 leading-relaxed wrap-break-word whitespace-pre-line"
+    class="text-foreground px-2 leading-relaxed wrap-break-word"
   >
     <MessagePrimitiveParts />
     <span v-if="pulsing" class="animate-pulse">…</span>

--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -3,7 +3,9 @@ import { MessagePrimitiveParts, useAuiState } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
 
 const role = useAuiState((s) => s.message.role);
-const empty = useAuiState((s) => s.message.content.length === 0);
+const pulsing = useAuiState(
+  (s) => s.message.content.length === 0 && s.thread.isRunning,
+);
 </script>
 
 <template>
@@ -20,6 +22,6 @@ const empty = useAuiState((s) => s.message.content.length === 0);
     class="text-foreground px-2 leading-relaxed wrap-break-word"
   >
     <MessagePrimitiveParts />
-    <span v-if="empty" class="animate-pulse">…</span>
+    <span v-if="pulsing" class="animate-pulse">…</span>
   </li>
 </template>

--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -1,21 +1,25 @@
 <script setup lang="ts">
-import { useAuiState } from "@assistant-ui/vue";
+import { MessagePrimitiveParts, useAuiState } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
 
 const role = useAuiState((s) => s.message.role);
-const text = useAuiState((s) => {
-  const part = s.message.content[0];
-  return (part?.type === "text" && part.text) || "…";
-});
+const empty = useAuiState((s) => s.message.content.length === 0);
 </script>
 
 <template>
+  <li v-if="role === 'user'" data-role="user" class="flex justify-end px-2">
+    <div
+      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word"
+    >
+      <MessagePrimitiveParts />
+    </div>
+  </li>
   <li
-    :data-role="role"
-    class="rounded-xl px-3 py-2"
-    :class="role === 'user' ? 'self-end bg-blue-50' : 'bg-neutral-100'"
+    v-else
+    data-role="assistant"
+    class="text-foreground px-2 leading-relaxed wrap-break-word"
   >
-    <span class="block text-xs text-neutral-400">{{ role }}</span>
-    <span>{{ text }}</span>
+    <MessagePrimitiveParts />
+    <span v-if="empty" class="animate-pulse">…</span>
   </li>
 </template>

--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -11,7 +11,7 @@ const pulsing = useAuiState(
 <template>
   <li v-if="role === 'user'" data-role="user" class="flex justify-end px-2">
     <div
-      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word"
+      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word whitespace-pre-line"
     >
       <MessagePrimitiveParts />
     </div>
@@ -19,7 +19,7 @@ const pulsing = useAuiState(
   <li
     v-else
     data-role="assistant"
-    class="text-foreground px-2 leading-relaxed wrap-break-word"
+    class="text-foreground px-2 leading-relaxed wrap-break-word whitespace-pre-line"
   >
     <MessagePrimitiveParts />
     <span v-if="pulsing" class="animate-pulse">…</span>

--- a/examples/with-vue/src/styles.css
+++ b/examples/with-vue/src/styles.css
@@ -1,1 +1,125 @@
 @import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+}
+
+.dark {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -61,6 +61,9 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `ThreadPrimitiveMessages` renders its default slot once per thread message, each instance scoped through `MessageByIndexProvider` (descendants read `s.message` and the message's edit composer as `s.composer`).
 - `ComposerPrimitiveInput` is a textarea bound to the composer text; Enter submits, Shift+Enter inserts a newline, IME composition is ignored.
 - `ComposerPrimitiveSend` and `ComposerPrimitiveCancel` are buttons wired to the composer with the same disabled semantics as the React primitives.
+- `ThreadPrimitiveViewport` is a scroll container that keeps the thread pinned to the bottom while the user is at the bottom, scrolls down on run start, and unpins when the user scrolls up.
+- `MessagePrimitiveParts` renders the current message's content parts, each scoped through `PartByIndexProvider`; a slot named after the part type overrides its rendering, and text parts render their text by default.
+- `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
 - `AuiIf` renders its slot while a state selector returns true.
 
 ```vue

--- a/packages/vue/src/AuiProvider.ts
+++ b/packages/vue/src/AuiProvider.ts
@@ -13,24 +13,7 @@ import {
   type AuiConfig,
 } from "@assistant-ui/store/client";
 import { auiInjectionKey, createClientFacade } from "./context";
-
-// Vite replaces the import.meta.env and process.env.NODE_ENV literals per
-// host; the try blocks cover hosts where neither binding exists.
-const isDevelopment = (() => {
-  try {
-    const env = (import.meta as { env?: { DEV?: boolean } }).env;
-    if (typeof env?.DEV === "boolean") return env.DEV;
-  } catch {
-    /* empty */
-  }
-  try {
-    return (
-      process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
-    );
-  } catch {
-    return false;
-  }
-})();
+import { isDevelopment } from "./isDevelopment";
 
 /**
  * Creates an `AssistantClient` from the given config and provides it to the

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  clearPartWarningsForTesting();
 });
 import { createApp, defineComponent, h, nextTick, type Component } from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
@@ -19,7 +20,10 @@ import { AuiProvider } from "../AuiProvider";
 import { useAuiState } from "../useAuiState";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
-import { MessagePrimitiveParts } from "../primitives/MessagePrimitiveParts";
+import {
+  MessagePrimitiveParts,
+  clearPartWarningsForTesting,
+} from "../primitives/MessagePrimitiveParts";
 import {
   BranchPickerPrimitiveCount,
   BranchPickerPrimitiveNext,

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type {
+  ExternalStoreAdapter,
+  ThreadMessageLike,
+} from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAuiState } from "../useAuiState";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
+import { MessagePrimitiveParts } from "../primitives/MessagePrimitiveParts";
+import {
+  BranchPickerPrimitiveCount,
+  BranchPickerPrimitiveNext,
+  BranchPickerPrimitiveNumber,
+  BranchPickerPrimitivePrevious,
+} from "../primitives/branchPicker";
+import {
+  isUserScrollUp,
+  isViewportAtBottom,
+  viewportOverflows,
+} from "../primitives/viewportScroll";
+
+type DemoMessage = {
+  role: "user" | "assistant";
+  content: ThreadMessageLike["content"];
+};
+
+const createTestRuntime = () => {
+  let messages: DemoMessage[] = [];
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    convertMessage: (message) => ({
+      role: message.role,
+      content: message.content,
+    }),
+    onNew: async () => {},
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const append = (message: DemoMessage) => {
+    messages = [...messages, message];
+    core.setAdapter(makeAdapter());
+  };
+  return { runtime, append };
+};
+
+const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(view) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+describe("MessagePrimitiveParts", () => {
+  it("renders text parts by default and routes typed slots in order", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadPrimitiveMessages, null, {
+          default: () =>
+            h("li", null, [
+              h(MessagePrimitiveParts, null, {
+                "tool-call": () => {
+                  const ToolProbe = defineComponent({
+                    setup() {
+                      const name = useAuiState((s) =>
+                        s.part.type === "tool-call" ? s.part.toolName : "",
+                      );
+                      return () => h("span", { class: "tool" }, name.value);
+                    },
+                  });
+                  return h(ToolProbe);
+                },
+              }),
+            ]),
+        }),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({
+        role: "assistant",
+        content: [
+          { type: "text", text: "before " },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            args: {},
+          },
+          { type: "text", text: " after" },
+        ],
+      }),
+    );
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("li")).not.toBeNull();
+      expect(el.querySelector("span.tool")?.textContent).toBe("search");
+    });
+    expect(el.querySelector("li")!.textContent).toBe("before search after");
+
+    unmount();
+  });
+});
+
+describe("BranchPickerPrimitive", () => {
+  it("disables both directions and renders 1/1 on a single branch", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadPrimitiveMessages, null, {
+          default: () => [
+            h(
+              BranchPickerPrimitivePrevious,
+              { class: "prev" },
+              { default: () => "<" },
+            ),
+            h("span", { class: "pos" }, [
+              h(BranchPickerPrimitiveNumber),
+              " / ",
+              h(BranchPickerPrimitiveCount),
+            ]),
+            h(
+              BranchPickerPrimitiveNext,
+              { class: "next" },
+              { default: () => ">" },
+            ),
+          ],
+        }),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({ role: "user", content: [{ type: "text", text: "hi" }] }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector(".pos")).not.toBeNull();
+    });
+
+    expect(el.querySelector(".pos")!.textContent).toBe("1 / 1");
+    expect(el.querySelector<HTMLButtonElement>(".prev")!.disabled).toBe(true);
+    expect(el.querySelector<HTMLButtonElement>(".next")!.disabled).toBe(true);
+
+    unmount();
+  });
+});
+
+describe("ThreadPrimitiveViewport", () => {
+  it("mounts as a scroll container and renders its slot", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          { default: () => h("p", { class: "content" }, "hello") },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    expect(el.querySelector("div.viewport p.content")?.textContent).toBe(
+      "hello",
+    );
+
+    flushTapSync(() =>
+      append({ role: "user", content: [{ type: "text", text: "hi" }] }),
+    );
+    await nextTick();
+
+    unmount();
+  });
+
+  it("computes bottom pinning from viewport metrics", () => {
+    expect(
+      isViewportAtBottom({
+        scrollTop: 900,
+        scrollHeight: 1000,
+        clientHeight: 100,
+      }),
+    ).toBe(true);
+    expect(
+      isViewportAtBottom({
+        scrollTop: 899,
+        scrollHeight: 1000,
+        clientHeight: 100,
+      }),
+    ).toBe(true);
+    expect(
+      isViewportAtBottom({
+        scrollTop: 800,
+        scrollHeight: 1000,
+        clientHeight: 100,
+      }),
+    ).toBe(false);
+    expect(
+      isViewportAtBottom({ scrollTop: 0, scrollHeight: 80, clientHeight: 100 }),
+    ).toBe(true);
+
+    expect(
+      viewportOverflows({
+        scrollTop: 0,
+        scrollHeight: 1000,
+        clientHeight: 100,
+      }),
+    ).toBe(true);
+    expect(
+      viewportOverflows({ scrollTop: 0, scrollHeight: 100, clientHeight: 100 }),
+    ).toBe(false);
+  });
+
+  it("distinguishes user scroll-up from content-driven shifts", () => {
+    expect(
+      isUserScrollUp(
+        { scrollTop: 500, scrollHeight: 1000 },
+        { scrollTop: 400, scrollHeight: 1000, clientHeight: 100 },
+      ),
+    ).toBe(true);
+    expect(
+      isUserScrollUp(
+        { scrollTop: 500, scrollHeight: 900 },
+        { scrollTop: 400, scrollHeight: 1000, clientHeight: 100 },
+      ),
+    ).toBe(false);
+    expect(
+      isUserScrollUp(
+        { scrollTop: 400, scrollHeight: 1000 },
+        { scrollTop: 500, scrollHeight: 1000, clientHeight: 100 },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -121,6 +121,44 @@ describe("MessagePrimitiveParts", () => {
   });
 });
 
+describe("MessagePrimitiveParts dev warning", () => {
+  it("warns once in dev for a part type without a slot", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadPrimitiveMessages, null, {
+          default: () => h(MessagePrimitiveParts),
+        }),
+    });
+    const { unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            args: {},
+          },
+        ],
+      }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(warn).toHaveBeenCalledTimes(1);
+    });
+    expect(warn.mock.calls[0]![0]).toContain(
+      'no slot for part type "tool-call"',
+    );
+
+    unmount();
+    warn.mockRestore();
+  });
+});
+
 describe("BranchPickerPrimitive", () => {
   it("disables both directions and renders 1/1 on a single branch", async () => {
     const { runtime, append } = createTestRuntime();

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -123,6 +123,45 @@ describe("MessagePrimitiveParts", () => {
 
     unmount();
   });
+
+  it("keeps text rendering when only a default slot is provided", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h("li", null, [
+          h(ThreadPrimitiveMessages, null, {
+            default: () =>
+              h(MessagePrimitiveParts, null, {
+                default: () => h("span", { class: "fallback" }, "[tool]"),
+              }),
+          }),
+        ]),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    flushTapSync(() =>
+      append({
+        role: "assistant",
+        content: [
+          { type: "text", text: "hello" },
+          {
+            type: "tool-call",
+            toolCallId: "call-1",
+            toolName: "search",
+            args: {},
+          },
+        ],
+      }),
+    );
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector("span.fallback")).not.toBeNull();
+    });
+    expect(el.querySelector("li")!.textContent).toBe("hello[tool]");
+
+    unmount();
+  });
 });
 
 describe("MessagePrimitiveParts dev warning", () => {

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 import { createApp, defineComponent, h, nextTick, type Component } from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
@@ -155,7 +159,6 @@ describe("MessagePrimitiveParts dev warning", () => {
     );
 
     unmount();
-    warn.mockRestore();
   });
 });
 
@@ -223,6 +226,86 @@ describe("ThreadPrimitiveViewport", () => {
       append({ role: "user", content: [{ type: "text", text: "hi" }] }),
     );
     await nextTick();
+
+    unmount();
+  });
+
+  it("follows content growth while pinned and stops after a user scrolls up", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () =>
+              h(ThreadPrimitiveMessages, null, {
+                default: () => h("p", "row"),
+              }),
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    let scrollHeight = 500;
+    let scrollTop = 0;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => scrollHeight,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    Object.defineProperty(div, "scrollTop", {
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+      configurable: true,
+    });
+    const scrollTo = vi.fn(({ top }: { top: number }) => {
+      scrollTop = Math.max(0, Math.min(top, scrollHeight - 100));
+    });
+    Object.defineProperty(div, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    });
+
+    flushTapSync(() =>
+      append({ role: "user", content: [{ type: "text", text: "one" }] }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(scrollTo).toHaveBeenCalled();
+    });
+    div.dispatchEvent(new Event("scroll"));
+    const callsWhilePinned = scrollTo.mock.calls.length;
+
+    scrollHeight = 600;
+    flushTapSync(() =>
+      append({ role: "assistant", content: [{ type: "text", text: "two" }] }),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(scrollTo.mock.calls.length).toBeGreaterThan(callsWhilePinned);
+    });
+    div.dispatchEvent(new Event("scroll"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    div.dispatchEvent(new Event("pointerdown"));
+    scrollTop = 50;
+    div.dispatchEvent(new Event("scroll"));
+    const callsAfterUnpin = scrollTo.mock.calls.length;
+
+    scrollHeight = 700;
+    flushTapSync(() =>
+      append({ role: "user", content: [{ type: "text", text: "three" }] }),
+    );
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(scrollTo.mock.calls.length).toBe(callsAfterUnpin);
 
     unmount();
   });

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -43,8 +43,10 @@ type DemoMessage = {
 
 const createTestRuntime = () => {
   let messages: DemoMessage[] = [];
+  let isRunning = false;
   const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
     messages,
+    isRunning,
     convertMessage: (message) => ({
       role: message.role,
       content: message.content,
@@ -57,7 +59,28 @@ const createTestRuntime = () => {
     messages = [...messages, message];
     core.setAdapter(makeAdapter());
   };
-  return { runtime, append };
+  const setRunning = (value: boolean) => {
+    isRunning = value;
+    core.setAdapter(makeAdapter());
+  };
+  return { runtime, append, setRunning };
+};
+
+const mockViewportGeometry = (div: HTMLElement) => {
+  Object.defineProperty(div, "scrollHeight", {
+    get: () => 500,
+    configurable: true,
+  });
+  Object.defineProperty(div, "clientHeight", {
+    get: () => 100,
+    configurable: true,
+  });
+  const scrollTo = vi.fn();
+  Object.defineProperty(div, "scrollTo", {
+    value: scrollTo,
+    configurable: true,
+  });
+  return scrollTo;
 };
 
 const mountChat = (runtime: AssistantRuntimeImpl, view: Component) => {
@@ -398,6 +421,53 @@ describe("ThreadPrimitiveViewport", () => {
     expect(scrollTo).not.toHaveBeenCalled();
 
     unmount();
+  });
+
+  it("scrolls on run start and stays put when that option is disabled", async () => {
+    const active = createTestRuntime();
+    const ActiveView = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          { default: () => h("p", "row") },
+        ),
+    });
+    const mountedActive = mountChat(active.runtime, ActiveView);
+    const activeScrollTo = mockViewportGeometry(
+      mountedActive.el.querySelector<HTMLElement>("div.viewport")!,
+    );
+
+    flushTapSync(() => active.setRunning(true));
+    await vi.waitFor(() => {
+      expect(activeScrollTo).toHaveBeenCalled();
+    });
+    mountedActive.unmount();
+
+    const disabled = createTestRuntime();
+    const DisabledView = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          {
+            class: "viewport",
+            autoScroll: false,
+            scrollToBottomOnInitialize: false,
+            scrollToBottomOnRunStart: false,
+          },
+          { default: () => h("p", "row") },
+        ),
+    });
+    const mountedDisabled = mountChat(disabled.runtime, DisabledView);
+    const disabledScrollTo = mockViewportGeometry(
+      mountedDisabled.el.querySelector<HTMLElement>("div.viewport")!,
+    );
+
+    flushTapSync(() => disabled.setRunning(true));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(disabledScrollTo).not.toHaveBeenCalled();
+
+    mountedDisabled.unmount();
   });
 
   it("computes bottom pinning from viewport metrics", () => {

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -349,6 +349,53 @@ describe("ThreadPrimitiveViewport", () => {
     unmount();
   });
 
+  it("stays put when every scroll option is disabled", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          {
+            class: "viewport",
+            autoScroll: false,
+            scrollToBottomOnInitialize: false,
+            scrollToBottomOnRunStart: false,
+          },
+          {
+            default: () =>
+              h(ThreadPrimitiveMessages, null, {
+                default: () => h("p", "row"),
+              }),
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => 500,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    const scrollTo = vi.fn();
+    Object.defineProperty(div, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    });
+
+    flushTapSync(() =>
+      append({ role: "user", content: [{ type: "text", text: "one" }] }),
+    );
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("computes bottom pinning from viewport metrics", () => {
     expect(
       isViewportAtBottom({

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,10 +5,19 @@ export { useAuiState } from "./useAuiState";
 export { useAuiEvent } from "./useAuiEvent";
 
 export { MessageByIndexProvider } from "./primitives/MessageByIndexProvider";
+export { PartByIndexProvider } from "./primitives/PartByIndexProvider";
 export { ThreadPrimitiveMessages } from "./primitives/ThreadPrimitiveMessages";
+export { ThreadPrimitiveViewport } from "./primitives/ThreadPrimitiveViewport";
+export { MessagePrimitiveParts } from "./primitives/MessagePrimitiveParts";
 export { ComposerPrimitiveInput } from "./primitives/ComposerPrimitiveInput";
 export { ComposerPrimitiveSend } from "./primitives/ComposerPrimitiveSend";
 export { ComposerPrimitiveCancel } from "./primitives/ComposerPrimitiveCancel";
+export {
+  BranchPickerPrimitivePrevious,
+  BranchPickerPrimitiveNext,
+  BranchPickerPrimitiveNumber,
+  BranchPickerPrimitiveCount,
+} from "./primitives/branchPicker";
 
 export {
   AuiConfig,

--- a/packages/vue/src/isDevelopment.ts
+++ b/packages/vue/src/isDevelopment.ts
@@ -1,0 +1,17 @@
+// Vite replaces the import.meta.env and process.env.NODE_ENV literals per
+// host; the try blocks cover hosts where neither binding exists.
+export const isDevelopment = (() => {
+  try {
+    const env = (import.meta as { env?: { DEV?: boolean } }).env;
+    if (typeof env?.DEV === "boolean") return env.DEV;
+  } catch {
+    /* empty */
+  }
+  try {
+    return (
+      process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test"
+    );
+  } catch {
+    return false;
+  }
+})();

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -19,7 +19,7 @@ export const MessagePrimitiveParts = defineComponent({
   name: "MessagePrimitiveParts",
   slots: Object as SlotsType<Record<string, (() => unknown) | undefined>>,
   setup(_, { slots }) {
-    const count = useAuiState((s) => s.message.content.length);
+    const count = useAuiState((s) => s.message.parts.length);
     const PartView = defineComponent({
       name: "MessagePartView",
       setup() {

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -6,6 +6,8 @@ import { PartByIndexProvider } from "./PartByIndexProvider";
 
 const warnedTypes = new Set<string>();
 
+export const clearPartWarningsForTesting = () => warnedTypes.clear();
+
 /**
  * Renders the current message's content parts in order, each scoped through
  * {@link PartByIndexProvider}. A slot named after the part type (`text`,

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -4,19 +4,20 @@ import { isDevelopment } from "../isDevelopment";
 import { useAuiState } from "../useAuiState";
 import { PartByIndexProvider } from "./PartByIndexProvider";
 
+const warnedTypes = new Set<string>();
+
 /**
  * Renders the current message's content parts in order, each scoped through
  * {@link PartByIndexProvider}. A slot named after the part type (`text`,
  * `reasoning`, `tool-call`, ...) renders that part; the `default` slot is the
- * fallback for types without a named slot. Text parts without any slot render
- * their text.
+ * fallback for types without a named slot, except text, which always renders
+ * its text unless a `text` slot overrides it.
  */
 export const MessagePrimitiveParts = defineComponent({
   name: "MessagePrimitiveParts",
   slots: Object as SlotsType<Record<string, (() => unknown) | undefined>>,
   setup(_, { slots }) {
     const count = useAuiState((s) => s.message.content.length);
-    const warned = new Set<string>();
     const PartView = defineComponent({
       name: "MessagePartView",
       setup() {
@@ -25,11 +26,14 @@ export const MessagePrimitiveParts = defineComponent({
           s.part.type === "text" ? s.part.text : "",
         );
         return () => {
+          if (type.value === "text") {
+            const slot = slots.text;
+            return slot ? slot() : text.value;
+          }
           const slot = slots[type.value] ?? slots.default;
           if (slot) return slot();
-          if (type.value === "text") return text.value;
-          if (isDevelopment && !warned.has(type.value)) {
-            warned.add(type.value);
+          if (isDevelopment && !warnedTypes.has(type.value)) {
+            warnedTypes.add(type.value);
             console.warn(
               `MessagePrimitiveParts: no slot for part type "${type.value}"; the part renders nothing. Add a #${type.value} or #default slot.`,
             );

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -28,7 +28,9 @@ export const MessagePrimitiveParts = defineComponent({
         return () => {
           if (type.value === "text") {
             const slot = slots.text;
-            return slot ? slot() : text.value;
+            return slot
+              ? slot()
+              : h("p", { style: { whiteSpace: "pre-line" } }, text.value);
           }
           const slot = slots[type.value] ?? slots.default;
           if (slot) return slot();

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,0 +1,41 @@
+import { defineComponent, h, type SlotsType } from "vue";
+import type {} from "@assistant-ui/core/store";
+import { useAuiState } from "../useAuiState";
+import { PartByIndexProvider } from "./PartByIndexProvider";
+
+/**
+ * Renders the current message's content parts in order, each scoped through
+ * {@link PartByIndexProvider}. A slot named after the part type (`text`,
+ * `reasoning`, `tool-call`, ...) renders that part; the `default` slot is the
+ * fallback for types without a named slot. Text parts without any slot render
+ * their text.
+ */
+export const MessagePrimitiveParts = defineComponent({
+  name: "MessagePrimitiveParts",
+  slots: Object as SlotsType<Record<string, (() => unknown) | undefined>>,
+  setup(_, { slots }) {
+    const count = useAuiState((s) => s.message.content.length);
+    const PartView = defineComponent({
+      name: "MessagePartView",
+      setup() {
+        const type = useAuiState((s) => s.part.type);
+        const text = useAuiState((s) =>
+          s.part.type === "text" ? s.part.text : "",
+        );
+        return () => {
+          const slot = slots[type.value] ?? slots.default;
+          if (slot) return slot();
+          return type.value === "text" ? text.value : null;
+        };
+      },
+    });
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          PartByIndexProvider,
+          { index, key: index },
+          { default: () => h(PartView) },
+        ),
+      );
+  },
+});

--- a/packages/vue/src/primitives/MessagePrimitiveParts.ts
+++ b/packages/vue/src/primitives/MessagePrimitiveParts.ts
@@ -1,5 +1,6 @@
 import { defineComponent, h, type SlotsType } from "vue";
 import type {} from "@assistant-ui/core/store";
+import { isDevelopment } from "../isDevelopment";
 import { useAuiState } from "../useAuiState";
 import { PartByIndexProvider } from "./PartByIndexProvider";
 
@@ -15,6 +16,7 @@ export const MessagePrimitiveParts = defineComponent({
   slots: Object as SlotsType<Record<string, (() => unknown) | undefined>>,
   setup(_, { slots }) {
     const count = useAuiState((s) => s.message.content.length);
+    const warned = new Set<string>();
     const PartView = defineComponent({
       name: "MessagePartView",
       setup() {
@@ -25,7 +27,14 @@ export const MessagePrimitiveParts = defineComponent({
         return () => {
           const slot = slots[type.value] ?? slots.default;
           if (slot) return slot();
-          return type.value === "text" ? text.value : null;
+          if (type.value === "text") return text.value;
+          if (isDevelopment && !warned.has(type.value)) {
+            warned.add(type.value);
+            console.warn(
+              `MessagePrimitiveParts: no slot for part type "${type.value}"; the part renders nothing. Add a #${type.value} or #default slot.`,
+            );
+          }
+          return null;
         };
       },
     });

--- a/packages/vue/src/primitives/PartByIndexProvider.ts
+++ b/packages/vue/src/primitives/PartByIndexProvider.ts
@@ -1,0 +1,38 @@
+import { computed, defineComponent, h, type SlotsType } from "vue";
+import { AuiConfig, Derived } from "@assistant-ui/store/client";
+import type {} from "@assistant-ui/core/store";
+import { AuiProvider } from "../AuiProvider";
+import { useAui } from "../useAui";
+
+/**
+ * Scopes the subtree to the message part at `index`: descendants read the
+ * part through `s.part`.
+ */
+export const PartByIndexProvider = defineComponent({
+  name: "PartByIndexProvider",
+  props: {
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const aui = useAui();
+    const config = computed(() =>
+      AuiConfig({
+        part: Derived({
+          source: "message",
+          query: { type: "index", index: props.index },
+          get: (aui) => aui.message.part({ index: props.index }),
+        }),
+      }),
+    );
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -23,7 +23,10 @@ import {
  * scrolls down, and scrolling up unpins until the user returns to the bottom.
  * The four options mirror the React hook and are independent: `autoScroll`
  * covers follow-on-content-growth, and the other three gate the
- * first-messages, run-start, and thread-switch scrolls.
+ * first-messages, run-start, and thread-switch scrolls. The React viewport's
+ * top-anchor system and its imperative scroll-to-bottom channel (the one
+ * `ThreadPrimitive.ScrollToBottom` drives) live in the React viewport store
+ * and are not ported yet.
  */
 export const ThreadPrimitiveViewport = defineComponent({
   name: "ThreadPrimitiveViewport",

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -1,0 +1,154 @@
+import {
+  defineComponent,
+  h,
+  onMounted,
+  onScopeDispose,
+  shallowRef,
+  watch,
+  type SlotsType,
+} from "vue";
+import type {} from "@assistant-ui/core/store";
+import { useAuiEvent } from "../useAuiEvent";
+import { useAuiState } from "../useAuiState";
+import {
+  isUserScrollUp,
+  isViewportAtBottom,
+  observeContentResize,
+  viewportOverflows,
+} from "./viewportScroll";
+
+/**
+ * A scrollable container that keeps the thread pinned to the bottom: content
+ * growth scrolls back down while the user sits at the bottom, a run start
+ * scrolls down, and scrolling up unpins until the user returns to the bottom.
+ * Set `autoScroll` to false to keep only the explicit run-start scroll.
+ */
+export const ThreadPrimitiveViewport = defineComponent({
+  name: "ThreadPrimitiveViewport",
+  props: {
+    autoScroll: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const divRef = shallowRef<HTMLElement | null>(null);
+    let intent: ScrollBehavior | null = null;
+    let isAtBottom = true;
+    let lastScrollTop = 0;
+    let lastScrollHeight = 0;
+    let lastObservedScrollHeight = 0;
+    let lastObservedClientHeight = 0;
+    let frame: number | null = null;
+
+    const scrollToBottom = (behavior: ScrollBehavior) => {
+      const div = divRef.value;
+      if (!div) return;
+      intent = behavior;
+      div.scrollTo?.({ top: div.scrollHeight, behavior });
+    };
+
+    const scheduleScrollToBottom = (behavior: ScrollBehavior) => {
+      intent = behavior;
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        scrollToBottom(behavior);
+      });
+    };
+
+    const handleScroll = () => {
+      const div = divRef.value;
+      if (!div) return;
+
+      const newIsAtBottom = isViewportAtBottom(div);
+      const inFlightDownward = !newIsAtBottom && lastScrollTop < div.scrollTop;
+      if (!inFlightDownward) {
+        if (newIsAtBottom) {
+          // At-bottom is ambiguous while the viewport does not overflow; keep
+          // the intent alive until content can actually scroll.
+          if (viewportOverflows(div)) intent = null;
+        } else if (
+          isUserScrollUp(
+            { scrollTop: lastScrollTop, scrollHeight: lastScrollHeight },
+            div,
+          )
+        ) {
+          intent = null;
+        }
+        if (newIsAtBottom || intent === null) isAtBottom = newIsAtBottom;
+      }
+
+      lastScrollTop = div.scrollTop;
+      lastScrollHeight = div.scrollHeight;
+    };
+
+    const onContentResize = () => {
+      const div = divRef.value;
+      if (!div) return;
+      const { scrollHeight, clientHeight } = div;
+      if (
+        scrollHeight === lastObservedScrollHeight &&
+        clientHeight === lastObservedClientHeight
+      ) {
+        return;
+      }
+      lastObservedScrollHeight = scrollHeight;
+      lastObservedClientHeight = clientHeight;
+
+      if (intent) {
+        scrollToBottom(intent);
+      } else if (props.autoScroll && isAtBottom) {
+        scrollToBottom("instant");
+      }
+      handleScroll();
+    };
+
+    // A pointer gesture invalidates pending bottom-scroll intent; otherwise an
+    // intent kept alive by a non-overflowing thread hijacks the next content
+    // growth.
+    const onPointerdown = () => {
+      intent = null;
+    };
+
+    let disconnect: (() => void) | undefined;
+    onMounted(() => {
+      const div = divRef.value;
+      if (!div) return;
+      disconnect = observeContentResize(div, onContentResize);
+    });
+    onScopeDispose(() => {
+      disconnect?.();
+      if (frame !== null) cancelAnimationFrame(frame);
+    });
+
+    const hasMessages = useAuiState((s) => s.thread.messages.length > 0);
+    let initialized = false;
+    watch(
+      hasMessages,
+      (has) => {
+        if (!has) {
+          initialized = false;
+          return;
+        }
+        if (initialized) return;
+        initialized = true;
+        if (intent !== null) return;
+        scheduleScrollToBottom("instant");
+      },
+      { immediate: true },
+    );
+
+    useAuiEvent("thread.runStart", () => {
+      scheduleScrollToBottom("auto");
+    });
+
+    return () =>
+      h(
+        "div",
+        { ref: divRef, onScroll: handleScroll, onPointerdown },
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -21,14 +21,26 @@ import {
  * A scrollable container that keeps the thread pinned to the bottom: content
  * growth scrolls back down while the user sits at the bottom, a run start
  * scrolls down, and scrolling up unpins until the user returns to the bottom.
- * Setting `autoScroll` to false disables only the follow-on-content-growth
- * behavior; the first-messages and run-start scrolls remain, matching the
- * React hook's independent option defaults.
+ * The four options mirror the React hook and are independent: `autoScroll`
+ * covers follow-on-content-growth, and the other three gate the
+ * first-messages, run-start, and thread-switch scrolls.
  */
 export const ThreadPrimitiveViewport = defineComponent({
   name: "ThreadPrimitiveViewport",
   props: {
     autoScroll: {
+      type: Boolean,
+      default: true,
+    },
+    scrollToBottomOnInitialize: {
+      type: Boolean,
+      default: true,
+    },
+    scrollToBottomOnRunStart: {
+      type: Boolean,
+      default: true,
+    },
+    scrollToBottomOnThreadSwitch: {
       type: Boolean,
       default: true,
     },
@@ -138,6 +150,7 @@ export const ThreadPrimitiveViewport = defineComponent({
     watch(
       hasMessages,
       (has) => {
+        if (!props.scrollToBottomOnInitialize) return;
         if (!has) {
           initialized = false;
           return;
@@ -151,10 +164,12 @@ export const ThreadPrimitiveViewport = defineComponent({
     );
 
     useAuiEvent("thread.runStart", () => {
+      if (!props.scrollToBottomOnRunStart) return;
       scheduleScrollToBottom("auto");
     });
 
     useAuiEvent("threadListItem.switchedTo", () => {
+      if (!props.scrollToBottomOnThreadSwitch) return;
       scheduleScrollToBottom("instant");
     });
 

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -148,14 +148,13 @@ export const ThreadPrimitiveViewport = defineComponent({
     const hasMessages = useAuiState((s) => s.thread.messages.length > 0);
     let initialized = false;
     watch(
-      hasMessages,
-      (has) => {
-        if (!props.scrollToBottomOnInitialize) return;
+      [hasMessages, () => props.scrollToBottomOnInitialize],
+      ([has, enabled]) => {
         if (!has) {
           initialized = false;
           return;
         }
-        if (initialized) return;
+        if (!enabled || initialized) return;
         initialized = true;
         if (intent !== null) return;
         scheduleScrollToBottom("instant");

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -112,7 +112,8 @@ export const ThreadPrimitiveViewport = defineComponent({
 
     // A pointer gesture invalidates pending bottom-scroll intent; otherwise an
     // intent kept alive by a non-overflowing thread hijacks the next content
-    // growth.
+    // growth. Unlike the React hook, an already scheduled frame is cancelled
+    // too, so the gesture also wins the race against a just-planted intent.
     const onPointerdown = () => {
       intent = null;
       if (frame !== null) {

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -153,6 +153,10 @@ export const ThreadPrimitiveViewport = defineComponent({
       scheduleScrollToBottom("auto");
     });
 
+    useAuiEvent("threadListItem.switchedTo", () => {
+      scheduleScrollToBottom("instant");
+    });
+
     return () =>
       h(
         "div",

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -21,7 +21,9 @@ import {
  * A scrollable container that keeps the thread pinned to the bottom: content
  * growth scrolls back down while the user sits at the bottom, a run start
  * scrolls down, and scrolling up unpins until the user returns to the bottom.
- * Set `autoScroll` to false to keep only the explicit run-start scroll.
+ * Setting `autoScroll` to false disables only the follow-on-content-growth
+ * behavior; the first-messages and run-start scrolls remain, matching the
+ * React hook's independent option defaults.
  */
 export const ThreadPrimitiveViewport = defineComponent({
   name: "ThreadPrimitiveViewport",
@@ -52,8 +54,7 @@ export const ThreadPrimitiveViewport = defineComponent({
     const scheduleScrollToBottom = (behavior: ScrollBehavior) => {
       intent = behavior;
       // The immediate watch below runs synchronously during SSR, where no
-      // frame scheduler exists; the planted intent still scrolls on the first
-      // client-side content resize.
+      // frame scheduler exists.
       if (typeof requestAnimationFrame === "undefined") return;
       if (frame !== null) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
@@ -114,6 +115,10 @@ export const ThreadPrimitiveViewport = defineComponent({
     // growth.
     const onPointerdown = () => {
       intent = null;
+      if (frame !== null) {
+        cancelAnimationFrame(frame);
+        frame = null;
+      }
     };
 
     let disconnect: (() => void) | undefined;

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -51,6 +51,10 @@ export const ThreadPrimitiveViewport = defineComponent({
 
     const scheduleScrollToBottom = (behavior: ScrollBehavior) => {
       intent = behavior;
+      // The immediate watch below runs synchronously during SSR, where no
+      // frame scheduler exists; the planted intent still scrolls on the first
+      // client-side content resize.
+      if (typeof requestAnimationFrame === "undefined") return;
       if (frame !== null) cancelAnimationFrame(frame);
       frame = requestAnimationFrame(() => {
         frame = null;

--- a/packages/vue/src/primitives/branchPicker.ts
+++ b/packages/vue/src/primitives/branchPicker.ts
@@ -1,0 +1,83 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  type ComputedRef,
+  type SlotsType,
+} from "vue";
+import type {} from "@assistant-ui/core/store";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+const branchButton = (
+  name: string,
+  useDisabled: () => ComputedRef<boolean>,
+  position: "previous" | "next",
+) =>
+  defineComponent({
+    name,
+    inheritAttrs: false,
+    slots: Object as SlotsType<{ default?: () => unknown }>,
+    setup(_, { attrs, slots }) {
+      const aui = useAui();
+      const disabled = useDisabled();
+      const onClick = (event: MouseEvent) => {
+        if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+          return;
+        aui.message.switchToBranch({ position });
+      };
+      return () =>
+        h(
+          "button",
+          mergeProps(attrs, {
+            type: "button",
+            disabled: disabled.value || isAttrDisabled(attrs),
+            onClick,
+          }),
+          slots.default?.(),
+        );
+    },
+  });
+
+/** A button that switches the current message to its previous branch. */
+export const BranchPickerPrimitivePrevious = branchButton(
+  "BranchPickerPrimitivePrevious",
+  () =>
+    useAuiState(
+      (s) =>
+        s.message.branchNumber <= 1 ||
+        (s.thread.isRunning && !s.thread.capabilities.switchBranchDuringRun),
+    ),
+  "previous",
+);
+
+/** A button that switches the current message to its next branch. */
+export const BranchPickerPrimitiveNext = branchButton(
+  "BranchPickerPrimitiveNext",
+  () =>
+    useAuiState(
+      (s) =>
+        s.message.branchNumber >= s.message.branchCount ||
+        (s.thread.isRunning && !s.thread.capabilities.switchBranchDuringRun),
+    ),
+  "next",
+);
+
+/** Renders the current message's 1-based branch number as text. */
+export const BranchPickerPrimitiveNumber = defineComponent({
+  name: "BranchPickerPrimitiveNumber",
+  setup() {
+    const branchNumber = useAuiState((s) => s.message.branchNumber);
+    return () => String(branchNumber.value);
+  },
+});
+
+/** Renders the current message's branch count as text. */
+export const BranchPickerPrimitiveCount = defineComponent({
+  name: "BranchPickerPrimitiveCount",
+  setup() {
+    const branchCount = useAuiState((s) => s.message.branchCount);
+    return () => String(branchCount.value);
+  },
+});

--- a/packages/vue/src/primitives/viewportScroll.ts
+++ b/packages/vue/src/primitives/viewportScroll.ts
@@ -1,0 +1,49 @@
+export type ViewportMetrics = {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+};
+
+export const isViewportAtBottom = (metrics: ViewportMetrics): boolean =>
+  Math.abs(metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight) <=
+    1 || metrics.scrollHeight <= metrics.clientHeight;
+
+export const viewportOverflows = (metrics: ViewportMetrics): boolean =>
+  metrics.scrollHeight > metrics.clientHeight + 1;
+
+// scrollHeight equality rules out content-driven shifts being misread as a
+// user scroll up.
+export const isUserScrollUp = (
+  previous: { scrollTop: number; scrollHeight: number },
+  current: ViewportMetrics,
+): boolean =>
+  previous.scrollTop > current.scrollTop &&
+  previous.scrollHeight === current.scrollHeight;
+
+export const observeContentResize = (
+  el: HTMLElement,
+  callback: () => void,
+): (() => void) => {
+  if (typeof ResizeObserver === "undefined") return () => {};
+  const resizeObserver = new ResizeObserver(() => callback());
+  const mutationObserver = new MutationObserver((mutations) => {
+    // Style-only attribute mutations feed back from code paths that write
+    // styles in response to viewport changes.
+    const relevant = mutations.some(
+      (mutation) =>
+        mutation.type !== "attributes" || mutation.attributeName !== "style",
+    );
+    if (relevant) callback();
+  });
+  resizeObserver.observe(el);
+  mutationObserver.observe(el, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  });
+  return () => {
+    resizeObserver.disconnect();
+    mutationObserver.disconnect();
+  };
+};

--- a/packages/vue/src/primitives/viewportScroll.ts
+++ b/packages/vue/src/primitives/viewportScroll.ts
@@ -24,26 +24,31 @@ export const observeContentResize = (
   el: HTMLElement,
   callback: () => void,
 ): (() => void) => {
-  if (typeof ResizeObserver === "undefined") return () => {};
-  const resizeObserver = new ResizeObserver(() => callback());
-  const mutationObserver = new MutationObserver((mutations) => {
-    // Style-only attribute mutations feed back from code paths that write
-    // styles in response to viewport changes.
-    const relevant = mutations.some(
-      (mutation) =>
-        mutation.type !== "attributes" || mutation.attributeName !== "style",
-    );
-    if (relevant) callback();
-  });
-  resizeObserver.observe(el);
-  mutationObserver.observe(el, {
-    childList: true,
-    subtree: true,
-    attributes: true,
-    characterData: true,
-  });
+  const disposers: (() => void)[] = [];
+  if (typeof ResizeObserver !== "undefined") {
+    const resizeObserver = new ResizeObserver(() => callback());
+    resizeObserver.observe(el);
+    disposers.push(() => resizeObserver.disconnect());
+  }
+  if (typeof MutationObserver !== "undefined") {
+    const mutationObserver = new MutationObserver((mutations) => {
+      // Style-only attribute mutations feed back from code paths that write
+      // styles in response to viewport changes.
+      const relevant = mutations.some(
+        (mutation) =>
+          mutation.type !== "attributes" || mutation.attributeName !== "style",
+      );
+      if (relevant) callback();
+    });
+    mutationObserver.observe(el, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+    disposers.push(() => mutationObserver.disconnect());
+  }
   return () => {
-    resizeObserver.disconnect();
-    mutationObserver.disconnect();
+    for (const dispose of disposers) dispose();
   };
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3271,6 +3271,9 @@ importers:
       '@assistant-ui/vue':
         specifier: workspace:*
         version: link:../../packages/vue
+      lucide-vue-next:
+        specifier: ^1.0.0
+        version: 1.0.0(vue@3.5.41(typescript@7.0.2))
       vue:
         specifier: ^3.5.41
         version: 3.5.41(typescript@7.0.2)
@@ -14571,6 +14574,12 @@ packages:
     resolution: {integrity: sha512-raglYVR2+VkMfJL158krjVmE+rV5ST2lzA/KQm1FRSjMHT4MnWaegHxoVEpmc2So3nOEhp9oGejJwAPX8MoAjg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide-vue-next@1.0.0:
+    resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
+    deprecated: Package deprecated. Please use @lucide/vue instead.
+    peerDependencies:
+      vue: '>=3.0.1'
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -28653,6 +28662,10 @@ snapshots:
   lucide-react@1.26.0(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  lucide-vue-next@1.0.0(vue@3.5.41(typescript@7.0.2)):
+    dependencies:
+      vue: 3.5.41(typescript@7.0.2)
 
   lz-string@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3271,9 +3271,9 @@ importers:
       '@assistant-ui/vue':
         specifier: workspace:*
         version: link:../../packages/vue
-      lucide-vue-next:
-        specifier: ^1.0.0
-        version: 1.0.0(vue@3.5.41(typescript@7.0.2))
+      '@lucide/vue':
+        specifier: ^1.26.0
+        version: 1.28.0(vue@3.5.41(typescript@7.0.2))
       vue:
         specifier: ^3.5.41
         version: 3.5.41(typescript@7.0.2)
@@ -7759,6 +7759,11 @@ packages:
 
   '@livekit/protocol@1.50.4':
     resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
+
+  '@lucide/vue@1.28.0':
+    resolution: {integrity: sha512-cO89UyNM/0i2Srdi04nFWeEOQkqzDZlM2ehtWyBhcMpRTJDKpMZPCGAVlmVBgBgr5HaeL5L6FsU8RHsOdwXtKw==}
+    peerDependencies:
+      vue: '>=3.0.1'
 
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
@@ -14575,12 +14580,6 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  lucide-vue-next@1.0.0:
-    resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
-    deprecated: Package deprecated. Please use @lucide/vue instead.
-    peerDependencies:
-      vue: '>=3.0.1'
-
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -21181,6 +21180,10 @@ snapshots:
   '@livekit/protocol@1.50.4':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
+
+  '@lucide/vue@1.28.0(vue@3.5.41(typescript@7.0.2))':
+    dependencies:
+      vue: 3.5.41(typescript@7.0.2)
 
   '@lukeed/ms@2.0.2': {}
 
@@ -28662,10 +28665,6 @@ snapshots:
   lucide-react@1.26.0(react@19.2.8):
     dependencies:
       react: 19.2.8
-
-  lucide-vue-next@1.0.0(vue@3.5.41(typescript@7.0.2)):
-    dependencies:
-      vue: 3.5.41(typescript@7.0.2)
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## summary

- adds ThreadPrimitiveViewport, a scroll container porting the React auto-scroll contract: the 1px bottom detection, the scrollHeight-equality rule that separates user scroll-up from content-driven shifts, intent kept alive while the viewport does not overflow, pointerdown cancelling pending intent, ResizeObserver plus MutationObserver content tracking (style-only attribute mutations filtered), and a run-start scroll through the thread.runStart event; the React top-anchor system lives in its viewport store and is not ported
- adds MessagePrimitiveParts and PartByIndexProvider: content parts render in order, each scoped so descendants read s.part; a slot named after the part type (for example #tool-call) overrides that type, default slot is the fallback, and text parts render their text with no slot at all
- adds BranchPickerPrimitivePrevious/Next/Number/Count with the exact disabled expressions of the React primitive hooks (branch bounds plus the switchBranchDuringRun capability), on the same attr-proof button shape as the composer buttons
- restyles examples/with-vue to the canonical assistant-ui design: the shadcn theme tokens copied verbatim from with-ai-sdk-v7, centered welcome state, muted user bubbles with plain assistant text in a max-w-2xl column, and the standard composer bar with the circular ArrowUp send and Square stop (lucide-vue-next)

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/vue -> 33/33: typed part slot routing (text + tool-call + text in order), branch picker disabled and 1/1 display on a single branch, viewport mount smoke plus pure-predicate coverage of bottom detection, overflow, and user-scroll-up discrimination
- [x] browser smoke on the dev server: pinned follow across 8 turns, scroll-up then reply lands without yanking (scrollTop stays 0), returning to bottom re-pins, run start scrolls down; welcome state and conversation state screenshots match the React examples' Thread design
- [x] `pnpm exec vitest run` in packages/store -> 123/123; examples/with-vue `vite build` green; `pnpm lint` clean

### reviewer should verify

- [ ] in examples/with-vue, scroll up mid-run: the echo reply must not scroll the viewport back down; returning to the bottom re-enables following

## notes

- icons come from @lucide/vue (the maintained rename of the deprecated lucide-vue-next stub), on the same version line as the repo's lucide-react pins
- vue stays private, no changeset; core and store untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->