### PR TITLE
feat(vue): thread list primitives

### DIFF
--- a/examples/with-vue/src/App.vue
+++ b/examples/with-vue/src/App.vue
@@ -7,81 +7,104 @@ import {
   SuggestionPrimitiveDescription,
   SuggestionPrimitiveTitle,
   SuggestionPrimitiveTrigger,
+  ThreadListPrimitiveItems,
+  ThreadListPrimitiveNew,
   ThreadPrimitiveMessages,
   ThreadPrimitiveScrollToBottom,
   ThreadPrimitiveSuggestions,
   ThreadPrimitiveViewport,
 } from "@assistant-ui/vue";
 import type {} from "@assistant-ui/core/store";
-import { ArrowDownIcon, ArrowUpIcon, SquareIcon } from "@lucide/vue";
+import { ArrowDownIcon, ArrowUpIcon, PlusIcon, SquareIcon } from "@lucide/vue";
 import Message from "./Message.vue";
+import ThreadItem from "./ThreadItem.vue";
 </script>
 
 <template>
-  <div class="bg-background flex h-full flex-col">
-    <ThreadPrimitiveViewport
-      class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+  <div class="bg-background flex h-full">
+    <aside
+      class="border-border/60 flex w-64 shrink-0 flex-col gap-2 border-r p-3"
     >
-      <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
-        <AuiIf :condition="(s) => s.thread.messages.length === 0">
-          <div
-            class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
-          >
-            <h1 class="text-2xl font-semibold">How can I help you today?</h1>
-            <div class="flex flex-wrap items-center justify-center gap-2 px-4">
-              <ThreadPrimitiveSuggestions>
-                <SuggestionPrimitiveTrigger
-                  send
-                  class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
-                >
-                  <span class="font-medium"><SuggestionPrimitiveTitle /></span>
-                  <span class="text-muted-foreground text-xs">
-                    <SuggestionPrimitiveDescription />
-                  </span>
-                </SuggestionPrimitiveTrigger>
-              </ThreadPrimitiveSuggestions>
-            </div>
-          </div>
-        </AuiIf>
-        <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
-          <ThreadPrimitiveMessages>
-            <Message />
-          </ThreadPrimitiveMessages>
-        </ol>
-        <ThreadPrimitiveScrollToBottom
-          class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
-          aria-label="Scroll to bottom"
-        >
-          <ArrowDownIcon class="size-4" />
-        </ThreadPrimitiveScrollToBottom>
-      </div>
-    </ThreadPrimitiveViewport>
-    <div class="mx-auto w-full max-w-2xl px-4 pb-4">
-      <div
-        class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+      <ThreadListPrimitiveNew
+        class="border-border/60 hover:bg-muted flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors"
       >
-        <ComposerPrimitiveInput
-          class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
-          placeholder="Send a message..."
-          rows="1"
-        />
-        <div class="flex items-center justify-end">
-          <AuiIf :condition="(s) => !s.thread.isRunning">
-            <ComposerPrimitiveSend
-              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
-              aria-label="Send"
+        <PlusIcon class="size-4" /> New chat
+      </ThreadListPrimitiveNew>
+      <div class="flex flex-col gap-1 overflow-y-auto">
+        <ThreadListPrimitiveItems>
+          <ThreadItem />
+        </ThreadListPrimitiveItems>
+      </div>
+    </aside>
+    <div class="flex min-w-0 flex-1 flex-col">
+      <ThreadPrimitiveViewport
+        class="relative flex flex-1 flex-col overflow-x-auto overflow-y-scroll scroll-smooth"
+      >
+        <div class="mx-auto flex w-full max-w-2xl flex-1 flex-col px-4 pt-12">
+          <AuiIf :condition="(s) => s.thread.messages.length === 0">
+            <div
+              class="flex flex-1 flex-col items-center justify-center gap-6 pb-24"
             >
-              <ArrowUpIcon class="size-4.5" />
-            </ComposerPrimitiveSend>
+              <h1 class="text-2xl font-semibold">How can I help you today?</h1>
+              <div
+                class="flex flex-wrap items-center justify-center gap-2 px-4"
+              >
+                <ThreadPrimitiveSuggestions>
+                  <SuggestionPrimitiveTrigger
+                    send
+                    class="text-foreground hover:bg-muted border-border/60 flex h-auto flex-col items-start gap-0.5 rounded-2xl border px-3.5 py-2 text-sm transition-colors"
+                  >
+                    <span class="font-medium"
+                      ><SuggestionPrimitiveTitle
+                    /></span>
+                    <span class="text-muted-foreground text-xs">
+                      <SuggestionPrimitiveDescription />
+                    </span>
+                  </SuggestionPrimitiveTrigger>
+                </ThreadPrimitiveSuggestions>
+              </div>
+            </div>
           </AuiIf>
