### PR TITLE
fix(react-lexical): clear stale drafts on thread switch

### DIFF
--- a/.changeset/clear-lexical-thread-draft.md
+++ b/.changeset/clear-lexical-thread-draft.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-lexical": patch
+---
+
+fix: clear stale composer text when switching to a thread with an empty draft

--- a/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getRoot, type LexicalEditor } from "lexical";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SyncPlugin } from "./SyncPlugin";
+
+const mocks = vi.hoisted(() => ({
+  aui: undefined as unknown,
+}));
+
+vi.mock("@assistant-ui/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@assistant-ui/store")>();
+  return {
+    ...actual,
+    useAui: () => mocks.aui,
+  };
+});
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const createAui = (text: string) => {
+  const runtime = {
+    getState: () => ({ text }),
+    subscribe: () => () => {},
+  };
+
+  return {
+    composer: {
+      __internal_getRuntime: () => runtime,
+      setText: vi.fn(),
+    },
+  };
+};
+
+const readEditorText = (editor: LexicalEditor) =>
+  editor.getEditorState().read(() => $getRoot().getTextContent());
+
+function EditorProbe({
+  capture,
+}: {
+  capture: (editor: LexicalEditor) => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    capture(editor);
+  }, [capture, editor]);
+
+  return null;
+}
+
+describe("SyncPlugin", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let editor: LexicalEditor;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("clears the editor when switching to a composer with an empty draft", async () => {
+    const initialConfig = {
+      namespace: "sync-plugin-test",
+      onError: (error: Error) => {
+        throw error;
+      },
+    };
+    const capture = (capturedEditor: LexicalEditor) => {
+      editor = capturedEditor;
+    };
+    const render = () =>
+      root.render(
+        <LexicalComposer initialConfig={initialConfig}>
+          <SyncPlugin />
+          <EditorProbe capture={capture} />
+        </LexicalComposer>,
+      );
+
+    mocks.aui = createAui("draft from thread A");
+    await act(async () => {
+      render();
+    });
+    expect(readEditorText(editor)).toBe("draft from thread A");
+
+    mocks.aui = createAui("");
+    await act(async () => {
+      render();
+    });
+
+    expect(readEditorText(editor)).toBe("");
+  });
+});

--- a/packages/react-lexical/src/plugins/SyncPlugin.tsx
+++ b/packages/react-lexical/src/plugins/SyncPlugin.tsx
@@ -205,7 +205,7 @@ export function SyncPlugin({
     if (!composerRuntime) return;
 
     const initialText = composerRuntime.getState().text;
-    if (initialText && initialText !== lastSyncedTextRef.current) {
+    if (initialText !== lastSyncedTextRef.current) {
       isSyncingFromRuntimeRef.current = true;
       lastSyncedTextRef.current = initialText;
       syncRuntimeToLexical(editor, initialText, parserRef.current, () => {


### PR DESCRIPTION
## Summary

- sync empty composer drafts into Lexical when the bound composer runtime changes
- add a regression test that switches from a populated thread draft to an empty one
- add a patch changeset for `@assistant-ui/react-lexical`

## Why

When a user switched from thread A with a draft to thread B with an empty draft, the editor continued showing A's text. The initial runtime-to-Lexical sync used a truthiness check, so the valid empty string from B was skipped. Typing or sending from that editor could then carry stale text into the wrong thread.

The fix compares the incoming draft with the last synchronized value regardless of whether it is empty. Initial empty editors remain a no-op, while a switch from non-empty to empty now clears the editor.

## Verification

- reproduced the failure with the real Lexical composer and `SyncPlugin`
- `pnpm --filter @assistant-ui/react-lexical test` (37 tests)
- `pnpm --filter @assistant-ui/react-lexical build`
- focused oxlint and oxfmt checks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/assistant-ui/assistant-ui/pull/5739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.pfJi1RO336IG56scKDqM94t_Zyy31ywe1rC3vZTVOjrAfu7S6rPXPeJRX-w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->