### PR TITLE
fix(assistant-stream): isolate tool execution callbacks

### DIFF
--- a/.changeset/quiet-tools-settle.md
+++ b/.changeset/quiet-tools-settle.md
@@ -1,0 +1,5 @@
+---
+"assistant-stream": patch
+---
+
+fix: isolate tool execution lifecycle callback errors from stream settlement

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -41,6 +41,19 @@ type ToolExecutionOptions = {
   onExecutionEnd?: ((toolCallId: string, toolName: string) => void) | undefined;
 };
 
+const invokeExecutionCallback = (
+  name: "onExecutionStart" | "onExecutionEnd",
+  callback: ((toolCallId: string, toolName: string) => void) | undefined,
+  toolCallId: string,
+  toolName: string,
+) => {
+  try {
+    callback?.(toolCallId, toolName);
+  } catch (error) {
+    console.error(`[assistant-stream] ${name} callback threw an error`, error);
+  }
+};
+
 const enqueueIfOpen = (
   controller: TransformStreamDefaultController<AssistantStreamChunk>,
   chunk: AssistantStreamChunk,
@@ -165,14 +178,24 @@ export class ToolExecutionStream extends PipeableTransformStream<
                   // Only mark as executing if the tool has frontend execution
                   if (executeResult !== undefined) {
                     isExecuting = true;
-                    options.onExecutionStart?.(toolCallId, toolName);
+                    invokeExecutionCallback(
+                      "onExecutionStart",
+                      options.onExecutionStart,
+                      toolCallId,
+                      toolName,
+                    );
                   }
 
                   return executeResult;
                 },
                 (c) => {
                   if (isExecuting) {
-                    options.onExecutionEnd?.(toolCallId, toolName);
+                    invokeExecutionCallback(
+                      "onExecutionEnd",
+                      options.onExecutionEnd,
+                      toolCallId,
+                      toolName,
+                    );
                   }
 
                   if (c === undefined) return;
@@ -193,7 +216,12 @@ export class ToolExecutionStream extends PipeableTransformStream<
                 },
                 (e) => {
                   if (isExecuting) {
-                    options.onExecutionEnd?.(toolCallId, toolName);
+                    invokeExecutionCallback(
+                      "onExecutionEnd",
+                      options.onExecutionEnd,
+                      toolCallId,
+                      toolName,
+                    );
                   }
 
                   const result = new ToolResponse({

--- a/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
+++ b/packages/assistant-stream/src/core/tool/ToolExecutionStream.ts
@@ -48,7 +48,13 @@ const invokeExecutionCallback = (
   toolName: string,
 ) => {
   try {
-    callback?.(toolCallId, toolName);
+    const result = callback?.(toolCallId, toolName) as unknown;
+    void Promise.resolve(result).catch((error) => {
+      console.error(
+        `[assistant-stream] ${name} callback threw an error`,
+        error,
+      );
+    });
   } catch (error) {
     console.error(`[assistant-stream] ${name} callback threw an error`, error);
   }

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   toolResultStream as unstable_toolResultStream,
   unstable_runPendingTools,
@@ -31,6 +31,10 @@ const captureUnhandledRejections = async (
     process.off("unhandledRejection", listener);
   }
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("unstable_runPendingTools", () => {
   it("settles a tool that returns no value with a concrete result", async () => {
@@ -934,14 +938,22 @@ describe("unstable_runPendingTools", () => {
   });
 
   describe("execution lifecycle callbacks", () => {
-    it.each(["onExecutionStart", "onExecutionEnd"] as const)(
-      "preserves tool results when %s throws",
-      async (callbackName) => {
-        const callbackError = new Error(`${callbackName} failed`);
+    it.each([
+      ["onExecutionStart", "throws"],
+      ["onExecutionStart", "rejects"],
+      ["onExecutionEnd", "throws"],
+      ["onExecutionEnd", "rejects"],
+    ] as const)(
+      "preserves tool results when %s %s",
+      async (callbackName, behavior) => {
+        const callbackError = new Error(`${callbackName} ${behavior}`);
         const error = vi.spyOn(console, "error").mockImplementation(() => {});
-        const lifecycleCallback = vi.fn(() => {
-          throw callbackError;
-        });
+        const lifecycleCallback =
+          behavior === "throws"
+            ? vi.fn(() => {
+                throw callbackError;
+              })
+            : vi.fn(() => Promise.reject(callbackError));
         const inputChunks: AssistantStreamChunk[] = [
           {
             type: "part-start",
@@ -1000,7 +1012,6 @@ describe("unstable_runPendingTools", () => {
           `[assistant-stream] ${callbackName} callback threw an error`,
           callbackError,
         );
-        error.mockRestore();
       },
     );
   });

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -939,14 +939,16 @@ describe("unstable_runPendingTools", () => {
 
   describe("execution lifecycle callbacks", () => {
     it.each([
-      ["onExecutionStart", "throws"],
-      ["onExecutionStart", "rejects"],
-      ["onExecutionEnd", "throws"],
-      ["onExecutionEnd", "rejects"],
+      ["onExecutionStart", "throws", "succeeds"],
+      ["onExecutionStart", "rejects", "succeeds"],
+      ["onExecutionEnd", "throws", "succeeds"],
+      ["onExecutionEnd", "rejects", "succeeds"],
+      ["onExecutionEnd", "throws", "fails"],
     ] as const)(
-      "preserves tool results when %s %s",
-      async (callbackName, behavior) => {
+      "preserves tool settlement when %s %s and the tool %s",
+      async (callbackName, behavior, toolOutcome) => {
         const callbackError = new Error(`${callbackName} ${behavior}`);
+        const toolError = new Error("tool failed");
         const error = vi.spyOn(console, "error").mockImplementation(() => {});
         const lifecycleCallback =
           behavior === "throws"
@@ -976,36 +978,44 @@ describe("unstable_runPendingTools", () => {
         });
         const outputChunks: AssistantStreamChunk[] = [];
 
-        await inputStream
-          .pipeThrough(
-            unstable_toolResultStream(
-              {
-                succeed: {
-                  parameters: { type: "object", properties: {} },
-                  execute: async () => "done",
-                },
-              },
-              new AbortController().signal,
-              async () => {},
-              callbackName === "onExecutionStart"
-                ? { onExecutionStart: lifecycleCallback }
-                : { onExecutionEnd: lifecycleCallback },
-            ),
-          )
-          .pipeTo(
-            new WritableStream<AssistantStreamChunk>({
-              write(chunk) {
-                outputChunks.push(chunk);
-              },
-            }),
-          );
+        const unhandledRejections = await captureUnhandledRejections(
+          async () => {
+            await inputStream
+              .pipeThrough(
+                unstable_toolResultStream(
+                  {
+                    succeed: {
+                      parameters: { type: "object", properties: {} },
+                      execute: async () => {
+                        if (toolOutcome === "fails") throw toolError;
+                        return "done";
+                      },
+                    },
+                  },
+                  new AbortController().signal,
+                  async () => {},
+                  callbackName === "onExecutionStart"
+                    ? { onExecutionStart: lifecycleCallback }
+                    : { onExecutionEnd: lifecycleCallback },
+                ),
+              )
+              .pipeTo(
+                new WritableStream<AssistantStreamChunk>({
+                  write(chunk) {
+                    outputChunks.push(chunk);
+                  },
+                }),
+              );
+          },
+        );
 
+        expect(unhandledRejections).toEqual([]);
         expect(lifecycleCallback).toHaveBeenCalledOnce();
         expect(outputChunks.find((chunk) => chunk.type === "result")).toEqual(
           expect.objectContaining({
             type: "result",
-            result: "done",
-            isError: false,
+            result: toolOutcome === "fails" ? String(toolError) : "done",
+            isError: toolOutcome === "fails",
           }),
         );
         expect(error).toHaveBeenCalledWith(

--- a/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.test.ts
@@ -932,4 +932,76 @@ describe("unstable_runPendingTools", () => {
       expect(called).toBe(false);
     });
   });
+
+  describe("execution lifecycle callbacks", () => {
+    it.each(["onExecutionStart", "onExecutionEnd"] as const)(
+      "preserves tool results when %s throws",
+      async (callbackName) => {
+        const callbackError = new Error(`${callbackName} failed`);
+        const error = vi.spyOn(console, "error").mockImplementation(() => {});
+        const lifecycleCallback = vi.fn(() => {
+          throw callbackError;
+        });
+        const inputChunks: AssistantStreamChunk[] = [
+          {
+            type: "part-start",
+            path: [],
+            part: {
+              type: "tool-call",
+              toolCallId: "tc-lifecycle",
+              toolName: "succeed",
+            },
+          },
+          { type: "text-delta", path: [0], textDelta: "{}" },
+          { type: "tool-call-args-text-finish", path: [0] },
+          { type: "part-finish", path: [0] },
+        ];
+        const inputStream = new ReadableStream<AssistantStreamChunk>({
+          start(controller) {
+            for (const chunk of inputChunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        });
+        const outputChunks: AssistantStreamChunk[] = [];
+
+        await inputStream
+          .pipeThrough(
+            unstable_toolResultStream(
+              {
+                succeed: {
+                  parameters: { type: "object", properties: {} },
+                  execute: async () => "done",
+                },
+              },
+              new AbortController().signal,
+              async () => {},
+              callbackName === "onExecutionStart"
+                ? { onExecutionStart: lifecycleCallback }
+                : { onExecutionEnd: lifecycleCallback },
+            ),
+          )
+          .pipeTo(
+            new WritableStream<AssistantStreamChunk>({
+              write(chunk) {
+                outputChunks.push(chunk);
+              },
+            }),
+          );
+
+        expect(lifecycleCallback).toHaveBeenCalledOnce();
+        expect(outputChunks.find((chunk) => chunk.type === "result")).toEqual(
+          expect.objectContaining({
+            type: "result",
+            result: "done",
+            isError: false,
+          }),
+        );
+        expect(error).toHaveBeenCalledWith(
+          `[assistant-stream] ${callbackName} callback threw an error`,
+          callbackError,
+        );
+        error.mockRestore();
+      },
+    );
+  });
 });

--- a/packages/assistant-stream/src/core/tool/toolResultStream.ts
+++ b/packages/assistant-stream/src/core/tool/toolResultStream.ts
@@ -219,9 +219,9 @@ export async function unstable_runPendingTools(
 }
 
 export type ToolResultStreamOptions = {
-  /** Called immediately before a frontend tool's `execute` function runs. */
+  /** Called after frontend tool execution starts. Callback failures are reported without interrupting the tool. */
   onExecutionStart?: (toolCallId: string, toolName: string) => void;
-  /** Called after frontend tool execution finishes or fails. */
+  /** Called after frontend tool execution finishes or fails. Callback failures are reported without changing the result. */
   onExecutionEnd?: (toolCallId: string, toolName: string) => void;
 };
 


### PR DESCRIPTION
## Summary

- isolate synchronous and asynchronous `onExecutionStart` and `onExecutionEnd` failures from tool settlement
- preserve the tool result and original execution outcome when lifecycle instrumentation fails
- document the non-fatal callback contract and add focused regression coverage

## Problem

The lifecycle callbacks commonly carry telemetry or UI bookkeeping, but they currently run inside the tool stream settlement path. A throwing `onExecutionStart` turns a successful tool result into an error result. A throwing `onExecutionEnd` rejects the stream, discards the result chunk, and can produce an unhandled rejection. Promise-returning callbacks can likewise reject globally even though the public callback type is `void`.

## Root cause

`ToolExecutionStream` invoked both callbacks directly from the `withPromiseOrValue` callback and settlement handlers. Their failures therefore became tool execution failures instead of remaining observer failures.

## Fix

Invoke each lifecycle callback immediately through a guarded helper. Synchronous throws and asynchronous rejections are reported with `console.error`, while callback timing and tool settlement remain unchanged. The tests cover both callback positions and both failure forms.

## Verification

- reproduced the incorrect error result, stream rejection, and unhandled rejection before the fix
- `pnpm --filter assistant-stream test`
- `pnpm --filter assistant-stream build`
- `pnpm exec oxlint packages/assistant-stream/src/core/tool/ToolExecutionStream.ts packages/assistant-stream/src/core/tool/toolResultStream.ts packages/assistant-stream/src/core/tool/toolResultStream.test.ts`