-          <AuiIf :condition="(s) => s.thread.isRunning">
-            <ComposerPrimitiveCancel
-              class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
-              aria-label="Stop"
-            >
-              <SquareIcon class="size-3.5 fill-current" />
-            </ComposerPrimitiveCancel>
-          </AuiIf>
+          <ol class="mb-4 flex flex-col gap-y-6 empty:hidden">
+            <ThreadPrimitiveMessages>
+              <Message />
+            </ThreadPrimitiveMessages>
+          </ol>
+          <ThreadPrimitiveScrollToBottom
+            class="border-border/60 bg-background sticky bottom-2 z-10 mx-auto rounded-full border p-2 shadow-sm transition-[opacity,visibility] disabled:invisible disabled:opacity-0"
+            aria-label="Scroll to bottom"
+          >
+            <ArrowDownIcon class="size-4" />
+          </ThreadPrimitiveScrollToBottom>
+        </div>
+      </ThreadPrimitiveViewport>
+      <div class="mx-auto w-full max-w-2xl px-4 pb-4">
+        <div
+          class="border-border/60 focus-within:border-border flex w-full flex-col gap-2 rounded-2xl border p-2.5 shadow-[0_4px_16px_-8px_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.04)] transition-[border-color,box-shadow] focus-within:shadow-[0_6px_24px_-8px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.05)]"
+        >
+          <ComposerPrimitiveInput
+            class="caret-primary placeholder:text-muted-foreground/80 max-h-32 min-h-10 w-full resize-none bg-transparent px-2.5 py-1 text-base outline-none"
+            placeholder="Send a message..."
+            rows="1"
+          />
+          <div class="flex items-center justify-end">
+            <AuiIf :condition="(s) => !s.thread.isRunning">
+              <ComposerPrimitiveSend
+                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full transition-opacity disabled:opacity-50"
+                aria-label="Send"
+              >
+                <ArrowUpIcon class="size-4.5" />
+              </ComposerPrimitiveSend>
+            </AuiIf>
+            <AuiIf :condition="(s) => s.thread.isRunning">
+              <ComposerPrimitiveCancel
+                class="bg-primary text-primary-foreground flex size-7 items-center justify-center rounded-full"
+                aria-label="Stop"
+              >
+                <SquareIcon class="size-3.5 fill-current" />
+              </ComposerPrimitiveCancel>
+            </AuiIf>
+          </div>
         </div>
       </div>
     </div>

--- a/examples/with-vue/src/ThreadItem.vue
+++ b/examples/with-vue/src/ThreadItem.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import {
+  ThreadListItemPrimitiveTitle,
+  ThreadListItemPrimitiveTrigger,
+  useAuiState,
+} from "@assistant-ui/vue";
+import type {} from "@assistant-ui/core/store";
+
+const isMain = useAuiState((s) => s.threadListItem.isMain);
+</script>
+
+<template>
+  <ThreadListItemPrimitiveTrigger
+    class="hover:bg-muted w-full truncate rounded-lg px-3 py-2 text-left text-sm transition-colors"
+    :class="isMain ? 'bg-muted' : 'text-muted-foreground'"
+  >
+    <ThreadListItemPrimitiveTitle fallback="New Chat" />
+  </ThreadListItemPrimitiveTrigger>
+</template>

--- a/examples/with-vue/src/ThreadItem.vue
+++ b/examples/with-vue/src/ThreadItem.vue
@@ -2,17 +2,12 @@
 import {
   ThreadListItemPrimitiveTitle,
   ThreadListItemPrimitiveTrigger,
-  useAuiState,
 } from "@assistant-ui/vue";
-import type {} from "@assistant-ui/core/store";
-
-const isMain = useAuiState((s) => s.threadListItem.isMain);
 </script>
 
 <template>
   <ThreadListItemPrimitiveTrigger
-    class="hover:bg-muted w-full truncate rounded-lg px-3 py-2 text-left text-sm transition-colors"
-    :class="isMain ? 'bg-muted' : 'text-muted-foreground'"
+    class="hover:bg-muted text-muted-foreground data-[active=true]:bg-muted data-[active=true]:text-foreground w-full truncate rounded-lg px-3 py-2 text-left text-sm transition-colors"
   >
     <ThreadListItemPrimitiveTitle fallback="New Chat" />
   </ThreadListItemPrimitiveTrigger>

--- a/examples/with-vue/src/runtime.ts
+++ b/examples/with-vue/src/runtime.ts
@@ -10,6 +10,12 @@ export type EchoMessage = {
   text: string;
 };
 
+type EchoThread = {
+  id: string;
+  title: string;
+  messages: EchoMessage[];
+};
+
 let nextId = 0;
 const freshId = (prefix: string) => `${prefix}-${nextId++}`;
 
