### PR TITLE
fix(react-ai-sdk): refresh suggestions after adapter changes

### DIFF
--- a/.changeset/fresh-suggestions-adapter.md
+++ b/.changeset/fresh-suggestions-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-ai-sdk": patch
+---
+
+fix: refresh generated suggestions when the suggestion adapter changes

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.test.ts
@@ -878,6 +878,67 @@ describe("useAISDKRuntime", () => {
     expect(result.current.thread.getState().suggestions).toEqual([]);
   });
 
+  it("refreshes suggestions when the suggestion adapter changes", async () => {
+    let resolveFirstGenerate!: (value: readonly { prompt: string }[]) => void;
+    const firstGenerate = vi.fn().mockImplementation(
+      () =>
+        new Promise<readonly { prompt: string }[]>((resolve) => {
+          resolveFirstGenerate = resolve;
+        }),
+    );
+    const secondGenerate = vi
+      .fn()
+      .mockResolvedValue([{ prompt: "from second adapter" }]);
+    const chat = createChatHelpers([
+      { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      {
+        id: "a1",
+        role: "assistant",
+        parts: [{ type: "text", text: "hello" }],
+      },
+    ]);
+
+    const { result, rerender } = renderHook(
+      ({ status, generate }) => {
+        chat.status = status;
+        return useAISDKRuntime(chat, {
+          adapters: { suggestion: { generate } },
+        });
+      },
+      {
+        initialProps: {
+          status: "submitted" as string,
+          generate: firstGenerate,
+        },
+      },
+    );
+
+    rerender({ status: "ready", generate: firstGenerate });
+
+    await waitFor(() => {
+      expect(firstGenerate).toHaveBeenCalledTimes(1);
+    });
+    const firstSignal = firstGenerate.mock.calls[0]![0].signal as AbortSignal;
+
+    rerender({ status: "ready", generate: secondGenerate });
+
+    expect(firstSignal.aborted).toBe(true);
+    await waitFor(() => {
+      expect(secondGenerate).toHaveBeenCalledTimes(1);
+      expect(result.current.thread.getState().suggestions).toEqual([
+        { prompt: "from second adapter" },
+      ]);
+    });
+
+    resolveFirstGenerate([{ prompt: "stale" }]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+    expect(result.current.thread.getState().suggestions).toEqual([
+      { prompt: "from second adapter" },
+    ]);
+  });
+
   it("merges consecutive assistant messages into one turn by default", async () => {
     const chat = createChatHelpers([
       { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },

--- a/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
+++ b/packages/react-ai-sdk/src/ui/use-chat/useAISDKRuntime.ts
@@ -128,7 +128,8 @@ const useGeneratedSuggestions = (
   messagesRef.current = messages;
   const adapterRef = useRef(suggestionAdapter);
   adapterRef.current = suggestionAdapter;
-  const hasAdapter = suggestionAdapter != null;
+  const generate = suggestionAdapter?.generate;
+  const previousGenerateRef = useRef(generate);
 
   useEffect(() => {
     const clearSuggestions = () => {
@@ -136,6 +137,10 @@ const useGeneratedSuggestions = (
       controllerRef.current = null;
       setSuggestions((prev) => (prev.length === 0 ? prev : EMPTY_SUGGESTIONS));
     };
+
+    const generateChanged = previousGenerateRef.current !== generate;
+    previousGenerateRef.current = generate;
+    if (generateChanged) clearSuggestions();
 
     const adapter = adapterRef.current;
     if (!adapter) {
@@ -152,7 +157,7 @@ const useGeneratedSuggestions = (
       return;
     }
 
-    if (!wasRunningRef.current) return;
+    if (!wasRunningRef.current && !generateChanged) return;
     wasRunningRef.current = false;
 
     const currentMessages = messagesRef.current;
@@ -177,7 +182,7 @@ const useGeneratedSuggestions = (
         });
       } catch {}
     })();
-  }, [hasAdapter, isRunning]);
+  }, [generate, isRunning]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary

- detect changes to the active suggestion generator
- abort and clear suggestions produced by the previous adapter
- regenerate suggestions for the settled assistant message with the replacement adapter

## Why

While switching the suggestion adapter from A to B, I found that the generated-suggestions effect only tracked whether an adapter existed. Because both adapters were present, the effect did not rerun: an in-flight request from A remained active, B was never called, and A could publish stale suggestions after an account, workspace, or model change.

The adapter has one behavioral entry point, `generate`. Tracking that function detects a real generator replacement while allowing callers to recreate the surrounding `{ generate }` object without restarting suggestion generation.

## Verification

- reproduced the previous behavior with an A-to-B replacement test: A was not aborted and B was not invoked
- verified A is aborted, B runs once, and A cannot overwrite B after resolving late
- `pnpm --filter @assistant-ui/react-ai-sdk test` (14 files, 214 tests)
- `pnpm --filter @assistant-ui/react-ai-sdk build`
- changed files pass oxlint, oxfmt, and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.0csetrN5CCBvc5YmUUO3f5cjL1Q6pm1_dp511dUwUjZOzh4JPgwMztxfGLc?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->