### PR TITLE
feat(vue): suggestions primitives

### DIFF
--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -4,7 +4,11 @@ import {
   ComposerPrimitiveCancel,
   ComposerPrimitiveInput,
   ComposerPrimitiveSend,
+  SuggestionPrimitiveDescription,
+  SuggestionPrimitiveTitle,
+  SuggestionPrimitiveTrigger,
   ThreadPrimitiveMessages,
+  ThreadPrimitiveSuggestions,
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
@@ -19,8 +23,23 @@ import Message from "./Message.vue";
     >
       <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
         <AuiIf :condition="(s) => s.thread.messages.length === 0">
-          <div class="flex flex-1 flex-col items-center justify-center pb-24">
+          <div
+            class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
+          >
             <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+            <div class="flex flex-wrap items-center justify-center gap-2 px-4">
+              <ThreadPrimitiveSuggestions>
+                <SuggestionPrimitiveTrigger
+                  send
+                  class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+                >
+                  <span class="font-medium"><SuggestionPrimitiveTitle /></span>
+                  <span class="text-muted-foreground text-xs">
+                    <SuggestionPrimitiveDescription />
+                  </span>
+                </SuggestionPrimitiveTrigger>
+              </ThreadPrimitiveSuggestions>
+            </div>
           </div>
         </AuiIf>
         <ol class="mb-14 flex flex-col gap-y-6 empty:hidden">

--- a/examples/with-vue/src/Root.vue
+++ b/examples/with-vue/src/Root.vue
@@ -1,10 +1,25 @@
 <script setup lang="ts">
 import { AuiConfig, AuiProvider } from "@assistant-ui/vue";
-import { RuntimeAdapter } from "@assistant-ui/core/store";
+import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
 import App from "./App.vue";
 import { createEchoRuntime } from "./runtime";
 
-const config = AuiConfig({ threads: RuntimeAdapter(createEchoRuntime()) });
+const config = AuiConfig({
+  threads: RuntimeAdapter(createEchoRuntime()),
+  suggestions: Suggestions([
+    { title: "Say hello", label: "a friendly opener", prompt: "Hello there!" },
+    {
+      title: "Ask anything",
+      label: "it will echo back",
+      prompt: "What can you do?",
+    },
+    {
+      title: "Tell a story",
+      label: "a longer prompt",
+      prompt: "Tell me a story about an echo.",
+    },
+  ]),
+});
 </script>
 
 <template>

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -65,6 +65,7 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `MessagePrimitiveParts` renders the current message's content parts, each scoped through `PartByIndexProvider`; a slot named after the part type overrides its rendering, and text parts render their text by default.
 - `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
 - `ActionBarPrimitiveEdit`, `ActionBarPrimitiveReload`, and `ActionBarPrimitiveCopy` cover the widget-free message actions; inside a message scope the composer primitives double as the edit UI (`beginEdit` seeds the edit composer, `ComposerPrimitiveSend` saves into a new branch, `ComposerPrimitiveCancel` discards).
+- `ThreadPrimitiveSuggestions` renders the default slot once per configured suggestion (`Suggestions([...])` from `@assistant-ui/core/store` in the provider config), scoped through `SuggestionByIndexProvider`; `SuggestionPrimitiveTrigger` sends the prompt (`send`) or inserts it into the composer, and `SuggestionPrimitiveTitle`/`Description` render its text.
 - `AuiIf` renders its slot while a state selector returns true.
 
 ```vue

--- a/packages/vue/src/__tests__/primitives-suggestions.test.ts
+++ b/packages/vue/src/__tests__/primitives-suggestions.test.ts
@@ -170,6 +170,68 @@ describe("suggestions primitives", () => {
     mounted.unmount();
   });
 
+  it("queues a send during a run without clearing the draft and forwards runConfig", async () => {
+    let isRunning = false;
+    const onNew = vi.fn(async () => {});
+    const steer = vi.fn();
+    const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+      messages: [],
+      isRunning,
+      convertMessage: (message) => ({
+        id: message.id,
+        role: message.role,
+        content: [{ type: "text", text: message.text }],
+      }),
+      onNew,
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue: () => {},
+        steer,
+        move: () => {},
+        edit: () => {},
+        remove: () => {},
+      },
+    });
+    const core = new ExternalStoreRuntimeCore(makeAdapter());
+    const runtime = new AssistantRuntimeImpl(core);
+    const setRunning = (value: boolean) => {
+      isRunning = value;
+      core.setAdapter(makeAdapter());
+    };
+
+    const { el, unmount } = mountSuggestions(runtime, { send: true });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+
+    flushTapSync(() => {
+      runtime.thread.composer.setRunConfig({ custom: { mode: "echo" } });
+      runtime.thread.composer.setText("half-typed draft");
+      setRunning(true);
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.disabled,
+      ).toBe(false);
+    });
+
+    el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.click();
+    await vi.waitFor(() => {
+      expect(steer).toHaveBeenCalledTimes(1);
+    });
+    expect(steer.mock.calls[0]![0]).toMatchObject({
+      content: [{ type: "text", text: "Hello there!" }],
+      runConfig: { custom: { mode: "echo" } },
+    });
+    expect(onNew).not.toHaveBeenCalled();
+    expect(runtime.thread.composer.getState().text).toBe("half-typed draft");
+
+    unmount();
+  });
+
   it("disables sending chips while a run is in flight", async () => {
     const { runtime, setRunning } = createSuggestingRuntime();
     const { el, unmount } = mountSuggestions(runtime, { send: true });

--- a/packages/vue/src/__tests__/primitives-suggestions.test.ts
+++ b/packages/vue/src/__tests__/primitives-suggestions.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter, Suggestions } from "@assistant-ui/core/store";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import {
+  SuggestionPrimitiveDescription,
+  SuggestionPrimitiveTitle,
+  SuggestionPrimitiveTrigger,
+  ThreadPrimitiveSuggestions,
+} from "../primitives/suggestions";
+
+type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
+
+const createSuggestingRuntime = () => {
+  let isRunning = false;
+  const onNew = vi.fn(async () => {});
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages: [],
+    isRunning,
+    convertMessage: (message) => ({
+      id: message.id,
+      role: message.role,
+      content: [{ type: "text", text: message.text }],
+    }),
+    onNew,
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const sync = () => core.setAdapter(makeAdapter());
+  const setRunning = (value: boolean) => {
+    isRunning = value;
+    sync();
+  };
+  return { runtime, onNew, setRunning };
+};
+
+const mountSuggestions = (
+  runtime: AssistantRuntimeImpl,
+  triggerProps?: Record<string, unknown>,
+) => {
+  const View = defineComponent({
+    setup: () => () =>
+      h(ThreadPrimitiveSuggestions, null, {
+        default: () =>
+          h(
+            SuggestionPrimitiveTrigger,
+            { class: "chip", ...triggerProps },
+            {
+              default: () => [
+                h("b", null, [h(SuggestionPrimitiveTitle)]),
+                h("i", null, [h(SuggestionPrimitiveDescription)]),
+              ],
+            },
+          ),
+      }),
+  }) as Component;
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          {
+            config: AuiConfig({
+              threads: RuntimeAdapter(runtime),
+              suggestions: Suggestions([
+                {
+                  title: "Say hello",
+                  label: "a friendly opener",
+                  prompt: "Hello there!",
+                },
+                {
+                  title: "Ask the time",
+                  label: "small talk",
+                  prompt: "What time is it?",
+                },
+              ]),
+            }),
+          },
+          { default: () => h(View) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+describe("suggestions primitives", () => {
+  it("renders one scoped chip per suggestion with title and label", async () => {
+    const { runtime } = createSuggestingRuntime();
+    const { el, unmount } = mountSuggestions(runtime);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+    const chips = [...el.querySelectorAll("button.chip")];
+    expect(chips.map((chip) => chip.querySelector("b")!.textContent)).toEqual([
+      "Say hello",
+      "Ask the time",
+    ]);
+    expect(chips.map((chip) => chip.querySelector("i")!.textContent)).toEqual([
+      "a friendly opener",
+      "small talk",
+    ]);
+
+    unmount();
+  });
+
+  it("sends the prompt as a message when send is set", async () => {
+    const { runtime, onNew } = createSuggestingRuntime();
+    const { el, unmount } = mountSuggestions(runtime, { send: true });
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+    el.querySelectorAll<HTMLButtonElement>("button.chip")[1]!.click();
+
+    await vi.waitFor(() => {
+      expect(onNew).toHaveBeenCalledTimes(1);
+    });
+    expect(onNew.mock.calls[0]![0]).toMatchObject({
+      content: [{ type: "text", text: "What time is it?" }],
+    });
+
+    unmount();
+  });
+
+  it("replaces the composer text without send, and appends when clearComposer is false", async () => {
+    const { runtime } = createSuggestingRuntime();
+    const { el, unmount } = mountSuggestions(runtime);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+    el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.click();
+    await vi.waitFor(() => {
+      expect(runtime.thread.composer.getState().text).toBe("Hello there!");
+    });
+
+    unmount();
+
+    const appending = createSuggestingRuntime();
+    const mounted = mountSuggestions(appending.runtime, {
+      clearComposer: false,
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(mounted.el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+    flushTapSync(() =>
+      appending.runtime.thread.composer.setText("Existing draft"),
+    );
+    mounted.el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.click();
+    await vi.waitFor(() => {
+      expect(appending.runtime.thread.composer.getState().text).toBe(
+        "Existing draft Hello there!",
+      );
+    });
+
+    mounted.unmount();
+  });
+
+  it("disables sending chips while a run is in flight", async () => {
+    const { runtime, setRunning } = createSuggestingRuntime();
+    const { el, unmount } = mountSuggestions(runtime, { send: true });
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.chip")).toHaveLength(2);
+    });
+    expect(
+      el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.disabled,
+    ).toBe(false);
+
+    flushTapSync(() => setRunning(true));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        el.querySelectorAll<HTMLButtonElement>("button.chip")[0]!.disabled,
+      ).toBe(true);
+    });
+
+    unmount();
+  });
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -23,6 +23,13 @@ export {
   ActionBarPrimitiveReload,
   ActionBarPrimitiveCopy,
 } from "./primitives/actionBar";
+export {
+  SuggestionByIndexProvider,
+  ThreadPrimitiveSuggestions,
+  SuggestionPrimitiveTrigger,
+  SuggestionPrimitiveTitle,
+  SuggestionPrimitiveDescription,
+} from "./primitives/suggestions";
 
 export {
   AuiConfig,

--- a/packages/vue/src/primitives/suggestions.ts
+++ b/packages/vue/src/primitives/suggestions.ts
@@ -1,0 +1,148 @@
+import { computed, defineComponent, h, mergeProps, type SlotsType } from "vue";
+import { AuiConfig, Derived } from "@assistant-ui/store/client";
+import { flushTapSync } from "@assistant-ui/tap";
+import type {} from "@assistant-ui/core/store";
+import { AuiProvider } from "../AuiProvider";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+/**
+ * Scopes the subtree to the suggestion at `index`: descendants read it
+ * through `s.suggestion`.
+ */
+export const SuggestionByIndexProvider = defineComponent({
+  name: "SuggestionByIndexProvider",
+  props: {
+    index: {
+      type: Number,
+      required: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const aui = useAui();
+    const config = computed(() =>
+      AuiConfig({
+        suggestion: Derived({
+          source: "suggestions",
+          query: { index: props.index },
+          get: (aui) => aui.suggestions.suggestion({ index: props.index }),
+        }),
+      }),
+    );
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});
+
+/**
+ * Renders the default slot once per thread suggestion, each instance scoped
+ * through {@link SuggestionByIndexProvider}.
+ */
+export const ThreadPrimitiveSuggestions = defineComponent({
+  name: "ThreadPrimitiveSuggestions",
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { slots }) {
+    const count = useAuiState((s) => s.suggestions.suggestions.length);
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          SuggestionByIndexProvider,
+          { index, key: index },
+          { default: () => slots.default?.() },
+        ),
+      );
+  },
+});
+
+/**
+ * A button that triggers the current suggestion. With `send`, the prompt is
+ * appended as a message (queued sends never clear a draft the user is still
+ * composing); without it, the prompt replaces the composer text, or is
+ * appended to it when `clearComposer` is false.
+ */
+export const SuggestionPrimitiveTrigger = defineComponent({
+  name: "SuggestionPrimitiveTrigger",
+  inheritAttrs: false,
+  props: {
+    send: {
+      type: Boolean,
+      default: false,
+    },
+    clearComposer: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { attrs, slots }) {
+    const aui = useAui();
+    const prompt = useAuiState((s) => s.suggestion.prompt);
+    const disabled = useAuiState(
+      (s) =>
+        s.thread.isDisabled ||
+        (props.send && s.thread.isRunning && !s.thread.capabilities.queue),
+    );
+
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || disabled.value || isAttrDisabled(attrs))
+        return;
+      flushTapSync(() => {
+        if (props.send) {
+          const { isRunning, capabilities } = aui.thread.getState();
+          if (isRunning && !capabilities.queue) return;
+          aui.thread.append({
+            content: [{ type: "text", text: prompt.value }],
+            runConfig: aui.composer.getState().runConfig,
+          });
+          if (props.clearComposer && !isRunning) {
+            aui.composer.setText("");
+          }
+        } else if (props.clearComposer) {
+          aui.composer.setText(prompt.value);
+        } else {
+          const currentText = aui.composer.getState().text;
+          aui.composer.setText(
+            currentText.trim()
+              ? `${currentText} ${prompt.value}`
+              : prompt.value,
+          );
+        }
+      });
+    };
+
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: disabled.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+/** Renders the current suggestion's title as text. */
+export const SuggestionPrimitiveTitle = defineComponent({
+  name: "SuggestionPrimitiveTitle",
+  setup() {
+    const title = useAuiState((s) => s.suggestion.title);
+    return () => title.value;
+  },
+});
+
+/** Renders the current suggestion's label as text. */
+export const SuggestionPrimitiveDescription = defineComponent({
+  name: "SuggestionPrimitiveDescription",
+  setup() {
+    const label = useAuiState((s) => s.suggestion.label);
+    return () => label.value;
+  },
+});


### PR DESCRIPTION
## summary

- adds ThreadPrimitiveSuggestions (default slot rendered once per configured suggestion, scoped through the new SuggestionByIndexProvider so descendants read s.suggestion), SuggestionPrimitiveTrigger, and the SuggestionPrimitiveTitle/Description text primitives
- the trigger mirrors useSuggestionTrigger exactly: with send the prompt is appended as a message carrying the composer runConfig and a send queued during a run never clears the draft the user is composing; without send the prompt replaces the composer text, or is appended with a space when clearComposer is false; disabled while the thread is disabled or a sending chip would race a non-queueing run; same attr-proof button shape as the other primitives
- suggestions come from the provider config (Suggestions([...]) from @assistant-ui/core/store), matching the React welcome-chips path; the runtime adapter's suggestions field feeds s.thread.suggestions and is a separate channel this PR does not touch
- examples/with-vue gains three welcome suggestion chips (title plus label, canonical rounded-outline styling) that send on click

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/vue -> 49/49: chip rendering with title and label, send mode dispatching the prompt through onNew, replace and append composer modes, and send chips disabled while a run is in flight
- [x] browser smoke on the dev server: the welcome state shows three chips, clicking one sends its prompt, the echo reply lands, and the welcome state dismisses
- [x] `pnpm exec vitest run` in packages/store -> 123/123; examples/with-vue `vite build` green; `pnpm lint` clean

### reviewer should verify

- [ ] in examples/with-vue, click a welcome chip: its prompt is sent as a message and the reply follows; type a draft first and click a chip mid-run to see the draft preserved

## notes

- vue stays private, no changeset; core and store untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.lQifxBKGGKbuE23GnQaD59Yi1dB5yTBobQuz91xVyP6d0QznKDQx-EtbHxo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->