### PR TITLE
fix(assistant-stream): await merged stream cleanup

### DIFF
--- a/.changeset/fair-lions-clean.md
+++ b/.changeset/fair-lions-clean.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: await merged stream cleanup during cancellation

--- a/.changeset/fair-lions-clean.md
+++ b/.changeset/fair-lions-clean.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: await merged stream cleanup after cancellation and child errors
+fix: await merged stream cleanup during cancellation

--- a/.changeset/fair-lions-clean.md
+++ b/.changeset/fair-lions-clean.md
@@ -2,4 +2,4 @@
 "assistant-stream": patch
 ---
 
-fix: await merged stream cleanup during cancellation
+fix: await merged stream cleanup after cancellation and child errors

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -236,22 +236,27 @@ describe("createAssistantStream task settlement", () => {
     }
   });
 
-  it("surfaces an error when merging a locked stream", async () => {
+  it("emits an error chunk when merging a locked stream", async () => {
     const source = new ReadableStream();
     const sourceReader = source.getReader();
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
 
     try {
-      const stream = createAssistantStream((controller) => {
-        controller.merge(source);
-      });
+      const chunks = await collectChunks(
+        createAssistantStream((controller) => {
+          controller.merge(source);
+        }),
+      );
 
-      await expect(collectChunks(stream)).rejects.toBeInstanceOf(TypeError);
+      expect(chunks).toEqual([
+        {
+          type: "error",
+          path: [],
+          error:
+            "TypeError: Cannot merge a stream that is already locked to a reader.",
+        },
+      ]);
     } finally {
       sourceReader.releaseLock();
-      consoleError.mockRestore();
     }
   });
 });

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -91,6 +91,30 @@ describe("createAssistantStream task settlement", () => {
     expect(unhandledRejections).toEqual([]);
   });
 
