### PR TITLE
fix: ExternalThread edit composer reads editing state live

### DIFF
--- a/.changeset/edit-composer-live-state.md
+++ b/.changeset/edit-composer-live-state.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react": patch
+---
+
+fix: ExternalThread edit composer reads editing state live, so a same-tick beginEdit + setText + send dispatches the edit

--- a/.changeset/edit-composer-live-state.md
+++ b/.changeset/edit-composer-live-state.md
@@ -2,4 +2,4 @@
 "@assistant-ui/react": patch
 ---
 
-fix: ExternalThread edit composer reads editing state live, so a same-tick beginEdit + setText + send dispatches the edit
+fix: ExternalThread edit composer reads editing state live, so a same-tick beginEdit + setText + send dispatches the edit; send before beginEdit and double beginEdit now throw (legacy runtime parity)

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -1,11 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useEffect,
-  useEffectEvent,
-  useCallback,
-  useRef,
-} from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { resource, withKey } from "@assistant-ui/tap";
 import {
   type ClientElement,
@@ -152,7 +145,6 @@ const useMessageClient = ({
 }: MessageClientProps): ClientOutput<"message"> => {
   const [isCopied, setIsCopied] = useState(false);
   const [isHovering, setIsHovering] = useState(false);
-  const [isEditing, setIsEditing] = useState(false);
 
   const partClients = useClientLookup(
     message.content.map((part, idx) =>
@@ -184,11 +176,6 @@ const useMessageClient = ({
 
   const handleBeginEdit = () => {
     if (!onEdit) throw new Error("Runtime does not support editing.");
-    setIsEditing(true);
-  };
-
-  const handleCancelEdit = () => {
-    setIsEditing(false);
   };
 
   const handleSendEdit = (msg: AppendMessage) => {
@@ -198,15 +185,12 @@ const useMessageClient = ({
       parentId,
       sourceId: message.id,
     });
-    setIsEditing(false);
   };
 
   const composerClient = useClientResource(
     ComposerClientResource({
       type: "edit",
-      isEditing,
       canCancel: true,
-      onCancel: handleCancelEdit,
       onBeginEdit: handleBeginEdit,
       onSend: handleSendEdit,
       message,
@@ -411,10 +395,9 @@ const AttachmentResource = resource(useAttachmentResource);
 
 type ComposerClientResourceProps = {
   type: "thread" | "edit";
-  isEditing: boolean;
   canCancel: boolean;
   isSendDisabled?: boolean;
-  onCancel: () => void;
+  onCancel?: () => void;
   onBeginEdit?: () => void;
   onSend?: (message: AppendMessage) => void;
   message?: ExternalThreadMessage;
@@ -471,7 +454,6 @@ const useLiveState = <T>(initial: T) => {
 // Composer Client - minimal implementation
 const useComposerClientResource = ({
   type,
-  isEditing,
   canCancel,
   isSendDisabled = false,
   onCancel,
@@ -481,6 +463,9 @@ const useComposerClientResource = ({
   queue,
   attachmentAdapter,
 }: ComposerClientResourceProps): ClientOutput<"composer"> => {
+  const [isEditing, setIsEditing, isEditingRef] = useLiveState(
+    type === "thread",
+  );
   const [text, setText, textRef] = useLiveState("");
   const [role, setRole, roleRef] = useLiveState<
     "user" | "assistant" | "system"
@@ -495,26 +480,16 @@ const useComposerClientResource = ({
     { readonly text: string; readonly messageId: string } | undefined
   >(undefined);
 
-  // Update composer values when editing begins
-  const updateFromMessage = useEffectEvent(() => {
-    if (message) {
-      // Extract text from message content (text parts only)
-      const textParts = message.content.filter((part) => part.type === "text");
-      const messageText = textParts
-        .map((part) => ("text" in part ? part.text : ""))
-        .join("\n\n");
-
-      setText(messageText);
-      setRole(message.role);
-      setAttachments(message.attachments ?? []);
-    }
-  });
-
-  useEffect(() => {
-    if (isEditing) {
-      updateFromMessage();
-    }
-  }, [isEditing]);
+  const updateFromMessage = () => {
+    if (!message) return;
+    const messageText = message.content
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n\n");
+    setText(messageText);
+    setRole(message.role);
+    setAttachments(message.attachments ?? []);
+  };
 
   const attachmentClients = useClientLookup(
     attachments.map((attachment) =>
@@ -679,7 +654,8 @@ const useComposerClientResource = ({
       const currentText = textRef.current;
       const currentAttachments = attachmentsRef.current;
       const isEmpty = !currentText.trim() && !currentAttachments.length;
-      if (!isEditing || isEmpty || isSendDisabled) return;
+      if (!isEditingRef.current) throw new Error("Composer is not available");
+      if (isEmpty || isSendDisabled) return;
 
       setText("");
       setAttachments([]);
@@ -708,6 +684,7 @@ const useComposerClientResource = ({
         } else {
           onSend?.(composedMessage);
         }
+        if (type === "edit") setIsEditing(false);
       };
 
       if (attachmentAdapter && currentAttachments.length > 0) {
@@ -732,9 +709,15 @@ const useComposerClientResource = ({
         dispatch(currentAttachments);
       }
     },
-    cancel: onCancel,
+    cancel: () => {
+      onCancel?.();
+      if (type === "edit") setIsEditing(false);
+    },
     beginEdit: () => {
       onBeginEdit?.();
+      if (isEditingRef.current) return;
+      setIsEditing(true);
+      updateFromMessage();
     },
     startDictation: () => {},
     stopDictation: () => {},
@@ -978,7 +961,6 @@ const useExternalThread = ({
   const composerClient = useClientResource(
     ComposerClientResource({
       type: "thread",
-      isEditing: true,
       canCancel: isRunning,
       isSendDisabled,
       onCancel: handleCancelRun,

--- a/packages/react/src/client/ExternalThread.ts
+++ b/packages/react/src/client/ExternalThread.ts
@@ -715,7 +715,8 @@ const useComposerClientResource = ({
     },
     beginEdit: () => {
       onBeginEdit?.();
-      if (isEditingRef.current) return;
+      if (type === "thread") return;
+      if (isEditingRef.current) throw new Error("Edit already in progress");
       setIsEditing(true);
       updateFromMessage();
     },

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -129,10 +129,11 @@ const useInMemoryThreadList = (
 
   const handleDelete = (threadId: string) => {
     setThreads((prev) => prev.filter((t) => t.id !== threadId));
-    if (mainThreadId === threadId) {
-      const remaining = threads.filter((t) => t.id !== threadId);
-      setMainThreadId(remaining[0]?.id || "main");
-    }
+    setMainThreadId((prev) =>
+      prev === threadId
+        ? (threads.find((t) => t.id !== threadId)?.id ?? "main")
+        : prev,
+    );
   };
 
   const handleSwitchToNewThread = () => {

--- a/packages/react/src/client/InMemoryThreadList.ts
+++ b/packages/react/src/client/InMemoryThreadList.ts
@@ -131,7 +131,7 @@ const useInMemoryThreadList = (
     setThreads((prev) => prev.filter((t) => t.id !== threadId));
     setMainThreadId((prev) =>
       prev === threadId
-        ? (threads.find((t) => t.id !== threadId)?.id ?? "main")
+        ? threads.find((t) => t.id !== threadId)?.id || "main"
         : prev,
     );
   };

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -322,6 +322,57 @@ describe("ExternalThread composer", () => {
     expect(steer).not.toHaveBeenCalled();
   });
 
+  it("dispatches a same-tick beginEdit + setText + send sequence", async () => {
+    const onEdit = vi.fn();
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: false,
+      onEdit,
+    });
+
+    const composer = () => aui().thread.message({ id: "u1" }).composer();
+    composer().beginEdit();
+    composer().setText("edited");
+    composer().send();
+
+    await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1));
+    expect(onEdit.mock.calls[0]![0]).toMatchObject({
+      sourceId: "u1",
+      content: [{ type: "text", text: "edited" }],
+    });
+    await waitFor(() => expect(composer().getState().isEditing).toBe(false));
+  });
+
+  it("throws on edit-composer send before beginEdit", () => {
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "u1",
+          role: "user",
+          content: [{ type: "text", text: "hi" }],
+          createdAt: new Date(0),
+          attachments: [],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: false,
+      onEdit: vi.fn(),
+    });
+
+    expect(() => aui().thread.message({ id: "u1" }).composer().send()).toThrow(
+      "Composer is not available",
+    );
+  });
+
   it("throws on beginEdit when the runtime has no edit handler", () => {
     const { aui } = renderThread({
       messages: [

--- a/packages/react/src/tests/external-thread-parity.test.tsx
+++ b/packages/react/src/tests/external-thread-parity.test.tsx
@@ -352,6 +352,50 @@ describe("ExternalThread composer", () => {
     await waitFor(() => expect(composer().getState().isEditing).toBe(false));
   });
 
+  it("prefills the edit composer from the message on beginEdit", async () => {
+    const onEdit = vi.fn();
+    const { aui } = renderThread({
+      messages: [
+        {
+          id: "a1",
+          role: "assistant",
+          content: [{ type: "text", text: "original answer" }],
+          createdAt: new Date(0),
+          attachments: [
+            {
+              id: "att1",
+              type: "file",
+              name: "a.txt",
+              contentType: "text/plain",
+              status: { type: "complete" },
+              content: [],
+            },
+          ],
+          metadata: { custom: {} },
+        } as unknown as ExternalThreadMessage,
+      ],
+      isRunning: false,
+      onEdit,
+    });
+
+    const composer = () => aui().thread.message({ id: "a1" }).composer();
+    composer().beginEdit();
+    await waitFor(() => {
+      const state = composer().getState();
+      expect(state.text).toBe("original answer");
+      expect(state.role).toBe("assistant");
+      expect(state.attachments).toHaveLength(1);
+    });
+    expect(() => composer().beginEdit()).toThrow("Edit already in progress");
+
+    composer().send();
+    await waitFor(() => expect(onEdit).toHaveBeenCalledTimes(1));
+    expect(onEdit.mock.calls[0]![0]).toMatchObject({
+      sourceId: "a1",
+      content: [{ type: "text", text: "original answer" }],
+    });
+  });
+
   it("throws on edit-composer send before beginEdit", () => {
     const { aui } = renderThread({
       messages: [

--- a/packages/react/src/tests/in-memory-thread-list.test.tsx
+++ b/packages/react/src/tests/in-memory-thread-list.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { render, waitFor } from "@testing-library/react";
+import type { FC } from "react";
+import { describe, it, expect } from "vitest";
+import { useAui, AuiProvider } from "@assistant-ui/store";
+import { InMemoryThreadList } from "../client/InMemoryThreadList";
+import { ExternalThread } from "../client/ExternalThread";
+
+const renderThreads = () => {
+  const captured: { aui?: ReturnType<typeof useAui> } = {};
+  const Capture: FC = () => {
+    captured.aui = useAui();
+    return null;
+  };
+  const App: FC = () => {
+    const aui = useAui({
+      threads: InMemoryThreadList({
+        thread: () => ExternalThread({ messages: [] }),
+      }),
+    });
+    return (
+      <AuiProvider value={aui}>
+        <Capture />
+      </AuiProvider>
+    );
+  };
+  render(<App />);
+  return { aui: () => captured.aui! };
+};
+
+describe("InMemoryThreadList delete", () => {
+  it("falls back to a live thread when the switch target is deleted in the same tick", async () => {
+    const { aui } = renderThreads();
+
+    aui().threads.switchToNewThread();
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).not.toBe("main"),
+    );
+    const newId = aui().threads.getState().mainThreadId;
+    aui().threads.switchToThread("main");
+    await waitFor(() =>
+      expect(aui().threads.getState().mainThreadId).toBe("main"),
+    );
+
+    aui().threads.switchToThread(newId);
+    aui().threads.item({ id: newId }).delete();
+
+    await waitFor(() => {
+      const state = aui().threads.getState();
+      expect(state.mainThreadId).toBe("main");
+      expect(state.threadIds).not.toContain(newId);
+    });
+  });
+});


### PR DESCRIPTION
## Bug

On the ExternalThread client, the programmatic same-tick sequence `composer().beginEdit(); composer().setText(...); composer().send()` silently no-oped (verified against published 0.15.10). Split across render boundaries the same sequence worked and dispatched the edit with `sourceId`.

## Root cause

The composer's `send` closed over the `isEditing` useState value from the render it was created in (`if (!isEditing || isEmpty || isSendDisabled) return;`); `beginEdit`'s `setIsEditing(true)` only commits on re-render. The composer already reads text/role/attachments/quote through live refs (`useLiveState`) for exactly this reason — editing state was the one guard left behind.

## Fix

- Editing state now lives in the composer resource itself via `useLiveState` (thread composers are always editing; edit composers start not editing), so `beginEdit`/`send`/`cancel` all observe same-tick writes through the ref.
- `beginEdit` populates the draft from the message synchronously instead of via a `useEffect` on `isEditing` — the deferred effect could also clobber a same-tick `setText` on the next render.
- `send` on a non-editing edit composer now throws `"Composer is not available"`, matching the legacy runtime (`ComposerRuntimeImpl` throws this when the edit composer core is absent). Empty/`isSendDisabled` sends remain silent returns, matching legacy `canSend` guard semantics.

## Audit (same class: callbacks capturing useState values a same-tick prior call may have changed)

| Location | Finding | Action |
|---|---|---|
| `ExternalThread.ts` composer `send` | stale `isEditing` prop closure | fixed (live ref, owned by composer) |
| `ExternalThread.ts` `updateFromMessage` effect | populate deferred to next render; clobbers same-tick `setText` after `beginEdit` | fixed (synchronous populate in `beginEdit`) |
| `ExternalThread.ts` message client `beginEdit`/`cancelEdit`/`sendEdit` | managed `isEditing` via plain `useState` | fixed (ownership moved into composer resource) |
| `InMemoryThreadList.ts` `handleDelete` | read `mainThreadId` render state; same-tick `switchToThread(x); delete(x)` left main pointing at deleted thread | fixed (functional `setMainThreadId`) |
| `InMemoryThreadList.ts` `handleDelete` fallback | fallback id computed from render-state `threads` (stale only under two same-tick deletes) | left (in-memory demo list, contrived sequence) |
| `ExternalThread.ts` composer text/role/runConfig/attachments/quote | already live via `useLiveState` refs | none needed |
| `item()`/`thread()`/`message()` selector lookups | read rendered client lookups; clients only exist post-render | left (inherent to client-lookup design) |

## Test

`external-thread-parity.test.tsx`: same-tick `beginEdit + setText + send` dispatches `onEdit` with `sourceId` (fails on the previous code), and edit-composer `send` before `beginEdit` throws. Full package suite: 442 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.0kcm-n7MYWJFi616pL-mkxA2y3Wd0STQ7Qwn6zBs3eRjScZ3JY1JubuGlME?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

