### PR TITLE
feat(vue): edit, reload, and copy action bar primitives

### DIFF
--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -1,27 +1,117 @@
 <script setup lang="ts">
-import { MessagePrimitiveParts, useAuiState } from "@assistant-ui/vue";
+import {
+  ActionBarPrimitiveCopy,
+  ActionBarPrimitiveEdit,
+  ActionBarPrimitiveReload,
+  AuiIf,
+  BranchPickerPrimitiveCount,
+  BranchPickerPrimitiveNext,
+  BranchPickerPrimitiveNumber,
+  BranchPickerPrimitivePrevious,
+  ComposerPrimitiveCancel,
+  ComposerPrimitiveInput,
+  ComposerPrimitiveSend,
+  MessagePrimitiveParts,
+  useAuiState,
+} from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  PencilIcon,
+  RefreshCwIcon,
+} from "@lucide/vue";
 
 const role = useAuiState((s) => s.message.role);
 const pulsing = useAuiState(
   (s) => s.message.content.length === 0 && s.thread.isRunning,
 );
+const editing = useAuiState((s) => s.composer.isEditing);
+const copied = useAuiState((s) => s.message.isCopied);
 </script>
 
 <template>
-  <li v-if="role === 'user'" data-role="user" class="flex justify-end px-2">
+  <li
+    :data-role="role"
+    class="group flex flex-col gap-1"
+    :class="role === 'user' ? 'items-end' : 'items-start'"
+  >
     <div
-      class="bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2 wrap-break-word"
+      v-if="editing"
+      class="border-border/60 flex w-full max-w-[80%] flex-col gap-2 rounded-xl border p-2"
+    >
+      <ComposerPrimitiveInput
+        class="w-full resize-none bg-transparent px-1 py-0.5 outline-none"
+        rows="2"
+      />
+      <div class="flex justify-end gap-2 text-sm">
+        <ComposerPrimitiveCancel
+          class="text-muted-foreground rounded-lg px-2 py-1"
+        >
+          Discard
+        </ComposerPrimitiveCancel>
+        <ComposerPrimitiveSend
+          class="bg-primary text-primary-foreground rounded-lg px-2 py-1 disabled:opacity-50"
+        >
+          Save
+        </ComposerPrimitiveSend>
+      </div>
+    </div>
+    <div
+      v-else
+      class="px-2 wrap-break-word"
+      :class="
+        role === 'user'
+          ? 'bg-muted text-foreground max-w-[80%] rounded-xl px-4 py-2'
+          : 'text-foreground leading-relaxed'
+      "
     >
       <MessagePrimitiveParts />
+      <span v-if="pulsing" class="animate-pulse">…</span>
     </div>
-  </li>
-  <li
-    v-else
-    data-role="assistant"
-    class="text-foreground px-2 leading-relaxed wrap-break-word"
-  >
-    <MessagePrimitiveParts />
-    <span v-if="pulsing" class="animate-pulse">…</span>
+    <div
+      class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100"
+    >
+      <ActionBarPrimitiveEdit
+        v-if="role === 'user'"
+        class="hover:text-foreground rounded p-1"
+        aria-label="Edit"
+      >
+        <PencilIcon class="size-3.5" />
+      </ActionBarPrimitiveEdit>
+      <ActionBarPrimitiveCopy
+        class="hover:text-foreground rounded p-1"
+        aria-label="Copy"
+      >
+        <CheckIcon v-if="copied" class="size-3.5" />
+        <CopyIcon v-else class="size-3.5" />
+      </ActionBarPrimitiveCopy>
+      <ActionBarPrimitiveReload
+        v-if="role === 'assistant'"
+        class="hover:text-foreground rounded p-1"
+        aria-label="Regenerate"
+      >
+        <RefreshCwIcon class="size-3.5" />
+      </ActionBarPrimitiveReload>
+      <AuiIf :condition="(s) => s.message.branchCount > 1">
+        <span class="flex items-center gap-0.5 text-xs">
+          <BranchPickerPrimitivePrevious
+            class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+            aria-label="Previous branch"
+          >
+            <ChevronLeftIcon class="size-3.5" />
+          </BranchPickerPrimitivePrevious>
+          <BranchPickerPrimitiveNumber /> / <BranchPickerPrimitiveCount />
+          <BranchPickerPrimitiveNext
+            class="hover:text-foreground rounded p-0.5 disabled:opacity-40"
+            aria-label="Next branch"
+          >
+            <ChevronRightIcon class="size-3.5" />
+          </BranchPickerPrimitiveNext>
+        </span>
+      </AuiIf>
+    </div>
   </li>
 </template>

