### PR TITLE
fix(core,react-langgraph): fail fast on invalid converter output, skip RemoveMessage explicitly

### DIFF
--- a/.changeset/converter-invalid-output-error.md
+++ b/.changeset/converter-invalid-output-error.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/core": patch
+---
+
+fix: name the offending input when an external message converter returns an invalid message

--- a/.changeset/langgraph-remove-message-skip.md
+++ b/.changeset/langgraph-remove-message-skip.md
@@ -1,0 +1,5 @@
+---
+"@assistant-ui/react-langgraph": patch
+---
+
+fix: skip RemoveMessage explicitly in convertLangChainMessages

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -943,7 +943,8 @@ type LangChainMessage = {
 } | {
   id: string;
   type: "remove";
-  content?: string;
+  content: string | [
+  ];
   additional_kwargs?: Record<string, unknown>;
 } | {
   id?: string;

--- a/api-surface/assistant-ui__react-langgraph.ts
+++ b/api-surface/assistant-ui__react-langgraph.ts
@@ -941,6 +941,11 @@ type LangChainMessage = {
   artifact?: any;
   status: "error" | "success";
 } | {
+  id: string;
+  type: "remove";
+  content?: string;
+  additional_kwargs?: Record<string, unknown>;
+} | {
   id?: string;
   type: "ai";
   content: AssistantMessageContent;

--- a/packages/core/src/react/runtimes/external-message-converter.test.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.test.ts
@@ -343,4 +343,34 @@ describe("convertExternalMessages", () => {
       expect(result[0]!.role).toBe("user");
     });
   });
+
+  describe("invalid converter output", () => {
+    it("throws a descriptive error when the callback returns undefined", () => {
+      const messages = [{ id: "m1", type: "remove" }];
+      const callback = (() =>
+        undefined) as unknown as useExternalMessageConverter.Callback<
+        (typeof messages)[number]
+      >;
+
+      expect(() =>
+        convertExternalMessages(messages, callback, false, {}),
+      ).toThrowError(
+        /returned an invalid message \(undefined\) for input \{"id":"m1","type":"remove"\}/,
+      );
+    });
+
+    it("throws a descriptive error when the callback returns an array containing undefined", () => {
+      const messages = [{ id: "m1", role: "user" as const, content: "hi" }];
+      const callback = ((msg: (typeof messages)[number]) => [
+        msg,
+        undefined,
+      ]) as unknown as useExternalMessageConverter.Callback<
+        (typeof messages)[number]
+      >;
+
+      expect(() =>
+        convertExternalMessages(messages, callback, false, {}),
+      ).toThrowError(/returned an invalid message \(undefined\)/);
+    });
+  });
 });

--- a/packages/core/src/react/runtimes/external-message-converter.test.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.test.ts
@@ -372,5 +372,46 @@ describe("convertExternalMessages", () => {
         convertExternalMessages(messages, callback, false, {}),
       ).toThrowError(/returned an invalid message \(undefined\)/);
     });
+
+    it("throws a descriptive error when the callback returns an unsupported role", () => {
+      const messages = [{ id: "m1", role: "user" as const, content: "hi" }];
+      const callback = (() => ({
+        role: "other",
+        content: "hi",
+      })) as unknown as useExternalMessageConverter.Callback<
+        (typeof messages)[number]
+      >;
+
+      expect(() =>
+        convertExternalMessages(messages, callback, false, {}),
+      ).toThrowError(/returned an invalid message \(\{"role":"other"/);
+    });
+
+    it("throws a descriptive error when the callback returns a message without content", () => {
+      const messages = [{ id: "m1", role: "user" as const, content: "hi" }];
+      const callback = (() => ({
+        role: "user",
+      })) as unknown as useExternalMessageConverter.Callback<
+        (typeof messages)[number]
+      >;
+
+      expect(() =>
+        convertExternalMessages(messages, callback, false, {}),
+      ).toThrowError(/returned an invalid message \(\{"role":"user"\}\)/);
+    });
+
+    it("throws a descriptive error when the callback returns a tool message without toolCallId", () => {
+      const messages = [{ id: "m1", role: "user" as const, content: "hi" }];
+      const callback = (() => ({
+        role: "tool",
+        result: "ok",
+      })) as unknown as useExternalMessageConverter.Callback<
+        (typeof messages)[number]
+      >;
+
+      expect(() =>
+        convertExternalMessages(messages, callback, false, {}),
+      ).toThrowError(/returned an invalid message \(\{"role":"tool"/);
+    });
   });
 });

