### PR TITLE
fix(core): paginate cloud thread lists

### DIFF
--- a/.changeset/paginate-core-cloud-threads.md
+++ b/.changeset/paginate-core-cloud-threads.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: expose additional Cloud thread pages through the thread list runtime

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { renderHook } from "@testing-library/react";
+import type { AssistantCloud } from "assistant-cloud";
+import { describe, expect, it, vi } from "vitest";
+import { useCloudThreadListAdapter } from "./useCloudThreadListAdapter";
+
+const makeThread = (id: string) => ({
+  id,
+  title: id,
+  is_archived: false,
+  external_id: null,
+  metadata: null,
+  last_message_at: new Date(0),
+  created_at: new Date(0),
+  updated_at: new Date(0),
+  project_id: "project-1",
+  workspace_id: "workspace-1",
+});
+
+describe("useCloudThreadListAdapter", () => {
+  it("exposes full Cloud pages through the remote thread cursor", async () => {
+    const firstPage = Array.from({ length: 20 }, (_, index) =>
+      makeThread(`thread-${index + 1}`),
+    );
+    const secondPage = [makeThread("thread-21")];
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ threads: firstPage })
+      .mockResolvedValueOnce({ threads: secondPage });
+    const cloud = { threads: { list } } as unknown as AssistantCloud;
+    const { result } = renderHook(() => useCloudThreadListAdapter({ cloud }));
+
+    const first = await result.current.list();
+    expect(list).toHaveBeenNthCalledWith(1, { limit: 20 });
+    expect(first.threads).toHaveLength(20);
+    expect(first.nextCursor).toBe("thread-20");
+
+    const second = await result.current.list({ after: first.nextCursor });
+    expect(list).toHaveBeenNthCalledWith(2, {
+      limit: 20,
+      after: "thread-20",
+    });
+    expect(second.threads.map((thread) => thread.remoteId)).toEqual([
+      "thread-21",
+    ]);
+    expect(second.nextCursor).toBeUndefined();
+  });
+});

--- a/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
+++ b/packages/core/src/react/runtimes/cloud/useCloudThreadListAdapter.tsx
@@ -37,6 +37,8 @@ const autoCloud = baseUrl
   ? new AssistantCloud({ baseUrl, anonymous: true })
   : undefined;
 
+const CLOUD_THREAD_PAGE_SIZE = 20;
+
 export const useCloudThreadListAdapter = (
   adapter: CloudThreadListAdapterOptions,
 ): RemoteThreadListAdapter => {
@@ -88,8 +90,11 @@ export const useCloudThreadListAdapter = (
     }
 
     return {
-      list: async () => {
-        const { threads } = await cloud.threads.list();
+      list: async ({ after } = {}) => {
+        const { threads } = await cloud.threads.list({
+          limit: CLOUD_THREAD_PAGE_SIZE,
+          ...(after ? { after } : {}),
+        });
         return {
           threads: threads.map((t) => ({
             status: t.is_archived ? "archived" : "regular",
@@ -101,6 +106,10 @@ export const useCloudThreadListAdapter = (
             externalId: t.external_id ?? undefined,
             custom: toCustom(t.metadata),
           })),
+          nextCursor:
+            threads.length === CLOUD_THREAD_PAGE_SIZE
+              ? threads.at(-1)?.id
+              : undefined,
         };
       },
 


### PR DESCRIPTION
## Summary

- forward the remote thread-list `after` cursor to Assistant Cloud
- request Cloud threads in explicit 20-item pages
- return a `nextCursor` so the runtime can load older pages

## Problem

The core Cloud thread-list adapter ignored the pagination options supplied by the remote thread-list runtime and never returned `nextCursor`. Assistant Cloud defaults list requests to 20 threads, so users with 21 or more threads could not reach older threads through this adapter.

## Fix

Request a 20-thread page, pass through the incoming `after` cursor, and expose the last thread ID as the next cursor when a full page is returned. Short pages end pagination normally. An exact multiple of 20 may make one harmless empty follow-up request because the API does not return a dedicated next cursor.

## Backend contract verification

Confirmed against the current Cloud API implementation:

- `limit` accepts 1 through 100 and defaults to 20
- `after` is a thread ID in the same user and archive scope
- the endpoint looks up that thread’s `last_message_at` and applies stable keyset pagination ordered by `last_message_at DESC, id DESC`

This PR wires the existing runtime pagination contract. The default registry thread list does not currently render a load-more affordance; that UI addition is a separate concern.

## Verification

- `pnpm --filter @assistant-ui/core test`
- `pnpm --filter @assistant-ui/core build`
- focused regression covering the first and second Cloud pages