--- a/examples/with-vue/src/Message.vue
+++ b/examples/with-vue/src/Message.vue
@@ -72,7 +72,7 @@ const copied = useAuiState((s) => s.message.isCopied);
       <span v-if="pulsing" class="animate-pulse">…</span>
     </div>
     <div
-      class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100"
+      class="text-muted-foreground flex items-center gap-1 px-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
     >
       <ActionBarPrimitiveEdit
         v-if="role === 'user'"

--- a/examples/with-vue/src/runtime.ts
+++ b/examples/with-vue/src/runtime.ts
@@ -4,37 +4,76 @@ import {
   ExternalStoreRuntimeCore,
 } from "@assistant-ui/core/internal";
 
-export type EchoMessage = { role: "user" | "assistant"; text: string };
+export type EchoMessage = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+};
+
+let nextId = 0;
+const freshId = (prefix: string) => `${prefix}-${nextId++}`;
 
 const messageText = (message: AppendMessage) =>
   message.content
     .map((part) => (part.type === "text" ? part.text : ""))
     .join("");
 
+const convertEchoMessage = (message: EchoMessage) => ({
+  id: message.id,
+  role: message.role,
+  content: [{ type: "text" as const, text: message.text }],
+});
+
 export const createEchoRuntime = () => {
   let messages: EchoMessage[] = [];
   let isRunning = false;
   let replyTimer: ReturnType<typeof setTimeout> | undefined;
 
+  const reply = (text: string) => {
+    isRunning = true;
+    sync();
+    replyTimer = setTimeout(() => {
+      messages = [
+        ...messages,
+        { id: freshId("assistant"), role: "assistant", text: `Echo: ${text}` },
+      ];
+      isRunning = false;
+      sync();
+    }, 600);
+  };
+
   const makeAdapter = (): ExternalStoreAdapter<EchoMessage> => ({
     messages,
     isRunning,
-    convertMessage: (message) => ({
-      role: message.role,
-      content: [{ type: "text", text: message.text }],
-    }),
-    onNew: async (message) => {
-      messages = [...messages, { role: "user", text: messageText(message) }];
-      isRunning = true;
+    convertMessage: convertEchoMessage,
+    setMessages: (next) => {
+      messages = next;
       sync();
-      replyTimer = setTimeout(() => {
-        messages = [
-          ...messages,
-          { role: "assistant", text: `Echo: ${messages.at(-1)!.text}` },
-        ];
-        isRunning = false;
-        sync();
-      }, 600);
+    },
+    onNew: async (message) => {
+      const text = messageText(message);
+      messages = [...messages, { id: freshId("user"), role: "user", text }];
+      reply(text);
+    },
+    onEdit: async (message) => {
+      const text = messageText(message);
+      const parentIndex = message.parentId
+        ? messages.findIndex((entry) => entry.id === message.parentId) + 1
+        : 0;
+      messages = [
+        ...messages.slice(0, parentIndex),
+        { id: freshId("user"), role: "user", text },
+      ];
+      reply(text);
+    },
+    onReload: async () => {
+      const lastUser = [...messages]
+        .reverse()
+        .find((entry) => entry.role === "user");
+      messages = messages.filter(
+        (entry) => !(entry.role === "assistant" && entry === messages.at(-1)),
+      );
+      reply(`${lastUser?.text ?? ""} (again)`);
     },
     onCancel: async () => {
       clearTimeout(replyTimer);

--- a/examples/with-vue/src/runtime.ts
+++ b/examples/with-vue/src/runtime.ts
@@ -67,9 +67,12 @@ export const createEchoRuntime = () => {
       reply(text);
     },
     onReload: async (parentId) => {
-      const parentIndex = parentId
-        ? messages.findIndex((entry) => entry.id === parentId) + 1
-        : 0;
+      let parentIndex = 0;
+      if (parentId) {
+        const index = messages.findIndex((entry) => entry.id === parentId);
+        if (index === -1) return;
+        parentIndex = index + 1;
+      }
       const sliced = messages.slice(0, parentIndex);
       const lastUser = [...sliced]
         .reverse()

--- a/examples/with-vue/src/runtime.ts
+++ b/examples/with-vue/src/runtime.ts
@@ -66,13 +66,15 @@ export const createEchoRuntime = () => {
       ];
       reply(text);
     },
-    onReload: async () => {
-      const lastUser = [...messages]
+    onReload: async (parentId) => {
+      const parentIndex = parentId
+        ? messages.findIndex((entry) => entry.id === parentId) + 1
+        : 0;
+      const sliced = messages.slice(0, parentIndex);
+      const lastUser = [...sliced]
         .reverse()
         .find((entry) => entry.role === "user");
-      messages = messages.filter(
-        (entry) => !(entry.role === "assistant" && entry === messages.at(-1)),
-      );
+      messages = sliced;
       reply(`${lastUser?.text ?? ""} (again)`);
     },
     onCancel: async () => {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -64,6 +64,7 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `ThreadPrimitiveViewport` is a scroll container that keeps the thread pinned to the bottom while the user is at the bottom, scrolls down on run start, and unpins when the user scrolls up.
 - `MessagePrimitiveParts` renders the current message's content parts, each scoped through `PartByIndexProvider`; a slot named after the part type overrides its rendering, and text parts render their text by default.
 - `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
+- `ActionBarPrimitiveEdit`, `ActionBarPrimitiveReload`, and `ActionBarPrimitiveCopy` cover the widget-free message actions; inside a message scope the composer primitives double as the edit UI (`beginEdit` seeds the edit composer, `ComposerPrimitiveSend` saves into a new branch, `ComposerPrimitiveCancel` discards).
 - `AuiIf` renders its slot while a state selector returns true.
 
 ```vue

--- a/packages/vue/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/vue/src/__tests__/primitives-actionbar.test.ts
@@ -335,6 +335,62 @@ describe("edit flow and branches", () => {
     unmount();
   });
 
+  it("drops a late copy completion after the branch under the index changes", async () => {
+    let resolveWrite!: () => void;
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveWrite = resolve;
+        }),
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    const user = userItem(el);
+    q(user, "button.copy").click();
+    expect(writeText).toHaveBeenCalledWith("hello");
+
+    q(user, "button.edit").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe(
+        "hello",
+      );
+    });
+    const editor = q<HTMLTextAreaElement>(user, "textarea.editor");
+    editor.value = "goodbye";
+    flushTapSync(() => editor.dispatchEvent(new Event("input")));
+    q(user, "button.send").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.text").textContent).toBe("goodbye");
+    });
+
+    resolveWrite();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(q(userItem(el), "button.copy").hasAttribute("data-copied")).toBe(
+      false,
+    );
+
+    unmount();
+  });
+
   it("stays inert when the clipboard API is unavailable", async () => {
     const { runtime, seed } = createEditableRuntime();
     const { el, unmount } = mountChat(runtime);

--- a/packages/vue/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/vue/src/__tests__/primitives-actionbar.test.ts
@@ -335,6 +335,32 @@ describe("edit flow and branches", () => {
     unmount();
   });
 
+  it("stays inert when the clipboard API is unavailable", async () => {
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    expect(() =>
+      q<HTMLButtonElement>(assistantItem(el), "button.copy").click(),
+    ).not.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(
+      q(assistantItem(el), "button.copy").hasAttribute("data-copied"),
+    ).toBe(false);
+
+    unmount();
+  });
+
   it("copies message text and flags data-copied for the configured window", async () => {
     const writeText = vi.fn(() => Promise.resolve());
     Object.defineProperty(navigator, "clipboard", {

--- a/packages/vue/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/vue/src/__tests__/primitives-actionbar.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { useAuiState } from "../useAuiState";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import { ComposerPrimitiveInput } from "../primitives/ComposerPrimitiveInput";
+import { ComposerPrimitiveSend } from "../primitives/ComposerPrimitiveSend";
+import { ComposerPrimitiveCancel } from "../primitives/ComposerPrimitiveCancel";
+import {
+  ActionBarPrimitiveCopy,
+  ActionBarPrimitiveEdit,
+  ActionBarPrimitiveReload,
+} from "../primitives/actionBar";
+import {
+  BranchPickerPrimitiveCount,
+  BranchPickerPrimitiveNext,
+  BranchPickerPrimitiveNumber,
+  BranchPickerPrimitivePrevious,
+} from "../primitives/branchPicker";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
+
+const convertDemoMessage = (message: DemoMessage) => ({
+  id: message.id,
+  role: message.role,
+  content: [{ type: "text" as const, text: message.text }],
+});
+
+let nextId = 0;
+const freshId = (prefix: string) => `${prefix}-${nextId++}`;
+
+const createEditableRuntime = () => {
+  let messages: DemoMessage[] = [];
+  let isRunning = false;
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages,
+    isRunning,
+    convertMessage: convertDemoMessage,
+    onNew: async () => {},
+    setMessages: (next) => {
+      messages = next;
+      sync();
+    },
+    onEdit: async (message) => {
+      const text = message.content
+        .map((part) => (part.type === "text" ? part.text : ""))
+        .join("");
+      messages = [
+        { id: freshId("user"), role: "user", text },
+        { id: freshId("assistant"), role: "assistant", text: `Echo: ${text}` },
+      ];
+      sync();
+    },
+    onReload: async () => {
+      messages = [
+        ...messages.slice(0, -1),
+        {
+          id: freshId("assistant"),
+          role: "assistant",
+          text: `${messages.at(-1)!.text} (again)`,
+        },
+      ];
+      sync();
+    },
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const sync = () => core.setAdapter(makeAdapter());
+  const seed = (next: DemoMessage[]) => {
+    messages = next;
+    sync();
+  };
+  const setRunning = (value: boolean) => {
+    isRunning = value;
+    sync();
+  };
+  return { runtime, seed, setRunning };
+};
+
+const MessageView = defineComponent({
+  setup() {
+    const role = useAuiState((s) => s.message.role);
+    const text = useAuiState((s) => {
+      const part = s.message.content[0];
+      return part?.type === "text" ? part.text : "";
+    });
+    const copiedProbe = useAuiState((s) => s.message.isCopied);
+    return () =>
+      h("li", { class: "msg", "data-role": role.value }, [
+        h("span", { class: "probe" }, String(copiedProbe.value)),
+        h("span", { class: "text" }, text.value),
+        h(ActionBarPrimitiveEdit, { class: "edit" }, { default: () => "Edit" }),
+        h(
+          ActionBarPrimitiveCopy,
+          { class: "copy", copiedDuration: 300 },
+          {
+            default: () => "Copy",
+          },
+        ),
+        h(
+          ActionBarPrimitiveReload,
+          { class: "reload" },
+          { default: () => "Reload" },
+        ),
+        h(
+          BranchPickerPrimitivePrevious,
+          { class: "prev" },
+          { default: () => "<" },
+        ),
+        h("span", { class: "pos" }, [
+          h(BranchPickerPrimitiveNumber),
+          "/",
+          h(BranchPickerPrimitiveCount),
+        ]),
+        h(BranchPickerPrimitiveNext, { class: "next" }, { default: () => ">" }),
+        h(ComposerPrimitiveInput, { class: "editor" }),
+        h(ComposerPrimitiveSend, { class: "send" }, { default: () => "Save" }),
+        h(
+          ComposerPrimitiveCancel,
+          { class: "cancel" },
+          { default: () => "Discard" },
+        ),
+      ]);
+  },
+});
+
+const mountChat = (runtime: AssistantRuntimeImpl, view?: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          {
+            default: () =>
+              h(ThreadPrimitiveMessages, null, {
+                default: () => h(view ?? MessageView),
+              }),
+          },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+const userItem = (el: HTMLElement) =>
+  el.querySelector<HTMLElement>('li[data-role="user"]')!;
+const assistantItem = (el: HTMLElement) =>
+  el.querySelector<HTMLElement>('li[data-role="assistant"]')!;
+const q = <T extends HTMLElement>(scope: HTMLElement, selector: string) =>
+  scope.querySelector<T>(selector)!;
+
+describe("edit flow and branches", () => {
+  it("edits a user message into a second branch and switches between them", async () => {
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    const user = userItem(el);
+    expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe("");
+
+    q(user, "button.edit").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe(
+        "hello",
+      );
+    });
+    expect(q<HTMLButtonElement>(user, "button.edit").disabled).toBe(true);
+
+    const editor = q<HTMLTextAreaElement>(user, "textarea.editor");
+    editor.value = "goodbye";
+    flushTapSync(() => editor.dispatchEvent(new Event("input")));
+    q(user, "button.send").click();
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.text").textContent).toBe("goodbye");
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.pos").textContent).toBe("2/2");
+    });
+    expect(q(assistantItem(el), "span.text").textContent).toBe("Echo: goodbye");
+
+    const prev = q<HTMLButtonElement>(userItem(el), "button.prev");
+    expect(prev.disabled).toBe(false);
+    expect(q<HTMLButtonElement>(userItem(el), "button.next").disabled).toBe(
+      true,
+    );
+
+    prev.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.text").textContent).toBe("hello");
+    });
+    expect(q(userItem(el), "span.pos").textContent).toBe("1/2");
+
+    q<HTMLButtonElement>(userItem(el), "button.next").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.text").textContent).toBe("goodbye");
+    });
+
+    unmount();
+  });
+
+  it("blocks branch switching while a run is in flight", async () => {
+    const { runtime, seed, setRunning } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    const user = userItem(el);
+    q(user, "button.edit").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe(
+        "hello",
+      );
+    });
+    const editor = q<HTMLTextAreaElement>(user, "textarea.editor");
+    editor.value = "goodbye";
+    flushTapSync(() => editor.dispatchEvent(new Event("input")));
+    q(user, "button.send").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(userItem(el), "span.pos").textContent).toBe("2/2");
+    });
+
+    flushTapSync(() => setRunning(true));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLButtonElement>(userItem(el), "button.prev").disabled).toBe(
+        true,
+      );
+    });
+
+    unmount();
+  });
+
+  it("discards an edit through the cancel button", async () => {
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() => seed([{ id: "u1", role: "user", text: "hello" }]));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(1);
+    });
+
+    const user = userItem(el);
+    q(user, "button.edit").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe(
+        "hello",
+      );
+    });
+
+    q(user, "button.cancel").click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q<HTMLTextAreaElement>(user, "textarea.editor").value).toBe("");
+    });
+    expect(q<HTMLButtonElement>(user, "button.edit").disabled).toBe(false);
+    expect(q(user, "span.text").textContent).toBe("hello");
+
+    unmount();
+  });
+
+  it("reloads an assistant message into a second branch", async () => {
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    expect(q<HTMLButtonElement>(userItem(el), "button.reload").disabled).toBe(
+      true,
+    );
+    const reload = q<HTMLButtonElement>(assistantItem(el), "button.reload");
+    expect(reload.disabled).toBe(false);
+
+    reload.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(q(assistantItem(el), "span.text").textContent).toBe(
+        "Echo: hello (again)",
+      );
+    });
+    expect(q(assistantItem(el), "span.pos").textContent).toBe("2/2");
+
+    unmount();
+  });
+
+  it("copies message text and flags data-copied for the configured window", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const { runtime, seed } = createEditableRuntime();
+    const { el, unmount } = mountChat(runtime);
+
+    flushTapSync(() =>
+      seed([
+        { id: "u1", role: "user", text: "hello" },
+        { id: "a1", role: "assistant", text: "Echo: hello" },
+      ]),
+    );
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("li.msg")).toHaveLength(2);
+    });
+
+    const copy = q<HTMLButtonElement>(assistantItem(el), "button.copy");
+    expect(copy.disabled).toBe(false);
+    copy.click();
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(writeText).toHaveBeenCalledWith("Echo: hello");
+      expect(q(assistantItem(el), "span.probe").textContent).toBe("true");
+      expect(
+        q(assistantItem(el), "button.copy").hasAttribute("data-copied"),
+      ).toBe(true);
+    });
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        q(assistantItem(el), "button.copy").hasAttribute("data-copied"),
+      ).toBe(false);
+    });
+
+    unmount();
+  });
+});

