### PR TITLE
fix(cloud-ai-sdk): clear deleted thread selections

### DIFF
--- a/.changeset/clear-deleted-cloud-selection.md
+++ b/.changeset/clear-deleted-cloud-selection.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: clear the selected Cloud thread after deleting it

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -285,6 +285,55 @@ describe("useThreads", () => {
     ]);
   });
 
+  it("clears the selected thread after deleting it", async () => {
+    const cloud = createCloud("thread-1");
+    cloud.threads.delete.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+    expect(result.current.threadId).toBe("thread-1");
+
+    await act(async () => {
+      await result.current.delete("thread-1");
+    });
+
+    expect(result.current.threadId).toBeNull();
+  });
+
+  it("preserves a newer selection when a deletion finishes", async () => {
+    const cloud = createCloud("thread-1");
+    const deletion = createDeferred<void>();
+    cloud.threads.delete.mockReturnValueOnce(deletion.promise);
+
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+
+    let deletePromise!: Promise<boolean>;
+    act(() => {
+      deletePromise = result.current.delete("thread-1");
+    });
+    act(() => {
+      result.current.selectThread("thread-2");
+    });
+
+    await act(async () => {
+      deletion.resolve();
+      await deletePromise;
+    });
+
+    expect(result.current.threadId).toBe("thread-2");
+  });
+
   it("avoids unmounted state updates during async refresh", async () => {
     const deferred = createDeferred<{ threads: never[] }>();
     const consoleErrorSpy = vi

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -175,14 +175,21 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
       return await withAction(
         async (commit) => {
           await cloud.threads.delete(id);
-          commit(() => setThreads((prev) => prev.filter((t) => t.id !== id)));
+          commit(() => {
+            setThreads((prev) => prev.filter((t) => t.id !== id));
+            setSelection((current) =>
+              current.scope === scope && current.threadId === id
+                ? { scope, threadId: null }
+                : current,
+            );
+          });
           return true;
         },
         false,
         isCurrentCloud,
       );
     },
-    [cloud, isCurrentCloud, withAction],
+    [cloud, isCurrentCloud, scope, withAction],
   );
 
   const rename = useCallback(


### PR DESCRIPTION
## Summary

- clear `threadId` after the selected Cloud thread is deleted successfully
- preserve a newer thread selection if the user switches while deletion is pending
- add focused regression coverage and a patch changeset

## Problem

`useThreads().delete()` removed the thread from the visible list but left its ID selected. `ThreadSessionManager` then treated that deleted ID as an existing remote thread, so the next message could attempt to load or persist through a thread that no longer exists.

The selection is cleared only after a successful deletion and only when the deleted thread is still selected. Failed deletions and newer user selections keep their existing behavior.

## Verification

- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm exec oxlint packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts`
- `pnpm exec oxfmt --check packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts .changeset/clear-deleted-cloud-selection.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.QCpplm0tCU0AW7ydF_EqDKbibK0sOxCjP7KSnPG3TobXgHP-mea9sipbta8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->