### PR TITLE
fix(eve): isolate lifecycle callbacks

### DIFF
--- a/.changeset/eve-lifecycle-callback-errors.md
+++ b/.changeset/eve-lifecycle-callback-errors.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/eve": patch
+---
+
+fix: isolate observe-only Eve lifecycle callbacks

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -40,6 +40,46 @@ const createAgent = (overrides: Record<string, unknown>) => ({
 });
 
 describe("useEveAgentRuntime status forwarding", () => {
+  it.each(["onError", "onEvent", "onFinish", "onSessionChange"] as const)(
+    "isolates %s callback errors",
+    (callbackName) => {
+      const callbackError = new Error(`${callbackName} failed`);
+      const callback = vi.fn(() => {
+        throw callbackError;
+      });
+      const agent = createAgent({ data: { messages: [] } });
+      let capturedOptions: Record<
+        string,
+        ((value: unknown) => void) | undefined
+      > = {};
+      mockUseEveAgent.mockImplementation((options) => {
+        capturedOptions = options as typeof capturedOptions;
+        return agent as never;
+      });
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      renderHook(() =>
+        useEveAgentRuntime({ [callbackName]: callback } as never),
+      );
+
+      const value =
+        callbackName === "onFinish"
+          ? { status: "ready" }
+          : callbackName === "onError"
+            ? new Error("run failed")
+            : {};
+      expect(() => capturedOptions[callbackName]?.(value)).not.toThrow();
+      expect(callback).toHaveBeenCalledWith(value);
+      expect(consoleError).toHaveBeenCalledWith(
+        `[assistant-ui/eve] ${callbackName} callback threw an error`,
+        callbackError,
+      );
+      consoleError.mockRestore();
+    },
+  );
+
   it("maps the session error onto the interrupted assistant message", () => {
     mockUseEveAgent.mockReturnValue(
       createAgent({ status: "error", error: new Error("boom") }) as never,

--- a/packages/eve/src/useEveAgentRuntime.test.tsx
+++ b/packages/eve/src/useEveAgentRuntime.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { mockUseEveAgent } = vi.hoisted(() => ({
   mockUseEveAgent: vi.fn(),
@@ -39,13 +39,25 @@ const createAgent = (overrides: Record<string, unknown>) => ({
   ...overrides,
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("useEveAgentRuntime status forwarding", () => {
-  it.each(["onError", "onEvent", "onFinish", "onSessionChange"] as const)(
-    "isolates %s callback errors",
-    (callbackName) => {
+  it.each(
+    (["onError", "onEvent", "onFinish", "onSessionChange"] as const).flatMap(
+      (callbackName) =>
+        (["throws", "rejects"] as const).map(
+          (failureMode) => [callbackName, failureMode] as const,
+        ),
+    ),
+  )(
+    "isolates %s callback errors when it %s",
+    async (callbackName, failureMode) => {
       const callbackError = new Error(`${callbackName} failed`);
       const callback = vi.fn(() => {
-        throw callbackError;
+        if (failureMode === "throws") throw callbackError;
+        return Promise.reject(callbackError);
       });
       const agent = createAgent({ data: { messages: [] } });
       let capturedOptions: Record<
@@ -72,11 +84,12 @@ describe("useEveAgentRuntime status forwarding", () => {
             : {};
       expect(() => capturedOptions[callbackName]?.(value)).not.toThrow();
       expect(callback).toHaveBeenCalledWith(value);
-      expect(consoleError).toHaveBeenCalledWith(
-        `[assistant-ui/eve] ${callbackName} callback threw an error`,
-        callbackError,
-      );
-      consoleError.mockRestore();
+      await waitFor(() => {
+        expect(consoleError).toHaveBeenCalledWith(
+          `[assistant-ui/eve] ${callbackName} callback threw an error`,
+          callbackError,
+        );
+      });
     },
   );
 

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -41,6 +41,18 @@ const sendCancelledError = new Error(
   "eve send was dropped because the run was cancelled.",
 );
 
+const invokeEveLifecycleCallback = <T>(
+  name: string,
+  callback: ((value: T) => void) | undefined,
+  value: T,
+) => {
+  try {
+    callback?.(value);
+  } catch (error) {
+    console.error(`[assistant-ui/eve] ${name} callback threw an error`, error);
+  }
+};
+
 const hasRunConfig = (
   runConfig: AppendMessage["runConfig"],
 ): runConfig is NonNullable<AppendMessage["runConfig"]> =>
@@ -100,14 +112,36 @@ export const useEveAgentRuntime = (options: UseEveAgentRuntimeOptions = {}) => {
     ? true
     : never;
 
-  const { onFinish } = agentOptions;
+  const { onError, onEvent, onFinish, onSessionChange } = agentOptions;
   const lastFinishStatusRef = useRef<UseEveAgentStatus | null>(null);
   const agent = useEveAgent({
     ...agentOptions,
+    ...(onError
+      ? {
+          onError: (error) =>
+            invokeEveLifecycleCallback("onError", onError, error),
+        }
+      : {}),
+    ...(onEvent
+      ? {
+          onEvent: (event) =>
+            invokeEveLifecycleCallback("onEvent", onEvent, event),
+        }
+      : {}),
     onFinish: (snapshot) => {
       lastFinishStatusRef.current = snapshot.status;
-      onFinish?.(snapshot);
+      invokeEveLifecycleCallback("onFinish", onFinish, snapshot);
     },
+    ...(onSessionChange
+      ? {
+          onSessionChange: (session) =>
+            invokeEveLifecycleCallback(
+              "onSessionChange",
+              onSessionChange,
+              session,
+            ),
+        }
+      : {}),
   });
   const runtimeAdapters = useRuntimeAdapters();
   const [toolStatuses, setToolStatuses] = useState<

--- a/packages/eve/src/useEveAgentRuntime.ts
+++ b/packages/eve/src/useEveAgentRuntime.ts
@@ -41,15 +41,32 @@ const sendCancelledError = new Error(
   "eve send was dropped because the run was cancelled.",
 );
 
+type EveLifecycleCallbackName =
+  | "onError"
+  | "onEvent"
+  | "onFinish"
+  | "onSessionChange";
+
+const reportEveLifecycleCallbackError = (
+  name: EveLifecycleCallbackName,
+  error: unknown,
+) => {
+  console.error(`[assistant-ui/eve] ${name} callback threw an error`, error);
+};
+
 const invokeEveLifecycleCallback = <T>(
-  name: string,
-  callback: ((value: T) => void) | undefined,
+  name: EveLifecycleCallbackName,
+  callback: ((value: T) => unknown) | undefined,
   value: T,
 ) => {
+  if (!callback) return;
+
   try {
-    callback?.(value);
+    void Promise.resolve(callback(value)).catch((error) => {
+      reportEveLifecycleCallbackError(name, error);
+    });
   } catch (error) {
-    console.error(`[assistant-ui/eve] ${name} callback threw an error`, error);
+    reportEveLifecycleCallbackError(name, error);
   }
 };
 


### PR DESCRIPTION
## Summary

- isolate synchronous and asynchronous Eve observer callback failures from the agent send lifecycle
- preserve internal finish-status tracking when a consumer callback fails
- cover `onEvent`, `onError`, `onFinish`, and `onSessionChange` with regression tests

## Why

Eve [documents these callbacks as observe-only](https://github.com/vercel/eve/blob/eve%400.27.6/packages/eve/src/client/eve-agent-store.ts#L38-L50), but [invokes them inside its send lifecycle](https://github.com/vercel/eve/blob/eve%400.27.6/packages/eve/src/client/eve-agent-store.ts#L181-L217). A consumer callback used for telemetry or UI state can therefore terminate a healthy stream, replace the real run error, or make an otherwise completed `send()` reject. The runtime now reports both thrown errors and rejected callback promises without letting them alter the agent outcome. `prepareSend` remains untouched because it intentionally transforms the request.

The wrappers continue to refresh with the latest callbacks on every render, matching Eve's [`setCallbacks()` behavior](https://github.com/vercel/eve/blob/eve%400.27.6/packages/eve/src/react/use-eve-agent.ts#L111-L143).

## Sequencing

This file is also touched by active Eve PRs, including #5626, #5627, and #5630. This PR should be rebased after the applicable Eve work lands; the behavioral change is otherwise independent.

## Testing

- `vitest run packages/eve/src/useEveAgentRuntime.test.tsx` (35 passed)
- focused oxlint
- `aui-build` for `@assistant-ui/eve`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.Ny6v91VtZOdx2y01v46GL114ug1R5L4d3108p1wRBe7tEcG8VLuShDHeIec?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->