### PR TITLE
feat(vue): scroll-to-bottom command channel and button

### DIFF
--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -8,11 +8,12 @@ import {
   SuggestionPrimitiveTitle,
   SuggestionPrimitiveTrigger,
   ThreadPrimitiveMessages,
+  ThreadPrimitiveScrollToBottom,
   ThreadPrimitiveSuggestions,
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
-import { ArrowUpIcon, SquareIcon } from "@lucide/vue";
+import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
 import Message from "./Message.vue";
 </script>
 
@@ -42,11 +43,17 @@ import Message from "./Message.vue";
             </div>
           </div>
         </AuiIf>
-        <ol class="mb-14 flex flex-col gap-y-6 empty:hidden">
+        <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
           <ThreadPrimitiveMessages>
             <Message />
           </ThreadPrimitiveMessages>
         </ol>
+        <ThreadPrimitiveScrollToBottom
+          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-opacity disabled:invisible"
+          aria-label="Scroll to bottom"
+        >
+          <ArrowDownIcon class="size-4" />
+        </ThreadPrimitiveScrollToBottom>
       </div>
     </ThreadPrimitiveViewport>
     <div class="mx-auto w-full max-w-2xl px-4 pb-4">

--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -49,7 +49,7 @@ import Message from "./Message.vue";
           </ThreadPrimitiveMessages>
         </ol>
         <ThreadPrimitiveScrollToBottom
-          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-opacity disabled:invisible"
+          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-opacity disabled:pointer-events-none disabled:opacity-0"
           aria-label="Scroll to bottom"
         >
           <ArrowDownIcon class="size-4" />

--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -49,7 +49,7 @@ import Message from "./Message.vue";
           </ThreadPrimitiveMessages>
         </ol>
         <ThreadPrimitiveScrollToBottom
-          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-opacity disabled:pointer-events-none disabled:opacity-0"
+          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
           aria-label="Scroll to bottom"
         >
           <ArrowDownIcon class="size-4" />

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -61,7 +61,7 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `ThreadPrimitiveMessages` renders its default slot once per thread message, each instance scoped through `MessageByIndexProvider` (descendants read `s.message` and the message's edit composer as `s.composer`).
 - `ComposerPrimitiveInput` is a textarea bound to the composer text; Enter submits, Shift+Enter inserts a newline, IME composition is ignored.
 - `ComposerPrimitiveSend` and `ComposerPrimitiveCancel` are buttons wired to the composer with the same disabled semantics as the React primitives.
-- `ThreadPrimitiveViewport` is a scroll container that keeps the thread pinned to the bottom while the user is at the bottom, scrolls down on run start, and unpins when the user scrolls up.
+- `ThreadPrimitiveViewport` is a scroll container that keeps the thread pinned to the bottom while the user is at the bottom, scrolls down on run start, and unpins when the user scrolls up. It provides the scroll channel `ThreadPrimitiveScrollToBottom` drives: a button, placed inside the viewport, that jumps back down and disables while already at the bottom.
 - `MessagePrimitiveParts` renders the current message's content parts, each scoped through `PartByIndexProvider`; a slot named after the part type overrides its rendering, and text parts render their text by default.
 - `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
 - `ActionBarPrimitiveEdit`, `ActionBarPrimitiveReload`, and `ActionBarPrimitiveCopy` cover the widget-free message actions; inside a message scope the composer primitives double as the edit UI (`beginEdit` seeds the edit composer, `ComposerPrimitiveSend` saves into a new branch, `ComposerPrimitiveCancel` discards).

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 afterEach(() => {
   vi.restoreAllMocks();
   clearPartWarningsForTesting();
+  clearScrollToBottomWarningForTesting();
 });
 import { createApp, defineComponent, h, nextTick, type Component } from "vue";
 import { flushTapSync } from "@assistant-ui/tap";
@@ -20,7 +21,10 @@ import { AuiProvider } from "../AuiProvider";
 import { useAuiState } from "../useAuiState";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
-import { ThreadPrimitiveScrollToBottom } from "../primitives/ThreadPrimitiveScrollToBottom";
+import {
+  ThreadPrimitiveScrollToBottom,
+  clearScrollToBottomWarningForTesting,
+} from "../primitives/ThreadPrimitiveScrollToBottom";
 import {
   MessagePrimitiveParts,
   clearPartWarningsForTesting,

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -20,6 +20,7 @@ import { AuiProvider } from "../AuiProvider";
 import { useAuiState } from "../useAuiState";
 import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
 import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
+import { ThreadPrimitiveScrollToBottom } from "../primitives/ThreadPrimitiveScrollToBottom";
 import {
   MessagePrimitiveParts,
   clearPartWarningsForTesting,
@@ -468,6 +469,97 @@ describe("ThreadPrimitiveViewport", () => {
     expect(disabledScrollTo).not.toHaveBeenCalled();
 
     mountedDisabled.unmount();
+  });
+
+  it("enables scroll-to-bottom only while scrolled up and scrolls on click", async () => {
+    const { runtime, append } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport" },
+          {
+            default: () => [
+              h(ThreadPrimitiveMessages, null, {
+                default: () => h("p", "row"),
+              }),
+              h(
+                ThreadPrimitiveScrollToBottom,
+                { class: "jump" },
+                { default: () => "Jump" },
+              ),
+            ],
+          },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    let scrollTop = 400;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => 500,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    Object.defineProperty(div, "scrollTop", {
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = value;
+      },
+      configurable: true,
+    });
+    const scrollTo = vi.fn(({ top }: { top: number }) => {
+      scrollTop = Math.max(0, Math.min(top, 400));
+    });
+    Object.defineProperty(div, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    });
+
+    div.dispatchEvent(new Event("scroll"));
+    const button = el.querySelector<HTMLButtonElement>("button.jump")!;
+    expect(button.disabled).toBe(true);
+
+    scrollTop = 50;
+    div.dispatchEvent(new Event("scroll"));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+        false,
+      );
+    });
+
+    el.querySelector<HTMLButtonElement>("button.jump")!.click();
+    expect(scrollTo).toHaveBeenCalledWith({ top: 500, behavior: "auto" });
+    div.dispatchEvent(new Event("scroll"));
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+        true,
+      );
+    });
+
+    unmount();
+  });
+
+  it("renders scroll-to-bottom disabled outside a viewport", () => {
+    const { runtime } = createTestRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(
+          ThreadPrimitiveScrollToBottom,
+          { class: "jump" },
+          { default: () => "Jump" },
+        ),
+    });
+    const { el, unmount } = mountChat(runtime, View);
+    expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
+      true,
+    );
+    unmount();
   });
 
   it("computes bottom pinning from viewport metrics", () => {

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -545,7 +545,8 @@ describe("ThreadPrimitiveViewport", () => {
     unmount();
   });
 
-  it("renders scroll-to-bottom disabled outside a viewport", () => {
+  it("renders scroll-to-bottom disabled outside a viewport and warns in dev", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { runtime } = createTestRuntime();
     const View = defineComponent({
       setup: () => () =>
@@ -559,6 +560,8 @@ describe("ThreadPrimitiveViewport", () => {
     expect(el.querySelector<HTMLButtonElement>("button.jump")!.disabled).toBe(
       true,
     );
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain("no surrounding");
     unmount();
   });
 

--- a/packages/vue/src/__tests__/primitives-content.test.ts
+++ b/packages/vue/src/__tests__/primitives-content.test.ts
@@ -472,7 +472,7 @@ describe("ThreadPrimitiveViewport", () => {
   });
 
   it("enables scroll-to-bottom only while scrolled up and scrolls on click", async () => {
-    const { runtime, append } = createTestRuntime();
+    const { runtime } = createTestRuntime();
     const View = defineComponent({
       setup: () => () =>
         h(

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -8,6 +8,7 @@ export { MessageByIndexProvider } from "./primitives/MessageByIndexProvider";
 export { PartByIndexProvider } from "./primitives/PartByIndexProvider";
 export { ThreadPrimitiveMessages } from "./primitives/ThreadPrimitiveMessages";
 export { ThreadPrimitiveViewport } from "./primitives/ThreadPrimitiveViewport";
+export { ThreadPrimitiveScrollToBottom } from "./primitives/ThreadPrimitiveScrollToBottom";
 export { MessagePrimitiveParts } from "./primitives/MessagePrimitiveParts";
 export { ComposerPrimitiveInput } from "./primitives/ComposerPrimitiveInput";
 export { ComposerPrimitiveSend } from "./primitives/ComposerPrimitiveSend";

--- a/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
@@ -6,8 +6,11 @@ import {
   type PropType,
   type SlotsType,
 } from "vue";
+import { isDevelopment } from "../isDevelopment";
 import { isAttrDisabled } from "./attrDisabled";
 import { viewportInjectionKey } from "./viewportContext";
+
+let warnedOutsideViewport = false;
 
 /**
  * A button that scrolls the surrounding {@link ThreadPrimitiveViewport} to
@@ -26,6 +29,12 @@ export const ThreadPrimitiveScrollToBottom = defineComponent({
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(props, { attrs, slots }) {
     const viewport = inject(viewportInjectionKey, null);
+    if (isDevelopment && !viewport && !warnedOutsideViewport) {
+      warnedOutsideViewport = true;
+      console.warn(
+        "ThreadPrimitiveScrollToBottom: no surrounding ThreadPrimitiveViewport provides the scroll channel; the button stays disabled. Place it inside the viewport.",
+      );
+    }
     const onClick = (event: MouseEvent) => {
       if (
         event.defaultPrevented ||

--- a/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
@@ -12,6 +12,10 @@ import { viewportInjectionKey } from "./viewportContext";
 
 let warnedOutsideViewport = false;
 
+export const clearScrollToBottomWarningForTesting = () => {
+  warnedOutsideViewport = false;
+};
+
 /**
  * A button that scrolls the surrounding {@link ThreadPrimitiveViewport} to
  * the bottom. Disabled while the viewport is already at the bottom, or when

--- a/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveScrollToBottom.ts
@@ -1,0 +1,51 @@
+import {
+  defineComponent,
+  h,
+  inject,
+  mergeProps,
+  type PropType,
+  type SlotsType,
+} from "vue";
+import { isAttrDisabled } from "./attrDisabled";
+import { viewportInjectionKey } from "./viewportContext";
+
+/**
+ * A button that scrolls the surrounding {@link ThreadPrimitiveViewport} to
+ * the bottom. Disabled while the viewport is already at the bottom, or when
+ * no viewport provides the channel.
+ */
+export const ThreadPrimitiveScrollToBottom = defineComponent({
+  name: "ThreadPrimitiveScrollToBottom",
+  inheritAttrs: false,
+  props: {
+    behavior: {
+      type: String as PropType<ScrollBehavior>,
+      default: "auto",
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { attrs, slots }) {
+    const viewport = inject(viewportInjectionKey, null);
+    const onClick = (event: MouseEvent) => {
+      if (
+        event.defaultPrevented ||
+        !viewport ||
+        viewport.isAtBottom.value ||
+        isAttrDisabled(attrs)
+      )
+        return;
+      viewport.scrollToBottom(props.behavior);
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled:
+            !viewport || viewport.isAtBottom.value || isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -3,6 +3,7 @@ import {
   h,
   onMounted,
   onScopeDispose,
+  provide,
   shallowRef,
   watch,
   type SlotsType,
@@ -16,6 +17,7 @@ import {
   observeContentResize,
   viewportOverflows,
 } from "./viewportScroll";
+import { viewportInjectionKey } from "./viewportContext";
 
 /**
  * A scrollable container that keeps the thread pinned to the bottom: content
@@ -23,10 +25,10 @@ import {
  * scrolls down, and scrolling up unpins until the user returns to the bottom.
  * The four options mirror the React hook and are independent: `autoScroll`
  * covers follow-on-content-growth, and the other three gate the
- * first-messages, run-start, and thread-switch scrolls. The React viewport's
- * top-anchor system and its imperative scroll-to-bottom channel (the one
- * `ThreadPrimitive.ScrollToBottom` drives) live in the React viewport store
- * and are not ported yet.
+ * first-messages, run-start, and thread-switch scrolls. Provides the
+ * scroll-to-bottom channel that {@link ThreadPrimitiveScrollToBottom} drives;
+ * the React viewport's top-anchor system stays in the React viewport store
+ * and is not ported.
  */
 export const ThreadPrimitiveViewport = defineComponent({
   name: "ThreadPrimitiveViewport",
@@ -52,7 +54,7 @@ export const ThreadPrimitiveViewport = defineComponent({
   setup(props, { slots }) {
     const divRef = shallowRef<HTMLElement | null>(null);
     let intent: ScrollBehavior | null = null;
-    let isAtBottom = true;
+    const isAtBottom = shallowRef(true);
     let lastScrollTop = 0;
     let lastScrollHeight = 0;
     let lastObservedScrollHeight = 0;
@@ -97,7 +99,7 @@ export const ThreadPrimitiveViewport = defineComponent({
         ) {
           intent = null;
         }
-        if (newIsAtBottom || intent === null) isAtBottom = newIsAtBottom;
+        if (newIsAtBottom || intent === null) isAtBottom.value = newIsAtBottom;
       }
 
       lastScrollTop = div.scrollTop;
@@ -119,7 +121,7 @@ export const ThreadPrimitiveViewport = defineComponent({
 
       if (intent) {
         scrollToBottom(intent);
-      } else if (props.autoScroll && isAtBottom) {
+      } else if (props.autoScroll && isAtBottom.value) {
         scrollToBottom("instant");
       }
       handleScroll();
@@ -173,6 +175,12 @@ export const ThreadPrimitiveViewport = defineComponent({
     useAuiEvent("threadListItem.switchedTo", () => {
       if (!props.scrollToBottomOnThreadSwitch) return;
       scheduleScrollToBottom("instant");
+    });
+
+    provide(viewportInjectionKey, {
+      isAtBottom,
+      scrollToBottom: (behavior: ScrollBehavior = "auto") =>
+        scrollToBottom(behavior),
     });
 
     return () =>

--- a/packages/vue/src/primitives/viewportContext.ts
+++ b/packages/vue/src/primitives/viewportContext.ts
@@ -1,0 +1,10 @@
+import type { InjectionKey, ShallowRef } from "vue";
+
+export type ViewportContext = {
+  isAtBottom: ShallowRef<boolean>;
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+};
+
+export const viewportInjectionKey: InjectionKey<ViewportContext> = Symbol(
+  "assistant-ui.vue.viewport",
+);


### PR DESCRIPTION
## summary

- ThreadPrimitiveViewport now provides a scroll channel over provide/inject: a reactive isAtBottom (promoted from a closure variable to a shallowRef, no behavior change) plus a scrollToBottom(behavior) command, closing the divergence recorded in the viewport docstring; only the React top-anchor system remains unported
- adds ThreadPrimitiveScrollToBottom, mirroring the React primitive: disabled while the viewport is already at the bottom or when no surrounding viewport provides the channel, a behavior prop defaulting to auto, and the same attr-proof button shape as the other primitives
- the channel's scope is the viewport subtree by construction (provide/inject flows down), so the button must live inside the viewport; the canonical React layout already nests the composer area inside the viewport, and the example follows with a sticky bottom placement
- examples/with-vue gains the floating jump-to-bottom button (rounded, disabled:invisible, ArrowDown icon), sticky at the viewport bottom

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/vue -> 52/52: disabled at bottom, enabled after a user scroll-up, click issues scrollTo with the bottom target and auto behavior then re-disables on re-pin, and disabled render outside a viewport
- [x] browser smoke on the dev server: hidden at the bottom (disabled:invisible), appears after scrolling up, click jumps back down and hides again
- [x] `pnpm exec vitest run` in packages/store -> 123/123; examples/with-vue `vite build` green; `pnpm lint` clean

### reviewer should verify

- [ ] in examples/with-vue, fill the thread past overflow, scroll up, click the floating arrow: the viewport returns to the bottom and the button hides

## notes

- test fixture note encoded in the suite: after mocking viewport geometry, dispatch one synchronizing scroll event first, or the tracked lastScrollTop of 0 makes the next scroll-up read as an in-flight downward scroll
- vue stays private, no changeset; core and store untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.i1M2lpm8q_wurjcLy6jD8oFEohGTQ35-umlo528GJQ3anBnOmlYo8B46PUw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->