@@ -25,71 +31,133 @@ const convertEchoMessage = (message: EchoMessage) => ({
 });
 
 export const createEchoRuntime = () => {
-  let messages: EchoMessage[] = [];
+  let threads: EchoThread[] = [
+    { id: freshId("thread"), title: "", messages: [] },
+  ];
+  let currentId = threads[0]!.id;
   let isRunning = false;
   let replyTimer: ReturnType<typeof setTimeout> | undefined;
 
+  const current = () => threads.find((thread) => thread.id === currentId)!;
+  const updateCurrent = (updater: (thread: EchoThread) => EchoThread) => {
+    threads = threads.map((thread) =>
+      thread.id === currentId ? updater(thread) : thread,
+    );
+  };
+
   const reply = (text: string) => {
+    const replyTo = currentId;
     isRunning = true;
     sync();
     replyTimer = setTimeout(() => {
-      messages = [
-        ...messages,
-        { id: freshId("assistant"), role: "assistant", text: `Echo: ${text}` },
-      ];
+      if (currentId !== replyTo) return;
+      updateCurrent((thread) => ({
+        ...thread,
+        messages: [
+          ...thread.messages,
+          {
+            id: freshId("assistant"),
+            role: "assistant",
+            text: `Echo: ${text}`,
+          },
+        ],
+      }));
       isRunning = false;
       sync();
     }, 600);
   };
 
+  const appendUser = (text: string) => {
+    updateCurrent((thread) => ({
+      ...thread,
+      title: thread.title || text.slice(0, 40),
+      messages: [
+        ...thread.messages,
+        { id: freshId("user"), role: "user", text },
+      ],
+    }));
+  };
+
   const makeAdapter = (): ExternalStoreAdapter<EchoMessage> => ({
-    messages,
+    messages: current().messages,
     isRunning,
     convertMessage: convertEchoMessage,
     setMessages: (next) => {
-      messages = next;
+      updateCurrent((thread) => ({ ...thread, messages: next }));
       sync();
     },
     onNew: async (message) => {
       const text = messageText(message);
-      messages = [...messages, { id: freshId("user"), role: "user", text }];
+      appendUser(text);
       reply(text);
     },
     onEdit: async (message) => {
       const text = messageText(message);
       const parentIndex = message.parentId
-        ? messages.findIndex((entry) => entry.id === message.parentId) + 1
+        ? current().messages.findIndex(
+            (entry) => entry.id === message.parentId,
+          ) + 1
         : 0;
-      messages = [
-        ...messages.slice(0, parentIndex),
-        { id: freshId("user"), role: "user", text },
-      ];
+      updateCurrent((thread) => ({
+        ...thread,
+        messages: thread.messages.slice(0, parentIndex),
+      }));
+      appendUser(text);
       reply(text);
     },
     onReload: async (parentId) => {
       let parentIndex = 0;
       if (parentId) {
-        const index = messages.findIndex((entry) => entry.id === parentId);
+        const index = current().messages.findIndex(
+          (entry) => entry.id === parentId,
+        );
         if (index === -1) return;
         parentIndex = index + 1;
       }
-      const sliced = messages.slice(0, parentIndex);
+      const sliced = current().messages.slice(0, parentIndex);
       const lastUser = [...sliced]
         .reverse()
         .find((entry) => entry.role === "user");
-      messages = sliced;
+      updateCurrent((thread) => ({ ...thread, messages: sliced }));
       reply(`${lastUser?.text ?? ""} (again)`);
     },
     onCancel: async () => {
       clearTimeout(replyTimer);
-      if (isRunning && messages.at(-1)?.role === "user") {
-        messages = messages.slice(0, -1);
+      if (isRunning && current().messages.at(-1)?.role === "user") {
+        updateCurrent((thread) => ({
+          ...thread,
+          messages: thread.messages.slice(0, -1),
+        }));
       }
       isRunning = false;
       // cancelRun restores the trailing user message into the composer
       // synchronously after onCancel returns; an eager sync would delete it
       // before that restore reads it.
       queueMicrotask(sync);
+    },
+    adapters: {
+      threadList: {
+        threadId: currentId,
+        threads: threads.map((thread) => ({
+          status: "regular" as const,
+          id: thread.id,
+          title: thread.title,
+        })),
+        onSwitchToThread: (threadId) => {
+          clearTimeout(replyTimer);
+          isRunning = false;
+          currentId = threadId;
+          sync();
+        },
+        onSwitchToNewThread: () => {
+          clearTimeout(replyTimer);
+          isRunning = false;
+          const id = freshId("thread");
+          threads = [...threads, { id, title: "", messages: [] }];
+          currentId = id;
+          sync();
+        },
+      },
     },
   });
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -66,6 +66,7 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
 - `ActionBarPrimitiveEdit`, `ActionBarPrimitiveReload`, and `ActionBarPrimitiveCopy` cover the widget-free message actions; inside a message scope the composer primitives double as the edit UI (`beginEdit` seeds the edit composer, `ComposerPrimitiveSend` saves into a new branch, `ComposerPrimitiveCancel` discards).
 - `ThreadPrimitiveSuggestions` renders the default slot once per configured suggestion (`Suggestions([...])` from `@assistant-ui/core/store` in the provider config), scoped through `SuggestionByIndexProvider`; `SuggestionPrimitiveTrigger` sends the prompt (`send`) or inserts it into the composer, and `SuggestionPrimitiveTitle`/`Description` render its text.
+- `ThreadListPrimitiveItems` renders the default slot once per thread (scoped through `ThreadListItemByIndexProvider`), with `ThreadListPrimitiveNew`, `ThreadListItemPrimitiveTrigger`, and `ThreadListItemPrimitiveTitle` covering the sidebar basics; the runtime supplies the list through the external-store `adapters.threadList`.
 - `AuiIf` renders its slot while a state selector returns true.
 
 ```vue

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -66,7 +66,7 @@ Headless components for runtime-backed threads, mirroring the React primitives. 
 - `BranchPickerPrimitivePrevious`/`Next`/`Number`/`Count` navigate and display message branches.
 - `ActionBarPrimitiveEdit`, `ActionBarPrimitiveReload`, and `ActionBarPrimitiveCopy` cover the widget-free message actions; inside a message scope the composer primitives double as the edit UI (`beginEdit` seeds the edit composer, `ComposerPrimitiveSend` saves into a new branch, `ComposerPrimitiveCancel` discards).
 - `ThreadPrimitiveSuggestions` renders the default slot once per configured suggestion (`Suggestions([...])` from `@assistant-ui/core/store` in the provider config), scoped through `SuggestionByIndexProvider`; `SuggestionPrimitiveTrigger` sends the prompt (`send`) or inserts it into the composer, and `SuggestionPrimitiveTitle`/`Description` render its text.
-- `ThreadListPrimitiveItems` renders the default slot once per thread (scoped through `ThreadListItemByIndexProvider`), with `ThreadListPrimitiveNew`, `ThreadListItemPrimitiveTrigger`, and `ThreadListItemPrimitiveTitle` covering the sidebar basics; the runtime supplies the list through the external-store `adapters.threadList`.
+- `ThreadListPrimitiveItems` renders the default slot once per thread (scoped through `ThreadListItemByIndexProvider`), with `ThreadListPrimitiveNew`, `ThreadListItemPrimitiveTrigger`, and `ThreadListItemPrimitiveTitle` (default slot or `fallback` string when the title is empty) covering the sidebar basics; the runtime supplies the list through the external-store `adapters.threadList`.
 - `AuiIf` renders its slot while a state selector returns true.
 
 ```vue

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -166,6 +166,11 @@ describe("thread list primitives", () => {
           .getAttribute("aria-current"),
       ).toBe("true");
     });
+    expect(
+      el
+        .querySelectorAll<HTMLButtonElement>("button.item")[0]!
+        .hasAttribute("data-active"),
+    ).toBe(false);
     await vi.waitFor(() => {
       expect(runtime.thread.getState().messages[0]!.content[0]).toMatchObject({
         type: "text",

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, type Component } from "vue";
+import { flushTapSync } from "@assistant-ui/tap";
+import { AuiConfig } from "@assistant-ui/store/client";
+import { RuntimeAdapter } from "@assistant-ui/core/store";
+import type { ExternalStoreAdapter } from "@assistant-ui/core";
+import {
+  AssistantRuntimeImpl,
+  ExternalStoreRuntimeCore,
+} from "@assistant-ui/core/internal";
+import { AuiProvider } from "../AuiProvider";
+import { ThreadPrimitiveMessages } from "../primitives/ThreadPrimitiveMessages";
+import { ThreadPrimitiveViewport } from "../primitives/ThreadPrimitiveViewport";
+import {
+  ThreadListItemPrimitiveTitle,
+  ThreadListItemPrimitiveTrigger,
+  ThreadListPrimitiveItems,
+  ThreadListPrimitiveNew,
+} from "../primitives/threadList";
+
+type DemoMessage = { id: string; role: "user" | "assistant"; text: string };
+type DemoThread = { id: string; title: string; messages: DemoMessage[] };
+
+const createMultiThreadRuntime = () => {
+  let threads: DemoThread[] = [
+    {
+      id: "t1",
+      title: "First thread",
+      messages: [{ id: "m1", role: "user", text: "hello from one" }],
+    },
+    {
+      id: "t2",
+      title: "Second thread",
+      messages: [{ id: "m2", role: "user", text: "hello from two" }],
+    },
+  ];
+  let currentId = "t1";
+  let nextThread = 3;
+  const onSwitchToThread = vi.fn((threadId: string) => {
+    currentId = threadId;
+    sync();
+  });
+  const onSwitchToNewThread = vi.fn(() => {
+    const id = `t${nextThread++}`;
+    threads = [...threads, { id, title: "", messages: [] }];
+    currentId = id;
+    sync();
+  });
+  const makeAdapter = (): ExternalStoreAdapter<DemoMessage> => ({
+    messages: threads.find((thread) => thread.id === currentId)!.messages,
+    convertMessage: (message) => ({
+      id: message.id,
+      role: message.role,
+      content: [{ type: "text", text: message.text }],
+    }),
+    onNew: async () => {},
+    adapters: {
+      threadList: {
+        threadId: currentId,
+        threads: threads.map((thread) => ({
+          status: "regular" as const,
+          id: thread.id,
+          title: thread.title,
+        })),
+        onSwitchToThread,
+        onSwitchToNewThread,
+      },
+    },
+  });
+  const core = new ExternalStoreRuntimeCore(makeAdapter());
+  const runtime = new AssistantRuntimeImpl(core);
+  const sync = () => core.setAdapter(makeAdapter());
+  return { runtime, onSwitchToThread, onSwitchToNewThread };
+};
+
+const SidebarView = defineComponent({
+  setup: () => () => [
+    h(ThreadListPrimitiveNew, { class: "new" }, { default: () => "New" }),
+    h(ThreadListPrimitiveItems, null, {
+      default: () =>
+        h(
+          ThreadListItemPrimitiveTrigger,
+          { class: "item" },
+          {
+            default: () =>
+              h(ThreadListItemPrimitiveTitle, { fallback: "New Chat" }),
+          },
+        ),
+    }),
+  ],
+});
+
+const mountView = (runtime: AssistantRuntimeImpl, view: Component) => {
+  const app = createApp(
+    defineComponent({
+      setup: () => () =>
+        h(
+          AuiProvider,
+          { config: AuiConfig({ threads: RuntimeAdapter(runtime) }) },
+          { default: () => h(view) },
+        ),
+    }),
+  );
+  const el = document.createElement("div");
+  app.mount(el);
+  return { el, unmount: () => app.unmount() };
+};
+
+describe("thread list primitives", () => {
+  it("renders one scoped item per thread with titles", async () => {
+    const { runtime } = createMultiThreadRuntime();
+    const { el, unmount } = mountView(runtime, SidebarView);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+    expect(
+      [...el.querySelectorAll("button.item")].map((item) => item.textContent),
+    ).toEqual(["First thread", "Second thread"]);
+
+    unmount();
+  });
+
+  it("switches threads through the item trigger and swaps the thread state", async () => {
+    const { runtime, onSwitchToThread } = createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () => [
+        h(SidebarView),
+        h("ol", null, [
+          h(ThreadPrimitiveMessages, null, {
+            default: () => h("li", "row"),
+          }),
+        ]),
+      ],
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+
+    el.querySelectorAll<HTMLButtonElement>("button.item")[1]!.click();
+    await vi.waitFor(() => {
+      expect(onSwitchToThread).toHaveBeenCalledWith("t2");
+    });
+    await vi.waitFor(() => {
+      expect(runtime.thread.getState().messages[0]!.content[0]).toMatchObject({
+        type: "text",
+        text: "hello from two",
+      });
+    });
+
+    unmount();
+  });
+
+  it("starts a new thread through the new button", async () => {
+    const { runtime, onSwitchToNewThread } = createMultiThreadRuntime();
+    const { el, unmount } = mountView(runtime, SidebarView);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+
+    el.querySelector<HTMLButtonElement>("button.new")!.click();
+    await vi.waitFor(() => {
+      expect(onSwitchToNewThread).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(3);
+    });
+    expect(
+      el.querySelectorAll<HTMLButtonElement>("button.item")[2]!.textContent,
+    ).toBe("New Chat");
+
+    unmount();
+  });
+
+  it("scrolls the viewport to the bottom on thread switch", async () => {
+    const { runtime } = createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () => [
+        h(SidebarView),
+        h(
+          ThreadPrimitiveViewport,
+          { class: "viewport", scrollToBottomOnInitialize: false },
+          {
+            default: () =>
+              h(ThreadPrimitiveMessages, null, {
+                default: () => h("p", "row"),
+              }),
+          },
+        ),
+      ],
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    const div = el.querySelector<HTMLElement>("div.viewport")!;
+    Object.defineProperty(div, "scrollHeight", {
+      get: () => 500,
+      configurable: true,
+    });
+    Object.defineProperty(div, "clientHeight", {
+      get: () => 100,
+      configurable: true,
+    });
+    const scrollTo = vi.fn();
+    Object.defineProperty(div, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    });
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    el.querySelectorAll<HTMLButtonElement>("button.item")[1]!.click();
+    await vi.waitFor(() => {
+      expect(scrollTo).toHaveBeenCalled();
+    });
+
+    unmount();
+  });
+});

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -261,11 +261,11 @@ describe("thread list primitives", () => {
       await nextTick();
       expect(el.querySelectorAll("button.item")).toHaveLength(2);
     });
-    expect(el.querySelector<HTMLButtonElement>("button.new")!.disabled).toBe(
-      true,
-    );
+    const newButton = el.querySelector<HTMLButtonElement>("button.new")!;
+    expect(newButton.disabled).toBe(true);
 
-    el.querySelector<HTMLButtonElement>("button.new")!.click();
+    newButton.disabled = false;
+    newButton.click();
     el.querySelectorAll<HTMLButtonElement>("button.item")[1]!.click();
     await nextTick();
     await Promise.resolve();

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -61,6 +61,9 @@ const createMultiThreadRuntime = () => {
           id: thread.id,
           title: thread.title,
         })),
+        archivedThreads: [
+          { status: "archived" as const, id: "ta", title: "Archived one" },
+        ],
         onSwitchToThread,
         onSwitchToNewThread,
       },
