### PR TITLE
Edit composer send always emits the edit op

### DIFF
--- a/.changeset/edit-composer-always-emits.md
+++ b/.changeset/edit-composer-always-emits.md
@@ -1,6 +1,6 @@
 ---
-"@assistant-ui/core": minor
-"@assistant-ui/react": minor
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
 ---
 
 Edit composer send always emits: an unchanged edit re-sends the message on a new branch instead of silently closing the composer.

--- a/.changeset/edit-composer-always-emits.md
+++ b/.changeset/edit-composer-always-emits.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": minor
+"@assistant-ui/react": minor
+---
+
+Edit composer send always emits: an unchanged edit re-sends the message on a new branch instead of silently closing the composer.

--- a/api-surface/assistant-ui__core.ts
+++ b/api-surface/assistant-ui__core.ts
@@ -1445,8 +1445,6 @@ declare class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
   get canSend(): boolean;
   protected getAttachmentAdapter(): AttachmentAdapter | undefined;
   protected getDictationAdapter(): DictationAdapter | undefined;
-  private _previousText;
-  private _previousAttachments;
   private _nonTextPassthrough;
   private _parentId;
   private _sourceId;

--- a/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
+++ b/packages/core/src/runtime/base/default-edit-composer-runtime-core.ts
@@ -1,7 +1,7 @@
 import type { AppendMessage, ThreadMessage } from "../../types/message";
 import type { CompleteAttachment } from "../../types/attachment";
 import { getThreadMessageText } from "../../utils/text";
-import { attachmentsEqual, liftNonTextParts } from "../../adapters/attachment";
+import { liftNonTextParts } from "../../adapters/attachment";
 import type { AttachmentAdapter } from "../../adapters/attachment";
 import type { DictationAdapter } from "../../adapters/speech";
 import type { SendOptions } from "../interfaces/composer-runtime-core";
@@ -26,8 +26,6 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     return this.runtime.adapters?.dictation;
   }
 
-  private _previousText;
-  private _previousAttachments: readonly CompleteAttachment[];
   private _nonTextPassthrough: readonly ThreadMessage["content"][number][];
   private _parentId: string | null;
   private _sourceId: string | null;
@@ -58,24 +56,24 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     this.endEditCallback = endEditCallback;
     this._parentId = parentId;
     this._sourceId = message.id;
-    this._previousText = getThreadMessageText(message);
-    this.setText(this._previousText);
+    this.setText(getThreadMessageText(message));
 
     this.setRole(message.role);
 
+    let attachments: readonly CompleteAttachment[];
     if (message.role === "user") {
-      this._previousAttachments = [
+      attachments = [
         ...(message.attachments ?? []),
         ...liftNonTextParts(message.content),
       ];
       this._nonTextPassthrough = [];
     } else {
-      this._previousAttachments = message.attachments ?? [];
+      attachments = message.attachments ?? [];
       this._nonTextPassthrough = message.content.filter(
         (p) => p.type !== "text",
       );
     }
-    this.setAttachments(this._previousAttachments);
+    this.setAttachments(attachments);
 
     this.setRunConfig({ ...runtime.composer.runConfig });
   }