--- a/packages/core/src/react/runtimes/external-message-converter.test.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.test.ts
@@ -400,18 +400,18 @@ describe("convertExternalMessages", () => {
       ).toThrowError(/returned an invalid message \(\{"role":"user"\}\)/);
     });
 
-    it("throws a descriptive error when the callback returns a tool message without toolCallId", () => {
+    it("tolerates a tool message without toolCallId as an orphaned tool result", () => {
       const messages = [{ id: "m1", role: "user" as const, content: "hi" }];
-      const callback = (() => ({
-        role: "tool",
-        result: "ok",
-      })) as unknown as useExternalMessageConverter.Callback<
+      const callback = ((msg: (typeof messages)[number]) => [
+        msg,
+        { role: "tool", result: "ok" },
+      ]) as unknown as useExternalMessageConverter.Callback<
         (typeof messages)[number]
       >;
 
-      expect(() =>
-        convertExternalMessages(messages, callback, false, {}),
-      ).toThrowError(/returned an invalid message \(\{"role":"tool"/);
+      const result = convertExternalMessages(messages, callback, false, {});
+      expect(result[0]!.role).toBe("user");
+      expect(result[1]!.content).toHaveLength(0);
     });
   });
 });

--- a/packages/core/src/react/runtimes/external-message-converter.test.tsx
+++ b/packages/core/src/react/runtimes/external-message-converter.test.tsx
@@ -100,6 +100,15 @@ describe("useExternalMessageConverter", () => {
     });
   });
 
