### PR TITLE
chore: bump @assistant-ui/core past the stuck 0.3.10 staged publish

### DIFF
--- a/.changeset/core-republish.md
+++ b/.changeset/core-republish.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+Republish: 0.3.10 was left staged on npm by a failed publish and cannot be re-pushed.


### PR DESCRIPTION
npm left core@0.3.10 in staged state (E409 "Cannot publish over previously staged version") after the publish run half-failed; same-version republish is impossible. This patch changeset moves core to 0.3.11, which still satisfies @assistant-ui/react@0.15.11's ^0.3.10 range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.XQb0w_M2718Tf9RcP8LPcxma4g4mUAx2MolAa3USVyylfmtgI0akP-HX9rs?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->