@@ -92,49 +90,33 @@ export class DefaultEditComposerRuntimeCore extends BaseComposerRuntimeCore {
     message: Omit<AppendMessage, "parentId" | "sourceId">,
     options?: SendOptions,
   ) {
-    let appendTask: void | Promise<void> = undefined;
-    const text = getThreadMessageText(message as AppendMessage);
-    const attachmentsChanged = !attachmentsEqual(
-      message.attachments ?? [],
-      this._previousAttachments,
+    const content =
+      this._nonTextPassthrough.length > 0
+        ? ([
+            ...message.content,
+            ...this._nonTextPassthrough,
+          ] as AppendMessage["content"])
+        : message.content;
+    // Gate live state against the new branch's prefix (messages up to the
+    // parent): an unchanged interactable re-stamps the prior baseline, an
+    // interactable edited since the original message stamps its newest state.
+    const messages = this.runtime.messages;
+    const parentIndex =
+      this._parentId === null
+        ? -1
+        : messages.findIndex((m) => m.id === this._parentId);
+    const composerMetadata = gateInteractableComposerMetadata(
+      this.runtime.getModelContext().unstable_composerMetadata,
+      messages.slice(0, parentIndex + 1),
     );
-
-    if (
-      text !== this._previousText ||
-      attachmentsChanged ||
-      options?.startRun
-    ) {
-      const content =
-        this._nonTextPassthrough.length > 0
-          ? ([
-              ...message.content,
-              ...this._nonTextPassthrough,
-            ] as AppendMessage["content"])
-          : message.content;
-      // Gate live state against the new branch's prefix (messages up to the
-      // parent): an unchanged interactable re-stamps the prior baseline, an
-      // interactable edited since the original message stamps its newest state.
-      const messages = this.runtime.messages;
-      const parentIndex =
-        this._parentId === null
-          ? -1
-          : messages.findIndex((m) => m.id === this._parentId);
-      const composerMetadata = gateInteractableComposerMetadata(
-        this.runtime.getModelContext().unstable_composerMetadata,
-        messages.slice(0, parentIndex + 1),
-      );
-      const enriched = this.enrichWithComposerMetadata(
-        message,
-        composerMetadata,
-      );
-      appendTask = this.runtime.append({
-        ...enriched,
-        content,
-        parentId: this._parentId,
-        sourceId: this._sourceId,
-        startRun: options?.startRun,
-      });
-    }
+    const enriched = this.enrichWithComposerMetadata(message, composerMetadata);
+    const appendTask = this.runtime.append({
+      ...enriched,
+      content,
+      parentId: this._parentId,
+      sourceId: this._sourceId,
+      startRun: options?.startRun,
+    });
 
     this.handleCancel();
     return appendTask;

--- a/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
+++ b/packages/core/src/tests/default-edit-composer-runtime-core.test.ts
@@ -132,7 +132,7 @@ describe("DefaultEditComposerRuntimeCore", () => {
   });
 
   describe("send behavior", () => {
-    it("does not call append when nothing changed", async () => {
+    it("calls append even when nothing changed, branching with the same message", async () => {
       const { runtime, append } = makeRuntime();
       const composer = new DefaultEditComposerRuntimeCore(runtime, () => {}, {
         parentId: "p1",
@@ -141,7 +141,11 @@ describe("DefaultEditComposerRuntimeCore", () => {
         }),
       });
       await composer.send();
-      expect(append).not.toHaveBeenCalled();
+      expect(append).toHaveBeenCalledTimes(1);
+      const appended = append.mock.calls[0]![0] as AppendMessage;
+      expect(appended.content).toEqual([{ type: "text", text: "same" }]);
+      expect(appended.parentId).toBe("p1");
+      expect(appended.sourceId).toBe("msg-1");
     });
 
     it("calls append when text changes", async () => {


### PR DESCRIPTION
## Behavior change

An unchanged edit-and-send now creates a sibling branch with the re-sent message and starts a run, instead of silently closing the composer as a no-op. `DefaultEditComposerRuntimeCore.handleSend` no longer gates the append on `text !== previousText || attachmentsChanged || startRun` — every send emits `runtime.append`.

- `startRun` stays as a pass-through field on the append call; it is no longer a force flag for the emit.
- Dead tracking state (`_previousText`, `_previousAttachments`) removed; api-surface regenerated accordingly.
- Tests updated to pin the new contract: an unchanged send appends on the same parent with the same content.

Design approved by Simon in agentdoc thread c5795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.EI78AMNFLmwazjTmvVLOAig2D7MTblEU66y_7_C68cIWsfU8X_ewN4H-lX8?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->