+  it("throws the descriptive converter error when the callback returns an invalid message", () => {
+    const bad = (() =>
+      undefined) as unknown as useExternalMessageConverter.Callback<TestMessage>;
+
+    expect(() => renderConverter({ callback: bad })).toThrowError(
+      /External message converter: the converter callback returned an invalid message \(undefined\) for input \{"id":"u1"/,
+    );
+  });
+
   it.each([
     ["false", false],
     ["zero", 0],

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -77,11 +77,14 @@ type CallbackResult<T> = {
 };
 
 const stringifyForError = (value: unknown) => {
+  let text;
   try {
-    return JSON.stringify(value) ?? String(value);
+    text = value instanceof Error ? String(value) : JSON.stringify(value);
   } catch {
-    return String(value);
+    /* circular */
   }
+  text ??= String(value);
+  return text.length > 200 ? `${text.slice(0, 200)}…` : text;
 };
 
 const toCallbackOutputs = (
@@ -95,15 +98,12 @@ const toCallbackOutputs = (
     const valid =
       typeof o === "object" &&
       o !== null &&
-      (o.role === "tool"
-        ? typeof o.toolCallId === "string"
-        : (o.role === "assistant" ||
-            o.role === "user" ||
-            o.role === "system") &&
-          (typeof o.content === "string" || Array.isArray(o.content)));
+      (o.role === "tool" ||
+        ((o.role === "assistant" || o.role === "user" || o.role === "system") &&
+          (typeof o.content === "string" || Array.isArray(o.content))));
     if (!valid)
       throw new Error(
-        `useExternalMessageConverter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
+        `External message converter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
       );
   }
   return outputs;

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -92,7 +92,16 @@ const toCallbackOutputs = (
 ): useExternalMessageConverter.Message[] => {
   const outputs = Array.isArray(output) ? output : [output];
   for (const o of outputs) {
-    if (typeof o !== "object" || o === null || typeof o.role !== "string")
+    const valid =
+      typeof o === "object" &&
+      o !== null &&
+      (o.role === "tool"
+        ? typeof o.toolCallId === "string"
+        : (o.role === "assistant" ||
+            o.role === "user" ||
+            o.role === "system") &&
+          (typeof o.content === "string" || Array.isArray(o.content)));
+    if (!valid)
       throw new Error(
         `useExternalMessageConverter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
       );

--- a/packages/core/src/react/runtimes/external-message-converter.ts
+++ b/packages/core/src/react/runtimes/external-message-converter.ts
@@ -76,6 +76,30 @@ type CallbackResult<T> = {
   outputs: useExternalMessageConverter.Message[];
 };
 
+const stringifyForError = (value: unknown) => {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const toCallbackOutputs = (
+  output:
+    | useExternalMessageConverter.Message
+    | useExternalMessageConverter.Message[],
+  input: unknown,
+): useExternalMessageConverter.Message[] => {
+  const outputs = Array.isArray(output) ? output : [output];
+  for (const o of outputs) {
+    if (typeof o !== "object" || o === null || typeof o.role !== "string")
+      throw new Error(
+        `useExternalMessageConverter: the converter callback returned an invalid message (${stringifyForError(o)}) for input ${stringifyForError(input)}. Return an empty array to skip a message.`,
+      );
+  }
+  return outputs;
+};
+
 type CallbackCacheEntry<T> = CallbackResult<T> & {
   metadata: useExternalMessageConverter.Metadata;
   callback: useExternalMessageConverter.Callback<T>;
@@ -354,7 +378,7 @@ export const convertExternalMessages = <T extends WeakKey>(
   const callbackResults: CallbackResult<T>[] = [];
   for (const message of messages) {
     const output = callback(message, metadata);
-    const outputs = Array.isArray(output) ? output : [output];
+    const outputs = toCallbackOutputs(output, message);
     const result = { input: message, outputs };
     callbackResults.push(result);
   }
@@ -444,7 +468,7 @@ export const useExternalMessageConverter = <T extends WeakKey>({
         result.callback !== state.callback
       ) {
         const output = state.callback(message, state.metadata);
-        const outputs = Array.isArray(output) ? output : [output];
+        const outputs = toCallbackOutputs(output, message);
         result = {
           input: message,
           outputs,

--- a/packages/react-langgraph/src/convertLangChainMessages.test.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { AppendMessage } from "@assistant-ui/core";
 import { convertExternalMessages } from "@assistant-ui/core/react";
 import {
@@ -1439,6 +1439,20 @@ describe("convertLangChainMessages unknown message types", () => {
     };
 
     expect(call(removeMessage)).toEqual([]);
+  });
+
+  it("does not emit the unknown-message dev warning for type:remove", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(
+        call({ type: "remove", id: "some-message-id", content: "" }),
+      ).toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      vi.unstubAllEnvs();
+    }
   });
 
   it("returns an empty array for any other unknown message type", () => {

--- a/packages/react-langgraph/src/convertLangChainMessages.ts
+++ b/packages/react-langgraph/src/convertLangChainMessages.ts
@@ -342,6 +342,8 @@ export const convertLangChainMessages: useExternalMessageConverter.Callback<
         ...(message.status && { status: message.status }),
       };
     }
+    case "remove":
+      return [];
     case "tool":
       return {
         role: "tool",

--- a/packages/react-langgraph/src/normalizeLangGraphTupleMessage.ts
+++ b/packages/react-langgraph/src/normalizeLangGraphTupleMessage.ts
@@ -71,6 +71,7 @@ const isLangChainMessage = (
     value.type === "system" ||
     value.type === "human" ||
     value.type === "tool" ||
+    value.type === "remove" ||
     value.type === "ai"
   );
 };

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -168,7 +168,7 @@ export type LangChainMessage =
       /** RemoveMessage: a deletion instruction targeting `id`, carrying no renderable content. */
       id: string;
       type: "remove";
-      content?: string;
+      content: string | [];
       additional_kwargs?: Record<string, unknown>;
     }
   | {

--- a/packages/react-langgraph/src/types.ts
+++ b/packages/react-langgraph/src/types.ts
@@ -165,6 +165,13 @@ export type LangChainMessage =
       status: "success" | "error";
     }
   | {
+      /** RemoveMessage: a deletion instruction targeting `id`, carrying no renderable content. */
+      id: string;
+      type: "remove";
+      content?: string;
+      additional_kwargs?: Record<string, unknown>;
+    }
+  | {
       id?: string;
       type: "ai";
       content: AssistantMessageContent;

--- a/packages/react-langgraph/src/useLangGraphMessages.test.ts
+++ b/packages/react-langgraph/src/useLangGraphMessages.test.ts
@@ -1910,6 +1910,110 @@ describe("useLangGraphMessages", {}, () => {
     expect(result.current.messages.map((m) => m.id)).toEqual(["sum-1"]);
   });
 
+  it("removes the referenced message when a messages tuple event carries a RemoveMessage", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "I will be pruned",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { run_attempt: 1 },
+        ],
+      },
+      {
+        event: "messages",
+        data: [
+          {
+            type: "remove",
+            id: "ai-1",
+            content: [],
+            additional_kwargs: {},
+            response_metadata: {},
+          },
+          { run_attempt: 1 },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage([{ type: "human", content: "hi" }], {});
+    });
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0]!.type).toEqual("human");
+    expect(
+      result.current.messages.find((m) => m.id === "ai-1"),
+    ).toBeUndefined();
+  });
+
+  it("clears all messages when a messages tuple event carries the REMOVE_ALL_MESSAGES sentinel", async () => {
+    const mockStreamCallback = mockStreamCallbackFactory([
+      metadataEvent,
+      {
+        event: "messages",
+        data: [
+          {
+            id: "ai-1",
+            content: "long history to be summarized",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { run_attempt: 1 },
+        ],
+      },
+      {
+        event: "messages",
+        data: [
+          {
+            type: "remove",
+            id: "__remove_all__",
+            content: [],
+            additional_kwargs: {},
+            response_metadata: {},
+          },
+          { run_attempt: 1 },
+        ],
+      },
+      {
+        event: "messages",
+        data: [
+          {
+            id: "sum-1",
+            content: "summary of the conversation",
+            type: "AIMessageChunk",
+            tool_call_chunks: [],
+          },
+          { run_attempt: 1 },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() =>
+      useLangGraphMessages({
+        stream: mockStreamCallback,
+        appendMessage: appendLangChainChunk,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.sendMessage([{ type: "human", content: "hi" }], {});
+    });
+
+    expect(result.current.messages.map((m) => m.id)).toEqual(["sum-1"]);
+  });
+
   it("syncs messages from values event when no tuple events", async () => {
     const mockStreamCallback = mockStreamCallbackFactory([
       metadataEvent,


### PR DESCRIPTION
## Crash path

A LangGraph thread containing a message type outside the converter's supported set — notably a serialized `RemoveMessage` (`type: "remove"`, e.g. emitted by SummarizationMiddleware), which the load/`setMessages` path hands to the converter directly — used to make `convertLangChainMessages` fall through its `switch` and return `undefined`. `convertExternalMessages` wrapped that as `outputs: [undefined]` and `chunkExternalMessages` read `output.role`, throwing:

> Cannot read properties of undefined (reading 'role')

One unrenderable message crashed the entire thread view, and the error named nothing useful.

#5293 already made the fall-through return `[]`; this PR finishes the hardening on both sides of the seam:

## Changes

**@assistant-ui/react-langgraph**
- `LangChainMessage` gains an explicit `type: "remove"` member (a deletion instruction targeting `id`, no renderable content), and `convertLangChainMessages` skips it with a deliberate `case "remove": return []` instead of the unknown-type fall-through — a legitimate RemoveMessage no longer triggers the dev "Unknown message type" warning.
- The `messages`/`messages-tuple` normalizer (`isLangChainMessage`) accepts `type: "remove"`, so a RemoveMessage arriving over the tuple channel reaches the accumulator's `applyRemove` (including the `__remove_all__` sentinel) instead of being warn-and-dropped.

**@assistant-ui/core** (re-exported by `@assistant-ui/react`)
- `convertExternalMessages` / `useExternalMessageConverter` validate every converter output and throw a descriptive error naming the invalid output and the offending input (with a hint to return an empty array to skip), instead of the bare TypeError deep in chunking.

## Tests

- core: malformed converter outputs (`undefined`, unknown role, missing content, array containing `undefined`) surface the descriptive error naming the input — through both `convertExternalMessages` and the `useExternalMessageConverter` hook; orphaned tool results stay tolerated.
- react-langgraph: `type: "remove"` converts to `[]`, a state containing a RemoveMessage renders the remaining turns, and tuple-channel `remove` / `__remove_all__` events prune the accumulator; all 265 tests pass, core's 956 pass, and `turbo build` for core/react-langgraph is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- rupic:badge:start -->
<a href="https://rupic.dev/s/s2.BrJWChVVVYL9r4SUSUQ-hfyK4QRGKSm_eoU6ijcKwJ99xIjNjhI2idOkT7w?ref=github" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://rupic.dev/badges/track-dark-v1.svg"><img alt="Track in Rupic" src="https://rupic.dev/badges/track-light-v1.svg"></picture></a>
<!-- rupic:badge:end -->
