### PR TITLE
feat(react): speech adapter for ExternalThread

### DIFF
--- a/.changeset/external-thread-speech-adapter.md
+++ b/.changeset/external-thread-speech-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: speech synthesis adapter support in ExternalThread

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2197,6 +2197,7 @@ type ExternalThreadProps = {
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   onLoadExternalState?: ((state: unknown) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  speechAdapter?: SpeechSynthesisAdapter | undefined;
   queue?: ExternalThreadQueueAdapter;
   branches?: ExternalThreadBranchAdapter;
   onRespondToToolApproval?: (options: RespondToToolApprovalOptions) => void;

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -734,19 +734,25 @@ const ComposerClientResource = resource(useComposerClientResource);
 const createSpeechController = (
   notify: (speech: SpeechState | undefined) => void,
 ) => {
-  let session: { messageId: string; stop: () => void } | undefined;
+  let session: { messageId: string; cancel: () => void } | undefined;
+
+  const clear = () => {
+    session?.cancel();
+    session = undefined;
+  };
 
   return {
     speak: (
       adapter: SpeechSynthesisAdapter,
       message: ExternalThreadMessage,
     ) => {
-      session?.stop();
+      clear();
 
       const utterance = adapter.speak(getThreadMessageText(message));
-      const unsub = utterance.subscribe(() => {
+      let unsub: (() => void) | undefined;
+      unsub = utterance.subscribe(() => {
         if (utterance.status.type === "ended") {
-          unsub();
+          unsub?.();
           session = undefined;
           notify(undefined);
         } else {
@@ -754,28 +760,37 @@ const createSpeechController = (
         }
       });
 
-      notify({ messageId: message.id, status: utterance.status });
+      if (utterance.status.type === "ended") {
+        unsub();
+        notify(undefined);
+        return;
+      }
 
       session = {
         messageId: message.id,
-        stop: () => {
+        cancel: () => {
           utterance.cancel();
-          unsub();
-          session = undefined;
-          notify(undefined);
+          unsub!();
         },
       };
+      notify({ messageId: message.id, status: utterance.status });
     },
     stop: () => {
       if (!session) throw new Error("No message is being spoken");
-      session.stop();
+      clear();
+      notify(undefined);
     },
     stopMessage: (messageId: string) => {
       if (session?.messageId !== messageId)
         throw new Error("Message is not being spoken");
-      session.stop();
+      clear();
+      notify(undefined);
     },
-    dispose: () => session?.stop(),
+    dispose: () => {
+      if (!session) return;
+      clear();
+      notify(undefined);
+    },
   };
 };
 
@@ -827,10 +842,12 @@ const useExternalThread = ({
   const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
   const [speechController] = useState(() => createSpeechController(setSpeech));
 
-  useEffect(
-    () => () => speechController.dispose(),
-    [speechAdapter, speechController],
-  );
+  const hasSpeechAdapter = !!speechAdapter;
+  useEffect(() => {
+    if (!hasSpeechAdapter) speechController.dispose();
+  }, [hasSpeechAdapter, speechController]);
+
+  useEffect(() => () => speechController.dispose(), [speechController]);
 
   const handleSpeak = (message: ExternalThreadMessage) => {
     if (!speechAdapter) throw new Error("Speech adapter not configured");

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -248,10 +248,7 @@ const useMessageClient = ({
       onReload?.();
     },
     speak: onSpeak,
-    stopSpeaking: () => {
-      if (!speech) throw new Error("Message is not being spoken");
-      onStopSpeaking();
-    },
+    stopSpeaking: onStopSpeaking,
     submitFeedback: () => {},
     switchToBranch: ({ position, branchId }) => {
       if (!branches) return;
@@ -734,6 +731,53 @@ const useComposerClientResource = ({
 
 const ComposerClientResource = resource(useComposerClientResource);
 
+const createSpeechController = (
+  notify: (speech: SpeechState | undefined) => void,
+) => {
+  let session: { messageId: string; stop: () => void } | undefined;
+
+  return {
+    speak: (
+      adapter: SpeechSynthesisAdapter,
+      message: ExternalThreadMessage,
+    ) => {
+      session?.stop();
+
+      const utterance = adapter.speak(getThreadMessageText(message));
+      const unsub = utterance.subscribe(() => {
+        if (utterance.status.type === "ended") {
+          session = undefined;
+          notify(undefined);
+        } else {
+          notify({ messageId: message.id, status: utterance.status });
+        }
+      });
+
+      notify({ messageId: message.id, status: utterance.status });
+
+      session = {
+        messageId: message.id,
+        stop: () => {
+          utterance.cancel();
+          unsub();
+          session = undefined;
+          notify(undefined);
+        },
+      };
+    },
+    stop: () => {
+      if (!session) throw new Error("No message is being spoken");
+      session.stop();
+    },
+    stopMessage: (messageId: string) => {
+      if (session?.messageId !== messageId)
+        throw new Error("Message is not being spoken");
+      session.stop();
+    },
+    dispose: () => session?.stop(),
+  };
+};
+
 const dedupeMessagesById = (messages: readonly ExternalThreadMessage[]) => {
   const seenIds = new Set<string>();
   const deduped: ExternalThreadMessage[] = [];
@@ -780,37 +824,14 @@ const useExternalThread = ({
   );
 
   const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
-  const stopSpeakingRef = useRef<(() => void) | undefined>(undefined);
+  const [speechController] = useState(() => createSpeechController(setSpeech));
 
-  const handleSpeak = useEffectEvent((message: ExternalThreadMessage) => {
+  useEffect(() => () => speechController.dispose(), [speechController]);
+
+  const handleSpeak = (message: ExternalThreadMessage) => {
     if (!speechAdapter) throw new Error("Speech adapter not configured");
-
-    stopSpeakingRef.current?.();
-
-    const utterance = speechAdapter.speak(getThreadMessageText(message));
-    const unsub = utterance.subscribe(() => {
-      if (utterance.status.type === "ended") {
-        stopSpeakingRef.current = undefined;
-        setSpeech(undefined);
-      } else {
-        setSpeech({ messageId: message.id, status: utterance.status });
-      }
-    });
-
-    setSpeech({ messageId: message.id, status: utterance.status });
-
-    stopSpeakingRef.current = () => {
-      utterance.cancel();
-      unsub();
-      setSpeech(undefined);
-      stopSpeakingRef.current = undefined;
-    };
-  });
-
-  const handleStopSpeaking = useEffectEvent(() => {
-    if (!stopSpeakingRef.current) throw new Error("No message is being spoken");
-    stopSpeakingRef.current();
-  });
+    speechController.speak(speechAdapter, message);
+  };
 
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);
@@ -835,7 +856,7 @@ const useExternalThread = ({
         attachmentAdapter,
         speech: speech?.messageId === msg.id ? speech : undefined,
         onSpeak: () => handleSpeak(msg),
-        onStopSpeaking: handleStopSpeaking,
+        onStopSpeaking: () => speechController.stopMessage(msg.id),
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));
@@ -998,7 +1019,7 @@ const useExternalThread = ({
       }
       return messageClients.get(selector);
     },
-    stopSpeaking: handleStopSpeaking,
+    stopSpeaking: speechController.stop,
     connectVoice: () => {},
     disconnectVoice: () => {},
     getVoiceVolume: () => 0,

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -782,7 +782,7 @@ const useExternalThread = ({
   const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
   const stopSpeakingRef = useRef<(() => void) | undefined>(undefined);
 
-  const handleSpeak = (message: ExternalThreadMessage) => {
+  const handleSpeak = useEffectEvent((message: ExternalThreadMessage) => {
     if (!speechAdapter) throw new Error("Speech adapter not configured");
 
     stopSpeakingRef.current?.();
@@ -805,12 +805,12 @@ const useExternalThread = ({
       setSpeech(undefined);
       stopSpeakingRef.current = undefined;
     };
-  };
+  });
 
-  const handleStopSpeaking = () => {
+  const handleStopSpeaking = useEffectEvent(() => {
     if (!stopSpeakingRef.current) throw new Error("No message is being spoken");
     stopSpeakingRef.current();
-  };
+  });
 
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -737,8 +737,10 @@ const createSpeechController = (
   let session: { messageId: string; cancel: () => void } | undefined;
 
   const clear = () => {
-    session?.cancel();
+    if (!session) return;
+    session.cancel();
     session = undefined;
+    notify(undefined);
   };
 
   return {
@@ -769,8 +771,8 @@ const createSpeechController = (
       session = {
         messageId: message.id,
         cancel: () => {
-          utterance.cancel();
           unsub!();
+          utterance.cancel();
         },
       };
       notify({ messageId: message.id, status: utterance.status });
@@ -778,19 +780,13 @@ const createSpeechController = (
     stop: () => {
       if (!session) throw new Error("No message is being spoken");
       clear();
-      notify(undefined);
     },
     stopMessage: (messageId: string) => {
       if (session?.messageId !== messageId)
         throw new Error("Message is not being spoken");
       clear();
-      notify(undefined);
     },
-    dispose: () => {
-      if (!session) return;
-      clear();
-      notify(undefined);
-    },
+    dispose: clear,
   };
 };
 
@@ -839,10 +835,13 @@ const useExternalThread = ({
     [messagesProp],
   );
 
-  const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
+  const [speechState, setSpeech] = useState<SpeechState | undefined>(
+    undefined,
+  );
   const [speechController] = useState(() => createSpeechController(setSpeech));
 
   const hasSpeechAdapter = !!speechAdapter;
+  const speech = hasSpeechAdapter ? speechState : undefined;
   useEffect(() => {
     if (!hasSpeechAdapter) speechController.dispose();
   }, [hasSpeechAdapter, speechController]);

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -33,6 +33,8 @@ import type {
   ExternalThreadQueueAdapter,
   ExternalThreadBranchAdapter,
   QueuePlacement,
+  SpeechState,
+  SpeechSynthesisAdapter,
 } from "@assistant-ui/core";
 import { ToolResponse } from "assistant-stream";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -97,6 +99,7 @@ export type ExternalThreadProps = {
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   onLoadExternalState?: ((state: unknown) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  speechAdapter?: SpeechSynthesisAdapter | undefined;
   /** Queue adapter for runtimes that support message queuing and steering. */
   queue?: ExternalThreadQueueAdapter;
   /** Branch adapter for runtimes that track sibling variants of messages. */
@@ -119,6 +122,9 @@ type MessageClientProps = {
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  speech: SpeechState | undefined;
+  onSpeak: () => void;
+  onStopSpeaking: () => void;
 };
 
 // Message Client - minimal implementation
@@ -134,6 +140,9 @@ const useMessageClient = ({
   onAddToolResult,
   onResumeToolCall,
   attachmentAdapter,
+  speech,
+  onSpeak,
+  onStopSpeaking,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -211,7 +220,7 @@ const useMessageClient = ({
       isLast: false, // Will be set by thread
       branchNumber,
       branchCount,
-      speech: undefined,
+      speech,
       parts: partClients.state,
       isCopied,
       isHovering,
@@ -228,6 +237,7 @@ const useMessageClient = ({
     partClients.state,
     branchNumber,
     branchCount,
+    speech,
   ]);
 
   return {
@@ -237,8 +247,11 @@ const useMessageClient = ({
     reload: () => {
       onReload?.();
     },
-    speak: () => {},
-    stopSpeaking: () => {},
+    speak: onSpeak,
+    stopSpeaking: () => {
+      if (!speech) throw new Error("Message is not being spoken");
+      onStopSpeaking();
+    },
     submitFeedback: () => {},
     switchToBranch: ({ position, branchId }) => {
       if (!branches) return;
@@ -756,6 +769,7 @@ const useExternalThread = ({
   onResumeToolCall,
   onLoadExternalState,
   attachmentAdapter,
+  speechAdapter,
   queue,
   branches,
   onRespondToToolApproval,
@@ -764,6 +778,39 @@ const useExternalThread = ({
     () => dedupeMessagesById(messagesProp),
     [messagesProp],
   );
+
+  const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
+  const stopSpeakingRef = useRef<(() => void) | undefined>(undefined);
+
+  const handleSpeak = (message: ExternalThreadMessage) => {
+    if (!speechAdapter) throw new Error("Speech adapter not configured");
+
+    stopSpeakingRef.current?.();
+
+    const utterance = speechAdapter.speak(getThreadMessageText(message));
+    const unsub = utterance.subscribe(() => {
+      if (utterance.status.type === "ended") {
+        stopSpeakingRef.current = undefined;
+        setSpeech(undefined);
+      } else {
+        setSpeech({ messageId: message.id, status: utterance.status });
+      }
+    });
+
+    setSpeech({ messageId: message.id, status: utterance.status });
+
+    stopSpeakingRef.current = () => {
+      utterance.cancel();
+      unsub();
+      setSpeech(undefined);
+      stopSpeakingRef.current = undefined;
+    };
+  };
+
+  const handleStopSpeaking = () => {
+    if (!stopSpeakingRef.current) throw new Error("No message is being spoken");
+    stopSpeakingRef.current();
+  };
 
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);
@@ -786,6 +833,9 @@ const useExternalThread = ({
         onAddToolResult,
         onResumeToolCall,
         attachmentAdapter,
+        speech: speech?.messageId === msg.id ? speech : undefined,
+        onSpeak: () => handleSpeak(msg),
+        onStopSpeaking: handleStopSpeaking,
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));
@@ -833,6 +883,7 @@ const useExternalThread = ({
   const hasEdit = !!onEdit;
   const hasReload = !!onReload;
   const hasAttachments = !!attachmentAdapter;
+  const hasSpeech = !!speechAdapter;
   const state = useMemo(() => {
     const messageStates = messageClients.state.map((s, idx, arr) => ({
       ...s,
@@ -850,7 +901,7 @@ const useExternalThread = ({
         reload: hasReload,
         refetchThread: false,
         cancel: isRunning,
-        speech: false,
+        speech: hasSpeech,
         attachments: hasAttachments,
         feedback: false,
         voice: false,
@@ -864,7 +915,7 @@ const useExternalThread = ({
       state: threadState ?? {},
       suggestions: [],
       extras,
-      speech: undefined,
+      speech,
       voice: undefined,
       composer: composerClient.state,
     };
@@ -879,6 +930,8 @@ const useExternalThread = ({
     hasEdit,
     hasReload,
     hasAttachments,
+    hasSpeech,
+    speech,
     messageClients.state,
     composerClient.state,
   ]);
@@ -945,7 +998,7 @@ const useExternalThread = ({
       }
       return messageClients.get(selector);
     },
-    stopSpeaking: () => {},
+    stopSpeaking: handleStopSpeaking,
     connectVoice: () => {},
     disconnectVoice: () => {},
     getVoiceVolume: () => 0,

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -835,9 +835,7 @@ const useExternalThread = ({
     [messagesProp],
   );
 
-  const [speechState, setSpeech] = useState<SpeechState | undefined>(
-    undefined,
-  );
+  const [speechState, setSpeech] = useState<SpeechState | undefined>(undefined);
   const [speechController] = useState(() => createSpeechController(setSpeech));
 
   const hasSpeechAdapter = !!speechAdapter;

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -746,6 +746,7 @@ const createSpeechController = (
       const utterance = adapter.speak(getThreadMessageText(message));
       const unsub = utterance.subscribe(() => {
         if (utterance.status.type === "ended") {
+          unsub();
           session = undefined;
           notify(undefined);
         } else {
@@ -826,7 +827,10 @@ const useExternalThread = ({
   const [speech, setSpeech] = useState<SpeechState | undefined>(undefined);
   const [speechController] = useState(() => createSpeechController(setSpeech));
 
-  useEffect(() => () => speechController.dispose(), [speechController]);
+  useEffect(
+    () => () => speechController.dispose(),
+    [speechAdapter, speechController],
+  );
 
   const handleSpeak = (message: ExternalThreadMessage) => {
     if (!speechAdapter) throw new Error("Speech adapter not configured");

--- a/packages/react/src/tests/external-thread-speech.test.tsx
+++ b/packages/react/src/tests/external-thread-speech.test.tsx
@@ -248,7 +248,7 @@ describe("ExternalThread speech", () => {
     expect(aui().thread.getState().speech).toBeUndefined();
   });
 
-  it("cancels the utterance when the adapter is replaced", async () => {
+  it("keeps the utterance alive when the adapter identity changes", async () => {
     const first = createFakeAdapter();
     const second = createFakeAdapter();
     const aui = renderThreadWithProps({ speechAdapter: first.adapter });
@@ -260,14 +260,16 @@ describe("ExternalThread speech", () => {
       aui.rerender({ speechAdapter: second.adapter });
     });
 
-    expect(first.utterances[0]!.cancel).toHaveBeenCalledTimes(1);
-    await waitFor(() => {
-      expect(aui().thread.getState().speech).toBeUndefined();
+    expect(first.utterances[0]!.cancel).not.toHaveBeenCalled();
+    expect(aui().thread.getState().speech).toEqual({
+      messageId: "a1",
+      status: { type: "starting" },
     });
 
     await act(async () => {
       aui().thread.message({ id: "u1" }).speak();
     });
+    expect(first.utterances[0]!.cancel).toHaveBeenCalledTimes(1);
     expect(second.utterances[0]!.text).toBe("hi");
     await waitFor(() => {
       expect(aui().thread.getState().speech).toEqual({
@@ -275,6 +277,30 @@ describe("ExternalThread speech", () => {
         status: { type: "starting" },
       });
     });
+  });
+
+  it("handles utterances that end synchronously on subscribe", async () => {
+    const cancel = vi.fn();
+    const adapter: SpeechSynthesisAdapter = {
+      speak: () => ({
+        status: { type: "ended", reason: "finished" },
+        cancel,
+        subscribe: (callback) => {
+          callback();
+          return () => {};
+        },
+      }),
+    };
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+
+    expect(aui().thread.getState().speech).toBeUndefined();
+    expect(() => aui().thread.stopSpeaking()).toThrow(
+      "No message is being spoken",
+    );
   });
 
   it("cancels the utterance on unmount", async () => {

--- a/packages/react/src/tests/external-thread-speech.test.tsx
+++ b/packages/react/src/tests/external-thread-speech.test.tsx
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import type { SpeechSynthesisAdapter } from "@assistant-ui/core";
+import type {
+  ExternalThreadMessage,
+  ExternalThreadProps,
+} from "../client/ExternalThread";
+import { ExternalThread } from "../client/ExternalThread";
+
+const MESSAGES = [
+  {
+    id: "u1",
+    role: "user",
+    content: [{ type: "text", text: "hi" }],
+    createdAt: new Date(0),
+    attachments: [],
+    metadata: { custom: {} },
+  },
+  {
+    id: "a1",
+    role: "assistant",
+    content: [{ type: "text", text: "hello there" }],
+    createdAt: new Date(0),
+    metadata: { custom: {} },
+  },
+] as unknown as readonly ExternalThreadMessage[];
+
+type FakeUtterance = {
+  text: string;
+  cancel: ReturnType<typeof vi.fn>;
+  emit: (status: SpeechSynthesisAdapter.Status) => void;
+};
+
+const createFakeAdapter = () => {
+  const utterances: FakeUtterance[] = [];
+  const adapter: SpeechSynthesisAdapter = {
+    speak: (text) => {
+      const subscribers = new Set<() => void>();
+      const cancel = vi.fn();
+      const utterance: SpeechSynthesisAdapter.Utterance = {
+        status: { type: "starting" },
+        cancel,
+        subscribe: (callback) => {
+          subscribers.add(callback);
+          return () => subscribers.delete(callback);
+        },
+      };
+      utterances.push({
+        text,
+        cancel,
+        emit: (status) => {
+          utterance.status = status;
+          for (const subscriber of subscribers) subscriber();
+        },
+      });
+      return utterance;
+    },
+  };
+  return { adapter, utterances };
+};
+
+const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC = () => {
+    const aui = useAui({
+      thread: ExternalThread({
+        messages: MESSAGES,
+        isRunning: false,
+        ...props,
+      }),
+    });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+
+  render(<App />);
+  return () => captured.aui!;
+};
+
+describe("ExternalThread speech", () => {
+  it("reports the speech capability based on adapter presence", () => {
+    const withoutAdapter = renderThreadWithProps({});
+    expect(withoutAdapter().thread.getState().capabilities.speech).toBe(false);
+
+    const { adapter } = createFakeAdapter();
+    const withAdapter = renderThreadWithProps({ speechAdapter: adapter });
+    expect(withAdapter().thread.getState().capabilities.speech).toBe(true);
+  });
+
+  it("throws on speak when no adapter is configured", () => {
+    const aui = renderThreadWithProps({});
+    expect(() => aui().thread.message({ id: "a1" }).speak()).toThrow(
+      "Speech adapter not configured",
+    );
+  });
+
+  it("tracks utterance status in thread and message state", async () => {
+    const { adapter, utterances } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+
+    expect(utterances[0]!.text).toBe("hello there");
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toEqual({
+        messageId: "a1",
+        status: { type: "starting" },
+      });
+      expect(aui().thread.message({ id: "a1" }).getState().speech).toEqual({
+        messageId: "a1",
+        status: { type: "starting" },
+      });
+      expect(
+        aui().thread.message({ id: "u1" }).getState().speech,
+      ).toBeUndefined();
+    });
+
+    await act(async () => {
+      utterances[0]!.emit({ type: "running" });
+    });
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toEqual({
+        messageId: "a1",
+        status: { type: "running" },
+      });
+    });
+
+    await act(async () => {
+      utterances[0]!.emit({ type: "ended", reason: "finished" });
+    });
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeUndefined();
+      expect(
+        aui().thread.message({ id: "a1" }).getState().speech,
+      ).toBeUndefined();
+    });
+  });
+
+  it("cancels the previous utterance when a new speak starts", async () => {
+    const { adapter, utterances } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await act(async () => {
+      aui().thread.message({ id: "u1" }).speak();
+    });
+
+    expect(utterances).toHaveLength(2);
+    expect(utterances[0]!.cancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toEqual({
+        messageId: "u1",
+        status: { type: "starting" },
+      });
+    });
+
+    // the superseded utterance no longer affects thread state
+    await act(async () => {
+      utterances[0]!.emit({ type: "ended", reason: "cancelled" });
+    });
+    expect(aui().thread.getState().speech).toEqual({
+      messageId: "u1",
+      status: { type: "starting" },
+    });
+  });
+
+  it("stopSpeaking cancels the utterance and clears state", async () => {
+    const { adapter, utterances } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await act(async () => {
+      aui().thread.stopSpeaking();
+    });
+
+    expect(utterances[0]!.cancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeUndefined();
+    });
+    expect(() => aui().thread.stopSpeaking()).toThrow(
+      "No message is being spoken",
+    );
+  });
+
+  it("message stopSpeaking throws unless that message is being spoken", async () => {
+    const { adapter } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeDefined();
+    });
+
+    expect(() => aui().thread.message({ id: "u1" }).stopSpeaking()).toThrow(
+      "Message is not being spoken",
+    );
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).stopSpeaking();
+    });
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeUndefined();
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+});

--- a/packages/react/src/tests/external-thread-speech.test.tsx
+++ b/packages/react/src/tests/external-thread-speech.test.tsx
@@ -69,7 +69,7 @@ const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
     captured.aui = useAui();
     return null;
   };
-  const App: FC = () => {
+  const App: FC<{ props: Partial<ExternalThreadProps> }> = ({ props }) => {
     const aui = useAui({
       thread: ExternalThread({
         messages: MESSAGES,
@@ -84,8 +84,12 @@ const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
     );
   };
 
-  render(<App />);
-  return () => captured.aui!;
+  const view = render(<App props={props} />);
+  const aui = () => captured.aui!;
+  aui.rerender = (nextProps: Partial<ExternalThreadProps>) =>
+    view.rerender(<App props={nextProps} />);
+  aui.unmount = () => view.unmount();
+  return aui;
 };
 
 describe("ExternalThread speech", () => {
@@ -169,7 +173,6 @@ describe("ExternalThread speech", () => {
       });
     });
 
-    // the superseded utterance no longer affects thread state
     await act(async () => {
       utterances[0]!.emit({ type: "ended", reason: "cancelled" });
     });
@@ -220,6 +223,72 @@ describe("ExternalThread speech", () => {
     await waitFor(() => {
       expect(aui().thread.getState().speech).toBeUndefined();
     });
+  });
+
+  it("cancels the utterance when the adapter is removed", async () => {
+    const { adapter, utterances } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await act(async () => {
+      aui.rerender({});
+    });
+
+    expect(utterances[0]!.cancel).toHaveBeenCalledTimes(1);
+    expect(aui().thread.getState().capabilities.speech).toBe(false);
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeUndefined();
+    });
+
+    await act(async () => {
+      utterances[0]!.emit({ type: "running" });
+    });
+    expect(aui().thread.getState().speech).toBeUndefined();
+  });
+
+  it("cancels the utterance when the adapter is replaced", async () => {
+    const first = createFakeAdapter();
+    const second = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: first.adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await act(async () => {
+      aui.rerender({ speechAdapter: second.adapter });
+    });
+
+    expect(first.utterances[0]!.cancel).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toBeUndefined();
+    });
+
+    await act(async () => {
+      aui().thread.message({ id: "u1" }).speak();
+    });
+    expect(second.utterances[0]!.text).toBe("hi");
+    await waitFor(() => {
+      expect(aui().thread.getState().speech).toEqual({
+        messageId: "u1",
+        status: { type: "starting" },
+      });
+    });
+  });
+
+  it("cancels the utterance on unmount", async () => {
+    const { adapter, utterances } = createFakeAdapter();
+    const aui = renderThreadWithProps({ speechAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+    });
+    await act(async () => {
+      aui.unmount();
+    });
+
+    expect(utterances[0]!.cancel).toHaveBeenCalledTimes(1);
   });
 
   afterEach(() => {

--- a/packages/react/src/tests/external-thread-speech.test.tsx
+++ b/packages/react/src/tests/external-thread-speech.test.tsx
@@ -200,23 +200,23 @@ describe("ExternalThread speech", () => {
   });
 
   it("message stopSpeaking throws unless that message is being spoken", async () => {
-    const { adapter } = createFakeAdapter();
+    const { adapter, utterances } = createFakeAdapter();
     const aui = renderThreadWithProps({ speechAdapter: adapter });
 
-    await act(async () => {
-      aui().thread.message({ id: "a1" }).speak();
-    });
-    await waitFor(() => {
-      expect(aui().thread.getState().speech).toBeDefined();
-    });
-
-    expect(() => aui().thread.message({ id: "u1" }).stopSpeaking()).toThrow(
+    expect(() => aui().thread.message({ id: "a1" }).stopSpeaking()).toThrow(
       "Message is not being spoken",
     );
 
+    // speak and stopSpeaking in the same tick, before any re-render
     await act(async () => {
+      aui().thread.message({ id: "a1" }).speak();
+      expect(() => aui().thread.message({ id: "u1" }).stopSpeaking()).toThrow(
+        "Message is not being spoken",
+      );
       aui().thread.message({ id: "a1" }).stopSpeaking();
     });
+
+    expect(utterances[0]!.cancel).toHaveBeenCalledTimes(1);
     await waitFor(() => {
       expect(aui().thread.getState().speech).toBeUndefined();
     });

--- a/packages/react/src/tests/external-thread-speech.test.tsx
+++ b/packages/react/src/tests/external-thread-speech.test.tsx
@@ -40,7 +40,12 @@ const createFakeAdapter = () => {
   const adapter: SpeechSynthesisAdapter = {
     speak: (text) => {
       const subscribers = new Set<() => void>();
-      const cancel = vi.fn();
+      // mirror WebSpeechSynthesisAdapter: cancel transitions to ended and notifies synchronously
+      const cancel = vi.fn(() => {
+        if (utterance.status.type === "ended") return;
+        utterance.status = { type: "ended", reason: "cancelled" };
+        for (const subscriber of subscribers) subscriber();
+      });
       const utterance: SpeechSynthesisAdapter.Utterance = {
         status: { type: "starting" },
         cancel,


### PR DESCRIPTION
## Summary

Adds a `speechAdapter?: SpeechSynthesisAdapter | undefined` option to the store-based `ExternalThread`, wiring the message-level speak controls that were previously stubbed.

Mirrors the legacy `BaseThreadRuntimeCore` speak machinery (no new semantics):
- `speak()` creates an utterance via the adapter from the message text and tracks `{ messageId, status }` in thread state; message state exposes it only for the spoken message
- starting a new speak cancels the prior utterance; superseded utterances no longer affect state
- `stopSpeaking()` cancels and clears state; throws when nothing is being spoken (message-level throws "Message is not being spoken" for other messages, matching `MessageRuntimeImpl`)
- the `speech` capability flag reflects adapter presence

Includes contract tests (`external-thread-speech.test.tsx`), a changeset, and the regenerated api surface.

For @yonom's manual review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.5Ls-I6ZnVPvBp9IlIEeRi6CIwgEUnlkp41FYZ9pqCj2X2FElDWnriiAIBl0?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->