@@ -193,6 +196,122 @@ describe("thread list primitives", () => {
     expect(
       el.querySelectorAll<HTMLButtonElement>("button.item")[2]!.textContent,
     ).toBe("New Chat");
+
+    unmount();
+  });
+
+  it("renders archived items separately with archived", async () => {
+    const { runtime } = createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () => [
+        h(SidebarView),
+        h(
+          ThreadListPrimitiveItems,
+          { archived: true },
+          {
+            default: () =>
+              h(
+                ThreadListItemPrimitiveTrigger,
+                { class: "arch" },
+                { default: () => h(ThreadListItemPrimitiveTitle) },
+              ),
+          },
+        ),
+      ],
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.arch")).toHaveLength(1);
+    });
+    expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    expect(el.querySelector("button.arch")!.textContent).toBe("Archived one");
+
+    unmount();
+  });
+
+  it("ignores clicks while disabled or default-prevented", async () => {
+    const { runtime, onSwitchToThread, onSwitchToNewThread } =
+      createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () => [
+        h(
+          ThreadListPrimitiveNew,
+          { class: "new", disabled: true },
+          { default: () => "New" },
+        ),
+        h(ThreadListPrimitiveItems, null, {
+          default: () =>
+            h(ThreadListItemPrimitiveTrigger, {
+              class: "item",
+              onClick: (event: MouseEvent) => event.preventDefault(),
+            }),
+        }),
+      ],
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+    expect(el.querySelector<HTMLButtonElement>("button.new")!.disabled).toBe(
+      true,
+    );
+
+    el.querySelector<HTMLButtonElement>("button.new")!.click();
+    el.querySelectorAll<HTMLButtonElement>("button.item")[1]!.click();
+    await nextTick();
+    await Promise.resolve();
+    expect(onSwitchToNewThread).not.toHaveBeenCalled();
+    expect(onSwitchToThread).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("renders the default slot as the title fallback", async () => {
+    const { runtime } = createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () => [
+        h(ThreadListPrimitiveNew, { class: "new" }, { default: () => "New" }),
+        h(ThreadListPrimitiveItems, null, {
+          default: () =>
+            h(
+              ThreadListItemPrimitiveTrigger,
+              { class: "item" },
+              {
+                default: () =>
+                  h(
+                    ThreadListItemPrimitiveTitle,
+                    { fallback: "unused" },
+                    { default: () => h("em", "Untitled") },
+                  ),
+              },
+            ),
+        }),
+      ],
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+    expect(
+      el.querySelectorAll<HTMLButtonElement>("button.item")[0]!.textContent,
+    ).toBe("First thread");
+
+    el.querySelector<HTMLButtonElement>("button.new")!.click();
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(3);
+    });
+    expect(
+      el
+        .querySelectorAll<HTMLButtonElement>("button.item")[2]!
+        .querySelector("em")!.textContent,
+    ).toBe("Untitled");
 
     unmount();
   });

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -275,6 +275,36 @@ describe("thread list primitives", () => {
     unmount();
   });
 
