### PR TITLE
fix: route edit sends to onEdit instead of the queue adapter

### DIFF
--- a/.changeset/edit-send-source-id-routing.md
+++ b/.changeset/edit-send-source-id-routing.md
@@ -1,0 +1,6 @@
+---
+"@assistant-ui/core": patch
+"@assistant-ui/react": patch
+---
+
+fix: route sourceId-carrying edit sends to onEdit instead of the queue adapter, and fail fast on beginEdit without an edit handler

--- a/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
+++ b/packages/core/src/runtimes/external-store/external-store-thread-runtime-core.ts
@@ -466,7 +466,11 @@ export class ExternalStoreThreadRuntimeCore
   }
 
   public async append(message: AppendMessage): Promise<void> {
-    const isEdit = message.parentId !== (this.messages.at(-1)?.id ?? null);
+    // sourceId marks an edit send; the parent may coincide with the head
+    // after a resync (e.g. cancelRun dropped the edited message).
+    const isEdit =
+      message.sourceId != null ||
+      message.parentId !== (this.messages.at(-1)?.id ?? null);
 
     // Buffering does not start a run, so the tool-abort below must wait until
     // the queue flushes. By then the prior run (and its tools) has settled.

--- a/packages/core/src/tests/external-store-thread-runtime-core.test.ts
+++ b/packages/core/src/tests/external-store-thread-runtime-core.test.ts
@@ -883,6 +883,42 @@ describe("ExternalStoreThreadRuntimeCore - message queue", () => {
     expect(queue.steer).toHaveBeenCalledTimes(1);
   });
 
+  it("routes an edit send to onEdit even when anchored at the head", async () => {
+    const queue = makeQueue();
+    const onNew = vi.fn();
+    const onEdit = vi.fn();
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ queue, onNew, onEdit }),
+    );
+
+    await runtime.append(appendMessage({ sourceId: "u1" }));
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onEdit.mock.calls[0]![0]).toMatchObject({
+      sourceId: "u1",
+      parentId: null,
+    });
+    expect(onNew).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+    expect(queue.steer).not.toHaveBeenCalled();
+  });
+
+  it("throws the edit capability error for an edit send instead of queueing it", async () => {
+    const queue = makeQueue();
+    const onNew = vi.fn();
+    const runtime = new ExternalStoreThreadRuntimeCore(
+      mockContextProvider,
+      makeStore({ queue, onNew }),
+    );
+
+    await expect(
+      runtime.append(appendMessage({ sourceId: "u1" })),
+    ).rejects.toThrow("Runtime does not support editing messages.");
+    expect(onNew).not.toHaveBeenCalled();
+    expect(queue.enqueue).not.toHaveBeenCalled();
+  });
+
   it("defaults a mid-run send to steer and an idle send to enqueue", async () => {
     const queue = makeQueue();
     const running = new ExternalStoreThreadRuntimeCore(

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -168,6 +168,7 @@ const useMessageClient = ({
   );
 
   const handleBeginEdit = () => {
+    if (!onEdit) throw new Error("Runtime does not support editing.");
     setIsEditing(true);
   };
 

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -177,7 +177,8 @@ const useMessageClient = ({
   };
 
   const handleSendEdit = (msg: AppendMessage) => {
-    onEdit?.({
+    if (!onEdit) throw new Error("Runtime does not support editing.");
+    onEdit({
       ...msg,
       parentId,
       sourceId: message.id,

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -322,6 +322,35 @@ describe("ExternalThread composer", () => {
     expect(steer).not.toHaveBeenCalled();
   });
 
+  it("throws on beginEdit when the runtime has no edit handler", () => {
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: false,
+      queue: {
+        items: [],
+        steerItems: [],
+        enqueue: vi.fn(),
+        steer: vi.fn(),
+        move: vi.fn(),
+        edit: vi.fn(),
+        remove: vi.fn(),
+      },
+    });
+
+    expect(() =>
+      aui().thread.message({ id: "u1" }).composer().beginEdit(),
+    ).toThrow("Runtime does not support editing.");
+  });
+
   it("still refuses to send an empty composer synchronously after a send", async () => {
     const onNew = vi.fn();
     const { aui } = renderThread({ messages: [], isRunning: false, onNew });


### PR DESCRIPTION
## Problem
When an external-store runtime has a queue adapter installed (in-repo, `@assistant-ui/react-langgraph` is the consumer that installs one and reads `sourceId` for fork resolution), an edit send whose parent anchoring coincides with the current head (e.g. after `cancelRun` dropped the trailing user message mid-edit) was misclassified as a new-message send by `ExternalStoreThreadRuntimeCore.append`'s `parentId !== head` heuristic and funneled into `queue.enqueue`/`steer`, silently downgrading the edit to an append and dropping its `sourceId`. Separately, `ExternalThread`'s message edit composer allowed `beginEdit()` on runtimes without an `onEdit` handler and then silently discarded the send.

## Fix
- `ExternalStoreThreadRuntimeCore.append` treats any `sourceId`-carrying message as an edit, routing it to `onEdit` (or throwing the existing "Runtime does not support editing messages." capability error) before the queue-adapter branch is considered.
- `ExternalThread`'s `beginEdit` throws "Runtime does not support editing." when no `onEdit` is installed, matching the legacy runtime core.
- `ExternalThread`'s `handleSendEdit` throws the same capability error instead of optional-chaining `onEdit`, so an edit send can never silently no-op.

Known divergence: `LocalThreadRuntimeCore.append` still uses the bare `parentId === head` tail check. It is reachable only when the head shrinks under an open edit composer (message deletion mid-edit), and aligning it touches the `unstable_queueClearOnRewind` path, so it is left as a follow-up rather than widened into this patch.

## Tests
- core: edit send with queue adapter installed reaches `onEdit` with `sourceId`/`parentId` intact and never touches the queue or `onNew`; without `onEdit` it throws the capability error instead of queueing.
- react: `beginEdit` without an edit handler throws on a queue-adapter runtime.

Task: i31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.piU49IiEOqJ5hESddxKWJYiyIP3yIaXaWV9ZHCgBFEFKjfcwibJhCKcEyEI?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
