### PR TITLE
fix(docs): hide scrollbar gutter inside demo embed iframes

### DIFF
--- a/apps/docs/app/(demos)/demos/[slug]/embed/page.tsx
+++ b/apps/docs/app/(demos)/demos/[slug]/embed/page.tsx
@@ -26,6 +26,8 @@ export default async function DemoEmbedPage({
 
   return (
     <div className="bg-background flex h-dvh flex-col overflow-hidden">
+      {/* The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the embed iframe that reserves a permanent 6px scrollbar strip along the right edge. */}
+      <style>{`html { overflow: hidden; }`}</style>
       <main className="min-h-0 flex-1">
         <DocsRuntimeProvider>
           <DemoComponent />

--- a/apps/docs/app/(demos)/learn/preview/[stageId]/page.tsx
+++ b/apps/docs/app/(demos)/learn/preview/[stageId]/page.tsx
@@ -9,6 +9,14 @@ import { getLearnPreview } from "@/lib/xulux/learn/preview-registry";
 // Each preview needs its own server-side usage-budget session.
 export const dynamic = "force-dynamic";
 
+// The docs stylesheet sets `overflow-y: scroll` on html for gutter stability; inside the preview iframe that reserves a permanent 6px scrollbar strip along the right edge.
+const PreviewShell = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-background h-dvh overflow-hidden">
+    <style>{`html { overflow: hidden; }`}</style>
+    {children}
+  </div>
+);
+
 export function generateStaticParams() {
   return listLearnStageIds(DEFAULT_LEARN_COURSE_ID).map((stageId) => ({
     stageId,
@@ -34,20 +42,20 @@ export default async function LearnStagePreviewPage({
   const preview = <StagePage />;
 
   if (!previewDefinition.loadRuntime) {
-    return <div className="bg-background h-dvh overflow-hidden">{preview}</div>;
+    return <PreviewShell>{preview}</PreviewShell>;
   }
 
   const { RuntimeProvider } = await previewDefinition.loadRuntime();
   const previewSessionId = crypto.randomUUID();
 
   return (
-    <div className="bg-background h-dvh overflow-hidden">
+    <PreviewShell>
       <RuntimeProvider
         api={`/api/xulux/learn/preview/${stageId}/chat?sessionId=${previewSessionId}`}
         storagePrefix={`generative-ui-course:${stageId}:`}
       >
         {preview}
       </RuntimeProvider>
-    </div>
+    </PreviewShell>
   );
 }


### PR DESCRIPTION
The docs stylesheet sets `overflow-y: scroll` on `html` for a stable scrollbar gutter across pages. The demo embed route (`/demos/[slug]/embed`) renders in its own iframe document, so this rule also forces a scrollbar there — and with the site's 6px classic scrollbar styling, the iframe permanently reserves a 6px strip of page background along its right edge. On the docs landing page demo showcase this shows up as a black gap between the demo and its container border.

The embed page is a non-scrolling, chrome-free document (`h-dvh overflow-hidden`), so this overrides the document scrollbar off with a one-line `<style>` scoped to the iframe's document. Inline demos and regular docs pages are unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.L-xUeKxRJChhsNDCLgwVlXWB-fb8eeZ_ERTyITMVHhR4rzUdvzdfIP9Fads?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->