--- a/packages/vue/src/__tests__/primitives-actionbar.test.ts
+++ b/packages/vue/src/__tests__/primitives-actionbar.test.ts
@@ -28,6 +28,8 @@ import {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // vi.restoreAllMocks does not undo hand-installed property descriptors.
+  Reflect.deleteProperty(navigator, "clipboard");
 });
 
 type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
@@ -392,6 +394,10 @@ describe("edit flow and branches", () => {
   });
 
   it("stays inert when the clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
     const { runtime, seed } = createEditableRuntime();
     const { el, unmount } = mountChat(runtime);
 

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -18,6 +18,11 @@ export {
   BranchPickerPrimitiveNumber,
   BranchPickerPrimitiveCount,
 } from "./primitives/branchPicker";
+export {
+  ActionBarPrimitiveEdit,
+  ActionBarPrimitiveReload,
+  ActionBarPrimitiveCopy,
+} from "./primitives/actionBar";
 
 export {
   AuiConfig,

--- a/packages/vue/src/primitives/actionBar.ts
+++ b/packages/vue/src/primitives/actionBar.ts
@@ -1,0 +1,156 @@
+import {
+  defineComponent,
+  h,
+  mergeProps,
+  onScopeDispose,
+  type SlotsType,
+} from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import type {} from "@assistant-ui/core/store";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+/** A button that begins editing the current message. Disabled while editing. */
+export const ActionBarPrimitiveEdit = defineComponent({
+  name: "ActionBarPrimitiveEdit",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const disabled = useAuiState((s) => s.composer.isEditing);
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+      aui.composer.beginEdit();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+/**
+ * A button that regenerates the current assistant message. Disabled while a
+ * run is in flight, the thread is disabled, or the message is not an
+ * assistant message.
+ */
+export const ActionBarPrimitiveReload = defineComponent({
+  name: "ActionBarPrimitiveReload",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const disabled = useAuiState(
+      (s) =>
+        s.thread.isRunning ||
+        s.thread.isDisabled ||
+        s.message.role !== "assistant",
+    );
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+      aui.message.reload();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+const defaultCopyToClipboard = (text: string) =>
+  navigator.clipboard.writeText(text);
+
+/**
+ * A button that copies the current message (or, while editing, the edit
+ * composer text). `data-copied` is present for `copiedDuration` milliseconds
+ * after a successful copy. Disabled while an assistant message is still
+ * running or the message has no text.
+ */
+export const ActionBarPrimitiveCopy = defineComponent({
+  name: "ActionBarPrimitiveCopy",
+  inheritAttrs: false,
+  props: {
+    copiedDuration: {
+      type: Number,
+      default: 3000,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { attrs, slots }) {
+    const aui = useAui();
+    const disabled = useAuiState(
+      (s) =>
+        !(
+          (s.message.role !== "assistant" ||
+            s.message.status?.type !== "running") &&
+          s.message.parts.some(
+            (part) => part.type === "text" && part.text.length > 0,
+          )
+        ),
+    );
+    const isCopied = useAuiState((s) => s.message.isCopied);
+    const isEditing = useAuiState((s) => s.composer.isEditing);
+    const composerText = useAuiState((s) => s.composer.text);
+
+    let copiedTimer: ReturnType<typeof setTimeout> | undefined;
+    let disposed = false;
+    onScopeDispose(() => {
+      disposed = true;
+      if (copiedTimer === undefined) return;
+      clearTimeout(copiedTimer);
+      copiedTimer = undefined;
+      aui.message.setIsCopied(false);
+    });
+
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+      const value = isEditing.value
+        ? composerText.value
+        : aui.message.getCopyText();
+      if (!value) return;
+      // The rejection handler swallows clipboard write failures (permission
+      // denied, API unavailable) so they don't surface as unhandled promise
+      // rejections.
+      Promise.resolve(defaultCopyToClipboard(value)).then(
+        () => {
+          if (disposed) return;
+          if (copiedTimer !== undefined) clearTimeout(copiedTimer);
+          flushTapSync(() => aui.message.setIsCopied(true));
+          copiedTimer = setTimeout(() => {
+            copiedTimer = undefined;
+            if (!disposed) flushTapSync(() => aui.message.setIsCopied(false));
+          }, props.copiedDuration);
+        },
+        () => {},
+      );
+    };
+
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          ...(isCopied.value && { "data-copied": "" }),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/actionBar.ts
+++ b/packages/vue/src/primitives/actionBar.ts
@@ -128,17 +128,25 @@ export const ActionBarPrimitiveCopy = defineComponent({
         ? composerText.value
         : aui.message.getCopyText();
       if (!value) return;
+      // A by-index scope follows whatever message occupies the slot, so late
+      // completions and timers re-check the copied message's id before
+      // touching state.
+      const copiedMessageId = aui.message.getState().id;
+      const stillCopiedMessage = () =>
+        !disposed && aui.message.getState().id === copiedMessageId;
       // The rejection handler swallows clipboard write failures (permission
       // denied, API unavailable) so they don't surface as unhandled promise
       // rejections.
       Promise.resolve(defaultCopyToClipboard(value)).then(
         () => {
-          if (disposed) return;
+          if (!stillCopiedMessage()) return;
           if (copiedTimer !== undefined) clearTimeout(copiedTimer);
           flushTapSync(() => aui.message.setIsCopied(true));
           copiedTimer = setTimeout(() => {
             copiedTimer = undefined;
-            if (!disposed) flushTapSync(() => aui.message.setIsCopied(false));
+            if (stillCopiedMessage()) {
+              flushTapSync(() => aui.message.setIsCopied(false));
+            }
           }, props.copiedDuration);
         },
         () => {},

--- a/packages/vue/src/primitives/actionBar.ts
+++ b/packages/vue/src/primitives/actionBar.ts
@@ -72,8 +72,12 @@ export const ActionBarPrimitiveReload = defineComponent({
   },
 });
 
-const defaultCopyToClipboard = (text: string) =>
-  navigator.clipboard.writeText(text);
+const defaultCopyToClipboard = (text: string) => {
+  if (typeof navigator === "undefined" || !navigator.clipboard) {
+    return Promise.reject(new Error("Clipboard API is not available."));
+  }
+  return navigator.clipboard.writeText(text);
+};
 
 /**
  * A button that copies the current message (or, while editing, the edit


### PR DESCRIPTION
## summary

- adds ActionBarPrimitiveEdit, ActionBarPrimitiveReload, and ActionBarPrimitiveCopy with the exact disabled expressions and actions of the React primitive hooks (useActionBarEdit/Reload/Copy): edit disabled while editing, reload gated on isRunning/isDisabled/assistant role, copy gated on running assistant or empty text, copying the edit composer text while editing, with setIsCopied plus a copiedDuration window surfaced as a data-copied attribute and cleaned up on unmount; all three ride the same attr-proof button shape as the composer and branch picker buttons
- the edit UI itself needs no new components: beginEdit seeds the message-scoped edit composer, so ComposerPrimitiveInput/Send/Cancel double as the editor, save routes through onEdit into a sibling branch, and discard ends editing
- closes the branch coverage gap deferred from #5691: tests now drive a real edit into a second branch, switch previous/next, block switching while a run is in flight, reload into an "(again)" branch, and pin the copy window
- examples/with-vue gains hover action bars (Edit and Copy on user messages, Copy and Regenerate on assistant messages), an inline Save/Discard edit card, and a branch navigator that appears at branchCount > 1; the echo runtime now carries stable message ids plus setMessages/onEdit/onReload so branching actually works

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/vue -> 43/43; the new suite covers edit-to-branch, branch switching both ways, run-blocked switching, discard, reload branching, and the copy flow against a mocked clipboard
- [x] browser smoke on the dev server: Edit seeds "hello world", Save produces the "goodbye world" branch with its echo, Previous switches the whole subtree back, Regenerate lands "Echo: hello world (again)"
- [x] `pnpm exec vitest run` in packages/store -> 123/123; examples/with-vue `vite build` green; `pnpm lint` clean

### reviewer should verify

- [ ] in examples/with-vue, hover a user message, edit it, save, and flip between the branches with the chevron navigator; the assistant reply follows the selected branch

## notes

- two fixture lessons are encoded in the tests: external-store branch bookkeeping needs stable message ids plus a stable convertMessage function identity (rebuilding the converter per sync regenerates every id and erases branches), and transient assertions must outlast vi.waitFor's 50ms poll interval
- vue stays private, no changeset; core and store untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._FRvdA3eLbCJ6oZCVyHAG0A06QGDuq7uXB1ZG0isQBtaNC3BufzqsQMAj28?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->