### PR TITLE
fix(react): clear dropped assistant transport resume intent

### DIFF
--- a/.changeset/soft-carrots-resume.md
+++ b/.changeset/soft-carrots-resume.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: clear dropped assistant transport resume requests

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransport.spec.md
@@ -23,6 +23,7 @@ Resume State
 - The resume request carries `runId` and no `state`: the server replays from the snapshot it retained for that run, so neither `body` overrides nor a `prepareSendCommandsRequest` rebuild can substitute a different base. `runId` takes precedence over `body` fields and is re-attached after `prepareSendCommandsRequest` so a rebuilt body cannot drop it. The local base is replaced by the snapshot only after the resume stream responds OK, so a rejected resume keeps the local state.
 - A 204 response means no active run: the resume is skipped without error, and queued commands are flushed in a follow-up run.
 - A malformed snapshot response fails the resume before the replay request is sent.
+- If a pending resume is dropped by an error or cancellation, later commands start normal runs.
 - Runs execute on a `queueMicrotask`, so multiple synchronous enqueues coalesce into a single request: the first run's flush takes all of them, and the coalesced follow-up run no-ops.
 
 Command Queue

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.test.tsx
@@ -75,6 +75,35 @@ const installFetch = () => {
   return { requests, servers };
 };
 
+const installPendingFetch = () => {
+  const requests: RecordedRequest[] = [];
+  const pending: {
+    resolve: (response: Response) => void;
+    reject: (reason: unknown) => void;
+  }[] = [];
+
+  vi.stubGlobal("fetch", (url: RequestInfo | URL, init: RequestInit = {}) => {
+    requests.push({
+      url: String(url),
+      init,
+      body: JSON.parse(init.body as string),
+    });
+
+    return new Promise<Response>((resolve, reject) => {
+      pending.push({ resolve, reject });
+      init.signal?.addEventListener(
+        "abort",
+        () => reject(init.signal?.reason),
+        {
+          once: true,
+        },
+      );
+    });
+  });
+
+  return { requests, pending };
+};
+
 const mountRuntime = (
   options?: Partial<AssistantTransportOptions<unknown>>,
 ) => {
@@ -215,6 +244,56 @@ describe("useAssistantTransportRuntime", () => {
     act(() => fetchMock.servers[2]!.close());
     await waitFor(() => expect(aui().thread.getState().isRunning).toBe(false));
   });
+
+  it.each(["error", "cancellation"] as const)(
+    "does not apply a dropped resume after run %s",
+    async (settlement) => {
+      const fetchMock = installPendingFetch();
+      const onError = vi.fn();
+      const { aui, sendCommand } = mountRuntime({
+        resumeApi: "https://example.com/resume",
+        onError,
+      });
+      await waitFor(() =>
+        expect(
+          (aui().thread.getState().extras as { sendCommand?: unknown })
+            ?.sendCommand,
+        ).toBeTypeOf("function"),
+      );
+
+      act(() => sendCommand(createMessageCommand("a")));
+      await waitFor(() => expect(fetchMock.requests).toHaveLength(1));
+
+      await act(async () => {
+        await aui().thread.resumeRun({ parentId: null });
+      });
+      if (settlement === "cancellation") {
+        act(() => aui().thread.cancelRun());
+      } else {
+        await act(async () => {
+          fetchMock.pending[0]!.reject(new Error("request failed"));
+        });
+      }
+      await waitFor(() =>
+        expect(aui().thread.getState().isRunning).toBe(false),
+      );
+
+      act(() => sendCommand(createMessageCommand("b")));
+      await waitFor(() => expect(fetchMock.requests).toHaveLength(2));
+      expect(fetchMock.requests[1]!.url).toBe("https://example.com/api");
+      expect(fetchMock.requests[1]!.body["commands"]).toEqual([
+        createMessageCommand("b"),
+      ]);
+
+      await act(async () => {
+        fetchMock.pending[1]!.resolve(new Response("", { status: 200 }));
+      });
+      await waitFor(() =>
+        expect(aui().thread.getState().isRunning).toBe(false),
+      );
+      expect(onError).toHaveBeenCalledTimes(settlement === "error" ? 1 : 0);
+    },
+  );
 
   it("applies resumed operations to the retained initial state", async () => {
     const requests: RecordedRequest[] = [];

--- a/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
+++ b/packages/react/src/legacy-runtime/runtime-cores/assistant-transport/useAssistantTransportRuntime.ts
@@ -348,6 +348,7 @@ const useAssistantTransportThreadRuntime = <T>(
       });
     },
     onError: async (error) => {
+      resumeFlagRef.current = false;
       setIsReplaying(false);
       const inTransitCmds = [...commandQueue.state.inTransit];
       const queuedCmds = [...commandQueue.state.queued];
@@ -422,6 +423,7 @@ const useAssistantTransportThreadRuntime = <T>(
       },
     }),
     onCancel: async () => {
+      resumeFlagRef.current = false;
       runManager.cancel();
     },
     onResume: async () => {


### PR DESCRIPTION
## Summary

- clear a pending resume intent when the active run errors or is cancelled
- keep the next unrelated command on the normal transport endpoint
- cover both dropped-resume paths and document the scheduling behavior

## Why

This is a follow-up to #5249. A resume requested during an active run shares the run manager's pending follow-up slot. If the active run errors or is cancelled, that slot is cleared, but `resumeFlagRef` previously stayed set. The next normal command was then mistaken for the dropped resume and sent to `resumeApi` before its actual command request.

The resume intent is now cleared alongside the error and cancellation paths that discard it. Successful pending resumes are unchanged.

## Testing

- reproduced both paths before the fix: the next request incorrectly targeted `resumeApi`
- `useAssistantTransportRuntime.test.tsx`: 12 tests passed
- targeted oxlint and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.c-Kjnqk80Ze8k4sbi-Hu1rl928ah8Bsd_NovTYKFKxfIQ6bEr24mWPTwFq8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->