### PR TITLE
fix(react): allow retrying failed live completions

### DIFF
--- a/.changeset/green-lemons-retry.md
+++ b/.changeset/green-lemons-retry.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: allow failed live completion searches to be retried

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -129,6 +129,33 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.adapter.search!("ab")).toEqual([item("ab")]);
   });
 
+  it("allows a failed query to be retried", async () => {
+    const fetcher = vi
+      .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockRejectedValueOnce(new Error("still unavailable"))
+      .mockResolvedValueOnce([item("alice")]);
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    for (const attempt of [1, 2]) {
+      await act(async () => {
+        result.current.adapter.search!("alice");
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(fetcher).toHaveBeenCalledTimes(attempt);
+      expect(result.current.isLoading).toBe(false);
+    }
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
+  });
+
   it("drops an in-flight fetch when the query returns to a cached value", async () => {
     const resolvers: Record<
       string,

--- a/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.test.tsx
@@ -156,6 +156,69 @@ describe("unstable_useLiveCompletionAdapter", () => {
     expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
   });
 
+  it("does not automatically retry when search runs during every render", async () => {
+    const fetcher = vi
+      .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockImplementation(
+        () => new Promise<readonly Unstable_TriggerItem[]>(() => {}),
+      );
+    const { result } = renderHook(() => {
+      const completion = unstable_useLiveCompletionAdapter({
+        fetcher,
+        debounceMs: 0,
+      });
+      completion.adapter.search!("alice");
+      return completion;
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.isLoading).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms a failed query when its pending retry is interrupted", async () => {
+    const fetcher = vi
+      .fn<(query: string) => Promise<readonly Unstable_TriggerItem[]>>()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockImplementationOnce(
+        () => new Promise<readonly Unstable_TriggerItem[]>(() => {}),
+      )
+      .mockResolvedValueOnce([item("alice")]);
+    const { result } = renderHook(() =>
+      unstable_useLiveCompletionAdapter({ fetcher, debounceMs: 0 }),
+    );
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      result.current.adapter.search!("alicex");
+    });
+    await act(async () => {
+      result.current.adapter.search!("alice");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(fetcher).toHaveBeenLastCalledWith("alice");
+    expect(result.current.adapter.search!("alice")).toEqual([item("alice")]);
+  });
+
   it("drops an in-flight fetch when the query returns to a cached value", async () => {
     const resolvers: Record<
       string,

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -57,7 +57,8 @@ export function unstable_useLiveCompletionAdapter(
   const [state, setState] = useState<{
     query: string;
     items: readonly Unstable_TriggerItem[];
-  }>({ query: NO_QUERY, items: [] });
+    failed: boolean;
+  }>({ query: NO_QUERY, items: [], failed: false });
   const [isLoading, setIsLoading] = useState(false);
 
   const fetcherRef = useRef(fetcher);
@@ -66,6 +67,7 @@ export function unstable_useLiveCompletionAdapter(
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tokenRef = useRef(0);
   const pendingQueryRef = useRef<string | null>(null);
+  const retryableQueryRef = useRef<string | null>(null);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -78,6 +80,9 @@ export function unstable_useLiveCompletionAdapter(
     (query: string) => {
       if (!enabled) return;
       if (pendingQueryRef.current === query) return;
+      if (retryableQueryRef.current === query) {
+        retryableQueryRef.current = null;
+      }
       pendingQueryRef.current = query;
       cancelTimer();
       const token = ++tokenRef.current;
@@ -87,12 +92,13 @@ export function unstable_useLiveCompletionAdapter(
         fetcherRef.current(query).then(
           (items) => {
             if (token !== tokenRef.current) return;
-            setState({ query, items });
+            setState({ query, items, failed: false });
             setIsLoading(false);
           },
           () => {
             if (token !== tokenRef.current) return;
-            setState({ query, items: [] });
+            pendingQueryRef.current = null;
+            setState({ query, items: [], failed: true });
             setIsLoading(false);
           },
         );
@@ -112,11 +118,15 @@ export function unstable_useLiveCompletionAdapter(
     if (enabled) return;
     invalidatePending();
     setState((s) =>
-      s.query === NO_QUERY ? s : { query: NO_QUERY, items: [] },
+      s.query === NO_QUERY ? s : { query: NO_QUERY, items: [], failed: false },
     );
   }, [enabled, invalidatePending]);
 
   useEffect(() => cancelTimer, [cancelTimer]);
+
+  useEffect(() => {
+    retryableQueryRef.current = state.failed ? state.query : null;
+  }, [state]);
 
   const adapter = useMemo<Unstable_TriggerAdapter>(
     () => ({
@@ -125,7 +135,7 @@ export function unstable_useLiveCompletionAdapter(
       search: (query: string) => {
         // search() runs inside the popover's render; defer state updates with
         // queueMicrotask so they are not dispatched while another component renders.
-        if (query !== state.query) {
+        if (query !== state.query || retryableQueryRef.current === query) {
           queueMicrotask(() => scheduleFetch(query));
         } else if (
           pendingQueryRef.current !== null &&

--- a/packages/react/src/unstable/useLiveCompletionAdapter.ts
+++ b/packages/react/src/unstable/useLiveCompletionAdapter.ts
@@ -68,6 +68,7 @@ export function unstable_useLiveCompletionAdapter(
   const tokenRef = useRef(0);
   const pendingQueryRef = useRef<string | null>(null);
   const retryableQueryRef = useRef<string | null>(null);
+  const pendingRetryQueryRef = useRef<string | null>(null);
 
   const cancelTimer = useCallback(() => {
     if (timerRef.current !== null) {
@@ -76,12 +77,21 @@ export function unstable_useLiveCompletionAdapter(
     }
   }, []);
 
+  const rearmPendingRetry = useCallback(() => {
+    const query = pendingRetryQueryRef.current;
+    if (query === null) return;
+    retryableQueryRef.current = query;
+    pendingRetryQueryRef.current = null;
+  }, []);
+
   const scheduleFetch = useCallback(
     (query: string) => {
       if (!enabled) return;
       if (pendingQueryRef.current === query) return;
+      rearmPendingRetry();
       if (retryableQueryRef.current === query) {
         retryableQueryRef.current = null;
+        pendingRetryQueryRef.current = query;
       }
       pendingQueryRef.current = query;
       cancelTimer();
@@ -92,27 +102,30 @@ export function unstable_useLiveCompletionAdapter(
         fetcherRef.current(query).then(
           (items) => {
             if (token !== tokenRef.current) return;
+            pendingRetryQueryRef.current = null;
             setState({ query, items, failed: false });
             setIsLoading(false);
           },
           () => {
             if (token !== tokenRef.current) return;
             pendingQueryRef.current = null;
+            pendingRetryQueryRef.current = null;
             setState({ query, items: [], failed: true });
             setIsLoading(false);
           },
         );
       }, debounceMs);
     },
-    [enabled, debounceMs, cancelTimer],
+    [enabled, debounceMs, cancelTimer, rearmPendingRetry],
   );
 
   const invalidatePending = useCallback(() => {
+    rearmPendingRetry();
     cancelTimer();
     pendingQueryRef.current = null;
     tokenRef.current += 1;
     setIsLoading(false);
-  }, [cancelTimer]);
+  }, [cancelTimer, rearmPendingRetry]);
 
   useEffect(() => {
     if (enabled) return;
@@ -124,6 +137,8 @@ export function unstable_useLiveCompletionAdapter(
 
   useEffect(() => cancelTimer, [cancelTimer]);
 
+  // Arm retries only after the failed state commits. Arming during rejection
+  // would let the failure render immediately schedule another request.
   useEffect(() => {
     retryableQueryRef.current = state.failed ? state.query : null;
   }, [state]);


### PR DESCRIPTION
## Summary

- stop treating failed live-completion queries as successfully cached results
- allow the same query to be retried after one or more temporary failures
- keep failed results empty without starting an automatic retry loop

## Why

`unstable_useLiveCompletionAdapter()` stored a rejected query as the current cached query and left its pending marker set. Later searches for the same text therefore returned the cached empty array without calling the fetcher again. A temporary search or network failure could leave that query unusable for the lifetime of the adapter.

The adapter now records failed results separately and only makes them retryable after the failure render commits. A later search can retry, while an unavailable backend does not cause continuous automatic requests.

## Testing

- reproduced on `main`: a second search after rejection left the fetcher at one call
- regression covers two consecutive failures followed by a successful retry
- `useLiveCompletionAdapter.test.tsx`: 6 tests passed
- targeted oxlint and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.r0UtcsUXClyWy2dB7ygegPnOAtbZsKjXZbHlfcMIsqLICGmg18ssvpTyYT4?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->