+  it("waits for merged source cleanup during cancellation", async () => {
+    let finishCleanup = () => {};
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const cancelSource = vi.fn(() => cleanup);
+    const stream = createAssistantStream((controller) => {
+      controller.merge(new ReadableStream({ cancel: cancelSource }));
+      return new Promise(() => {});
+    });
+
+    let cancelSettled = false;
+    const cancel = stream.cancel().then(() => {
+      cancelSettled = true;
+    });
+
+    await vi.waitFor(() => expect(cancelSource).toHaveBeenCalledOnce());
+    expect(cancelSettled).toBe(false);
+
+    finishCleanup();
+    await expect(cancel).resolves.toBeUndefined();
+    expect(cancelSettled).toBe(true);
+  });
+
   it("reports callback failures after the controller is explicitly closed", async () => {
     const error = new Error("cleanup failed");
     const consoleError = vi
@@ -167,6 +191,55 @@ describe("createAssistantStream task settlement", () => {
 
       expect(unhandledRejections).toEqual([]);
       expect(consoleError).toHaveBeenCalledWith(streamError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it("waits for sibling cleanup before surfacing a merged stream error", async () => {
+    let finishCleanup = () => {};
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const cancelSource = vi.fn(() => cleanup);
+    const streamError = new Error("merged stream failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const stream = createAssistantStream((controller) => {
+        controller.merge(
+          new ReadableStream({
+            start(streamController) {
+              streamController.error(streamError);
+            },
+          }),
+        );
+        controller.merge(new ReadableStream({ cancel: cancelSource }));
+        return new Promise(() => {});
+      });
+      let readSettled = false;
+      const readResult = stream
+        .getReader()
+        .read()
+        .then(
+          (value) => {
+            readSettled = true;
+            return { value };
+          },
+          (error: unknown) => {
+            readSettled = true;
+            return { error };
+          },
+        );
+
+      await vi.waitFor(() => expect(cancelSource).toHaveBeenCalledOnce());
+      expect(readSettled).toBe(false);
+
+      finishCleanup();
+      await expect(readResult).resolves.toEqual({ error: streamError });
+      expect(readSettled).toBe(true);
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -235,6 +235,25 @@ describe("createAssistantStream task settlement", () => {
       consoleError.mockRestore();
     }
   });
+
+  it("surfaces an error when merging a locked stream", async () => {
+    const source = new ReadableStream();
+    const sourceReader = source.getReader();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    try {
+      const stream = createAssistantStream((controller) => {
+        controller.merge(source);
+      });
+
+      await expect(collectChunks(stream)).rejects.toBeInstanceOf(TypeError);
+    } finally {
+      sourceReader.releaseLock();
+      consoleError.mockRestore();
+    }
+  });
 });
 
 describe("addToolCallPart with an immediate response", () => {

--- a/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.test.ts
@@ -196,7 +196,7 @@ describe("createAssistantStream task settlement", () => {
     }
   });
 
-  it("waits for sibling cleanup before surfacing a merged stream error", async () => {
+  it("surfaces a merged stream error while sibling cleanup continues", async () => {
     let finishCleanup = () => {};
     const cleanup = new Promise<void>((resolve) => {
       finishCleanup = resolve;
@@ -219,28 +219,19 @@ describe("createAssistantStream task settlement", () => {
         controller.merge(new ReadableStream({ cancel: cancelSource }));
         return new Promise(() => {});
       });
-      let readSettled = false;
       const readResult = stream
         .getReader()
         .read()
         .then(
-          (value) => {
-            readSettled = true;
-            return { value };
-          },
-          (error: unknown) => {
-            readSettled = true;
-            return { error };
-          },
+          (value) => ({ value }),
+          (error: unknown) => ({ error }),
         );
 
       await vi.waitFor(() => expect(cancelSource).toHaveBeenCalledOnce());
-      expect(readSettled).toBe(false);
-
-      finishCleanup();
       await expect(readResult).resolves.toEqual({ error: streamError });
-      expect(readSettled).toBe(true);
     } finally {
+      finishCleanup();
+      await cleanup;
       consoleError.mockRestore();
     }
   });

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -160,6 +160,17 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
     this._state.closeSubscriber = callback;
   }
 
+  private _addTransformedStream(
+    stream: AssistantStream,
+    transformer: ReadableWritablePair<
+      AssistantStreamChunk,
+      AssistantStreamChunk
+    >,
+  ) {
+    const pipeTask = stream.pipeTo(transformer.writable);
+    this._state.merger.addStream(transformer.readable, pipeTask);
+  }
+
   private _addPart(part: PartInit, stream: AssistantStream) {
     if (this._state.append) {
       this._state.append.controller.close();
@@ -171,16 +182,16 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
       part,
       path: [],
     });
-    this._state.merger.addStream(
-      stream.pipeThrough(
-        new PathAppendEncoder(this._state.contentCounter.value),
-      ),
+    this._addTransformedStream(
+      stream,
+      new PathAppendEncoder(this._state.contentCounter.value),
     );
   }
 
   merge(stream: AssistantStream) {
-    this._state.merger.addStream(
-      stream.pipeThrough(new PathMergeEncoder(this._state.contentCounter)),
+    this._addTransformedStream(
+      stream,
+      new PathMergeEncoder(this._state.contentCounter),
     );
   }
 

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -167,7 +167,12 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
       AssistantStreamChunk
     >,
   ) {
-    const pipeTask = stream.pipeTo(transformer.writable);
+    const pipeTask = stream
+      .pipeTo(transformer.writable)
+      .catch(async (error) => {
+        await transformer.writable.abort(error).catch(() => undefined);
+        throw error;
+      });
     this._state.merger.addStream(transformer.readable, pipeTask);
   }
 

--- a/packages/assistant-stream/src/core/modules/assistant-stream.ts
+++ b/packages/assistant-stream/src/core/modules/assistant-stream.ts
@@ -167,6 +167,12 @@ class AssistantStreamControllerImpl implements AssistantStreamController {
       AssistantStreamChunk
     >,
   ) {
+    if (stream.locked) {
+      throw new TypeError(
+        "Cannot merge a stream that is already locked to a reader.",
+      );
+    }
+
     const pipeTask = stream
       .pipeTo(transformer.writable)
       .catch(async (error) => {

--- a/packages/assistant-stream/src/core/utils/stream/merge.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { createMergeStream } from "./merge";
+
+describe("createMergeStream", () => {
+  it("waits for every child reader to finish cancellation", async () => {
+    let finishCleanup = () => {};
+    const cleanup = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const delayedCancel = vi.fn(() => cleanup);
+    const rejectedCancel = vi.fn(() => Promise.reject(new Error("failed")));
+    const merger = createMergeStream();
+
+    merger.addStream(new ReadableStream({ cancel: delayedCancel }));
+    merger.addStream(new ReadableStream({ cancel: rejectedCancel }));
+
+    let cancelSettled = false;
+    const cancel = merger.readable
+      .getReader()
+      .cancel()
+      .then(() => {
+        cancelSettled = true;
+      });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(delayedCancel).toHaveBeenCalledOnce();
+    expect(rejectedCancel).toHaveBeenCalledOnce();
+    expect(cancelSettled).toBe(false);
+
+    finishCleanup();
+    await expect(cancel).resolves.toBeUndefined();
+    expect(cancelSettled).toBe(true);
+  });
+});

--- a/packages/assistant-stream/src/core/utils/stream/merge.test.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.test.ts
@@ -32,4 +32,16 @@ describe("createMergeStream", () => {
     await expect(cancel).resolves.toBeUndefined();
     expect(cancelSettled).toBe(true);
   });
+
+  it("cancels streams rejected after sealing", async () => {
+    const cancelSource = vi.fn();
+    const merger = createMergeStream();
+    merger.seal();
+
+    expect(() =>
+      merger.addStream(new ReadableStream({ cancel: cancelSource })),
+    ).toThrow("Cannot add streams after the run callback has settled.");
+
+    await vi.waitFor(() => expect(cancelSource).toHaveBeenCalledOnce());
+  });
 });

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -52,19 +52,17 @@ export const createMergeStream = () => {
           currentPull?.resolve();
           currentPull = undefined;
         })
-        .catch(async (e) => {
+        .catch((e) => {
           if (cancelled || errored) return;
 
           errored = true;
           console.error(e);
-          const cleanup = cancelAllReaders();
+          void cancelAllReaders();
 
           controller.error(e);
 
           currentPull?.reject(e);
           currentPull = undefined;
-
-          await cleanup;
         });
     }
   };

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -3,6 +3,7 @@ import { promiseWithResolvers } from "../../../utils/promiseWithResolvers";
 
 type MergeStreamItem = {
   reader: ReadableStreamDefaultReader<AssistantStreamChunk>;
+  pipeTask?: Promise<unknown> | undefined;
   promise?: Promise<unknown> | undefined;
 };
 
@@ -13,16 +14,16 @@ export const createMergeStream = () => {
   let errored = false;
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
+  let cleanupPromise: Promise<void> | undefined;
 
-  const cancelAllReaders = async () => {
-    const readers = list.splice(0).map((item) => item.reader);
-    await Promise.all(
-      readers.map(async (reader) => {
-        try {
-          await reader.cancel();
-        } catch {}
+  const cancelAllReaders = () => {
+    cleanupPromise ??= Promise.all(
+      list.splice(0).map(async (item) => {
+        await item.reader.cancel().catch(() => undefined);
+        await item.pipeTask;
       }),
-    );
+    ).then(() => undefined);
+    return cleanupPromise;
   };
 
   const handlePull = (item: MergeStreamItem) => {
@@ -50,12 +51,13 @@ export const createMergeStream = () => {
           currentPull?.resolve();
           currentPull = undefined;
         })
-        .catch((e) => {
+        .catch(async (e) => {
           if (cancelled || errored) return;
 
           errored = true;
           console.error(e);
-          void cancelAllReaders();
+          await cancelAllReaders();
+          if (cancelled) return;
 
           controller.error(e);
 
@@ -102,18 +104,27 @@ export const createMergeStream = () => {
       sealed = true;
       if (list.length === 0) controller.close();
     },
-    addStream(stream: ReadableStream<AssistantStreamChunk>) {
+    addStream(
+      stream: ReadableStream<AssistantStreamChunk>,
+      pipeTask?: Promise<unknown>,
+    ) {
+      const handledPipeTask = pipeTask?.catch(() => undefined);
       if (cancelled || errored) {
-        void stream.cancel().catch(() => undefined);
+        void stream
+          .cancel()
+          .catch(() => undefined)
+          .then(() => handledPipeTask);
         return;
       }
 
-      if (sealed)
+      if (sealed) {
+        void stream.cancel().catch(() => undefined);
         throw new Error(
           "Cannot add streams after the run callback has settled.",
         );
+      }
 
-      const item = { reader: stream.getReader() };
+      const item = { reader: stream.getReader(), pipeTask: handledPipeTask };
       list.push(item);
       handlePull(item);
     },

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -14,11 +14,15 @@ export const createMergeStream = () => {
   let controller: ReadableStreamDefaultController<AssistantStreamChunk>;
   let currentPull: ReturnType<typeof promiseWithResolvers<void>> | undefined;
 
-  const cancelAllReaders = () => {
-    list.forEach((item) => {
-      void item.reader.cancel().catch(() => undefined);
-    });
-    list.length = 0;
+  const cancelAllReaders = async () => {
+    const readers = list.splice(0).map((item) => item.reader);
+    await Promise.all(
+      readers.map(async (reader) => {
+        try {
+          await reader.cancel();
+        } catch {}
+      }),
+    );
   };
 
   const handlePull = (item: MergeStreamItem) => {
@@ -51,7 +55,7 @@ export const createMergeStream = () => {
 
           errored = true;
           console.error(e);
-          cancelAllReaders();
+          void cancelAllReaders();
 
           controller.error(e);
 
@@ -73,11 +77,12 @@ export const createMergeStream = () => {
 
       return currentPull.promise;
     },
-    cancel() {
+    async cancel() {
       cancelled = true;
-      cancelAllReaders();
+      const cleanup = cancelAllReaders();
       currentPull?.resolve();
       currentPull = undefined;
+      await cleanup;
     },
   });
 

--- a/packages/assistant-stream/src/core/utils/stream/merge.ts
+++ b/packages/assistant-stream/src/core/utils/stream/merge.ts
@@ -17,6 +17,7 @@ export const createMergeStream = () => {
   let cleanupPromise: Promise<void> | undefined;
 
   const cancelAllReaders = () => {
+    // Repeated cancellation must wait for cleanup already in progress.
     cleanupPromise ??= Promise.all(
       list.splice(0).map(async (item) => {
         await item.reader.cancel().catch(() => undefined);
@@ -56,13 +57,14 @@ export const createMergeStream = () => {
 
           errored = true;
           console.error(e);
-          await cancelAllReaders();
-          if (cancelled) return;
+          const cleanup = cancelAllReaders();
 
           controller.error(e);
 
           currentPull?.reject(e);
           currentPull = undefined;
+
+          await cleanup;
         });
     }
   };
@@ -110,10 +112,7 @@ export const createMergeStream = () => {
     ) {
       const handledPipeTask = pipeTask?.catch(() => undefined);
       if (cancelled || errored) {
-        void stream
-          .cancel()
-          .catch(() => undefined)
-          .then(() => handledPipeTask);
+        void stream.cancel().catch(() => undefined);
         return;
       }
 


### PR DESCRIPTION
## Summary

- await cleanup of the original producer when a merged AssistantStream is cancelled
- retain each explicit pipeTo task so cancellation crosses PathAppendEncoder and PathMergeEncoder
- isolate child cleanup failures while surfacing merged-stream errors immediately
- preserve synchronous locked-source validation as the documented error chunk
- cancel transformed streams rejected after sealing so their newly-started pipes do not leak
- cover cancellation, error ordering, and locked-source behavior through the public createAssistantStream API

## Why

The previous implementation awaited cancellation of the transformed child reader. That reader can settle before the internal pipe reaches and finishes cleanup on the original database, remote-store, or network source.

Merged streams now retain the explicit pipeTo task and await it during consumer-requested cancellation. Child errors still reach consumers immediately, while sibling cleanup continues in the background. Unexpected asynchronous pipe failures are forwarded into the transformed readable, while invalid locked inputs keep the existing synchronous error-chunk behavior.

## Validation

- pnpm --filter assistant-stream test (423 passed, 20 skipped)
- pnpm --filter assistant-stream build
- focused oxlint and oxfmt checks

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.qF5nWe6dhAWOYBWlyQEnWBgMGM6anX0Bbgx3NV7m95KvaLsbBqxVe3VLaZ0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->