### PR TITLE
fix(cloud-ai-sdk): clear archived thread selections

### DIFF
--- a/.changeset/clear-hidden-archived-thread.md
+++ b/.changeset/clear-hidden-archived-thread.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/cloud-ai-sdk": patch
+---
+
+fix: clear a selected Cloud thread when archiving removes it from the list

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -324,6 +324,70 @@ describe("useThreads", () => {
     expect(result.current.threadId).toBeNull();
   });
 
+  it("preserves the selected thread when archived threads remain visible", async () => {
+    const cloud = createCloud("thread-1");
+    cloud.threads.update.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useThreads({
+        cloud: cloud as never,
+        enabled: false,
+        includeArchived: true,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+
+    await act(async () => {
+      await result.current.archive("thread-1");
+    });
+
+    expect(result.current.threadId).toBe("thread-1");
+    expect(result.current.threads[0]?.status).toBe("archived");
+  });
+
+  it("uses the latest archive visibility after options change", async () => {
+    const cloud = createCloud("thread-1");
+    const archive = createDeferred<void>();
+    cloud.threads.update.mockReturnValueOnce(archive.promise);
+
+    const { result, rerender } = renderHook(
+      ({ includeArchived }) =>
+        useThreads({
+          cloud: cloud as never,
+          enabled: false,
+          includeArchived,
+        }),
+      { initialProps: { includeArchived: true } },
+    );
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+
+    let archivePromise!: Promise<boolean>;
+    act(() => {
+      archivePromise = result.current.archive("thread-1");
+    });
+    rerender({ includeArchived: false });
+
+    await act(async () => {
+      archive.resolve();
+      await archivePromise;
+    });
+
+    expect(result.current.threadId).toBeNull();
+    expect(result.current.threads).toEqual([]);
+  });
+
   it("preserves a newer selection when an archive finishes", async () => {
     const cloud = createCloud("thread-1");
     const archive = createDeferred<void>();

--- a/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.test.ts
@@ -305,6 +305,54 @@ describe("useThreads", () => {
     expect(result.current.threadId).toBeNull();
   });
 
+  it("clears the selected thread after archiving hides it", async () => {
+    const cloud = createCloud("thread-1");
+    cloud.threads.update.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+
+    await act(async () => {
+      await result.current.archive("thread-1");
+    });
+
+    expect(result.current.threadId).toBeNull();
+  });
+
+  it("preserves a newer selection when an archive finishes", async () => {
+    const cloud = createCloud("thread-1");
+    const archive = createDeferred<void>();
+    cloud.threads.update.mockReturnValueOnce(archive.promise);
+
+    const { result } = renderHook(() =>
+      useThreads({ cloud: cloud as never, enabled: false }),
+    );
+
+    act(() => {
+      result.current.selectThread("thread-1");
+    });
+
+    let archivePromise!: Promise<boolean>;
+    act(() => {
+      archivePromise = result.current.archive("thread-1");
+    });
+    act(() => {
+      result.current.selectThread("thread-2");
+    });
+
+    await act(async () => {
+      archive.resolve();
+      await archivePromise;
+    });
+
+    expect(result.current.threadId).toBe("thread-2");
+  });
+
   it("preserves a newer selection when a deletion finishes", async () => {
     const cloud = createCloud("thread-1");
     const deletion = createDeferred<void>();

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -217,7 +217,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         async (commit) => {
           await cloud.threads.update(id, { is_archived: true });
 
-          commit(() =>
+          commit(() => {
             setThreads((prev) => {
               if (includeArchived) {
                 return prev.map((t) =>
@@ -225,8 +225,15 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
                 );
               }
               return prev.filter((t) => t.id !== id);
-            }),
-          );
+            });
+            if (!includeArchived) {
+              setSelection((current) =>
+                current.scope === scope && current.threadId === id
+                  ? { scope, threadId: null }
+                  : current,
+              );
+            }
+          });
 
           return true;
         },
@@ -234,7 +241,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         isCurrentCloud,
       );
     },
-    [cloud, includeArchived, isCurrentCloud, withAction],
+    [cloud, includeArchived, isCurrentCloud, scope, withAction],
   );
 
   const unarchive = useCallback(

--- a/packages/cloud-ai-sdk/src/threads/useThreads.ts
+++ b/packages/cloud-ai-sdk/src/threads/useThreads.ts
@@ -36,6 +36,10 @@ function toCloudThread(t: {
 
 export function useThreads(options: UseThreadsOptions): UseThreadsResult {
   const { cloud, includeArchived = false, enabled = true } = options;
+  const includeArchivedRef = useRef(includeArchived);
+  useLayoutEffect(() => {
+    includeArchivedRef.current = includeArchived;
+  }, [includeArchived]);
 
   const [threads, setThreads] = useState<CloudThread[]>([]);
   const [isLoading, setIsLoading] = useState(enabled);
@@ -218,15 +222,16 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
           await cloud.threads.update(id, { is_archived: true });
 
           commit(() => {
+            const shouldIncludeArchived = includeArchivedRef.current;
             setThreads((prev) => {
-              if (includeArchived) {
+              if (shouldIncludeArchived) {
                 return prev.map((t) =>
                   t.id === id ? { ...t, status: "archived" } : t,
                 );
               }
               return prev.filter((t) => t.id !== id);
             });
-            if (!includeArchived) {
+            if (!shouldIncludeArchived) {
               setSelection((current) =>
                 current.scope === scope && current.threadId === id
                   ? { scope, threadId: null }
@@ -241,7 +246,7 @@ export function useThreads(options: UseThreadsOptions): UseThreadsResult {
         isCurrentCloud,
       );
     },
-    [cloud, includeArchived, isCurrentCloud, scope, withAction],
+    [cloud, isCurrentCloud, scope, withAction],
   );
 
   const unarchive = useCallback(


### PR DESCRIPTION
## Summary

- clear the selected thread when archiving removes it from the visible list
- preserve a newer thread selection if the archive request finishes later
- use the latest `includeArchived` option if visibility changes while archiving
- keep the selection unchanged when `includeArchived` keeps the thread visible

## Problem

When the selected thread is archived with `includeArchived: false`, the thread disappears from `threads` but its ID remains in `threadId`. `useCloudChat` continues consuming that stale ID, so a message sent afterward can be persisted to the now-hidden archived thread.

## Fix

Clear the selection after the archive succeeds only when the same Cloud scope is still active and the archived thread is still selected. Read the latest committed visibility option when the request settles, so changing `includeArchived` during an in-flight archive cannot make the list and selection disagree. A newer selection made while the request is pending remains untouched.

## Verification

- `pnpm --filter @assistant-ui/cloud-ai-sdk test`
- `pnpm --filter @assistant-ui/cloud-ai-sdk build`
- regressions for hidden archived selections, visible archived selections, option changes during an archive, and newer selections during an archive