### PR TITLE
feat(cloud-ai-sdk): load properly for archived threads when requested

### DIFF
--- a/.changeset/load-archived-cloud-threads.md
+++ b/.changeset/load-archived-cloud-threads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: include archived Cloud threads when requested

--- a/.changeset/load-archived-cloud-threads.md
+++ b/.changeset/load-archived-cloud-threads.md
@@ -1,5 +1,6 @@
 ---
 "@assistant-ui/cloud-ai-sdk": patch
+"assistant-cloud": patch
 ---
 
-fix: include archived Cloud threads when requested
+fix: include archived Cloud threads when requested and preserve archive filters

--- a/apps/docs/content/docs/cloud/ai-sdk.mdx
+++ b/apps/docs/content/docs/cloud/ai-sdk.mdx
@@ -332,7 +332,7 @@ Plus all other properties from AI SDK's [`UseChatHelpers`](https://sdk.vercel.ai
 | Value | Type | Description |
 |-------|------|-------------|
 | `threads.cloud` | `AssistantCloud` | The cloud instance used for thread operations |
-| `threads.threads` | `CloudThread[]` | Active threads sorted by recency |
+| `threads.threads` | `CloudThread[]` | Threads sorted by recency; includes archived threads when supplied by `useThreads({ includeArchived: true })` |
 | `threads.threadId` | `string \| null` | Current thread ID (`null` for a new unsaved chat) |
 | `threads.selectThread` | `(id: string \| null) => void` | Switch threads or pass `null` for a new chat |
 | `threads.isLoading` | `boolean` | `true` during initial load or refresh |

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -134,6 +134,41 @@ describe("useThreads", () => {
     });
   });
 
