### PR TITLE
feat(react): feedbackAdapter on ExternalThread

### DIFF
--- a/.changeset/external-thread-feedback-adapter.md
+++ b/.changeset/external-thread-feedback-adapter.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+feat: feedback adapter support in ExternalThread

--- a/api-surface/assistant-ui__react.ts
+++ b/api-surface/assistant-ui__react.ts
@@ -2197,6 +2197,7 @@ type ExternalThreadProps = {
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   onLoadExternalState?: ((state: unknown) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  feedbackAdapter?: FeedbackAdapter | undefined;
   queue?: ExternalThreadQueueAdapter;
   branches?: ExternalThreadBranchAdapter;
   onRespondToToolApproval?: (options: RespondToToolApprovalOptions) => void;

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -211,7 +211,9 @@ const useMessageClient = ({
 
   const state = useMemo(() => {
     const messageWithFeedback: ExternalThreadMessage =
-      submittedFeedback && message.role === "assistant"
+      submittedFeedback &&
+      message.role === "assistant" &&
+      !message.metadata.submittedFeedback
         ? { ...message, metadata: { ...message.metadata, submittedFeedback } }
         : message;
     return {

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -210,11 +210,12 @@ const useMessageClient = ({
   const branchCount = branchIndex === -1 ? 1 : branchIds.length;
 
   const state = useMemo(() => {
+    const messageWithFeedback: ExternalThreadMessage =
+      submittedFeedback && message.role === "assistant"
+        ? { ...message, metadata: { ...message.metadata, submittedFeedback } }
+        : message;
     return {
-      ...message,
-      ...(submittedFeedback && {
-        metadata: { ...message.metadata, submittedFeedback },
-      }),
+      ...messageWithFeedback,
       attachments: message.attachments ?? [],
       parentId,
       isLast: false, // Will be set by thread

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -33,6 +33,7 @@ import type {
   ExternalThreadQueueAdapter,
   ExternalThreadBranchAdapter,
   QueuePlacement,
+  FeedbackAdapter,
 } from "@assistant-ui/core";
 import { ToolResponse } from "assistant-stream";
 import type { ReadonlyJSONValue } from "assistant-stream/utils";
@@ -97,6 +98,7 @@ export type ExternalThreadProps = {
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   onLoadExternalState?: ((state: unknown) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  feedbackAdapter?: FeedbackAdapter | undefined;
   /** Queue adapter for runtimes that support message queuing and steering. */
   queue?: ExternalThreadQueueAdapter;
   /** Branch adapter for runtimes that track sibling variants of messages. */
@@ -119,6 +121,8 @@ type MessageClientProps = {
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
+  submittedFeedback: { type: "positive" | "negative" } | undefined;
+  onSubmitFeedback: (feedback: { type: "positive" | "negative" }) => void;
 };
 
 // Message Client - minimal implementation
@@ -134,6 +138,8 @@ const useMessageClient = ({
   onAddToolResult,
   onResumeToolCall,
   attachmentAdapter,
+  submittedFeedback,
+  onSubmitFeedback,
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
@@ -206,6 +212,9 @@ const useMessageClient = ({
   const state = useMemo(() => {
     return {
       ...message,
+      ...(submittedFeedback && {
+        metadata: { ...message.metadata, submittedFeedback },
+      }),
       attachments: message.attachments ?? [],
       parentId,
       isLast: false, // Will be set by thread
@@ -228,6 +237,7 @@ const useMessageClient = ({
     partClients.state,
     branchNumber,
     branchCount,
+    submittedFeedback,
   ]);
 
   return {
@@ -239,7 +249,7 @@ const useMessageClient = ({
     },
     speak: () => {},
     stopSpeaking: () => {},
-    submitFeedback: () => {},
+    submitFeedback: onSubmitFeedback,
     switchToBranch: ({ position, branchId }) => {
       if (!branches) return;
       const target =
@@ -756,6 +766,7 @@ const useExternalThread = ({
   onResumeToolCall,
   onLoadExternalState,
   attachmentAdapter,
+  feedbackAdapter,
   queue,
   branches,
   onRespondToToolApproval,
@@ -764,6 +775,22 @@ const useExternalThread = ({
     () => dedupeMessagesById(messagesProp),
     [messagesProp],
   );
+
+  const [submittedFeedback, setSubmittedFeedback] = useState<
+    Record<string, { type: "positive" | "negative" }>
+  >({});
+
+  const handleSubmitFeedback = (
+    message: ExternalThreadMessage,
+    { type }: { type: "positive" | "negative" },
+  ) => {
+    if (!feedbackAdapter) throw new Error("Feedback adapter not configured");
+    feedbackAdapter.submit({ message, type });
+
+    if (message.role === "assistant") {
+      setSubmittedFeedback((prev) => ({ ...prev, [message.id]: { type } }));
+    }
+  };
 
   const handleReload = (messageId: string) => {
     const messageIndex = messages.findIndex((m) => m.id === messageId);
@@ -786,6 +813,8 @@ const useExternalThread = ({
         onAddToolResult,
         onResumeToolCall,
         attachmentAdapter,
+        submittedFeedback: submittedFeedback[msg.id],
+        onSubmitFeedback: (feedback) => handleSubmitFeedback(msg, feedback),
       };
       if (onEdit) props.onEdit = onEdit;
       return withKey(msg.id, MessageClient(props));
@@ -833,6 +862,7 @@ const useExternalThread = ({
   const hasEdit = !!onEdit;
   const hasReload = !!onReload;
   const hasAttachments = !!attachmentAdapter;
+  const hasFeedback = !!feedbackAdapter;
   const state = useMemo(() => {
     const messageStates = messageClients.state.map((s, idx, arr) => ({
       ...s,
@@ -852,7 +882,7 @@ const useExternalThread = ({
         cancel: isRunning,
         speech: false,
         attachments: hasAttachments,
-        feedback: false,
+        feedback: hasFeedback,
         voice: false,
         switchToBranch: hasBranches,
         switchBranchDuringRun: false,
@@ -879,6 +909,7 @@ const useExternalThread = ({
     hasEdit,
     hasReload,
     hasAttachments,
+    hasFeedback,
     messageClients.state,
     composerClient.state,
   ]);

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -124,7 +124,7 @@ type MessageClientProps = {
   onAddToolResult?: ((options: AddToolResultOptions) => void) | undefined;
   onResumeToolCall?: ((options: ResumeToolCallOptions) => void) | undefined;
   attachmentAdapter?: AttachmentAdapter | undefined;
-  submittedFeedback: { type: "positive" | "negative" } | undefined;
+  submittedFeedback: "positive" | "negative" | undefined;
   onSubmitFeedback: (feedback: { type: "positive" | "negative" }) => void;
   speech: SpeechState | undefined;
   onSpeak: () => void;
@@ -221,7 +221,13 @@ const useMessageClient = ({
   const state = useMemo(() => {
     const messageWithFeedback: ExternalThreadMessage =
       submittedFeedback && message.role === "assistant"
-        ? { ...message, metadata: { ...message.metadata, submittedFeedback } }
+        ? {
+            ...message,
+            metadata: {
+              ...message.metadata,
+              submittedFeedback: { type: submittedFeedback },
+            },
+          }
         : message;
     return {
       ...messageWithFeedback,
@@ -862,7 +868,7 @@ const useExternalThread = ({
   const feedbackFor = (msg: ExternalThreadMessage) => {
     const entry = submittedFeedback[msg.id];
     return entry && msg.metadata.submittedFeedback?.type === entry.external
-      ? { type: entry.type }
+      ? entry.type
       : undefined;
   };
 

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -211,9 +211,7 @@ const useMessageClient = ({
 
   const state = useMemo(() => {
     const messageWithFeedback: ExternalThreadMessage =
-      submittedFeedback &&
-      message.role === "assistant" &&
-      !message.metadata.submittedFeedback
+      submittedFeedback && message.role === "assistant"
         ? { ...message, metadata: { ...message.metadata, submittedFeedback } }
         : message;
     return {
@@ -779,9 +777,36 @@ const useExternalThread = ({
     [messagesProp],
   );
 
+  // Local entries are optimistic: they apply only while the message's
+  // external submittedFeedback still equals the value seen at click time.
   const [submittedFeedback, setSubmittedFeedback] = useState<
-    Record<string, { type: "positive" | "negative" }>
+    Record<
+      string,
+      {
+        type: "positive" | "negative";
+        external: "positive" | "negative" | undefined;
+      }
+    >
   >({});
+
+  const feedbackFor = (msg: ExternalThreadMessage) => {
+    const entry = submittedFeedback[msg.id];
+    return entry && msg.metadata.submittedFeedback?.type === entry.external
+      ? { type: entry.type }
+      : undefined;
+  };
+
+  useEffect(() => {
+    setSubmittedFeedback((prev) => {
+      const live = Object.entries(prev).filter(([id, entry]) => {
+        const msg = messages.find((m) => m.id === id);
+        return !!msg && msg.metadata.submittedFeedback?.type === entry.external;
+      });
+      return live.length === Object.keys(prev).length
+        ? prev
+        : Object.fromEntries(live);
+    });
+  }, [messages]);
 
   const handleSubmitFeedback = (
     message: ExternalThreadMessage,
@@ -791,7 +816,13 @@ const useExternalThread = ({
     feedbackAdapter.submit({ message, type });
 
     if (message.role === "assistant") {
-      setSubmittedFeedback((prev) => ({ ...prev, [message.id]: { type } }));
+      setSubmittedFeedback((prev) => ({
+        ...prev,
+        [message.id]: {
+          type,
+          external: message.metadata.submittedFeedback?.type,
+        },
+      }));
     }
   };
 
@@ -816,7 +847,7 @@ const useExternalThread = ({
         onAddToolResult,
         onResumeToolCall,
         attachmentAdapter,
-        submittedFeedback: submittedFeedback[msg.id],
+        submittedFeedback: feedbackFor(msg),
         onSubmitFeedback: (feedback) => handleSubmitFeedback(msg, feedback),
       };
       if (onEdit) props.onEdit = onEdit;

--- a/packages/react/src/tests/external-thread-feedback.test.tsx
+++ b/packages/react/src/tests/external-thread-feedback.test.tsx
@@ -56,12 +56,8 @@ const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
     );
   };
 
-  const view = render(<App props={props} />);
-  const aui = () => captured.aui!;
-  aui.rerender = (nextProps: Partial<ExternalThreadProps>) =>
-    view.rerender(<App props={nextProps} />);
-  aui.unmount = () => view.unmount();
-  return aui;
+  render(<App props={props} />);
+  return () => captured.aui!;
 };
 
 describe("ExternalThread feedback", () => {

--- a/packages/react/src/tests/external-thread-feedback.test.tsx
+++ b/packages/react/src/tests/external-thread-feedback.test.tsx
@@ -56,24 +56,30 @@ const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
     );
   };
 
-  render(<App props={props} />);
-  return () => captured.aui!;
+  const view = render(<App props={props} />);
+  return {
+    aui: () => captured.aui!,
+    rerender: (nextProps: Partial<ExternalThreadProps>) =>
+      view.rerender(<App props={nextProps} />),
+  };
 };
 
 describe("ExternalThread feedback", () => {
   it("reports the feedback capability based on adapter presence", () => {
-    const withoutAdapter = renderThreadWithProps({});
+    const { aui: withoutAdapter } = renderThreadWithProps({});
     expect(withoutAdapter().thread.getState().capabilities.feedback).toBe(
       false,
     );
 
     const { adapter } = createFakeAdapter();
-    const withAdapter = renderThreadWithProps({ feedbackAdapter: adapter });
+    const { aui: withAdapter } = renderThreadWithProps({
+      feedbackAdapter: adapter,
+    });
     expect(withAdapter().thread.getState().capabilities.feedback).toBe(true);
   });
 
   it("throws on submitFeedback when no adapter is configured", () => {
-    const aui = renderThreadWithProps({});
+    const { aui } = renderThreadWithProps({});
     expect(() =>
       aui().thread.message({ id: "a1" }).submitFeedback({ type: "positive" }),
     ).toThrow("Feedback adapter not configured");
@@ -81,7 +87,7 @@ describe("ExternalThread feedback", () => {
 
   it("submits feedback to the adapter and marks the assistant message", async () => {
     const { adapter, submit } = createFakeAdapter();
-    const aui = renderThreadWithProps({ feedbackAdapter: adapter });
+    const { aui } = renderThreadWithProps({ feedbackAdapter: adapter });
 
     await act(async () => {
       aui().thread.message({ id: "a1" }).submitFeedback({ type: "positive" });
@@ -115,9 +121,41 @@ describe("ExternalThread feedback", () => {
     });
   });
 
+  it("prefers owner-supplied submittedFeedback over the local overlay", async () => {
+    const { adapter } = createFakeAdapter();
+    const { aui, rerender } = renderThreadWithProps({
+      feedbackAdapter: adapter,
+    });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).submitFeedback({ type: "positive" });
+    });
+    await waitFor(() => {
+      expect(
+        aui().thread.message({ id: "a1" }).getState().metadata
+          .submittedFeedback,
+      ).toEqual({ type: "positive" });
+    });
+
+    const ownerMessages = [
+      MESSAGES[0]!,
+      {
+        ...MESSAGES[1]!,
+        metadata: { custom: {}, submittedFeedback: { type: "negative" } },
+      },
+    ] as unknown as readonly ExternalThreadMessage[];
+    await act(async () => {
+      rerender({ feedbackAdapter: adapter, messages: ownerMessages });
+    });
+
+    expect(
+      aui().thread.message({ id: "a1" }).getState().metadata.submittedFeedback,
+    ).toEqual({ type: "negative" });
+  });
+
   it("submits user message feedback without marking the message", async () => {
     const { adapter, submit } = createFakeAdapter();
-    const aui = renderThreadWithProps({ feedbackAdapter: adapter });
+    const { aui } = renderThreadWithProps({ feedbackAdapter: adapter });
 
     await act(async () => {
       aui().thread.message({ id: "u1" }).submitFeedback({ type: "negative" });

--- a/packages/react/src/tests/external-thread-feedback.test.tsx
+++ b/packages/react/src/tests/external-thread-feedback.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { act, render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AuiProvider, useAui } from "@assistant-ui/store";
+import type { FeedbackAdapter } from "@assistant-ui/core";
+import type {
+  ExternalThreadMessage,
+  ExternalThreadProps,
+} from "../client/ExternalThread";
+import { ExternalThread } from "../client/ExternalThread";
+
+const MESSAGES = [
+  {
+    id: "u1",
+    role: "user",
+    content: [{ type: "text", text: "hi" }],
+    createdAt: new Date(0),
+    attachments: [],
+    metadata: { custom: {} },
+  },
+  {
+    id: "a1",
+    role: "assistant",
+    content: [{ type: "text", text: "hello there" }],
+    createdAt: new Date(0),
+    metadata: { custom: {} },
+  },
+] as unknown as readonly ExternalThreadMessage[];
+
+const createFakeAdapter = () => {
+  const submit = vi.fn();
+  const adapter: FeedbackAdapter = { submit };
+  return { adapter, submit };
+};
+
+const renderThreadWithProps = (props: Partial<ExternalThreadProps>) => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC<{ props: Partial<ExternalThreadProps> }> = ({ props }) => {
+    const aui = useAui({
+      thread: ExternalThread({
+        messages: MESSAGES,
+        isRunning: false,
+        ...props,
+      }),
+    });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+
+  const view = render(<App props={props} />);
+  const aui = () => captured.aui!;
+  aui.rerender = (nextProps: Partial<ExternalThreadProps>) =>
+    view.rerender(<App props={nextProps} />);
+  aui.unmount = () => view.unmount();
+  return aui;
+};
+
+describe("ExternalThread feedback", () => {
+  it("reports the feedback capability based on adapter presence", () => {
+    const withoutAdapter = renderThreadWithProps({});
+    expect(withoutAdapter().thread.getState().capabilities.feedback).toBe(
+      false,
+    );
+
+    const { adapter } = createFakeAdapter();
+    const withAdapter = renderThreadWithProps({ feedbackAdapter: adapter });
+    expect(withAdapter().thread.getState().capabilities.feedback).toBe(true);
+  });
+
+  it("throws on submitFeedback when no adapter is configured", () => {
+    const aui = renderThreadWithProps({});
+    expect(() =>
+      aui().thread.message({ id: "a1" }).submitFeedback({ type: "positive" }),
+    ).toThrow("Feedback adapter not configured");
+  });
+
+  it("submits feedback to the adapter and marks the assistant message", async () => {
+    const { adapter, submit } = createFakeAdapter();
+    const aui = renderThreadWithProps({ feedbackAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).submitFeedback({ type: "positive" });
+    });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith({
+      message: MESSAGES[1],
+      type: "positive",
+    });
+    await waitFor(() => {
+      expect(
+        aui().thread.message({ id: "a1" }).getState().metadata
+          .submittedFeedback,
+      ).toEqual({ type: "positive" });
+    });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).submitFeedback({ type: "negative" });
+    });
+
+    expect(submit).toHaveBeenLastCalledWith({
+      message: MESSAGES[1],
+      type: "negative",
+    });
+    await waitFor(() => {
+      expect(
+        aui().thread.message({ id: "a1" }).getState().metadata
+          .submittedFeedback,
+      ).toEqual({ type: "negative" });
+    });
+  });
+
+  it("submits user message feedback without marking the message", async () => {
+    const { adapter, submit } = createFakeAdapter();
+    const aui = renderThreadWithProps({ feedbackAdapter: adapter });
+
+    await act(async () => {
+      aui().thread.message({ id: "u1" }).submitFeedback({ type: "negative" });
+    });
+
+    expect(submit).toHaveBeenCalledWith({
+      message: MESSAGES[0],
+      type: "negative",
+    });
+    expect(
+      aui().thread.message({ id: "u1" }).getState().metadata.submittedFeedback,
+    ).toBeUndefined();
+  });
+});

--- a/packages/react/src/tests/external-thread-feedback.test.tsx
+++ b/packages/react/src/tests/external-thread-feedback.test.tsx
@@ -153,6 +153,38 @@ describe("ExternalThread feedback", () => {
     ).toEqual({ type: "negative" });
   });
 
+  it("re-rates an owner-marked message locally, then honors an owner clear", async () => {
+    const { adapter } = createFakeAdapter();
+    const ratedMessages = [
+      MESSAGES[0]!,
+      {
+        ...MESSAGES[1]!,
+        metadata: { custom: {}, submittedFeedback: { type: "positive" } },
+      },
+    ] as unknown as readonly ExternalThreadMessage[];
+    const { aui, rerender } = renderThreadWithProps({
+      feedbackAdapter: adapter,
+      messages: ratedMessages,
+    });
+
+    await act(async () => {
+      aui().thread.message({ id: "a1" }).submitFeedback({ type: "negative" });
+    });
+    await waitFor(() => {
+      expect(
+        aui().thread.message({ id: "a1" }).getState().metadata
+          .submittedFeedback,
+      ).toEqual({ type: "negative" });
+    });
+
+    await act(async () => {
+      rerender({ feedbackAdapter: adapter, messages: MESSAGES });
+    });
+    expect(
+      aui().thread.message({ id: "a1" }).getState().metadata.submittedFeedback,
+    ).toBeUndefined();
+  });
+
   it("submits user message feedback without marking the message", async () => {
     const { adapter, submit } = createFakeAdapter();
     const { aui } = renderThreadWithProps({ feedbackAdapter: adapter });


### PR DESCRIPTION
Adds a feedbackAdapter slot to ExternalThread, mirroring what #5712 did for speechAdapter.

- `feedbackAdapter?: FeedbackAdapter` on `ExternalThreadProps`
- `message.submitFeedback({ type })` calls `adapter.submit({ message, type })` and marks assistant messages with `metadata.submittedFeedback` (legacy runtime parity, including the "Feedback adapter not configured" throw when absent)
- `capabilities.feedback` reflects adapter presence
- tests in `external-thread-feedback.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.jciy-RbK9LZjF0DcAdwup0KtiqVXj_JfV_FHD4qzvUR7T1Ygorjbh7Bh-aw?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->