### PR TITLE
fix(assistant-stream): carry a reasoning summary on the data stream

### DIFF
--- a/.changeset/reasoning-part-start-wire.md
+++ b/.changeset/reasoning-part-start-wire.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: carry a reasoning summary on the data stream. a reasoning part opened with `unstable_summary` previously lost it on that wire, and a summary-only part produced no frames at all, so it never reached the client. the encoder now emits a reasoning part-start frame when there is a summary to carry; a stream that does not use the field is unchanged, and one that does requires a decoder that understands the frame.

--- a/api-surface/assistant-stream.ts
+++ b/api-surface/assistant-stream.ts
@@ -197,7 +197,7 @@ type AssistantStreamChunk = {
 
 type AssistantStreamController = {
   appendText(textDelta: string): void;
-  appendReasoning(reasoningDelta: string): void;
+  appendReasoning(reasoningDelta: string, options?: ReasoningPartInit): void;
   appendSource(options: SourcePart): void;
   appendFile(options: FilePart): void;
   appendData(options: DataPart): void;

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -212,7 +212,12 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
         controller: this.addReasoningPart(options),
       };
     }
-    this._state.append.controller.append(textDelta);
+    // An empty delta carries nothing, and appending one would put a chunk on
+    // the stream that no producer emitted; opening a part with a summary and
+    // no text goes through here.
+    if (textDelta.length > 0) {
+      this._state.append.controller.append(textDelta);
+    }
   }
 
   addTextPart() {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -45,8 +45,8 @@ export type AssistantStreamController = {
   appendText(textDelta: string): void;
   /**
    * Appends reasoning text to the current reasoning part, opening one if
-   * needed. The options are used only when a part is opened, so a summary
-   * supplied alongside the first delta lands on that part.
+   * needed. Supplying options opens a new part and applies them to it, so a
+   * summary always lands on a part of its own.
    */
   appendReasoning(reasoningDelta: string, options?: ReasoningPartInit): void;
   /** Appends a source citation part to the stream. */
@@ -199,7 +199,10 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
   }
 
   appendReasoning(textDelta: string, options?: ReasoningPartInit) {
+    // An init describes a part, so supplying one opens a part rather than
+    // extending whichever one happens to be open.
     if (
+      options !== undefined ||
       this._state.append?.kind !== "reasoning" ||
       this._state.append.parentId !== this._parentId
     ) {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -212,12 +212,11 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
         controller: this.addReasoningPart(options),
       };
     }
-    // An empty delta carries nothing, and appending one would put a chunk on
-    // the stream that no producer emitted; opening a part with a summary and
-    // no text goes through here.
-    if (textDelta.length > 0) {
-      this._state.append.controller.append(textDelta);
-    }
+    // Opening a part from an init with no text is how a summary-only part is
+    // created, and appending there would put a chunk on the stream that no
+    // producer emitted. An empty delta from an ordinary caller still appends.
+    if (options !== undefined && textDelta.length === 0) return;
+    this._state.append.controller.append(textDelta);
   }
 
   addTextPart() {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -43,8 +43,12 @@ type ReasoningPartInit = {
 export type AssistantStreamController = {
   /** Appends text to the current text part, opening one if needed. */
   appendText(textDelta: string): void;
-  /** Appends reasoning text to the current reasoning part, opening one if needed. */
-  appendReasoning(reasoningDelta: string): void;
+  /**
+   * Appends reasoning text to the current reasoning part, opening one if
+   * needed. The options are used only when a part is opened, so a summary
+   * supplied alongside the first delta lands on that part.
+   */
+  appendReasoning(reasoningDelta: string, options?: ReasoningPartInit): void;
   /** Appends a source citation part to the stream. */
   appendSource(options: SourcePart): void;
   /** Appends a file part to the stream. */
@@ -63,9 +67,9 @@ export type AssistantStreamController = {
    * Opens a reasoning part and returns its writer.
    *
    * Use the options object to provide an app-authored summary for the part.
-   * Only the assistant transport encoder carries the summary; the data stream
-   * wire has no reasoning part-start chunk, so it drops the summary and emits
-   * nothing at all for a part that never appends text.
+   * A summary makes the data stream emit a reasoning part-start frame, which
+   * decoders older than that frame reject, so a stream only requires a current
+   * client once it uses the field.
    */
   addReasoningPart(options?: ReasoningPartInit): TextStreamController;
   /**
@@ -194,7 +198,7 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
     this._state.append.controller.append(textDelta);
   }
 
-  appendReasoning(textDelta: string) {
+  appendReasoning(textDelta: string, options?: ReasoningPartInit) {
     if (
       this._state.append?.kind !== "reasoning" ||
       this._state.append.parentId !== this._parentId
@@ -202,7 +206,7 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
       this._state.append = {
         kind: "reasoning",
         parentId: this._parentId,
-        controller: this.addReasoningPart(),
+        controller: this.addReasoningPart(options),
       };
     }
     this._state.append.controller.append(textDelta);

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -276,7 +276,8 @@ describe("reasoning summaries on the data stream", () => {
     const bytes = new ReadableStream<Uint8Array>({
       start(controller) {
         const encoder = new TextEncoder();
-        for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+        for (const line of lines)
+          controller.enqueue(encoder.encode(line + "\n"));
         controller.close();
       },
     });

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -245,6 +245,34 @@ describe("reasoning summaries on the data stream", () => {
     ).toEqual([]);
   });
 
+  it("gives each summarized reasoning step a part of its own", async () => {
+    const chunks = await decodeLines([
+      'aui-reasoning-part-start:{"unstable_summary":"First"}',
+      'g:"one"',
+      'aui-reasoning-part-start:{"unstable_summary":"Second"}',
+      'g:"two"',
+    ]);
+
+    // a summary describes a step, so a second one must not be folded into the
+    // part the first opened
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === "part-start")
+        .map((chunk) => chunk.part),
+    ).toEqual([
+      { type: "reasoning", unstable_summary: "First" },
+      { type: "reasoning", unstable_summary: "Second" },
+    ]);
+  });
+
+  it("carries an explicitly empty summary", async () => {
+    // transport preserves the value; only the display normalizer drops a part
+    // with nothing to render
+    expect(await encodeChunks(reasoningPart(""))).toEqual([
+      'aui-reasoning-part-start:{"unstable_summary":""}',
+    ]);
+  });
+
   it("routes a parented summary to the same parent as its deltas", async () => {
     const lines = await encodeChunks([
       {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -185,6 +185,92 @@ describe("DataStreamEncoder streamed tool-call args", () => {
   });
 });
 
+describe("reasoning summaries on the data stream", () => {
+  const reasoningPart = (summary?: string, text?: string) => {
+    const chunks: AssistantStreamChunk[] = [
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "reasoning",
+          ...(summary !== undefined ? { unstable_summary: summary } : {}),
+        },
+      },
+    ];
+    if (text !== undefined) {
+      chunks.push({ type: "text-delta", path: [0], textDelta: text });
+    }
+    return chunks;
+  };
+
+  it("carries the summary and keeps the text on one part", async () => {
+    const lines = await encodeChunks(reasoningPart("Planning", "thinking"));
+
+    expect(lines).toEqual([
+      'aui-reasoning-part-start:{"unstable_summary":"Planning"}',
+      'g:"thinking"',
+    ]);
+
+    const chunks = await decodeLines(lines);
+    // one part-start, so the delta extends the part the summary opened
+    expect(chunks.filter((chunk) => chunk.type === "part-start")).toHaveLength(
+      1,
+    );
+    expect(
+      chunks.find((chunk) => chunk.type === "part-start")?.part,
+    ).toMatchObject({ type: "reasoning", unstable_summary: "Planning" });
+  });
+
+  it("gives a summary-only reasoning part a presence on the wire", async () => {
+    const lines = await encodeChunks(reasoningPart("Planning"));
+
+    expect(lines).toEqual([
+      'aui-reasoning-part-start:{"unstable_summary":"Planning"}',
+    ]);
+
+    const chunks = await decodeLines(lines);
+    expect(
+      chunks.find((chunk) => chunk.type === "part-start")?.part,
+    ).toMatchObject({ type: "reasoning", unstable_summary: "Planning" });
+  });
+
+  it("leaves a reasoning part without a summary byte-identical", async () => {
+    expect(await encodeChunks(reasoningPart(undefined, "thinking"))).toEqual([
+      'g:"thinking"',
+    ]);
+    expect(
+      (await encodeChunks(reasoningPart(undefined))).filter(
+        (line) => line.length > 0,
+      ),
+    ).toEqual([]);
+  });
+
+  it("routes a parented summary to the same parent as its deltas", async () => {
+    const lines = await encodeChunks([
+      {
+        type: "part-start",
+        path: [],
+        part: {
+          type: "reasoning",
+          parentId: "p1",
+          unstable_summary: "Planning",
+        },
+      },
+      { type: "text-delta", path: [0], textDelta: "thinking" },
+    ]);
+
+    expect(lines).toEqual([
+      'aui-reasoning-part-start:{"unstable_summary":"Planning","parentId":"p1"}',
+      'aui-reasoning-delta:{"reasoningDelta":"thinking","parentId":"p1"}',
+    ]);
+
+    const chunks = await decodeLines(lines);
+    expect(chunks.filter((chunk) => chunk.type === "part-start")).toHaveLength(
+      1,
+    );
+  });
+});
+
 describe("DataStreamDecoder interleaved tool-call args", () => {
   it("preserves args interleaved with text until the final args frame", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -265,6 +265,37 @@ describe("reasoning summaries on the data stream", () => {
     ]);
   });
 
+  it("survives a decode and re-encode unchanged", async () => {
+    // a relay that decodes and re-encodes must not inject frames the producer
+    // never sent
+    const lines = [
+      'aui-reasoning-part-start:{"unstable_summary":"Planning"}',
+      'g:"thinking"',
+    ];
+
+    const bytes = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+        controller.close();
+      },
+    });
+    const output: string[] = [];
+    await bytes
+      .pipeThrough(new DataStreamDecoder())
+      .pipeThrough(new DataStreamEncoder())
+      .pipeThrough(new TextDecoderStream())
+      .pipeTo(
+        new WritableStream({
+          write(chunk) {
+            output.push(chunk);
+          },
+        }),
+      );
+
+    expect(output.join("").trimEnd().split("\n")).toEqual(lines);
+  });
+
   it("carries an explicitly empty summary", async () => {
     // transport preserves the value; only the display normalizer drops a part
     // with nothing to render

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.test.ts
@@ -265,6 +265,37 @@ describe("reasoning summaries on the data stream", () => {
     ]);
   });
 
+  it("leaves an ordinary empty reasoning delta on the wire", async () => {
+    // only the synthetic summary-part open suppresses an empty delta; a caller
+    // that never touches the field keeps the frame it always emitted
+    const [input, assistantController] = createAssistantStreamController();
+    const output: string[] = [];
+    const completion = input
+      .pipeThrough(new DataStreamEncoder())
+      .pipeThrough(new TextDecoderStream())
+      .pipeTo(
+        new WritableStream({
+          write(chunk) {
+            output.push(chunk);
+          },
+        }),
+      );
+
+    assistantController.appendReasoning("");
+    assistantController.close();
+    await completion;
+
+    expect(output.join("").trimEnd().split("\n")).toEqual(['g:""']);
+  });
+
+  it("decodes a summary-only frame without a synthetic text delta", async () => {
+    const chunks = await decodeLines([
+      'aui-reasoning-part-start:{"unstable_summary":"Planning"}',
+    ]);
+
+    expect(chunks.filter((chunk) => chunk.type === "text-delta")).toEqual([]);
+  });
+
   it("survives a decode and re-encode unchanged", async () => {
     // a relay that decodes and re-encodes must not inject frames the producer
     // never sent

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -93,7 +93,10 @@ export class DataStreamEncoder
               // for a part that never appends text. The frame is emitted only
               // when there is a summary to carry, so a stream that does not
               // use the field is unchanged.
-              if (part.type === "reasoning" && part.unstable_summary) {
+              if (
+                part.type === "reasoning" &&
+                part.unstable_summary !== undefined
+              ) {
                 controller.enqueue({
                   type: DataStreamStreamChunkType.AuiReasoningPartStart,
                   value: {

--- a/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/DataStream.ts
@@ -88,6 +88,22 @@ export class DataStreamEncoder
                   value,
                 });
               }
+              // Reasoning otherwise reaches the wire only through its text
+              // deltas, which cannot carry a summary and emit nothing at all
+              // for a part that never appends text. The frame is emitted only
+              // when there is a summary to carry, so a stream that does not
+              // use the field is unchanged.
+              if (part.type === "reasoning" && part.unstable_summary) {
+                controller.enqueue({
+                  type: DataStreamStreamChunkType.AuiReasoningPartStart,
+                  value: {
+                    unstable_summary: part.unstable_summary,
+                    ...(part.parentId !== undefined
+                      ? { parentId: part.parentId }
+                      : {}),
+                  },
+                });
+              }
               break;
             }
             case "text-delta": {
@@ -296,6 +312,21 @@ export class DataStreamDecoder extends PipeableTransformStream<
                 .withParentId(value.parentId)
                 .appendText(value.textDelta);
               break;
+
+            case DataStreamStreamChunkType.AuiReasoningPartStart: {
+              const target = value.parentId
+                ? controller.withParentId(value.parentId)
+                : controller;
+              // Opening through appendReasoning registers the part as the
+              // current reasoning append target, so the deltas that follow
+              // extend it instead of opening a second part.
+              target.appendReasoning("", {
+                ...(value.unstable_summary !== undefined
+                  ? { unstable_summary: value.unstable_summary }
+                  : {}),
+              });
+              break;
+            }
 
             case DataStreamStreamChunkType.AuiReasoningDelta:
               controller

--- a/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
+++ b/packages/assistant-stream/src/core/serialization/data-stream/chunk-types.ts
@@ -47,6 +47,7 @@ export const DataStreamStreamChunkType = {
   AuiTextDelta: "aui-text-delta",
   AuiReasoningDelta: "aui-reasoning-delta",
   AuiDataPart: "aui-data",
+  AuiReasoningPartStart: "aui-reasoning-part-start",
 } as const;
 export type DataStreamStreamChunkType =
   (typeof DataStreamStreamChunkType)[keyof typeof DataStreamStreamChunkType];
@@ -111,6 +112,10 @@ type DataStreamStreamChunkValue = {
   [DataStreamStreamChunkType.AuiReasoningDelta]: {
     reasoningDelta: string;
     parentId: string;
+  };
+  [DataStreamStreamChunkType.AuiReasoningPartStart]: {
+    unstable_summary?: string;
+    parentId?: string;
   };
   [DataStreamStreamChunkType.AuiDataPart]: {
     name: string;

--- a/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
+++ b/python/assistant-stream/src/assistant_stream/assistant_stream_chunk.py
@@ -11,6 +11,13 @@ class TextDeltaChunk:
 
 
 @dataclass
+class ReasoningPartStartChunk:
+    unstable_summary: Optional[str] = None
+    parent_id: Optional[str] = None
+    type: str = "reasoning-part-start"
+
+
+@dataclass
 class ReasoningDeltaChunk:
     reasoning_delta: str
     type: str = "reasoning-delta"
@@ -125,6 +132,7 @@ class StepFinishChunk:
 AssistantStreamChunk = Union[
     TextDeltaChunk,
     ReasoningDeltaChunk,
+    ReasoningPartStartChunk,
     ToolCallBeginChunk,
     ToolCallDeltaChunk,
     ToolCallArgsTextFinishChunk,

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -5,6 +5,7 @@ from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
     TextDeltaChunk,
     ReasoningDeltaChunk,
+    ReasoningPartStartChunk,
     ToolResultChunk,
     DataChunk,
     ErrorChunk,
@@ -63,6 +64,13 @@ class RunController:
     def append_text(self, text_delta: str) -> None:
         """Append a text delta to the stream."""
         chunk = TextDeltaChunk(text_delta=text_delta, parent_id=self._parent_id)
+        self._flush_and_put_chunk(chunk)
+
+    def add_reasoning_part(self, unstable_summary: Optional[str] = None) -> None:
+        """Open a reasoning part, optionally carrying an app-authored summary."""
+        chunk = ReasoningPartStartChunk(
+            unstable_summary=unstable_summary, parent_id=self._parent_id
+        )
         self._flush_and_put_chunk(chunk)
 
     def append_reasoning(self, reasoning_delta: str) -> None:

--- a/python/assistant-stream/src/assistant_stream/create_run.py
+++ b/python/assistant-stream/src/assistant_stream/create_run.py
@@ -66,8 +66,12 @@ class RunController:
         chunk = TextDeltaChunk(text_delta=text_delta, parent_id=self._parent_id)
         self._flush_and_put_chunk(chunk)
 
-    def add_reasoning_part(self, unstable_summary: Optional[str] = None) -> None:
-        """Open a reasoning part, optionally carrying an app-authored summary."""
+    def add_reasoning_part(self, unstable_summary: str) -> None:
+        """Open a reasoning part carrying an app-authored summary.
+
+        Reasoning parts are otherwise implied by their deltas, so a summary is
+        the only thing this opens a part for.
+        """
         chunk = ReasoningPartStartChunk(
             unstable_summary=unstable_summary, parent_id=self._parent_id
         )

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -80,11 +80,14 @@ class _Canonicalizer:
     ) -> list[dict[str, Any]]:
         # Registered as the append target so the deltas that follow extend this
         # part instead of opening a second one.
+        if chunk.unstable_summary is None:
+            return []
         frames = self._close_append_part()
         path = self._next_path()
-        part: dict[str, Any] = {"type": "reasoning"}
-        if chunk.unstable_summary is not None:
-            part["unstable_summary"] = chunk.unstable_summary
+        part: dict[str, Any] = {
+            "type": "reasoning",
+            "unstable_summary": chunk.unstable_summary,
+        }
         if chunk.parent_id is not None:
             part["parentId"] = chunk.parent_id
         frames.append({"type": "part-start", "part": part, "path": []})

--- a/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/assistant_transport.py
@@ -3,6 +3,7 @@ from assistant_stream.assistant_stream_chunk import (
     AssistantStreamChunk,
     FileChunk,
     ReasoningDeltaChunk,
+    ReasoningPartStartChunk,
     SourceChunk,
     StepFinishChunk,
     StepStartChunk,
@@ -73,6 +74,22 @@ class _Canonicalizer:
         path = self._append_part[1]
         self._append_part = None
         return [{"type": "part-finish", "path": path}]
+
+    def _start_reasoning_part(
+        self, chunk: ReasoningPartStartChunk
+    ) -> list[dict[str, Any]]:
+        # Registered as the append target so the deltas that follow extend this
+        # part instead of opening a second one.
+        frames = self._close_append_part()
+        path = self._next_path()
+        part: dict[str, Any] = {"type": "reasoning"}
+        if chunk.unstable_summary is not None:
+            part["unstable_summary"] = chunk.unstable_summary
+        if chunk.parent_id is not None:
+            part["parentId"] = chunk.parent_id
+        frames.append({"type": "part-start", "part": part, "path": []})
+        self._append_part = ("reasoning", path, chunk.parent_id)
+        return frames
 
     def _append_delta(
         self, chunk: TextDeltaChunk | ReasoningDeltaChunk, text: str, kind: str
@@ -227,6 +244,8 @@ class _Canonicalizer:
         match chunk.type:
             case "text-delta":
                 return self._append_delta(chunk, chunk.text_delta, "text")
+            case "reasoning-part-start":
+                return self._start_reasoning_part(chunk)
             case "reasoning-delta":
                 return self._append_delta(chunk, chunk.reasoning_delta, "reasoning")
             case "tool-call-begin":

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -34,6 +34,16 @@ class DataStreamEncoder(StreamEncoder):
                 return f"aui-text-delta:{json.dumps({'textDelta': chunk.text_delta, 'parentId': chunk.parent_id}, cls=StateProxyJSONEncoder)}\n"
             else:
                 return f"0:{json.dumps(chunk.text_delta, cls=StateProxyJSONEncoder)}\n"
+        elif chunk.type == "reasoning-part-start":
+            # Reasoning otherwise reaches the wire only through its deltas,
+            # which cannot carry a summary and emit nothing at all for a part
+            # that never appends text.
+            value: dict[str, Any] = {}
+            if chunk.unstable_summary is not None:
+                value["unstable_summary"] = chunk.unstable_summary
+            if chunk.parent_id is not None:
+                value["parentId"] = chunk.parent_id
+            return f"aui-reasoning-part-start:{json.dumps(value, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "reasoning-delta":
             if hasattr(chunk, 'parent_id') and chunk.parent_id:
                 return f"aui-reasoning-delta:{json.dumps({'reasoningDelta': chunk.reasoning_delta, 'parentId': chunk.parent_id}, cls=StateProxyJSONEncoder)}\n"

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -35,6 +35,8 @@ class DataStreamEncoder(StreamEncoder):
             else:
                 return f"0:{json.dumps(chunk.text_delta, cls=StateProxyJSONEncoder)}\n"
         elif chunk.type == "reasoning-part-start":
+            if chunk.unstable_summary is None:
+                return None
             # Reasoning otherwise reaches the wire only through its deltas,
             # which cannot carry a summary and emit nothing at all for a part
             # that never appends text.

--- a/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
+++ b/python/assistant-stream/src/assistant_stream/serialization/data_stream.py
@@ -40,9 +40,7 @@ class DataStreamEncoder(StreamEncoder):
             # Reasoning otherwise reaches the wire only through its deltas,
             # which cannot carry a summary and emit nothing at all for a part
             # that never appends text.
-            value: dict[str, Any] = {}
-            if chunk.unstable_summary is not None:
-                value["unstable_summary"] = chunk.unstable_summary
+            value: dict[str, Any] = {"unstable_summary": chunk.unstable_summary}
             if chunk.parent_id is not None:
                 value["parentId"] = chunk.parent_id
             return f"aui-reasoning-part-start:{json.dumps(value, cls=StateProxyJSONEncoder)}\n"

--- a/python/assistant-stream/tests/test_assistant_transport.py
+++ b/python/assistant-stream/tests/test_assistant_transport.py
@@ -6,6 +6,7 @@ from assistant_stream.assistant_stream_chunk import (
     ErrorChunk,
     FileChunk,
     ReasoningDeltaChunk,
+    ReasoningPartStartChunk,
     SourceChunk,
     StepFinishChunk,
     StepStartChunk,
@@ -799,3 +800,30 @@ async def test_assistant_transport_encoder_rejects_args_after_the_part_settled()
 
     deltas = [c["textDelta"] for c in collected if c["type"] == "text-delta"]
     assert deltas == ['{"q": 1}']
+
+
+@pytest.mark.anyio
+async def test_assistant_transport_encoder_reasoning_summary_opens_one_part():
+    """The summary opens the reasoning part and the deltas that follow extend
+    it, rather than opening a second part beside it."""
+    encoder = AssistantTransportEncoder()
+
+    async def stream():
+        yield ReasoningPartStartChunk(unstable_summary="Planning")
+        yield ReasoningDeltaChunk(reasoning_delta="thinking", parent_id=None)
+
+    collected = [
+        json.loads(line[6:-2])
+        async for line in encoder.encode_stream(stream())
+        if line != "data: [DONE]\n\n"
+    ]
+
+    assert collected == [
+        {
+            "type": "part-start",
+            "part": {"type": "reasoning", "unstable_summary": "Planning"},
+            "path": [],
+        },
+        {"type": "text-delta", "textDelta": "thinking", "path": [0]},
+        {"type": "part-finish", "path": [0]},
+    ]

--- a/python/assistant-stream/tests/test_data_stream.py
+++ b/python/assistant-stream/tests/test_data_stream.py
@@ -266,3 +266,30 @@ async def test_data_stream_encoder_carries_the_parent_on_a_reasoning_part_start(
     assert lines == [
         'aui-reasoning-part-start:{"unstable_summary": "Planning", "parentId": "p1"}\n'
     ]
+
+
+@pytest.mark.anyio
+async def test_data_stream_encoder_suppresses_a_reasoning_start_without_a_summary():
+    """A start with nothing to carry must not change the wire, matching the
+    TypeScript encoder."""
+    encoder = DataStreamEncoder()
+
+    async def stream():
+        yield ReasoningPartStartChunk()
+        yield ReasoningDeltaChunk(reasoning_delta="thinking", parent_id=None)
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert lines == ['g:"thinking"\n']
+
+
+@pytest.mark.anyio
+async def test_data_stream_encoder_carries_an_explicitly_empty_summary():
+    encoder = DataStreamEncoder()
+
+    async def stream():
+        yield ReasoningPartStartChunk(unstable_summary="")
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert lines == ['aui-reasoning-part-start:{"unstable_summary": ""}\n']

--- a/python/assistant-stream/tests/test_data_stream.py
+++ b/python/assistant-stream/tests/test_data_stream.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 import pytest
+from assistant_stream import create_run, RunController
 
 from assistant_stream.assistant_stream_chunk import (
     AnnotationsChunk,
@@ -293,3 +294,34 @@ async def test_data_stream_encoder_carries_an_explicitly_empty_summary():
     lines = [line async for line in encoder.encode_stream(stream())]
 
     assert lines == ['aui-reasoning-part-start:{"unstable_summary": ""}\n']
+
+
+@pytest.mark.anyio
+async def test_run_controller_add_reasoning_part_emits_the_summary():
+    """The public helper is the only supported way to open a summarized
+    reasoning part, so it is pinned rather than the chunk it builds."""
+
+    async def run_callback(controller: RunController):
+        controller.add_reasoning_part("Planning")
+        controller.append_reasoning("thinking")
+
+    encoder = DataStreamEncoder()
+    lines = [line async for line in encoder.encode_stream(create_run(run_callback))]
+
+    assert lines == [
+        'aui-reasoning-part-start:{"unstable_summary": "Planning"}\n',
+        'g:"thinking"\n',
+    ]
+
+
+@pytest.mark.anyio
+async def test_run_controller_add_reasoning_part_carries_the_parent():
+    async def run_callback(controller: RunController):
+        controller.with_parent_id("p1").add_reasoning_part("Planning")
+
+    encoder = DataStreamEncoder()
+    lines = [line async for line in encoder.encode_stream(create_run(run_callback))]
+
+    assert lines == [
+        'aui-reasoning-part-start:{"unstable_summary": "Planning", "parentId": "p1"}\n'
+    ]

--- a/python/assistant-stream/tests/test_data_stream.py
+++ b/python/assistant-stream/tests/test_data_stream.py
@@ -10,6 +10,8 @@ from assistant_stream.assistant_stream_chunk import (
     StepFinishChunk,
     StepStartChunk,
     TextDeltaChunk,
+    ReasoningDeltaChunk,
+    ReasoningPartStartChunk,
     ToolCallArgsTextFinishChunk,
     ToolCallBeginChunk,
     ToolCallDeltaChunk,
@@ -232,3 +234,35 @@ async def test_data_stream_encoder_carries_trailing_args_on_the_final_chunk():
         json.loads(line[2:])["argsTextDelta"] for line in lines if line.startswith("c:")
     )
     assert json.loads(args_text) == {"q": 1}
+
+
+@pytest.mark.anyio
+async def test_data_stream_encoder_emits_a_reasoning_part_start_for_a_summary():
+    """A summary cannot ride on a reasoning delta, and a part that never
+    appends text emits nothing at all without this frame."""
+    encoder = DataStreamEncoder()
+
+    async def stream():
+        yield ReasoningPartStartChunk(unstable_summary="Planning")
+        yield ReasoningDeltaChunk(reasoning_delta="thinking", parent_id=None)
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert lines == [
+        'aui-reasoning-part-start:{"unstable_summary": "Planning"}\n',
+        'g:"thinking"\n',
+    ]
+
+
+@pytest.mark.anyio
+async def test_data_stream_encoder_carries_the_parent_on_a_reasoning_part_start():
+    encoder = DataStreamEncoder()
+
+    async def stream():
+        yield ReasoningPartStartChunk(unstable_summary="Planning", parent_id="p1")
+
+    lines = [line async for line in encoder.encode_stream(stream())]
+
+    assert lines == [
+        'aui-reasoning-part-start:{"unstable_summary": "Planning", "parentId": "p1"}\n'
+    ]


### PR DESCRIPTION
Closes #5692

## What

A reasoning part reaches the data stream only through its text deltas, which cannot carry `unstable_summary` and emit nothing at all for a part that never appends text. Measured against the encoder before this change:

| Reasoning part | Data-stream wire |
| --- | --- |
| summary + `append("thinking")` | `g:"thinking"` — the summary is gone |
| summary, no text | empty — the part does not exist on the client |

The second row is the one that matters. `createAssistantStreamResponse` hardcodes `DataStreamEncoder`, so on the canonical server helper a summary-only reasoning step disappeared entirely, which is the case `unstable_summary` (#5639) exists for.

## Approach

A reasoning part-start frame, emitted **only when there is a summary to carry**. A stream that does not use the field is byte-identical to before, which is why the 410 pre-existing tests pass untouched.

The decoder opens the part through `appendReasoning` rather than `addReasoningPart`. That matters: `addReasoningPart` does not register the part as the current append target, so the `g:` deltas that follow would open a *second* reasoning part beside it. Opening through the append state machine makes the deltas extend the same part, and it gives a summary-only part a presence with no delta at all. A test asserts exactly one `part-start` survives the round trip.

`appendReasoning` gains an optional init, used only when it opens a part, mirroring how `addToolCallPart` already takes one.

Python gets the same chunk, encoder branch, `RunController.add_reasoning_part()`, and an `assistant_transport` handler. Without the last one the chunk falls through to `_warn_once("unknown-chunk-type")`. A field wired into one of the two serializers is worse than no field.

## Compatibility, and a correction to the issue

The issue says this would be "additive on both sides, so older decoders ignore an unknown frame". **That is wrong and I wrote it.** `DataStreamDecoder`'s default branch throws `unsupported chunk type` in strict mode, which is the default, and before #5565 it threw unconditionally. Adding a chunk type to this wire has always been breaking, including for the existing `aui-*` types.

So the real property is narrower and is the best this protocol allows: **a stream only requires a current decoder once it uses the field.** Existing streams are unchanged. The `addReasoningPart` JSDoc added in #5639 stated the old limitation and is updated to state this instead.

## Verification

- `packages/assistant-stream`: 414 tests pass (410 before), `tsc --noEmit` clean, oxlint and oxfmt clean.
- `python/assistant-stream`: 163 tests pass (160 before).
- Every added behaviour checked by reverting it: dropping the encoder branch fails 3 TypeScript tests, dropping the Python encoder branch and transport handler fails 3 Python tests.
- Round trip verified through the real encoder, decoder and accumulator for both rows of the table above.

## Why the decoder goes through `appendReasoning` rather than tracking its own controller

`DataStreamDecoder` could hold the `TextStreamController` returned by `addReasoningPart(init)` in its closure, the way it already tracks `toolCallControllers`, and avoid touching the public `appendReasoning` signature at all. It does not, because the reasoning part has to be invalidated by unrelated content and `_state.append` already does that correctly.

Decoding `aui-reasoning-part-start` then `g:"one"` then `0:"prose"` then `g:"two"` yields a `part-finish` on the reasoning part when the text part opens, and a **new** reasoning part for the trailing delta. A decoder-local controller would append `"two"` to the part opened at the start, putting a later reasoning step inside an earlier one. Getting that right in the decoder means reimplementing the append-invalidation state machine beside the one that already exists.

The cost is that `appendReasoning`'s second parameter is a permanent public surface whose no-append case has no caller outside the decoder. The asymmetry is forced by compatibility: `appendReasoning("")` has to keep emitting its frame for callers that predate this change, so only the init-driven open can suppress.