+  it("loads active and archived threads when requested", async () => {
+    const active = createThreadListResponse("Active", "active").threads[0]!;
+    const archived = {
+      ...createThreadListResponse("Archived", "archived").threads[0]!,
+      is_archived: true,
+      last_message_at: new Date("2026-02-01T00:00:00.000Z"),
+    };
+    const list = vi.fn(async (query?: { is_archived?: boolean }) => ({
+      threads: query?.is_archived ? [archived] : [active],
+    }));
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result } = renderHook(() =>
+      useThreads({ cloud, includeArchived: true, enabled: false }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(list).toHaveBeenNthCalledWith(1, { is_archived: false });
+    expect(list).toHaveBeenNthCalledWith(2, { is_archived: true });
+    expect(result.current.threads).toMatchObject([
+      { id: "archived", status: "archived" },
+      { id: "active", status: "regular" },
+    ]);
+  });
+
   it("keeps the latest refresh when requests resolve out of order", async () => {
     const first = createDeferred<ReturnType<typeof createThreadListResponse>>();
     const second =

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -169,6 +169,39 @@ describe("useThreads", () => {
     ]);
   });
 
+  it("deduplicates threads returned by both archive filters", async () => {
+    const active = createThreadListResponse("Active", "shared").threads[0]!;
+    const archived = {
+      ...active,
+      title: "Archived",
+      is_archived: true,
+    };
+    const list = vi.fn(async (query?: { is_archived?: boolean }) => ({
+      threads: query?.is_archived ? [archived] : [active],
+    }));
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result } = renderHook(() =>
+      useThreads({ cloud, includeArchived: true, enabled: false }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.threads).toHaveLength(1);
+    expect(result.current.threads).toMatchObject([
+      { id: "shared", title: "Archived", status: "archived" },
+    ]);
+  });
+
   it("keeps the previous complete list when an archived refresh fails", async () => {
     const active = createThreadListResponse("Active", "active").threads[0]!;
     const archived = {

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -169,6 +169,44 @@ describe("useThreads", () => {
     ]);
   });
 
+  it("keeps the previous complete list when an archived refresh fails", async () => {
+    const active = createThreadListResponse("Active", "active").threads[0]!;
+    const archived = {
+      ...createThreadListResponse("Archived", "archived").threads[0]!,
+      is_archived: true,
+    };
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: [active] })
+      .mockResolvedValueOnce({ threads: [archived] })
+      .mockResolvedValueOnce({ threads: [{ ...active, title: "Updated" }] })
+      .mockRejectedValueOnce(new Error("archived refresh failed"));
+    const cloud = {
+      threads: {
+        list,
+        get: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+        update: vi.fn(),
+      },
+    } as never;
+    const { result } = renderHook(() =>
+      useThreads({ cloud, includeArchived: true, enabled: false }),
+    );
+
+    await act(async () => {
+      expect(await result.current.refresh()).toBe(true);
+    });
+    const completeThreads = result.current.threads;
+
+    await act(async () => {
+      expect(await result.current.refresh()).toBe(false);
+    });
+
+    expect(result.current.error?.message).toBe("archived refresh failed");
+    expect(result.current.threads).toBe(completeThreads);
+  });
+
   it("keeps the latest refresh when requests resolve out of order", async () => {
     const first = createDeferred<ReturnType<typeof createThreadListResponse>>();
     const second =

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -113,6 +113,8 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     try {
       return await withAction(
         async (commit) => {
+          // Keep includeArchived refreshes atomic; withAction preserves the
+          // previous complete list and exposes either request's failure.
           const responses = includeArchived
             ? await Promise.all([
                 cloud.threads.list({ is_archived: false }),

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -113,10 +113,23 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
     try {
       return await withAction(
         async (commit) => {
-          const response = await cloud.threads.list(
-            includeArchived ? undefined : { is_archived: false },
+          const responses = includeArchived
+            ? await Promise.all([
+                cloud.threads.list({ is_archived: false }),
+                cloud.threads.list({ is_archived: true }),
+              ])
+            : [await cloud.threads.list({ is_archived: false })];
+          const nextThreads = responses.flatMap((response) =>
+            response.threads.map(toCloudThread),
           );
-          commit(() => setThreads(() => response.threads.map(toCloudThread)));
+          if (includeArchived) {
+            nextThreads.sort((a, b) => {
+              const timeDifference =
+                b.lastMessageAt.getTime() - a.lastMessageAt.getTime();
+              return timeDifference || b.id.localeCompare(a.id);
+            });
+          }
+          commit(() => setThreads(nextThreads));
           return true;
         },
         false,

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -121,8 +121,13 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
                 cloud.threads.list({ is_archived: true }),
               ])
             : [await cloud.threads.list({ is_archived: false })];
-          const nextThreads = responses.flatMap((response) =>
-            response.threads.map(toCloudThread),
+          const nextThreads = Array.from(
+            new Map(
+              responses
+                .flatMap((response) => response.threads)
+                .map((thread) => [thread.id, thread] as const),
+            ).values(),
+            toCloudThread,
           );
           if (includeArchived) {
             nextThreads.sort((a, b) => {

--- a/packages/cloud/src/AssistantCloudThreads.test.ts
+++ b/packages/cloud/src/AssistantCloudThreads.test.ts
@@ -22,6 +22,21 @@ const threadResponse = {
 };
 
 describe("AssistantCloudThreads responses", () => {
+  it("forwards both archive filter values", async () => {
+    const { threads, makeRequest } = createCloudThreads();
+    makeRequest.mockResolvedValue({ threads: [] });
+
+    await threads.list({ is_archived: false });
+    expect(makeRequest).toHaveBeenLastCalledWith("/threads", {
+      query: { is_archived: "false" },
+    });
+
+    await threads.list({ is_archived: true });
+    expect(makeRequest).toHaveBeenLastCalledWith("/threads", {
+      query: { is_archived: "true" },
+    });
+  });
+
   it("decodes canonical thread list responses", async () => {
     const { threads, makeRequest } = createCloudThreads();
     makeRequest.mockResolvedValue({ threads: [threadResponse] });

--- a/packages/cloud/src/AssistantCloudThreads.ts
+++ b/packages/cloud/src/AssistantCloudThreads.ts
@@ -88,8 +88,12 @@ export class AssistantCloudThreads {
   public async list(
     query?: AssistantCloudThreadsListQuery,
   ): Promise<AssistantCloudThreadsListResponse> {
+    const requestQuery =
+      query?.is_archived === undefined
+        ? query
+        : { ...query, is_archived: String(query.is_archived) };
     const response = readCloudRecord(
-      await this.cloud.makeRequest("/threads", { query }),
+      await this.cloud.makeRequest("/threads", { query: requestQuery }),
       "thread list response",
     );
     const threads = readCloudArray(response.threads, "threads");


### PR DESCRIPTION
## Problem

With `@assistant-ui/cloud-ai-sdk@0.1.29` and `assistant-cloud@0.1.38`, `useThreads({ includeArchived: true })` made the same unfiltered list call as the default mode. The Cloud `/v1/threads` endpoint evaluates a missing archive filter as `is_archived ?? false`, so a workspace containing one active thread and one archived thread returned only the active thread in both modes.

That server contract is confirmed in `assistant-internal/apps/cloud-api/src/endpoints/threads/list.ts`: both the cursor lookup and the main query apply `eq(threadsTable.is_archived, data.is_archived ?? false)`.

`AssistantCloudAPI` also omits raw boolean `false` query values. Although the current endpoint default still makes that request active-only, relying on the omission hides the intended filter from the wire.

The same backend default exposes a separate archived-thread gap in the older core Cloud adapter. That follow-up is tracked in #5716 and remains outside this focused PR.

## Minimal reproduction

1. Create one active Cloud thread and one thread with `is_archived: true`.
2. Render the hook and refresh:

```tsx
const { result } = renderHook(() =>
  useThreads({ cloud, includeArchived: true, enabled: false }),
);

await act(() => result.current.refresh());
console.log(result.current.threads.map(({ id, status }) => ({ id, status })));
```

Before this PR, the result contains only the active thread. After this PR, it contains both `{ status: "regular" }` and `{ status: "archived" }`, ordered by `lastMessageAt`. The cloneable regression is `packages/cloud-ai-sdk/src/threads/useThreads.test.ts`; run it from this repository with:

```bash
pnpm install --frozen-lockfile
pnpm --filter assistant-cloud build
pnpm --filter @assistant-ui/cloud-ai-sdk exec vitest run src/threads/useThreads.test.ts
```

## Fix

- request the active and archived status pages separately when `includeArchived` is enabled
- merge both responses by message recency
- stringify `is_archived` in `AssistantCloudThreads.list()` so both `false` and `true` reach the shared query serializer explicitly
- keep the default mode to one active-thread request

The two status requests intentionally fail together: returning only one status while reporting a successful `includeArchived` refresh would silently violate the option and hide an API failure. Existing thread data remains mounted when a refresh fails.

## Verification

- `pnpm --filter assistant-cloud test` (59 passed)
- `pnpm --filter assistant-cloud build`
- `pnpm --filter @assistant-ui/cloud-ai-sdk test` (69 passed with AI SDK v7 and 69 with peer-v6, plus peer-v6 type checking)
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- `pnpm exec oxlint packages/cloud/src/AssistantCloudThreads.ts packages/cloud/src/AssistantCloudThreads.test.ts packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts`
- `pnpm exec oxfmt --check packages/cloud/src/AssistantCloudThreads.ts packages/cloud/src/AssistantCloudThreads.test.ts packages/cloud-ai-sdk/src/threads/useThreads.ts packages/cloud-ai-sdk/src/threads/useThreads.test.ts .changeset/load-archived-cloud-threads.md`