+  it("ignores item trigger clicks while disabled", async () => {
+    const { runtime, onSwitchToThread } = createMultiThreadRuntime();
+    const View = defineComponent({
+      setup: () => () =>
+        h(ThreadListPrimitiveItems, null, {
+          default: () =>
+            h(ThreadListItemPrimitiveTrigger, {
+              class: "item",
+              disabled: true,
+            }),
+        }),
+    });
+    const { el, unmount } = mountView(runtime, View);
+
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(el.querySelectorAll("button.item")).toHaveLength(2);
+    });
+
+    const trigger = el.querySelectorAll<HTMLButtonElement>("button.item")[1]!;
+    expect(trigger.disabled).toBe(true);
+    trigger.disabled = false;
+    trigger.click();
+    await nextTick();
+    await Promise.resolve();
+    expect(onSwitchToThread).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   it("renders the default slot as the title fallback", async () => {
     const { runtime } = createMultiThreadRuntime();
     const View = defineComponent({

--- a/packages/vue/src/__tests__/primitives-threadlist.test.ts
+++ b/packages/vue/src/__tests__/primitives-threadlist.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { createApp, defineComponent, h, nextTick, type Component } from "vue";
-import { flushTapSync } from "@assistant-ui/tap";
 import { AuiConfig } from "@assistant-ui/store/client";
 import { RuntimeAdapter } from "@assistant-ui/core/store";
 import type { ExternalStoreAdapter } from "@assistant-ui/core";
@@ -141,9 +140,28 @@ describe("thread list primitives", () => {
       expect(el.querySelectorAll("button.item")).toHaveLength(2);
     });
 
+    expect(
+      el
+        .querySelectorAll<HTMLButtonElement>("button.item")[0]!
+        .getAttribute("data-active"),
+    ).toBe("true");
+    expect(
+      el
+        .querySelectorAll<HTMLButtonElement>("button.item")[1]!
+        .hasAttribute("data-active"),
+    ).toBe(false);
+
     el.querySelectorAll<HTMLButtonElement>("button.item")[1]!.click();
     await vi.waitFor(() => {
       expect(onSwitchToThread).toHaveBeenCalledWith("t2");
+    });
+    await vi.waitFor(async () => {
+      await nextTick();
+      expect(
+        el
+          .querySelectorAll<HTMLButtonElement>("button.item")[1]!
+          .getAttribute("aria-current"),
+      ).toBe("true");
     });
     await vi.waitFor(() => {
       expect(runtime.thread.getState().messages[0]!.content[0]).toMatchObject({

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -31,6 +31,13 @@ export {
   SuggestionPrimitiveTitle,
   SuggestionPrimitiveDescription,
 } from "./primitives/suggestions";
+export {
+  ThreadListItemByIndexProvider,
+  ThreadListPrimitiveItems,
+  ThreadListPrimitiveNew,
+  ThreadListItemPrimitiveTrigger,
+  ThreadListItemPrimitiveTitle,
+} from "./primitives/threadList";
 
 export {
   AuiConfig,

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -172,8 +172,10 @@ export const ThreadPrimitiveViewport = defineComponent({
       scheduleScrollToBottom("auto");
     });
 
-    // The switchedTo relay emits from the thread-list lookup instance inside
-    // the threads scope, which the default listener scope does not cover.
+    // A non-star subscription matches the emitting client against the
+    // listener's scope binding at delivery time; on a switch the event is
+    // emitted by the newly main item client before the derived threadListItem
+    // binding re-resolves to it, so only a star scope observes the emission.
     useAuiEvent({ scope: "*", event: "threadListItem.switchedTo" }, () => {
       if (!props.scrollToBottomOnThreadSwitch) return;
       scheduleScrollToBottom("instant");

--- a/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
+++ b/packages/vue/src/primitives/ThreadPrimitiveViewport.ts
@@ -172,7 +172,9 @@ export const ThreadPrimitiveViewport = defineComponent({
       scheduleScrollToBottom("auto");
     });
 
-    useAuiEvent("threadListItem.switchedTo", () => {
+    // The switchedTo relay emits from the thread-list lookup instance inside
+    // the threads scope, which the default listener scope does not cover.
+    useAuiEvent({ scope: "*", event: "threadListItem.switchedTo" }, () => {
       if (!props.scrollToBottomOnThreadSwitch) return;
       scheduleScrollToBottom("instant");
     });

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -79,13 +79,19 @@ export const ThreadListPrimitiveItems = defineComponent({
   },
 });
 
-/** A button that switches to a new thread. */
+/**
+ * A button that switches to a new thread. Carries `data-active` and
+ * `aria-current` while the new thread is the main one.
+ */
 export const ThreadListPrimitiveNew = defineComponent({
   name: "ThreadListPrimitiveNew",
   inheritAttrs: false,
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
+    const active = useAuiState(
+      (s) => s.threads.newThreadId === s.threads.mainThreadId,
+    );
     const onClick = (event: MouseEvent) => {
       if (event.defaultPrevented || isAttrDisabled(attrs)) return;
       aui.threads.switchToNewThread();
@@ -96,6 +102,10 @@ export const ThreadListPrimitiveNew = defineComponent({
         mergeProps(attrs, {
           type: "button",
           disabled: isAttrDisabled(attrs),
+          ...(active.value && {
+            "data-active": "true",
+            "aria-current": "true",
+          }),
           onClick,
         }),
         slots.default?.(),
@@ -103,13 +113,17 @@ export const ThreadListPrimitiveNew = defineComponent({
   },
 });
 
-/** A button that switches to the current thread-list item's thread. */
+/**
+ * A button that switches to the current thread-list item's thread. Carries
+ * `data-active` and `aria-current` while that thread is the main one.
+ */
 export const ThreadListItemPrimitiveTrigger = defineComponent({
   name: "ThreadListItemPrimitiveTrigger",
   inheritAttrs: false,
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(_, { attrs, slots }) {
     const aui = useAui();
+    const active = useAuiState((s) => s.threadListItem.isMain);
     const onClick = (event: MouseEvent) => {
       if (event.defaultPrevented || isAttrDisabled(attrs)) return;
       aui.threadListItem.switchTo();
@@ -120,6 +134,10 @@ export const ThreadListItemPrimitiveTrigger = defineComponent({
         mergeProps(attrs, {
           type: "button",
           disabled: isAttrDisabled(attrs),
+          ...(active.value && {
+            "data-active": "true",
+            "aria-current": "true",
+          }),
           onClick,
         }),
         slots.default?.(),

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -1,0 +1,143 @@
+import { computed, defineComponent, h, mergeProps, type SlotsType } from "vue";
+import { AuiConfig, Derived } from "@assistant-ui/store/client";
+import type {} from "@assistant-ui/core/store";
+import { AuiProvider } from "../AuiProvider";
+import { isAttrDisabled } from "./attrDisabled";
+import { useAui } from "../useAui";
+import { useAuiState } from "../useAuiState";
+
+/**
+ * Scopes the subtree to the thread-list item at `index`: descendants read it
+ * through `s.threadListItem`.
+ */
+export const ThreadListItemByIndexProvider = defineComponent({
+  name: "ThreadListItemByIndexProvider",
+  props: {
+    index: {
+      type: Number,
+      required: true,
+    },
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const aui = useAui();
+    const config = computed(() =>
+      AuiConfig({
+        threadListItem: Derived({
+          source: "threads",
+          query: {
+            type: "index",
+            index: props.index,
+            archived: props.archived,
+          },
+          get: (aui) =>
+            aui.threads.item({ index: props.index, archived: props.archived }),
+        }),
+      }),
+    );
+    return () =>
+      h(
+        AuiProvider,
+        { config: config.value, extends: aui },
+        { default: () => slots.default?.() },
+      );
+  },
+});
+
+/**
+ * Renders the default slot once per thread in the list (or per archived
+ * thread with `archived`), each instance scoped through
+ * {@link ThreadListItemByIndexProvider}.
+ */
+export const ThreadListPrimitiveItems = defineComponent({
+  name: "ThreadListPrimitiveItems",
+  props: {
+    archived: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
+    const count = useAuiState((s) =>
+      props.archived
+        ? s.threads.archivedThreadIds.length
+        : s.threads.threadIds.length,
+    );
+    return () =>
+      Array.from({ length: count.value }, (_, index) =>
+        h(
+          ThreadListItemByIndexProvider,
+          { index, archived: props.archived, key: index },
+          { default: () => slots.default?.() },
+        ),
+      );
+  },
+});
+
+/** A button that switches to a new thread. */
+export const ThreadListPrimitiveNew = defineComponent({
+  name: "ThreadListPrimitiveNew",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+      aui.threads.switchToNewThread();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+/** A button that switches to the current thread-list item's thread. */
+export const ThreadListItemPrimitiveTrigger = defineComponent({
+  name: "ThreadListItemPrimitiveTrigger",
+  inheritAttrs: false,
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(_, { attrs, slots }) {
+    const aui = useAui();
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || isAttrDisabled(attrs)) return;
+      aui.threadListItem.switchTo();
+    };
+    return () =>
+      h(
+        "button",
+        mergeProps(attrs, {
+          type: "button",
+          disabled: isAttrDisabled(attrs),
+          onClick,
+        }),
+        slots.default?.(),
+      );
+  },
+});
+
+/** Renders the current thread-list item's title, or `fallback` when empty. */
+export const ThreadListItemPrimitiveTitle = defineComponent({
+  name: "ThreadListItemPrimitiveTitle",
+  props: {
+    fallback: {
+      type: String,
+      default: "",
+    },
+  },
+  setup(props) {
+    const title = useAuiState((s) => s.threadListItem.title);
+    return () => title.value || props.fallback;
+  },
+});

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -160,6 +160,7 @@ export const ThreadListItemPrimitiveTitle = defineComponent({
   slots: Object as SlotsType<{ default?: () => unknown }>,
   setup(props, { slots }) {
     const title = useAuiState((s) => s.threadListItem.title);
-    return () => title.value || slots.default?.() || props.fallback;
+    return () =>
+      title.value || (slots.default ? slots.default() : props.fallback);
   },
 });

--- a/packages/vue/src/primitives/threadList.ts
+++ b/packages/vue/src/primitives/threadList.ts
@@ -145,7 +145,10 @@ export const ThreadListItemPrimitiveTrigger = defineComponent({
   },
 });
 
-/** Renders the current thread-list item's title, or `fallback` when empty. */
+/**
+ * Renders the current thread-list item's title. When the title is empty,
+ * renders the default slot, or the `fallback` string.
+ */
 export const ThreadListItemPrimitiveTitle = defineComponent({
   name: "ThreadListItemPrimitiveTitle",
   props: {
@@ -154,8 +157,9 @@ export const ThreadListItemPrimitiveTitle = defineComponent({
       default: "",
     },
   },
-  setup(props) {
+  slots: Object as SlotsType<{ default?: () => unknown }>,
+  setup(props, { slots }) {
     const title = useAuiState((s) => s.threadListItem.title);
-    return () => title.value || props.fallback;
+    return () => title.value || slots.default?.() || props.fallback;
   },
 });


### PR DESCRIPTION
## summary

- adds ThreadListPrimitiveItems (default slot per thread, archived prop, scoped through the new ThreadListItemByIndexProvider so descendants read s.threadListItem), ThreadListPrimitiveNew and ThreadListItemPrimitiveTrigger buttons (switchToNewThread / switchTo on the same attr-proof shape), and ThreadListItemPrimitiveTitle with the React title-or-fallback semantics
- closes the thread-switch scroll coverage promised in #5691, and fixes the listener it exposed: the threadListItem.switchedTo relay emits from the thread-list lookup instance inside the threads scope, which the default event listener scope does not cover (verified empirically: default scope receives 0, scope "*" receives 1), so the viewport's thread-switch listener now subscribes with scope "*" with the reason recorded inline
- examples/with-vue gains a canonical sidebar (New chat, per-thread items with auto titles from the first user message, active-thread highlight) on a multi-thread echo runtime wired through the external-store adapters.threadList (per-thread message stores, switch cancels an in-flight reply)

## test plan

### already verified

- [x] `pnpm exec vitest run` in packages/vue -> 56/56: item rendering with titles, trigger switching swapping thread state, new-thread creation with the fallback title, and the viewport scrolling to the bottom on thread switch
- [x] browser smoke on the dev server: sending sets the thread title, New chat opens a fresh welcome thread, switching back swaps the first thread's messages in, active item highlights
- [x] `pnpm exec vitest run` in packages/store -> 123/123; examples/with-vue `vite build` green; `pnpm lint` clean

### reviewer should verify

- [ ] in examples/with-vue, send in one thread, start a New chat, send again, then flip between the sidebar items: each thread keeps its own messages and the viewport lands at the bottom

## notes

- archive/unarchive/delete buttons are a later slice; the provider already accepts archived for the item scope
- vue stays private, no changeset; core and store untouched

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2._Tum414pUc5PS_1fFrajgXKpLkFHTrbgwbbJjRPS7UmfC3XD2I2cQ2gq9OI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->