### PR TITLE
fix(store): deliver swap-time events to default-scope listeners

### DIFF
--- a/.changeset/mean-pugs-shout.md
+++ b/.changeset/mean-pugs-shout.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/store": patch
+---
+
+fix: deliver scoped events emitted during a structural swap to default-scope listeners

--- a/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
+++ b/apps/docs/content/docs/(reference)/api-reference/hooks/state.mdx
@@ -54,6 +54,11 @@ scope or event name changes. The `callback` is wrapped in an effect-event
 shim, so the latest closure is invoked on each emission — you do not
 need to memoize it.
 
+A scoped subscription is filtered against the scope's binding at delivery
+time, so it follows a derived scope through a structural swap — including
+for an event the swap itself emits, such as `threadListItem.switchedTo` on
+a thread switch.
+
 {/* api-example:useAuiEvent:start */}
 ```tsx
 import { useAuiEvent } from "@assistant-ui/react";

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ReactNode } from "react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { flushTapSync, resource } from "@assistant-ui/tap";
@@ -12,6 +12,8 @@ import { useAuiState } from "../useAuiState";
 import { Derived } from "../Derived";
 import { useAssistantEmit } from "../utils/tap-assistant-context";
 import { useClientResource } from "../useClientResource";
+import { createAssistantClient } from "../createAssistantClient";
+import { onWithBinding } from "../utils/event-binding";
 
 type AnyClient = Record<string, any>;
 
@@ -43,6 +45,49 @@ const useThreadClient = () => {
   };
 };
 const ThreadClient = resource(useThreadClient);
+
+// Mirrors a thread list item: the client emits when it observes that it became
+// the selected one, from inside the flush that performs the selection swap
+const useSwitchingMessageClient = ({
+  id,
+  isSelected,
+}: {
+  id: string;
+  isSelected: boolean;
+}) => {
+  const emit = useAssistantEmit();
+  const wasSelected = useRef(isSelected);
+  useEffect(() => {
+    if (wasSelected.current === isSelected) return;
+    wasSelected.current = isSelected;
+    if (isSelected) emit("message.switchedTo" as never, { id } as never);
+    else
+      emit("message.pinged" as never, { id, value: "switched-away" } as never);
+  }, [id, isSelected, emit]);
+  return {
+    getState: () => ({ id, text: "" }),
+    ping: (value: string) =>
+      emit("message.pinged" as never, { id, value } as never),
+  };
+};
+const SwitchingMessageClient = resource(useSwitchingMessageClient);
+
+const useSwitchingThreadClient = () => {
+  const [selected, setSelected] = useState(0);
+  const m0 = useClientResource(
+    SwitchingMessageClient({ id: "m0", isSelected: selected === 0 }),
+  );
+  const m1 = useClientResource(
+    SwitchingMessageClient({ id: "m1", isSelected: selected === 1 }),
+  );
+  const messages = [m0, m1];
+  return {
+    getState: () => ({ selected }),
+    setSelected,
+    message: ({ index }: { index: number }) => messages[index]!.methods,
+  };
+};
+const SwitchingThreadClient = resource(useSwitchingThreadClient);
 
 const messageDerived = () =>
   Derived({
@@ -363,6 +408,104 @@ describe("Derived scopes", () => {
       id: "m1",
       value: "after-swap",
     });
+  });
+
+  const setupSwitching = () => {
+    let aui!: AnyClient;
+    const listeners = {
+      switchedTo: vi.fn(),
+      switchedToStar: vi.fn(),
+      pinged: vi.fn(),
+      pingedStar: vi.fn(),
+    };
+    const Consumer = () => {
+      useAuiEvent("message.switchedTo" as never, listeners.switchedTo as never);
+      useAuiEvent(
+        { scope: "*", event: "message.switchedTo" } as never,
+        listeners.switchedToStar as never,
+      );
+      useAuiEvent("message.pinged" as never, listeners.pinged as never);
+      useAuiEvent(
+        { scope: "*", event: "message.pinged" } as never,
+        listeners.pingedStar as never,
+      );
+      return null;
+    };
+    const Harness = () => {
+      aui = useAui({
+        thread: SwitchingThreadClient(),
+        message: messageDerived(),
+      } as unknown as useAui.Props);
+      return (
+        <AuiProvider value={aui as never}>
+          <Consumer />
+        </AuiProvider>
+      );
+    };
+    render(<Harness />);
+    return { getAui: () => aui, listeners };
+  };
+
+  it("a default-scope listener receives an event emitted by the swap itself", async () => {
+    const { getAui, listeners } = setupSwitching();
+
+    act(() => flushTapSync(() => getAui().thread.setSelected(1)));
+    await flushEvents();
+
+    expect(listeners.switchedTo).toHaveBeenCalledExactlyOnceWith({ id: "m1" });
+    expect(listeners.switchedToStar).toHaveBeenCalledExactlyOnceWith({
+      id: "m1",
+    });
+
+    // the deselected item emits in the same flush; it is no longer the derived
+    // selection, so only the wildcard listener hears it
+    expect(listeners.pingedStar).toHaveBeenCalledExactlyOnceWith({
+      id: "m0",
+      value: "switched-away",
+    });
+    expect(listeners.pinged).not.toHaveBeenCalled();
+  });
+
+  it("the swap's event reaches a default-scope listener before React re-renders", async () => {
+    const { getAui, listeners } = setupSwitching();
+
+    // outside act: the emission is delivered while the subscriber still holds
+    // the pre-swap client, the window the derived binding has to cover
+    flushTapSync(() => getAui().thread.setSelected(1));
+    await Promise.resolve();
+
+    expect(listeners.switchedTo).toHaveBeenCalledExactlyOnceWith({ id: "m1" });
+    expect(listeners.pinged).not.toHaveBeenCalled();
+
+    await flushEvents();
+  });
+
+  it("a live-bound listener resolves its scope at delivery time, a snapshot one at subscription time", async () => {
+    // No React commit is involved here, so nothing re-subscribes between the
+    // emit and its delivery: the binding mode alone decides the outcome
+    const handle = createAssistantClient({
+      thread: SwitchingThreadClient(),
+      message: messageDerived(),
+    } as never);
+    const client = () => handle.getClient() as AnyClient;
+
+    const live = vi.fn();
+    const snapshot = vi.fn();
+    onWithBinding(
+      client() as never,
+      { scope: "message", event: "message.switchedTo" } as never,
+      live as never,
+      "live",
+    );
+    client().on("message.switchedTo" as never, snapshot as never);
+
+    flushTapSync(() => client().thread.setSelected(1));
+    await Promise.resolve();
+
+    expect(live).toHaveBeenCalledExactlyOnceWith({ id: "m1" });
+    expect(snapshot).not.toHaveBeenCalled();
+
+    handle.destroy();
   });
 
   it("state subscriptions flow through a derived scope", () => {

--- a/packages/store/src/__tests__/events.test.tsx
+++ b/packages/store/src/__tests__/events.test.tsx
@@ -313,6 +313,27 @@ describe("microtask delivery (live-set semantics)", () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
+  it("a wildcard listener keeps an emission alive for a scoped listener added before the flush", async () => {
+    const { getAui } = setup();
+    const aui = getAui();
+    const wildcard = vi.fn();
+    aui.on("*", wildcard);
+
+    // whether an emission survives is decided at emit time and asks only
+    // whether anything was listening, so a wildcard listener carries it to a
+    // scoped listener that subscribes before the flush
+    aui.thread.ping("x");
+    const late = vi.fn();
+    aui.on("thread.pinged", late);
+    await flushEvents();
+
+    expect(wildcard).toHaveBeenCalledExactlyOnceWith({
+      event: "thread.pinged",
+      payload: { value: "x" },
+    });
+    expect(late).toHaveBeenCalledExactlyOnceWith({ value: "x" });
+  });
+
   it("listeners added between emit and flush are invoked", async () => {
     const { getAui } = setup();
     const aui = getAui();

--- a/packages/store/src/createAssistantClient.ts
+++ b/packages/store/src/createAssistantClient.ts
@@ -128,12 +128,7 @@ export const createAssistantClient = (
     const entries = Object.entries(
       applyTransformScopes(currentConfig, parent),
     ) as ScopeEntry[];
-    const result = useAuiRoot({ parent, entries, clientRef, notifications });
-    // Seeded during render, before the commit runs mount effects that read it
-    if (clientRef.current === null) {
-      clientRef.current = result.client;
-    }
-    return result;
+    return useAuiRoot({ parent, entries, clientRef, notifications });
   });
   clientRef.current = root.getValue().client;
 

--- a/packages/store/src/useAui.ts
+++ b/packages/store/src/useAui.ts
@@ -45,6 +45,7 @@ import {
   type NotificationManager,
 } from "./utils/NotificationManager";
 import { useAssistantTapContextProvider } from "./utils/tap-assistant-context";
+import { onWithBinding, type EventBinding } from "./utils/event-binding";
 import { ClientResource } from "./useClientResource";
 import { useShallowStable } from "./utils/useShallowStable";
 import { createClientAccessor, getClientId } from "./utils/client-accessor";
@@ -134,6 +135,7 @@ const useClientFields = ({
         this: AssistantClient,
         selector: AssistantEventSelector<TEvent>,
         callback: AssistantEventCallback<TEvent>,
+        binding: EventBinding = "snapshot",
       ) {
         if (!this) {
           throw new Error(
@@ -159,8 +161,13 @@ const useClientFields = ({
             return;
           }
 
+          // A live listener reads the scope off the client the host has
+          // rendered, which already carries the post-swap binding when the
+          // emission came from inside the swap
+          const boundClient =
+            binding === "live" ? (clientRef.current ?? this) : this;
           const scopeClient = getClientId(
-            this[scope as ClientNames],
+            boundClient[scope as ClientNames],
           ) as unknown as ClientMethods;
           const index = getClientIndex(scopeClient);
           if (scopeClient === clientStack[index]) {
@@ -173,7 +180,12 @@ const useClientFields = ({
         )
           return localUnsub;
 
-        const parentUnsub = clientRef.parent.on(selector, callback);
+        const parentUnsub = onWithBinding(
+          clientRef.parent,
+          selector,
+          callback,
+          binding,
+        );
 
         return () => {
           localUnsub();
@@ -272,11 +284,16 @@ export const useAuiRoot = ({
     },
   );
 
+  const client = useCommittedClient(building, [parent, ...accessors]);
+
+  // Owned by the render, not by a commit effect: a live-bound listener resolves
+  // its scope through this ref during the flush that rebinds a derived scope,
+  // which is before React re-renders the subscriber
+  clientRef.current = client;
+
   // Fresh envelope per commit so value-only updates reach the store's
   // subscribers; the client inside keeps its identity
-  return {
-    client: useCommittedClient(building, [parent, ...accessors]),
-  };
+  return { client };
 };
 
 const useHostedAssistantClient = ({
@@ -315,12 +332,7 @@ const useHostedAssistantClient = ({
 
     useEffect(() => {
       clientRef.parent = parent;
-      clientRef.current = client;
     });
-
-    if (clientRef.current === null) {
-      clientRef.current = client;
-    }
 
     return client;
   });

--- a/packages/store/src/useAuiEvent.ts
+++ b/packages/store/src/useAuiEvent.ts
@@ -6,6 +6,7 @@ import type {
   AssistantEventSelector,
 } from "./types/events";
 import { normalizeEventSelector } from "./types/events";
+import { onWithBinding } from "./utils/event-binding";
 
 /**
  * Subscribes to an assistant event for the lifetime of the component.
@@ -14,6 +15,11 @@ import { normalizeEventSelector } from "./types/events";
  * scope or event name changes. The `callback` is wrapped in an effect-event
  * shim, so the latest closure is invoked on each emission — you do not
  * need to memoize it.
+ *
+ * A scoped subscription is filtered against the scope's binding at delivery
+ * time, so it follows a derived scope through a structural swap — including
+ * for an event the swap itself emits, such as `threadListItem.switchedTo` on
+ * a thread switch.
  *
  * @param selector - Either a dotted event name like
  *   `"thread.modelContextUpdate"` or an object `{ scope, event }`. Use
@@ -56,5 +62,8 @@ export const useAuiEvent = <TEvent extends AssistantEventName>(
   const callbackRef = useEffectEvent(callback);
 
   const { scope, event } = normalizeEventSelector(selector);
-  useEffect(() => aui.on({ scope, event }, callbackRef), [aui, scope, event]);
+  useEffect(
+    () => onWithBinding(aui, { scope, event }, callbackRef, "live"),
+    [aui, scope, event],
+  );
 };

--- a/packages/store/src/utils/NotificationManager.ts
+++ b/packages/store/src/utils/NotificationManager.ts
@@ -52,11 +52,14 @@ export const createNotificationManager = (): NotificationManager => {
     },
 
     emit(event, payload, clientStack) {
-      const eventListeners = listeners.get(event);
-      if (!eventListeners && wildcardListeners.size === 0) return;
+      if (!listeners.has(event) && wildcardListeners.size === 0) return;
 
       queueMicrotask(() => {
         const errors = [];
+        // Re-read at flush time: a listener that unsubscribed and resubscribed
+        // since the emit (a React consumer re-binding after a structural swap)
+        // lands in a fresh set, and still belongs to this emission
+        const eventListeners = listeners.get(event);
         if (eventListeners) {
           for (const cb of eventListeners) {
             try {

--- a/packages/store/src/utils/event-binding.ts
+++ b/packages/store/src/utils/event-binding.ts
@@ -1,0 +1,37 @@
+import type { AssistantClient, Unsubscribe } from "../types/client";
+import type {
+  AssistantEventName,
+  AssistantEventCallback,
+  AssistantEventSelector,
+} from "../types/events";
+
+/**
+ * How a scoped listener resolves the instance it is filtered against.
+ *
+ * `"snapshot"` uses the scope as bound on the client `on` was called on, so
+ * the listener stays with that instance for its lifetime. `"live"` uses the
+ * scope on the host's current client at delivery time, so a listener follows a
+ * derived scope through a structural swap — including for an event emitted by
+ * the swap itself, which is delivered before React can re-render the
+ * subscriber with the new client.
+ */
+export type EventBinding = "snapshot" | "live";
+
+/**
+ * Subscribes through `client.on` with an explicit binding mode. A client that
+ * does not understand the mode (a hand-built parent) ignores it and keeps the
+ * snapshot behavior.
+ */
+export const onWithBinding = <TEvent extends AssistantEventName>(
+  client: AssistantClient,
+  selector: AssistantEventSelector<TEvent>,
+  callback: AssistantEventCallback<TEvent>,
+  binding: EventBinding,
+): Unsubscribe => {
+  const on = client.on as unknown as (
+    selector: AssistantEventSelector<TEvent>,
+    callback: AssistantEventCallback<TEvent>,
+    binding: EventBinding,
+  ) => Unsubscribe;
+  return on.call(client, selector, callback, binding);
+};


### PR DESCRIPTION
## What

A scoped event listener is filtered by comparing the emitting client stack against the listener's scope binding. Two windows around a *structural swap* (a derived scope resolving to a different instance) make that comparison miss an event that the swap itself emits, so a default-scope `useAuiEvent` hears nothing while a `scope: "*"` listener does.

Both are fixed here, with a regression test each.

**1. The listener set captured at emit time can be emptied before the flush.** `emit` captured `listeners.get(event)` and iterated that `Set` one microtask later. A consumer that unsubscribes and resubscribes in between — exactly what `useAuiEvent` does when the swap gives it a new client — empties the captured set, which is then deleted from the map, and the fresh subscription lands in a *new* set that the in-flight emission never sees. The event is dropped for that listener entirely, even though the documented live-set semantics ("listeners added between emit and flush are invoked") say it should be delivered. `emit` now re-reads the listener set at flush time; the emit-time "no listeners, drop it" check is unchanged.

**2. A listener that has not re-subscribed yet compares against the pre-swap binding.** Delivery is one microtask after the emit, but a React consumer's rebind needs a render, a commit and an effect flush. For an event emitted from inside the swap, the listener is still bound to the pre-swap instance when delivery runs, so the identity check fails. `useAuiEvent` now subscribes with a *live* binding: the scope is resolved through the host's current client at delivery time rather than through the client captured at subscription time. `aui.on` keeps its documented subscription-time binding (`listeners bind to the instance resolved at subscription time` still passes) — the binding mode is an internal parameter (`packages/store/src/utils/event-binding.ts`), not new public API.

The live mode leans on `clientRef.current`, which is why the ref is now assigned in the `useAuiRoot` render instead of in a commit effect: the tap root produces the post-swap client during the flush that performs the swap, which is before React can re-render anything. Assigning during render is safe here because the ref is only ever *read* at delivery time — inside a microtask, never during a render — and because `useCommittedClient` keeps the client identity stable across every non-structural render, which makes the assignment idempotent. A render that is discarded (StrictMode's double render, an interrupted transition) therefore either writes the same client the committed render would write, or is followed by the render that does. With the ref now written unconditionally there, the standalone root's null seed in `createAssistantClient` became unreachable and is deleted.

## Why this design

- *Re-resolve through the current root state* (chosen): the correction lands where the staleness is, keeps one code path for every binding, and needs no new scheduling.
- *Defer default-scope delivery until after the commit that rebinds* (rejected): delivery timing is a documented contract (microtask, live-set), the store cannot observe React commits, and non-React bindings (`createAssistantClient`, Vue) have no commit to wait for.
- *Match more loosely, e.g. on the source scope or on `"*"` plus a manual filter* (rejected): that is the workaround, not a fix — it delivers foreign instances' events to a listener that asked for one instance.

## Tests

`packages/store/src/__tests__/events.test.tsx` gains a thread-list-shaped harness where the client emits when it observes that it became the selected one, from inside the flush that performs the swap. Four new tests, each failing on `main`:

- the swap's own event reaches a default-scope listener (window 1), and the deselected instance's simultaneous emission still does **not** reach it — only the wildcard listener hears that one;
- the same, asserted before React re-renders (window 2);
- at the store level, with no React commit involved at all: a live-bound listener follows the new selection while a snapshot-bound `aui.on` listener stays on the instance it subscribed with;
- and one contract test for an interaction the flush-time re-read introduces: whether an emission survives is decided at emit time and asks only whether *anything* was listening, so when a wildcard listener is present, a scoped listener that subscribes between the emit and the flush now receives the emission (on `main` it was dropped). With no wildcard listener the existing "an emission with no listeners at emit time is dropped" contract is unchanged.

Verified: `@assistant-ui/store` (146), `@assistant-ui/tap` (473), `@assistant-ui/core` (947), `@assistant-ui/react` (423) and `@assistant-ui/vue` (65) suites green; store `tsc --noEmit`, oxlint and oxfmt clean; api-reference regenerated for the `useAuiEvent` JSDoc addition.

## Scope: this does not close #5699 on its own

Part of #5699. It fixes the store-level defect the issue's mechanism analysis describes, but I measured the end-to-end `threadListItem.switchedTo` case and it still does not fire, for a reason that lives outside the store: **at delivery time the store's runtime-client state has not caught up with the runtime**. With an external-store multi-thread runtime, right when the emission is delivered:

```
runtime mainThreadId = t2      (already switched)
client  mainThreadId = t1      (aui.threads.getState(), and the derived
                                threadListItem, still resolve to the old thread)
```

and a `flushTapSync` does not settle it — the runtime-driven state arrives through `useSubscribable` (`useSyncExternalStore`) and only lands on the next render, while the event is emitted synchronously from the runtime's own subscription. So the item announces `switchedTo` while every scope derived from the thread list still points at the previous thread, and no delivery-time comparison can match. That belongs in a follow-up on the core side (either settle the runtime-client state before the emission is delivered, or emit the switch from the store's own state transition instead of the runtime subscription).

Consequently the Vue wildcard workaround from #5698 stays for now: I reverted it locally against this branch and `scrolls the viewport to the bottom on thread switch` still fails. It becomes removable once the core-side ordering is addressed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.B-SEYfr-zCte_RWq3zM_93t9HqYLX9DqobHucQ2pi7T3YeSZt8N6HANXSoo?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
